### PR TITLE
Put decode helpers directly on Request for Response.

### DIFF
--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -29,8 +29,8 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
       // https://github.com/http4s/http4s/issues/157
       // TODO Urgh.  We need to make testing these smoother.
       def getBody(body: EntityBody): Array[Byte] = body.runLog.run.reduce(_ ++ _).toArray
-      val req = Request().withBody(jNumberOrNull(157))
-      val body = json(req.run) { json => Response(Ok).withBody(json.number.flatMap(_.toLong).getOrElse(0L).toString) }.run.body
+      val req = Request().withBody(jNumberOrNull(157)).run
+      val body = req.decode { json: Json => Response(Ok).withBody(json.number.flatMap(_.toLong).getOrElse(0L).toString) }.run.body
       new String(getBody(body), StandardCharsets.UTF_8) must_== "157"
     }
   }

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -21,18 +21,6 @@ import util.byteVector._
   * @tparam T result type produced by the decoder
   */
 sealed trait EntityDecoder[T] { self =>
-
-  /** Helper method for decoding [[Request]]s
-    *
-    * Attempt to decode the [[Request]] and, if successful, execute the continuation to get a [[Response]].
-    * If decoding fails, a BadRequest [[Response]] is generated.
-    */
-  final def apply(request: Request)(f: T => Task[Response]): Task[Response] =
-    decode(request).fold(
-      e => Response(Status.BadRequest, request.httpVersion).withBody(e.sanitized),
-      f
-    ).join
-
   /** Attempt to decode the body of the [[Message]] */
   def decode(msg: Message): DecodeResult[T]
 

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -195,18 +195,14 @@ case class Request(
     * Attempt to decode the [[Request]] and, if successful, execute the continuation to get a [[Response]].
     * If decoding fails, a BadRequest [[Response]] is generated.
     */
-  def decode[T](f: T => Task[Response])(implicit decoder: EntityDecoder[T]): Task[Response] =
+  def decode[A](f: A => Task[Response])(implicit decoder: EntityDecoder[A]): Task[Response] =
     decoder.decode(this).fold(
       e => Response(Status.BadRequest, httpVersion).withBody(e.sanitized),
       f
     ).join
 
   /** Like [[decode]], but with an explicit decoder. */
-  def decodeWith[T](decoder: EntityDecoder[T])(f: T => Task[Response]): Task[Response] =
-    decoder.decode(this).fold(
-      e => Response(Status.BadRequest, httpVersion).withBody(e.sanitized),
-      f
-    ).join
+  def decodeWith[A](decoder: EntityDecoder[A])(f: A => Task[Response]): Task[Response] = decode(f)(decoder)
 }
 
 object Request {

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -81,7 +81,7 @@ object ExampleService {
 
     case req @ POST -> Root / "sum"  =>
       // EntityDecoders allow turning the body into something useful
-      formEncoded(req) { data =>
+      req.decodeWith(formEncoded) { data =>
         data.get("sum") match {
           case Some(Seq(s, _*)) =>
             val sum = s.split(' ').filter(_.length > 0).map(_.trim.toInt).sum
@@ -103,7 +103,7 @@ object ExampleService {
 
     case req @ POST -> Root / "form-encoded" =>
       // EntityDecoders return a Task[A] which is easy to sequence
-      formEncoded(req) { m =>
+      req.decodeWith(formEncoded) { m =>
         val s = m.mkString("\n")
         Ok(s"Form Encoded Data\n$s")
       }
@@ -124,7 +124,7 @@ object ExampleService {
   // Services don't have to be monolithic, and middleware just transforms a service to a service
   def service2 = EntityLimiter(HttpService {
     case req @ POST -> Root / "short-sum"  =>
-      formEncoded(req) { data =>
+      req.decodeWith(formEncoded) { data =>
         data.get("short-sum") match {
           case Some(Seq(s, _*)) =>
             val sum = s.split(" ").filter(_.length > 0).map(_.trim.toInt).sum

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -6,6 +6,7 @@ import org.http4s.server.HttpService
 import org.http4s.scalaxml._
 import scodec.bits.ByteVector
 
+import scala.xml.Elem
 import scalaz.{Reducer, Monoid}
 import scalaz.concurrent.Task
 import scalaz.stream.Process
@@ -20,7 +21,7 @@ object ScienceExperiments {
   def service = HttpService {
     ///////////////// Misc //////////////////////
     case req @ POST -> Root / "root-element-name" =>
-      xml(req)(root => Ok(root.label))
+      req.decode { root: Elem => Ok(root.label) }
 
     case req @ GET -> Root / "date" =>
       val date = DateTime(100)

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -37,6 +37,4 @@ trait ElemInstances {
       }
     }
   }
-
-  def xml: EntityDecoder[Elem] = xml()
 }

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -3,6 +3,7 @@ package scalaxml
 
 import scodec.bits.ByteVector
 
+import scala.xml.Elem
 import scalaz.concurrent.Task
 import scalaz.stream.Process
 import scalaz.stream.Process.emit
@@ -28,7 +29,7 @@ class ScalaXmlSpec extends Http4sSpec {
 
   "xml" should {
     val server: Request => Task[Response] = { req =>
-      xml(req) { elem => Response(Ok).withBody(elem.label) }
+      req.decode { elem: Elem => Response(Ok).withBody(elem.label) }
     }
 
     "parse the XML" in {

--- a/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
@@ -15,7 +15,7 @@ class EntityLimiterSpec extends Specification {
   import Http4s._
 
   val s = HttpService {
-    case r: Request if r.uri.path == "/echo" => EntityDecoder.text(r)(Response(Ok).withBody)
+    case r: Request if r.uri.path == "/echo" => r.decode[String](Response(Ok).withBody)
   }
 
   val b = emit(ByteVector.view("hello".getBytes(StandardCharsets.UTF_8)))
@@ -37,7 +37,7 @@ class EntityLimiterSpec extends Specification {
 
     "Chain correctly with other HttpServices" in {
       val s2 = HttpService {
-        case r: Request if r.uri.path == "/echo2" => EntityDecoder.text(r)(Response(Ok).withBody)
+        case r: Request if r.uri.path == "/echo2" => r.decode[String](Response(Ok).withBody)
       }
 
       val st = EntityLimiter(s, 3) orElse s2


### PR DESCRIPTION
The apply method on EntityEncoder is awkward to call when the decoder
takes an implicit parameter.  This gives rise to awkward overloads, like
xml, which surprisingly provide a default without regard to the scoped
implicit.  By moving the call to the request, we can move the implicit
decoder to the end, and remove the syntactic urge for troublesome
overloads.

Request decodings that prefer to be explicit can use the new
`decodeWith` for a reasonable syntax.