### PR TITLE
Make EntityEncoder based on Show explicit.

### DIFF
--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -54,7 +54,8 @@ object EntityEncoder extends EntityEncoderInstances {
 }
 
 trait EntityEncoderInstances0 {
-  implicit def showEncoder[A](implicit charset: Charset = Charset.`UTF-8`, show: Show[A]): EntityEncoder[A] =
+  /** Encodes a value from its Show instance.  Too broad to be implicit, too useful to not exist. */
+  def showEncoder[A](implicit charset: Charset = Charset.`UTF-8`, show: Show[A]): EntityEncoder[A] =
     simple(
       a => ByteVector.view(show.shows(a).getBytes(charset.nioCharset)),
       Headers(`Content-Type`(MediaType.`text/plain`).withCharset(charset))
@@ -89,6 +90,8 @@ trait EntityEncoderInstances extends EntityEncoderInstances0 {
   implicit def charArrayEncoder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[Array[Char]] =
     charSequenceEncoder.contramap(new String(_))
 
+  implicit val charEncoder: EntityEncoder[Char] = charSequenceEncoder.contramap(Character.toString)
+
   implicit val byteVectorEncoder: EntityEncoder[ByteVector] = simple(
     identity,
     Headers(`Content-Type`(MediaType.`application/octet-stream`))
@@ -97,6 +100,8 @@ trait EntityEncoderInstances extends EntityEncoderInstances0 {
   implicit val byteArrayEncoder: EntityEncoder[Array[Byte]] = byteVectorEncoder.contramap(ByteVector.apply)
 
   implicit val byteBufferEncoder: EntityEncoder[ByteBuffer] = byteVectorEncoder.contramap(ByteVector.apply)
+
+  implicit val byteEncoder: EntityEncoder[Byte] = byteVectorEncoder.contramap(ByteVector.apply(_))
 
   // TODO split off to module to drop scala-xml core dependency
   // TODO infer HTML, XHTML, etc.

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -103,7 +103,7 @@ object ExampleService {
         data.get("sum") match {
           case Some(Seq(s, _*)) =>
             val sum = s.split(' ').filter(_.length > 0).map(_.trim.toInt).sum
-            Ok(sum)
+            Ok(sum.toString)
 
           case None => BadRequest(s"Invalid data: " + data)
         }
@@ -156,7 +156,7 @@ object ExampleService {
         data.get("short-sum") match {
           case Some(Seq(s, _*)) =>
             val sum = s.split(" ").filter(_.length > 0).map(_.trim.toInt).sum
-            Ok(sum)
+            Ok(sum.toString)
 
           case None => BadRequest(s"Invalid data: " + data)
         }


### PR DESCRIPTION
Show is overly broad, and may render things that don't make a lot of
sense as an entity (e.g., `\/`).  We keep the encoder for its
contramap, but only use it explicitly.
