### PR TITLE
Omnibus dependency upgrade commit.

### DIFF
--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -55,11 +55,13 @@ object Http4sBuild extends Build {
   lazy val alpn_boot           = "org.mortbay.jetty.alpn"    % "alpn-boot"               %  "8.0.0.v20140317" // must use Java8!
   lazy val base64              = "net.iharder"               % "base64"                  % "2.3.8"
   lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.8.0-SNAPSHOT"
+  lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"
+  lazy val gatlingHighCharts   = "io.gatling.highcharts"     % "gatling-charts-highcharts" % gatlingTest.revision
   lazy val http4sWebsocket     = "org.http4s"               %% "http4s-websocket"        % "0.1.1"
   lazy val javaxServletApi     = "javax.servlet"             % "javax.servlet-api"       % "3.1.0"
-  lazy val jawnParser          = "org.spire-math"           %% "jawn-parser"             % "0.7.4"
-  lazy val jawnStreamz         = "org.http4s"               %% "jawn-streamz"            % "0.3.1"
-  lazy val jettyServer         = "org.eclipse.jetty"         % "jetty-server"            % "9.2.10.v20150310"
+  lazy val jawnParser          = "org.spire-math"           %% "jawn-parser"             % "0.8.0"
+  lazy val jawnStreamz         = "org.http4s"               %% "jawn-streamz"            % "0.4.1"
+  lazy val jettyServer         = "org.eclipse.jetty"         % "jetty-server"            % "9.2.11.v20150529"
   lazy val jettyServlet        = "org.eclipse.jetty"         % "jetty-servlet"           % jettyServer.revision
   lazy val json4sCore          = "org.json4s"               %% "json4s-core"             % "3.2.11"
   lazy val json4sJackson       = "org.json4s"               %% "json4s-jackson"          % json4sCore.revision
@@ -68,7 +70,7 @@ object Http4sBuild extends Build {
   lazy val jspApi              = "javax.servlet.jsp"         % "javax.servlet.jsp-api"   % "2.3.1" // YourKit hack
   lazy val log4s               = "org.log4s"                %% "log4s"                   % "1.1.3"
   lazy val logbackClassic      = "ch.qos.logback"            % "logback-classic"         % "1.1.3"
-  lazy val metricsCore         = "io.dropwizard.metrics"     % "metrics-core"            % "3.1.1"
+  lazy val metricsCore         = "io.dropwizard.metrics"     % "metrics-core"            % "3.1.2"
   lazy val metricsJetty9       = "io.dropwizard.metrics"     % "metrics-jetty9"          % metricsCore.revision
   lazy val metricsServlet      = "io.dropwizard.metrics"     % "metrics-servlet"         % metricsCore.revision
   lazy val metricsServlets     = "io.dropwizard.metrics"     % "metrics-servlets"        % metricsCore.revision
@@ -77,14 +79,11 @@ object Http4sBuild extends Build {
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
   lazy val scalameter          = "com.storm-enroute"        %% "scalameter"              % "0.6"
   lazy val scalaXml            = "org.scala-lang.modules"   %% "scala-xml"               % "1.0.3"
-  lazy val scalazScalacheckBinding = "org.scalaz"           %% "scalaz-scalacheck-binding" % "7.1.1"
+  lazy val scalazScalacheckBinding = "org.scalaz"           %% "scalaz-scalacheck-binding" % "7.1.2"
   lazy val scalazSpecs2        = "org.typelevel"            %% "scalaz-specs2"           % "0.3.0"
-  lazy val scalazStream        = "org.scalaz.stream"        %% "scalaz-stream"           % "0.7a"
+  lazy val scalazStream        = "org.scalaz.stream"        %% "scalaz-stream"           % "0.7.1a"
   lazy val scodecBits          = "org.scodec"               %% "scodec-bits"             % "1.0.6"
   lazy val tomcatCatalina      = "org.apache.tomcat"         % "tomcat-catalina"         % "8.0.21"
   lazy val tomcatCoyote        = "org.apache.tomcat"         % "tomcat-coyote"           % tomcatCatalina.revision
   lazy val twirlApi            = "com.typesafe.play"        %% "twirl-api"               % "1.0.4"
-  lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"    % "2.1.4"
-  lazy val gatlingHighCharts   = "io.gatling.highcharts"     % "gatling-charts-highcharts" % gatlingTest.revision
-
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8


### PR DESCRIPTION
Missing: scalaz-specs2-0.4, which introduces breaking changes via
Specs2-3.x.