### PR TITLE
Dont throw exceptions from the HttpParser

### DIFF
--- a/core/src/main/scala/org/http4s/parser/ContentTypeHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/ContentTypeHeader.scala
@@ -26,7 +26,7 @@ private[parser] trait ContentTypeHeader {
   def CONTENT_TYPE(value: String) = new ContentTypeParser(value).parse
 
   private class ContentTypeParser(input: ParserInput) extends Http4sHeaderParser[`Content-Type`](input) with MediaParser {
-    def entry: _root_.org.parboiled2.Rule1[`Content-Type`] = rule {
+    def entry: org.parboiled2.Rule1[`Content-Type`] = rule {
       (MediaRangeDef ~ optional(zeroOrMore(MediaTypeExtension)) ~ EOL) ~> { (range: MediaRange, exts: Option[Seq[(String, String)]]) =>
         val mediaType = range match {
           case m: MediaType => m

--- a/core/src/main/scala/org/http4s/parser/ScalazDeliverySchemes.scala
+++ b/core/src/main/scala/org/http4s/parser/ScalazDeliverySchemes.scala
@@ -14,6 +14,6 @@ private[http4s] object ScalazDeliverySchemes {
       type Result = ParseFailure \/ Out
       def success(result: L) = \/-(unpack(result))
       def parseError(error: ParseError) = -\/(ParseFailure("", error.formatExpectedAsString))
-      def failure(error: Throwable) = throw error
+      def failure(error: Throwable) = -\/(ParseFailure("Exception during parsing.", error.getMessage))
     }
 }

--- a/core/src/test/scala/org/http4s/parser/HeaderParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/HeaderParserSpec.scala
@@ -1,0 +1,16 @@
+package org.http4s
+package parser
+
+import util.CaseInsensitiveString._
+
+import org.specs2.mutable.Specification
+
+
+class HeaderParserSpec extends Specification {
+
+  "Header parsing should catch errors" in {
+    val h2 = Header.Raw("Date".ci, "Fri, 06 Feb 0010 15:28:43 GMT") // Invalid year: must be >= 1800
+    h2.parsed must not (throwA[Exception])
+  }
+
+}


### PR DESCRIPTION
Partial cause of issue http4s/rho#50

I don't think we should be throwing things when the parser chokes else we return an Internal Service Error, which may be true, but not very informative to the user.