### PR TITLE
Split scala-xml support into own package. #153

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,10 +30,12 @@ lazy val `json4s-jackson` = project.dependsOn(json4s, jawn % "compile;test->test
 
 lazy val argonaut = project.dependsOn(core % "compile;test->test", jawn % "compile;test->test")
 
+lazy val `scala-xml` = project.dependsOn(core % "compile;test->test")
+
 // The plugin must be enabled for the tests
 lazy val twirl = project.dependsOn(core % "compile;test->test").enablePlugins(SbtTwirl)
 
-lazy val examples = project.dependsOn(server, dsl, argonaut, twirl).enablePlugins(SbtTwirl)
+lazy val examples = project.dependsOn(server, dsl, argonaut, `scala-xml`, twirl).enablePlugins(SbtTwirl)
 
 lazy val `examples-blaze` = Project("examples-blaze", file("examples/blaze")).dependsOn(examples, `blaze-server`)
 

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -2,6 +2,7 @@ package org.http4s
 package client
 
 import org.http4s.Status.ResponseClass._
+import org.parboiled2.ParseError
 
 import scalaz.concurrent.Task
 
@@ -85,8 +86,10 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
     }
 
     "attemptAs with failed parsing result" in {
-      client(req).attemptAs(EntityDecoder.xml())
-        .run.run must beLeftDisjunction
+      val grouchyEncoder = EntityDecoder.decodeBy[Any](MediaRange.`*/*`) { _ =>
+        DecodeResult.failure(ParseFailure("MEH!", "MEH!"))
+      }
+      client(req).attemptAs[Any](grouchyEncoder).run.run must beLeftDisjunction
     }
 
     "prepAs must add Accept header" in {

--- a/core/src/main/scala/org/http4s/util/ByteVector.scala
+++ b/core/src/main/scala/org/http4s/util/ByteVector.scala
@@ -4,7 +4,9 @@ import scodec.bits.ByteVector
 
 import scalaz.Monoid
 
-object ByteVectorInstances {
+trait ByteVectorInstances {
   // This is defined in sodec, which we don't (yet) depend on.
   implicit val byteVectorMonoidInstance: Monoid[ByteVector] = Monoid.instance(_ ++ _, ByteVector.empty)
 }
+
+object byteVector extends ByteVectorInstances

--- a/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -42,25 +42,6 @@ class EntityDecoderSpec extends Http4sSpec {
     }
   }
 
-  "xml" should {
-
-    val server: Request => Task[Response] = { req =>
-      xml(req) { elem => ResponseBuilder(Ok, elem.label) }
-    }
-
-    "parse the XML" in {
-      val resp = server(Request(body = emit("<html><h1>h1</h1></html>").map(s => ByteVector(s.getBytes)))).run
-      resp.status must_==(Ok)
-      getBody(resp.body) must_== ("html".getBytes)
-    }
-
-    "return 400 on parse error" in {
-      val body = strBody("This is not XML.")
-      val tresp = server(Request(body = body))
-      tresp.run.status must equal (Status.BadRequest)
-    }
-  }
-
   "application/x-www-form-urlencoded" should {
 
     val server: Request => Task[Response] = { req =>
@@ -140,7 +121,7 @@ class EntityDecoderSpec extends Http4sSpec {
 
     "Not match invalid media type" in {
       val req = ResponseBuilder(Ok, "foo").run
-      EntityDecoder.xml().matchesMediaType(req) must_== false
+      EntityDecoder.formEncoded.matchesMediaType(req) must_== false
     }
 
     "Match valid media range" in {
@@ -158,8 +139,8 @@ class EntityDecoderSpec extends Http4sSpec {
       val req = Request(headers = Headers(`Content-Type`(tpe)))
       (EntityDecoder.text.matchesMediaType(req) must_== true)   and
       (EntityDecoder.text.matchesMediaType(tpe) must_== true)   and
-      (EntityDecoder.xml().matchesMediaType(req) must_== false) and
-      (EntityDecoder.xml().matchesMediaType(tpe) must_== false)
+      (EntityDecoder.formEncoded.matchesMediaType(req) must_== false) and
+      (EntityDecoder.formEncoded.matchesMediaType(tpe) must_== false)
     }
 
   }

--- a/core/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/core/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -13,10 +13,9 @@ import scalaz.concurrent.Task
 import scalaz.stream.text.utf8Decode
 import scalaz.stream.Process
 
+import util.byteVector._
+
 object EntityEncoderSpec {
-
-  implicit val byteVectorMonoid: scalaz.Monoid[ByteVector] = scalaz.Monoid.instance(_ ++ _, ByteVector.empty)
-
   def writeToString[A](a: A)(implicit W: EntityEncoder[A]): String =
     Process.eval(W.toEntity(a))
       .collect { case EntityEncoder.Entity(body, _ ) => body }
@@ -49,11 +48,6 @@ class EntityEncoderSpec extends Http4sSpec {
 
     "calculate the content length of strings" in {
       implicitly[EntityEncoder[String]].toEntity("pong").run.length must_== Some(4)
-    }
-
-    "render html" in {
-      val html = <html><body>Hello</body></html>
-      writeToString(html) must_== "<html><body>Hello</body></html>"
     }
 
     "render byte arrays" in {

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -10,6 +10,7 @@ import org.http4s._
 import org.http4s.MediaType._
 import org.http4s.dsl._
 import org.http4s.argonaut._
+import org.http4s.scalaxml._
 import org.http4s.server._
 import org.http4s.server.middleware.EntityLimiter
 import org.http4s.server.middleware.EntityLimiter.EntityTooLarge

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -3,6 +3,7 @@ package com.example.http4s
 import org.http4s._
 import org.http4s.dsl._
 import org.http4s.server.HttpService
+import org.http4s.scalaxml._
 import scodec.bits.ByteVector
 
 import scalaz.{Reducer, Monoid}

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -71,6 +71,7 @@ object Http4sBuild extends Build {
   lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.0.1"
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
   lazy val scalameter          = "com.storm-enroute"        %% "scalameter"              % "0.6"
+  lazy val scalaXml            = "org.scala-lang.modules"   %% "scala-xml"               % "1.0.3"
   lazy val scalazScalacheckBinding = "org.scalaz"           %% "scalaz-scalacheck-binding" % "7.1.0"
   lazy val scalazSpecs2        = "org.typelevel"            %% "scalaz-specs2"           % "0.3.0"
   lazy val scalazStream        = "org.scalaz.stream"        %% "scalaz-stream"           % "0.6a"

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -1,0 +1,43 @@
+package org.http4s
+package scalaxml
+
+import java.io.StringReader
+
+import Header.`Content-Type`
+import scala.util.control.NonFatal
+import scala.xml._
+import scalaz.concurrent.Task
+
+trait ElemInstances {
+  // TODO infer HTML, XHTML, etc.
+  implicit def htmlEncoder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[Elem] =
+    EntityEncoder.stringEncoder(charset)
+      .contramap[Elem](xml => xml.buildString(false))
+      .withContentType(`Content-Type`(MediaType.`text/html`))
+
+  /**
+   * Handles a message body as XML.
+   *
+   * TODO Not an ideal implementation.  Would be much better with an asynchronous XML parser, such as Aalto.
+   *
+   * @param parser the SAX parser to use to parse the XML
+   * @return an XML element
+   */
+  implicit def xml(implicit parser: SAXParser = XML.parser): EntityDecoder[Elem] = {
+    import EntityDecoder._
+    decodeBy(MediaType.`text/xml`, MediaType.`text/html`, MediaType.`application/xml`){ msg =>
+      collectBinary(msg).flatMap[Elem] { arr =>
+        val source = new InputSource(new StringReader(new String(arr.toArray, msg.charset.nioCharset)))
+        try DecodeResult.success(Task.now(XML.loadXML(source, parser)))
+        catch {
+          case e: SAXParseException =>
+            val msg = s"${e.getMessage}; Line: ${e.getLineNumber}; Column: ${e.getColumnNumber}"
+            DecodeResult.failure(Task.now(ParseFailure("Invalid XML", msg)))
+          case NonFatal(e) => DecodeResult(Task.fail(e))
+        }
+      }
+    }
+  }
+
+  def xml: EntityDecoder[Elem] = xml()
+}

--- a/scala-xml/src/main/scala/scalaxml/package.scala
+++ b/scala-xml/src/main/scala/scalaxml/package.scala
@@ -1,0 +1,3 @@
+package org.http4s
+
+package object scalaxml extends ElemInstances

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -1,0 +1,53 @@
+package org.http4s
+package scalaxml
+
+import scodec.bits.ByteVector
+
+import scalaz.concurrent.Task
+import scalaz.stream.Process
+import scalaz.stream.Process.emit
+import scalaz.stream.text.utf8Decode
+import Status.Ok
+
+class ScalaXmlSpec extends Http4sSpec {
+
+  def getBody(body: EntityBody): Array[Byte] = body.runLog.run.reduce(_ ++ _).toArray
+
+  def strBody(body: String) = emit(body).map(s => ByteVector(s.getBytes))
+
+  implicit val byteVectorMonoid: scalaz.Monoid[ByteVector] = scalaz.Monoid.instance(_ ++ _, ByteVector.empty)
+
+  def writeToString[A](a: A)(implicit W: EntityEncoder[A]): String =
+    Process.eval(W.toEntity(a))
+      .collect { case EntityEncoder.Entity(body, _ ) => body }
+      .flatMap(identity)
+      .fold1Monoid
+      .pipe(utf8Decode)
+      .runLastOr("")
+      .run
+
+  "xml" should {
+    val server: Request => Task[Response] = { req =>
+      xml(req) { elem => ResponseBuilder(Ok, elem.label) }
+    }
+
+    "parse the XML" in {
+      val resp = server(Request(body = emit("<html><h1>h1</h1></html>").map(s => ByteVector(s.getBytes)))).run
+      resp.status must_==(Ok)
+      getBody(resp.body) must_== ("html".getBytes)
+    }
+
+    "return 400 on parse error" in {
+      val body = strBody("This is not XML.")
+      val tresp = server(Request(body = body))
+      tresp.run.status must equal (Status.BadRequest)
+    }
+  }
+
+  "htmlEncoder" should {
+    "render html" in {
+      val html = <html><body>Hello</body></html>
+      writeToString(html) must_== "<html><body>Hello</body></html>"
+    }
+  }
+}


### PR DESCRIPTION
`scala.xml` has been moved out of stdlib in 2.11 and its instances will be removed from Scalaz in 7.2.  Good XML support is still important, but it should not be considered core.
