### PR TITLE
Fix servlet request URI to include context and servlet path.

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -127,7 +127,7 @@ class Http4sServlet(service: HttpService,
   private def toRequest(req: HttpServletRequest): ParseResult[Request] =
     for {
       method <- Method.fromString(req.getMethod)
-      uri <- Uri.requestTarget(s"${req.getPathInfo}?${req.getQueryString}")
+      uri <- Uri.requestTarget(s"${req.getRequestURI}?${req.getQueryString}")
       version <- HttpVersion.fromString(req.getProtocol)
     } yield Request(
       method = method,


### PR DESCRIPTION
When we added the query string, we introduced a bug in how
we get the path from the servlet request.  This keeps the
query fix and reverts the bug.