### PR TITLE
Change pattern for making blaze clients

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledClient.scala
@@ -2,6 +2,7 @@ package org.http4s.client.blaze
 
 import java.net.InetSocketAddress
 import java.nio.channels.AsynchronousChannelGroup
+import java.util.concurrent.ExecutorService
 
 import org.http4s.Request
 import org.http4s.blaze.channel.nio2.ClientChannelFactory
@@ -18,14 +19,14 @@ import scalaz.stream.Process.halt
 /** Provides a foundation for pooling clients */
 abstract class PooledClient(maxPooledConnections: Int,
                                       bufferSize: Int,
-                                        executor: ExecutionContext,
+                                        executor: ExecutorService,
                                            group: Option[AsynchronousChannelGroup]) extends BlazeClient {
 
   private[this] val logger = getLogger
 
-  assert(maxPooledConnections > 0, "Must have positive collection pool")
+  require(maxPooledConnections > 0, "Must have finite connection pool size")
 
-  final override implicit protected def ec: ExecutionContext = executor
+  final override implicit protected def ec: ExecutionContext = ExecutionContext.fromExecutor(executor)
 
   private var closed = false
   private val cs = new mutable.Queue[(InetSocketAddress, BlazeClientStage)]()

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -1,13 +1,25 @@
 package org.http4s.client.blaze
 
 import java.nio.channels.AsynchronousChannelGroup
+import java.util.concurrent.ExecutorService
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-class PooledHttp1Client(maxPooledConnections: Int = 10,
-                       protected val timeout: Duration = DefaultTimeout,
-                                  bufferSize: Int = DefaultBufferSize,
-                                    executor: ExecutionContext = ClientDefaultEC,
-                                       group: Option[AsynchronousChannelGroup] = None)
+class PooledHttp1Client protected (maxPooledConnections: Int,
+                                  protected val timeout: Duration,
+                                             bufferSize: Int,
+                                               executor: ExecutorService,
+                                                  group: Option[AsynchronousChannelGroup])
   extends PooledClient(maxPooledConnections, bufferSize, executor, group) with Http1SSLSupport
+
+/** Http client which will attempt to recycle connections */
+object PooledHttp1Client {
+
+  /** Construct a new PooledHttp1Client */
+  def apply(maxPooledConnections: Int = 10,
+                         timeout: Duration = DefaultTimeout,
+                      bufferSize: Int = DefaultBufferSize,
+                        executor: ExecutorService = ClientDefaultEC,
+                           group: Option[AsynchronousChannelGroup] = None) =
+    new PooledHttp1Client(maxPooledConnections, timeout, bufferSize, executor, group)
+}

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
@@ -1,6 +1,7 @@
 package org.http4s.client.blaze
 
 import java.nio.channels.AsynchronousChannelGroup
+import java.util.concurrent.ExecutorService
 
 import org.http4s.Request
 import org.http4s.blaze.channel.nio2.ClientChannelFactory
@@ -12,13 +13,13 @@ import scalaz.concurrent.Task
 
 
 /** A default implementation of the Blaze Asynchronous client for HTTP/1.x */
-class SimpleHttp1Client(protected val timeout: Duration,
+class SimpleHttp1Client protected (protected val timeout: Duration,
                                    bufferSize: Int,
-                                     executor: ExecutionContext,
+                                     executor: ExecutorService,
                                         group: Option[AsynchronousChannelGroup])
        extends BlazeClient with Http1Support with Http1SSLSupport
 {
-  final override implicit protected def ec: ExecutionContext = executor
+  final override implicit protected def ec: ExecutionContext = ExecutionContext.fromExecutor(executor)
 
     /** Shutdown this client, closing any open connections and freeing resources */
   override def shutdown(): Task[Unit] = Task.now(())
@@ -35,4 +36,10 @@ class SimpleHttp1Client(protected val timeout: Duration,
   }
 }
 
-object SimpleHttp1Client extends SimpleHttp1Client(DefaultTimeout, DefaultBufferSize, ClientDefaultEC, None)
+object SimpleHttp1Client {
+  def apply(timeout: Duration = DefaultTimeout,
+         bufferSize: Int = DefaultBufferSize,
+           executor: ExecutorService = ClientDefaultEC,
+              group: Option[AsynchronousChannelGroup] = None) =
+  new SimpleHttp1Client(timeout, bufferSize, executor, group)
+}

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
@@ -3,10 +3,13 @@ package org.http4s.client
 import java.io.IOException
 import java.net.InetSocketAddress
 
-import org.http4s.blaze.util.{Execution, TickWheelExecutor}
+import org.http4s.blaze.util.TickWheelExecutor
 
 import scala.concurrent.duration._
+
 import scalaz.\/
+import scalaz.concurrent.Strategy.DefaultExecutorService
+
 
 package object blaze {
 
@@ -15,6 +18,9 @@ package object blaze {
   // Centralize some defaults
   private[blaze] val DefaultTimeout: Duration = 60.seconds
   private[blaze] val DefaultBufferSize: Int = 8*1024
-  private[blaze] val ClientDefaultEC = Execution.trampoline
+  private[blaze] def ClientDefaultEC = DefaultExecutorService
   private[blaze] val ClientTickWheel = new TickWheelExecutor()
+
+  /** Default blaze client */
+  val defaultClient = SimpleHttp1Client(DefaultTimeout, DefaultBufferSize, ClientDefaultEC, None)
 }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazePooledHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazePooledHttp1ClientSpec.scala
@@ -3,5 +3,5 @@ package org.http4s.client.blaze
 import org.http4s.client.ClientRouteTestBattery
 
 
-class BlazePooledHttp1ClientSpec extends ClientRouteTestBattery("Blaze PooledHttp1Client", new PooledHttp1Client())
+class BlazePooledHttp1ClientSpec extends ClientRouteTestBattery("Blaze PooledHttp1Client", PooledHttp1Client())
 

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeSimpleHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeSimpleHttp1ClientSpec.scala
@@ -2,4 +2,4 @@ package org.http4s.client.blaze
 
 import org.http4s.client.ClientRouteTestBattery
 
-class BlazeSimpleHttp1ClientSpec extends ClientRouteTestBattery("SimpleHttp1Client", SimpleHttp1Client)
+class BlazeSimpleHttp1ClientSpec extends ClientRouteTestBattery("SimpleHttp1Client", defaultClient)

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
@@ -11,7 +11,7 @@ import org.specs2.time.NoTimeConversions
 class ExternalBlazeHttp1ClientSpec extends Http4sSpec with NoTimeConversions with After {
 
   "Blaze Simple Http1 Client" should {
-    def client = SimpleHttp1Client
+    def client = defaultClient
 
     "Make simple http requests" in {
       val resp = client(uri("https://github.com/")).as[String]
@@ -30,7 +30,7 @@ class ExternalBlazeHttp1ClientSpec extends Http4sSpec with NoTimeConversions wit
     }
   }
 
-  val client = new PooledHttp1Client()
+  val client = PooledHttp1Client()
 
   "RecyclingHttp1Client" should {
 


### PR DESCRIPTION
Factory methods are now used to hide the underlying OO structure.
