### PR TITLE
Topic/index seq query

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -137,7 +137,7 @@ case class Request(
 
   lazy val pathTranslated: Option[File] = attributes.get(Keys.PathTranslated)
 
-  def queryString: String = uri.query.getOrElse("")
+  def queryString: String = uri.query.renderString
 
   /**
    * Representation of the query string as a map

--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -1,0 +1,108 @@
+package org.http4s
+
+import org.http4s.Query._
+import org.http4s.parser.QueryParser
+import org.http4s.util.{Writer, Renderable}
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.immutable.IndexedSeq
+import scala.collection.mutable.ListBuffer
+import scala.collection.{ IndexedSeqOptimized, mutable }
+
+
+final case class Query private(params: Vector[KV])
+  extends IndexedSeq[KV] 
+  with IndexedSeqOptimized[KV, Query]
+  with Renderable 
+{
+
+  override def apply(idx: Int): KV = params.apply(idx)
+
+  override def length: Int = params.length
+
+  override def +:[B >: KV, That](elem: B)(implicit bf: CanBuildFrom[Query, B, That]): That = {
+    if (bf eq Query.cbf) Query((elem +: params).asInstanceOf[Vector[KV]]).asInstanceOf[That]
+    else super.+:(elem)
+  }
+
+  override def :+[B >: KV, That](elem: B)(implicit bf: CanBuildFrom[Query, B, That]): That = {
+    if (bf eq Query.cbf) Query((params :+ elem).asInstanceOf[Vector[KV]]).asInstanceOf[That]
+    else super.:+(elem)
+  }
+
+
+  /** Base method for rendering this object efficiently */
+  override def render(writer: Writer): writer.type = {
+    var first = true
+    params.foreach {
+      case KV(n, None) =>
+        if (!first) writer.append('&')
+        else first = false
+        writer.append(n)
+
+      case KV(n, Some(v)) =>
+        if (!first) writer.append('&')
+        else first = false
+        writer.append(n)
+          .append("=")
+          .append(v)
+    }
+    writer
+  }
+
+  def asMap: Map[String, Seq[String]] = {
+    if (isEmpty) Map.empty[String, Seq[String]]
+    else {
+      val m = mutable.Map.empty[String, ListBuffer[String]]
+      foreach {
+        case KV(k, None) => m.getOrElseUpdate(k, new ListBuffer)
+        case KV(k, Some(v)) => m.getOrElseUpdate(k, new ListBuffer) += v
+      }
+
+      m.toMap
+    }
+  }
+
+  override protected[this] def newBuilder: mutable.Builder[KV, Query] = Query.newBuilder
+}
+
+object Query {
+  
+  case class KV(key: String, value: Option[String])
+
+  val empty: Query = Query(Vector.empty)
+
+  def fromPairs(xs: (String, String)*): Query = {
+    val b = newBuilder
+    xs.foreach{ case (k, v) => b += KV(k, Some(v)) }
+    b.result()
+  }
+
+  def fromOptions(xs: (String, Option[String])*): Query = {
+    val b = newBuilder
+    xs.foreach{ case (k, v) => b += KV(k, v) }
+    b.result()
+  }
+
+  def fromString(query: String): Query = {
+    if (query.isEmpty) Query(Vector(KV("", None)))
+    else QueryParser.parseQueryString(query).getOrElse(Query.empty)
+  }
+  
+  def fromMap(map: Map[String, Seq[String]]): Query = {
+    val b = newBuilder
+    map.foreach {
+      case (k, Seq()) => b +=  KV(k, None)
+      case (k, vs)    => vs.foreach(v => b += KV(k, Some(v)))
+    }
+    b.result()
+  }
+
+  def newBuilder: mutable.Builder[KV, Query] =
+    Vector.newBuilder[KV].mapResult(v => new Query(v))
+
+  implicit val cbf: CanBuildFrom[Query, KV, Query] = new CanBuildFrom[Query, KV, Query] {
+    override def apply(from: Query): mutable.Builder[KV, Query] = newBuilder
+    override def apply(): mutable.Builder[KV, Query] = newBuilder
+  }
+}

--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -39,7 +39,6 @@ final case class Query (params: Vector[KeyValue])
     else super.:+(elem)
   }
 
