### PR TITLE
Support gathering server metrics on servlet containers

### DIFF
--- a/examples/jetty/examples-jetty.sbt
+++ b/examples/jetty/examples-jetty.sbt
@@ -6,8 +6,11 @@ publishArtifact := false
 
 fork := true
 
+libraryDependencies ++= Seq(
+  metricsServlets
+)
+
 seq(Revolver.settings: _*)
 
 (mainClass in Revolver.reStart) := Some("com.example.http4s.jetty.JettyExample")
-
 

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
@@ -1,13 +1,19 @@
 package com.example.http4s
 package jetty
 
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.servlets.MetricsServlet
 import org.http4s.server.jetty.JettyBuilder
 
 /// code_ref: jetty_example
 object JettyExample extends App {
+  val metrics = new MetricRegistry
+
   JettyBuilder
     .bindHttp(8080)
+    .withMetricRegistry(metrics)
     .mountService(ExampleService.service, "/http4s")
+    .mountServlet(new MetricsServlet(metrics), "/metrics/*")
     .run
     .awaitShutdown()
 }

--- a/examples/tomcat/examples-tomcat.sbt
+++ b/examples/tomcat/examples-tomcat.sbt
@@ -6,6 +6,10 @@ publishArtifact := false
 
 fork := true
 
+libraryDependencies ++= Seq(
+  metricsServlets
+)
+
 seq(Revolver.settings: _*)
 
 (mainClass in Revolver.reStart) := Some("com.example.http4s.tomcat.TomcatExample")

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
@@ -1,12 +1,18 @@
 package com.example.http4s.tomcat
 
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.servlets.MetricsServlet
 import com.example.http4s.ExampleService
 import org.http4s.server.tomcat.TomcatBuilder
 
 object TomcatExample extends App {
+  val metrics = new MetricRegistry
+
   TomcatBuilder
     .bindHttp(8080)
+    .withMetricRegistry(metrics)
     .mountService(ExampleService.service, "/http4s")
+    .mountServlet(new MetricsServlet(metrics), "/metrics/*")
     .run
     .awaitShutdown()
 }

