### PR TITLE
Switch to parboiled 2.1

### DIFF
--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -65,12 +65,12 @@ private[parser] trait Rfc3986Parser { this: Parser =>
                                                    6.times(H16 ~ ":") ~ LS32 |
                                             "::" ~ 5.times(H16 ~ ":") ~ LS32 |
           optional(H16) ~                   "::" ~ 4.times(H16 ~ ":") ~ LS32 |
-    (0 to 2).times(H16).separatedBy(":")  ~ "::" ~ 3.times(H16 ~ ":") ~ LS32 |
-    (0 to 3).times(H16).separatedBy(":")  ~ "::" ~ 2.times(H16 ~ ":") ~ LS32 |
-    (0 to 4).times(H16).separatedBy(":")  ~ "::" ~         H16 ~ ":"  ~ LS32 |
-    (0 to 5).times(H16).separatedBy(":")  ~ "::" ~                      LS32 |
-    (0 to 6).times(H16).separatedBy(":")  ~ "::" ~                      H16  |
-    (0 to 7).times(H16).separatedBy(":")  ~ "::"
+    optional((1 to 2).times(H16).separatedBy(":"))  ~ "::" ~ 3.times(H16 ~ ":") ~ LS32 |
+    optional((1 to 3).times(H16).separatedBy(":"))  ~ "::" ~ 2.times(H16 ~ ":") ~ LS32 |
+    optional((1 to 4).times(H16).separatedBy(":"))  ~ "::" ~         H16 ~ ":"  ~ LS32 |
+    optional((1 to 5).times(H16).separatedBy(":"))  ~ "::" ~                      LS32 |
+    optional((1 to 6).times(H16).separatedBy(":"))  ~ "::" ~                      H16  |
+    optional((1 to 7).times(H16).separatedBy(":"))  ~ "::"
   }
 
   def H16 = rule { (1 to 4).times(HexDigit) }

--- a/core/src/main/scala/org/http4s/parser/ScalazDeliverySchemes.scala
+++ b/core/src/main/scala/org/http4s/parser/ScalazDeliverySchemes.scala
@@ -3,17 +3,19 @@ package org.http4s.parser
 import scalaz._
 
 import org.http4s.ParseFailure
-import org.parboiled2.ParseError
+import org.parboiled2.{ ErrorFormatter, ParseError }
 import org.parboiled2.Parser.DeliveryScheme
 import org.parboiled2.support.Unpack
 import shapeless.HList
 
 private[http4s] object ScalazDeliverySchemes {
+  private val errorFormattter = new ErrorFormatter()
+
   implicit def Disjunction[L <: HList, Out](implicit unpack: Unpack.Aux[L, Out]) =
     new DeliveryScheme[L] {
       type Result = ParseFailure \/ Out
       def success(result: L) = \/-(unpack(result))
-      def parseError(error: ParseError) = -\/(ParseFailure("", error.formatExpectedAsString))
+      def parseError(error: ParseError) = -\/(ParseFailure("", errorFormattter.formatExpectedAsString(error)))
       def failure(error: Throwable) = -\/(ParseFailure("Exception during parsing.", error.getMessage))
     }
 }

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -72,7 +72,7 @@ object Http4sBuild extends Build {
   lazy val metricsJetty9       = "io.dropwizard.metrics"     % "metrics-jetty9"          % metricsCore.revision
   lazy val metricsServlet      = "io.dropwizard.metrics"     % "metrics-servlet"         % metricsCore.revision
   lazy val metricsServlets     = "io.dropwizard.metrics"     % "metrics-servlets"        % metricsCore.revision
-  lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.0.1"
+  lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.1.0"
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
   lazy val scalameter          = "com.storm-enroute"        %% "scalameter"              % "0.6"
   lazy val scalaXml            = "org.scala-lang.modules"   %% "scala-xml"               % "1.0.3"


### PR DESCRIPTION
This PR updates the parboiled version to 2.1, which is *not* binary compatible with 2.0, hence the necessity of the upgrade. Very few changes and the tests still pass, but I'm a total parboiled noob :-), so read this carefully.