### PR TITLE
Allow PHP-style [] in query strings

### DIFF
--- a/core/src/main/scala/org/http4s/parser/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/parser/QueryParser.scala
@@ -112,7 +112,7 @@ private[http4s] object QueryParser {
 
   /** Defines the characters that are allowed unquoted within a query string as
     * defined in RFC 3986*/
-  val QChars = BitSet((Pchar ++ "/?[]".toSet - '&' - '=').map(_.toInt).toSeq:_*)
+  val QChars = BitSet((Pchar ++ "/?".toSet - '&' - '=').map(_.toInt).toSeq:_*)
   /** PHP also includes square brackets ([ and ]) with query strings. This goes
     * against the spec but due to PHP's widespread adoption it is necessary to
     * support this extension. */

--- a/core/src/main/scala/org/http4s/parser/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/parser/QueryParser.scala
@@ -110,7 +110,7 @@ private[http4s] object QueryParser {
   private case object KEY extends State
   private case object VALUE extends State
 
-  private val QChars = BitSet((Pchar ++ "/?".toSet - '&' - '=').map(_.toInt).toSeq:_*)
+  private val QChars = BitSet((Pchar ++ "/?[]".toSet - '&' - '=').map(_.toInt).toSeq:_*)
   private def Pchar = Unreserved ++ SubDelims ++ ":@%".toSet
   private def Unreserved =  "-._~".toSet ++ AlphaNum
   private def SubDelims  = "!$&'()*+,;=".toSet

--- a/core/src/main/scala/org/http4s/parser/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/parser/QueryParser.scala
@@ -18,7 +18,7 @@ import scalaz.{-\/, \/-, \/}
   * If "" should be interpreted as no query that __MUST__ be
   * checked beforehand.
   */
-private[http4s] class QueryParser(codec: Codec, colonSeparators: Boolean) {
+private[http4s] class QueryParser(codec: Codec, colonSeparators: Boolean, qChars: BitSet = QueryParser.ExtendedQChars) {
 
   /** Decodes the input into key value pairs.
     * `flush` signals that this is the last input */
@@ -79,7 +79,7 @@ private[http4s] class QueryParser(codec: Codec, colonSeparators: Boolean) {
             valAcc.clear()
           }
 
-        case c if (QChars.contains(c)) => valAcc.append(c)
+        case c if (qChars.contains(c)) => valAcc.append(c)
 
         case c => error = s"Invalid char while splitting key/value pairs: '$c'"
       }
@@ -110,7 +110,13 @@ private[http4s] object QueryParser {
   private case object KEY extends State
   private case object VALUE extends State
 
-  private val QChars = BitSet((Pchar ++ "/?[]".toSet - '&' - '=').map(_.toInt).toSeq:_*)
+  /** Defines the characters that are allowed unquoted within a query string as
+    * defined in RFC 3986*/
+  val QChars = BitSet((Pchar ++ "/?[]".toSet - '&' - '=').map(_.toInt).toSeq:_*)
+  /** PHP also includes square brackets ([ and ]) with query strings. This goes
+    * against the spec but due to PHP's widespread adoption it is necessary to
+    * support this extension. */
+  val ExtendedQChars = QChars ++ ("[]".map(_.toInt).toSet)
   private def Pchar = Unreserved ++ SubDelims ++ ":@%".toSet
   private def Unreserved =  "-._~".toSet ++ AlphaNum
   private def SubDelims  = "!$&'()*+,;=".toSet

--- a/core/src/test/scala/org/http4s/parser/QueryParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/QueryParserSpec.scala
@@ -52,6 +52,11 @@ class QueryParserSpec extends Http4sSpec {
       parseQueryString("a[]=b&a[]=c") must beRightDisjunction(Query("a[]" -> Some("b"), "a[]" -> Some("c")))
     }
 
+    "QueryParser using QChars doesn't allow PHP-style [] in keys" in {
+      val queryString = "a[]=b&a[]=c"
+      new QueryParser(Codec.UTF8, true, QueryParser.QChars).decode(CharBuffer.wrap(queryString), true) must beLeftDisjunction
+    }
+
     "Reject a query with invalid char" in {
       parseQueryString("獾") must beLeftDisjunction
       parseQueryString("foo獾bar") must beLeftDisjunction

--- a/core/src/test/scala/org/http4s/parser/QueryParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/QueryParserSpec.scala
@@ -48,6 +48,10 @@ class QueryParserSpec extends Http4sSpec {
       parseQueryString("a=b;c") must beRightDisjunction(Query("a" -> Some("b"), "c" -> None))
     }
 
+    "Allow PHP-style [] in keys" in {
+      parseQueryString("a[]=b&a[]=c") must beRightDisjunction(Query("a[]" -> Some("b"), "a[]" -> Some("c")))
+    }
+
     "Reject a query with invalid char" in {
       parseQueryString("獾") must beLeftDisjunction
       parseQueryString("foo獾bar") must beLeftDisjunction


### PR DESCRIPTION
PHP encodes arrays in query strings using square brackets. This goes
against the spec, but PHP ain't got no time for your spec poindexter.

This is a minimal change that only allows square brackets in keys and
values. Arguably a more permissive parser (allowing any non-separator or
terminator character in keys and values) would be better for the wild
and crazy world we call the web.