### PR TITLE
Topic/authorization

### DIFF
--- a/examples/src/main/twirl/com/example/http4s/index.scala.html
+++ b/examples/src/main/twirl/com/example/http4s/index.scala.html
@@ -19,6 +19,7 @@
 
     <li><a href="form-encoded">A submission form</a></li>
     <li><a href="push">Server push</a></li>
+    <li><a href="protected">Digest authentication</a></li>
 </ul>
 </body>
 </html>

--- a/server/server.sbt
+++ b/server/server.sbt
@@ -3,7 +3,8 @@ name := "http4s-server"
 description := "Server bindings for http4s"
 
 libraryDependencies ++= Seq(
-  metricsCore
+  metricsCore,
+  "com.typesafe.akka" %% "akka-actor" % "2.3.9"
 )
 
 mimaSettings

--- a/server/server.sbt
+++ b/server/server.sbt
@@ -3,8 +3,7 @@ name := "http4s-server"
 description := "Server bindings for http4s"
 
 libraryDependencies ++= Seq(
-  metricsCore,
-  "com.typesafe.akka" %% "akka-actor" % "2.3.9"
+  metricsCore
 )
 
 mimaSettings

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/Authentication.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/Authentication.scala
@@ -22,7 +22,7 @@ trait Authentication {
    *         response that is returned to the client.
    *
    */
-  def getChallenge(req: Request): Task[Option[Challenge]]
+  protected def getChallenge(req: Request): Task[Option[Challenge]]
 
   def apply(service: HttpService): HttpService = Service.lift {
     case req: Request => getChallenge(req).flatMap(_ match {

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/Authentication.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/Authentication.scala
@@ -1,0 +1,37 @@
+package org.http4s
+package server
+package middleware
+package authentication
+
+import scalaz.concurrent.Task
+import org.http4s.headers.`WWW-Authenticate`
+
+/**
+ * Authentication instances are middleware that provide a
+ * {@link HttpService} with HTTP authentication.
+ */
+trait Authentication {
+  /**
+   * Check if req contains valid credentials. You may assume that
+   * getChallenge( req ) is called at most once for every req object
+   * (to allow for side-effects, e.g. the incrementation of a nonce
+   * counter in DigestAuthentication).
+   * @param req The request received from the client.
+   * @return If req contains valid credentials, None is returned.
+   *         Otherwise, Some(challenge) is returned. In this case,
+   *         challenge will be included in the HTTP 401 Unauthorized
+   *         response that is returned to the client.
+   *
+   */
+  def getChallenge(req: Request): Option[Challenge]
+
+  def apply(service: HttpService): HttpService = Service.lift {
+    case req: Request => getChallenge(req) match {
+      case None => service(req)
+
+      case Some(challenge) =>
+        Task.now(Some(Response(Status.Unauthorized).putHeaders(`WWW-Authenticate`(challenge))))
+    }
+  }
+}
+

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuthentication.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuthentication.scala
@@ -1,0 +1,42 @@
+package org.http4s
+package server
+package middleware
+package authentication
+
+import org.http4s.headers.Authorization
+
+/**
+ * Provides Basic Authentication from RFC 2617.
+ * @param realm The realm used for authentication purposes.
+ * @param store A partial function mapping (realm, user) to the
+ *              appropriate password.
+ */
+class BasicAuthentication(realm: String, store: AuthenticationStore) extends Authentication {
+  def getChallenge(req: Request): Option[Challenge] = checkAuth(req) match {
+    case OK => None
+    case _ => Some(Challenge("Basic", realm, Nil.toMap))
+  }
+
+  private def checkAuth(req: Request): AuthReply = {
+    req.headers.foldLeft(NoAuthorizationHeader: AuthReply) {
+      case (acc, h) =>
+        if (acc != NoAuthorizationHeader)
+          acc
+        else h match {
+          case Authorization(auth) =>
+            auth.credentials match {
+              case BasicCredentials(user, client_pass) =>
+                if (!store.isDefinedAt((realm, user)))
+                  UserUnknown
+                else
+                  store((realm, user)) match {
+                    case server_pass if server_pass == client_pass => OK
+                    case _ => WrongPassword
+                  }
+              case _ => NoCredentials
+            }
+          case _ => NoAuthorizationHeader
+        }
+    }
+  }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuthentication.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuthentication.scala
@@ -4,6 +4,7 @@ package middleware
 package authentication
 
 import org.http4s.headers.Authorization
+import scalaz.concurrent.Task
 
 /**
  * Provides Basic Authentication from RFC 2617.
@@ -12,10 +13,10 @@ import org.http4s.headers.Authorization
  *              appropriate password.
  */
 class BasicAuthentication(realm: String, store: AuthenticationStore) extends Authentication {
-  def getChallenge(req: Request): Option[Challenge] = checkAuth(req) match {
+  def getChallenge(req: Request): Task[Option[Challenge]] = Task.now(checkAuth(req) match {
     case OK => None
     case _ => Some(Challenge("Basic", realm, Nil.toMap))
-  }
+  })
 
   private def checkAuth(req: Request): AuthReply = {
     req.headers.foldLeft(NoAuthorizationHeader: AuthReply) {

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuthentication.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuthentication.scala
@@ -1,0 +1,192 @@
+package org.http4s
+package server
+package middleware
+package authentication
+
+import java.security.SecureRandom
+import java.math.BigInteger
+import java.util.Date
+import scala.concurrent._
+import scala.concurrent.duration._
+import akka.actor._
+import akka.pattern.ask
+import akka.util.{Timeout => ATimeout}
+import org.http4s.headers.Authorization
+import scala.collection.immutable.HashMap
+
+/**
+ * Provides Digest Authentication from RFC 2617.
+ * @param realm The realm used for authentication purposes.
+ * @param store A partial function mapping (realm, user) to the
+ *              appropriate password.
+ * @param nonceCleanupInterval Interval (in seconds) at which stale
+ *                             nonces should be cleaned up.
+ * @param nonceStaleTime Amount of time (in seconds) after which a nonce
+ *                       is considered stale (i.e. not used for authentication
+ *                       purposes anymore).
+ * @param nonceBits The number of random bits a nonce should consist of.
+ */
+class DigestAuthentication(realm: String, store: AuthenticationStore, nonceCleanupInterval: Long = 3600, nonceStaleTime: Long = 3600, nonceBits: Int = 160) extends Authentication {
+
+  val actor_system = ActorSystem("DigestAuthentication")
+  val nonce_keeper = actor_system.actorOf(Props(new NonceKeeper(nonceStaleTime * 1000, nonceBits)), "nonce_keeper")
+
+  val cleanup_interval = nonceCleanupInterval.seconds
+
+  import actor_system.dispatcher
+
+  val remove_stale_task = actor_system.scheduler.schedule(cleanup_interval, cleanup_interval, nonce_keeper, NonceKeeper.RemoveStale)
+
+  val stale_timeout = nonceStaleTime * 1000
+
+  // Side-effect: If req contains a valid AuthorizationHeader, the
+  // corresponding nonce counter (nc) is increased.
+  def getChallenge(req: Request) = checkAuth(req) match {
+    case OK => None
+    case StaleNonce => Some(Challenge("Digest", realm, getChallengeParams(true)))
+    case _ => Some(Challenge("Digest", realm, getChallengeParams(false)))
+  }
+
+  case object StaleNonce extends AuthReply
+
+  case object BadNC extends AuthReply
+
+  case object WrongResponse extends AuthReply
+
+  case object BadParameters extends AuthReply
+
+  private def checkAuth(req: Request): AuthReply = {
+    req.headers.foldLeft(NoAuthorizationHeader: AuthReply) {
+      case (acc, h) =>
+        if (acc != NoAuthorizationHeader)
+          acc
+        else h match {
+          case Authorization(auth) =>
+            auth.credentials match {
+              case GenericCredentials(AuthScheme.Digest, params) =>
+                checkAuthParams(req, params)
+              case _ => NoCredentials
+            }
+          case _ => NoAuthorizationHeader
+        }
+    }
+  }
+
+  private def getChallengeParams(staleNonce: Boolean) = {
+    val f = ask(nonce_keeper, NonceKeeper.NewNonce)(ATimeout(5.seconds)).mapTo[String]
+    val nonce = Await.result(f, 5.seconds)
+    val m = Map("qop" -> "auth", "nonce" -> nonce)
+    if (staleNonce)
+      m + ("stale" -> "TRUE")
+    else
+      m
+  }
+
+  private def checkAuthParams(req: Request, params: Map[String, String]): AuthReply = {
+    if (!(Set("realm", "nonce", "nc", "username", "cnonce", "qop") subsetOf params.keySet))
+      return BadParameters
+
+    val method = req.method.toString
+    val uri = req.uri.toString
+
+    if (params.get("realm") != Some(realm))
+      return BadParameters
+
+    val nonce = params("nonce")
+    val nc = params("nc")
+    val f = ask(nonce_keeper, NonceKeeper.ReceiveNonce(nonce, Integer.parseInt(nc, 16)))(ATimeout(5.seconds)).mapTo[NonceKeeper.Reply]
+    Await.result(f, 5.seconds) match {
+      case NonceKeeper.StaleReply => StaleNonce
+      case NonceKeeper.BadNCReply => BadNC
+      case NonceKeeper.OKReply =>
+        if (!store.isDefinedAt((realm, params("username"))))
+          UserUnknown
+        else
+          store((realm, params("username"))) match {
+            case password => {
+              val resp = DigestUtil.computeResponse(method, params("username"), realm, password, uri, nonce, nc, params("cnonce"), params("qop"))
+              if (resp == params("response"))
+                OK
+              else
+                WrongResponse
+            }
+          }
+    }
+  }
+}
+
+class Nonce(val created: Date, var nc: Int, val data: String) {
+}
+
+object Nonce {
+  val random = new SecureRandom()
+
+  private def getRandomData(bits: Int) = new BigInteger(bits, random).toString(16)
+
+  def apply(bits: Int) = {
+    new Nonce(new Date(), 0, getRandomData(bits))
+  }
+}
+
+object NonceKeeper {
+
+  case object NewNonce
+
+  case class ReceiveNonce(data: String, nc: Int)
+
+  case object RemoveStale
+
+  abstract class Reply
+
+  case object StaleReply extends Reply
+
+  case object OKReply extends Reply
+
+  case object BadNCReply extends Reply
+
+}
+
+/**
+ * An {@link Actor} used to manage a database of nonces.
+ * Sending the {@link NonceKeeper.NewNonce} message yields a reply
+ * containing a fresh nonce as a {@link String}. On receiving a
+ * {@link NonceKeeper.ReceiveNonce} message, this actor checks if it
+ * is known and the nc value is correct. If so, the nc value associated
+ * with the nonce is increased and either {@link NonceKeeper.OKReply}
+ * or {@link NonceKeeper.BadNCReply} is replied. Finally, on
+ * receiving a {@link NonceKeeper.RemoveStale} message, the actor
+ * removes nonces that are older than staleTimeout.
+ */
+class NonceKeeper(staleTimeout: Long, bits: Int) extends Actor {
+  assert(bits > 0)
+  var nonces: Map[String, Nonce] = new HashMap[String, Nonce]
+
+  def isStale(past: Date, now: Date) = staleTimeout < now.getTime() - past.getTime()
+
+  def receive = {
+    case NonceKeeper.NewNonce => {
+      var n: Nonce = null
+      do {
+        n = Nonce(bits)
+      } while (nonces.contains(n.data))
+      nonces = nonces + (n.data -> n)
+      sender() ! n.data
+    }
+    case NonceKeeper.ReceiveNonce(data, nc) => {
+      nonces.get(data) match {
+        case None => sender() ! NonceKeeper.StaleReply
+        case Some(n) => {
+          if (nc > n.nc) {
+            n.nc = n.nc + 1
+            sender() ! NonceKeeper.OKReply
+          } else
+            sender() ! NonceKeeper.BadNCReply
+        }
+      }
+    }
+    case NonceKeeper.RemoveStale =>
+      nonces = nonces.filter { case (_, n) =>
+        !isStale(n.created, new Date())
+      }
+  }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuthentication.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuthentication.scala
@@ -5,9 +5,12 @@ package authentication
 
 import java.security.SecureRandom
 import java.math.BigInteger
-import java.util.{TimerTask, Timer, Date}
+import java.util.Date
+
 import org.http4s.headers.Authorization
-import scala.collection.immutable.HashMap
+
+import scala.concurrent.duration._
+
 import scalaz.concurrent.Task
 
 /**
@@ -24,55 +27,33 @@ import scalaz.concurrent.Task
  *                       purposes anymore).
  * @param nonceBits The number of random bits a nonce should consist of.
  */
-class DigestAuthentication(realm: String, store: AuthenticationStore, nonceCleanupInterval: Long = 3600000, nonceStaleTime: Long = 3600000, nonceBits: Int = 160) extends Authentication {
-  private val nonceKeeper = new NonceKeeper(nonceStaleTime, nonceBits)
-  private val timer = new Timer(true)
-  scheduleStaleNonceRemoval()
-
-  private def scheduleStaleNonceRemoval(): Unit = {
-    val task: TimerTask = new TimerTask {
-      override def run(): Unit = {
-        nonceKeeper.removeStale()
-        scheduleStaleNonceRemoval()
-      }
-    }
-    timer.schedule(task, nonceCleanupInterval)
-  }
-
-  /**
-   * Cancels the nonce cleanup thread.
-   */
-  def shutdown() = timer.cancel()
+class DigestAuthentication(realm: String, store: AuthenticationStore, nonceCleanupInterval: Duration = 3600.seconds, nonceStaleTime: Duration = 3600.seconds, nonceBits: Int = 160) extends Authentication {
+  private val nonceKeeper = new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits)
 
   /** Side-effect of running the returned task: If req contains a valid
     * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
     */
-  def getChallenge(req: Request) = {
+  protected def getChallenge(req: Request) = {
     def paramsToChallenge(params: Map[String, String]) = Some(Challenge("Digest", realm, params))
     checkAuth(req).flatMap(_ match {
-      case OK => Task.now(None)
+      case OK         => Task.now(None)
       case StaleNonce => getChallengeParams(true).map(paramsToChallenge)
-      case _ => getChallengeParams(false).map(paramsToChallenge)
+      case _          => getChallengeParams(false).map(paramsToChallenge)
     })
   }
 
-  case object StaleNonce extends AuthReply
+  private case object StaleNonce extends AuthReply
 
-  case object BadNC extends AuthReply
+  private case object BadNC extends AuthReply
 
-  case object WrongResponse extends AuthReply
+  private case object WrongResponse extends AuthReply
 
-  case object BadParameters extends AuthReply
+  private case object BadParameters extends AuthReply
 
-  private def checkAuth(req: Request) = Task {
-    req.headers.get(Authorization) match {
-      case None => NoAuthorizationHeader
-      case Some(auth) => auth.credentials match {
-        case GenericCredentials(AuthScheme.Digest, params) =>
-          checkAuthParams(req, params)
-        case _ => NoCredentials
-      }
-    }
+  private def checkAuth(req: Request) = req.headers.get(Authorization) match {
+      case Some(Authorization(GenericCredentials(AuthScheme.Digest, params))) => checkAuthParams(req, params)
+      case Some(Authorization(_)) => Task.now(NoCredentials)
+      case None => Task.now(NoAuthorizationHeader)
   }
 
   private def getChallengeParams(staleNonce: Boolean) = Task {
@@ -84,121 +65,42 @@ class DigestAuthentication(realm: String, store: AuthenticationStore, nonceClean
       m
   }
 
-  private def checkAuthParams(req: Request, params: Map[String, String]): AuthReply = {
+  private def checkAuthParams(req: Request, params: Map[String, String]): Task[AuthReply] = {
     if (!(Set("realm", "nonce", "nc", "username", "cnonce", "qop") subsetOf params.keySet))
-      return BadParameters
+      return Task.now(BadParameters)
 
     val method = req.method.toString
     val uri = req.uri.toString
 
     if (params.get("realm") != Some(realm))
-      return BadParameters
+      return Task.now(BadParameters)
 
     val nonce = params("nonce")
     val nc = params("nc")
     nonceKeeper.receiveNonce(nonce, Integer.parseInt(nc, 16)) match {
-      case NonceKeeper.StaleReply => StaleNonce
-      case NonceKeeper.BadNCReply => BadNC
+      case NonceKeeper.StaleReply => Task.now(StaleNonce)
+      case NonceKeeper.BadNCReply => Task.now(BadNC)
       case NonceKeeper.OKReply =>
-        if (!store.isDefinedAt((realm, params("username"))))
-          UserUnknown
-        else
-          store((realm, params("username"))) match {
-            case password => {
-              val resp = DigestUtil.computeResponse(method, params("username"), realm, password, uri, nonce, nc, params("cnonce"), params("qop"))
-              if (resp == params("response"))
-                OK
-              else
-                WrongResponse
-            }
-          }
+        store(realm, params("username")).map {
+          case None => UserUnknown
+          case Some(password) =>
+            val resp = DigestUtil.computeResponse(method, params("username"), realm, password, uri, nonce, nc, params("cnonce"), params("qop"))
+
+            if (resp == params("response")) OK
+            else WrongResponse
+        }
     }
   }
 }
 
-class Nonce(val created: Date, var nc: Int, val data: String) {
-}
+private[authentication] class Nonce(val created: Date, var nc: Int, val data: String)
 
-object Nonce {
+private[authentication] object Nonce {
   val random = new SecureRandom()
 
   private def getRandomData(bits: Int) = new BigInteger(bits, random).toString(16)
 
-  def apply(bits: Int) = {
+  def gen(bits: Int) = {
     new Nonce(new Date(), 0, getRandomData(bits))
   }
-}
-
-object NonceKeeper {
-
-  sealed abstract class Reply
-
-  case object StaleReply extends Reply
-
-  case object OKReply extends Reply
-
-  case object BadNCReply extends Reply
-
-}
-
-/**
- * A thread-safe class used to manage a database of nonces.
- *
- * @param staleTimeout Amount of time (in milliseconds) after which a nonce
- *                     is considered stale (i.e. not used for authentication
- *                     purposes anymore).
- * @param bits The number of random bits a nonce should consist of.
- */
-class NonceKeeper(staleTimeout: Long, bits: Int) {
-  require(bits > 0, "Please supply a positive integer for bits.")
-  var nonces: Map[String, Nonce] = new HashMap[String, Nonce]
-
-  private def isStale(past: Date, now: Date) = staleTimeout < now.getTime() - past.getTime()
-
-  /**
-   * Removes nonces that are older than staleTimeout
-   */
-  def removeStale() = {
-    val d = new Date()
-    this.synchronized {
-      nonces = nonces.filter { case (_, n) => !isStale(n.created, d) }
-    }
-  }
-
-  /**
-   * Get a fresh nonce in form of a {@link String}.
-   * @return A fresh nonce.
-   */
-  def newNonce() = {
-    var n: Nonce = null
-    this.synchronized {
-      do {
-        n = Nonce(bits)
-      } while (nonces.contains(n.data))
-      nonces = nonces + (n.data -> n)
-    }
-    n.data
-  }
-
-  /**
-   * Checks if the nonce {@link data} is known and the {@link nc} value is
-   * correct. If this is so, the nc value associated with the nonce is increased
-   * and the appropriate status is returned.
-   * @param data The nonce.
-   * @param nc The nonce counter.
-   * @return A reply indicating the status of (data, nc).
-   */
-  def receiveNonce(data: String, nc: Int) =
-    this.synchronized {
-      nonces.get(data) match {
-        case None => NonceKeeper.StaleReply
-        case Some(n) => {
-          if (nc > n.nc) {
-            n.nc = n.nc + 1
-            NonceKeeper.OKReply
-          } else
-            NonceKeeper.BadNCReply
-        }
-      }
-    }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
@@ -5,7 +5,7 @@ package authentication
 
 import java.security.MessageDigest
 
-object DigestUtil {
+private[authentication] object DigestUtil {
   private def bytes2hex(bytes: Array[Byte]) = bytes.map("%02x".format(_)).mkString
 
   private def md5(str: String) = bytes2hex(MessageDigest.getInstance("MD5").digest(str.getBytes))

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
@@ -1,0 +1,34 @@
+package org.http4s
+package server
+package middleware
+package authentication
+
+import java.security.MessageDigest
+
+object DigestUtil {
+  private def bytes2hex(bytes: Array[Byte]) = bytes.map("%02x".format(_)).mkString
+
+  private def md5(str: String) = bytes2hex(MessageDigest.getInstance("MD5").digest(str.getBytes))
+
+  /**
+   * Computes the response value used in Digest Authentication.
+   * @param method
+   * @param username
+   * @param realm
+   * @param password
+   * @param uri
+   * @param nonce
+   * @param nc
+   * @param cnonce
+   * @param qop
+   * @return
+   */
+  def computeResponse(method: String, username: String, realm: String, password: String, uri: String, nonce: String, nc: String, cnonce: String, qop: String) = {
+    val ha1str = username + ":" + realm + ":" + password
+    val ha1 = md5(ha1str)
+    val ha2str = method + ":" + uri
+    val ha2 = md5(ha2str)
+    val respstr = ha1 + ":" + nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2
+    md5(respstr)
+  }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
@@ -1,0 +1,94 @@
+package org.http4s.server.middleware.authentication
+
+import java.util.LinkedHashMap
+
+import scala.annotation.tailrec
+
+
+private[authentication] object NonceKeeper {
+
+  sealed abstract class Reply
+
+  case object StaleReply extends Reply
+
+  case object OKReply extends Reply
+
+  case object BadNCReply extends Reply
+
+}
+
+/**
+ * A thread-safe class used to manage a database of nonces.
+ *
+ * @param staleTimeout Amount of time (in milliseconds) after which a nonce
+ *                     is considered stale (i.e. not used for authentication
+ *                     purposes anymore).
+ * @param bits The number of random bits a nonce should consist of.
+ */
+private[authentication] class NonceKeeper(staleTimeout: Long, nonceCleanupInterval: Long, bits: Int) {
+  require(bits > 0, "Please supply a positive integer for bits.")
+  private val nonces = new LinkedHashMap[String, Nonce]
+  private var lastCleanup = System.currentTimeMillis()
+
+  /**
+   * Removes nonces that are older than staleTimeout
+   * Note: this _MUST_ be executed inside a block synchronized on `nonces`
+   */
+  private def checkStale() = {
+    val d = System.currentTimeMillis()
+    if (d - lastCleanup > nonceCleanupInterval) {
+      lastCleanup = d
+
+      // Because we are using an LinkedHashMap, the keys will be returned in the order they were
+      // inserted. Therefor, once we reach a non-stale value, the remaining values are also not stale.
+      val it = nonces.values().iterator()
+      @tailrec
+      def dropStale(): Unit = {
+        if (it.hasNext && staleTimeout > d - it.next().created.getTime) {
+          it.remove()
+          dropStale()
+        }
+      }
+      dropStale()
+    }
+  }
+
+  /**
+   * Get a fresh nonce in form of a {@link String}.
+   * @return A fresh nonce.
+   */
+  def newNonce(): String = {
+    var n: Nonce = null
+    nonces.synchronized {
+      checkStale()
+      do {
+        n = Nonce.gen(bits)
+      } while (nonces.get(n.data) != null)
+      nonces.put(n.data, n)
+    }
+    n.data
+  }
+
+  /**
+   * Checks if the nonce {@link data} is known and the {@link nc} value is
+   * correct. If this is so, the nc value associated with the nonce is increased
+   * and the appropriate status is returned.
+   * @param data The nonce.
+   * @param nc The nonce counter.
+   * @return A reply indicating the status of (data, nc).
+   */
+  def receiveNonce(data: String, nc: Int): NonceKeeper.Reply =
+    nonces.synchronized {
+      checkStale()
+      nonces.get(data) match {
+        case null => NonceKeeper.StaleReply
+        case n: Nonce => {
+          if (nc > n.nc) {
+            n.nc = n.nc + 1
+            NonceKeeper.OKReply
+          } else
+            NonceKeeper.BadNCReply
+        }
+      }
+    }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
@@ -2,10 +2,12 @@ package org.http4s
 package server
 package middleware
 
+import scalaz.concurrent.Task
+
 package object authentication {
   // A function mapping (realm, username) to password, None if no password
   // exists for that (realm, username) pair.
-  type AuthenticationStore = PartialFunction[(String, String), String]
+  type AuthenticationStore = (String, String) =>  Task[Option[String]]
 
   case object UserUnknown extends AuthReply
 

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
@@ -2,14 +2,10 @@ package org.http4s
 package server
 package middleware
 
-import scalaz.concurrent.Task
-
 package object authentication {
   // A function mapping (realm, username) to password, None if no password
   // exists for that (realm, username) pair.
   type AuthenticationStore = PartialFunction[(String, String), String]
-
-  class AuthReply
 
   case object UserUnknown extends AuthReply
 

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
@@ -1,0 +1,24 @@
+package org.http4s
+package server
+package middleware
+
+import scalaz.concurrent.Task
+
+package object authentication {
+  // A function mapping (realm, username) to password, None if no password
+  // exists for that (realm, username) pair.
+  type AuthenticationStore = PartialFunction[(String, String), String]
+
+  class AuthReply
+
+  case object UserUnknown extends AuthReply
+
+  case object OK extends AuthReply
+
+  case object NoCredentials extends AuthReply
+
+  case object NoAuthorizationHeader extends AuthReply
+
+  case object WrongPassword extends AuthReply
+
+}

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -1,0 +1,154 @@
+package org.http4s.server.middleware.authentication
+
+import org.http4s.{Uri, Request, Response, BasicCredentials, Headers, GenericCredentials}
+import org.http4s.server.HttpService
+import org.http4s.Challenge
+import org.http4s.Status._
+import org.http4s.headers._
+import org.http4s.parser.HttpParser
+import org.http4s.util.CaseInsensitiveString
+
+import org.specs2.mutable.Specification
+
+class AuthenticationSpec extends Specification {
+
+  val service = HttpService {
+    case r if r.pathInfo == "/" => Response(Ok).withBody("foo")
+    case r => Response.notFound(r)
+  }
+
+  val realm = "Test Realm"
+  val username = "Test User"
+  val password = "Test Password"
+ 
+  val auth_store : PartialFunction[(String, String), String] = {
+    case (r, u) if r == realm && u == username => password
+  }
+
+  val basic = new BasicAuthentication( realm, auth_store )( service )
+
+  "BasicAuthentication" should {
+    "Respond to a request without authentication with 401" in {
+      val req = Request(uri = Uri(path = "/"))
+      val res = basic(req).run
+
+      res.isDefined must_== true
+      res.get.status must_== Unauthorized
+      res.get.headers.get(`WWW-Authenticate`).map(_.value) must beSome(Challenge("Basic", realm, Nil.toMap ).toString)
+    }
+
+    "Respond to a request with unknown username with 401" in {
+      val req = Request(uri = Uri(path = "/"), headers = Headers(Authorization(BasicCredentials("Wrong User", password))))
+      val res = basic(req).run
+
+      res.isDefined must_== true
+      res.get.status must_== Unauthorized
+      res.get.headers.get(`WWW-Authenticate`).map(_.value) must beSome(Challenge("Basic", realm, Nil.toMap ).toString)
+    }
+
+    "Respond to a request with wrong password with 401" in {
+      val req = Request(uri = Uri(path = "/"), headers = Headers(Authorization(BasicCredentials(username, "Wrong Password"))))
+      val res = basic(req).run
+
+      res.isDefined must_== true
+      res.get.status must_== Unauthorized
+      res.get.headers.get(`WWW-Authenticate`).map(_.value) must beSome(Challenge("Basic", realm, Nil.toMap ).toString)
+    }
+
+    "Respond to a request with correct credentials" in {
+      val req = Request(uri = Uri(path = "/"), headers = Headers(Authorization(BasicCredentials(username, password))))
+      val res = basic(req).run
+
+      res.isDefined must_== true
+      res.get.status must_== Ok
+    }
+  }
+
+  val digest = new DigestAuthentication( realm, auth_store )( service )
+
+  private def parse( value : String ) = HttpParser.WWW_AUTHENTICATE(value).fold(err => sys.error(s"Couldn't parse: $value"), identity)
+
+  "DigestAuthentication" should {
+    "Respond to a request without authentication with 401" in {
+      val req = Request(uri = Uri(path = "/"))
+      val res = digest(req).run
+
+      res.isDefined must_== true
+      res.get.status must_== Unauthorized
+      val opt = res.get.headers.get(`WWW-Authenticate`).map(_.value) 
+      opt.isDefined must beTrue
+      val challenge = parse(opt.get).values.head
+      (challenge match { 
+        case Challenge("Digest", realm, _) => true 
+        case _ => false
+      }) must_== true
+    }
+
+    "Respond to a request with correct credentials" in {
+      // Get auth data
+      val req = Request(uri = Uri(path = "/"))
+      val res = digest(req).run
+
+      res.isDefined must_== true
+      res.get.status must_== Unauthorized
+      val opt = res.get.headers.get(`WWW-Authenticate`).map(_.value) 
+      opt.isDefined must beTrue
+      val challenge = parse(opt.get).values.head
+      (challenge match { 
+        case Challenge("Digest", realm, _) => true 
+        case _ => false
+      }) must_== true
+
+      // Second request with credentials
+      val method = "GET"
+      val uri = "/"
+      val qop = "auth"
+      val nc = "00000001"
+      val cnonce = "abcdef"
+      val nonce = challenge.params("nonce")
+      
+      val response = DigestUtil.computeResponse( method, username, realm, password, uri, nonce, nc, cnonce, qop )
+      val params : Map[String, String] = Map( "username" -> username, "realm" -> realm, "nonce" -> nonce,
+                     "uri" -> uri, "qop" -> qop, "nc" -> nc, "cnonce" -> cnonce, "response" -> response , 
+                     "method" -> method )
+      val header = Authorization(GenericCredentials(CaseInsensitiveString("Digest"), params))
+
+      val req2 = Request(uri = Uri(path = "/"), headers = Headers(header))
+      val res2 = digest(req2).run
+
+      res2.isDefined must_== true
+      res2.get.status must_== Ok     
+
+      // Digest prevents replay
+      val res3 = digest(req2).run
+      res3.isDefined must_== true
+      res3.get.status must_== Unauthorized
+    }
+
+    "Respond to invalid requests with 401" in {
+      val method = "GET"
+      val uri = "/"
+      val qop = "auth"
+      val nc = "00000001"
+      val cnonce = "abcdef"
+      val nonce = "abcdef"
+
+      val response = DigestUtil.computeResponse( method, username, realm, password, uri, nonce, nc, cnonce, qop )
+      val params : Map[String, String] = Map( "username" -> username, "realm" -> realm, "nonce" -> nonce,
+                     "uri" -> uri, "qop" -> qop, "nc" -> nc, "cnonce" -> cnonce, "response" -> response ,
+                     "method" -> method )
+
+      val expected = (0 to params.size).map( i => (true, Unauthorized))
+      val result = (0 to params.size).map( i => {
+        val invalid_params = params.take(i) ++ params.drop(i+1)
+        val header = Authorization(GenericCredentials(CaseInsensitiveString("Digest"), invalid_params))
+        val req = Request(uri = Uri(path = "/"), headers = Headers(header))
+        val res = digest(req).run
+
+        (res.isDefined, res.get.status)
+      } )
+
+      expected must_== result
+    }
+  }
+}

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -1,5 +1,7 @@
 package org.http4s.server.middleware.authentication
 
+import java.util.concurrent.Executors
+
 import org.http4s.{Uri, Request, Response, BasicCredentials, Headers, GenericCredentials}
 import org.http4s.server.HttpService
 import org.http4s.Challenge
@@ -9,6 +11,8 @@ import org.http4s.parser.HttpParser
 import org.http4s.util.CaseInsensitiveString
 
 import org.specs2.mutable.Specification
+
+import scalaz.concurrent.Task
 
 class AuthenticationSpec extends Specification {
 
@@ -20,12 +24,12 @@ class AuthenticationSpec extends Specification {
   val realm = "Test Realm"
   val username = "Test User"
   val password = "Test Password"
- 
-  val auth_store : PartialFunction[(String, String), String] = {
+
+  val authStore: PartialFunction[(String, String), String] = {
     case (r, u) if r == realm && u == username => password
   }
 
-  val basic = new BasicAuthentication( realm, auth_store )( service )
+  val basic = new BasicAuthentication(realm, authStore)(service)
 
   "BasicAuthentication" should {
     "Respond to a request without authentication with 401" in {
@@ -34,7 +38,7 @@ class AuthenticationSpec extends Specification {
 
       res.isDefined must_== true
       res.get.status must_== Unauthorized
-      res.get.headers.get(`WWW-Authenticate`).map(_.value) must beSome(Challenge("Basic", realm, Nil.toMap ).toString)
+      res.get.headers.get(`WWW-Authenticate`).map(_.value) must beSome(Challenge("Basic", realm, Nil.toMap).toString)
     }
 
     "Respond to a request with unknown username with 401" in {
@@ -43,7 +47,7 @@ class AuthenticationSpec extends Specification {
 
       res.isDefined must_== true
       res.get.status must_== Unauthorized
-      res.get.headers.get(`WWW-Authenticate`).map(_.value) must beSome(Challenge("Basic", realm, Nil.toMap ).toString)
+      res.get.headers.get(`WWW-Authenticate`).map(_.value) must beSome(Challenge("Basic", realm, Nil.toMap).toString)
     }
 
     "Respond to a request with wrong password with 401" in {
@@ -52,7 +56,7 @@ class AuthenticationSpec extends Specification {
 
       res.isDefined must_== true
       res.get.status must_== Unauthorized
-      res.get.headers.get(`WWW-Authenticate`).map(_.value) must beSome(Challenge("Basic", realm, Nil.toMap ).toString)
+      res.get.headers.get(`WWW-Authenticate`).map(_.value) must beSome(Challenge("Basic", realm, Nil.toMap).toString)
     }
 
     "Respond to a request with correct credentials" in {
@@ -64,41 +68,48 @@ class AuthenticationSpec extends Specification {
     }
   }
 
-  val digest = new DigestAuthentication( realm, auth_store )( service )
 
-  private def parse( value : String ) = HttpParser.WWW_AUTHENTICATE(value).fold(err => sys.error(s"Couldn't parse: $value"), identity)
+  private def parse(value: String) = HttpParser.WWW_AUTHENTICATE(value).fold(err => sys.error(s"Couldn't parse: $value"), identity)
 
   "DigestAuthentication" should {
     "Respond to a request without authentication with 401" in {
+      val da = new DigestAuthentication(realm, authStore)
+      val digest = da(service)
       val req = Request(uri = Uri(path = "/"))
       val res = digest(req).run
 
       res.isDefined must_== true
       res.get.status must_== Unauthorized
-      val opt = res.get.headers.get(`WWW-Authenticate`).map(_.value) 
+      val opt = res.get.headers.get(`WWW-Authenticate`).map(_.value)
       opt.isDefined must beTrue
       val challenge = parse(opt.get).values.head
-      (challenge match { 
-        case Challenge("Digest", realm, _) => true 
+      (challenge match {
+        case Challenge("Digest", realm, _) => true
         case _ => false
       }) must_== true
+
+      da.shutdown()
+
+      ok
     }
 
-    "Respond to a request with correct credentials" in {
+    // Send a request without authorization, receive challenge.
+    def doDigestAuth1(digest: HttpService) = {
       // Get auth data
       val req = Request(uri = Uri(path = "/"))
       val res = digest(req).run
 
       res.isDefined must_== true
       res.get.status must_== Unauthorized
-      val opt = res.get.headers.get(`WWW-Authenticate`).map(_.value) 
+      val opt = res.get.headers.get(`WWW-Authenticate`).map(_.value)
       opt.isDefined must beTrue
       val challenge = parse(opt.get).values.head
-      (challenge match { 
-        case Challenge("Digest", realm, _) => true 
-        case _ => false
-      }) must_== true
+      challenge
+    }
 
+    // Respond to a challenge with a correct response.
+    // If withReplay is true, also send a replayed request.
+    def doDigestAuth2(digest: HttpService, challenge: Challenge, withReplay: Boolean) = {
       // Second request with credentials
       val method = "GET"
       val uri = "/"
@@ -106,26 +117,95 @@ class AuthenticationSpec extends Specification {
       val nc = "00000001"
       val cnonce = "abcdef"
       val nonce = challenge.params("nonce")
-      
-      val response = DigestUtil.computeResponse( method, username, realm, password, uri, nonce, nc, cnonce, qop )
-      val params : Map[String, String] = Map( "username" -> username, "realm" -> realm, "nonce" -> nonce,
-                     "uri" -> uri, "qop" -> qop, "nc" -> nc, "cnonce" -> cnonce, "response" -> response , 
-                     "method" -> method )
+
+      val response = DigestUtil.computeResponse(method, username, realm, password, uri, nonce, nc, cnonce, qop)
+      val params: Map[String, String] = Map("username" -> username, "realm" -> realm, "nonce" -> nonce,
+        "uri" -> uri, "qop" -> qop, "nc" -> nc, "cnonce" -> cnonce, "response" -> response,
+        "method" -> method)
       val header = Authorization(GenericCredentials(CaseInsensitiveString("Digest"), params))
 
       val req2 = Request(uri = Uri(path = "/"), headers = Headers(header))
       val res2 = digest(req2).run
 
+      if (withReplay) {
+        val res3 = digest(req2).run
+        (res2, res3)
+      } else
+        (res2, null)
+    }
+
+    "Respond to a request with correct credentials" in {
+      val da = new DigestAuthentication(realm, authStore)
+      val digest = da(service)
+      val challenge = doDigestAuth1(digest)
+
+      (challenge match {
+        case Challenge("Digest", realm, _) => true
+        case _ => false
+      }) must_== true
+
+      val (res2, res3) = doDigestAuth2(digest, challenge, true)
+
       res2.isDefined must_== true
-      res2.get.status must_== Ok     
+      res2.get.status must_== Ok
 
       // Digest prevents replay
-      val res3 = digest(req2).run
       res3.isDefined must_== true
       res3.get.status must_== Unauthorized
+
+      da.shutdown()
+
+      ok
+    }
+
+    "Respond to many concurrent requests while cleaning up nonces" in {
+      val n = 100
+      val sched = Executors.newFixedThreadPool(4)
+      val da = new DigestAuthentication(realm, authStore, 2, 2)
+      val digest = da(service)
+      val tasks = (1 to n).map(i =>
+        Task {
+          val challenge = doDigestAuth1(digest)
+          (challenge match {
+            case Challenge("Digest", realm, _) => true
+            case _ => false
+          }) must_== true
+          val res = doDigestAuth2(digest, challenge, false)._1
+          res.isDefined must_== true
+          // We don't check whether res.get.status is Ok since it may not
+          // be due to the low nonce stale timer.
+        }(sched))
+      Task.gatherUnordered(tasks).run
+
+      da.shutdown()
+
+      ok
+    }
+
+    "Avoid many concurrent replay attacks" in {
+      val n = 100
+      val sched = Executors.newFixedThreadPool(4)
+      val da = new DigestAuthentication(realm, authStore)
+      val digest = da(service)
+      val challenge = doDigestAuth1(digest)
+      val tasks = (1 to n).map(i =>
+        Task {
+          val res = doDigestAuth2(digest, challenge, false)._1
+          res.isDefined must_== true
+          res.get.status
+        }(sched))
+      val res = Task.gatherUnordered(tasks).run
+      res.filter(s => s == Ok).size must_== 1
+      res.filter(s => s == Unauthorized).size must_== n - 1
+
+      da.shutdown()
+
+      ok
     }
 
     "Respond to invalid requests with 401" in {
+      val da = new DigestAuthentication(realm, authStore)
+      val digest = da(service)
       val method = "GET"
       val uri = "/"
       val qop = "auth"
@@ -133,22 +213,27 @@ class AuthenticationSpec extends Specification {
       val cnonce = "abcdef"
       val nonce = "abcdef"
 
-      val response = DigestUtil.computeResponse( method, username, realm, password, uri, nonce, nc, cnonce, qop )
-      val params : Map[String, String] = Map( "username" -> username, "realm" -> realm, "nonce" -> nonce,
-                     "uri" -> uri, "qop" -> qop, "nc" -> nc, "cnonce" -> cnonce, "response" -> response ,
-                     "method" -> method )
+      val response = DigestUtil.computeResponse(method, username, realm, password, uri, nonce, nc, cnonce, qop)
+      val params: Map[String, String] = Map("username" -> username, "realm" -> realm, "nonce" -> nonce,
+        "uri" -> uri, "qop" -> qop, "nc" -> nc, "cnonce" -> cnonce, "response" -> response,
+        "method" -> method)
 
-      val expected = (0 to params.size).map( i => (true, Unauthorized))
-      val result = (0 to params.size).map( i => {
-        val invalid_params = params.take(i) ++ params.drop(i+1)
+      val expected = (0 to params.size).map(i => (true, Unauthorized))
+
+      val result = (0 to params.size).map(i => {
+        val invalid_params = params.take(i) ++ params.drop(i + 1)
         val header = Authorization(GenericCredentials(CaseInsensitiveString("Digest"), invalid_params))
         val req = Request(uri = Uri(path = "/"), headers = Headers(header))
         val res = digest(req).run
 
         (res.isDefined, res.get.status)
-      } )
+      })
 
       expected must_== result
+
+      da.shutdown()
+
+      ok
     }
   }
 }


### PR DESCRIPTION
This is a continuation of PR #258 submitted by @frehn. I think its good to go but needs a broader review.

Some possible points of interest:
* The action of this as a middleware is troubling because of the type signature of our ```HttpService```, namely ```Request => Task[Option[Response]]```. Namely, if you ```orElse``` another route behind a service that has been wrapped by the authentication middleware, you must still authenticate. If we change the signature back to ```Request => Task[Option[Response]]``` we can query if the route exists and then attempt authentication, otherwise move on.
* By using a ```LinkedHashMap``` cleanup operations should be pretty cheap so I wonder if it would be worth it to just do cleanup every time a nonce is created and or queried.

A big thanks to @frehn, he did the vast majority of the work here including the great documentation this PR enjoys.