### PR TITLE
two small changes to Path parsing (fixes #257)

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Path.scala
@@ -9,6 +9,7 @@ package org.http4s
 package dsl
 
 import org.http4s.QueryParamDecoder
+import org.http4s.util.UrlCodingUtils
 
 import scalaz.syntax.traverse._
 import scalaz.std.list._
@@ -31,11 +32,8 @@ object Path {
       Path("/" + str)
     else {
       val slash = str.lastIndexOf('/')
-      val prefix = Path(str.substring(0, slash))
-      if (slash == str.length - 1)
-        prefix
-      else
-        prefix / str.substring(slash + 1)
+      val prefix = Path(UrlCodingUtils.urlDecode(str.substring(0, slash)))
+      prefix / UrlCodingUtils.urlDecode(str.substring(slash + 1))
     }
 
   def apply(first: String, rest: String*): Path =

--- a/dsl/src/main/scala/org/http4s/dsl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Path.scala
@@ -9,11 +9,13 @@ package org.http4s
 package dsl
 
 import org.http4s.QueryParamDecoder
-import org.http4s.util.UrlCodingUtils
+import org.http4s.util.{UrlCodingUtils, UrlFormCodec}
 
 import scalaz.syntax.traverse._
 import scalaz.std.list._
 import scalaz.std.option._
+
+import collection.immutable.BitSet
 
 /** Base class for path extractors. */
 abstract class Path {
@@ -32,7 +34,7 @@ object Path {
       Path("/" + str)
     else {
       val slash = str.lastIndexOf('/')
-      val prefix = Path(UrlCodingUtils.urlDecode(str.substring(0, slash)))
+      val prefix = Path(str.substring(0, slash))
       prefix / UrlCodingUtils.urlDecode(str.substring(slash + 1))
     }
 
@@ -47,6 +49,7 @@ object Path {
 
   def unapply(request: Request): Option[Path] = Some(Path(request.pathInfo))
 
+  val pathUnreserved = UrlFormCodec.urlUnreserved ++ BitSet(":@!$&'()*+,;=".toList.map(_.toInt): _*)
 }
 
 object :? {
@@ -88,7 +91,7 @@ object ~ {
 case class /(parent: Path, child: String) extends Path {
   lazy val toList: List[String] = parent.toList ++ List(child)
   def lastOption: Option[String] = Some(child)
-  lazy val asString = parent.toString + "/" + child
+  lazy val asString = parent.toString + "/" + UrlCodingUtils.urlEncode(child, toSkip = Path.pathUnreserved)
   override def toString = asString
   def startsWith(other: Path) = {
     val components = other.toList

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -91,6 +91,20 @@ class PathSpec extends Http4sSpec {
         case _                                    => false
       }) must beTrue
     }
+    
+    "trailing slash" in {
+      (Path("/1/2/3/") match {
+        case Root / "1" / "2" / "3" / "" => true
+        case _                           => false
+      }) must beTrue
+    }
+    
+    "encoded chars" in {
+      (Path("/foo%20bar/1%2F2") match {
+        case Root / "foo bar" / "1/2" => true
+        case _                        => false
+      }) must beTrue
+    }
 
     "Int extractor" in {
       (Path("/user/123") match {

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -100,10 +100,15 @@ class PathSpec extends Http4sSpec {
     }
     
     "encoded chars" in {
-      (Path("/foo%20bar/1%2F2") match {
-        case Root / "foo bar" / "1/2" => true
-        case _                        => false
+      (Path("/foo%20bar/and%2For/1%2F2") match {
+        case Root / "foo bar" / "and/or" / "1/2" => true
+        case _                                   => false
       }) must beTrue
+    }
+
+    "encode chars in toString" in {
+      (Root / "foo bar" / "and/or" / "1/2").toString must_==
+        "/foo%20bar/and%2For/1%2F2"
     }
 
     "Int extractor" in {


### PR DESCRIPTION
Don't strip trailing `/`s in Path. Formerly, `Root / "foo"` would match
both `/foo` and `/foo/`. Now, you can/must do `Root / "foo" / ""` to
match the latter.

*Note: this change seems likely to break user code, but did not break any existing test.*

URL-decode path segments, so that it's possible to encode characters
like `/` and space.