### PR TITLE
fix dependency of scodec

### DIFF
--- a/core/core.sbt
+++ b/core/core.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   rl,
   scalazStream,
   scalaloggingSlf4j,
-  scodecCore,
+  scodecBits,
   Http4sDependencies.config
 )
 

--- a/core/src/test/scala/org/http4s/WritableSpec.scala
+++ b/core/src/test/scala/org/http4s/WritableSpec.scala
@@ -13,6 +13,9 @@ import scalaz.stream.text.utf8Decode
 import scalaz.stream.Process
 
 object WritableSpec {
+
+  implicit val byteVectorMonoid: scalaz.Monoid[ByteVector] = scalaz.Monoid.instance(_ ++ _, ByteVector.empty)
+
   def writeToString[A](a: A)(implicit W: Writable[A]): String =
     Process.eval(W.toEntity(a))
       .collect { case Writable.Entity(body, _ ) => body }

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -55,7 +55,7 @@ object Http4sDependencies {
   lazy val scalazScalacheckBinding = "org.scalaz"           %% "scalaz-scalacheck-binding" % "7.1.0"
   lazy val scalazSpecs2        = "org.typelevel"            %% "scalaz-specs2"           % "0.3.0"
   lazy val scalazStream        = "org.scalaz.stream"        %% "scalaz-stream"           % "0.5a"
-  lazy val scodecCore          = "org.typelevel"            %% "scodec-core"             % "1.2.0"
+  lazy val scodecBits          = "org.typelevel"            %% "scodec-bits"             % "1.0.4"
   lazy val tomcatCatalina      = "org.apache.tomcat"         % "tomcat-catalina"         % "7.0.53"
   lazy val tomcatCoyote        = "org.apache.tomcat"         % "tomcat-coyote"           % tomcatCatalina.revision
 }


### PR DESCRIPTION
I think that http4s don't need to depend on scodec-core, because ByteVector Monoid instance is used by only WritableSpec.
