### PR TITLE
Add Metrics middleware

### DIFF
--- a/examples/blaze/examples-blaze.sbt
+++ b/examples/blaze/examples-blaze.sbt
@@ -6,6 +6,10 @@ publishArtifact := false
 
 fork := true
 
+libraryDependencies ++= Seq(
+  "io.dropwizard.metrics" % "metrics-json" % "3.1.0"
+)
+
 seq(Revolver.settings: _*)
 
 

--- a/examples/blaze/examples-blaze.sbt
+++ b/examples/blaze/examples-blaze.sbt
@@ -6,9 +6,7 @@ publishArtifact := false
 
 fork := true
 
-libraryDependencies ++= Seq(
-  "io.dropwizard.metrics" % "metrics-json" % "3.1.0"
-)
+libraryDependencies += metricsJson
 
 seq(Revolver.settings: _*)
 

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -1,0 +1,39 @@
+package com.example.http4s.blaze
+
+/// code_ref: blaze_server_example
+
+import java.util.concurrent.TimeUnit
+
+import com.example.http4s.ExampleService
+import org.http4s.server.HttpService
+import org.http4s.server.blaze.BlazeBuilder
+import org.http4s.server.middleware.Metrics
+import org.http4s.dsl._
+
+
+
+import com.codahale.metrics._
+import com.codahale.metrics.json.MetricsModule
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
+object BlazeMetricsExample extends App {
+
+  val metrics = new MetricRegistry()
+  val mapper = new ObjectMapper()
+                  .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.SECONDS, true))
+
+  val metricsService = HttpService {
+    case GET -> Root / "metrics" =>
+      val writer = mapper.writerWithDefaultPrettyPrinter()
+      Ok(writer.writeValueAsString(metrics))
+  }
+
+  val srvc = Metrics.meter(metrics, "Sample")(ExampleService.service orElse metricsService)
+
+  BlazeBuilder.bindHttp(8080)
+    .mountService(srvc, "/http4s")
+    .run
+    .awaitShutdown()
+}
+/// end_code_ref

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -1,7 +1,5 @@
 package com.example.http4s
 
-import _root_.argonaut.JString
-
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -8,14 +8,18 @@ import org.http4s.scalaxml._
 import scodec.bits.ByteVector
 
 import scala.xml.Elem
+import scala.concurrent.duration._
 import scalaz.{Reducer, Monoid}
 import scalaz.concurrent.Task
 import scalaz.stream.Process
