### PR TITLE
use FQCN in uri macro

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -109,7 +109,7 @@ object Uri extends UriFunctions {
         case Literal(Constant(s: String)) =>
           Uri.fromString(s).fold(
             e => c.abort(c.enclosingPosition, e.details),
-            qValue => c.Expr(q"Uri.fromString($s).valueOr(e => throw new org.http4s.ParseException(e))")
+            qValue => c.Expr(q"org.http4s.Uri.fromString($s).valueOr(e => throw new org.http4s.ParseException(e))")
           )
         case _ =>
           c.abort(c.enclosingPosition, s"only supports literal Strings")


### PR DESCRIPTION
to avoid this error:
```
[error] not found: value Uri
[error]   val x = org.http4s.Uri.uri("http://uri.com")
[error]                             ^
```
without having to import the Uri object first.