### PR TITLE
Message syntax was ugly, so I made it better.

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
@@ -112,7 +112,7 @@ object ServerTestRoutes {
   def apply(): HttpService = {
     case req if req.requestMethod == Method.GET && req.pathInfo == "/get" => Ok("get")
     case req if req.requestMethod == Method.GET && req.pathInfo == "/chunked" =>
-      Ok(eval(Task("chu")) ++ eval(Task("nk"))).addHeader(Header.`Transfer-Encoding`(TransferCoding.chunked))
+      Ok(eval(Task("chu")) ++ eval(Task("nk"))).addHeaders(Header.`Transfer-Encoding`(TransferCoding.chunked))
 
     case req if req.requestMethod == Method.GET && req.pathInfo == "/cachechunked" =>
       Ok(eval(Task("chu")) ++ eval(Task("nk")))

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import scala.collection.{mutable, immutable}
+import scala.collection.{immutable, mutable}
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.ListBuffer
 import org.http4s.HeaderKey.StringKey
@@ -10,6 +10,8 @@ import org.http4s.util.CaseInsensitiveString
 final class Headers private (headers: List[Header])
   extends immutable.Seq[Header]
   with collection.SeqLike[Header, Headers] {
+
+  override def toList: List[Header] = headers
 
   override protected def newBuilder: mutable.Builder[Header, Headers] = Headers.newBuilder
 

--- a/core/src/main/scala/org/http4s/MessageMethods.scala
+++ b/core/src/main/scala/org/http4s/MessageMethods.scala
@@ -1,0 +1,93 @@
+package org.http4s
+
+import org.http4s.Header.{`Set-Cookie`, `Content-Type`}
+
+import scalaz.concurrent.Task
+
+
+trait MessageMethods {
+  type Self
+
+  /** Remove headers that satisfy the predicate
+    *
+    * @param f predicate
+    * @return a new message object which lacks the specified headers
+    */
+  def filterHeaders(f: Header => Boolean): Self
+
+  /** Generates a new message object with the specified key/value pair appended to the [[org.http4s.AttributeMap]]
+    *
+    * @param key [[AttributeKey]] with which to associate the value
+    * @param value value associated with the key
+    * @tparam A type of the value to store
+    * @return a new message object with the key/value pair appended
+    */
+  def withAttribute[A](key: AttributeKey[A], value: A): Self
+
+  /** Generates a new message object with the specified key/value pair appended to the [[org.http4s.AttributeMap]]
+    *
+    * @param entry [[AttributeEntry]] entry to add
+    * @tparam V type of the value to store
+    * @return a new message object with the key/value pair appended
+    */
+  def withAttribute[V](entry: AttributeEntry[V]): Self = withAttribute(entry.key, entry.value)
+
+  /** Added the [[`Content-Type`]] header to the response */
+  def withType(t: MediaType): Self = putHeaders(`Content-Type`(t))
+
+  def withContentType(contentType: Option[`Content-Type`]): Self = contentType match {
+    case Some(t) => putHeaders(t)
+    case None => filterHeaders(_.is(`Content-Type`))
+  }
+
+  def removeHeader(key: HeaderKey): Self = filterHeaders(_ isNot key)
+
+  /** Replaces the [[Header]]s of the incoming Request object
+    *
+    * @param headers [[Headers]] containing the desired headers
+    * @return a new Request object
+    */
+  def withHeaders(headers: Headers): Self
+
+  /** Replace the existing headers with those provided */
+  def withHeaders(headers: Header*): Self = withHeaders(Headers(headers.toList))
+
+  /** Add the provided headers to the existing headers */
+  def addHeaders(headers: Header*): Self
+
+  /** Add the provided headers to the existing headers, replacing those of the same header name */
+  def putHeaders(headers: Header*): Self
+
+  def withTrailerHeaders(trailerHeaders: Task[Headers]): Self =
+    withAttribute(Message.Keys.TrailerHeaders, trailerHeaders)
+}
+
+
+trait ResponseMethods extends MessageMethods {
+
+  /** Change the status of this response object
+    *
+    * @param status value to replace on the response object
+    * @tparam S type that can be converted to a [[Status]]
+    * @return a new response object with the new status code
+    */
+  def withStatus[S <% Status](status: S): Self
+
+  /** Add a Set-Cookie header for the provided [[Cookie]] */
+  def addCookie(cookie: Cookie): Self = addHeaders(Header.`Set-Cookie`(cookie))
+
+  /** Add a Set-Cookie header with the provided values */
+  def addCookie(name: String,
+                content: String,
+                expires: Option[DateTime] = None): Self = addCookie(Cookie(name, content, expires))
+
+  /** Add a [[`Set-Cookie`]] which will remove the specified cookie from the client */
+  def removeCookie(cookie: Cookie): Self = addHeaders(`Set-Cookie`(cookie.copy(content = "",
+    expires = Some(DateTime.UnixEpoch), maxAge = Some(0))))
+
+  /** Add a Set-Cookie which will remove the specified cookie from the client */
+  def removeCookie(name: String): Self = addHeaders(Header.`Set-Cookie`(
+    Cookie(name, "", expires = Some(DateTime.UnixEpoch), maxAge = Some(0))
+  ))
+}
+

--- a/core/src/main/scala/org/http4s/MessageSyntax.scala
+++ b/core/src/main/scala/org/http4s/MessageSyntax.scala
@@ -1,49 +1,30 @@
 package org.http4s
 
-import org.http4s.Writable.Entity
-
 import scalaz.concurrent.Task
-import org.http4s.Header.{`Set-Cookie`, `Content-Type`}
 
 object MessageSyntax extends MessageSyntax
 
 trait MessageSyntax {
 
-  implicit def addHelpers(r: Task[Response]) = new ResponseSyntax[Task[Response]] {
-    override protected def translateMessage(f: Response => Response) = r.map(f)
-
-    override protected def translateWithTask(f: (Response) => Task[Response]): Task[Response] = r.flatMap(f)
+  implicit def requestSyntax(req: Task[Request]): TaskMessageMethods[Request] = new TaskMessageMethods[Request] {
+    override def r = req
   }
 
-  implicit def addHelpers(r: Task[Request]) = new MessageSyntax[Task[Request], Request] {
-    override protected def translateMessage(f: (Request) => Request): Task[Request] = r.map(f)
-
-    override protected def translateWithTask(f: (Request) => Task[Request]): Task[Request] = r.flatMap(f)
+  implicit def responseSyntax(resp: Task[Response]): TaskResponseMethods = new TaskResponseMethods {
+    override def r = resp
   }
 
-  trait MessageSyntax[T, M <: Message] {
+  /////////////// instance traits ///////////////////////////////////////////////
 
-    protected def translateMessage(f: M => M#Self): T
-    
-    protected def translateWithTask(f: M => Task[M#Self]): Task[M#Self]
+  trait TaskMessageMethods[M <: Message] extends MessageMethods {
+    type Self = Task[M#Self]
 
-    /** Replace the body of the incoming Request object
-      *
-      * @param body body of type T
-      * @param w [[Writable]] corresponding to the body
-      * @tparam B type of the body
-      * @return new message
+    def r: Task[M]
+
+    /** Add a body to the message
+      * @see [[Message]]
       */
-    def withBody[B](body: B)(implicit w: Writable[B]): Task[M#Self] = withBody(body, w.headers)
-
-    def withBody[B](body: B, headers: Headers)(implicit w: Writable[B]): Task[M#Self] = {
-      translateWithTask { self =>
-        w.toEntity(body).map { case Entity(proc, len) =>
-          val h = self.headers ++ headers ++ len.fold(Headers.empty)(l => Headers(Header.`Content-Length`(l)))
-          self.withBHA(body = proc, headers = h)
-        }
-      }
-    }
+    def withBody[T](b: T)(implicit w: Writable[T]): Self = r.flatMap(_.withBody(b)(w))
 
     /** Generates a new message object with the specified key/value pair appended to the [[org.http4s.AttributeMap]]
       *
@@ -52,90 +33,27 @@ trait MessageSyntax {
       * @tparam A type of the value to store
       * @return a new message object with the key/value pair appended
       */
-    def withAttribute[A](key: AttributeKey[A], value: A): T = translateMessage { r =>
-      r.withBHA(attributes = r.attributes.put(key, value))
-    }
-
-    /** Added the [[`Content-Type`]] header to the response */
-    def withType(t: MediaType): T = translateMessage{ r =>
-      r.withBHA(headers = r.headers :+ `Content-Type`(t))
-    }
-
-    /** Replace the body of the incoming Request object
-      *
-      * @param body scalaz.stream.Process[Task,Chunk] representing the new body
-      * @return a new Request object
-      */
-    def withBody(body: EntityBody): T = translateMessage{ r => r.withBHA(body = body) }
-
-    def withContentType(contentType: Option[`Content-Type`]): T = translateMessage { r =>
-      r.withBHA(headers = contentType match {
-        case Some(ct) => r.headers.put(ct)
-        case None => r.headers.filterNot(_.is(Header.`Content-Type`))
-      })
-    }
-
-    def filterHeaders(f: Header => Boolean): T = translateMessage { r => r.withBHA(headers = r.headers.filter(f))}
-
-    def removeHeader(key: HeaderKey): T = filterHeaders(_ isNot key)
+    override def withAttribute[A](key: AttributeKey[A], value: A): Self = r.map(_.withAttribute(key, value))
 
     /** Replaces the [[Header]]s of the incoming Request object
       *
       * @param headers [[Headers]] containing the desired headers
       * @return a new Request object
       */
-    def withHeaders(headers: Headers): T = translateMessage(_.withBHA(headers = headers))
-
-    /** Replace the existing headers with those provided */
-    def withHeaders(headers: Header*): T = withHeaders(Headers(headers.toList))
-
-    /** Add the provided headers to the existing headers */
-    def addHeaders(headers: Header*): T = translateMessage(r => r.withBHA(headers = r.headers ++ headers))
-
-    /** Add the provided header to the existing headers */
-    def addHeader(header: Header): T = translateMessage(r => r.withBHA(headers = header +: r.headers))
-
-    /** Add the provided header to the existing headers, replacing those of the same header name */
-    def putHeader(header: Header): T = translateMessage(r => r.withBHA(headers = r.headers.put(header)))
+    override def withHeaders(headers: Headers): Self = r.map(_.withHeaders(headers))
 
     /** Add the provided headers to the existing headers, replacing those of the same header name */
-    def putHeaders(headers: Header*): T = translateMessage(r => r.withBHA(headers = r.headers.put(headers:_*)))
+    override def putHeaders(headers: Header*): Self = r.map(_.putHeaders(headers:_*))
 
-    def addAttribute[V](entry: AttributeEntry[V]): T = addAttribute(entry.key, entry.value)
+    override def filterHeaders(f: (Header) => Boolean): Self = r.map(_.filterHeaders(f))
 
-    def addAttribute[V](key: AttributeKey[V], value: V): T = translateMessage { r =>
-      r.withBHA(attributes = r.attributes.put(key, value))
-    }
-
-    def withTrailerHeaders(trailerHeaders: Task[Headers]): T = translateMessage{ r =>
-      r.withBHA(attributes = r.attributes.put(Message.Keys.TrailerHeaders, trailerHeaders))
-    }
+    /** Add the provided headers to the existing headers */
+    override def addHeaders(headers: Header*): Self = r.map(_.addHeaders(headers:_*))
   }
 
-
-  trait ResponseSyntax[T] extends MessageSyntax[T, Response] {
+  trait TaskResponseMethods extends TaskMessageMethods[Response] with ResponseMethods {
 
     /** Response specific extension methods */
-
-    /** Add a Set-Cookie header for the provided [[Cookie]] */
-    def addCookie(cookie: Cookie): T = addHeaders(Header.`Set-Cookie`(cookie))
-
-    /** Add a Set-Cookie header with the provided values */
-    def addCookie(name: String,
-                  content: String,
-                  expires: Option[DateTime] = None): T = addCookie(Cookie(name, content, expires))
-
-    /** Add a [[`Set-Cookie`]] which will remove the specified cookie from the client */
-    def removeCookie(cookie: Cookie): T = addHeaders(`Set-Cookie`(cookie.copy(content = "",
-        expires = Some(DateTime.UnixEpoch), maxAge = Some(0))))
-
-    /** Add a Set-Cookie which will remove the specified cookie from the client */
-    def removeCookie(name: String): T = addHeaders(Header.`Set-Cookie`(
-      Cookie(name, "", expires = Some(DateTime.UnixEpoch), maxAge = Some(0))
-    ))
-
-    def withStatus[T <% Status](status: T) = translateMessage(_.copy(status = status))
+    override def withStatus[S <% Status](status: S): Self = r.map(_.withStatus(status))
   }
-
 }
-

--- a/core/src/main/scala/org/http4s/Status.scala
+++ b/core/src/main/scala/org/http4s/Status.scala
@@ -128,7 +128,8 @@ trait StatusInstances {
     // TODO type this header
     def apply[A](range: String, body: A, headers: Headers = Headers.empty)(implicit w: Writable[A]): Task[Response] =
       apply(body).map { r =>
-        headers.foldLeft(r.addHeader(Header("Range", range))) { _.addHeader(_) }
+        val hs = Header("Range", range)::headers.toList
+        r.addHeaders(hs:_*)
       }
   }
   val MultiStatus = new Status(207, "Multi-Status") with EntityResponseGenerator
@@ -152,7 +153,8 @@ trait StatusInstances {
     def apply[A](wwwAuthenticate: String, body: A, headers: Headers = Headers.empty)(implicit w: Writable[A]): Task[Response] =
     // TODO type this header
       apply(body).map { r =>
-        headers.foldLeft(r.addHeader(Header("WWW-Authenticate", wwwAuthenticate))) { _.addHeader(_) }
+        val hs = Header("WWW-Authenticate", wwwAuthenticate)::headers.toList
+        r.addHeaders(hs:_*)
       }
   }
   val PaymentRequired = new Status(402, "Payment Required") with EntityResponseGenerator
@@ -163,15 +165,17 @@ trait StatusInstances {
   object MethodNotAllowed extends Status(405, "Method Not Allowed") with EntityResponseGenerator {
     def apply[A](allowed: TraversableOnce[Method], body: A, headers: Headers = Headers.empty)(implicit w: Writable[A]): Task[Response] =
       apply(body).map { r =>
-        headers.foldLeft(r.addHeader(Header("Allowed", allowed.mkString(", ")))) { _.addHeader(_) }
+        val hs = Header("Allowed", allowed.mkString(", "))::headers.toList
+        r.addHeaders(hs:_*)
       }
   }
   val NotAcceptable = new Status(406, "Not Acceptable") with EntityResponseGenerator
   object ProxyAuthenticationRequired extends Status(407, "Proxy Authentication Required") with EntityResponseGenerator {
     // TODO type this header
-    def apply[F[_], A](proxyAuthenticate: String, body: A, headers: Headers = Headers.empty)(implicit w: Writable[A]): Task[Response] =
+    def apply[A](proxyAuthenticate: String, body: A, headers: Headers = Headers.empty)(implicit w: Writable[A]): Task[Response] =
       apply(body).map { r =>
-        headers.foldLeft(r.addHeader(Header("Proxy-Authenticate", proxyAuthenticate))) { _.addHeader(_) }
+        val hs = Header("Proxy-Authenticate", proxyAuthenticate)::headers.toList
+        r.addHeaders(hs:_*)
       }
   }
   val RequestTimeOut = new Status(408, "Request Time-out") with EntityResponseGenerator

--- a/core/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/core/src/test/scala/org/http4s/ResponderSpec.scala
@@ -19,9 +19,9 @@ class ResponderSpec extends Specification {
     "Replace content type" in {
       import Header._
       resp.contentType should be (None)
-      val c1 = resp.addHeader(Header.`Content-Length`(4))
+      val c1 = resp.addHeaders(Header.`Content-Length`(4))
         .withContentType(Some(`Content-Type`.`text/plain`))
-        .addHeader(Header.Host("foo"))
+        .addHeaders(Header.Host("foo"))
 
       c1.headers.count(_ is `Content-Type`) must_== (1)
       c1.headers.count(_ is `Content-Length`) must_== (1)
@@ -37,7 +37,7 @@ class ResponderSpec extends Specification {
     }
 
     "Replace headers" in {
-      val wHeader = resp.addHeader(Header.Connection("close".ci))
+      val wHeader = resp.addHeaders(Header.Connection("close".ci))
       wHeader.headers.get(Header.Connection) must beSome(Header.Connection("close".ci))
 
       val newHeaders = wHeader.removeHeader(Header.Connection)

--- a/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -26,10 +26,10 @@ object ChunkAggregator extends LazyLogging {
 
   def apply(route: HttpService): HttpService = route andThen (_.map { response =>
     val chunks = compact(response.body)
-    if (!chunks.isEmpty)
-      response.putHeader(`Content-Length`(chunks.head.length))
-        .withBody(emitSeq(chunks))
-
+    if (!chunks.isEmpty) {
+      val h = response.headers :+ `Content-Length`(chunks.head.length)
+      response.copy(body = emitSeq(chunks), headers = h)
+    }
     else response
   })
 }

--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -39,7 +39,7 @@ object GZip extends StrictLogging {
                         resp.body.pipe(scalaz.stream.compress.deflate(level = level, nowrap = true))
               
               resp.removeHeader(`Content-Length`)
-                .addHeader(`Content-Encoding`(ContentCoding.gzip))
+                .addHeaders(`Content-Encoding`(ContentCoding.gzip))
                 .copy(body = b)
             }
             else resp  // Don't touch it, Content-Encoding already set

--- a/server/src/main/scala/org/http4s/server/websocket/package.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/package.scala
@@ -13,5 +13,5 @@ package object websocket {
   def WS(source: Process[Task, WSFrame] = halt,
          sink: Sink[Task, WSFrame] = halt,
          status: Task[Response] = Status.NotImplemented("This is a WebSocket route.")): Task[Response] =
-    status.map(_.addAttribute(websocketKey, Websocket(source, sink)))
+    status.map(_.withAttribute(websocketKey, Websocket(source, sink)))
 }


### PR DESCRIPTION
In the name of DRY, I had made the `MessageSyntax` overly complex. It turns out, I didn't really save too many keystrokes. This commit is a much more conventional approach to adding the syntax.

If nobody objects, I'll merge this tomorrow morning (Monday Aug 11, ~ 8AM EST).