+import scalaz.stream.time.awakeEvery
 import scalaz.stream.Process._
 
 /** These are routes that we tend to use for testing purposes
   * and will likely get folded into unit tests later in life */
 object ScienceExperiments {
+
+  private implicit def timedES = scalaz.concurrent.Strategy.DefaultTimeoutScheduler
 
   val flatBigString = (0 until 1000).map{ i => s"This is string number $i" }.foldLeft(""){_ + _}
 
@@ -94,6 +98,14 @@ object ScienceExperiments {
     case req @ GET -> Root / "hanging-body" =>
       Ok(Process(Task.now(ByteVector(Seq(' '.toByte))), Task.async[ByteVector] { cb => /* hang */}).eval)
         .withHeaders(`Transfer-Encoding`(TransferCoding.chunked))
+
+    case req @ GET -> Root / "broken-body" =>
+      Ok(Process(Task{"Hello "}) ++ Process(Task{sys.error("Boom!")}) ++ Process(Task{"world!"}))
+
+    case req @ GET -> Root / "slow-body" =>
+      val resp = "Hello world!".map(_.toString())
+      val body = awakeEvery(2.seconds).zipWith(Process.emitAll(resp))((_, c) => c)
+      Ok(body).withHeaders(`Transfer-Encoding`(TransferCoding.chunked))
 
     case req @ POST -> Root / "ill-advised-echo" =>
       // Reads concurrently from the input.  Don't do this at home.

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -72,6 +72,7 @@ object Http4sBuild extends Build {
   lazy val metricsJetty9       = "io.dropwizard.metrics"     % "metrics-jetty9"          % metricsCore.revision
   lazy val metricsServlet      = "io.dropwizard.metrics"     % "metrics-servlet"         % metricsCore.revision
   lazy val metricsServlets     = "io.dropwizard.metrics"     % "metrics-servlets"        % metricsCore.revision
+  lazy val metricsJson         = "io.dropwizard.metrics"     % "metrics-json"            % metricsCore.revision
   lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.1.0"
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
   lazy val scalameter          = "com.storm-enroute"        %% "scalameter"              % "0.6"

--- a/server/src/main/scala/org/http4s/server/middleware/Metrics.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Metrics.scala
@@ -1,0 +1,119 @@
+package org.http4s.server.middleware
+
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics._
+
+import org.http4s.{Method, Response, Request}
+import org.http4s.server.{Service, HttpService}
+
+import scalaz.stream.Cause.End
+import scalaz.{\/, -\/, \/-}
+import scalaz.concurrent.Task
+import scalaz.stream.Process.{Halt, halt}
+
+object Metrics {
+
+  def meter(m: MetricRegistry, name: String)(srvc: HttpService): HttpService = {
+
+    val active_requests = m.counter(name + ".active-requests")
+
+    val abnormal_termination = m.timer(name + ".abnormal-termination")
+    val service_failure = m.timer(name + ".service-error")
+    val headers_times = m.timer(name + ".headers-times")
+
+
+    val resp1xx = m.timer(name + ".1xx-responses")
+    val resp2xx = m.timer(name + ".2xx-responses")
+    val resp3xx = m.timer(name + ".3xx-responses")
+    val resp4xx = m.timer(name + ".4xx-responses")
+    val resp5xx = m.timer(name + ".5xx-responses")
+//    "org.eclipse.jetty.servlet.ServletContextHandler.async-dispatches"
+//    "org.eclipse.jetty.servlet.ServletContextHandler.async-timeouts"
+
+//    "http.connections"
+
+//    "org.eclipse.jetty.servlet.ServletContextHandler.dispatches"
+    val get_req = m.timer(name + ".get-requests")
+    val post_req = m.timer(name + ".post-requests")
+    val put_req = m.timer(name + ".put-requests")
+    val head_req = m.timer(name + ".head-requests")
+    val move_req = m.timer(name + ".move-requests")
+    val options_req = m.timer(name + ".options-requests")
+
+    val trace_req = m.timer(name + ".trace-requests")
+    val connect_req = m.timer(name + ".connect-requests")
+    val delete_req = m.timer(name + ".delete-requests")
+    val other_req = m.timer(name + ".other-requests")
+    val total_req = m.timer(name + ".requests")
+
+
+    def generalMetrics(method: Method, elapsed: Long): Unit = {
+      method match {
+        case Method.GET     => get_req.update(elapsed, TimeUnit.NANOSECONDS)
+        case Method.POST    => post_req.update(elapsed, TimeUnit.NANOSECONDS)
+        case Method.PUT     => put_req.update(elapsed, TimeUnit.NANOSECONDS)
+        case Method.HEAD    => head_req.update(elapsed, TimeUnit.NANOSECONDS)
+        case Method.MOVE    => move_req.update(elapsed, TimeUnit.NANOSECONDS)
+        case Method.OPTIONS => options_req.update(elapsed, TimeUnit.NANOSECONDS)
+        case Method.TRACE   => trace_req.update(elapsed, TimeUnit.NANOSECONDS)
+        case Method.CONNECT => connect_req.update(elapsed, TimeUnit.NANOSECONDS)
+        case Method.DELETE  => delete_req.update(elapsed, TimeUnit.NANOSECONDS)
+        case _              => other_req.update(elapsed, TimeUnit.NANOSECONDS)
+      }
+
+      total_req.update(elapsed, TimeUnit.NANOSECONDS)
+      active_requests.dec()
+    }
+
+    def onFinish(method: Method, start: Long)(r: Throwable\/Option[Response]): Throwable\/Option[Response] = {
+      val elapsed = System.nanoTime() - start
+
+      r match {
+        case \/-(Some(r)) =>
+          headers_times.update(System.nanoTime() - start, TimeUnit.NANOSECONDS)
+          val code = r.status.code
+
+          val body = r.body.onHalt { cause =>
+            val elapsed = System.nanoTime() - start
+
+            generalMetrics(method, elapsed)
+
+            if (code < 200) resp1xx.update(elapsed, TimeUnit.NANOSECONDS)
+            else if (code < 300) resp2xx.update(elapsed, TimeUnit.NANOSECONDS)
+            else if (code < 400) resp3xx.update(elapsed, TimeUnit.NANOSECONDS)
+            else if (code < 500) resp4xx.update(elapsed, TimeUnit.NANOSECONDS)
+            else resp5xx.update(elapsed, TimeUnit.NANOSECONDS)
+
+            cause match {
+              case End => halt
+              case _   =>
+                abnormal_termination.update(elapsed, TimeUnit.NANOSECONDS)
+                Halt(cause)
+            }
+          }
+
+          \/-(Some(r.copy(body = body)))
+
+        case r@ \/-(None)    =>
+          generalMetrics(method, elapsed)
+          resp4xx.update(elapsed, TimeUnit.NANOSECONDS)
+          r
+
+        case e@ -\/(_)       =>
+          generalMetrics(method, elapsed)
+          resp5xx.update(elapsed, TimeUnit.NANOSECONDS)
+          service_failure.update(elapsed, TimeUnit.NANOSECONDS)
+          e
+      }
+    }
+
+    def go(req: Request): Task[Option[Response]] = {
+      val now = System.nanoTime()
+      active_requests.inc()
+      new Task(srvc.run(req).get.map(onFinish(req.method, now)))
+    }
+
+    Service.lift(go)
+  }
+}

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -3,6 +3,7 @@ package org.http4s
 import scalaz.concurrent.Task
 
 package object server {
+  type Middleware  = HttpService => HttpService
   type HttpService = Service[Request, Response]
 
   object HttpService {


### PR DESCRIPTION
Metrics can be done backend independently if we simple use it as a
middleware.

This implementation is modeled after the reference
metrics-jetty package.