### PR TITLE
UriTemplate.expandQuery should respect a QueryParameterEncoder if supplied.

### DIFF
--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -64,7 +64,7 @@ case class UriTemplate(
    */
   def expandQuery[T: QueryParamEncoder](name: String, values: List[T]): UriTemplate = {
     if (query.isEmpty) this
-    else copy(query = expandQueryN(query, name, values.map(String.valueOf(_))))
+    else copy(query = expandQueryN(query, name, values.map(QueryParamEncoder[T].encode(_).value)))
   }
 
   /**

--- a/core/src/test/scala/org/http4s/UriTemplateSpec.scala
+++ b/core/src/test/scala/org/http4s/UriTemplateSpec.scala
@@ -679,6 +679,20 @@ object UriTemplateSpec extends Specification {
       val tpl = UriTemplate(query = List(ParamExp("some")))
       tpl.expandQuery("unknown") must equalTo(tpl)
     }
+    "expand using a custom encoder if defined" in {
+      val types = ParamExp("type")
+      val path = List(PathElm("orders"))
+
+      case class Foo(bar: String)
+
+      val qpe =
+        new QueryParamEncoder[Foo] {
+          def encode(value: Foo) = new QueryParameterValue(value.bar)
+        }
+
+      UriTemplate(path = path, query = List(types)).expandQuery("type", Foo("whee"))(qpe) must
+        equalTo(UriTemplate(path = path, query = List(ParamElm("type", "whee"))))
+    }
   }
 
   "UriTemplate.expandFragment" should {


### PR DESCRIPTION
...enough said? :)