### PR TITLE
add Uri.resolve(Uri) out of RFC 3986, plus tests #185

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -5,11 +5,12 @@ import java.nio.charset.StandardCharsets
 import scala.language.experimental.macros
 import scala.reflect.macros.Context
 
-import Uri._
+import org.http4s.Uri._
 
 import org.http4s.parser.{ ScalazDeliverySchemes, RequestUriParser }
 import org.http4s.util.{ Writer, Renderable, CaseInsensitiveString }
 import org.http4s.util.string.ToCaseInsensitiveStringSyntax
+import org.http4s.util.option.ToOptionOps
 
 /** Representation of the [[Request]] URI
   * Structure containing information related to a Uri. All fields except the
@@ -34,6 +35,8 @@ case class Uri(
   def host: Option[Host] = authority.map(_.host)
   def port: Option[Int] = authority.flatMap(_.port)
   def userInfo: Option[UserInfo] = authority.flatMap(_.userInfo)
+
+  def resolve(relative: Uri): Uri = Uri.resolve(this,relative)
 
   /**
    * Representation of the query string as a map
@@ -185,4 +188,74 @@ trait UriFunctions {
    * at compile time.
    */
   def uri(s: String): Uri = macro Uri.macros.uriLiteral
+
+  /**
+   * Remove dot sequences from a Path, per RFC 3986 Sec 5.2.4
+   */
+  private[http4s] def removeDotSequences(path: Path): Path = {
+    var output = ""
+    var input = path
+
+    while (input.length > 0) {
+      var checkpoint = input
+      // step a: strip ../ or ./
+      input = input.replaceAll("""(^\.\./)|(^\./)""","")
+      // step b: replace /./ or /. with /
+      input = input.replaceAll("""(^/\./)|(^/\.$)""","/")
+      // step c: delete /../ or /.. and pop in output
+      val rule2c = """(^/\.\./)|(^/\.\.$)"""
+      if (input.matches(s"($rule2c).*")) {
+        input = input.replaceAll(rule2c,"/")
+        if (output.contains('/'))
+          output = output.substring(0, output.lastIndexOf('/'))
+      }
+      // step d: ignore orphan . or ..
+      input = input.replaceAll("""^(\.|\.\.)$""","")
+      // step e: move path segment to output
+      val rule2e = """(^/?[^/]*)(.*)""".r
+      if (checkpoint == input) // don't continue unless none of the previous rules can be applied
+        input match {
+          case rule2e(segment, rest) =>
+            output += segment
+            input = rest
+          case _ =>
+        }
+    }
+    output
+  }
+
+  /**
+   * Resolve a relative Uri reference, per RFC 3986 sec 5.2
+   */
+  def resolve(base: Uri, reference: Uri): Uri = {
+
+    /** per RFC2396 5.2.3 */
+    def merge(base: Path, reference: Path): Path =
+      base.substring(0, base.lastIndexOf('/')+1) + reference
+
+    val Uri(bS, bA, bP, bQ, bF) = base
+    val Uri(rS, rA, rP, rQ, rF) = reference
+
+    // rF
+    val target =
+      if (rS.isDefined) // rS, rA, rP, rQ
+        reference
+      else // bS
+      if (rA.isDefined) // rA, rP, rQ
+        Uri(bS, rA, rP, rQ, rF)
+      else // bA
+      if (rP == "") // bP
+        if (!rQ.isEmpty) // rQ
+          Uri(bS,bA,bP,rQ,rF)
+        else // bQ
+          Uri(bS,bA,bP,bQ,rF)
+      else // rQ
+      if (rP.head == '/') // rP
+        Uri(bS,bA,rP,rQ,rF)
+      else // bP + rP
+        Uri(bS,bA,merge(bP,rP),rQ,rF)
+
+
+    target.withPath(removeDotSequences(target.path))
+  }
 }

--- a/core/src/main/scala/org/http4s/util/option.scala
+++ b/core/src/main/scala/org/http4s/util/option.scala
@@ -1,0 +1,16 @@
+package org.http4s.util
+
+import scalaz.syntax.Ops
+
+trait OptionOps[A] extends Ops[Option[A]] {
+  // present in scala 2.11 but not 2.10
+  def contains(a: A) = self.isDefined && self.get == a
+}
+
+trait OptionSyntax {
+  implicit def ToOptionOps[A](o: Option[A]) = new OptionOps[A] {
+    def self: Option[A] = o
+  }
+}
+
+object option extends OptionSyntax

--- a/core/src/test/scala/org/http4s/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/UriSpec.scala
@@ -670,9 +670,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       "g#s/./x"       shouldResolveTo "http://a/b/c/g#s/./x"
       "g#s/../x"      shouldResolveTo "http://a/b/c/g#s/../x"
 
-      // choose one:
-      "http:g"        shouldResolveTo "http:g"         // for strict parsers
-      // "http:g"        shouldResolveTo "http://a/b/c/g" // for backward compatibility
+      "http:g"        shouldResolveTo "http:g"
     }
   }
 }

