### PR TITLE
Make implicit UrlForm encoder, improve syntax, show example.

### DIFF
--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -34,8 +34,9 @@ object UrlForm {
   val empty: UrlForm = new UrlForm(Map.empty)
 
   def apply(values: Map[String, Seq[String]]): UrlForm =
-    // value key -> Seq() is just noise and it is not maintain during encoding round trip
-    new UrlForm(values.filter(_._2.nonEmpty))
+    // value "" -> Seq() is just noise and it is not maintain during encoding round trip
+    if(values.get("").fold(false)(_.isEmpty)) new UrlForm(values - "")
+    else new UrlForm(values)
 
   def apply(values: (String, String)*): UrlForm =
     values.foldLeft(empty)(_ + _)

--- a/core/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/core/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -6,8 +6,8 @@ import org.specs2.ScalaCheck
 import org.specs2.matcher.Parameters
 
 import scala.collection.immutable.BitSet
-import scalaz.\/-
-
+import scalaz.{NonEmptyList, \/-}
+import scalaz.scalacheck.ScalazArbitrary.NonEmptyListArbitrary
 
 class UrlFormSpec extends Http4sSpec with ScalaCheck {
   // These tests are slow.  Let's lower the bar.
@@ -70,12 +70,13 @@ class UrlFormSpec extends Http4sSpec with ScalaCheck {
       UrlForm(Map("key" -> Seq("a", "b", "c"))).getFirstOrElse("notFound", "d") must_== "d"
     }
 
-    "construct consistently from kv-pairs or and Map[String, Seq[String]]" in check { map: Map[String, Seq[String]] =>
-      val flattened = for {
-        (k, vs) <- map.toSeq
-        v <- vs
-      } yield (k -> v)
-      UrlForm(flattened: _*) must_== UrlForm(map)
+    "construct consistently from kv-pairs or and Map[String, Seq[String]]" in check {
+      map: Map[String, NonEmptyList[String]] => // non-empty because the kv-constructor can't represent valueless fields
+        val flattened = for {
+          (k, vs) <- map.toSeq
+          v <- vs.list
+        } yield (k -> v)
+        UrlForm(flattened: _*) must_== UrlForm(map.mapValues(_.list))
     }
   }
 

--- a/core/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/core/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -69,6 +69,14 @@ class UrlFormSpec extends Http4sSpec with ScalaCheck {
     "getFirstOrElse returns default if no matching key" in {
       UrlForm(Map("key" -> Seq("a", "b", "c"))).getFirstOrElse("notFound", "d") must_== "d"
     }
+
+    "construct consistently from kv-pairs or and Map[String, Seq[String]]" in check { map: Map[String, Seq[String]] =>
+      val flattened = for {
+        (k, vs) <- map.toSeq
+        v <- vs
+      } yield (k -> v)
+      UrlForm(flattened: _*) must_== UrlForm(map)
+    }
   }
 
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
@@ -1,0 +1,12 @@
+package com.example.http4s.blaze
+
+import org.http4s._
+import org.http4s.dsl._
+import org.http4s.client._
+import org.http4s.client.blaze.{defaultClient => client}
+
+object ClientPostExample extends App {
+  val req = POST(uri("https://duckduckgo.com/"), UrlForm("q" -> "http4s"))
+  val responseBody = client(req).as[String]
+  println(responseBody.run)
+}


### PR DESCRIPTION
This eases the common case of a POST request with a
x-www-form-urlencoded body.