### PR TITLE
Change AttributeKey matching to singleton matching

### DIFF
--- a/core/src/main/scala/org/http4s/AttributeMap.scala
+++ b/core/src/main/scala/org/http4s/AttributeMap.scala
@@ -7,18 +7,19 @@
 package org.http4s
 
 // T must be invariant to work properly.
-//  Because it is sealed and the only instances go through AttributeKey.apply,
-//  a single AttributeKey instance cannot conform to AttributeKey[T] for different Ts
 
 /** A key in an [[AttributeMap]] that constrains its associated value to be of type `T`.
-  * The key is uniquely defined by its [[name]] and type `T`, represented at runtime by [[manifest]]. */
+  * The key is uniquely defined by its reference: there are no duplicate keys, even
+  * those with the same name and type. */
 final class AttributeKey[T] private (val name: String) {
   def apply(value: T): AttributeEntry[T] = AttributeEntry(this, value)
 
-  override final def toString = name
+  override def toString = name
 }
 
 object AttributeKey {
+
+  /** Construct an [[AttributeKey]] */
   def apply[T](name: String): AttributeKey[T] = new AttributeKey(name)
 
   /**
@@ -28,39 +29,32 @@ object AttributeKey {
     apply("org.http4s."+name)
 }
 
-/** An immutable map where a key is the tuple `(String,T)` for a fixed type `T` and can only be associated with values of type `T`.
-  * It is therefore possible for this map to contain mappings for keys with the same label but different types.
-  * Excluding this possibility is the responsibility of the client if desired. */
-class AttributeMap private(private val backing: Map[AttributeKey[_], Any]) {
+/** An immutable map where an [[AttributeKey]]  for a fixed type `T` can only be associated with values of type `T`.
+  * Because the equality of keys is based on reference, it is therefore possible for this map to contain mappings
+  * for keys with the same label and same types. */
+final class AttributeMap private(private val backing: Map[AttributeKey[_], Any]) {
 
-  /** Gets the value of type `T` associated with the key `k`.
-    * If a key with the same label but different type is defined, this method will fail. */
+  /** Gets the value of type `T` associated with the key `k`. */
   def apply[T](k: AttributeKey[T]): T = backing(k).asInstanceOf[T]
 
-  /** Gets the value of type `T` associated with the key `k` or `None` if no value is associated.
-    * If a key with the same label but a different type is defined, this method will return `None`. */
+  /** Gets the value of type `T` associated with the key `k` or `None` if no value is associated. */
   def get[T](k: AttributeKey[T]): Option[T] = backing.get(k).asInstanceOf[Option[T]]
 
-  /** Returns this map without the mapping for `k`.
-    * This method will not remove a mapping for a key with the same label but a different type. */
+  /** Returns this map without the mapping for `k`. */
   def remove[T](k: AttributeKey[T]): AttributeMap = new AttributeMap(backing - k)
 
-  /** Returns true if this map contains a mapping for `k`.
-    * If a key with the same label but a different type is defined in this map, this method will return `false`. */
+  /** Returns true if this map contains a mapping for `k`. */
   def contains[T](k: AttributeKey[T]): Boolean = backing.contains(k)
 
-  /** Adds the mapping `k -> value` to this map, replacing any existing mapping for `k`.
-    * Any mappings for keys with the same label but different types are unaffected. */
+  /** Adds the mapping `k -> value` to this map, replacing any existing mapping for `k`. */
   def put[T](k: AttributeKey[T], value: T): AttributeMap = new AttributeMap(backing.updated(k, value))
 
-  /** All keys with defined mappings.  There may be multiple keys with the same `label`, but different types. */
+  /** All keys with defined mappings. */
   def keys: Iterable[AttributeKey[_]] = backing.keys
 
   /** Adds the mappings in `o` to this map, with mappings in `o` taking precedence over existing mappings.*/
-  def ++(o: Iterable[AttributeEntry[_]]): AttributeMap = {
-    val newBacking = o.foldLeft(backing) { case (b, AttributeEntry(key, value)) => b.updated(key, value) }
-    new AttributeMap(newBacking)
-  }
+  def ++(o: Iterable[AttributeEntry[_]]): AttributeMap =
+    new AttributeMap(backing ++ o.iterator.map { e => (e.key, e.value) })
 
   /** Combines the mappings in `o` with the mappings in this map, with mappings in `o` taking precedence over existing mappings.*/
   def ++(o: AttributeMap): AttributeMap = new AttributeMap(backing ++ o.backing)

--- a/core/src/test/scala/org/http4s/AttributeMapSpec.scala
+++ b/core/src/test/scala/org/http4s/AttributeMapSpec.scala
@@ -28,8 +28,9 @@ class AttributeMapSpec extends Specification {
 
     // This is a compile test
     "Maintain the correct static type for keys" in {
-      val mismatchedKey = AttributeKey.apply[Option[Int]]("mismatched")
-//      val ii = m.get(mismatchedKey).get + 5   // FAILS TO COMPILE
+      case class Foo(stuff: String)
+      val mismatchedKey = AttributeKey.apply[Foo]("mismatched")
+//      val ii = m(mismatchedKey) + 5   // FAILS TO COMPILE: Foo doesn't `+` with 5
 
       val i: Int = m.get(k1).get + 4
       i must_== 5


### PR DESCRIPTION
This pull request is the fruit of the discussion around issue #83.

Removes the ClassTag and makes it impossible to generate imposter keys, forcing a one to (one or none) correspondance between key and entry whereas it had been possible to generate "imposter" keys by using the same name and type.

**If we wanted to allow the creation of multiple keys that could access the same value, this should be rejected.** eg, if [this test](https://github.com/http4s/http4s/blob/topic/SingletonAttributeKeys/core/src/test/scala/org/http4s/AttributeMapSpec.scala#L26) should fail, which is the behavior on master.
