### PR TITLE
Don't accidentally load non-blocking servlet API. #229

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -20,7 +20,7 @@ import org.log4s.getLogger
 class Http4sServlet(service: HttpService,
                     asyncTimeout: Duration = Duration.Inf,
                     threadPool: ExecutorService = Strategy.DefaultExecutorService,
-                    private[this] var servletIo: ServletIo = NonBlockingServletIo(4096))
+                    private[this] var servletIo: ServletIo = BlockingServletIo(4096))
   extends HttpServlet
 {
   private[this] val logger = getLogger
@@ -39,6 +39,8 @@ class Http4sServlet(service: HttpService,
     serverSoftware = ServerSoftware(servletContext.getServerInfo)
   }
 
+  // TODO This is a dodgy check.  It will have already triggered class loading of javax.servlet.WriteListener.
+  // Remove when we can break binary compatibility.
   private def verifyServletIo(servletApiVersion: ServletApiVersion): Unit = servletIo match {
     case NonBlockingServletIo(chunkSize) if servletApiVersion < ServletApiVersion(3, 1) =>
       logger.warn("Non-blocking servlet I/O requires Servlet API >= 3.1. Falling back to blocking I/O.")

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -20,7 +20,7 @@ import org.log4s.getLogger
 class Http4sServlet(service: HttpService,
                     asyncTimeout: Duration = Duration.Inf,
                     threadPool: ExecutorService = Strategy.DefaultExecutorService,
-                    private[this] var servletIo: ServletIo = BlockingServletIo(4096))
+                    private[this] var servletIo: ServletIo = BlockingServletIo(DefaultChunkSize))
   extends HttpServlet
 {
   private[this] val logger = getLogger

--- a/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
@@ -22,7 +22,7 @@ trait ServletContainer
 }
 
 object ServletContainer {
-  val DefaultServletIo = NonBlockingServletIo(4096)
+  val DefaultServletIo = NonBlockingServletIo(DefaultChunkSize)
 
   /**
    * Trims an optional trailing slash and then appends "/\u002b'.  Translates an argument to

--- a/servlet/src/main/scala/org/http4s/servlet/package.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/package.scala
@@ -6,4 +6,6 @@ package object servlet {
   protected[servlet] type BodyWriter = Response => Task[Unit]
 
   protected[servlet] val NullBodyWriter: BodyWriter = { _ => Task.now(()) }
+
+  protected[servlet] val DefaultChunkSize = 4096
 }

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -3,14 +3,10 @@ package org.http4s.servlet.syntax
 import javax.servlet.{ServletRegistration, ServletContext}
 
 import org.http4s.server.{AsyncTimeoutSupport, HttpService}
-import org.http4s.servlet.{NonBlockingServletIo, Http4sServlet}
+import org.http4s.servlet._
 
 import scalaz.concurrent.Strategy
-import scalaz.syntax.Ops
 
-/**
- * Created by ross on 12/19/14.
- */
 trait ServletContextSyntax {
   implicit def ToServletContextOps(self: ServletContext): ServletContextOps = new ServletContextOps(self)
 }
@@ -22,13 +18,22 @@ final class ServletContextOps private[syntax](val self: ServletContext) extends 
       service = service,
       asyncTimeout = AsyncTimeoutSupport.DefaultAsyncTimeout,
       threadPool = Strategy.DefaultExecutorService,
-      servletIo = NonBlockingServletIo(4096)
+      servletIo = servletIo
     )
     val reg = self.addServlet(name, servlet)
     reg.setLoadOnStartup(1)
     reg.setAsyncSupported(true)
     reg.addMapping(mapping)
     reg
+  }
+
+  private def servletIo: ServletIo = {
+    val chunkSize = 4096
+    val version = ServletApiVersion(self.getMajorVersion, self.getMinorVersion)
+    if (version >= ServletApiVersion(3, 1))
+      NonBlockingServletIo(4096)
+    else
+      BlockingServletIo(chunkSize)
   }
 }
 

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -1,4 +1,5 @@
-package org.http4s.servlet.syntax
+package org.http4s.servlet
+package syntax
 
 import javax.servlet.{ServletRegistration, ServletContext}
 
@@ -28,12 +29,11 @@ final class ServletContextOps private[syntax](val self: ServletContext) extends 
   }
 
   private def servletIo: ServletIo = {
-    val chunkSize = 4096
     val version = ServletApiVersion(self.getMajorVersion, self.getMinorVersion)
     if (version >= ServletApiVersion(3, 1))
-      NonBlockingServletIo(4096)
+      NonBlockingServletIo(DefaultChunkSize)
     else
-      BlockingServletIo(chunkSize)
+      BlockingServletIo(DefaultChunkSize)
   }
 }
 


### PR DESCRIPTION
The check in Http4sServlet comes too late: NonBlockingServletIo is the
default, and it already tries to load classes that aren't there.  It's
fine in the xsbt-web-plugin with Jetty 9, but Tomcat 7 exposes the
problem.

Make the ServletContextOps default to the proper servlet I/O version.
Constructing a servlet by hand will now default to blocking I/O.  When
we can break binary compatibility, we will reinstate the option to
select based on the server.