### PR TITLE
Fix mapping of servlet query to request model

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -125,7 +125,7 @@ class Http4sServlet(service: HttpService,
   private def toRequest(req: HttpServletRequest): ParseResult[Request] =
     for {
       method <- Method.fromString(req.getMethod)
-      uri <- Uri.requestTarget(req.getRequestURI)
+      uri <- Uri.requestTarget(s"${req.getPathInfo}?${req.getQueryString}")
       version <- HttpVersion.fromString(req.getProtocol)
     } yield Request(
       method = method,


### PR DESCRIPTION
Now there are 2 issues with "servlet request mapping" to "http4s request":
1) (for sure) Query string is ignored: all the parameters passed to url (for example "?param1=val1&param2=val2") are ignored :)
2) (the philosophical one) using requestURI is incorrect because it contains a mount prefix (this makes routing invalid within a HttpService). Method getPathInfo returns a path without servlet url-pattern, so HttpService's become decoupled from uri prefix.

I (and a whole project) would be happy if this fix would be release as 0.6.2 in the nearest future :)
Thank you!