--- a/core/src/test/scala/org/http4s/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/UriSpec.scala
@@ -60,7 +60,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
   }
 
   "Uri's with a query and fragment" should {
-    "parse propperly" in {
+    "parse properly" in {
       val uri = getUri("http://localhost:8080/blah?x=abc#y=ijk")
       uri.query should_== Query.fromPairs("x"->"abc")
       uri.fragment should_== Some("y=ijk")
@@ -576,6 +576,103 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       val ps = Map("param" -> List("value"))
       val u = Uri(query = Query.fromString("param=value"))
       u =? ps must be_==(u =? ps)
+    }
+  }
+
+  "Uri relative resolution" should {
+
+    // delete this method once issue #184 is resolved
+    def getUri(s: String): Uri = {
+      def getAuthority(s: String): Authority = {
+        val AuthorityRegex = "^(.*@)?(.*)(:.*)?$".r
+        val AuthorityRegex(userinfo,host,port) = s
+        Authority(Option(userinfo),RegName(host),Option(port).map(_.toInt))
+      }
+
+      // regex copied from https://tools.ietf.org/html/rfc3986#appendix-B
+      val UriRegex = "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?".r
+      val UriRegex(_,scheme,_,authority,path,_,query,_,fragment) = s
+      Uri(
+        Option(scheme).map(_.ci),
+        Option(authority).map(getAuthority),
+        path,
+        Option(query).map(org.http4s.Query.fromString).getOrElse(org.http4s.Query.empty),
+        Option(fragment)
+      )
+    }
+
+    val base = getUri("http://a/b/c/d;p?q")
+
+    "correctly remove ./.. sequences" in {
+      implicit class checkDotSequences(path: String) {
+        def removingDotsShould_==(expected: String) =
+          s"$path -> $expected" in { removeDotSequences(path) should_== expected }
+      }
+
+      // from RFC 3986 sec 5.2.4
+      "mid/content=5/../6" removingDotsShould_== "mid/6"
+      "/a/b/c/./../../g"   removingDotsShould_== "/a/g"
+    }
+
+    implicit class check(relative: String) {
+      def shouldResolveTo(expected: String) =
+        s"$base @ $relative -> $expected" in { base resolve getUri(relative) should_== getUri(expected) }
+    }
+
+    "correctly resolve RFC 3986 sec 5.4 normal examples" in {
+
+      // normal examples
+      "g:h"           shouldResolveTo "g:h"
+      "g"             shouldResolveTo "http://a/b/c/g"
+      "./g"           shouldResolveTo "http://a/b/c/g"
+      "g/"            shouldResolveTo "http://a/b/c/g/"
+      "/g"            shouldResolveTo "http://a/g"
+      "//g"           shouldResolveTo "http://g"
+      "?y"            shouldResolveTo "http://a/b/c/d;p?y"
+      "g?y"           shouldResolveTo "http://a/b/c/g?y"
+      "#s"            shouldResolveTo "http://a/b/c/d;p?q#s"
+      "g#s"           shouldResolveTo "http://a/b/c/g#s"
+      "g?y#s"         shouldResolveTo "http://a/b/c/g?y#s"
+      ";x"            shouldResolveTo "http://a/b/c/;x"
+      "g;x"           shouldResolveTo "http://a/b/c/g;x"
+      "g;x?y#s"       shouldResolveTo "http://a/b/c/g;x?y#s"
+      ""              shouldResolveTo "http://a/b/c/d;p?q"
+      "."             shouldResolveTo "http://a/b/c/"
+      "./"            shouldResolveTo "http://a/b/c/"
+      ".."            shouldResolveTo "http://a/b/"
+      "../"           shouldResolveTo "http://a/b/"
+      "../g"          shouldResolveTo "http://a/b/g"
+      "../.."         shouldResolveTo "http://a/"
+      "../../"        shouldResolveTo "http://a/"
+      "../../g"       shouldResolveTo "http://a/g"
+    }
+
+    "correctly resolve RFC 3986 sec 5.4 abnormal examples" in {
+      "../../../g"    shouldResolveTo "http://a/g"
+      "../../../../g" shouldResolveTo "http://a/g"
+
+      "/./g"          shouldResolveTo "http://a/g"
+      "/../g"         shouldResolveTo "http://a/g"
+      "g."            shouldResolveTo "http://a/b/c/g."
+      ".g"            shouldResolveTo "http://a/b/c/.g"
+      "g.."           shouldResolveTo "http://a/b/c/g.."
+      "..g"           shouldResolveTo "http://a/b/c/..g"
+
+      "./../g"        shouldResolveTo "http://a/b/g"
+      "./g/."         shouldResolveTo "http://a/b/c/g/"
+      "g/./h"         shouldResolveTo "http://a/b/c/g/h"
+      "g/../h"        shouldResolveTo "http://a/b/c/h"
+      "g;x=1/./y"     shouldResolveTo "http://a/b/c/g;x=1/y"
+      "g;x=1/../y"    shouldResolveTo "http://a/b/c/y"
+
+      "g?y/./x"       shouldResolveTo "http://a/b/c/g?y/./x"
+      "g?y/../x"      shouldResolveTo "http://a/b/c/g?y/../x"
+      "g#s/./x"       shouldResolveTo "http://a/b/c/g#s/./x"
+      "g#s/../x"      shouldResolveTo "http://a/b/c/g#s/../x"
+
+      // choose one:
+      "http:g"        shouldResolveTo "http:g"         // for strict parsers
+      // "http:g"        shouldResolveTo "http://a/b/c/g" // for backward compatibility
     }
   }
 }


### PR DESCRIPTION
For #185.  9919979 has a very direct, imperative implementation, that mirrors the RFC language closely to be sure that it worked; then a1d2985 includes a little better-looking ones.  I included both commits so you can have your choice of either or neither :-)

The test suite currently includes a straw-man Uri parser in UriSpec.scala, which is good enough to pass all of the tests.  It can be deleted as soon as #184 is squared away.  (The tests also pass with the parser in @bryce-anderson's issue/184 branch.)