### PR TITLE
Fix unsanitized Strings in ParseFailures

### DIFF
--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -28,7 +28,7 @@ object HttpVersion extends HttpVersionInstances {
     case "HTTP/1.1" => right(`HTTP/1.1`)
     case "HTTP/1.0" => right(`HTTP/1.0`)
     case other => new Parser(s).HttpVersion.run()(ScalazDeliverySchemes.Disjunction).leftMap { _ =>
-      ParseFailure("Invalid charset", s"$s is not a supported CharSet on this system")
+      ParseFailure("Invalid HTTP version", s"$s was not found to be a valid HTTP version")
     }
   }
 

--- a/core/src/main/scala/org/http4s/ParseFailure.scala
+++ b/core/src/main/scala/org/http4s/ParseFailure.scala
@@ -13,7 +13,7 @@ import scalaz.{\/-, -\/, Equal}
  * @param details Contains any relevant details omitted from the sanitized
  *                version of the error.  This may freely echo a Request.
  */
-final case class ParseFailure(sanitized: String, details: String = "")
+final case class ParseFailure(sanitized: String, details: String)
 
 final case class ParseException(failure: ParseFailure) extends RuntimeException(failure.sanitized)
 
@@ -22,6 +22,6 @@ object ParseFailure {
 }
 
 object ParseResult {
-  def fail(sanitized: String, details: String = "") = -\/(ParseFailure(sanitized, details))
+  def fail(sanitized: String, details: String) = -\/(ParseFailure(sanitized, details))
   def success[A](a: A) = \/-(a)
 }

--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -88,7 +88,7 @@ object QueryParamDecoder {
   def fromUnsafeCast[T](cast: QueryParameterValue => T)(typeName: String): QueryParamDecoder[T] = new QueryParamDecoder[T]{
     def decode(value: QueryParameterValue): ValidationNel[ParseFailure, T] =
       Validation.fromTryCatchNonFatal(cast(value)).leftMap(t =>
-        ParseFailure(s"Could not parse ${value.value} as a $typeName", t.getMessage)
+        ParseFailure("Query decoding failed", t.getMessage)
       ).toValidationNel
   }
 
@@ -114,7 +114,8 @@ object QueryParamDecoder {
   implicit val charQueryParamDecoder: QueryParamDecoder[Char] = new QueryParamDecoder[Char]{
     def decode(value: QueryParameterValue): ValidationNel[ParseFailure, Char] =
       if(value.value.size == 1) value.value.head.successNel
-      else ParseFailure(s"Could not parse ${value.value} as a Char") .failureNel
+      else ParseFailure("Failed to parse Char query parameter",
+                       s"Could not parse ${value.value} as a Char") .failureNel
   }
 
   implicit val stringQueryParamDecoder: QueryParamDecoder[String] = new QueryParamDecoder[String]{

--- a/core/src/main/scala/org/http4s/parser/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/parser/QueryParser.scala
@@ -25,8 +25,8 @@ private[http4s] class QueryParser(codec: Codec, colonSeparators: Boolean) {
   def decode(input: CharBuffer, flush: Boolean): ParseResult[Query] = {
     val acc = Query.newBuilder
     decodeBuffer(input, (k,v) => acc += ((k,v)), flush) match {
-      case Some(e) => -\/(ParseFailure(e))
-      case None    => \/-(acc.result)
+      case Some(e) => ParseResult.fail("Decoding of url encoded data failed.", e)
+      case None    => ParseResult.success(acc.result)
     }
   }
 

--- a/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -32,10 +32,10 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
 
     "flatMapR with failure" in {
       EntityDecoder.text
-        .flatMapR(s => DecodeResult.failure[String](ParseFailure("bummer")))
+        .flatMapR(s => DecodeResult.failure[String](ParseFailure("bummer", "real bummer")))
         .decode(req)
         .run
-        .run must beLeftDisjunction(ParseFailure("bummer"))
+        .run must beLeftDisjunction(ParseFailure("bummer", "real bummer"))
     }
   }
 
@@ -50,7 +50,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
     }
 
     "wrap the ParseFailure in a ParseException on failure" in {
-      val grumpyDecoder = EntityDecoder.decodeBy(MediaRange.`*/*`)(_ => DecodeResult.failure[String](Task.now(ParseFailure("Bah!"))))
+      val grumpyDecoder = EntityDecoder.decodeBy(MediaRange.`*/*`)(_ => DecodeResult.failure[String](Task.now(ParseFailure("Bah!", ""))))
       val resp = request.decodeWith(grumpyDecoder) { _ => Task.now(Response())}.run
       resp.status must equal (Status.BadRequest)
     }
@@ -143,7 +143,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
     }
 
     val nonMatchingDecoder = EntityDecoder.decodeBy[String](MediaRange.`video/*`) { _ =>
-      DecodeResult.failure(ParseFailure("Nope."))
+      DecodeResult.failure(ParseFailure("Nope.", ""))
     }
 
     "Not match invalid media type" in {

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
@@ -158,7 +158,7 @@ object PathInHttpServiceSpec extends Http4sSpec {
     "validating parameter present with incorrect format" in {
       val response = server(Request(GET, Uri(path = "/valid", query = Query.fromString("counter=foo"))))
       response.status must equal (BadRequest)
-      response.body must equalTo("Could not parse foo as a Int")
+      response.body must equalTo("Query decoding failed")
     }
     "optional validating parameter present" in {
       val response = server(Request(GET, Uri(path = "/optvalid", query = Query.fromString("counter=3"))))
@@ -173,7 +173,7 @@ object PathInHttpServiceSpec extends Http4sSpec {
     "optional validating parameter present with incorrect format" in {
       val response = server(Request(GET, Uri(path = "/optvalid", query = Query.fromString("counter=foo"))))
       response.status must equal (BadRequest)
-      response.body must equalTo("Could not parse foo as a Int")
+      response.body must equalTo("Query decoding failed")
     }
 
   }


### PR DESCRIPTION
A few places where leaking unsanitized information into the sanitized field of ParseFailure.

Removed some default arguments to make it explicit that there are two messages bundled in a ParseFailure: `sanitized` and `details`.
