### PR TITLE
GZip will not throw an exception if the Accept-Encoding header is not gzip 

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -36,7 +36,7 @@ object GZip {
             else resp  // Don't touch it, Content-Encoding already set
           }(req)
 
-        case None =>  service(req)
+        case _ => service(req)
       }
     }
   }


### PR DESCRIPTION
When using the GZIp middleware, if the Accept-Encoding header is set but not gzip or x-gzip a scala.MatchError is thrown. I think in this case it should just fall through and continue processing the request.