### PR TITLE
Explicitly specify the UTF-8 charset in json encoders

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -18,7 +18,7 @@ trait ArgonautInstances {
     }
 
   implicit val jsonEncoder: EntityEncoder[Json] =
-    EntityEncoder[String].contramap[Json] { json =>
+    EntityEncoder.stringEncoder(Charset.`UTF-8`).contramap[Json] { json =>
       // TODO naive implementation materializes to a String.
       // Look into replacing after https://github.com/non/jawn/issues/6#issuecomment-65018736
       Argonaut.nospace.pretty(json)

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -20,7 +20,7 @@ trait Json4sInstances[J] {
   protected def jsonMethods: JsonMethods[J]
 
   implicit lazy val jsonEncoder: EntityEncoder[JValue] =
-    EntityEncoder[String].contramap[JValue] { json =>
+    EntityEncoder.stringEncoder(Charset.`UTF-8`).contramap[JValue] { json =>
       // TODO naive implementation materializes to a String.
       // Look into replacing after https://github.com/non/jawn/issues/6#issuecomment-65018736
       jsonMethods.compact(jsonMethods.render(json))


### PR DESCRIPTION
This PR does not address any known bugs. The current default charset for String encoding is UTF-8. The default String encoder is used for json encoding and thus get the correct charset, UTF-8.

This PR just makes the specification of UTF-8 explicit for documentation purposes and as insurance against any unlikely change of the default in the future.