### PR TITLE
Extend UrlForm API

### DIFF
--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -9,6 +9,18 @@ import scala.io.Codec
 
 class UrlForm(val values: Map[String, Seq[String]]) extends AnyVal {
   override def toString: String = values.toString()
+
+  def get(key: String): Seq[String] =
+    this.getOrElse(key, Seq.empty[String])
+
+  def getOrElse(key: String, default: => Seq[String]): Seq[String] =
+    values.get(key).getOrElse(default)
+
+  def getFirst(key: String): Option[String] =
+    values.get(key).flatMap(_.headOption)
+
+  def getFirstOrElse(key: String, default: => String): String =
+    this.getFirst(key).getOrElse(default)
 }
 
 object UrlForm {

--- a/core/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/core/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -37,6 +37,38 @@ class UrlFormSpec extends Http4sSpec with ScalaCheck {
         UrlForm.encodeString(charset)(urlForm)
       ) must_== \/-(urlForm)
     }
+
+    "get returns elements matching key" in {
+      UrlForm(Map("key" -> Seq("a", "b", "c"))).get("key") must_== Seq("a", "b", "c")
+    }
+
+    "get returns empty Seq if no matching key" in {
+      UrlForm(Map("key" -> Seq("a", "b", "c"))).get("notFound") must_== Seq.empty[String]
+    }
+
+    "getFirst returns first element matching key" in {
+      UrlForm(Map("key" -> Seq("a", "b", "c"))).getFirst("key") must_== Some("a")
+    }
+
+    "getFirst returns None if no matching key" in {
+      UrlForm(Map("key" -> Seq("a", "b", "c"))).getFirst("notFound") must_== None
+    }
+
+    "getOrElse returns elements matching key" in {
+      UrlForm(Map("key" -> Seq("a", "b", "c"))).getOrElse("key", Seq("d")) must_== Seq("a", "b", "c")
+    }
+
+    "getOrElse returns default if no matching key" in {
+      UrlForm(Map("key" -> Seq("a", "b", "c"))).getOrElse("notFound", Seq("d")) must_== Seq("d")
+    }
+
+    "getFirstOrElse returns first element matching key" in {
+      UrlForm(Map("key" -> Seq("a", "b", "c"))).getFirstOrElse("key", "d") must_== "a"
+    }
+
+    "getFirstOrElse returns default if no matching key" in {
+      UrlForm(Map("key" -> Seq("a", "b", "c"))).getFirstOrElse("notFound", "d") must_== "d"
+    }
   }
 
 }


### PR DESCRIPTION
This commit extends the UrlForm API with some handy utilities:

- get
- getOrElse
- getFirst
- getFirstOrElse

The names should be fairly self explanatory. These are utilities I found myself writing when using UrlForm.