### PR TITLE
Remove `Future ~> Task` and `Task ~> Future`.

### DIFF
--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -4,6 +4,7 @@ import java.io.{File, InputStream, Reader}
 import java.nio.ByteBuffer
 import java.nio.file.Path
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
 
 import org.http4s.EntityEncoder._
@@ -148,6 +149,12 @@ trait EntityEncoderInstances extends EntityEncoderInstances0 {
     override def toEntity(a: Task[A]): Task[Entity] = a.flatMap(W.toEntity)
     override def headers: Headers = W.headers
   }
+
+  implicit def futureEncoder[A](implicit W: EntityEncoder[A], ec: ExecutionContext): EntityEncoder[Future[A]] =
+    new EntityEncoder[Future[A]] {
+      override def toEntity(a: Future[A]): Task[Entity] = util.task.futureToTask(a).flatMap(W.toEntity)
+      override def headers: Headers = W.headers
+    }
 
   // TODO parameterize chunk size
   // TODO if Header moves to Entity, can add a Content-Disposition with the filename

--- a/core/src/main/scala/org/http4s/Http4s.scala
+++ b/core/src/main/scala/org/http4s/Http4s.scala
@@ -9,7 +9,6 @@ object Http4s extends Http4s
 
 trait Http4sInstances
   extends scalaz.std.AllInstances
-  with util.TaskInstances
   with EntityDecoderInstances
   with HttpVersionInstances
   with EntityEncoderInstances

--- a/core/src/main/scala/org/http4s/util/Task.scala
+++ b/core/src/main/scala/org/http4s/util/Task.scala
@@ -2,32 +2,28 @@ package org.http4s.util
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Success, Failure}
-import scalaz.{~>, \/-, -\/}
-import scalaz.\/._
+import scalaz.{-\/, \/-}
+import scalaz.syntax.either._
 import scalaz.concurrent.Task
 
-trait TaskInstances {
-  implicit val taskToFuture: Task ~> Future = new (Task ~> Future) {
-    def apply[A](task: Task[A]): Future[A] = {
-      val p = Promise[A]()
-      task.runAsync {
-        case \/-(a) => p.success(a)
-        case -\/(t) => p.failure(t)
-      }
-      p.future
+trait TaskFunctions {
+  def unsafeTaskToFuture[A](task: Task[A]): Future[A] = {
+    val p = Promise[A]()
+    task.runAsync {
+      case \/-(a) => p.success(a)
+      case -\/(t) => p.failure(t)
     }
+    p.future
   }
 
-  implicit def futureToTask(implicit ec: ExecutionContext): Future ~> Task = new (Future ~> Task) {
-    def apply[A](future: Future[A]): Task[A] = {
-      Task.async { f =>
-        future.onComplete {
-          case Success(a) => f(right(a))
-          case Failure(t) => f(left(t))
-        }
+  def futureToTask[A](f: => Future[A])(implicit ec: ExecutionContext): Task[A] = {
+    Task.async { cb =>
+      f.onComplete {
+        case Success(a) => cb(a.right)
+        case Failure(t) => cb(t.left)
       }
     }
   }
 }
 
-object task extends TaskInstances
+object task extends TaskFunctions


### PR DESCRIPTION
Fear not, we can still encode Scala Futures as entities.

Closes #112.
