### PR TITLE
Add a right-associative path extractor.

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Path.scala
@@ -125,6 +125,20 @@ case object Root extends Path {
   def startsWith(other: Path) = other == Root
 }
 
+/**
+ * Path separator extractor:
+ *   Path("/1/2/3/test.json") match {
+ *     case "1" /: "2" /: _ =>  ...
+ */
+object /: {
+  def unapply(path: Path): Option[(String, Path)] = {
+    path.toList match {
+      case Nil => None
+      case head :: tail => Some((head, Path(tail)))
+    }
+  }
+}
+
 // Base class for Integer and LongParam extractors.
 protected class NumericPathVar[A <: AnyVal](cast: String => A) {
   def unapply(str: String): Option[A] = {

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -18,7 +18,6 @@ class PathSpec extends Http4sSpec {
       Path("foo/bar").toList must_== (List("foo", "bar"))
     }
 
-
     "~ extractor on Path" in {
       (Path("/foo.json") match {
         case Root / "foo" ~ "json" => true
@@ -90,6 +89,13 @@ class PathSpec extends Http4sSpec {
         case Root / "1" / "2" / "3" / "test.json" => true
         case _                                    => false
       }) must beTrue
+    }
+
+    "/: extractor" in {
+      (Path("/1/2/3/test.json") match {
+        case "1" /: "2" /: path => Some(path)
+        case _ => None
+      }) must_== Some(Path("/3/test.json"))
     }
     
     "trailing slash" in {

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -65,6 +65,12 @@ object ExampleService {
       Ok("<h2>This will have an html content type!</h2>")
           .withHeaders(`Content-Type`(`text/html`))
 
+    case req @ GET -> "static" /: path =>
+      // captures everything after "/directory" into `path`
+      // Try http://localhost:8080/http4s/nasa_blackhole_image.jpg
+      // See also org.http4s.server.staticcontent to create a mountable service for static content
+      StaticFile.fromResource(path.toString, Some(req)).fold(NotFound())(Task.now)
+
     ///////////////////////////////////////////////////////////////
     //////////////// Dealing with the message body ////////////////
     case req @ POST -> Root / "echo" =>


### PR DESCRIPTION
Comes from the Finagle HTTP path from which the DSL was originally
inspired.  Supports matching the remainder of a path after a
specified prefix.