### PR TITLE
blaze backend uses ISO 8859-1 charset instead of US-Ascii

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -26,7 +26,7 @@ class Http1ClientStageSpec extends Specification with NoTimeConversions {
   val resp = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndone"
 
   def mkBuffer(s: String): ByteBuffer =
-    ByteBuffer.wrap(s.getBytes(StandardCharsets.US_ASCII))
+    ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))
 
   def getSubmission(req: Request, resp: String, timeout: Duration): (String, String) = {
     val tail = new Http1ClientStage(timeout)
@@ -43,7 +43,7 @@ class Http1ClientStageSpec extends Specification with NoTimeConversions {
 
     h.stageShutdown()
     val buff = Await.result(h.result, timeout + 10.seconds)
-    val request = new String(ByteVector(buff).toArray, StandardCharsets.US_ASCII)
+    val request = new String(ByteVector(buff).toArray, StandardCharsets.ISO_8859_1)
     (request, result)
   }
 

--- a/blaze-core/src/main/scala/org/http4s/blaze/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blaze/Http1Stage.scala
@@ -66,12 +66,12 @@ trait Http1Stage { self: TailStage[ByteBuffer] =>
   /** Get the proper body encoder based on the message headers,
     * adding the appropriate Connection and Transfer-Encoding headers along the way */
   final protected def getEncoder(connectionHeader: Option[Header.Connection],
-                 bodyEncoding: Option[Header.`Transfer-Encoding`],
-                 lengthHeader: Option[Header.`Content-Length`],
-                 trailer: Task[Headers],
-                 rr: StringWriter,
-                 minor: Int,
-                 closeOnFinish: Boolean): ProcessWriter = lengthHeader match {
+                                     bodyEncoding: Option[Header.`Transfer-Encoding`],
+                                     lengthHeader: Option[Header.`Content-Length`],
+                                          trailer: Task[Headers],
+                                               rr: StringWriter,
+                                            minor: Int,
+                                    closeOnFinish: Boolean): ProcessWriter = lengthHeader match {
     case Some(h) if bodyEncoding.isEmpty =>
       logger.trace("Using static encoder")
 
@@ -79,7 +79,7 @@ trait Http1Stage { self: TailStage[ByteBuffer] =>
       if (!closeOnFinish && minor == 0 && connectionHeader.isEmpty) rr << "Connection:keep-alive\r\n\r\n"
       else rr << '\r' << '\n'
 
-      val b = ByteBuffer.wrap(rr.result().getBytes(StandardCharsets.US_ASCII))
+      val b = ByteBuffer.wrap(rr.result().getBytes(StandardCharsets.ISO_8859_1))
       new StaticWriter(b, h.length, this)
 
     case _ =>  // No Length designated for body or Transfer-Encoding included
@@ -87,7 +87,7 @@ trait Http1Stage { self: TailStage[ByteBuffer] =>
         if (closeOnFinish) {  // HTTP 1.0 uses a static encoder
           logger.trace("Using static encoder")
           rr << '\r' << '\n'
-          val b = ByteBuffer.wrap(rr.result().getBytes(StandardCharsets.US_ASCII))
+          val b = ByteBuffer.wrap(rr.result().getBytes(StandardCharsets.ISO_8859_1))
           new StaticWriter(b, -1, this)
         }
         else {  // HTTP 1.0, but request was Keep-Alive.

--- a/blaze-core/src/main/scala/org/http4s/blaze/util/CachingStaticWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blaze/util/CachingStaticWriter.scala
@@ -36,7 +36,7 @@ class CachingStaticWriter(writer: StringWriter, out: TailStage[ByteBuffer], buff
 
     if (innerWriter == null) {  // We haven't written anything yet
       writer << '\r' << '\n'
-      val b = ByteBuffer.wrap(writer.result().getBytes(StandardCharsets.US_ASCII))
+      val b = ByteBuffer.wrap(writer.result().getBytes(StandardCharsets.ISO_8859_1))
       new InnerWriter(b).writeBodyChunk(c, flush = true)
     }
     else writeBodyChunk(c, flush = true)    // we are already proceeding
@@ -48,7 +48,7 @@ class CachingStaticWriter(writer: StringWriter, out: TailStage[ByteBuffer], buff
       val c = addChunk(chunk)
       writer << "Content-Length: " << c.length << "\r\nConnection:Keep-Alive\r\n\r\n"
 
-      val b = ByteBuffer.wrap(writer.result().getBytes(StandardCharsets.US_ASCII))
+      val b = ByteBuffer.wrap(writer.result().getBytes(StandardCharsets.ISO_8859_1))
 
       new InnerWriter(b).writeEnd(c)
     }
@@ -58,10 +58,10 @@ class CachingStaticWriter(writer: StringWriter, out: TailStage[ByteBuffer], buff
     if (innerWriter != null) innerWriter.writeBodyChunk(chunk, flush)
     else {
       val c = addChunk(chunk)
-      if (c.length >= bufferSize) { // time to just abort and stream it
+      if (flush || c.length >= bufferSize) { // time to just abort and stream it
         _forceClose = true
         writer << '\r' << '\n'
-        val b = ByteBuffer.wrap(writer.result().getBytes(StandardCharsets.US_ASCII))
+        val b = ByteBuffer.wrap(writer.result().getBytes(StandardCharsets.ISO_8859_1))
         innerWriter = new InnerWriter(b)
         innerWriter.writeBodyChunk(chunk, flush)
       }

--- a/blaze-core/src/main/scala/org/http4s/blaze/util/ChunkProcessWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blaze/util/ChunkProcessWriter.scala
@@ -1,7 +1,7 @@
 package org.http4s.blaze.util
 
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.ISO_8859_1
 
 import org.http4s.Headers
 import org.http4s.blaze.pipeline.TailStage
@@ -35,7 +35,7 @@ class ChunkProcessWriter(private var headers: StringWriter,
           rr << '0' << '\r' << '\n'             // Last chunk
           trailerHeaders.foreach( h =>  rr << h.name.toString << ": " << h << '\r' << '\n')   // trailers
           rr << '\r' << '\n'          // end of chunks
-          ByteBuffer.wrap(rr.result().getBytes(StandardCharsets.US_ASCII))
+          ByteBuffer.wrap(rr.result().getBytes(ISO_8859_1))
         } else ByteBuffer.wrap(ChunkEndBytes)
       }.runAsync {
         case \/-(buffer) => promise.completeWith(pipe.channelWrite(buffer))
@@ -53,12 +53,12 @@ class ChunkProcessWriter(private var headers: StringWriter,
         h << s"Content-Length: ${body.remaining()}\r\n\r\n"
         
         // Trailers are optional, so dropping because we have no body.
-        val hbuff = ByteBuffer.wrap(h.result().getBytes(StandardCharsets.US_ASCII))
+        val hbuff = ByteBuffer.wrap(h.result().getBytes(ISO_8859_1))
         pipe.channelWrite(hbuff::body::Nil)
       }
       else {
         h << s"Content-Length: 0\r\n\r\n"
-        val hbuff = ByteBuffer.wrap(h.result().getBytes(StandardCharsets.US_ASCII))
+        val hbuff = ByteBuffer.wrap(h.result().getBytes(ISO_8859_1))
         pipe.channelWrite(hbuff)
       }
     } else {
@@ -68,7 +68,7 @@ class ChunkProcessWriter(private var headers: StringWriter,
   }
 
   private def writeLength(length: Int): ByteBuffer = {
-    val bytes = Integer.toHexString(length).getBytes(StandardCharsets.US_ASCII)
+    val bytes = Integer.toHexString(length).getBytes(ISO_8859_1)
     val b = ByteBuffer.allocate(bytes.length + 2)
     b.put(bytes).put(CRLFBytes).flip()
     b
@@ -79,7 +79,7 @@ class ChunkProcessWriter(private var headers: StringWriter,
     if (headers != null) {
       val i = headers
       i << "Transfer-Encoding: chunked\r\n\r\n"
-      val b = ByteBuffer.wrap(i.result().getBytes(StandardCharsets.US_ASCII))
+      val b = ByteBuffer.wrap(i.result().getBytes(ISO_8859_1))
       headers = null
       b::list
     } else list
@@ -87,6 +87,6 @@ class ChunkProcessWriter(private var headers: StringWriter,
 }
 
 object ChunkProcessWriter {
-  private val CRLFBytes = "\r\n".getBytes(StandardCharsets.US_ASCII)
-  private val ChunkEndBytes = "0\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
+  private val CRLFBytes = "\r\n".getBytes(ISO_8859_1)
+  private val ChunkEndBytes = "0\r\n\r\n".getBytes(ISO_8859_1)
 }

--- a/blaze-core/src/test/scala/org/http4s/blaze/ResponseParser.scala
+++ b/blaze-core/src/test/scala/org/http4s/blaze/ResponseParser.scala
@@ -37,10 +37,12 @@ class ResponseParser extends Http1ClientParser {
       body += parseContent(buffer)
     }
 
-    val bp = new String(body.map(ByteVector(_)).foldLeft(ByteVector.empty)((c1,c2) => c1 ++ c2).toArray,
-                                StandardCharsets.US_ASCII)
+    val bp = {
+      val bytes = body.foldLeft(ByteVector.empty)((c1, c2) => c1 ++ ByteVector(c2)).toArray
+      new String(bytes, StandardCharsets.ISO_8859_1)
+    }
 
-    val headers = this.headers.result.map{case (k,v) => Header(k,v): Header}.toSet
+    val headers = this.headers.result.map{ case (k,v) => Header(k,v): Header }.toSet
 
     val status = Status.fromIntAndReason(this.code, reason).valueOr(e => throw new ParseException(e))
 

--- a/blaze-core/src/test/scala/org/http4s/blaze/util/ProcessWriterSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blaze/util/ProcessWriterSpec.scala
@@ -37,11 +37,11 @@ class ProcessWriterSpec extends Specification {
     w.writeProcess(p).run
     head.stageShutdown()
     Await.ready(head.result, Duration.Inf)
-    new String(head.getBytes(), StandardCharsets.US_ASCII)
+    new String(head.getBytes(), StandardCharsets.ISO_8859_1)
   }
 
   val message = "Hello world!"
-  val messageBuffer = ByteVector(message.getBytes(StandardCharsets.US_ASCII))
+  val messageBuffer = ByteVector(message.getBytes(StandardCharsets.ISO_8859_1))
 
   def runNonChunkedTests(builder: TailStage[ByteBuffer] => ProcessWriter) = {
     import scalaz.stream.Process
@@ -89,11 +89,11 @@ class ProcessWriterSpec extends Specification {
         var counter = 2
         Task {
           counter -= 1
-          if (counter >= 0) ByteVector("foo".getBytes(StandardCharsets.US_ASCII))
+          if (counter >= 0) ByteVector("foo".getBytes(StandardCharsets.ISO_8859_1))
           else throw Cause.Terminated(Cause.End)
         }
       }
-      val p = Process.repeatEval(t) ++ emit(ByteVector("bar".getBytes(StandardCharsets.US_ASCII)))
+      val p = Process.repeatEval(t) ++ emit(ByteVector("bar".getBytes(StandardCharsets.ISO_8859_1)))
       writeProcess(p)(builder) must_== "Content-Length: 9\r\n\r\n" + "foofoobar"
     }
   }

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -159,7 +159,7 @@ class Http1ServerStage(service: HttpService,
         if (!closeOnFinish && minor == 0 && respConn.isEmpty) rr << "Connection:keep-alive\r\n\r\n"
         else rr << '\r' << '\n'
 
-        val b = ByteBuffer.wrap(rr.result().getBytes(StandardCharsets.US_ASCII))
+        val b = ByteBuffer.wrap(rr.result().getBytes(StandardCharsets.ISO_8859_1))
         new BodylessWriter(b, this, closeOnFinish)(ec)
       }
       else getEncoder(respConn, respTransferCoding, lengthHeader, resp.trailerHeaders, rr, minor, closeOnFinish)

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
@@ -43,7 +43,7 @@ trait WebSocketSupport extends Http1ServerStage {
             sb.append('\r').append('\n')
 
             // write the accept headers and reform the pipeline
-            channelWrite(ByteBuffer.wrap(sb.result().getBytes(US_ASCII))).onComplete {
+            channelWrite(ByteBuffer.wrap(sb.result().getBytes(ISO_8859_1))).onComplete {
               case Success(_) =>
                 logger.debug("Switching pipeline segments for websocket")
 

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http4sHttp1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http4sHttp1ServerStageSpec.scala
@@ -38,7 +38,7 @@ class Http1ServerStageSpec extends Specification with NoTimeConversions {
   }
 
   def runRequest(req: Seq[String], service: HttpService): Future[ByteBuffer] = {
-    val head = new SeqTestHead(req.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.US_ASCII))))
+    val head = new SeqTestHead(req.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
     val httpStage = new Http1ServerStage(service, None) {
       override def reset(): Unit = head.stageShutdown()     // shutdown the stage after a complete request
     }
@@ -87,7 +87,7 @@ class Http1ServerStageSpec extends Specification with NoTimeConversions {
   "Http1ServerStage: routes" should {
 
     def httpStage(service: HttpService, requests: Int, input: Seq[String]): Future[ByteBuffer] = {
-      val head = new SeqTestHead(input.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.US_ASCII))))
+      val head = new SeqTestHead(input.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
       val httpStage = new Http1ServerStage(service, None) {
         @volatile var count = 0
 

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -26,6 +26,9 @@ object ScienceExperiments {
       Ok(date.toRfc1123DateTimeString)
         .withHeaders(Header.Date(date))
 
+    case req @ GET -> Root / "echo-headers" =>
+      Ok(req.headers.mkString("\n"))
+
     ///////////////// Massive Data Loads //////////////////////
     case GET -> Root / "bigstring" =>
       Ok((0 until 1000).map(i => s"This is string number $i").mkString("\n"))


### PR DESCRIPTION
While the http protocol generally tries to use US-Ascii, its not strictly required in header value fields and ISO 8859-1 may be encountered.
