### PR TITLE
Handle Transfer-Encoding: identity correctly

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blaze/util/CachingStaticWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blaze/util/CachingStaticWriter.scala
@@ -67,7 +67,7 @@ class CachingStaticWriter(writer: StringWriter, out: TailStage[ByteBuffer], buff
   }
 
   // Make the write stuff public
-  private class InnerWriter(buffer: ByteBuffer) extends StaticWriter(buffer, -1, out) {
+  private class InnerWriter(buffer: ByteBuffer) extends IdentityWriter(buffer, -1, out) {
     override def writeEnd(chunk: ByteVector): Future[Unit] = super.writeEnd(chunk)
     override def writeBodyChunk(chunk: ByteVector, flush: Boolean): Future[Unit] = super.writeBodyChunk(chunk, flush)
   }

--- a/blaze-core/src/main/scala/org/http4s/blaze/util/IdentityWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blaze/util/IdentityWriter.scala
@@ -8,7 +8,7 @@ import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class StaticWriter(private var buffer: ByteBuffer, size: Int, out: TailStage[ByteBuffer])
+class IdentityWriter(private var buffer: ByteBuffer, size: Int, out: TailStage[ByteBuffer])
                   (implicit val ec: ExecutionContext)
                               extends ProcessWriter {
   private[this] val logger = getLogger
@@ -18,6 +18,8 @@ class StaticWriter(private var buffer: ByteBuffer, size: Int, out: TailStage[Byt
   private def checkWritten(): Unit = if (size > 0 && written > size) {
     logger.warn(s"Expected $size bytes, $written written")
   }
+
+  override def requireClose(): Boolean = size < 0
 
   protected def writeBodyChunk(chunk: ByteVector, flush: Boolean): Future[Unit] = {
     val b = chunk.toByteBuffer

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{Try, Success, Failure}
 
-import org.http4s.Status.{InternalServerError}
+import org.http4s.Status.InternalServerError
 import org.http4s.util.StringWriter
 import org.http4s.util.CaseInsensitiveString._
 import org.http4s.headers.{Connection, `Content-Length`}

--- a/core/src/main/scala/org/http4s/headers/Transfer-Encoding.scala
+++ b/core/src/main/scala/org/http4s/headers/Transfer-Encoding.scala
@@ -8,6 +8,7 @@ object `Transfer-Encoding` extends HeaderKey.Internal[`Transfer-Encoding`] with 
 final case class `Transfer-Encoding`(values: NonEmptyList[TransferCoding]) extends Header.RecurringRenderable {
   override def key = `Transfer-Encoding`
   def hasChunked = values.list.exists(_.renderString.equalsIgnoreCase("chunked"))
+  def hasIdentity = values.list.exists(_.renderString.equalsIgnoreCase("identity"))
   type Value = TransferCoding
 }
 

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -54,7 +54,7 @@ object Http4sBuild extends Build {
   lazy val argonautSupport     = "org.spire-math"           %% "argonaut-support"        % jawnParser.revision
   lazy val alpn_boot           = "org.mortbay.jetty.alpn"    % "alpn-boot"               %  "8.0.0.v20140317" // must use Java8!
   lazy val base64              = "net.iharder"               % "base64"                  % "2.3.8"
-  lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.8.0"
+  lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.8.1"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"
   lazy val gatlingHighCharts   = "io.gatling.highcharts"     % "gatling-charts-highcharts" % gatlingTest.revision
   lazy val http4sWebsocket     = "org.http4s"               %% "http4s-websocket"        % "0.1.1"


### PR DESCRIPTION
Previously, the identity was discarded and chunked encoding was used.
This change allows one to explicitly request identy encoding for times when
chunked encoding may not play well.
See server side events for an example: http://www.w3.org/TR/eventsource/