### PR TITLE
blaze client should add a User-Agent header

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -9,6 +9,7 @@ import javax.net.ssl.SSLContext
 
 import org.http4s.Uri.Scheme
 import org.http4s.blaze.channel.nio2.ClientChannelFactory
+import org.http4s.headers.`User-Agent`
 import org.http4s.util.task
 import org.http4s.{Uri, Request}
 import org.http4s.blaze.pipeline.LeafBuilder
@@ -28,6 +29,7 @@ import scalaz.{\/, -\/, \/-}
   * Also serves as a non-recycling [[ConnectionManager]] */
 final class Http1Support(bufferSize: Int,
                             timeout: Duration,
+                          userAgent: Option[`User-Agent`],
                                  es: ExecutorService,
                         osslContext: Option[SSLContext],
                               group: Option[AsynchronousChannelGroup])
@@ -67,7 +69,7 @@ final class Http1Support(bufferSize: Int,
   }
 
   private def buildStages(uri: Uri): (LeafBuilder[ByteBuffer], BlazeClientStage) = {
-    val t = new Http1ClientStage(timeout)(ec)
+    val t = new Http1ClientStage(userAgent, timeout)(ec)
     val builder = LeafBuilder(t)
     uri match {
       case Uri(Some(Https),_,_,_,_) =>

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -4,6 +4,8 @@ import java.nio.channels.AsynchronousChannelGroup
 import java.util.concurrent.ExecutorService
 import javax.net.ssl.SSLContext
 
+import org.http4s.headers.`User-Agent`
+
 import scala.concurrent.duration.Duration
 
 
@@ -13,11 +15,12 @@ object PooledHttp1Client {
   /** Construct a new PooledHttp1Client */
   def apply(maxPooledConnections: Int = 10,
                          timeout: Duration = DefaultTimeout,
+                       userAgent: Option[`User-Agent`] = DefaultUserAgent,
                       bufferSize: Int = DefaultBufferSize,
                         executor: ExecutorService = ClientDefaultEC,
                       sslContext: Option[SSLContext] = None,
                            group: Option[AsynchronousChannelGroup] = None) = {
-    val http1 = new Http1Support(bufferSize, timeout, executor, sslContext, group)
+    val http1 = new Http1Support(bufferSize, timeout, userAgent, executor, sslContext, group)
     val pool = new PoolManager(maxPooledConnections, http1)
     new BlazeClient(pool)
   }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
@@ -4,14 +4,16 @@ import java.nio.channels.AsynchronousChannelGroup
 import java.util.concurrent.ExecutorService
 import javax.net.ssl.SSLContext
 
+import org.http4s.headers.`User-Agent`
 import scala.concurrent.duration.Duration
 
 /** Create HTTP1 clients which will disconnect on completion of one request */
 object SimpleHttp1Client {
   def apply(timeout: Duration = DefaultTimeout,
          bufferSize: Int = DefaultBufferSize,
+          userAgent: Option[`User-Agent`] = DefaultUserAgent,
            executor: ExecutorService = ClientDefaultEC,
          sslContext: Option[SSLContext] = None,
               group: Option[AsynchronousChannelGroup] = None) =
-    new BlazeClient(new Http1Support(bufferSize, timeout, executor, sslContext, group))
+    new BlazeClient(new Http1Support(bufferSize, timeout, userAgent, executor, sslContext, group))
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
@@ -3,6 +3,8 @@ package org.http4s.client
 import java.util.concurrent.TimeUnit
 import java.util.concurrent._
 
+import org.http4s.BuildInfo
+import org.http4s.headers.{AgentProduct, `User-Agent`}
 import org.http4s.blaze.util.TickWheelExecutor
 
 import scala.concurrent.duration._
@@ -13,6 +15,7 @@ package object blaze {
   // Centralize some defaults
   private[blaze] val DefaultTimeout: Duration = 60.seconds
   private[blaze] val DefaultBufferSize: Int = 8*1024
+  private[blaze] val DefaultUserAgent = Some(`User-Agent`(AgentProduct("http4s-blaze", Some(BuildInfo.version))))
   private[blaze] val ClientDefaultEC = {
     val threadFactory = new ThreadFactory {
       val defaultThreadFactory = Executors.defaultThreadFactory()
@@ -35,5 +38,8 @@ package object blaze {
   private[blaze] val ClientTickWheel = new TickWheelExecutor()
 
   /** Default blaze client */
-  val defaultClient = SimpleHttp1Client(DefaultTimeout, DefaultBufferSize, ClientDefaultEC, None)
+  val defaultClient = SimpleHttp1Client(timeout = DefaultTimeout,
+                                     bufferSize = DefaultBufferSize,
+                                       executor = ClientDefaultEC,
+                                     sslContext = None)
 }


### PR DESCRIPTION
What should we do about version numbers? I know we will forget to update if we start hard coding them. Maybe we should think about generating the library version during build time.