### PR TITLE
the `withBody` helpers now allow the specification of header replacement

### DIFF
--- a/core/src/main/scala/org/http4s/MessageSyntax.scala
+++ b/core/src/main/scala/org/http4s/MessageSyntax.scala
@@ -18,7 +18,8 @@ trait TaskMessageOps[M <: Message] extends Any with MessageOps {
   /** Add a body to the message
     * @see [[Message]]
     */
-  def withBody[T](b: T)(implicit w: EntityEncoder[T]): Self = self.flatMap(_.withBody(b)(w))
+  def withBody[T](b: T, replaceHeaders: Boolean = false)(implicit w: EntityEncoder[T]): Self =
+    self.flatMap(_.withBody(b, replaceHeaders)(w))
 
   /** Generates a new message object with the specified key/value pair appended to the [[org.http4s.AttributeMap]]
     *

--- a/core/src/test/scala/org/http4s/MessageSyntaxSpec.scala
+++ b/core/src/test/scala/org/http4s/MessageSyntaxSpec.scala
@@ -1,0 +1,39 @@
+package org.http4s
+
+import org.http4s.Header.`Content-Type`
+import org.specs2.mutable.Specification
+import Http4s._
+
+import scalaz.concurrent.Task
+
+class MessageSyntaxSpec extends Specification {
+
+  "toBody syntax" should {
+    "Honor the 'replaceHeaders' flag" in {
+
+      ////// default to not replacing existing headers /////////////
+      val req1 = Request().withType(MediaType.`application/octet-stream`)
+                          .withBody("foo")
+
+      req1.run.headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.`application/octet-stream`))
+
+      val req2 = Task(Response()).withType(MediaType.`application/octet-stream`)
+                                 .withBody("foo")
+
+      req2.run.headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.`application/octet-stream`))
+
+      ////// replace flag set ///////////////////////////////
+
+      val req3 = Request().withType(MediaType.`application/octet-stream`)
+                          .withBody("foo", true)
+
+      req3.run.headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`))
+
+      val req4 = Task(Response()).withType(MediaType.`application/octet-stream`)
+                                 .withBody("foo", true)
+
+      req4.run.headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`))
+    }
+  }
+
+}


### PR DESCRIPTION
The default behavior has been changed from 'overwrite' to 'keep existing headers'.

closes #110