--- a/jetty/jetty.sbt
+++ b/jetty/jetty.sbt
@@ -3,6 +3,7 @@ name := "http4s-jetty"
 description := "Jetty backend for http4s"
 
 libraryDependencies ++= Seq(
+  metricsJetty9,
   jettyServlet
 )
 

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -90,6 +90,14 @@ sealed class JettyBuilder private (
   override def withServletIo(servletIo: ServletIo): Self =
     copy(servletIo = servletIo)
 
+  /**
+   * Collects metrics into the specified [[MetricRegistry]], including:
+   * * Connections via [[InstrumentedConnectionFactory]]
+   * * The Jetty thread pool via [[InstrumentedQueuedThreadPool]]
+   * * HTTP responses via [[InstrumentedHandler]]
+   *
+   * @param metricRegistry The registry to collect metrics into..
+   */
   override def withMetricRegistry(metricRegistry: MetricRegistry): Self =
     copy(metricRegistry = Some(metricRegistry))
 

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -68,6 +68,9 @@ object Http4sBuild extends Build {
   lazy val jspApi              = "javax.servlet.jsp"         % "javax.servlet.jsp-api"   % "2.3.1" // YourKit hack
   lazy val log4s               = "org.log4s"                %% "log4s"                   % "1.1.3"
   lazy val logbackClassic      = "ch.qos.logback"            % "logback-classic"         % "1.1.2"
+  lazy val metricsCore         = "io.dropwizard.metrics"     % "metrics-core"            % "3.1.0"
+  lazy val metricsJetty9       = "io.dropwizard.metrics"     % "metrics-jetty9"          % metricsCore.revision
+  lazy val metricsServlets     = "io.dropwizard.metrics"     % "metrics-servlets"        % metricsCore.revision
   lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.0.1"
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
   lazy val scalameter          = "com.storm-enroute"        %% "scalameter"              % "0.6"

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -70,6 +70,7 @@ object Http4sBuild extends Build {
   lazy val logbackClassic      = "ch.qos.logback"            % "logback-classic"         % "1.1.2"
   lazy val metricsCore         = "io.dropwizard.metrics"     % "metrics-core"            % "3.1.0"
   lazy val metricsJetty9       = "io.dropwizard.metrics"     % "metrics-jetty9"          % metricsCore.revision
+  lazy val metricsServlet      = "io.dropwizard.metrics"     % "metrics-servlet"         % metricsCore.revision
   lazy val metricsServlets     = "io.dropwizard.metrics"     % "metrics-servlets"        % metricsCore.revision
   lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.0.1"
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv

--- a/server/server.sbt
+++ b/server/server.sbt
@@ -2,4 +2,8 @@ name := "http4s-server"
 
 description := "Server bindings for http4s"
 
+libraryDependencies ++= Seq(
+  metricsCore
+)
+
 mimaSettings

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -1,9 +1,9 @@
 package org.http4s.server
 
 import java.net.{InetAddress, InetSocketAddress}
-import java.security.KeyStore
 import java.util.concurrent.ExecutorService
 
+import com.codahale.metrics.MetricRegistry
 import org.http4s.server.SSLSupport.StoreInfo
 
 import scala.concurrent.duration._
@@ -69,4 +69,8 @@ object SSLSupport {
                      protocol: String,
                    trustStore: Option[StoreInfo],
                    clientAuth: Boolean)
+}
+
+trait MetricsSupport { this: ServerBuilder =>
+  def withMetricRegistry(metricRegistry: MetricRegistry): Self
 }

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -76,4 +76,10 @@ trait MetricsSupport { this: ServerBuilder =>
    * Triggers collection of backend-specific Metrics into the specified [[MetricRegistry]].
    */
   def withMetricRegistry(metricRegistry: MetricRegistry): Self
+
+  /** Sets the prefix for metrics gathered by the server.*/
+  def withMetricPrefix(metricPrefix: String): Self
+}
+object MetricsSupport {
+  val DefaultPrefix = "org.http4s.server"
 }

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -72,5 +72,8 @@ object SSLSupport {
 }
 
 trait MetricsSupport { this: ServerBuilder =>
+  /**
+   * Triggers collection of backend-specific Metrics into the specified [[MetricRegistry]].
+   */
   def withMetricRegistry(metricRegistry: MetricRegistry): Self
 }

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -95,6 +95,12 @@ sealed class TomcatBuilder private (
   override def withServletIo(servletIo: ServletIo): Self =
     copy(servletIo = servletIo)
 
+  /**
+   * Installs an [[InstrumentedFilter]] around the root of the context to collect
+   * HTTP response metrics.
+   *
+   * @param metricRegistry The registry to collect metrics into..
+   */
   override def withMetricRegistry(metricRegistry: MetricRegistry): Self =
     copy(metricRegistry = Some(metricRegistry))
 

--- a/tomcat/tomcat.sbt
+++ b/tomcat/tomcat.sbt
@@ -3,6 +3,7 @@ name := "http4s-tomcat"
 description := "Tomcat backend for http4s"
 
 libraryDependencies ++= Seq(
+  metricsServlet,
   tomcatCatalina,
   tomcatCoyote
 )


### PR DESCRIPTION
An incomplete implementation of #35.  If `withMetricRegistry` is called, the Jetty and Tomcat builders will now gather server-specific metrics.  Users who don't call this will experience a bit of classpath bloat, but no runtime hit.

Viewing the metrics currently requires mounting a servlet.  This will be addressed in #196 so http4s-blaze-server can join the party.

I'd like to discuss unifying the metrics collected, but I'd first like to discuss what people like and don't like between these two implementations.  Even before that, I'd like to get this out there because wrongly named, incomplete numbers are better than no numbers at all.