### PR TITLE
Make QueryParameterKey and QueryParameterValue AnyVals

### DIFF
--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -5,9 +5,9 @@ import scalaz.syntax.validation._
 import scalaz.{Show, Validation, ValidationNel}
 
 
-final case class QueryParameterKey(value: String)
+final case class QueryParameterKey(value: String) extends AnyVal
 
-final case class QueryParameterValue(value: String)
+final case class QueryParameterValue(value: String) extends AnyVal
 
 /**
  * type class defining the key of a query parameter
@@ -21,12 +21,9 @@ object QueryParam {
   /** summon an implicit [[QueryParam]] */
   def apply[T](implicit ev: QueryParam[T]): QueryParam[T] = ev
 
-  def fromKey[T](k: QueryParameterKey): QueryParam[T] = new QueryParam[T] {
-    def key: QueryParameterKey = k
+  def fromKey[T](k: String): QueryParam[T] = new QueryParam[T] {
+    def key: QueryParameterKey = QueryParameterKey(k)
   }
-
-  def fromKey[T](k: String): QueryParam[T] =
-    fromKey(QueryParameterKey(k))
 }
 
 

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -199,7 +199,7 @@ case class Uri(
    */
   def setQueryParams[T: QueryParamEncoder](query: Map[String, Seq[T]]): Uri = {
     if (multiParams == query) this
-    else copy(query = renderQueryString(query.mapValues(_.map(QueryParamEncoder[T].encode).map(_.value))))
+    else copy(query = renderQueryString(query.mapValues(_.map(QueryParamEncoder[T].encode(_).value))))
   }
 
   /**


### PR DESCRIPTION
Related to issue #129 

This does a little performance tuning on the Query types. They are now descendants of `AnyVal`, so they are type safe yet no-overhead wrappers of a `String`.
