### PR TITLE
Add methods to allow modification of the parser registry.

### DIFF
--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -29,7 +29,7 @@ import scala.util.hashing.MurmurHash3
  * Abstract representation o the HTTP header
  * @see org.http4s.HeaderKey
  */
-trait Header extends Renderable with Product {
+sealed trait Header extends Renderable with Product {
   import Header.Raw
 
   def name: CaseInsensitiveString
@@ -82,7 +82,7 @@ object Header {
    * @param value String representation of the header value
    */
   final case class Raw(name: CaseInsensitiveString, override val value: String) extends Header {
-    override lazy val parsed = parser.HttpParser.parseHeader(this).getOrElse(this)
+    override lazy val parsed = parser.HttpHeaderParser.parseHeader(this).getOrElse(this)
     override def renderValue(writer: Writer): writer.type = writer.append(value)
   }
 

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -29,7 +29,7 @@ import scalaz.NonEmptyList
 /**
  * parser rules for all headers that can be parsed with one simple rule
  */
-private[parser] trait SimpleHeaders { self: HttpParser =>
+private[parser] trait SimpleHeaders {
 
   def ALLOW(value: String): ParseResult[Allow] = {
     new Http4sHeaderParser[Allow](value) {

--- a/core/src/test/scala/org/http4s/parser/AcceptCharsetSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AcceptCharsetSpec.scala
@@ -6,7 +6,7 @@ import scalaz.Validation
 
 class AcceptCharsetSpec extends Http4sSpec with HeaderParserHelper[`Accept-Charset`] {
 
-  def hparse(value: String): ParseResult[`Accept-Charset`] = HttpParser.ACCEPT_CHARSET(value)
+  def hparse(value: String): ParseResult[`Accept-Charset`] = HttpHeaderParser.ACCEPT_CHARSET(value)
 
   "Accept-Charset" should {
     "parse any list of CharsetRanges to itself" in {

--- a/core/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
@@ -7,7 +7,7 @@ import scalaz.Validation
 import Http4s._
 
 class AcceptEncodingSpec extends Specification with HeaderParserHelper[`Accept-Encoding`] {
-  def hparse(value: String): ParseResult[`Accept-Encoding`] = HttpParser.ACCEPT_ENCODING(value)
+  def hparse(value: String): ParseResult[`Accept-Encoding`] = HttpHeaderParser.ACCEPT_ENCODING(value)
 
   val gzip = `Accept-Encoding`(ContentCoding.gzip)
   val gzip5 = `Accept-Encoding`(ContentCoding.gzip.withQValue(q(0.5)))

--- a/core/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
@@ -11,7 +11,7 @@ import scalaz.Validation
 class AcceptHeaderSpec extends Specification with HeaderParserHelper[Accept] with Http4s {
 
 
-  def hparse(value: String): ParseResult[Accept] = HttpParser.ACCEPT(value)
+  def hparse(value: String): ParseResult[Accept] = HttpHeaderParser.ACCEPT(value)
 
   def ext = Map("foo" -> "bar", "baz" -> "whatever")
 

--- a/core/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
@@ -8,7 +8,7 @@ import org.http4s.{QValue, LanguageTag}
 
 class AcceptLanguageSpec extends Specification with HeaderParserHelper[`Accept-Language`] with Http4s {
 
-  def hparse(value: String): ParseResult[`Accept-Language`] = HttpParser.ACCEPT_LANGUAGE(value)
+  def hparse(value: String): ParseResult[`Accept-Language`] = HttpHeaderParser.ACCEPT_LANGUAGE(value)
 
   val en = `Accept-Language`(LanguageTag("en"))
   val fr = `Accept-Language`(LanguageTag("fr"))

--- a/core/src/test/scala/org/http4s/parser/AcceptRangesSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AcceptRangesSpec.scala
@@ -6,7 +6,7 @@ import org.http4s.RangeUnit
 
 class AcceptRangesSpec extends Specification with HeaderParserHelper[`Accept-Ranges`] {
 
-  def hparse(value: String) = HttpParser.ACCEPT_RANGES(value)
+  def hparse(value: String) = HttpHeaderParser.ACCEPT_RANGES(value)
 
   "Accept-Ranges header" should {
 

--- a/core/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
@@ -6,7 +6,7 @@ import org.http4s.headers.Authorization
 
 class AuthorizationHeaderSpec extends Http4sSpec {
 
-  def hparse(value: String) = HttpParser.AUTHORIZATION(value)
+  def hparse(value: String) = HttpHeaderParser.AUTHORIZATION(value)
 
   "Authorization header" should {
     "Parse a valid Oauth2 header" in {

--- a/core/src/test/scala/org/http4s/parser/CacheControlSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/CacheControlSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 import org.http4s.util.string._
 
 class CacheControlSpec extends Specification with HeaderParserHelper[`Cache-Control`] with NoTimeConversions {
-  def hparse(value: String): ParseResult[`Cache-Control`] = HttpParser.CACHE_CONTROL(value)
+  def hparse(value: String): ParseResult[`Cache-Control`] = HttpHeaderParser.CACHE_CONTROL(value)
 
   // Default values
   val valueless = List(`no-store`, `no-transform`, `only-if-cached`,

--- a/core/src/test/scala/org/http4s/parser/ContentTypeHeaderSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/ContentTypeHeaderSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable.Specification
 
 class ContentTypeHeaderSpec extends Specification with HeaderParserHelper[`Content-Type`] {
 
-  def hparse(value: String): ParseResult[`Content-Type`] = HttpParser.CONTENT_TYPE(value)
+  def hparse(value: String): ParseResult[`Content-Type`] = HttpHeaderParser.CONTENT_TYPE(value)
 
   def simple = `Content-Type`(`text/html`)
   def charset = `Content-Type`(`text/html`, Charset.`UTF-8`)

--- a/core/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
@@ -6,7 +6,7 @@ import org.specs2.mutable.Specification
 import scalaz.Validation
 
 class SetCookieHeaderSpec extends Specification with HeaderParserHelper[`Set-Cookie`] {
-  def hparse(value: String): ParseResult[`Set-Cookie`] = HttpParser.SET_COOKIE(value)
+  def hparse(value: String): ParseResult[`Set-Cookie`] = HttpHeaderParser.SET_COOKIE(value)
 
   "Set-Cookie parser" should {
 
@@ -39,7 +39,7 @@ class SetCookieHeaderSpec extends Specification with HeaderParserHelper[`Set-Coo
 }
 
 class CookieHeaderSpec extends Specification with HeaderParserHelper[headers.Cookie] {
-  def hparse(value: String): ParseResult[headers.Cookie] = HttpParser.COOKIE(value)
+  def hparse(value: String): ParseResult[headers.Cookie] = HttpHeaderParser.COOKIE(value)
 
   val cookiestr = "key1=value1; key2=\"value2\""
   val cookies = Seq(Cookie("key1", "value1"), Cookie("key2", "value2"))

--- a/core/src/test/scala/org/http4s/parser/ProxyAuthenticateHeaderSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/ProxyAuthenticateHeaderSpec.scala
@@ -5,7 +5,7 @@ import org.http4s._
 import org.specs2.mutable.Specification
 
 class ProxyAuthenticateHeaderSpec extends Specification with HeaderParserHelper[`Proxy-Authenticate`] {
-  def hparse(value: String): ParseResult[`Proxy-Authenticate`] = HttpParser.PROXY_AUTHENTICATE(value)
+  def hparse(value: String): ParseResult[`Proxy-Authenticate`] = HttpHeaderParser.PROXY_AUTHENTICATE(value)
 
   override def parse(value: String) =  hparse(value).fold(err => sys.error(s"Couldn't parse: $value"), identity)
 

--- a/core/src/test/scala/org/http4s/parser/RangeParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/RangeParserSpec.scala
@@ -18,7 +18,7 @@ class RangeParserSpec extends Http4sSpec {
       )
 
       forall(headers) { header =>
-        HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+        HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
       }
     }
   }
@@ -34,7 +34,7 @@ class RangeParserSpec extends Http4sSpec {
     )
 
     forall(headers) { header =>
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
     }
   }
 }

--- a/core/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -13,100 +13,100 @@ class SimpleHeadersSpec extends Http4sSpec {
 
     "parse Allow" in {
       val header = Allow(Method.GET, Method.POST)
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
     }
 
     "parse Connection" in {
       val header = Connection("closed".ci)
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
     }
 
     "parse Content-Length" in {
       val header = `Content-Length`(4)
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
 
       val bad = Header(header.name.toString, "foo")
-      HttpParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
     }
 
     "parse Content-Encoding" in {
       val header = `Content-Encoding`(ContentCoding.`pack200-gzip`)
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
     }
 
     "parse Content-Disposition" in {
       val header = `Content-Disposition`("foo", Map("one" -> "two", "three" -> "four"))
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
 
       val bad = Header(header.name.toString, "foo; bar")
-      HttpParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
     }
 
     "parse Date" in {       // mills are lost, get rid of them
       val header = Date(DateTime.now).toRaw.parsed
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
 
       val bad = Header(header.name.toString, "foo")
-      HttpParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
     }
 
     "parse Host" in {
       val header1 = Host("foo", Some(5))
-      HttpParser.parseHeader(header1.toRaw) must beRightDisjunction(header1)
+      HttpHeaderParser.parseHeader(header1.toRaw) must beRightDisjunction(header1)
 
       val header2 = Host("foo", None)
-      HttpParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
+      HttpHeaderParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
 
       val bad = Header(header1.name.toString, "foo:bar")
-      HttpParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
     }
 
     "parse Last-Modified" in {
       val header = `Last-Modified`(DateTime.now).toRaw.parsed
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
 
       val bad = Header(header.name.toString, "foo")
-      HttpParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
     }
 
     "parse If-Modified-Since" in {
       val header = `If-Modified-Since`(DateTime.now).toRaw.parsed
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
 
       val bad = Header(header.name.toString, "foo")
-      HttpParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
     }
 
     "parse ETag" in {
       val header = ETag("hash")
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
     }
 
     "parse If-None-Match" in {
       val header = `If-None-Match`("hash")
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
     }
 
     "parse Transfer-Encoding" in {
       val header = `Transfer-Encoding`(TransferCoding.chunked)
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
 
       val header2 = `Transfer-Encoding`(TransferCoding.compress)
-      HttpParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
+      HttpHeaderParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
     }
 
     "parse User-Agent" in {
       val header = `User-Agent`(AgentProduct("foo", Some("bar")), Seq(AgentComment("foo")))
       header.value must_== "foo/bar (foo)"
 
-      HttpParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
 
       val header2 = `User-Agent`(AgentProduct("foo"), Seq(AgentProduct("bar", Some("biz")), AgentComment("blah")))
       header2.value must_== "foo bar/biz (blah)"
-      HttpParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
+      HttpHeaderParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
 
       val headerstr = "Mozilla/5.0 (Android; Mobile; rv:30.0) Gecko/30.0 Firefox/30.0"
-      HttpParser.parseHeader(Header.Raw(`User-Agent`.name, headerstr)) must beRightDisjunction(
+      HttpHeaderParser.parseHeader(Header.Raw(`User-Agent`.name, headerstr)) must beRightDisjunction(
         `User-Agent`(AgentProduct("Mozilla", Some("5.0")), Seq(
             AgentComment("Android; Mobile; rv:30.0"),
             AgentProduct("Gecko", Some("30.0")),
@@ -118,14 +118,14 @@ class SimpleHeadersSpec extends Http4sSpec {
 
     "parse X-Forward-Spec" in {
       val header1 = `X-Forwarded-For`(NonEmptyList(Some(InetAddress.getLocalHost)))
-      HttpParser.parseHeader(header1.toRaw) must beRightDisjunction(header1)
+      HttpHeaderParser.parseHeader(header1.toRaw) must beRightDisjunction(header1)
 
       val header2 = `X-Forwarded-For`(NonEmptyList(Some(InetAddress.getLocalHost),
                                 Some(InetAddress.getLoopbackAddress)))
-      HttpParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
+      HttpHeaderParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
 
       val bad = Header(header1.name.toString, "foo")
-      HttpParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
     }
   }
 

--- a/core/src/test/scala/org/http4s/parser/WwwAuthenticateHeaderSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/WwwAuthenticateHeaderSpec.scala
@@ -7,7 +7,7 @@ import scalaz.Validation
 import scala.Predef._
 
 class WwwAuthenticateHeaderSpec extends Specification with HeaderParserHelper[`WWW-Authenticate`] {
-  def hparse(value: String): ParseResult[`WWW-Authenticate`] = HttpParser.WWW_AUTHENTICATE(value)
+  def hparse(value: String): ParseResult[`WWW-Authenticate`] = HttpHeaderParser.WWW_AUTHENTICATE(value)
 
   override def parse(value: String) =  hparse(value).fold(err => sys.error(s"Couldn't parse: $value"), identity)
 

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -7,7 +7,7 @@ import org.http4s.server.HttpService
 import org.http4s.Challenge
 import org.http4s.Status._
 import org.http4s.headers._
-import org.http4s.parser.HttpParser
+import org.http4s.parser.HttpHeaderParser
 import org.http4s.util.CaseInsensitiveString
 
 import org.specs2.mutable.Specification
@@ -73,7 +73,7 @@ class AuthenticationSpec extends Specification with NoTimeConversions {
   }
 
 
-  private def parse(value: String) = HttpParser.WWW_AUTHENTICATE(value).fold(err => sys.error(s"Couldn't parse: $value"), identity)
+  private def parse(value: String) = HttpHeaderParser.WWW_AUTHENTICATE(value).fold(err => sys.error(s"Couldn't parse: $value"), identity)
 
   "DigestAuthentication" should {
     "Respond to a request without authentication with 401" in {


### PR DESCRIPTION
I also renamed the class to HttpHeaderParser. That resulted in the bulk of the changes in the commit log. The only significant changes are in HttpHeaderParser.scala.