### PR TITLE
Change inferred media type of scala.xml.Elem to application/xml.

### DIFF
--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -32,35 +32,12 @@ object ExampleService {
   def service1(implicit executionContext: ExecutionContext) = HttpService {
 
     case req @ GET -> Root =>
+      // Supports Play Framework template -- see src/main/twirl.
+      Ok(html.index())
+
+    case GET -> Root / "ping" =>
       // EntityEncoder allows for easy conversion of types to a response body
-      Ok(
-        <html>
-          <body>
-            <h1>Welcome to http4s.</h1>
-
-            <p>Some examples:</p>
-
-            <ul>
-              <li><a href="/http4s/ping">Ping route</a></li>
-              <li><a href="/http4s/future">A asynchronous result</a></li>
-              <li><a href="/http4s/streaming">A streaming result</a></li>
-              <li><a href="/http4s/ip">Get your IP address</a></li>
-              <li><a href="/http4s/redirect">A redirect url</a></li>
-              <li><a href="/http4s/content-change">A HTML result written as a String</a></li>
-
-              <li><a href="/http4s/echo">Echo some form encoded data</a></li>
-              <li><a href="/http4s/echo2">Echo some form encoded data minus a few chars</a></li>
-              <li><a href="/http4s/sum">Calculate the sum of the submitted numbers</a></li>
-              <li><a href="/http4s/short-sum">Try to calculate a sum, but the body will be to large</a></li>
-
-              <li><a href="/http4s/form-encoded">A submission form</a></li>
-              <li><a href="/http4s/push">Server push</a></li>
-            </ul>
-          </body>
-        </html>
-      )
-
-    case GET -> Root / "ping" => Ok("pong")
+      Ok("pong")
 
     case GET -> Root / "future" =>
       // EntityEncoder allows rendering asynchronous results as well
@@ -92,7 +69,6 @@ object ExampleService {
         .withHeaders(`Content-Type`(`text/plain`), `Transfer-Encoding`(TransferCoding.chunked))
 
     case req @ GET -> Root / "echo" =>
-      // submissionForm is a Play Framework template -- see src/main/twirl.
       Ok(html.submissionForm("echo data"))
 
     case req @ POST -> Root / "echo2" =>
@@ -123,17 +99,7 @@ object ExampleService {
     ///////////////////////////////////////////////////////////////
     //////////////// Form encoding example ////////////////////////
     case req @ GET -> Root / "form-encoded" =>
-      val html =
-        <html><body>
-          <p>Submit something.</p>
-          <form name="input" method="post">
-            <p>First name: <input type="text" name="firstname"/></p>
-            <p>Last name: <input type="text" name="lastname"/></p>
-            <p><input type="submit" value="Submit"/></p>
-          </form>
-        </body></html>
-
-      Ok(html)
+      Ok(html.formEncoded())
 
     case req @ POST -> Root / "form-encoded" =>
       // EntityDecoders return a Task[A] which is easy to sequence

--- a/examples/src/main/twirl/com/example/http4s/formEncoded.scala.html
+++ b/examples/src/main/twirl/com/example/http4s/formEncoded.scala.html
@@ -1,0 +1,8 @@
+<html><body>
+<p>Submit something.</p>
+<form name="input" method="post">
+    <p>First name: <input type="text" name="firstname"/></p>
+    <p>Last name: <input type="text" name="lastname"/></p>
+    <p><input type="submit" value="Submit"/></p>
+</form>
+</body></html>

--- a/examples/src/main/twirl/com/example/http4s/index.scala.html
+++ b/examples/src/main/twirl/com/example/http4s/index.scala.html
@@ -1,0 +1,24 @@
+<html>
+<body>
+<h1>Welcome to http4s.</h1>
+
+<p>Some examples:</p>
+
+<ul>
+    <li><a href="ping">Ping route</a></li>
+    <li><a href="future">A asynchronous result</a></li>
+    <li><a href="streaming">A streaming result</a></li>
+    <li><a href="ip">Get your IP address</a></li>
+    <li><a href="redirect">A redirect url</a></li>
+    <li><a href="content-change">A HTML result written as a String</a></li>
+
+    <li><a href="echo">Echo some form encoded data</a></li>
+    <li><a href="echo2">Echo some form encoded data minus a few chars</a></li>
+    <li><a href="sum">Calculate the sum of the submitted numbers</a></li>
+    <li><a href="short-sum">Try to calculate a sum, but the body will be to large</a></li>
+
+    <li><a href="form-encoded">A submission form</a></li>
+    <li><a href="push">Server push</a></li>
+</ul>
+</body>
+</html>

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -9,11 +9,10 @@ import scala.xml._
 import scalaz.concurrent.Task
 
 trait ElemInstances {
-  // TODO infer HTML, XHTML, etc.
-  implicit def htmlEncoder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[Elem] =
+  implicit def xmlEnocder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[Elem] =
     EntityEncoder.stringEncoder(charset)
       .contramap[Elem](xml => xml.buildString(false))
-      .withContentType(`Content-Type`(MediaType.`text/html`))
+      .withContentType(`Content-Type`(MediaType.`application/xml`))
 
   /**
    * Handles a message body as XML.


### PR DESCRIPTION
This makes XML literals as HTML a Bad Idea, so they are ported to
Twirl in the example.

Related to #153.