-
   /** Base method for rendering this object efficiently */
   override def render(writer: Writer): writer.type = {
     var first = true

--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable.ListBuffer
 import scala.collection.{ IndexedSeqOptimized, mutable }
 
 
-final case class Query private(params: Vector[KeyValue])
+final case class Query (params: Vector[KeyValue])
   extends IndexedSeq[KeyValue]
   with IndexedSeqOptimized[KeyValue, Query]
   with QueryOps

--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -27,6 +27,8 @@ final class Query private(pairs: Vector[KeyValue])
 
   override def length: Int = pairs.length
 
+  override def slice(from: Int, until: Int): Query = new Query(pairs.slice(from, until))
+
   override def +:[B >: KeyValue, That](elem: B)(implicit bf: CanBuildFrom[Query, B, That]): That = {
     if (bf eq Query.cbf) new Query((elem +: pairs).asInstanceOf[Vector[KeyValue]]).asInstanceOf[That]
     else super.+:(elem)

--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -1,0 +1,207 @@
+package org.http4s
+
+import scalaz.Maybe
+import scalaz.syntax.std.option._
+
+trait QueryOps {
+
+  protected type Self <: QueryOps
+
+  protected val query: Query
+
+  protected def self: Self
+
+  protected def replaceQuery(query: Query): Self
+
+  /** alias for containsQueryParam */
+  def ?[K: QueryParamKeyLike](name: K): Boolean =
+    _containsQueryParam(QueryParamKeyLike[K].getKey(name))
+
+  /** alias for setQueryParams */
+  def =?[T: QueryParamEncoder](q: Map[String, Seq[T]]): Self =
+    setQueryParams(q)
+
+  /** alias for withQueryParam */
+  def +?[T: QueryParam]: Self =
+    _withQueryParam(QueryParam[T].key, Nil)
+
+  /** alias for withQueryParam */
+  def +*?[T: QueryParam : QueryParamEncoder](value: T): Self =
+    _withQueryParam(QueryParam[T].key, QueryParamEncoder[T].encode(value)::Nil)
+
+  /** alias for withQueryParam */
+  def +*?[T: QueryParam : QueryParamEncoder](values: Seq[T]): Self =
+    _withQueryParam(QueryParam[T].key, values.map(QueryParamEncoder[T].encode))
+
+  /** alias for withQueryParam */
+  def +?[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, value: T): Self =
+    +?(name, value::Nil)
+
+  /** alias for withQueryParam */
+  def +?[K: QueryParamKeyLike](name: K): Self =
+    _withQueryParam(QueryParamKeyLike[K].getKey(name), Nil)
+
+  /** alias for withQueryParam */
+  def +?[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, values: Seq[T]): Self =
+    _withQueryParam(QueryParamKeyLike[K].getKey(name), values.map(QueryParamEncoder[T].encode))
+
+  /** alias for withMaybeQueryParam */
+  def +??[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, value: Maybe[T]): Self =
+    _withMaybeQueryParam(QueryParamKeyLike[K].getKey(name), value map QueryParamEncoder[T].encode)
+
+  /** alias for withMaybeQueryParam */
+  def +??[T: QueryParam : QueryParamEncoder](value: Maybe[T]): Self =
+    _withMaybeQueryParam(QueryParam[T].key, value map QueryParamEncoder[T].encode)
+
+  /** alias for withOptionQueryParam */
+  def +??[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, value: Option[T]): Self =
+    _withMaybeQueryParam(QueryParamKeyLike[K].getKey(name), value.toMaybe map QueryParamEncoder[T].encode)
+
+  /** alias for withOptionQueryParam */
+  def +??[T: QueryParam : QueryParamEncoder](value: Option[T]): Self =
+    _withMaybeQueryParam(QueryParam[T].key, value.toMaybe map QueryParamEncoder[T].encode)
+
+  /** alias for removeQueryParam */
+  def -?[T](implicit key: QueryParam[T]): Self =
+    _removeQueryParam(key.key)
+
+  /** alias for removeQueryParam */
+  def -?[K: QueryParamKeyLike](key: K): Self =
+    _removeQueryParam(QueryParamKeyLike[K].getKey(key))
+
+  /**
+   * Checks if a specified parameter exists in the [[Query]]. A parameter
+   * without a name can be checked with an empty string.
+   */
+  def containsQueryParam[T](implicit key: QueryParam[T]): Boolean =
+    _containsQueryParam(key.key)
+
+  def containsQueryParam[K: QueryParamKeyLike](key: K): Boolean =
+    _containsQueryParam(QueryParamKeyLike[K].getKey(key))
+
+  private def _containsQueryParam(name: QueryParameterKey): Boolean = {
+    if (query.isEmpty) false
+    else query.exists { case (k, _) => k == name.value }
+  }
+
+  /**
+   * Creates maybe a new `Self` without the specified parameter in query.
+   * If no parameter with the given `key` exists then `this` will be
+   * returned.
+   */
+  def removeQueryParam[K: QueryParamKeyLike](key: K): Self =
+    _removeQueryParam(QueryParamKeyLike[K].getKey(key))
+
+  private def _removeQueryParam(name: QueryParameterKey): Self = {
+    if (query.isEmpty) self
+    else {
+      val newQuery = query.filterNot { case (n, _) => n == name.value }
+      replaceQuery(newQuery)
+    }
+  }
+
+  /**
+   * Creates maybe a new `Self` with the specified parameters. The entire
+   * [[Query]] will be replaced with the given one. If the given parameters
+   * equal the existing the same `Self` instance will be returned.
+   */
+  def setQueryParams[T: QueryParamEncoder](params: Map[String, Seq[T]]): Self = {
+    if (query.multiParams == params) self
+    else {
+      val enc = QueryParamEncoder[T]
+      val b = Query.newBuilder
+      params.foreach {
+        case (k, Seq()) => b +=  ((k, None))
+        case (k, vs)    => vs.foreach(v => b += ((k, Some(enc.encode(v).value))))
+      }
+      replaceQuery(b.result())
+    }
+  }
+
+  /**
+   * Creates a new `Self` with the specified parameter in the [[Query]].
+   * If a parameter with the given `QueryParam.key` already exists the values will be
+   * replaced with an empty list.
+   */
+  def withQueryParam[T: QueryParam]: Self =
+    _withQueryParam(QueryParam[T].key, Nil)
+
+  /**
+   * Creates a new `Self` with the specified parameter in the [[Query]].
+   * If a parameter with the given `key` already exists the values will be
+   * replaced with an empty list.
+   */
+  def withQueryParam[K: QueryParamKeyLike](key: K): Self =
+    _withQueryParam(QueryParamKeyLike[K].getKey(key), Nil)
+
+  /**
+   * Creates maybe a new `Self` with the specified parameter in the [[Query]].
+   * If a parameter with the given `key` already exists the values will be
+   * replaced. If the parameter to be added equal the existing entry the same
+   * instance of `Self` will be returned.
+   */
+  def withQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, value: T): Self =
+    _withQueryParam(QueryParamKeyLike[K].getKey(key), QueryParamEncoder[T].encode(value)::Nil)
+
+  /**
+   * Creates maybe a new `Self` with the specified parameters in the [[Query]].
+   * If a parameter with the given `key` already exists the values will be
+   * replaced. If the parameter to be added equal the existing entry the same
+   * instance of `Self` will be returned.
+   */
+  def withQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, values: Seq[T]): Self =
+    _withQueryParam(QueryParamKeyLike[K].getKey(key), values.map(QueryParamEncoder[T].encode))
+
+  private def _withQueryParam(name: QueryParameterKey, values: Seq[QueryParameterValue]): Self = {
+    lazy val stringValues = values.map(_.value)
+    if (query.multiParams.contains(name.value) && query.multiParams.getOrElse(name.value, Nil) == stringValues) self
+    else {
+      val p = query.multiParams updated (name.value, stringValues)
+      replaceQuery(Query.fromMap(p))
+    }
+  }
+
+  /**
+   * Creates maybe a new `Self` with the specified parameter in the [[Query]].
+   * If the value is empty or if the parameter to be added equal the existing
+   * entry the same instance of `Self` will be returned.
+   * If a parameter with the given `key` already exists the values will be
+   * replaced.
+   */
+  def withMaybeQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, value: Maybe[T]): Self =
+    _withMaybeQueryParam(QueryParamKeyLike[K].getKey(key), value map QueryParamEncoder[T].encode)
+
+  /**
+   * Creates maybe a new `Self` with the specified parameter in the [[Query]].
+   * If the value is empty or if the parameter to be added equal the existing
+   * entry the same instance of `Self` will be returned.
+   * If a parameter with the given `name` already exists the values will be
+   * replaced.
+   */
+  def withMaybeQueryParam[T: QueryParam: QueryParamEncoder](value: Maybe[T]): Self =
+    _withMaybeQueryParam(QueryParam[T].key, value map QueryParamEncoder[T].encode)
+
+  /**
+   * Creates maybe a new `Self` with the specified parameter in the [[Query]].
+   * If the value is empty or if the parameter to be added equal the existing
+   * entry the same instance of `Self` will be returned.
+   * If a parameter with the given `key` already exists the values will be
+   * replaced.
+   */
+  def withOptionQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, value: Option[T]): Self =
+    _withMaybeQueryParam(QueryParamKeyLike[K].getKey(key), value.toMaybe map QueryParamEncoder[T].encode)
+
+  /**
+   * Creates maybe a new `Self` with the specified parameter in the [[Query]].
+   * If the value is empty or if the parameter to be added equal the existing
+   * entry the same instance of `Self` will be returned.
+   * If a parameter with the given `name` already exists the values will be
+   * replaced.
+   */
+  def withOptionQueryParam[T: QueryParam: QueryParamEncoder](value: Option[T]): Self =
+    _withMaybeQueryParam(QueryParam[T].key, value.toMaybe map QueryParamEncoder[T].encode)
+
+  private def _withMaybeQueryParam(name: QueryParameterKey, value: Maybe[QueryParameterValue]): Self =
+    value.cata(v => _withQueryParam(name, v::Nil), self)
+
+}

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -55,7 +55,7 @@ case class Uri(
    * The query string is lazily parsed. If an error occurs during parsing
    * an empty `Map` is returned.
    */
-  lazy val multiParams: Map[String, Seq[String]] = query.multiParams
+  def multiParams: Map[String, Seq[String]] = query.multiParams
 
   /**
    * View of the head elements of the URI parameters in query string.
@@ -64,7 +64,7 @@ case class Uri(
    *
    * @see multiParams
    */
-  lazy val params: Map[String, String] = query.paramsView
+  def params: Map[String, String] = query.params
 
   override lazy val renderString: String =
     super.renderString

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -2,17 +2,14 @@ package org.http4s
 
 import java.nio.charset.StandardCharsets
 
-import org.http4s.Query.KV
-
 import scala.language.experimental.macros
 import scala.reflect.macros.Context
 
 import Uri._
 
 import scala.collection.mutable
-import mutable.ListBuffer
 
-import org.http4s.parser.{ ScalazDeliverySchemes, QueryParser, RequestUriParser }
+import org.http4s.parser.{ ScalazDeliverySchemes, RequestUriParser }
 import org.http4s.util.{ Writer, Renderable, CaseInsensitiveString }
 import org.http4s.util.string.ToCaseInsensitiveStringSyntax
 
@@ -158,7 +155,7 @@ case class Uri(
 
   private def _containsQueryParam(name: QueryParameterKey): Boolean = {
     if (query.isEmpty) false
-    else query.exists { case KV(k, _) => k == name.value }
+    else query.exists { case (k, _) => k == name.value }
   }
 
   /**
@@ -173,7 +170,7 @@ case class Uri(
   private def _removeQueryParam(name: QueryParameterKey): Uri = {
     if (query.isEmpty) this
     else {
-      val newQuery = query.filterNot { case KV(n, _) => n == name.value }
+      val newQuery = query.filterNot { case (n, _) => n == name.value }
       copy(query = newQuery)
     }
   }
@@ -189,8 +186,8 @@ case class Uri(
       val enc = QueryParamEncoder[T]
       val b = Query.newBuilder
       query.foreach {
-        case (k, Seq()) => b +=  KV(k, None)
-        case (k, vs)    => vs.foreach(v => b += KV(k, Some(enc.encode(v).value)))
+        case (k, Seq()) => b +=  ((k, None))
+        case (k, vs)    => vs.foreach(v => b += ((k, Some(enc.encode(v).value))))
       }
       copy(query = b.result())
     }

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -7,14 +7,9 @@ import scala.reflect.macros.Context
 
 import Uri._
 
-import scala.collection.mutable
-
 import org.http4s.parser.{ ScalazDeliverySchemes, RequestUriParser }
 import org.http4s.util.{ Writer, Renderable, CaseInsensitiveString }
 import org.http4s.util.string.ToCaseInsensitiveStringSyntax
-
-import scalaz.Maybe
-import scalaz.syntax.std.option._
 
 /** Representation of the [[Request]] URI
   * Structure containing information related to a Uri. All fields except the
@@ -31,7 +26,9 @@ case class Uri(
   authority: Option[Authority] = None,
   path: Path = "/",
   query: Query = Query.empty,
-  fragment: Option[Fragment] = None) extends Renderable {
+  fragment: Option[Fragment] = None)
+  extends QueryOps with Renderable
+{
   def withPath(path: Path): Uri = copy(path = path)
 
   def host: Option[Host] = authority.map(_.host)
@@ -58,7 +55,7 @@ case class Uri(
    * The query string is lazily parsed. If an error occurs during parsing
    * an empty `Map` is returned.
    */
-  lazy val multiParams: Map[String, Seq[String]] = query.asMap
+  lazy val multiParams: Map[String, Seq[String]] = query.multiParams
 
   /**
    * View of the head elements of the URI parameters in query string.
@@ -67,217 +64,10 @@ case class Uri(
    *
    * @see multiParams
    */
-  lazy val params: Map[String, String] = new ParamsView(multiParams)
+  lazy val params: Map[String, String] = query.paramsView
 
   override lazy val renderString: String =
     super.renderString
-
-  private class ParamsView(wrapped: Map[String, Seq[String]]) extends Map[String, String] {
-    override def +[B1 >: String](kv: (String, B1)): Map[String, B1] = {
-      val m = wrapped + (kv)
-      m.asInstanceOf[Map[String, B1]]
-    }
-
-    override def -(key: String): Map[String, String] = new ParamsView(wrapped - key)
-
-    override def iterator: Iterator[(String, String)] =
-      wrapped.iterator.map { case (k, s) => (k, s.headOption.getOrElse("")) }
-
-    override def get(key: String): Option[String] =
-      wrapped.get(key).flatMap(_.headOption)
-  }
-
-  /** alias for containsQueryParam */
-  def ?[K: QueryParamKeyLike](name: K): Boolean =
-    _containsQueryParam(QueryParamKeyLike[K].getKey(name))
-
-  /** alias for setQueryParams */
-  def =?[T: QueryParamEncoder](q: Map[String, Seq[T]]): Uri =
-    setQueryParams(q)
-
-  /** alias for withQueryParam */
-  def +?[T: QueryParam]: Uri =
-    _withQueryParam(QueryParam[T].key, Nil)
-
-  /** alias for withQueryParam */
-  def +*?[T: QueryParam : QueryParamEncoder](value: T): Uri =
-    _withQueryParam(QueryParam[T].key, QueryParamEncoder[T].encode(value)::Nil)
-
-  /** alias for withQueryParam */
-  def +*?[T: QueryParam : QueryParamEncoder](values: Seq[T]): Uri =
-    _withQueryParam(QueryParam[T].key, values.map(QueryParamEncoder[T].encode))
-
-  /** alias for withQueryParam */
-  def +?[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, value: T): Uri =
-    +?(name, value::Nil)
-
-  /** alias for withQueryParam */
-  def +?[K: QueryParamKeyLike](name: K): Uri =
-    _withQueryParam(QueryParamKeyLike[K].getKey(name), Nil)
-
-  /** alias for withQueryParam */
-  def +?[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, values: Seq[T]): Uri =
-    _withQueryParam(QueryParamKeyLike[K].getKey(name), values.map(QueryParamEncoder[T].encode))
-
-  /** alias for withMaybeQueryParam */
-  def +??[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, value: Maybe[T]): Uri =
-    _withMaybeQueryParam(QueryParamKeyLike[K].getKey(name), value map QueryParamEncoder[T].encode)
-
-  /** alias for withMaybeQueryParam */
-  def +??[T: QueryParam : QueryParamEncoder](value: Maybe[T]): Uri =
-    _withMaybeQueryParam(QueryParam[T].key, value map QueryParamEncoder[T].encode)
-
-  /** alias for withOptionQueryParam */
-  def +??[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, value: Option[T]): Uri =
-    _withMaybeQueryParam(QueryParamKeyLike[K].getKey(name), value.toMaybe map QueryParamEncoder[T].encode)
-
-  /** alias for withOptionQueryParam */
-  def +??[T: QueryParam : QueryParamEncoder](value: Option[T]): Uri =
-    _withMaybeQueryParam(QueryParam[T].key, value.toMaybe map QueryParamEncoder[T].encode)
-
-  /** alias for removeQueryParam */
-  def -?[T](implicit key: QueryParam[T]): Uri =
-    _removeQueryParam(key.key)
-
-  /** alias for removeQueryParam */
-  def -?[K: QueryParamKeyLike](key: K): Uri =
-    _removeQueryParam(QueryParamKeyLike[K].getKey(key))
-
-  /**
-   * Checks if a specified parameter exists in query string. A parameter
-   * without a name can be checked with an empty string.
-   */
-  def containsQueryParam[T](implicit key: QueryParam[T]): Boolean =
-    _containsQueryParam(key.key)
-
-  def containsQueryParam[K: QueryParamKeyLike](key: K): Boolean =
-    _containsQueryParam(QueryParamKeyLike[K].getKey(key))
-
-  private def _containsQueryParam(name: QueryParameterKey): Boolean = {
-    if (query.isEmpty) false
-    else query.exists { case (k, _) => k == name.value }
-  }
-
-  /**
-   * Creates maybe a new `Uri` without the specified parameter in query string.
-   * If no parameter with the given `key` exists the same `Uri` will be
-   * returned. If the parameter to be removed is not present the existing `Uri`
-   * instance of `Uri` will be returned.
-   */
-  def removeQueryParam[K: QueryParamKeyLike](key: K): Uri =
-    _removeQueryParam(QueryParamKeyLike[K].getKey(key))
-
-  private def _removeQueryParam(name: QueryParameterKey): Uri = {
-    if (query.isEmpty) this
-    else {
-      val newQuery = query.filterNot { case (n, _) => n == name.value }
-      copy(query = newQuery)
-    }
-  }
-
-  /**
-   * Creates maybe a new `Uri` with the specified parameters. The entire
-   * query string will be replaced with the given one. If the given parameters
-   * equal the existing the same `Uri` instance will be returned.
-   */
-  def setQueryParams[T: QueryParamEncoder](query: Map[String, Seq[T]]): Uri = {
-    if (multiParams == query) this
-    else {
-      val enc = QueryParamEncoder[T]
-      val b = Query.newBuilder
-      query.foreach {
-        case (k, Seq()) => b +=  ((k, None))
-        case (k, vs)    => vs.foreach(v => b += ((k, Some(enc.encode(v).value))))
-      }
-      copy(query = b.result())
-    }
-  }
-
-  /**
-   * Creates a new `Uri` with the specified parameter in query string.
-   * If a parameter with the given `QueryParam.key` already exists the values will be
-   * replaced with an empty list.
-   */
-  def withQueryParam[T: QueryParam]: Uri =
-    _withQueryParam(QueryParam[T].key, Nil)
-
-  /**
-   * Creates a new `Uri` with the specified parameter in query string.
-   * If a parameter with the given `key` already exists the values will be
-   * replaced with an empty list.
-   */
-  def withQueryParam[K: QueryParamKeyLike](key: K): Uri =
-    _withQueryParam(QueryParamKeyLike[K].getKey(key), Nil)
-
-  /**
-   * Creates maybe a new `Uri` with the specified parameter in query string.
-   * If a parameter with the given `key` already exists the values will be
-   * replaced. If the parameter to be added equal the existing entry the same
-   * instance of `Uri` will be returned.
-   */
-  def withQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, value: T): Uri =
-    _withQueryParam(QueryParamKeyLike[K].getKey(key), QueryParamEncoder[T].encode(value)::Nil)
-
-  /**
-   * Creates maybe a new `Uri` with the specified parameters in query string.
-   * If a parameter with the given `key` already exists the values will be
-   * replaced. If the parameter to be added equal the existing entry the same
-   * instance of `Uri` will be returned.
-   */
-  def withQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, values: Seq[T]): Uri =
-    _withQueryParam(QueryParamKeyLike[K].getKey(key), values.map(QueryParamEncoder[T].encode))
-
-  private def _withQueryParam(name: QueryParameterKey, values: Seq[QueryParameterValue]): Uri = {
-    lazy val stringValues = values.map(_.value)
-    if (multiParams.contains(name.value) && multiParams.getOrElse(name.value, Nil) == stringValues) this
-    else {
-      val p = multiParams updated (name.value, stringValues)
-      copy(query = Query.fromMap(p))
-    }
-  }
-
-  /**
-   * Creates maybe a new `Uri` with the specified parameter in query string.
-   * If the value is empty or if the parameter to be added equal the existing
-   * entry the same instance of `Uri` will be returned.
-   * If a parameter with the given `key` already exists the values will be
-   * replaced.
-   */
-  def withMaybeQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, value: Maybe[T]): Uri =
-    _withMaybeQueryParam(QueryParamKeyLike[K].getKey(key), value map QueryParamEncoder[T].encode)
-
-  /**
-   * Creates maybe a new `Uri` with the specified parameter in query string.
-   * If the value is empty or if the parameter to be added equal the existing
-   * entry the same instance of `Uri` will be returned.
-   * If a parameter with the given `name` already exists the values will be
-   * replaced.
-   */
-  def withMaybeQueryParam[T: QueryParam: QueryParamEncoder](value: Maybe[T]): Uri =
-    _withMaybeQueryParam(QueryParam[T].key, value map QueryParamEncoder[T].encode)
-
-  /**
-   * Creates maybe a new `Uri` with the specified parameter in query string.
-   * If the value is empty or if the parameter to be added equal the existing
-   * entry the same instance of `Uri` will be returned.
-   * If a parameter with the given `key` already exists the values will be
-   * replaced.
-   */
-  def withOptionQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, value: Option[T]): Uri =
-    _withMaybeQueryParam(QueryParamKeyLike[K].getKey(key), value.toMaybe map QueryParamEncoder[T].encode)
-
-  /**
-   * Creates maybe a new `Uri` with the specified parameter in query string.
-   * If the value is empty or if the parameter to be added equal the existing
-   * entry the same instance of `Uri` will be returned.
-   * If a parameter with the given `name` already exists the values will be
-   * replaced.
-   */
-  def withOptionQueryParam[T: QueryParam: QueryParamEncoder](value: Option[T]): Uri =
-    _withMaybeQueryParam(QueryParam[T].key, value.toMaybe map QueryParamEncoder[T].encode)
-
-  private def _withMaybeQueryParam(name: QueryParameterKey, value: Maybe[QueryParameterValue]): Uri =
-    value.cata(v => _withQueryParam(name, v::Nil), this)
 
   override def render(writer: Writer): writer.type = this match {
     case Uri(Some(s), Some(a), "/", q, None) if q.isEmpty =>
@@ -301,6 +91,13 @@ case class Uri(
       writer.append(path)
       renderParamsAndFragment(writer, params, fragment)
   }
+
+  /////////// Query Operations ///////////////
+  override protected type Self = Uri
+
+  override protected def self: Self = this
+
+  override protected def replaceQuery(query: Query): Self = copy(query = query)
 }
 
 object Uri extends UriFunctions {

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -1,6 +1,5 @@
 package org.http4s
 
-import org.http4s.Query.KV
 import org.http4s.Uri.{Authority, Host, IPv4, IPv6, RegName, Scheme}
 import org.http4s.UriTemplate._
 
@@ -288,9 +287,9 @@ object UriTemplate {
   protected def buildQuery(q: Query): org.http4s.Query = {
     val elements = Query.newBuilder
     q map {
-      case ParamElm(n, Nil) => elements += KV(n, None)
-      case ParamElm(n, List(v)) => elements += KV(n, Some(v))
-      case ParamElm(n, vs) => vs.foreach(v => elements += KV(n, Some(v)))
+      case ParamElm(n, Nil) => elements += ((n, None))
+      case ParamElm(n, List(v)) => elements += ((n, Some(v)))
+      case ParamElm(n, vs) => vs.foreach(v => elements += ((n, Some(v))))
       case u => throw new IllegalStateException(s"${u.getClass.getName} cannot be converted to a Uri")
     }
 

--- a/core/src/main/scala/org/http4s/parser/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/parser/QueryParser.scala
@@ -2,6 +2,7 @@ package org.http4s.parser
 
 import java.io.UnsupportedEncodingException
 import java.nio.CharBuffer
+import org.http4s.Query.KV
 import org.http4s._
 import org.http4s.util.string._
 
@@ -23,9 +24,9 @@ private[http4s] class QueryParser(codec: Codec, colonSeparators: Boolean) {
 
   /** Decodes the input into key value pairs.
     * `flush` signals that this is the last input */
-  def decode(input: CharBuffer, flush: Boolean): ParseResult[Seq[Param]] = {
-    val acc = new ListBuffer[Param]
-    decodeBuffer(input, (k,v) => acc += ((k,v)), flush) match {
+  def decode(input: CharBuffer, flush: Boolean): ParseResult[Query] = {
+    val acc = Query.newBuilder
+    decodeBuffer(input, (k,v) => acc += KV(k,v), flush) match {
       case Some(e) => -\/(ParseFailure(e))
       case None    => \/-(acc.result)
     }
@@ -102,9 +103,8 @@ private[http4s] class QueryParser(codec: Codec, colonSeparators: Boolean) {
 }
 
 private[http4s] object QueryParser {
-  type Param = (String,Option[String])
-  def parseQueryString(queryString: String, codec: Codec = Codec.UTF8): ParseResult[Seq[Param]] = {
-    if (queryString.isEmpty) \/-(Nil)
+  def parseQueryString(queryString: String, codec: Codec = Codec.UTF8): ParseResult[Query] = {
+    if (queryString.isEmpty) \/-(Query.empty)
     else new QueryParser(codec, true).decode(CharBuffer.wrap(queryString), true)
   }
 

--- a/core/src/main/scala/org/http4s/parser/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/parser/QueryParser.scala
@@ -2,13 +2,11 @@ package org.http4s.parser
 
 import java.io.UnsupportedEncodingException
 import java.nio.CharBuffer
-import org.http4s.Query.KV
 import org.http4s._
 import org.http4s.util.string._
 
 import scala.annotation.switch
 import scala.collection.immutable.BitSet
-import scala.collection.mutable.ListBuffer
 import scala.io.Codec
 
 import QueryParser._
@@ -26,7 +24,7 @@ private[http4s] class QueryParser(codec: Codec, colonSeparators: Boolean) {
     * `flush` signals that this is the last input */
   def decode(input: CharBuffer, flush: Boolean): ParseResult[Query] = {
     val acc = Query.newBuilder
-    decodeBuffer(input, (k,v) => acc += KV(k,v), flush) match {
+    decodeBuffer(input, (k,v) => acc += ((k,v)), flush) match {
       case Some(e) => -\/(ParseFailure(e))
       case None    => \/-(acc.result)
     }

--- a/core/src/main/scala/org/http4s/parser/RequestUriParser.scala
+++ b/core/src/main/scala/org/http4s/parser/RequestUriParser.scala
@@ -2,7 +2,7 @@ package org.http4s
 package parser
 
 import org.parboiled2._
-import scalaz.NonEmptyList
+import org.http4s.{ Query => Q }
 import java.nio.charset.Charset
 import org.http4s.util.string._
 
@@ -16,7 +16,10 @@ private[http4s] class RequestUriParser(val input: ParserInput, val charset: Char
     Authority ~> (auth => org.http4s.Uri(authority = Some(auth)))
   }
 
-  def OriginForm = rule { PathAbsolute ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) ~> ((path, query, fragment) => org.http4s.Uri(path = path, query = query, fragment = fragment)) }
+  def OriginForm = rule { PathAbsolute ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) ~> { (path, query, fragment) =>
+    val q = query.map(Q.fromString).getOrElse(Q.empty)
+    org.http4s.Uri(path = path, query = q, fragment = fragment)
+  } }
 
   def Asterisk: Rule1[Uri] = rule { "*" ~ push(org.http4s.Uri(authority = Some(org.http4s.Uri.Authority(host = org.http4s.Uri.RegName("*"))), path = "")) }
 }

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -7,6 +7,7 @@ import java.net.URLDecoder
 import shapeless.HNil
 import scalaz.syntax.std.option._
 import org.http4s.util.CaseInsensitiveString._
+import org.http4s.{ Query => Q }
 
 private[parser] trait Rfc3986Parser { this: Parser =>
   import CharPredicate.{Alpha, Digit, HexDigit}
@@ -25,8 +26,9 @@ private[parser] trait Rfc3986Parser { this: Parser =>
   def UriReference = rule { Uri | RelativeRef }
 
   def AbsoluteUri = rule {
-    Scheme ~ ":" ~ HierPart ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) ~>
-      ((scheme, auth, path, query, fragment) => org.http4s.Uri(Some(scheme), auth, path, query, fragment))
+    Scheme ~ ":" ~ HierPart ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) ~> { (scheme, auth, path, query, fragment) =>
+      org.http4s.Uri(Some(scheme), auth, path, query.map(Q.fromString).getOrElse(Q.empty), fragment)
+    }
   }
 
   def RelativeRef = rule { RelativePart ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) }

--- a/core/src/main/scala/org/http4s/util/UrlFormCodec.scala
+++ b/core/src/main/scala/org/http4s/util/UrlFormCodec.scala
@@ -9,7 +9,7 @@ import scala.io.Codec
 
 object UrlFormCodec {
   def decode(formData: String, codec: Codec = Codec.UTF8): ParseResult[Map[String, Seq[String]]] =
-    QueryParser.parseQueryString(formData.replace("+", "%20"), codec).map(_.asMap)
+    QueryParser.parseQueryString(formData.replace("+", "%20"), codec).map(_.multiParams)
 
   def encode(formData: Map[String,Seq[String]]): String = {
     val sb = new StringBuilder(formData.size * 20)

--- a/core/src/main/scala/org/http4s/util/UrlFormCodec.scala
+++ b/core/src/main/scala/org/http4s/util/UrlFormCodec.scala
@@ -9,7 +9,7 @@ import scala.io.Codec
 
 object UrlFormCodec {
   def decode(formData: String, codec: Codec = Codec.UTF8): ParseResult[Map[String, Seq[String]]] =
-    QueryParser.parseQueryString(formData.replace("+", "%20"), codec).map(convert)
+    QueryParser.parseQueryString(formData.replace("+", "%20"), codec).map(_.asMap)
 
   def encode(formData: Map[String,Seq[String]]): String = {
     val sb = new StringBuilder(formData.size * 20)
@@ -29,9 +29,6 @@ object UrlFormCodec {
 
   private def formEncode(s: String): String =
     UrlCodingUtils.urlEncode(s, spaceIsPlus = true, toSkip = urlReserved)
-
-  private def convert(seq: Seq[(String,Option[String])]): Map[String,Seq[String]] =
-    seq.groupBy(_._1).mapValues(_.flatMap(_._2))
 
   private val urlReserved = BitSet((('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ "-_.~".toSet).map(_.toInt): _*)
 }

--- a/core/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/core/src/test/scala/org/http4s/Http4sSpec.scala
@@ -1,7 +1,6 @@
 package org.http4s
 
-import org.specs2.matcher.{AnyMatchers, Matcher}
-import org.specs2.reporter.SpecFailureAssertionFailedError
+import org.specs2.matcher.AnyMatchers
 import org.specs2.scalaz.{Spec, ScalazMatchers}
 
 /**

--- a/core/src/test/scala/org/http4s/QuerySpec.scala
+++ b/core/src/test/scala/org/http4s/QuerySpec.scala
@@ -88,6 +88,10 @@ class QuerySpec extends Http4sSpec {
       q2 must beAnInstanceOf[Query]
       q2.toList must_== q.toList.dropRight(1)
     }
+
+    "get a tail for non-empty Query" ! forAll { q: Query =>
+      (q.nonEmpty) ==> (q.tail.toList == q.toList.tail)
+    }
   }
 
 }

--- a/core/src/test/scala/org/http4s/QuerySpec.scala
+++ b/core/src/test/scala/org/http4s/QuerySpec.scala
@@ -1,0 +1,56 @@
+package org.http4s
+
+import org.specs2.mutable.Specification
+
+import Query.KV
+
+class QuerySpec extends Specification {
+
+  "Query" can {
+    val elem = KV("k", Some("v"))
+
+    "append a single Pair element" in {
+      val q = Query.empty :+ elem
+      q must beAnInstanceOf[Query]
+      q.length must_== 1
+      q.head must_== elem
+    }
+
+    "append a single other element" in {
+      val q = Query.empty :+ "cat"
+      q.length must_== 1
+      q.head must_== "cat"
+      q.isInstanceOf[Query] must_== false
+    }
+
+    "prepend a single Pair element" in {
+      val q = elem +: Query.empty
+      q must beAnInstanceOf[Query]
+      q.length must_== 1
+      q.head must_== elem
+    }
+
+    "prepend a single other element" in {
+      val q = "cat" +: Query.empty
+      q.length must_== 1
+      q.head must_== "cat"
+      q.isInstanceOf[Query] must_== false
+    }
+
+    "append many Pair elements" in {
+      val q = Query.empty ++ Seq(elem, elem)
+      q must beAnInstanceOf[Query]
+      q.length must_== 2
+      q must_== Seq(elem, elem)
+    }
+
+    "append many other elements" in {
+      val things = Seq("cat", "dog")
+      val q = Query.empty ++ things
+      q.isInstanceOf[Query] must_== false
+      q.length must_== 2
+      q must_== things
+    }
+  }
+
+}

--- a/core/src/test/scala/org/http4s/QuerySpec.scala
+++ b/core/src/test/scala/org/http4s/QuerySpec.scala
@@ -1,9 +1,16 @@
 package org.http4s
 
-import org.specs2.mutable.Specification
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
 
 
-class QuerySpec extends Specification {
+class QuerySpec extends Http4sSpec {
+
+  checkAll("Query parsing", new Properties("Query") {
+    property("fromString(query.toString) == query if query.nonEmpty") = forAll { query: Query =>
+      (query.nonEmpty) ==> (Query.fromString(query.toString) == query)
+    }
+  })
 
   "Query" can {
     val elem = ("k", Some("v"))

--- a/core/src/test/scala/org/http4s/QuerySpec.scala
+++ b/core/src/test/scala/org/http4s/QuerySpec.scala
@@ -6,56 +6,87 @@ import org.scalacheck.Properties
 
 class QuerySpec extends Http4sSpec {
 
-  checkAll("Query parsing", new Properties("Query") {
-    property("fromString(query.toString) == query if query.nonEmpty") = forAll { query: Query =>
-      (query.nonEmpty) ==> (Query.fromString(query.toString) == query)
+  import Query.KeyValue
+
+  "fromString(query.toString) == query if query.nonEmpty" ! forAll { query: Query =>
+    (query.nonEmpty) ==> (Query.fromString(query.toString) == query)
+  }
+
+  "Query Builder" can {
+    "build a query from a Query" ! forAll { query: Query =>
+      val b = Query.newBuilder
+      query.foreach(b.+=)
+      b.result() must_== query
     }
-  })
+
+    "build a query from a Seq" ! forAll { elems: Seq[KeyValue] =>
+      val q = (Query.newBuilder ++= elems).result()
+      q must beAnInstanceOf[Query]
+      q.toSeq must_== elems
+    }
+  }
 
   "Query" can {
     val elem = ("k", Some("v"))
 
-    "append a single Pair element" in {
-      val q = Query.empty :+ elem
-      q must beAnInstanceOf[Query]
-      q.length must_== 1
-      q.head must_== elem
+    "append a query param" ! forAll { (p: KeyValue, q: Query) =>
+      val q2 = q :+ p
+      q2 must beAnInstanceOf[Query]
+      q2.length must_== q.length + 1
+      q2.last must_== p
+      q2.toList must_== (q.toList :+ p)
+
     }
 
-    "append a single other element" in {
-      val q = Query.empty :+ "cat"
-      q.length must_== 1
-      q.head must_== "cat"
-      q.isInstanceOf[Query] must_== false
+    "append a single other element" ! forAll { (s: String, q: Query) =>
+      val q2 = q :+ s
+      q2.isInstanceOf[Query] must_== false
+      q2.length must_== q.length + 1
+      q2.last must_== s
+      q2.toList must_==(q.toList :+ s)
     }
 
-    "prepend a single Pair element" in {
-      val q = elem +: Query.empty
-      q must beAnInstanceOf[Query]
-      q.length must_== 1
-      q.head must_== elem
+    "prepend a single Pair element" ! forAll { (q: Query, elem: KeyValue) =>
+      val q2 = elem +: q
+      q2.length must_== q.length + 1
+      q2 must beAnInstanceOf[Query]
+      q2.head must_== elem
+      q2.toList must_==(elem::q.toList)
+
     }
 
-    "prepend a single other element" in {
-      val q = "cat" +: Query.empty
-      q.length must_== 1
-      q.head must_== "cat"
-      q.isInstanceOf[Query] must_== false
+    "prepend a single other element" ! forAll { (q: Query, elem: String) =>
+      val q2 = elem +: q
+      q2.length must_== q.length + 1
+      q2.head must_== elem
+      q2.isInstanceOf[Query] must_== false
+      q2.toList must_==(elem::q.toList)
     }
 
-    "append many Pair elements" in {
-      val q = Query.empty ++ Seq(elem, elem)
-      q must beAnInstanceOf[Query]
-      q.length must_== 2
-      q must_== Seq(elem, elem)
+    "append many KeyValue elements" ! forAll { (q: Query, elems: Seq[KeyValue]) =>
+      val q2 = q ++ elems
+      q2 must beAnInstanceOf[Query]
+      q2.length must_== q.length + elems.length
+      q2.toList must_== (q.toList ::: elems.toList)
     }
 
-    "append many other elements" in {
-      val things = Seq("cat", "dog")
-      val q = Query.empty ++ things
-      q.isInstanceOf[Query] must_== false
-      q.length must_== 2
-      q must_== things
+    "append many other elements" ! forAll { (q: Query, elems: Seq[String]) =>
+      val q2 = q ++ elems
+      q2.isInstanceOf[Query] must_== false
+      q2.length must_== q.length + elems.length
+      q2.toList must_== (q.toList ::: elems.toList)
+    }
+
+    "Drop a head element" ! forAll { q: Query =>
+      val q2 = q.drop(1)
+      q2 must beAnInstanceOf[Query]
+      q2.toList must_== q.toList.drop(1)
+    }
+
+    "Drop a tail element" ! forAll { q: Query =>
+      val q2 = q.dropRight(1)
+      q2 must beAnInstanceOf[Query]
+      q2.toList must_== q.toList.dropRight(1)
     }
   }
 

--- a/core/src/test/scala/org/http4s/QuerySpec.scala
+++ b/core/src/test/scala/org/http4s/QuerySpec.scala
@@ -2,12 +2,11 @@ package org.http4s
 
 import org.specs2.mutable.Specification
 
-import Query.KV
 
 class QuerySpec extends Specification {
 
   "Query" can {
-    val elem = KV("k", Some("v"))
+    val elem = ("k", Some("v"))
 
     "append a single Pair element" in {
       val q = Query.empty :+ elem

--- a/core/src/test/scala/org/http4s/TestInstances.scala
+++ b/core/src/test/scala/org/http4s/TestInstances.scala
@@ -67,7 +67,7 @@ trait TestInstances {
     Arbitrary { for {
       n <- Gen.size
       vs <- containerOfN[Vector, (String, Option[String])](n % 8, arbitraryQueryParam.arbitrary)
-    } yield Query.fromOptions(vs:_*) }
+    } yield Query(vs:_*) }
 
   implicit val arbitraryHttpVersion: Arbitrary[HttpVersion] =
     Arbitrary { for {

--- a/core/src/test/scala/org/http4s/TestInstances.scala
+++ b/core/src/test/scala/org/http4s/TestInstances.scala
@@ -67,7 +67,7 @@ trait TestInstances {
     Arbitrary { for {
       n <- Gen.size
       vs <- containerOfN[Vector, (String, Option[String])](n % 8, arbitraryQueryParam.arbitrary)
-    } yield Query(vs) }
+    } yield Query.fromOptions(vs:_*) }
 
   implicit val arbitraryHttpVersion: Arbitrary[HttpVersion] =
     Arbitrary { for {

--- a/core/src/test/scala/org/http4s/TestInstances.scala
+++ b/core/src/test/scala/org/http4s/TestInstances.scala
@@ -46,7 +46,7 @@ trait TestInstances {
     val reserved    = Seq('/', '?', ':', '@', '$', ',')
     val unreserved  =  alphanum ++ mark
 
-    val droppsed = Seq(';', '&', '=', '+')
+    //val droppsed = Seq(';', '&', '=', '+') // Not valid in a query key or value, must be % encoded
     (reserved ++ unreserved).toVector
   }
 

--- a/core/src/test/scala/org/http4s/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/UriSpec.scala
@@ -510,23 +510,23 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
     }
     "replace a parameter" in {
       val u = Uri(query = Query.fromString("param1=value&param2=value")) +? ("param1", "newValue")
-      u must be_==(Uri(query = Query.fromString("param1=newValue&param2=value")))
+      u.multiParams must be_==(Uri(query = Query.fromString("param1=newValue&param2=value")).multiParams)
     }
     "replace a parameter without a value" in {
       val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2=value")) +? ("param2")
-      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
+      u.multiParams must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace the same parameter" in {
       val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) +? ("param1", Seq("value1", "value2"))
-      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
+      u.multiParams must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace the same parameter without a value" in {
       val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) +? ("param2")
-      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
+      u.multiParams must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace a parameter set" in {
       val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param1", "value")
-      u must be_==(Uri(query = Query.fromString("param1=value")))
+      u.multiParams must be_==(Uri(query = Query.fromString("param1=value")).multiParams)
     }
     "set a parameter with a value" in {
       val ps = Map("param" -> List("value"))

--- a/core/src/test/scala/org/http4s/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/UriSpec.scala
@@ -73,7 +73,8 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
 
     "Handle queries with no spaces properly" in {
       getQueryParams("http://localhost:8080/blah?x=abc&y=ijk") should_== Map("x" -> "abc", "y" -> "ijk")
-      getQueryParams("http://localhost:8080/blah?") should_== Map.empty
+      getQueryParams("http://localhost:8080/blah?") should_== Map("" -> "")
+      getQueryParams("http://localhost:8080/blah") should_== Map.empty
     }
 
     "Handle queries with spaces properly" in {
@@ -237,7 +238,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
 
   "Uri parameters" should {
     "parse empty query string" in {
-      Uri(query = Query.fromString("")).multiParams must be_==(Map.empty)
+      Uri(query = Query.fromString("")).multiParams must be_==(Map("" -> Nil))
     }
     "parse parameter without key but with empty value" in {
       Uri(query = Query.fromString("=")).multiParams must be_==(Map("" -> List("")))
@@ -309,8 +310,9 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       }
     }
     "work on empty list" in {
-      foreach (Uri(query = Query.fromString("")).params.iterator) { i =>
-        throw new Error(s"should not have $i") // should not happen
+      foreach (Uri(query = Query.fromString("")).params.iterator) { case (k,v) =>
+        k must_== ""
+        v must_== ""
       }
     }
     "work with empty keys" in {

--- a/core/src/test/scala/org/http4s/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/UriSpec.scala
@@ -23,7 +23,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
 
   "Uri" should {
     "Not UrlDecode the query String" in {
-      getUri("http://localhost:8080/blah?x=abc&y=ijk").query should_== Some("x=abc&y=ijk")
+      getUri("http://localhost:8080/blah?x=abc&y=ijk").query should_== Query.fromPairs("x"->"abc", "y"->"ijk")
     }
 
     "Not UrlDecode the uri fragment" in {
@@ -62,7 +62,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
   "Uri's with a query and fragment" should {
     "parse propperly" in {
       val uri = getUri("http://localhost:8080/blah?x=abc#y=ijk")
-      uri.query should_== Some("x=abc")
+      uri.query should_== Query.fromPairs("x"->"abc")
       uri.fragment should_== Some("y=ijk")
     }
   }
@@ -99,13 +99,13 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       } yield (f + "::" + b))
 
       foreach (variants) { s =>
-        Uri(Some("http".ci), Some(Authority(host = IPv6(s.ci))), "/foo", Some("bar=baz")).toString must_==
+        Uri(Some("http".ci), Some(Authority(host = IPv6(s.ci))), "/foo", Query.fromPairs("bar" -> "baz")).toString must_==
           (s"http://[$s]/foo?bar=baz")
       }
     }
 
     "render URL with parameters" in {
-      Uri(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci))), "/foo", Some("bar=baz")).toString must_==("http://www.foo.com/foo?bar=baz")
+      Uri(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci))), "/foo", Query.fromPairs("bar" -> "baz")).toString must_==("http://www.foo.com/foo?bar=baz")
     }
 
     "render URL with port" in {
@@ -117,7 +117,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
     }
 
     "render IPv4 URL with parameters" in {
-      Uri(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci), port = Some(80))), "/c", Some("GB=object&Class=one")).toString must_==("http://192.168.1.1:80/c?GB=object&Class=one")
+      Uri(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci), port = Some(80))), "/c", Query.fromPairs("GB"->"object","Class"->"one")).toString must_==("http://192.168.1.1:80/c?GB=object&Class=one")
     }
 
     "render IPv4 URL with port" in {
@@ -129,7 +129,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
     }
 
     "render IPv6 URL with parameters" in {
-      Uri(Some("http".ci), Some(Authority(host = IPv6("2001:db8::7".ci))), "/c", Some("GB=object&Class=one")).toString must_==("http://[2001:db8::7]/c?GB=object&Class=one")
+      Uri(Some("http".ci), Some(Authority(host = IPv6("2001:db8::7".ci))), "/c", Query.fromPairs("GB"->"object","Class"->"one")).toString must_==("http://[2001:db8::7]/c?GB=object&Class=one")
     }
 
     "render IPv6 URL with port" in {
@@ -145,23 +145,23 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
     }
 
     "render an URL with username and password" in {
-      Uri(Some("http".ci), Some(Authority(Some("username:password"), RegName("some.example.com"), None)), "/", None, None).toString must_==("http://username:password@some.example.com")
+      Uri(Some("http".ci), Some(Authority(Some("username:password"), RegName("some.example.com"), None)), "/", Query.empty, None).toString must_==("http://username:password@some.example.com")
     }
 
     "render an URL with username and password, path and params" in {
-      Uri(Some("http".ci), Some(Authority(Some("username:password"), RegName("some.example.com"), None)), "/some/path", Some("param1=5&param-without-value"), None).toString  must_==("http://username:password@some.example.com/some/path?param1=5&param-without-value")
+      Uri(Some("http".ci), Some(Authority(Some("username:password"), RegName("some.example.com"), None)), "/some/path", Query.fromString("param1=5&param-without-value"), None).toString  must_==("http://username:password@some.example.com/some/path?param1=5&param-without-value")
     }
 
     "render relative URI with empty query string" in {
-      Uri(path = "/", query = Some(""), fragment = None).toString must_==("/?")
+      Uri(path = "/", query = Query.fromString(""), fragment = None).toString must_==("/?")
     }
 
     "render relative URI with empty query string and fragment" in {
-      Uri(path = "/", query = Some(""), fragment = Some("")).toString must_==("/?#")
+      Uri(path = "/", query = Query.fromString(""), fragment = Some("")).toString must_==("/?#")
     }
 
     "render relative URI with empty fragment" in {
-      Uri(path = "/", query = None, fragment = Some("")).toString must_== ("/#")
+      Uri(path = "/", query = Query.empty, fragment = Some("")).toString must_== ("/#")
     }
 
     "render relative path with fragment" in {
@@ -169,11 +169,11 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
     }
 
     "render relative path with parameters" in {
-      Uri(path = "/foo/bar", query = Some("foo=bar&ding=dong")).toString must_==("/foo/bar?foo=bar&ding=dong")
+      Uri(path = "/foo/bar", query = Query.fromString("foo=bar&ding=dong")).toString must_==("/foo/bar?foo=bar&ding=dong")
     }
 
     "render relative path with parameters and fragment" in {
-      Uri(path = "/foo/bar", query = Some("foo=bar&ding=dong"), fragment = Some("an_anchor")).toString must_==("/foo/bar?foo=bar&ding=dong#an_anchor")
+      Uri(path = "/foo/bar", query = Query.fromString("foo=bar&ding=dong"), fragment = Some("an_anchor")).toString must_==("/foo/bar?foo=bar&ding=dong#an_anchor")
     }
 
     "render relative path without parameters" in {
@@ -185,11 +185,11 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
     }
 
     "render a query string with a single param" in {
-      Uri(query = Some("param1=test")).toString must_==("/?param1=test")
+      Uri(query = Query.fromString("param1=test")).toString must_==("/?param1=test")
     }
 
     "render a query string with multiple value in a param" in {
-      Uri(query = Some("param1=3&param2=2&param2=foo")).toString must_==("/?param1=3&param2=2&param2=foo")
+      Uri(query = Query.fromString("param1=3&param2=2&param2=foo")).toString must_==("/?param1=3&param2=2&param2=foo")
     }
 
     "round trip over URI examples from wikipedia" in {
@@ -237,31 +237,31 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
 
   "Uri parameters" should {
     "parse empty query string" in {
-      Uri(query = Some("")).multiParams must be_==(Map.empty)
+      Uri(query = Query.fromString("")).multiParams must be_==(Map.empty)
     }
     "parse parameter without key but with empty value" in {
-      Uri(query = Some("=")).multiParams must be_==(Map("" -> List("")))
+      Uri(query = Query.fromString("=")).multiParams must be_==(Map("" -> List("")))
     }
     "parse parameter without key but with value" in {
-      Uri(query = Some("=value")).multiParams must be_==(Map("" -> List("value")))
+      Uri(query = Query.fromString("=value")).multiParams must be_==(Map("" -> List("value")))
     }
     "parse single parameter with empty value" in {
-      Uri(query = Some("param1=")).multiParams must be_==(Map("param1" -> List("")))
+      Uri(query = Query.fromString("param1=")).multiParams must be_==(Map("param1" -> List("")))
     }
     "parse single parameter with value" in {
-      Uri(query = Some("param1=value")).multiParams must be_==(Map("param1" -> List("value")))
+      Uri(query = Query.fromString("param1=value")).multiParams must be_==(Map("param1" -> List("value")))
     }
     "parse single parameter without value" in {
-      Uri(query = Some("param1")).multiParams must be_==(Map("param1" -> Nil))
+      Uri(query = Query.fromString("param1")).multiParams must be_==(Map("param1" -> Nil))
     }
     "parse many parameter with value" in {
-      Uri(query = Some("param1=value&param2=value1&param2=value2&param3=value")).multiParams must_==(Map(
+      Uri(query = Query.fromString("param1=value&param2=value1&param2=value2&param3=value")).multiParams must_==(Map(
         "param1" -> List("value"),
         "param2" -> List("value1", "value2"),
         "param3" -> List("value")))
     }
     "parse many parameter without value" in {
-      Uri(query = Some("param1&param2&param3")).multiParams must_==(Map(
+      Uri(query = Query.fromString("param1&param2&param3")).multiParams must_==(Map(
         "param1" -> Nil,
         "param2" -> Nil,
         "param3" -> Nil))
@@ -270,57 +270,57 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
 
   "Uri.params.+" should {
     "add parameter to empty query" in {
-      val i = Uri(query = None).params + (("param", Seq("value")))
+      val i = Uri(query = Query.empty).params + (("param", Seq("value")))
       i must be_==(Map("param" -> Seq("value")))
     }
     "add parameter" in {
-      val i = Uri(query = Some("param1")).params + (("param2", Seq()))
+      val i = Uri(query = Query.fromString("param1")).params + (("param2", Seq()))
       i must be_==(Map("param1" -> Seq(), "param2" -> Seq()))
     }
     "replace an existing parameter" in {
-      val i = Uri(query = Some("param=value")).params + (("param", Seq("value1", "value2")))
+      val i = Uri(query = Query.fromString("param=value")).params + (("param", Seq("value1", "value2")))
       i must be_==(Map("param" -> Seq("value1", "value2")))
     }
     "replace an existing parameter with empty value" in {
-      val i = Uri(query = Some("param=value")).params + (("param", Seq()))
+      val i = Uri(query = Query.fromString("param=value")).params + (("param", Seq()))
       i must be_==(Map("param" -> Seq()))
     }
   }
 
   "Uri.params.-" should {
     "not do anything on an URI without a query" in {
-      val i = Uri(query = None).params - "param"
+      val i = Uri(query = Query.empty).params - "param"
       i must be_==(Map())
     }
     "not reduce a map if parameter does not match" in {
-      val i = Uri(query = Some("param1")).params - "param2"
+      val i = Uri(query = Query.fromString("param1")).params - "param2"
       i must be_==(Map("param1" -> ""))
     }
     "reduce a map if matching parameter found" in {
-      val i = Uri(query = Some("param")).params - "param"
+      val i = Uri(query = Query.fromString("param")).params - "param"
       i must be_==(Map())
     }
   }
 
   "Uri.params.iterate" should {
     "work on an URI without a query" in {
-      foreach (Uri(query = None).params.iterator) { i =>
+      foreach (Uri(query = Query.empty).params.iterator) { i =>
         throw new Error(s"should not have $i") // should not happen
       }
     }
     "work on empty list" in {
-      foreach (Uri(query = Some("")).params.iterator) { i =>
+      foreach (Uri(query = Query.fromString("")).params.iterator) { i =>
         throw new Error(s"should not have $i") // should not happen
       }
     }
     "work with empty keys" in {
-      val u = Uri(query = Some("=value1&=value2&=&"))
+      val u = Uri(query = Query.fromString("=value1&=value2&=&"))
       val i = u.params.iterator
       i.next must be_==("" -> "value1")
       i.next must throwA [NoSuchElementException]
     }
     "work on non-empty query string" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param1=value3&param2=value4&param2=value5"))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param1=value3&param2=value4&param2=value5"))
       val i = u.params.iterator
       i.next must be_==("param1" -> "value1")
       i.next must be_==("param2" -> "value4")
@@ -330,14 +330,14 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
 
   "Uri.multiParams" should {
     "find first value of parameter with many values" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param1=value3&param2=value4&param2=value5"))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param1=value3&param2=value4&param2=value5"))
       u.multiParams must be_==(
         Map(
           "param1" -> Seq("value1", "value2", "value3"),
           "param2" -> Seq("value4", "value5")))
     }
     "find parameter with empty key and a value" in {
-      val u = Uri(query = Some("param1=&=value-of-empty-key&param2=value"))
+      val u = Uri(query = Query.fromString("param1=&=value-of-empty-key&param2=value"))
       u.multiParams must be_==(
         Map(
           "" -> Seq("value-of-empty-key"),
@@ -345,30 +345,30 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
           "param2" -> Seq("value")))
     }
     "find first value of parameter with empty key" in {
-      Uri(query = Some("=value1&=value2")).multiParams must_== (
+      Uri(query = Query.fromString("=value1&=value2")).multiParams must_== (
         Map("" -> Seq("value1", "value2")))
-      Uri(query = Some("&=value1&=value2")).multiParams must_== (
+      Uri(query = Query.fromString("&=value1&=value2")).multiParams must_== (
         Map("" -> Seq("value1", "value2")))
-      Uri(query = Some("&&&=value1&&&=value2&=&")).multiParams must_== (
+      Uri(query = Query.fromString("&&&=value1&&&=value2&=&")).multiParams must_== (
         Map("" -> Seq("value1", "value2", "")))
     }
     "find parameter with empty key and without value" in {
-      Uri(query = Some("&")).multiParams must_==(Map("" -> Seq()))
-      Uri(query = Some("&&")).multiParams must_==(Map("" -> Seq()))
-      Uri(query = Some("&&&")).multiParams must_==(Map("" -> Seq()))
+      Uri(query = Query.fromString("&")).multiParams must_==(Map("" -> Seq()))
+      Uri(query = Query.fromString("&&")).multiParams must_==(Map("" -> Seq()))
+      Uri(query = Query.fromString("&&&")).multiParams must_==(Map("" -> Seq()))
     }
     "find parameter with an empty value" in {
-      Uri(query = Some("param1=")).multiParams must_==(Map("param1" -> Seq("")))
-      Uri(query = Some("param1=&param2=")).multiParams must_== (Map("param1" -> Seq(""), "param2" -> Seq("")))
+      Uri(query = Query.fromString("param1=")).multiParams must_==(Map("param1" -> Seq("")))
+      Uri(query = Query.fromString("param1=&param2=")).multiParams must_== (Map("param1" -> Seq(""), "param2" -> Seq("")))
     }
     "find parameter with single value" in {
-      Uri(query = Some("param1=value1&param2=value2")).multiParams must_==(
+      Uri(query = Query.fromString("param1=value1&param2=value2")).multiParams must_==(
         Map(
           "param1" -> Seq("value1"),
           "param2" -> Seq("value2")))
     }
     "find parameter without value" in {
-      Uri(query = Some("param1&param2&param3")).multiParams must_==(
+      Uri(query = Query.fromString("param1&param2&param3")).multiParams must_==(
         Map(
           "param1" -> Seq(),
           "param2" -> Seq(),
@@ -378,201 +378,201 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
 
   "Uri.params.get" should {
     "find first value of parameter with many values" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param1=value3&param2=value4&param2=value5"))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param1=value3&param2=value4&param2=value5"))
       u.params.get("param1") must be_==(Some("value1"))
       u.params.get("param2") must be_==(Some("value4"))
     }
     "find parameter with empty key and a value" in {
-      val u = Uri(query = Some("param1=&=valueWithEmptyKey&param2=value2"))
+      val u = Uri(query = Query.fromString("param1=&=valueWithEmptyKey&param2=value2"))
       u.params.get("") must be_==(Some("valueWithEmptyKey"))
     }
     "find first value of parameter with empty key" in {
-      Uri(query = Some("=value1&=value2")).params.get("") must be_==(Some("value1"))
-      Uri(query = Some("&=value1&=value2")).params.get("") must be_==(Some("value1"))
-      Uri(query = Some("&&&=value1")).params.get("") must be_==(Some("value1"))
+      Uri(query = Query.fromString("=value1&=value2")).params.get("") must be_==(Some("value1"))
+      Uri(query = Query.fromString("&=value1&=value2")).params.get("") must be_==(Some("value1"))
+      Uri(query = Query.fromString("&&&=value1")).params.get("") must be_==(Some("value1"))
     }
     "find parameter with empty key and without value" in {
-      Uri(query = Some("&")).params.get("") must be_==(None)
-      Uri(query = Some("&&")).params.get("") must be_==(None)
-      Uri(query = Some("&&&")).params.get("") must be_==(None)
+      Uri(query = Query.fromString("&")).params.get("") must be_==(None)
+      Uri(query = Query.fromString("&&")).params.get("") must be_==(None)
+      Uri(query = Query.fromString("&&&")).params.get("") must be_==(None)
     }
     "find parameter with an empty value" in {
-      val u = Uri(query = Some("param1=&param2=value2"))
+      val u = Uri(query = Query.fromString("param1=&param2=value2"))
       u.params.get("param1") must be_==(Some(""))
     }
     "find parameter with single value" in {
-      val u = Uri(query = Some("param1=value1&param2=value2"))
+      val u = Uri(query = Query.fromString("param1=value1&param2=value2"))
       u.params.get("param1") must be_==(Some("value1"))
       u.params.get("param2") must be_==(Some("value2"))
     }
     "find parameter without value" in {
-      val u = Uri(query = Some("param1&param2&param3"))
+      val u = Uri(query = Query.fromString("param1&param2&param3"))
       u.params.get("param1") must be_==(None)
       u.params.get("param2") must be_==(None)
       u.params.get("param3") must be_==(None)
     }
     "not find an unknown parameter" in {
-      Uri(query = Some("param1&param2&param3")).params.get("param4") must be_==(None)
+      Uri(query = Query.fromString("param1&param2&param3")).params.get("param4") must be_==(None)
     }
     "not find anything if query string is empty" in {
-      Uri(query = None).params.get("param1") must be_==(None)
+      Uri(query = Query.empty).params.get("param1") must be_==(None)
     }
   }
 
   "Uri parameter convenience methods" should {
     "add a parameter if no query is available" in {
-      val u = Uri(query = None) +? ("param1", "value")
-      u must be_==(Uri(query = Some("param1=value")))
+      val u = Uri(query = Query.empty) +? ("param1", "value")
+      u must be_==(Uri(query = Query.fromString("param1=value")))
     }
     "add a parameter" in {
-      val u = Uri(query = Some("param1=value1&param1=value2")) +? ("param2", "value")
-      u must be_==(Uri(query = Some("param1=value1&param1=value2&param2=value")))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2", "value")
+      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2=value")))
     }
     "add a parameter with boolean value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2")) +? ("param2", true)
-      u must be_==(Uri(query = Some("param1=value1&param1=value2&param2=true")))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2", true)
+      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2=true")))
     }
     "add a parameter without a value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2")) +? ("param2")
-      u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2")
+      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
     }
     "add a parameter with many values" in {
       val u = Uri() +? ("param1", Seq("value1", "value2"))
-      u must be_==(Uri(query = Some("param1=value1&param1=value2")))
+      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2")))
     }
     "add a parameter with many long values" in {
       val u = Uri() +? ("param1", Seq(1L, -1L))
-      u must be_==(Uri(query = Some(s"param1=1&param1=-1")))
+      u must be_==(Uri(query = Query.fromString(s"param1=1&param1=-1")))
     }
     "add a query parameter with a QueryParamEncoder" in {
       val u = Uri() +? ("test", Ttl(2))
-      u must be_==(Uri(query = Some(s"test=2")))
+      u must be_==(Uri(query = Query.fromString(s"test=2")))
     }
     "add a query parameter with a QueryParamEncoder and an implicit key" in {
       val u = Uri() +*? (Ttl(2))
-      u must be_==(Uri(query = Some(s"ttl=2")))
+      u must be_==(Uri(query = Query.fromString(s"ttl=2")))
     }
     "Work with queryParam" in {
       val u = Uri().withQueryParam[Ttl]
-      u must be_==(Uri(query = Some(s"ttl")))
+      u must be_==(Uri(query = Query.fromString(s"ttl")))
     }
     "add an optional query parameter (Just)" in {
       val u = Uri() +?? ("param1", Maybe.just(2))
-      u must be_==(Uri(query = Some(s"param1=2")))
+      u must be_==(Uri(query = Query.fromString(s"param1=2")))
     }
     "add an optional query parameter (Empty)" in {
       val u = Uri() +?? ("param1", Maybe.empty[Int])
-      u must be_==(Uri(query = None))
+      u must be_==(Uri(query = Query.empty))
     }
     "contains not a parameter" in {
-      Uri(query = None) ? "param1" must be_==(false)
+      Uri(query = Query.empty) ? "param1" must be_==(false)
     }
     "contains an empty parameter" in {
-      Uri(query = Some("")) ? "" must be_==(true)
-      Uri(query = Some("")) ? "param" must be_==(false)
-      Uri(query = Some("&&=value&&")) ? "" must be_==(true)
-      Uri(query = Some("&&=value&&")) ? "param" must be_==(false)
+      Uri(query = Query.fromString("")) ? "" must be_==(true)
+      Uri(query = Query.fromString("")) ? "param" must be_==(false)
+      Uri(query = Query.fromString("&&=value&&")) ? "" must be_==(true)
+      Uri(query = Query.fromString("&&=value&&")) ? "param" must be_==(false)
     }
     "contains a parameter" in {
-      Uri(query = Some("param1=value&param1=value")) ? "param1" must be_==(true)
-      Uri(query = Some("param1=value&param2=value")) ? "param2" must be_==(true)
-      Uri(query = Some("param1=value&param2=value")) ? "param3" must be_==(false)
+      Uri(query = Query.fromString("param1=value&param1=value")) ? "param1" must be_==(true)
+      Uri(query = Query.fromString("param1=value&param2=value")) ? "param2" must be_==(true)
+      Uri(query = Query.fromString("param1=value&param2=value")) ? "param3" must be_==(false)
     }
     "contains a parameter with many values" in {
-      Uri(query = Some("param1=value1&param1=value2&param1=value3")) ? "param1" must be_==(true)
+      Uri(query = Query.fromString("param1=value1&param1=value2&param1=value3")) ? "param1" must be_==(true)
     }
     "contains a parameter without a value" in {
-      Uri(query = Some("param1")) ? "param1" must be_==(true)
+      Uri(query = Query.fromString("param1")) ? "param1" must be_==(true)
     }
     "contains with many parameters" in {
-      Uri(query = Some("param1=value1&param1=value2&param2&=value3")) ? "param1" must be_==(true)
-      Uri(query = Some("param1=value1&param1=value2&param2&=value3")) ? "param2" must be_==(true)
-      Uri(query = Some("param1=value1&param1=value2&param2&=value3")) ? "" must be_==(true)
-      Uri(query = Some("param1=value1&param1=value2&param2&=value3")) ? "param3" must be_==(false)
+      Uri(query = Query.fromString("param1=value1&param1=value2&param2&=value3")) ? "param1" must be_==(true)
+      Uri(query = Query.fromString("param1=value1&param1=value2&param2&=value3")) ? "param2" must be_==(true)
+      Uri(query = Query.fromString("param1=value1&param1=value2&param2&=value3")) ? "" must be_==(true)
+      Uri(query = Query.fromString("param1=value1&param1=value2&param2&=value3")) ? "param3" must be_==(false)
     }
     "remove a parameter if present" in {
-      val u = Uri(query = Some("param1=value&param2=value")) -? ("param1")
-      u must be_==(Uri(query = Some("param2=value")))
+      val u = Uri(query = Query.fromString("param1=value&param2=value")) -? ("param1")
+      u must be_==(Uri(query = Query.fromString("param2=value")))
     }
     "remove an empty parameter from an empty query string" in {
-      val u = Uri(query = Some("")) -? ("")
-      u must be_==(Uri(query = None))
+      val u = Uri(query = Query.fromString("")) -? ("")
+      u must be_==(Uri(query = Query.empty))
     }
     "remove nothing if parameter is not present" in {
-      val u = Uri(query = Some("param1=value&param2=value"))
+      val u = Uri(query = Query.fromString("param1=value&param2=value"))
       u -? ("param3") must be_==(u)
     }
     "remove the last parameter" in {
-      val u = Uri(query = Some("param1=value")) -? ("param1")
+      val u = Uri(query = Query.fromString("param1=value")) -? ("param1")
       u must be_==(Uri())
     }
     "replace a parameter" in {
-      val u = Uri(query = Some("param1=value&param2=value")) +? ("param1", "newValue")
-      u must be_==(Uri(query = Some("param1=newValue&param2=value")))
+      val u = Uri(query = Query.fromString("param1=value&param2=value")) +? ("param1", "newValue")
+      u must be_==(Uri(query = Query.fromString("param1=newValue&param2=value")))
     }
     "replace a parameter without a value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param2=value")) +? ("param2")
-      u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2=value")) +? ("param2")
+      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
     }
     "replace the same parameter" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param2")) +? ("param1", Seq("value1", "value2"))
-      u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) +? ("param1", Seq("value1", "value2"))
+      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
     }
     "replace the same parameter without a value" in {
-      val u = Uri(query = Some("param1=value1&param1=value2&param2")) +? ("param2")
-      u must be_==(Uri(query = Some("param1=value1&param1=value2&param2")))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) +? ("param2")
+      u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
     }
     "replace a parameter set" in {
-      val u = Uri(query = Some("param1=value1&param1=value2")) +? ("param1", "value")
-      u must be_==(Uri(query = Some("param1=value")))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param1", "value")
+      u must be_==(Uri(query = Query.fromString("param1=value")))
     }
     "set a parameter with a value" in {
       val ps = Map("param" -> List("value"))
-      Uri() =? ps must be_==(Uri(query = Some("param=value")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param=value")))
     }
     "set a parameter with a boolean values" in {
       val ps = Map("param" -> List(true, false))
-      Uri() =? ps must be_==(Uri(query = Some("param=true&param=false")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param=true&param=false")))
     }
     "set a parameter with a char values" in {
       val ps = Map("param" -> List('x', 'y'))
-      Uri() =? ps must be_==(Uri(query = Some("param=x&param=y")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param=x&param=y")))
     }
     "set a parameter with a double values" in {
       val ps = Map("param" -> List(1.2, 2.1))
-      Uri() =? ps must be_==(Uri(query = Some("param=1.2&param=2.1")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param=1.2&param=2.1")))
     }
     "set a parameter with a float values" in {
       val ps = Map("param" -> List(1.2F, 2.1F))
-      Uri() =? ps must be_==(Uri(query = Some("param=1.2&param=2.1")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param=1.2&param=2.1")))
     }
     "set a parameter with a integer values" in {
       val ps = Map("param" -> List(1, 2, 3))
-      Uri() =? ps must be_==(Uri(query = Some("param=1&param=2&param=3")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param=1&param=2&param=3")))
     }
     "set a parameter with a long values" in {
       val ps = Map("param" -> List(Long.MaxValue, 0L, Long.MinValue))
-      Uri() =? ps must be_==(Uri(query = Some("param=9223372036854775807&param=0&param=-9223372036854775808")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param=9223372036854775807&param=0&param=-9223372036854775808")))
     }
     "set a parameter with a short values" in {
       val ps = Map("param" -> List(Short.MaxValue, Short.MinValue))
-      Uri() =? ps must be_==(Uri(query = Some("param=32767&param=-32768")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param=32767&param=-32768")))
     }
     "set a parameter with a string values" in {
       val ps = Map("param" -> List("some", "none"))
-      Uri() =? ps must be_==(Uri(query = Some("param=some&param=none")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param=some&param=none")))
     }
     "set a parameter without a value" in {
       val ps: Map[String, List[String]] = Map("param" -> Nil)
-      Uri() =? ps must be_==(Uri(query = Some("param")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param")))
     }
     "set many parameters" in {
       val ps = Map("param1" -> Nil, "param2" -> List("value1", "value2"), "param3" -> List("value"))
-      Uri() =? ps must be_==(Uri(query = Some("param1&param2=value1&param2=value2&param3=value")))
+      Uri() =? ps must be_==(Uri(query = Query.fromString("param1&param2=value1&param2=value2&param3=value")))
     }
     "set the same parameters again" in {
       val ps = Map("param" -> List("value"))
-      val u = Uri(query = Some("param=value"))
+      val u = Uri(query = Query.fromString("param=value"))
       u =? ps must be_==(u =? ps)
     }
   }

--- a/core/src/test/scala/org/http4s/UriTemplateSpec.scala
+++ b/core/src/test/scala/org/http4s/UriTemplateSpec.scala
@@ -34,30 +34,30 @@ object UriTemplateSpec extends Specification {
       UriTemplate(path = List(VarExp("rel"))).toString must equalTo("{rel}")
     }
     "render /?ref={path,name}" in {
-      val query = Some(List(ParamVarExp("ref", "path", "name")))
+      val query = List(ParamVarExp("ref", "path", "name"))
       UriTemplate(query = query).toString must equalTo("/?ref={path,name}")
     }
     "render /here?ref={+path,name}" in {
-      val query = Some(List(ParamReservedExp("ref", "path", "name")))
+      val query = List(ParamReservedExp("ref", "path", "name"))
       UriTemplate(query = query).toString must equalTo("/?ref={+path,name}")
     }
     "render /here?ref={path}" in {
       val path = List(PathElm("here"))
-      val query = Some(List(ParamVarExp("ref", "path")))
+      val query = List(ParamVarExp("ref", "path"))
       UriTemplate(path = path, query = query).toString must equalTo("/here?ref={path}")
     }
     "render /here?ref={+path}" in {
       val path = List(PathElm("here"))
-      val query = Some(List(ParamReservedExp("ref", "path")))
+      val query = List(ParamReservedExp("ref", "path"))
       UriTemplate(path = path, query = query).toString must equalTo("/here?ref={+path}")
     }
     "render {somewhere}?ref={path}" in {
       val path = List(VarExp("somewhere"))
-      val query = Some(List(ParamVarExp("ref", "path")))
+      val query = List(ParamVarExp("ref", "path"))
       UriTemplate(path = path, query = query).toString must equalTo("{somewhere}?ref={path}")
     }
     "render /?ref={file,folder}" in {
-      val query = Some(List(ParamVarExp("ref", List("file", "folder"))))
+      val query = List(ParamVarExp("ref", List("file", "folder")))
       UriTemplate(query = query).toString must equalTo("/?ref={file,folder}")
     }
     "render /orders{/id}" in {
@@ -88,67 +88,67 @@ object UriTemplateSpec extends Specification {
     }
     "render /some{rel}/test{?id}" in {
       val path = List(PathElm("some"), VarExp("rel"), PathElm("test"))
-      val query = Some(List(ParamExp("id")))
+      val query = List(ParamExp("id"))
       UriTemplate(path = path, query = query).toString must equalTo("/some{rel}/test{?id}")
     }
     "render /item{?id}{&option}" in {
       val path = List(PathElm("item"))
-      val query = Some(List(ParamExp("id"), ParamContExp("option")))
+      val query = List(ParamExp("id"), ParamContExp("option"))
       UriTemplate(path = path, query = query).toString must equalTo("/item{?id}{&option}")
     }
     "render /items{?start,limit}" in {
       val path = List(PathElm("items"))
-      val query = Some(List(ParamExp("start", "limit")))
+      val query = List(ParamExp("start", "limit"))
       UriTemplate(path = path, query = query).toString must equalTo("/items{?start,limit}")
     }
     "render /items?start=0{&limit}" in {
       val path = List(PathElm("items"))
-      val query = Some(List(ParamElm("start", "0"), ParamContExp("limit")))
+      val query = List(ParamElm("start", "0"), ParamContExp("limit"))
       UriTemplate(path = path, query = query).toString must equalTo("/items?start=0{&limit}")
     }
     "render /?switch" in {
-      UriTemplate(path = Nil, query = Some(List(ParamElm("switch")))).toString must equalTo("/?switch")
+      UriTemplate(path = Nil, query = List(ParamElm("switch"))).toString must equalTo("/?switch")
     }
     "render /?some=" in {
-      UriTemplate(query = Some(List(ParamElm("some", "")))).toString must equalTo("/?some=")
+      UriTemplate(query = List(ParamElm("some", ""))).toString must equalTo("/?some=")
     }
     "render /{?id}" in {
-      UriTemplate(query = Some(List(ParamExp("id")))).toString must equalTo("/{?id}")
-      UriTemplate(query = Some(List(ParamExp("id")))).toString must equalTo("/{?id}")
+      UriTemplate(query = List(ParamExp("id"))).toString must equalTo("/{?id}")
+      UriTemplate(query = List(ParamExp("id"))).toString must equalTo("/{?id}")
     }
     "render /test{?id}" in {
       val path = List(PathElm("test"))
-      val query = Some(List(ParamExp("id")))
+      val query = List(ParamExp("id"))
       UriTemplate(path = path, query = query).toString must equalTo("/test{?id}")
     }
     "render /test{?start,limit}" in {
       val path = List(PathElm("test"))
-      val query = Some(List(ParamExp("start", "limit")))
+      val query = List(ParamExp("start", "limit"))
       UriTemplate(path = path, query = query).toString must equalTo("/test{?start,limit}")
     }
     "render /orders?id=1{&start,limit}" in {
       val path = List(PathElm("orders"))
-      val query = Some(List(ParamElm("id", "1"), ParamContExp("start", "limit")))
+      val query = List(ParamElm("id", "1"), ParamContExp("start", "limit"))
       UriTemplate(path = path, query = query).toString must equalTo("/orders?id=1{&start,limit}")
     }
     "render /orders?item=2&item=4{&start,limit}" in {
       val path = List(PathElm("orders"))
-      val query = Some(List(ParamExp("start", "limit"), ParamElm("item", List("2", "4"))))
+      val query = List(ParamExp("start", "limit"), ParamElm("item", List("2", "4")))
       UriTemplate(path = path, query = query).toString must equalTo("/orders?item=2&item=4{&start,limit}")
     }
     "render /orders?item=2&item=4{&start}{&limit}" in {
       val path = List(PathElm("orders"))
-      val query = Some(List(ParamExp("start"), ParamElm("item", List("2", "4")), ParamExp("limit")))
+      val query = List(ParamExp("start"), ParamElm("item", List("2", "4")), ParamExp("limit"))
       UriTemplate(path = path, query = query).toString must equalTo("/orders?item=2&item=4{&start}{&limit}")
     }
     "render /search?option{&term}" in {
       val path = List(PathElm("search"))
-      val query = Some(List(ParamExp("term"), ParamElm("option")))
+      val query = List(ParamExp("term"), ParamElm("option"))
       UriTemplate(path = path, query = query).toString must equalTo("/search?option{&term}")
     }
     "render /search?option={&term}" in {
       val path = List(PathElm("search"))
-      val query = Some(List(ParamExp("term"), ParamElm("option", "")))
+      val query = List(ParamExp("term"), ParamElm("option", ""))
       UriTemplate(path = path, query = query).toString must equalTo("/search?option={&term}")
     }
     "render /{#frg}" in {
@@ -165,13 +165,13 @@ object UriTemplateSpec extends Specification {
     }
     "render {path}/search{?term}{#section}" in {
       val path = List(VarExp("path"), PathElm("search"))
-      val query = Some(List(ParamExp("term")))
+      val query = List(ParamExp("term"))
       val fragment = Some(List(SimpleFragmentExp("section")))
       UriTemplate(path = path, query = query, fragment = fragment).toString must equalTo("{path}/search{?term}{#section}")
     }
     "render {+path}/search{?term}{#section}" in {
       val path = List(ReservedExp("path"), PathElm("search"))
-      val query = Some(List(ParamExp("term")))
+      val query = List(ParamExp("term"))
       val fragment = Some(List(SimpleFragmentExp("section")))
       UriTemplate(path = path, query = query, fragment = fragment).toString must equalTo("{+path}/search{?term}{#section}")
     }
@@ -184,22 +184,22 @@ object UriTemplateSpec extends Specification {
       UriTemplate(path = path).toString must equalTo("{+path}/here")
     }
     "render /?" in {
-      UriTemplate(query = Some(List()), fragment = None).toString must equalTo("/?")
+      UriTemplate(query = List(ParamElm("", Nil)), fragment = None).toString must equalTo("/?")
     }
     "render /?#" in {
       val fragment = Some(List(FragmentElm("")))
-      UriTemplate(query = Some(List()), fragment = fragment).toString must equalTo("/?#")
+      UriTemplate(query = List(ParamElm("", Nil)), fragment = fragment).toString must equalTo("/?#")
     }
     "render /#" in {
       val fragment = Some(List(FragmentElm("")))
-      UriTemplate(query = None, fragment = fragment).toString must equalTo("/#")
+      UriTemplate(query = Nil, fragment = fragment).toString must equalTo("/#")
     }
     "render http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/foo?bar=baz" in {
       val scheme = Some("http".ci)
       val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
-      val query = Some(List(ParamElm("bar", "baz")))
+      val query = List(ParamElm("bar", "baz"))
       UriTemplate(scheme, authority, path, query).toString must
         equalTo("http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/foo?bar=baz")
     }
@@ -208,7 +208,7 @@ object UriTemplateSpec extends Specification {
       val host = RegName("www.foo.com")
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
-      val query = Some(List(ParamElm("bar", "baz")))
+      val query = List(ParamElm("bar", "baz"))
       UriTemplate(scheme, authority, path, query).toString must
         equalTo("http://www.foo.com/foo?bar=baz")
     }
@@ -217,7 +217,7 @@ object UriTemplateSpec extends Specification {
       val host = RegName("www.foo.com".ci)
       val authority = Some(Authority(host = host, port = Some(80)))
       val path = Nil
-      val query = None
+      val query = Nil
       UriTemplate(scheme, authority, path, query).toString must
         equalTo("http://www.foo.com:80")
     }
@@ -233,16 +233,16 @@ object UriTemplateSpec extends Specification {
       val scheme = Some("http".ci)
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(host = host, port = Some(8080)))
-      val query = Some(List())
+      val query = List(ParamElm("", Nil))
       UriTemplate(scheme, authority, Nil, query).toString must equalTo("http://192.168.1.1:8080/?")
-      UriTemplate(scheme, authority, Nil, None).toString must equalTo("http://192.168.1.1:8080")
+      UriTemplate(scheme, authority, Nil, Nil).toString must equalTo("http://192.168.1.1:8080")
     }
     "render http://192.168.1.1:80/c?GB=object&Class=one" in {
       val scheme = Some("http".ci)
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(host = host, port = Some(80)))
       val path = List(PathElm("c"))
-      val query = Some(List(ParamElm("GB", "object"), ParamElm("Class", "one")))
+      val query = List(ParamElm("GB", "object"), ParamElm("Class", "one"))
       UriTemplate(scheme, authority, path, query).toString must
         equalTo("http://192.168.1.1:80/c?GB=object&Class=one")
     }
@@ -265,7 +265,7 @@ object UriTemplateSpec extends Specification {
       val host = IPv6("2001:db8::7".ci)
       val authority = Some(Authority(host = host))
       val path = List(PathElm("c"))
-      val query = Some(List(ParamElm("GB", "object"), ParamElm("Class", "one")))
+      val query = List(ParamElm("GB", "object"), ParamElm("Class", "one"))
       UriTemplate(scheme, authority, path, query).toString must
         equalTo("http://[2001:db8::7]/c?GB=object&Class=one")
     }
@@ -292,7 +292,7 @@ object UriTemplateSpec extends Specification {
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
       val path = List(PathElm("some"), PathElm("path"))
-      val query = Some(List(ParamElm("param1", "5"), ParamElm("param-without-value")))
+      val query = List(ParamElm("param1", "5"), ParamElm("param-without-value"))
       UriTemplate(scheme, authority, path, query).toString must
         equalTo("http://username:password@some.example.com/some/path?param1=5&param-without-value")
     }
@@ -328,49 +328,49 @@ object UriTemplateSpec extends Specification {
     }
     "convert /some/{rel}/test{?id} to UriTemplate" in {
       val path = List(PathElm("some"), VarExp("rel"), PathElm("test"))
-      val query = Some(List(ParamExp("id")))
+      val query = List(ParamExp("id"))
       val tpl = UriTemplate(path = path, query = query)
       tpl.toUriIfPossible.isFailure
     }
     "convert /?switch to Uri" in {
-      UriTemplate(query = Some(List(ParamElm("switch")))).toUriIfPossible.get must
+      UriTemplate(query = List(ParamElm("switch"))).toUriIfPossible.get must
         equalTo(Uri(path = "/", query = Query.fromString("switch")))
     }
     "convert /?switch=foo&switch=bar to Uri" in {
-      UriTemplate(query = Some(List(ParamElm("switch", List("foo", "bar"))))).toUriIfPossible.get must
+      UriTemplate(query = List(ParamElm("switch", List("foo", "bar")))).toUriIfPossible.get must
         equalTo(Uri(path = "/", query = Query.fromString("switch=foo&switch=bar")))
     }
     "convert /{?id} to UriTemplate" in {
-      val tpl = UriTemplate(query = Some(List(ParamExp("id"))))
+      val tpl = UriTemplate(query = List(ParamExp("id")))
       tpl.toUriIfPossible.isFailure
     }
     "convert /test{?id} to UriTemplate" in {
       val path = List(PathElm("test"))
-      val query = Some(List(ParamExp("id")))
+      val query = List(ParamExp("id"))
       val tpl = UriTemplate(path = path, query = query)
       tpl.toUriIfPossible.isFailure
     }
     "convert /test{?start,limit} to UriTemplate" in {
       val path = List(PathElm("test"))
-      val query = Some(List(ParamExp("start"), ParamExp("limit")))
+      val query = List(ParamExp("start"), ParamExp("limit"))
       val tpl = UriTemplate(path = path, query = query)
       tpl.toUriIfPossible.isFailure
     }
     "convert /orders?id=1{&start,limit} to UriTemplate" in {
       val path = List(PathElm("orders"))
-      val query = Some(List(ParamElm("id", "1"), ParamExp("start"), ParamExp("limit")))
+      val query = List(ParamElm("id", "1"), ParamExp("start"), ParamExp("limit"))
       val tpl = UriTemplate(path = path, query = query)
       tpl.toUriIfPossible.isFailure
     }
     "convert /orders?item=2&item=4{&start,limit} to UriTemplate" in {
       val path = List(PathElm("orders"))
-      val query = Some(List(ParamExp("start"), ParamElm("item", List("2", "4")), ParamExp("limit")))
+      val query = List(ParamExp("start"), ParamElm("item", List("2", "4")), ParamExp("limit"))
       val tpl = UriTemplate(path = path, query = query)
       tpl.toUriIfPossible.isFailure
     }
     "convert /search?option{&term} to UriTemplate" in {
       val path = List(PathElm("search"))
-      val query = Some(List(ParamExp("term"), ParamElm("option")))
+      val query = List(ParamExp("term"), ParamElm("option"))
       val tpl = UriTemplate(path = path, query = query)
       tpl.toUriIfPossible.isFailure
     }
@@ -391,25 +391,25 @@ object UriTemplateSpec extends Specification {
     }
     "convert {path}/search{?term}{#section} to UriTemplate" in {
       val path = List(VarExp("path"), PathElm("search"))
-      val query = Some(List(ParamExp("term")))
+      val query = List(ParamExp("term"))
       val fragment = Some(List(SimpleFragmentExp("section")))
       val tpl = UriTemplate(path = path, query = query, fragment = fragment)
       tpl.toUriIfPossible.isFailure
     }
     "convert {+path}/search{?term}{#section} to UriTemplate" in {
       val path = List(ReservedExp("path"), PathElm("search"))
-      val query = Some(List(ParamExp("term")))
+      val query = List(ParamExp("term"))
       val fragment = Some(List(SimpleFragmentExp("section")))
       val tpl = UriTemplate(path = path, query = query, fragment = fragment)
       tpl.toUriIfPossible.isFailure
     }
     "convert /? to Uri" in {
-      UriTemplate(query = Some(List()), fragment = None).toUriIfPossible.get must
+      UriTemplate(query = List(ParamElm("", Nil)), fragment = None).toUriIfPossible.get must
         equalTo(Uri(query = Query.fromString("")))
     }
     "convert /?# to Uri" in {
       val fragment = Some(List())
-      UriTemplate(query = Some(List()), fragment = fragment).toUriIfPossible.get must
+      UriTemplate(query = List(ParamElm("", Nil)), fragment = fragment).toUriIfPossible.get must
         equalTo(Uri(query = Query.fromString(""), fragment = Some("")))
     }
     "convert /# to Uri" in {
@@ -422,7 +422,7 @@ object UriTemplateSpec extends Specification {
       val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
       val authority = Some(Authority(host = host))
       val path = List(VarExp("rel"), PathElm("search"))
-      val query = Some(List(ParamExp("term")))
+      val query = List(ParamExp("term"))
       val fragment = Some(List(SimpleFragmentExp("section")))
       val tpl = UriTemplate(scheme, authority, path, query, fragment)
       tpl.toUriIfPossible.isFailure
@@ -432,7 +432,7 @@ object UriTemplateSpec extends Specification {
       val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
       val authority = Some(Authority(host = host, port = Some(8080)))
       val path = List(VarExp("rel"), PathElm("search"))
-      val query = Some(List(ParamExp("term")))
+      val query = List(ParamExp("term"))
       val fragment = Some(List(SimpleFragmentExp("section")))
       val tpl = UriTemplate(scheme, authority, path, query, fragment)
       tpl.toUriIfPossible.isFailure
@@ -442,7 +442,7 @@ object UriTemplateSpec extends Specification {
       val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
-      val query = Some(List(ParamElm("bar", List("baz"))))
+      val query = List(ParamElm("bar", List("baz")))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
         equalTo(Uri(scheme, authority, "/foo", Query.fromString("bar=baz")))
     }
@@ -451,7 +451,7 @@ object UriTemplateSpec extends Specification {
       val host = RegName("www.foo.com")
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
-      val query = Some(List(ParamElm("bar", "baz")))
+      val query = List(ParamElm("bar", "baz"))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
         equalTo(Uri(scheme, authority, "/foo", Query.fromString("bar=baz")))
     }
@@ -481,16 +481,16 @@ object UriTemplateSpec extends Specification {
       val scheme = Some("http".ci)
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(host = host, port = Some(8080)))
-      val query = Some(List())
+      val query = List(ParamElm("", Nil))
       UriTemplate(scheme, authority, Nil, query).toUriIfPossible.get must equalTo(Uri(scheme, authority, "/", Query.fromString("")))
-      UriTemplate(scheme, authority, Nil, None).toUriIfPossible.get must equalTo(Uri(scheme, authority, "/", Query.empty))
+      UriTemplate(scheme, authority, Nil, Nil).toUriIfPossible.get must equalTo(Uri(scheme, authority, "/", Query.empty))
     }
     "convert http://192.168.1.1:80/c?GB=object&Class=one to Uri" in {
       val scheme = Some("http".ci)
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(host = host, port = Some(80)))
       val path = List(PathElm("c"))
-      val query = Some(List(ParamElm("GB", "object"), ParamElm("Class", "one")))
+      val query = List(ParamElm("GB", "object"), ParamElm("Class", "one"))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
         equalTo(Uri(scheme, authority, "/c", Query.fromString("GB=object&Class=one")))
     }
@@ -499,7 +499,7 @@ object UriTemplateSpec extends Specification {
       val host = IPv6("2001:db8::7".ci)
       val authority = Some(Authority(host = host))
       val path = List(PathElm("c"))
-      val query = Some(List(ParamElm("GB", "object"), ParamElm("Class", "one")))
+      val query = List(ParamElm("GB", "object"), ParamElm("Class", "one"))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
         equalTo(Uri(scheme, authority, "/c", Query.fromString("GB=object&Class=one")))
     }
@@ -521,7 +521,7 @@ object UriTemplateSpec extends Specification {
       val scheme = Some("https".ci)
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
-      UriTemplate(scheme, authority, Nil, None, None).toUriIfPossible.get must
+      UriTemplate(scheme, authority, Nil, Nil, None).toUriIfPossible.get must
         equalTo(Uri(scheme, authority))
     }
     "convert http://username:password@some.example.com/some/path?param1=5&param-without-value to Uri" in {
@@ -529,7 +529,7 @@ object UriTemplateSpec extends Specification {
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
       val path = List(PathElm("some"), PathElm("path"))
-      val query = Some(List(ParamElm("param1", "5"), ParamElm("param-without-value")))
+      val query = List(ParamElm("param1", "5"), ParamElm("param-without-value"))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
         equalTo(Uri(scheme, authority, "/some/path", Query.fromString("param1=5&param-without-value")))
     }
@@ -538,7 +538,7 @@ object UriTemplateSpec extends Specification {
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
       val path = List(PathElm("some"), PathElm("path"))
-      val query = Some(List(ParamElm("param1", "5"), ParamElm("param-without-value")))
+      val query = List(ParamElm("param1", "5"), ParamElm("param-without-value"))
       val fragment = Some(List(FragmentElm("sec-1.2")))
       UriTemplate(scheme, authority, path, query, fragment).toUriIfPossible.get must
         equalTo(Uri(scheme, authority, "/some/path", Query.fromString("param1=5&param-without-value"), Some("sec-1.2")))
@@ -557,24 +557,24 @@ object UriTemplateSpec extends Specification {
         equalTo(UriTemplate(path = List(PathElm("123"))))
     }
     "expand /?ref={path} to /?ref=123" in {
-      val query = Some(List(ParamVarExp("ref", "path")))
+      val query = List(ParamVarExp("ref", "path"))
       UriTemplate(query = query).expandAny("path", "123") must
-        equalTo(UriTemplate(query = Some(List(ParamElm("ref", "123")))))
+        equalTo(UriTemplate(query = List(ParamElm("ref", "123"))))
     }
     "expand /?ref={file,folder} to /?ref=123&ref={folder}" in {
-      val query = Some(List(ParamVarExp("ref", List("file", "folder"))))
+      val query = List(ParamVarExp("ref", List("file", "folder")))
       UriTemplate(query = query).expandAny("file", "123") must
-        equalTo(UriTemplate(query = Some(List(ParamElm("ref", "123"), ParamVarExp("ref", "folder")))))
+        equalTo(UriTemplate(query = List(ParamElm("ref", "123"), ParamVarExp("ref", "folder"))))
     }
     "expand /?ref={+path} to /?ref=123" in {
-      val query = Some(List(ParamReservedExp("ref", "path")))
+      val query = List(ParamReservedExp("ref", "path"))
       UriTemplate(query = query).expandAny("path", "123") must
-        equalTo(UriTemplate(query = Some(List(ParamElm("ref", "123")))))
+        equalTo(UriTemplate(query = List(ParamElm("ref", "123"))))
     }
     "expand /?ref={+file,folder} to /?ref=123&ref={+folder}" in {
-      val query = Some(List(ParamReservedExp("ref", List("file", "folder"))))
+      val query = List(ParamReservedExp("ref", List("file", "folder")))
       UriTemplate(query = query).expandAny("file", "123") must
-        equalTo(UriTemplate(query = Some(List(ParamElm("ref", "123"), ParamReservedExp("ref", "folder")))))
+        equalTo(UriTemplate(query = List(ParamElm("ref", "123"), ParamReservedExp("ref", "folder"))))
     }
     "expand {/id} to /123" in {
       val path = List(PathExp("id"))
@@ -637,46 +637,46 @@ object UriTemplateSpec extends Specification {
   "UriTemplate.expandQuery" should {
     "expand /{?start} to /?start=123" in {
       val exp = ParamExp("start")
-      val query = Some(List(exp))
+      val query = List(exp)
       UriTemplate(query = query).expandQuery("start", 123) must
-        equalTo(UriTemplate(query = Some(List(ParamElm("start", "123")))))
+        equalTo(UriTemplate(query = List(ParamElm("start", "123"))))
     }
     "expand /{?switch} to /?switch" in {
-      val query = Some(List(ParamExp("switch")))
+      val query = List(ParamExp("switch"))
       UriTemplate(query = query).expandQuery("switch") must
-        equalTo(UriTemplate(query = Some(List(ParamElm("switch")))))
+        equalTo(UriTemplate(query = List(ParamElm("switch"))))
     }
     "expand /{?term} to /?term=" in {
-      val query = Some(List(ParamExp("term")))
+      val query = List(ParamExp("term"))
       UriTemplate(query = query).expandQuery("term", "") must
-        equalTo(UriTemplate(query = Some(List(ParamElm("term", List(""))))))
+        equalTo(UriTemplate(query = List(ParamElm("term", List("")))))
     }
     "expand /?={path} to /?=123" in {
-      val query = Some(List(ParamVarExp("", "path")))
+      val query = List(ParamVarExp("", "path"))
       UriTemplate(query = query).expandQuery("path", 123L) must
-        equalTo(UriTemplate(query = Some(List(ParamElm("", "123")))))
+        equalTo(UriTemplate(query = List(ParamElm("", "123"))))
     }
     "expand /?={path} to /?=25.1&=56.9" in {
-      val query = Some(List(ParamVarExp("", "path")))
+      val query = List(ParamVarExp("", "path"))
       UriTemplate(query = query).expandQuery("path", List(25.1F, 56.9F)) must
-        equalTo(UriTemplate(query = Some(List(ParamElm("", List("25.1", "56.9"))))))
+        equalTo(UriTemplate(query = List(ParamElm("", List("25.1", "56.9")))))
     }
     "expand /orders{?start} to /orders?start=123&start=456" in {
       val exp = ParamExp("start")
-      val query = Some(List(exp))
+      val query = List(exp)
       val path = List(PathElm("orders"))
       UriTemplate(path = path, query = query).expandQuery("start", List("123", "456")) must
-        equalTo(UriTemplate(path = path, query = Some(List(ParamElm("start", List("123", "456"))))))
+        equalTo(UriTemplate(path = path, query = List(ParamElm("start", List("123", "456")))))
     }
     "expand /orders{?start,limit} to UriTemplate /orders?start=123{&limit}" in {
       val start = ParamExp("start")
       val limit = ParamExp("limit")
       val path = List(PathElm("orders"))
-      UriTemplate(path = path, query = Some(List(start, limit))).expandQuery("start", List("123")) must
-        equalTo(UriTemplate(path = path, query = Some(List(ParamElm("start", "123"), limit))))
+      UriTemplate(path = path, query = List(start, limit)).expandQuery("start", List("123")) must
+        equalTo(UriTemplate(path = path, query = List(ParamElm("start", "123"), limit)))
     }
     "expand nothing" in {
-      val tpl = UriTemplate(query = Some(List(ParamExp("some"))))
+      val tpl = UriTemplate(query = List(ParamExp("some")))
       tpl.expandQuery("unknown") must equalTo(tpl)
     }
   }

--- a/core/src/test/scala/org/http4s/UriTemplateSpec.scala
+++ b/core/src/test/scala/org/http4s/UriTemplateSpec.scala
@@ -334,11 +334,11 @@ object UriTemplateSpec extends Specification {
     }
     "convert /?switch to Uri" in {
       UriTemplate(query = Some(List(ParamElm("switch")))).toUriIfPossible.get must
-        equalTo(Uri(path = "/", query = Some("switch")))
+        equalTo(Uri(path = "/", query = Query.fromString("switch")))
     }
     "convert /?switch=foo&switch=bar to Uri" in {
       UriTemplate(query = Some(List(ParamElm("switch", List("foo", "bar"))))).toUriIfPossible.get must
-        equalTo(Uri(path = "/", query = Some("switch=foo&switch=bar")))
+        equalTo(Uri(path = "/", query = Query.fromString("switch=foo&switch=bar")))
     }
     "convert /{?id} to UriTemplate" in {
       val tpl = UriTemplate(query = Some(List(ParamExp("id"))))
@@ -405,12 +405,12 @@ object UriTemplateSpec extends Specification {
     }
     "convert /? to Uri" in {
       UriTemplate(query = Some(List()), fragment = None).toUriIfPossible.get must
-        equalTo(Uri(query = Some("")))
+        equalTo(Uri(query = Query.fromString("")))
     }
     "convert /?# to Uri" in {
       val fragment = Some(List())
       UriTemplate(query = Some(List()), fragment = fragment).toUriIfPossible.get must
-        equalTo(Uri(query = Some(""), fragment = Some("")))
+        equalTo(Uri(query = Query.fromString(""), fragment = Some("")))
     }
     "convert /# to Uri" in {
       val fragment = Some(List(FragmentElm("")))
@@ -444,7 +444,7 @@ object UriTemplateSpec extends Specification {
       val path = List(PathElm("foo"))
       val query = Some(List(ParamElm("bar", List("baz"))))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/foo", Some("bar=baz")))
+        equalTo(Uri(scheme, authority, "/foo", Query.fromString("bar=baz")))
     }
     "convert http://www.foo.com/foo?bar=baz to Uri" in {
       val scheme = Some("http".ci)
@@ -453,7 +453,7 @@ object UriTemplateSpec extends Specification {
       val path = List(PathElm("foo"))
       val query = Some(List(ParamElm("bar", "baz")))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/foo", Some("bar=baz")))
+        equalTo(Uri(scheme, authority, "/foo", Query.fromString("bar=baz")))
     }
     "convert http://www.foo.com:80 to Uri" in {
       val scheme = Some("http".ci)
@@ -482,8 +482,8 @@ object UriTemplateSpec extends Specification {
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(host = host, port = Some(8080)))
       val query = Some(List())
-      UriTemplate(scheme, authority, Nil, query).toUriIfPossible.get must equalTo(Uri(scheme, authority, "/", Some("")))
-      UriTemplate(scheme, authority, Nil, None).toUriIfPossible.get must equalTo(Uri(scheme, authority, "/", None))
+      UriTemplate(scheme, authority, Nil, query).toUriIfPossible.get must equalTo(Uri(scheme, authority, "/", Query.fromString("")))
+      UriTemplate(scheme, authority, Nil, None).toUriIfPossible.get must equalTo(Uri(scheme, authority, "/", Query.empty))
     }
     "convert http://192.168.1.1:80/c?GB=object&Class=one to Uri" in {
       val scheme = Some("http".ci)
@@ -492,7 +492,7 @@ object UriTemplateSpec extends Specification {
       val path = List(PathElm("c"))
       val query = Some(List(ParamElm("GB", "object"), ParamElm("Class", "one")))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/c", Some("GB=object&Class=one")))
+        equalTo(Uri(scheme, authority, "/c", Query.fromString("GB=object&Class=one")))
     }
     "convert http://[2001:db8::7]/c?GB=object&Class=one to Uri" in {
       val scheme = Some("http".ci)
@@ -501,7 +501,7 @@ object UriTemplateSpec extends Specification {
       val path = List(PathElm("c"))
       val query = Some(List(ParamElm("GB", "object"), ParamElm("Class", "one")))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/c", Some("GB=object&Class=one")))
+        equalTo(Uri(scheme, authority, "/c", Query.fromString("GB=object&Class=one")))
     }
     "convert http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344] to Uri" in {
       val scheme = Some("http".ci)
@@ -531,7 +531,7 @@ object UriTemplateSpec extends Specification {
       val path = List(PathElm("some"), PathElm("path"))
       val query = Some(List(ParamElm("param1", "5"), ParamElm("param-without-value")))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/some/path", Some("param1=5&param-without-value")))
+        equalTo(Uri(scheme, authority, "/some/path", Query.fromString("param1=5&param-without-value")))
     }
     "convert http://username:password@some.example.com/some/path?param1=5&param-without-value#sec-1.2 to Uri" in {
       val scheme = Some("http".ci)
@@ -541,7 +541,7 @@ object UriTemplateSpec extends Specification {
       val query = Some(List(ParamElm("param1", "5"), ParamElm("param-without-value")))
       val fragment = Some(List(FragmentElm("sec-1.2")))
       UriTemplate(scheme, authority, path, query, fragment).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/some/path", Some("param1=5&param-without-value"), Some("sec-1.2")))
+        equalTo(Uri(scheme, authority, "/some/path", Query.fromString("param1=5&param-without-value"), Some("sec-1.2")))
     }
   }
 

--- a/core/src/test/scala/org/http4s/UriTemplateSpec.scala
+++ b/core/src/test/scala/org/http4s/UriTemplateSpec.scala
@@ -152,27 +152,27 @@ object UriTemplateSpec extends Specification {
       UriTemplate(path = path, query = query).toString must equalTo("/search?option={&term}")
     }
     "render /{#frg}" in {
-      val fragment = Some(List(SimpleFragmentExp("frg")))
+      val fragment = List(SimpleFragmentExp("frg"))
       UriTemplate(fragment = fragment).toString must equalTo("/{#frg}")
     }
     "render /{#x,y}" in {
-      val fragment = Some(List(MultiFragmentExp("x", "y")))
+      val fragment = List(MultiFragmentExp("x", "y"))
       UriTemplate(fragment = fragment).toString must equalTo("/{#x,y}")
     }
     "render /#test" in {
-      val fragment = Some(List(FragmentElm("test")))
+      val fragment = List(FragmentElm("test"))
       UriTemplate(fragment = fragment).toString must equalTo("/#test")
     }
     "render {path}/search{?term}{#section}" in {
       val path = List(VarExp("path"), PathElm("search"))
       val query = List(ParamExp("term"))
-      val fragment = Some(List(SimpleFragmentExp("section")))
+      val fragment = List(SimpleFragmentExp("section"))
       UriTemplate(path = path, query = query, fragment = fragment).toString must equalTo("{path}/search{?term}{#section}")
     }
     "render {+path}/search{?term}{#section}" in {
       val path = List(ReservedExp("path"), PathElm("search"))
       val query = List(ParamExp("term"))
-      val fragment = Some(List(SimpleFragmentExp("section")))
+      val fragment = List(SimpleFragmentExp("section"))
       UriTemplate(path = path, query = query, fragment = fragment).toString must equalTo("{+path}/search{?term}{#section}")
     }
     "render {+var}" in {
@@ -184,14 +184,14 @@ object UriTemplateSpec extends Specification {
       UriTemplate(path = path).toString must equalTo("{+path}/here")
     }
     "render /?" in {
-      UriTemplate(query = List(ParamElm("", Nil)), fragment = None).toString must equalTo("/?")
+      UriTemplate(query = List(ParamElm("", Nil)), fragment = Nil).toString must equalTo("/?")
     }
     "render /?#" in {
-      val fragment = Some(List(FragmentElm("")))
+      val fragment = List(FragmentElm(""))
       UriTemplate(query = List(ParamElm("", Nil)), fragment = fragment).toString must equalTo("/?#")
     }
     "render /#" in {
-      val fragment = Some(List(FragmentElm("")))
+      val fragment = List(FragmentElm(""))
       UriTemplate(query = Nil, fragment = fragment).toString must equalTo("/#")
     }
     "render http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/foo?bar=baz" in {
@@ -375,45 +375,45 @@ object UriTemplateSpec extends Specification {
       tpl.toUriIfPossible.isFailure
     }
     "convert /{#frg} to UriTemplate" in {
-      val fragment = Some(List(SimpleFragmentExp("frg")))
+      val fragment = List(SimpleFragmentExp("frg"))
       val tpl = UriTemplate(fragment = fragment)
       tpl.toUriIfPossible.isFailure
     }
     "convert /{#x,y} to UriTemplate" in {
-      val fragment = Some(List(MultiFragmentExp("x", "y")))
+      val fragment = List(MultiFragmentExp("x", "y"))
       val tpl = UriTemplate(fragment = fragment)
       tpl.toUriIfPossible.isFailure
     }
     "convert /#test to Uri" in {
-      val fragment = Some(List(FragmentElm("test")))
+      val fragment = List(FragmentElm("test"))
       UriTemplate(fragment = fragment).toUriIfPossible.get must
         equalTo(Uri(fragment = Some("test")))
     }
     "convert {path}/search{?term}{#section} to UriTemplate" in {
       val path = List(VarExp("path"), PathElm("search"))
       val query = List(ParamExp("term"))
-      val fragment = Some(List(SimpleFragmentExp("section")))
+      val fragment = List(SimpleFragmentExp("section"))
       val tpl = UriTemplate(path = path, query = query, fragment = fragment)
       tpl.toUriIfPossible.isFailure
     }
     "convert {+path}/search{?term}{#section} to UriTemplate" in {
       val path = List(ReservedExp("path"), PathElm("search"))
       val query = List(ParamExp("term"))
-      val fragment = Some(List(SimpleFragmentExp("section")))
+      val fragment = List(SimpleFragmentExp("section"))
       val tpl = UriTemplate(path = path, query = query, fragment = fragment)
       tpl.toUriIfPossible.isFailure
     }
     "convert /? to Uri" in {
-      UriTemplate(query = List(ParamElm("", Nil)), fragment = None).toUriIfPossible.get must
+      UriTemplate(query = List(ParamElm("", Nil)), fragment = Nil).toUriIfPossible.get must
         equalTo(Uri(query = Query.fromString("")))
     }
     "convert /?# to Uri" in {
-      val fragment = Some(List())
+      val fragment = List(FragmentElm(""))
       UriTemplate(query = List(ParamElm("", Nil)), fragment = fragment).toUriIfPossible.get must
         equalTo(Uri(query = Query.fromString(""), fragment = Some("")))
     }
     "convert /# to Uri" in {
-      val fragment = Some(List(FragmentElm("")))
+      val fragment = List(FragmentElm(""))
       UriTemplate(fragment = fragment).toUriIfPossible.get must
         equalTo(Uri(fragment = Some("")))
     }
@@ -423,7 +423,7 @@ object UriTemplateSpec extends Specification {
       val authority = Some(Authority(host = host))
       val path = List(VarExp("rel"), PathElm("search"))
       val query = List(ParamExp("term"))
-      val fragment = Some(List(SimpleFragmentExp("section")))
+      val fragment = List(SimpleFragmentExp("section"))
       val tpl = UriTemplate(scheme, authority, path, query, fragment)
       tpl.toUriIfPossible.isFailure
     }
@@ -433,7 +433,7 @@ object UriTemplateSpec extends Specification {
       val authority = Some(Authority(host = host, port = Some(8080)))
       val path = List(VarExp("rel"), PathElm("search"))
       val query = List(ParamExp("term"))
-      val fragment = Some(List(SimpleFragmentExp("section")))
+      val fragment = List(SimpleFragmentExp("section"))
       val tpl = UriTemplate(scheme, authority, path, query, fragment)
       tpl.toUriIfPossible.isFailure
     }
@@ -521,7 +521,7 @@ object UriTemplateSpec extends Specification {
       val scheme = Some("https".ci)
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
-      UriTemplate(scheme, authority, Nil, Nil, None).toUriIfPossible.get must
+      UriTemplate(scheme, authority, Nil, Nil, Nil).toUriIfPossible.get must
         equalTo(Uri(scheme, authority))
     }
     "convert http://username:password@some.example.com/some/path?param1=5&param-without-value to Uri" in {
@@ -539,7 +539,7 @@ object UriTemplateSpec extends Specification {
       val authority = Some(Authority(Some("username:password"), host, None))
       val path = List(PathElm("some"), PathElm("path"))
       val query = List(ParamElm("param1", "5"), ParamElm("param-without-value"))
-      val fragment = Some(List(FragmentElm("sec-1.2")))
+      val fragment = List(FragmentElm("sec-1.2"))
       UriTemplate(scheme, authority, path, query, fragment).toUriIfPossible.get must
         equalTo(Uri(scheme, authority, "/some/path", Query.fromString("param1=5&param-without-value"), Some("sec-1.2")))
     }
@@ -683,30 +683,30 @@ object UriTemplateSpec extends Specification {
 
   "UriTemplate.expandFragment" should {
     "expand /{#section} to /#sec2.1" in {
-      val fragment = Some(List(SimpleFragmentExp("section")))
+      val fragment = List(SimpleFragmentExp("section"))
       UriTemplate(fragment = fragment).expandFragment("section", "sec2.1") must
-        equalTo(UriTemplate(fragment = Some(List(FragmentElm("sec2.1")))))
+        equalTo(UriTemplate(fragment = List(FragmentElm("sec2.1"))))
     }
     "expand /{#x,y} to /#23{#y}" in {
-      val tpl = UriTemplate(fragment = Some(List(MultiFragmentExp("x", "y"))))
+      val tpl = UriTemplate(fragment = List(MultiFragmentExp("x", "y")))
       tpl.expandFragment("x", "23") must
-        equalTo(UriTemplate(fragment = Some(List(FragmentElm("23"), MultiFragmentExp("y")))))
+        equalTo(UriTemplate(fragment = List(FragmentElm("23"), MultiFragmentExp("y"))))
     }
     "expand /{#x,y} to UriTemplate /#42{#x}" in {
-      val tpl = UriTemplate(fragment = Some(List(MultiFragmentExp("x", "y"))))
+      val tpl = UriTemplate(fragment = List(MultiFragmentExp("x", "y")))
       tpl.expandFragment("y", "42") must
-        equalTo(UriTemplate(fragment = Some(List(FragmentElm("42"), MultiFragmentExp("x")))))
+        equalTo(UriTemplate(fragment = List(FragmentElm("42"), MultiFragmentExp("x"))))
     }
     "expand /{#x,y,z} to UriTemplate /#42{#x,z}" in {
       val x = SimpleFragmentExp("x")
       val y = SimpleFragmentExp("y")
       val z = SimpleFragmentExp("z")
-      val tpl = UriTemplate(fragment = Some(List(MultiFragmentExp("x", "y", "z"))))
+      val tpl = UriTemplate(fragment = List(MultiFragmentExp("x", "y", "z")))
       tpl.expandFragment("y", "42") must
-        equalTo(UriTemplate(fragment = Some(List(FragmentElm("42"), MultiFragmentExp("x", "z")))))
+        equalTo(UriTemplate(fragment = List(FragmentElm("42"), MultiFragmentExp("x", "z"))))
     }
     "expand nothing" in {
-      val fragment = Some(List(FragmentElm("sec1.2"), SimpleFragmentExp("section")))
+      val fragment = List(FragmentElm("sec1.2"), SimpleFragmentExp("section"))
       val tpl = UriTemplate(fragment = fragment)
       tpl.expandFragment("unknown", "123") must equalTo(tpl)
     }

--- a/core/src/test/scala/org/http4s/parser/QueryParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/QueryParserSpec.scala
@@ -15,13 +15,13 @@ class QueryParserSpec extends Http4sSpec {
   "The QueryParser" should {
 
     "correctly extract complete key value pairs" in {
-      parseQueryString("key=value") must beRightDisjunction(Query.fromOptions("key" -> Some("value")))
-      parseQueryString("key=value&key2=value2") must beRightDisjunction(Query.fromOptions("key" -> Some("value"), "key2" -> Some("value2")))
+      parseQueryString("key=value") must beRightDisjunction(Query("key" -> Some("value")))
+      parseQueryString("key=value&key2=value2") must beRightDisjunction(Query("key" -> Some("value"), "key2" -> Some("value2")))
     }
 
     "decode URL-encoded keys and values" in {
-      parseQueryString("ke%25y=value") must beRightDisjunction(Query.fromOptions("ke%y" -> Some("value")))
-      parseQueryString("key=value%26&key2=value2") must beRightDisjunction(Query.fromOptions("key" -> Some("value&"), "key2" -> Some("value2")))
+      parseQueryString("ke%25y=value") must beRightDisjunction(Query("ke%y" -> Some("value")))
+      parseQueryString("key=value%26&key2=value2") must beRightDisjunction(Query("key" -> Some("value&"), "key2" -> Some("value2")))
     }
 
     "return an empty Map for an empty query string" in {
@@ -29,23 +29,23 @@ class QueryParserSpec extends Http4sSpec {
     }
 
     "return an empty value for keys without a value following the '=' and keys without following '='" in {
-      parseQueryString("key=&key2") must beRightDisjunction(Query.fromOptions("key" -> Some(""), "key2" -> None))
+      parseQueryString("key=&key2") must beRightDisjunction(Query("key" -> Some(""), "key2" -> None))
     }
 
     "accept empty key value pairs" in {
-      parseQueryString("&&b&") must beRightDisjunction(Query.fromOptions("" -> None, "" -> None, "b" -> None, "" -> None))
+      parseQueryString("&&b&") must beRightDisjunction(Query("" -> None, "" -> None, "b" -> None, "" -> None))
     }
 
     "Handle '=' in a query string" in {
-      parseQueryString("a=b=c") must beRightDisjunction(Query.fromOptions("a" -> Some("b=c")))
+      parseQueryString("a=b=c") must beRightDisjunction(Query("a" -> Some("b=c")))
     }
 
     "Gracefully handle invalid URL encoding" in {
-      parseQueryString("a=b%G") must beRightDisjunction(Query.fromOptions("a" -> Some("b%G")))
+      parseQueryString("a=b%G") must beRightDisjunction(Query("a" -> Some("b%G")))
     }
 
     "Allow ';' seperators" in {
-      parseQueryString("a=b;c") must beRightDisjunction(Query.fromOptions("a" -> Some("b"), "c" -> None))
+      parseQueryString("a=b;c") must beRightDisjunction(Query("a" -> Some("b"), "c" -> None))
     }
 
     "Reject a query with invalid char" in {
@@ -59,22 +59,22 @@ class QueryParserSpec extends Http4sSpec {
       val cs = CharBuffer.wrap(s)
       val r = new QueryParser(Codec.UTF8, true).decode(cs, false)
 
-      r must beRightDisjunction(Query.fromOptions("key" -> Some("value")))
+      r must beRightDisjunction(Query("key" -> Some("value")))
       cs.remaining must_== 9
 
       val r2 = new QueryParser(Codec.UTF8, true).decode(cs, false)
-      r2 must beRightDisjunction(Query.fromOptions())
+      r2 must beRightDisjunction(Query())
       cs.remaining() must_== 9
 
       val r3 = new QueryParser(Codec.UTF8, true).decode(cs, true)
-      r3 must beRightDisjunction(Query.fromOptions("stuff" -> Some("cat")))
+      r3 must beRightDisjunction(Query("stuff" -> Some("cat")))
       cs.remaining() must_== 0
     }
 
     "be stack safe" in {
       val value = Stream.continually('X').take(1000000).mkString
       val query = s"little=x&big=${value}"
-      parseQueryString(query) must beRightDisjunction(Query.fromOptions("little" -> Some("x"), "big" -> Some(value)))
+      parseQueryString(query) must beRightDisjunction(Query("little" -> Some("x"), "big" -> Some(value)))
     }
   }
 }

--- a/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -87,17 +87,17 @@ class UriParserSpec extends Http4sSpec {
 
     "parse relative URI with empty query string" in {
       val u = Uri.fromString("/foo/bar?")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromOptions("" -> None)))
+      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query("" -> None)))
     }
 
     "parse relative URI with empty query string followed by empty fragement" in {
       val u = Uri.fromString("/foo/bar?#")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromOptions("" -> None), fragment = Some("")))
+      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query("" -> None), fragment = Some("")))
     }
 
     "parse relative URI with empty query string followed by fragement" in {
       val u = Uri.fromString("/foo/bar?#Example_of_Fragment")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromOptions("" -> None), fragment = Some("Example_of_Fragment")))
+      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query("" -> None), fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with fragment" in {
@@ -107,7 +107,7 @@ class UriParserSpec extends Http4sSpec {
 
     "parse relative URI with single parameter without a value followed by a fragment" in {
       val u = Uri.fromString("/foo/bar?bar#Example_of_Fragment")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromOptions("bar" -> None), fragment = Some("Example_of_Fragment")))
+      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query("bar" -> None), fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with parameters and fragment" in {

--- a/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -53,13 +53,13 @@ class UriParserSpec extends Http4sSpec {
       val absoluteUris: Seq[(String, Uri)] = Seq(
         ("http://www.foo.com", Uri(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci))))),
         ("http://www.foo.com/foo?bar=baz",
-          Uri(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci))), "/foo", Some("bar=baz"))),
+          Uri(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci))), "/foo", Query.fromPairs("bar" -> "baz"))),
         ("http://192.168.1.1",
           Uri(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci))))),
         ("http://192.168.1.1:80/c?GB=object&Class=one",
-          Uri(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci), port = Some(80))), "/c", Some("GB=object&Class=one"))),
+          Uri(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci), port = Some(80))), "/c", Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         ("http://[2001:db8::7]/c?GB=object&Class=one",
-          Uri(Some("http".ci), Some(Authority(host = IPv6("2001:db8::7".ci))), "/c", Some("GB=object&Class=one"))),
+          Uri(Some("http".ci), Some(Authority(host = IPv6("2001:db8::7".ci))), "/c", Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         ("mailto:John.Doe@example.com",
           Uri(Some("mailto".ci), path = "John.Doe@example.com")))
 
@@ -69,7 +69,7 @@ class UriParserSpec extends Http4sSpec {
     "parse relative URIs" in {
       val relativeUris: Seq[(String, Uri)] = Seq(
         ("/foo/bar", Uri(path = "/foo/bar")),
-        ("/foo/bar?foo=bar&ding=dong", Uri(path = "/foo/bar", query = Some("foo=bar&ding=dong"))),
+        ("/foo/bar?foo=bar&ding=dong", Uri(path = "/foo/bar", query = Query.fromPairs("foo" -> "bar", "ding" -> "dong"))),
         ("/", Uri()))
 
       check(relativeUris)
@@ -77,27 +77,27 @@ class UriParserSpec extends Http4sSpec {
 
     "parse absolute URI with fragment" in {
       val u = Uri.fromString("http://foo.bar/foo#Examples")
-      u must beRightDisjunction(Uri(Some("http".ci), Some(Authority(host = RegName("foo.bar".ci))), "/foo", None, Some("Examples")))
+      u must beRightDisjunction(Uri(Some("http".ci), Some(Authority(host = RegName("foo.bar".ci))), "/foo", Query.empty, Some("Examples")))
     }
 
     "parse absolute URI with parameters and fragment" in {
       val u = Uri.fromString("http://foo.bar/foo?bar=baz#Example-Fragment")
-      u must beRightDisjunction(Uri(Some("http".ci), Some(Authority(host = RegName("foo.bar".ci))), "/foo", Some("bar=baz"), Some("Example-Fragment")))
+      u must beRightDisjunction(Uri(Some("http".ci), Some(Authority(host = RegName("foo.bar".ci))), "/foo", Query.fromPairs("bar" -> "baz"), Some("Example-Fragment")))
     }
 
     "parse relative URI with empty query string" in {
       val u = Uri.fromString("/foo/bar?")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Some("")))
+      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromOptions("" -> None)))
     }
 
     "parse relative URI with empty query string followed by empty fragement" in {
       val u = Uri.fromString("/foo/bar?#")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Some(""), fragment = Some("")))
+      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromOptions("" -> None), fragment = Some("")))
     }
 
     "parse relative URI with empty query string followed by fragement" in {
       val u = Uri.fromString("/foo/bar?#Example_of_Fragment")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Some(""), fragment = Some("Example_of_Fragment")))
+      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromOptions("" -> None), fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with fragment" in {
@@ -107,12 +107,12 @@ class UriParserSpec extends Http4sSpec {
 
     "parse relative URI with single parameter without a value followed by a fragment" in {
       val u = Uri.fromString("/foo/bar?bar#Example_of_Fragment")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Some("bar"), fragment = Some("Example_of_Fragment")))
+      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromOptions("bar" -> None), fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with parameters and fragment" in {
       val u = Uri.fromString("/foo/bar?bar=baz#Example_of_Fragment")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Some("bar=baz"), fragment = Some("Example_of_Fragment")))
+      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromPairs("bar" -> "baz"), fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with slash and fragment" in {
@@ -121,9 +121,9 @@ class UriParserSpec extends Http4sSpec {
     }
 
     {
-      val q = "param1=3&param2=2&param2=foo"
-      val u = Uri(query = Some(q))
-      "parse query and represent multiParams as a Map[String,Seq[String]]" in {
+      val q = Query.fromString("param1=3&param2=2&param2=foo")
+      val u = Uri(query = q)
+      "represent query as multiParams as a Map[String,Seq[String]]" in {
         u.multiParams must be_==(Map("param1" -> Seq("3"), "param2" -> Seq("2", "foo")))
       }
 

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
@@ -82,12 +82,12 @@ object PathInHttpServiceSpec extends Http4sSpec {
       response.body must equalTo("404 Not Found: /calc")
     }
     "GET /calc?decimal=1.3" in {
-      val response = server(Request(GET, Uri(path = "/calc", query = Some("decimal=1.3"))))
+      val response = server(Request(GET, Uri(path = "/calc", query = Query.fromString("decimal=1.3"))))
       response.status must equal (Ok)
       response.body must equalTo(s"result: 0.65")
     }
     "GET /items?list=1&list=2&list=3&list=4&list=5" in {
-      val response = server(Request(GET, Uri(path = "/items", query = Some("list=1&list=2&list=3&list=4&list=5"))))
+      val response = server(Request(GET, Uri(path = "/items", query = Query.fromString("list=1&list=2&list=3&list=4&list=5"))))
       response.status must equal (Ok)
       response.body must equalTo(s"items: 1,2,3,4,5")
     }
@@ -97,37 +97,37 @@ object PathInHttpServiceSpec extends Http4sSpec {
       response.body must equalTo("404 Not Found: /search")
     }
     "GET /search?term" in {
-      val response = server(Request(GET, Uri(path = "/search", query = Some("term"))))
+      val response = server(Request(GET, Uri(path = "/search", query = Query.fromString("term"))))
       response.status must equal (NotFound)
       response.body must equalTo("404 Not Found: /search")
     }
     "GET /search?term=" in {
-      val response = server(Request(GET, Uri(path = "/search", query = Some("term="))))
+      val response = server(Request(GET, Uri(path = "/search", query = Query.fromString("term="))))
       response.status must equal (Ok)
       response.body must equalTo("term: ")
     }
     "GET /search?term= http4s  " in {
-      val response = server(Request(GET, Uri(path = "/search", query = Some("term=%20http4s%20%20"))))
+      val response = server(Request(GET, Uri(path = "/search", query = Query.fromString("term=%20http4s%20%20"))))
       response.status must equal (Ok)
       response.body must equalTo("term:  http4s  ")
     }
     "GET /search?term=http4s" in {
-      val response = server(Request(GET, Uri(path = "/search", query = Some("term=http4s"))))
+      val response = server(Request(GET, Uri(path = "/search", query = Query.fromString("term=http4s"))))
       response.status must equal (Ok)
       response.body must equalTo("term: http4s")
     }
     "optional parameter present" in {
-      val response = server(Request(GET, Uri(path = "/app", query = Some("counter=3"))))
+      val response = server(Request(GET, Uri(path = "/app", query = Query.fromString("counter=3"))))
       response.status must equal (Ok)
       response.body must equalTo("counter: Some(3)")
     }
     "optional parameter absent" in {
-      val response = server(Request(GET, Uri(path = "/app", query = Some("other=john"))))
+      val response = server(Request(GET, Uri(path = "/app", query = Query.fromString("other=john"))))
       response.status must equal (Ok)
       response.body must equalTo("counter: None")
     }
     "optional parameter present with incorrect format" in {
-      val response = server(Request(GET, Uri(path = "/app", query = Some("counter=john"))))
+      val response = server(Request(GET, Uri(path = "/app", query = Query.fromString("counter=john"))))
       response.status must equal (NotFound)
     }
   }


### PR DESCRIPTION
This isn't quite finished, but I'd like to solicit opinions, suggestions, etc.
### Design
* Eagerly parsed. Initial benchmarks suggest its not a big penalty.
* ```Query``` is a wrapper around a ```Vector[(String, Option[String])]``` and extends the stdlib ```IndexedSeq``` trait. We could make a custom rolled structure ala spray. I'm still considering this.
* The api used on the ```Uri``` is shared with the ```Query``` through the ```QueryOps``` trait.

Generally, I like it, but I can forsee some performance impact on heavy query modification. Currently, the methods in ```QueryOps``` build an intermediate ```Map[String, Seq[String]]```, modify it, and then move back to a ```Query```. Adding multiple params in a row will be pretty nasty, eg
```scala
query +? (1k, 2v) +? (k2, v2) ...
```
I might spend a little time avoiding the intermediate map structure.