### PR TITLE
Add `withHost` method to ServerBuilder and implement for backends. Closes #46.

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -40,6 +40,7 @@ object BlazeServer {
     private var aggregateService = HttpService.empty
     private var port = 8080
     private var idleTimeout: Duration = Duration.Inf
+    private var host = "0.0.0.0"
 
     override def mountService(service: HttpService, prefix: String): this.type = {
       val prefixedService =
@@ -48,6 +49,12 @@ object BlazeServer {
       aggregateService =
         if (aggregateService eq HttpService.empty) prefixedService
         else prefixedService orElse aggregateService
+      this
+    }
+
+
+    override def withHost(host: String): this.type = {
+      this.host = host
       this
     }
 
@@ -68,7 +75,11 @@ object BlazeServer {
         else leaf
       }
       val factory = new SocketServerChannelFactory(stage, 12, 8 * 1024)
-      val channel = factory.bind(new InetSocketAddress(port))
+
+      val address = new InetSocketAddress(host, port)
+      if (address.isUnresolved) throw new Exception(s"Unresolved hostname: $host")
+
+      val channel = factory.bind(address)
       new BlazeServer(channel)
     }
   }

--- a/examples/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -6,6 +6,7 @@ import org.http4s.server.blaze.BlazeServer
 object BlazeExample extends App {
   println("Starting Http4s-blaze example")
   BlazeServer.newBuilder
+    .withHost("0.0.0.0")
     .mountService(ExampleService.service, "/http4s")
     .run()
 }

--- a/examples/src/main/scala/com/example/http4s/servlet/JettyExample.scala
+++ b/examples/src/main/scala/com/example/http4s/servlet/JettyExample.scala
@@ -6,6 +6,7 @@ import org.http4s.jetty.JettyServer
 
 object JettyExample extends App {
   JettyServer.newBuilder
+    .withHost("0.0.0.0")
     .mountService(ExampleService.service, "/http4s")
     .mountServlet(new RawServlet, "/raw/*")
     .run()

--- a/examples/src/main/scala/com/example/http4s/servlet/TomcatExample.scala
+++ b/examples/src/main/scala/com/example/http4s/servlet/TomcatExample.scala
@@ -6,6 +6,7 @@ import org.http4s.tomcat.TomcatServer
 
 object TomcatExample extends App {
   val tomcat = TomcatServer.newBuilder
+    .withHost("0.0.0.0")
     .mountService(ExampleService.service, "/http4s")
     .mountServlet(new RawServlet, "/raw/*")
     .run()

--- a/jetty/src/main/scala/org/http4s/jetty/JettyServer.scala
+++ b/jetty/src/main/scala/org/http4s/jetty/JettyServer.scala
@@ -42,10 +42,16 @@ object JettyServer {
 
     private val server = new JServer()
     private var port = 8080
+    private var host = "0.0.0.0"
     private var timeout: Duration = Duration.Inf
 
     override def withPort(port: Int): this.type = {
       this.port = port
+      this
+    }
+
+    override def withHost(host: String): this.type = {
+      this.host = host
       this
     }
 
@@ -55,6 +61,7 @@ object JettyServer {
 
     def build: To = {
       val connector = new ServerConnector(server)
+      connector.setHost(host)
       connector.setPort(port)
       server.addConnector(connector)
       val dur = if (timeout.isFinite) timeout.toMillis else -1

--- a/server/src/main/scala/org/http4s/server/Server.scala
+++ b/server/src/main/scala/org/http4s/server/Server.scala
@@ -24,6 +24,8 @@ trait ServerBuilder { self =>
   def build: To
 
   def withPort(port: Int): this.type
+  
+  def withHost(host: String): this.type
 
   def start: Task[To] = build.start
 

--- a/tomcat/src/main/scala/org/http4s/tomcat/TomcatServer.scala
+++ b/tomcat/src/main/scala/org/http4s/tomcat/TomcatServer.scala
@@ -57,6 +57,11 @@ object TomcatServer {
       this
     }
 
+    override def withHost(host: String): this.type = {
+      tomcat.getConnector.setAttribute("address", host)
+      this
+    }
+
     /** Add timeout for idle connections
       * '''WARNING:''' Tomcat maintains connections on a fixed interval determined by the global
       * attribute worker.maintain with a default interval of 60 seconds. In the worst case the connection


### PR DESCRIPTION
@rossabaker, I'd appreciate a quick review to make sure this is the prescribed fashion for setting the host on Jetty and Tomcat.
