### PR TITLE
Topic/query param key

### DIFF
--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -39,7 +39,7 @@ object QueryParamKeyLike {
 }
 
 /**
- * Type class defining how to encode a `T` as a [[QueryParameterValue]]
+ * Type class defining how to encode a `T` as a `Seq` of [[QueryParameterValue]]s
  * @see QueryParamCodecLaws
  */
 trait QueryParamEncoder[T] {

--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -26,6 +26,13 @@ object QueryParam {
   }
 }
 
+trait QueryParamKeyLike[T] {
+  def getKey(t: T): QueryParameterKey
+}
+
+object QueryParamKeyLike {
+  def apply[T](implicit ev: QueryParamKeyLike[T]): QueryParamKeyLike[T] = ev
+}
 
 /**
  * Type class defining how to encode a `T` as a [[QueryParameterValue]]

--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -39,11 +39,11 @@ object QueryParamKeyLike {
 }
 
 /**
- * Type class defining how to encode a `T` as a `Seq` of [[QueryParameterValue]]s
+ * Type class defining how to encode a `T` as a [[QueryParameterValue]]s
  * @see QueryParamCodecLaws
  */
 trait QueryParamEncoder[T] {
-  def encode(value: T): Seq[QueryParameterValue]
+  def encode(value: T): QueryParameterValue
 }
 
 object QueryParamEncoder {
@@ -52,13 +52,13 @@ object QueryParamEncoder {
   def apply[T](implicit ev: QueryParamEncoder[T]): QueryParamEncoder[T] = ev
 
   def encodeBy[T, U: QueryParamEncoder](f: T => U): QueryParamEncoder[T] = new QueryParamEncoder[T] {
-    def encode(value: T): Seq[QueryParameterValue] =
+    def encode(value: T): QueryParameterValue =
       QueryParamEncoder[U].encode(f(value))
   }
 
   def encode[T](f: T => String): QueryParamEncoder[T] = new QueryParamEncoder[T] {
-    def encode(value: T): Seq[QueryParameterValue] =
-      QueryParameterValue(f(value))::Nil
+    def encode(value: T): QueryParameterValue =
+      QueryParameterValue(f(value))
   }
 
   def fromShow[T: Show]: QueryParamEncoder[T] = encode(Show[T].shows)
@@ -71,16 +71,6 @@ object QueryParamEncoder {
   implicit val longQueryParamEncoder   : QueryParamEncoder[Long]    = fromShow[Long]
   implicit val charQueryParamEncoder   : QueryParamEncoder[Char]    = fromShow[Char]
   implicit val stringQueryParamEncoder : QueryParamEncoder[String]  = encode(identity)
-
-  implicit def seqEncoder[T](implicit enc: QueryParamEncoder[T]): QueryParamEncoder[Seq[T]] =
-    new QueryParamEncoder[Seq[T]] {
-      override def encode(values: Seq[T]): Seq[QueryParameterValue] = values.flatMap(enc.encode(_))
-    }
-
-  implicit val unitEncoder: QueryParamEncoder[Unit] = new QueryParamEncoder[Unit] {
-    override def encode(value: Unit): Seq[QueryParameterValue] = Nil
-  }
-
 }
 
 

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -184,9 +184,9 @@ case class Uri(
    * query string will be replaced with the given one. If the given parameters
    * equal the existing the same `Uri` instance will be returned.
    */
-  def setQueryParams[T: QueryParamEncoder](query: Map[String, Seq[T]]): Uri = {
+  def setQueryParams[T: QueryParamEncoder](query: Map[String, T]): Uri = {
     if (multiParams == query) this
-    else copy(query = renderQueryString(query.mapValues(_.flatMap(QueryParamEncoder[T].encode(_).map(_.value)))))
+    else copy(query = renderQueryString(query.mapValues(QueryParamEncoder[T].encode(_).map(_.value))))
   }
 
   /**
@@ -211,8 +211,8 @@ case class Uri(
    * replaced. If the parameter to be added equal the existing entry the same
    * instance of `Uri` will be returned.
    */
-  def withQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, values: Seq[T]): Uri =
-    _withQueryParam(QueryParamKeyLike[K].getKey(key), values flatMap QueryParamEncoder[T].encode)
+  def withQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, value: T): Uri =
+    _withQueryParam(QueryParamKeyLike[K].getKey(key), QueryParamEncoder[T].encode(value))
 
   private def _withQueryParam(name: QueryParameterKey, values: Seq[QueryParameterValue]): Uri = {
     lazy val stringValues = values.map(_.value)

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -48,14 +48,14 @@ case class UriTemplate(
    * matching `expansion` could be found the same instance will be returned.
    */
   def expandPath[T: QueryParamEncoder](name: String, values: List[T]): UriTemplate =
-    copy(path = expandPathN(path, name, values.map(QueryParamEncoder[T].encode)))
+    copy(path = expandPathN(path, name, values.flatMap(QueryParamEncoder[T].encode)))
 
   /**
    * Replaces any expansion type in `path` that matches the given `name`. If no
    * matching `expansion` could be found the same instance will be returned.
    */
   def expandPath[T: QueryParamEncoder](name: String, value: T): UriTemplate =
-    copy(path = expandPathN(path, name, List(QueryParamEncoder[T].encode(value))))
+    copy(path = expandPathN(path, name, QueryParamEncoder[T].encode(value).toList))
 
   /**
    * Replaces any expansion type in `query` that matches the specified `name`.

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -48,14 +48,14 @@ case class UriTemplate(
    * matching `expansion` could be found the same instance will be returned.
    */
   def expandPath[T: QueryParamEncoder](name: String, values: List[T]): UriTemplate =
-    copy(path = expandPathN(path, name, values.flatMap(QueryParamEncoder[T].encode)))
+    copy(path = expandPathN(path, name, values.map(QueryParamEncoder[T].encode)))
 
   /**
    * Replaces any expansion type in `path` that matches the given `name`. If no
    * matching `expansion` could be found the same instance will be returned.
    */
   def expandPath[T: QueryParamEncoder](name: String, value: T): UriTemplate =
-    copy(path = expandPathN(path, name, QueryParamEncoder[T].encode(value).toList))
+    copy(path = expandPathN(path, name, QueryParamEncoder[T].encode(value)::Nil))
 
   /**
    * Replaces any expansion type in `query` that matches the specified `name`.

--- a/core/src/test/scala/org/http4s/QueryParamCodecLaws.scala
+++ b/core/src/test/scala/org/http4s/QueryParamCodecLaws.scala
@@ -15,7 +15,8 @@ object QueryParamCodecLaws {
   def apply[T: Arbitrary: Equal: QueryParamDecoder: QueryParamEncoder] = new Properties("QueryParamCodec") {
 
     property("decode . encode == successNel") = forAll { value: T =>
-      QueryParamEncoder[T].encode(value).map(QueryParamDecoder[T].decode).head === value.successNel
+      val r = QueryParamEncoder[T].encode(value).map(QueryParamDecoder[T].decode)
+      r.length == 1 && r.head === value.successNel
     }
 
   }

--- a/core/src/test/scala/org/http4s/QueryParamCodecLaws.scala
+++ b/core/src/test/scala/org/http4s/QueryParamCodecLaws.scala
@@ -15,7 +15,7 @@ object QueryParamCodecLaws {
   def apply[T: Arbitrary: Equal: QueryParamDecoder: QueryParamEncoder] = new Properties("QueryParamCodec") {
 
     property("decode . encode == successNel") = forAll { value: T =>
-      (QueryParamDecoder[T].decode _ compose QueryParamEncoder[T].encode)(value) === value.successNel
+      QueryParamEncoder[T].encode(value).map(QueryParamDecoder[T].decode).head === value.successNel
     }
 
   }

--- a/core/src/test/scala/org/http4s/QueryParamCodecLaws.scala
+++ b/core/src/test/scala/org/http4s/QueryParamCodecLaws.scala
@@ -15,8 +15,7 @@ object QueryParamCodecLaws {
   def apply[T: Arbitrary: Equal: QueryParamDecoder: QueryParamEncoder] = new Properties("QueryParamCodec") {
 
     property("decode . encode == successNel") = forAll { value: T =>
-      val r = QueryParamEncoder[T].encode(value).map(QueryParamDecoder[T].decode)
-      r.length == 1 && r.head === value.successNel
+      (QueryParamDecoder[T].decode _ compose QueryParamEncoder[T].encode)(value) === value.successNel
     }
 
   }

--- a/core/src/test/scala/org/http4s/parser/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/UriSpec.scala
@@ -23,7 +23,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
   object Ttl {
     implicit val queryParamInstance = new QueryParamEncoder[Ttl] with QueryParam[Ttl] {
       def key: QueryParameterKey = QueryParameterKey("ttl")
-      def encode(value: Ttl): Seq[QueryParameterValue] = QueryParameterValue(value.seconds.toString)::Nil
+      def encode(value: Ttl): QueryParameterValue = QueryParameterValue(value.seconds.toString)
     }
   }
 
@@ -515,7 +515,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2=true")))
     }
     "add a parameter without a value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2")) +? ("param2", ())
+      val u = Uri(query = Some("param1=value1&param1=value2")) +? ("param2")
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
     }
     "add a parameter with many values" in {
@@ -531,8 +531,12 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       u must be_==(Uri(query = Some(s"test=2")))
     }
     "add a query parameter with a QueryParamEncoder and an implicit key" in {
-      val u = Uri() +? (Ttl(2))
+      val u = Uri() +*? (Ttl(2))
       u must be_==(Uri(query = Some(s"ttl=2")))
+    }
+    "Work with queryParam" in {
+      val u = Uri().withQueryParam[Ttl]
+      u must be_==(Uri(query = Some(s"ttl")))
     }
     "add an optional query parameter (Just)" in {
       val u = Uri() +?? ("param1", Maybe.just(2))
@@ -589,7 +593,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       u must be_==(Uri(query = Some("param1=newValue&param2=value")))
     }
     "replace a parameter without a value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param2=value")) +? ("param2", ())
+      val u = Uri(query = Some("param1=value1&param1=value2&param2=value")) +? ("param2")
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
     }
     "replace the same parameter" in {
@@ -597,7 +601,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
     }
     "replace the same parameter without a value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param2")) +? ("param2", ())
+      val u = Uri(query = Some("param1=value1&param1=value2&param2")) +? ("param2")
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
     }
     "replace a parameter set" in {

--- a/core/src/test/scala/org/http4s/parser/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/UriSpec.scala
@@ -23,7 +23,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
   object Ttl {
     implicit val queryParamInstance = new QueryParamEncoder[Ttl] with QueryParam[Ttl] {
       def key: QueryParameterKey = QueryParameterKey("ttl")
-      def encode(value: Ttl): QueryParameterValue = QueryParameterValue(value.seconds.toString)
+      def encode(value: Ttl): Seq[QueryParameterValue] = QueryParameterValue(value.seconds.toString)::Nil
     }
   }
 
@@ -515,15 +515,15 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2=true")))
     }
     "add a parameter without a value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2")) +? ("param2")
+      val u = Uri(query = Some("param1=value1&param1=value2")) +? ("param2", ())
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
     }
     "add a parameter with many values" in {
-      val u = Uri() +? ("param1", "value1", "value2")
+      val u = Uri() +? ("param1", Seq("value1", "value2"))
       u must be_==(Uri(query = Some("param1=value1&param1=value2")))
     }
     "add a parameter with many long values" in {
-      val u = Uri() +? ("param1", 1L, -1L)
+      val u = Uri() +? ("param1", Seq(1L, -1L))
       u must be_==(Uri(query = Some(s"param1=1&param1=-1")))
     }
     "add a query parameter with a QueryParamEncoder" in {
@@ -589,15 +589,15 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       u must be_==(Uri(query = Some("param1=newValue&param2=value")))
     }
     "replace a parameter without a value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param2=value")) +? ("param2")
+      val u = Uri(query = Some("param1=value1&param1=value2&param2=value")) +? ("param2", ())
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
     }
     "replace the same parameter" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param2")) +? ("param1", "value1", "value2")
+      val u = Uri(query = Some("param1=value1&param1=value2&param2")) +? ("param1", Seq("value1", "value2"))
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
     }
     "replace the same parameter without a value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param2")) +? ("param2")
+      val u = Uri(query = Some("param1=value1&param1=value2&param2")) +? ("param2", ())
       u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
     }
     "replace a parameter set" in {


### PR DESCRIPTION
this PR adds a typeclass that will represent a query key. It may not be finished (maybe it is), but I wanted to get this up for feedback. 

### Changes
* ```QueryParamEncoder[T].encode(T) : Seq[QueryParameterValue]``` instead of a single value. This is needed for the following point to work.
* Varadiac methods were dropped in favor of a single value which also is a type class. Multiple values can be handled by a typeclass that takes a ```Seq[T]```; typeclasses for other types of collections are needed.
* Quite a few methods were dropped from the ```Uri``` class, but not as many as I'd hoped. I cant help but feel the ```Maybe``` and ```Option``` receiving methods are largely clutter: the same functionality can be done with ```cata``` and ```fold``` or other standard techniques. Perhaps I just haven't needed them yet and they are really awsome: its really a matter of convenience. 
