### PR TITLE
Change the method name on ValueRenderable from value to stringValue

### DIFF
--- a/core/src/main/scala/org/http4s/Challenge.scala
+++ b/core/src/main/scala/org/http4s/Challenge.scala
@@ -23,7 +23,7 @@ import org.http4s.util.{Writer, ValueRenderable}
 case class Challenge(scheme: String,
                      realm: String,
                      params: Map[String, String] = Map.empty) extends ValueRenderable {
-  override lazy val value = super.value
+  override lazy val stringValue = super.stringValue
 
   def renderValue[W <: Writer](writer: W): writer.type = {
     writer.append(scheme).append(' ')
@@ -37,5 +37,5 @@ case class Challenge(scheme: String,
     b.append(',').append(k).append("=\"").append(v).append('"')
   }
 
-  override def toString = value
+  override def toString = stringValue
 }

--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -22,7 +22,6 @@ import org.http4s.util._
 import string._
 
 final case class ContentCoding (coding: CaseInsensitiveString, qValue: QValue = QValue.One) extends HasQValue with ValueRenderable {
-
   def withQValue(q: QValue): ContentCoding = copy(coding, q)
   def satisfies(encoding: ContentCoding) = encoding.satisfiedBy(this)
   def satisfiedBy(encoding: ContentCoding) = {

--- a/core/src/main/scala/org/http4s/Cookie.scala
+++ b/core/src/main/scala/org/http4s/Cookie.scala
@@ -111,7 +111,7 @@ class RequestCookieJar(headers: Seq[Cookie]) extends Iterable[Cookie] with Itera
   }
 
   override def toString(): String = {
-    s"RequestCookieJar(${map(_.value).mkString("\n")})"
+    s"RequestCookieJar(${map(_.stringValue).mkString("\n")})"
   }
 }
 
@@ -129,7 +129,7 @@ case class Cookie(
   extension: Option[String] = None
 ) extends ValueRenderable {
 
-  override lazy val value: String = super.value
+  override lazy val stringValue: String = super.stringValue
 
   def renderValue[W <: Writer](writer: W): writer.type = {
     writer.append(name).append("=\"").append(content).append('"')
@@ -143,5 +143,5 @@ case class Cookie(
     writer
   }
 
-  override def toString = value
+  override def toString = stringValue
 }

--- a/core/src/main/scala/org/http4s/Credentials.scala
+++ b/core/src/main/scala/org/http4s/Credentials.scala
@@ -26,20 +26,20 @@ import net.iharder.Base64
 
 sealed abstract class Credentials extends ValueRenderable {
   def authScheme: AuthScheme
-  override def toString = value
+  override def toString = stringValue
 }
 
 case class BasicCredentials(username: String, password: String) extends Credentials {
   val authScheme = AuthScheme.Basic
 
-  override lazy val value = {
+  override lazy val stringValue = {
     val userPass = username + ':' + password
     val bytes = userPass.getBytes(StandardCharsets.ISO_8859_1)
     val cookie = Base64.encodeBytes(bytes)
     "Basic " + cookie
   }
 
-  def renderValue[W <: Writer](writer: W): writer.type = writer.append(value)
+  def renderValue[W <: Writer](writer: W): writer.type = writer.append(stringValue)
 }
 
 object BasicCredentials {
@@ -62,7 +62,7 @@ case class OAuth2BearerToken(token: String) extends Credentials {
 
 
 case class GenericCredentials(authScheme: AuthScheme, params: Map[String, String]) extends Credentials {
-  override lazy val value = super.value
+  override lazy val stringValue = super.stringValue
 
   def renderValue[W <: Writer](writer: W): writer.type = {
     if (params.isEmpty) writer.append(authScheme.toString)

--- a/core/src/main/scala/org/http4s/MediaType.scala
+++ b/core/src/main/scala/org/http4s/MediaType.scala
@@ -54,7 +54,7 @@ sealed class MediaRange private[http4s](val mainType: String,
 
   def withExtensions(ext: Map[String, String]): MediaRange = new MediaRange(mainType, qValue, ext)
 
-  override def toString = "MediaRange(" + value + ')'
+  override def toString = "MediaRange(" + stringValue + ')'
 
   override def equals(obj: Any) = obj match {
     case _: MediaType => false
@@ -67,7 +67,7 @@ sealed class MediaRange private[http4s](val mainType: String,
       false
   }
 
-  override def hashCode(): Int = value.##
+  override def hashCode(): Int = stringValue.##
 
   @inline
   final def qualityMatches(that: MediaRange): Boolean = {
@@ -148,8 +148,8 @@ sealed class MediaType(mainType: String,
     case _ => false
   }
 
-  override def hashCode() = value.##
-  override def toString = "MediaType(" + value + ')'
+  override def hashCode() = stringValue.##
+  override def toString = "MediaType(" + stringValue + ')'
 }
 
 

--- a/core/src/main/scala/org/http4s/util/Renderable.scala
+++ b/core/src/main/scala/org/http4s/util/Renderable.scala
@@ -12,7 +12,7 @@ trait ValueRenderable extends Renderable {
 
   override def render[W <: Writer](writer: W): writer.type = renderValue(writer)
 
-  def value: String = renderValue(new StringWriter).result()
+  def stringValue: String = renderValue(new StringWriter).result()
 }
 
 trait Writer {

--- a/core/src/test/scala/org/http4s/parser/AcceptCharsetSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AcceptCharsetSpec.scala
@@ -1,16 +1,8 @@
 package org.http4s.parser
 
 import org.http4s.Header.`Accept-Charset`
-import org.http4s.scalacheck.ScalazProperties
 import org.http4s._
-import org.scalacheck.Prop
-import org.specs2.ScalaCheck
-import org.specs2.mutable.Specification
 import scalaz.Validation
-import org.http4s.Charset._
-import org.http4s.CharsetRange._
-import scalaz.syntax.id._
-import scalaz.syntax.validation._
 
 class AcceptCharsetSpec extends Http4sSpec with HeaderParserHelper[`Accept-Charset`] {
 

--- a/core/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
@@ -20,7 +20,7 @@ class AcceptEncodingSpec extends Specification with HeaderParserHelper[`Accept-E
 
     "parse all encodings" in {
       foreach(ContentCoding.snapshot) { case (name, coding) =>
-        parse(coding.value).values.head should be_==(coding)
+        parse(coding.stringValue).values.head should be_==(coding)
       }
     }
   }

--- a/core/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
@@ -24,7 +24,7 @@ class AcceptHeaderSpec extends Specification with HeaderParserHelper[Accept] wit
 
       // Parse the rest
       foreach(MediaRange.snapshot.values) { m =>
-        val r = parse(m.value).values.head
+        val r = parse(m.stringValue).values.head
         r must be_==(m)           // Structural equality
         (r eq m) must be_==(true) // Reference equality
       }
@@ -43,7 +43,7 @@ class AcceptHeaderSpec extends Specification with HeaderParserHelper[Accept] wit
 
       // Parse the rest
       foreach(MediaType.snapshot.values) { m =>
-        val r = parse(m.value).values.head
+        val r = parse(m.stringValue).values.head
         r must be_==(m)           // Structural equality
         (r eq m) must be_==(true) // Reference equality
       }

--- a/core/src/test/scala/org/http4s/parser/WwwAuthenticateHeaderSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/WwwAuthenticateHeaderSpec.scala
@@ -21,7 +21,7 @@ class WwwAuthenticateHeaderSpec extends Specification with HeaderParserHelper[`W
 
   "WWW-Authenticate Header parser" should {
     "Render challenge correctly" in {
-      c.value must be_==(str)
+      c.stringValue must be_==(str)
     }
 
     "Parse a basic authentication" in {
@@ -29,7 +29,7 @@ class WwwAuthenticateHeaderSpec extends Specification with HeaderParserHelper[`W
     }
 
     "Parse a basic authentication with params" in {
-      parse(wparams.value) must be_==(`WWW-Authenticate`(wparams))
+      parse(wparams.stringValue) must be_==(`WWW-Authenticate`(wparams))
     }
 
     "Parse multiple concatenated authentications" in {


### PR DESCRIPTION
It is more descriptive and opens up the `value` symbol for methods which return different types that String. I think this is a win, but decided a PR would be appropriate so others can review it to ensure I'm not going totally rogue.
