### PR TITLE
Uses an Exchange to model a WebSocket.

### DIFF
--- a/core/src/main/scala/org/http4s/websocket/Websocket.scala
+++ b/core/src/main/scala/org/http4s/websocket/Websocket.scala
@@ -1,9 +1,8 @@
 package org.http4s.websocket
 
-import scalaz.concurrent.Task
-import scalaz.stream.{Process, Sink}
+import scalaz.stream.Exchange
 
 import org.http4s.websocket.WebsocketBits.WebSocketFrame
 
-private[http4s] case class Websocket(source: Process[Task, WebSocketFrame], sink: Sink[Task, WebSocketFrame])
+private[http4s] case class Websocket(exchange: Exchange[WebSocketFrame, WebSocketFrame])
 

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -12,7 +12,7 @@ import org.http4s.server.middleware.URITranslation
 import org.http4s.websocket.WebsocketBits._
 
 import scalaz.concurrent.Strategy
-import scalaz.stream.DefaultScheduler
+import scalaz.stream.{DefaultScheduler, Exchange}
 import scalaz.stream.time.awakeEvery
 
 object BlazeWebSocketExample extends App {
@@ -36,7 +36,7 @@ import scala.concurrent.duration._
         case Text(t, _) => Task.delay( println(t))
         case f       => Task.delay(println(s"Unknown type: $f"))
       }
-      WS(src, sink)
+      WS(Exchange(src, sink))
 
     case req@ GET -> Root / "wsecho" =>
       val t = topic[WebSocketFrame]()
@@ -44,7 +44,7 @@ import scala.concurrent.duration._
         case Text(msg, _) => Text("You sent the server: " + msg)
       }
 
-      WS(src, t.publish)
+      WS(Exchange(src, t.publish))
   }
 
   def pipebuilder(conn: SocketConnection): LeafBuilder[ByteBuffer] =

--- a/server/src/main/scala/org/http4s/server/websocket/package.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/package.scala
@@ -4,15 +4,14 @@ package server
 import org.http4s.websocket.Websocket
 import org.http4s.websocket.WebsocketBits.WebSocketFrame
 
-import scalaz.stream.{Process, Sink}
+import scalaz.stream.{Exchange, Process, Sink}
 import scalaz.concurrent.Task
 import Process._
 
 package object websocket {
   val websocketKey = AttributeKey.http4s[Websocket]("websocket")
 
-  def WS(source: Process[Task, WebSocketFrame] = halt,
-         sink: Sink[Task, WebSocketFrame] = halt,
+  def WS(exchange: Exchange[WebSocketFrame, WebSocketFrame],
          status: Task[Response] = Response(Status.NotImplemented).withBody("This is a WebSocket route.")): Task[Response] =
-    status.map(_.withAttribute(websocketKey, Websocket(source, sink)))
+    status.map(_.withAttribute(websocketKey, Websocket(exchange)))
 }


### PR DESCRIPTION
Uses a scalaz-stream `Exchange` (see [here](https://github.com/scalaz/scalaz-stream/blob/master/src/main/scala/scalaz/stream/Exchange.scala#L30)) to model a `WebSocket`. An `Exchange` is the standard way in scalaz-stream to model a "source/sink" pair.

This opens the door to future improvements through use of `Exchange` combinators and other functions from scalaz-stream or [scalaz-netty](https://github.com/RichRelevance/scalaz-netty/blob/master/src/main/scala/scalaz/netty/Netty.scala#L49).