### PR TITLE
Add middleware that removes a trailing slash from the Request

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
@@ -1,0 +1,30 @@
+package org.http4s
+package server
+package middleware
+
+import scalaz.concurrent.Task
+
+/** Removes a trailing slash from [[Request]] path
+  *
+  * If a route exists with a file style [[Uri]], eg "/foo",
+  * this middleware will cause [[Request]]s with uri = "/foo" and
+  * uri = "/foo/" to match the route.
+  */
+object AutoSlash {
+
+  def apply(service: HttpService): HttpService = {
+    Service.lift { req =>
+      service.run(req).flatMap {
+        case r@Some(_) => Task.now(r)
+        case None      =>
+          val p = req.uri.path
+          if (p.isEmpty || p.charAt(p.length - 1) != '/') Task.now(None)
+          else {
+            val withSlash = req.copy(uri = req.uri.copy(path = p.substring(0, p.length - 1)))
+            service.run(withSlash)
+          }
+      }
+    }
+  }
+
+}

--- a/server/src/test/scala/org/http4s/server/MockRoute.scala
+++ b/server/src/test/scala/org/http4s/server/MockRoute.scala
@@ -15,6 +15,12 @@ object MockRoute extends Http4s {
     case req: Request if req.method == Method.POST && req.uri.path == "/echo" =>
       Task.now(Response(body = req.body))
 
+    case req: Request if req.uri.path ==  "/withslash" =>
+      Task.now(Response(Ok))
+
+    case req: Request if req.uri.path ==  "/withslash/" =>
+      Task.now(Response(Accepted))
+
     case req: Request if req.uri.path == "/fail" =>
       sys.error("Problem!")
       Response(Ok).withBody("No problem...")

--- a/server/src/test/scala/org/http4s/server/middleware/AutoSlashSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/AutoSlashSpec.scala
@@ -26,7 +26,7 @@ class AutoSlashSpec extends Http4sSpec {
       AutoSlash(route)(req).run.map(_.status) must_== Some(Status.Ok)
     }
 
-    "Not crash on empy paty" in {
+    "Not crash on empy path" in {
       val req = Request(uri = uri(""))
       AutoSlash(route)(req).run must_== None
     }

--- a/server/src/test/scala/org/http4s/server/middleware/AutoSlashSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/AutoSlashSpec.scala
@@ -1,0 +1,34 @@
+package org.http4s.server.middleware
+
+import org.http4s.{Status, Request, Http4sSpec}
+import org.http4s.server.MockRoute
+
+
+class AutoSlashSpec extends Http4sSpec {
+
+  val route = MockRoute.route()
+
+  "AutoSlash" should {
+    "Auto remove a trailing slash" in {
+      val req = Request(uri = uri("/ping/"))
+      route(req).run                          must_== None
+      AutoSlash(route)(req).run.map(_.status) must_== Some(Status.Ok)
+    }
+
+    "Match a route defined with a slash" in {
+      AutoSlash(route)(Request(uri = uri("/withslash"))).run.map(_.status)  must_== Some(Status.Ok)
+      AutoSlash(route)(Request(uri = uri("/withslash/"))).run.map(_.status) must_== Some(Status.Accepted)
+    }
+
+    "Respect an absent trailing slash" in {
+      val req = Request(uri = uri("/ping"))
+      route(req).run.map(_.status)            must_== Some(Status.Ok)
+      AutoSlash(route)(req).run.map(_.status) must_== Some(Status.Ok)
+    }
+
+    "Not crash on empy paty" in {
+      val req = Request(uri = uri(""))
+      AutoSlash(route)(req).run must_== None
+    }
+  }
+}


### PR DESCRIPTION
Closes #260.

Consider a route constructed with the built in DSL
```scala
Service{ case Root / "foo" => Ok("bar") }
```

Normally a request with uri = "/foo/" would fail to match, but with this middlware the request is first attempted normally, and if it fails to match, it will attempt again with the trailing slash removed uri="/foo".