### PR TITLE
Fix blaze-client when recieving HTTP1 without content-length header

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -112,6 +112,16 @@ class Http1ClientStageSpec extends Specification with NoTimeConversions {
 
       result.body.run.run must throwA[InvalidBodyException]
     }
+
+    "Interpret a lack of length with a EOF as a valid message" in {
+      val resp = "HTTP/1.1 200 OK\r\n\r\ndone"
+      val \/-(parsed) = Uri.fromString("http://www.foo.com")
+      val req = Request(uri = parsed)
+
+      val (_, response) = getSubmission(req, resp, 20.seconds)
+
+      response must_==("done")
+    }
   }
 
   "Http1ClientStage responses" should {

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -111,7 +111,7 @@ class Http1ServerStage(service: HttpService,
   }
 
   private def runRequest(buffer: ByteBuffer): Unit = {
-    val (body, cleanup) = collectBodyFromParser(buffer)
+    val (body, cleanup) = collectBodyFromParser(buffer, InvalidBodyException("Received premature EOF."))
 
     collectMessage(body) match {
       case Some(req) =>


### PR DESCRIPTION
fixes #172