### PR TITLE
Add `defaultCharset` to the decodeString function

### DIFF
--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -110,10 +110,10 @@ object EntityDecoder extends EntityDecoderInstances {
     DecodeResult.success(msg.body.runFoldMap(identity))
 
   /** Decodes a message to a String */
-  def decodeString(msg: Message): Task[String] = {
+  def decodeString(msg: Message, defaultCharset: Option[Charset] = None): Task[String] = {
     val buff = new StringBuilder
     (msg.body |> process1.fold(buff) { (b, c) => {
-      b.append(new String(c.toArray, msg.charset.getOrElse(Charset.`ISO-8859-1`).nioCharset))
+      b.append(new String(c.toArray, (msg.charset orElse defaultCharset getOrElse(Charset.`ISO-8859-1`)).nioCharset))
     }}).map(_.result()).runLastOr("")
   }
 }


### PR DESCRIPTION
See issue #279 for motivation.

Many types of messages are encoded as text, and some have a default charset. In situations like this, the Content-Type header may not acutally specify the charset. See UTF-8 for an example. https://tools.ietf.org/html/rfc7159

The commit allows the specification of a default charset for the `EntityDecoder.decodeString` function for situations like these.

This should be uncontroversial. I'll merge this tomorrow morning barring objections.