### PR TITLE
Fix race condition with timeout registration and route execution in blaze client

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
@@ -55,7 +55,7 @@ final class Http1ClientStage(userAgent: Option[`User-Agent`], timeout: Duration)
             case StartupCallbackTag =>
               val ex = -\/(mkTimeoutEx(req))
               if (!stageState.compareAndSet(StartupCallbackTag, ex)) run()
-              else { /* NOOP he registered error should be handled below */ }
+              else { /* NOOP the registered error should be handled below */ }
 
             case _ => // NOOP
           }
@@ -75,13 +75,13 @@ final class Http1ClientStage(userAgent: Option[`User-Agent`], timeout: Duration)
         case other =>
           c.cancel()
           stageShutdown()
-          Task.fail(new IllegalStateException(s"Somehow the client stage go a different result: $other"))
+          Task.fail(new IllegalStateException(s"Somehow the client stage got a different result: $other"))
       }
     }
   }
 
   private def mkTimeoutEx(req: Request) =
-    new TimeoutException(s"Client request $req  timed out after $timeout")
+    new TimeoutException(s"Client request $req timed out after $timeout")
 
   private def executeRequest(req: Request): Task[Response] = {
     logger.debug(s"Beginning request: $req")

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
@@ -33,31 +33,51 @@ final class Http1ClientStage(userAgent: Option[`User-Agent`], timeout: Duration)
   override protected def doParseContent(buffer: ByteBuffer): Option[ByteBuffer] = Option(parseContent(buffer))
 
   /** Generate a `Task[Response]` that will perform an HTTP 1 request on execution */
-  def runRequest(req: Request): Task[Response] = {
+  def runRequest(req: Request): Task[Response] = Task.suspend[Response] {
     // We need to race two Tasks, one that will result in failure, one that gives the Response
 
-      Task.suspend[Response] {
-        val c: Cancellable = ClientTickWheel.schedule(new Runnable {
-          override def run(): Unit = {
-            stageState.get() match {  // We must still be active, and the stage hasn't reset.
-              case c@ \/-(_) =>
-                val ex = mkTimeoutEx(req)
-                if (stageState.compareAndSet(c, -\/(ex))) {
-                  logger.debug(ex.getMessage)
-                  shutdown()
-                }
+    val StartupCallbackTag = -\/(null)
 
-              case _ => // NOOP
-            }
+    if (!stageState.compareAndSet(null, StartupCallbackTag)) Task.fail(InProgressException)
+    else {
+      val c = ClientTickWheel.schedule(new Runnable {
+        @tailrec
+        override def run(): Unit = {
+          stageState.get() match {  // We must still be active, and the stage hasn't reset.
+            case c@ \/-(_) =>
+              val ex = mkTimeoutEx(req)
+              if (stageState.compareAndSet(c, -\/(ex))) {
+                logger.debug(ex.getMessage)
+                shutdown()
+              }
+
+            // Somehow we have beaten the registration of this callback to stage
+            case StartupCallbackTag =>
+              val ex = -\/(mkTimeoutEx(req))
+              if (!stageState.compareAndSet(StartupCallbackTag, ex)) run()
+              else { /* NOOP he registered error should be handled below */ }
+
+            case _ => // NOOP
           }
-        }, timeout)
-
-        if (!stageState.compareAndSet(null, \/-(c))) {
-          c.cancel()
-          Task.fail(InProgressException)
         }
-        else executeRequest(req)
+      }, timeout)
+
+      // There should only be two options at this point: StartupTag or the timeout exception registered above
+      stageState.getAndSet(\/-(c)) match {
+        case StartupCallbackTag =>
+          executeRequest(req)
+
+        case -\/(e) =>
+          c.cancel()
+          stageShutdown()
+          Task.fail(e)
+
+        case other =>
+          c.cancel()
+          stageShutdown()
+          Task.fail(new IllegalStateException(s"Somehow the client stage go a different result: $other"))
       }
+    }
   }
 
   private def mkTimeoutEx(req: Request) =

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -197,6 +197,17 @@ class Http1ClientStageSpec extends Specification with NoTimeConversions {
   }
 
   "Http1ClientStage responses" should {
+    "Timeout immediately with a timeout of 0 seconds" in {
+      val \/-(parsed) = Uri.fromString("http://www.foo.com")
+      val req = Request(uri = parsed)
+
+      val tail = new Http1ClientStage(DefaultUserAgent, 0.seconds)
+      val h = new SlowTestHead(List(mkBuffer(resp)), 0.milli)
+      LeafBuilder(tail).base(h)
+
+      tail.runRequest(req).run must throwA[TimeoutException]
+    }
+
     "Timeout on slow response" in {
       val \/-(parsed) = Uri.fromString("http://www.foo.com")
       val req = Request(uri = parsed)


### PR DESCRIPTION
This fixes a race condition that occured between generating and registering the timeout callback in the blaze client. The problem is pretty small: it should happen rarely and the fallout is not timing out a request.