### PR TITLE
Avoid "//" in path uris when serving static content

### DIFF
--- a/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -36,7 +36,7 @@ object FileService {
     val uri = req.uri
     if (!uri.path.startsWith(config.pathPrefix)) Task.now(None)
     else OptionT(
-        getFile(config.systemPath + File.separator + getSubPath(uri, config.pathPrefix))
+        getFile(config.systemPath + '/' + getSubPath(uri, config.pathPrefix))
           .map{ f => config.pathCollector(f, config, req) }
           .getOrElse(Task.now(None))
       )

--- a/server/src/main/scala/org/http4s/server/staticcontent/package.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/package.scala
@@ -20,8 +20,15 @@ package object staticcontent {
 
   private[staticcontent] val AcceptRangeHeader = `Accept-Ranges`(RangeUnit.Bytes)
 
+  // Will strip the pathPrefix from the first part of the Uri, returning the remainder without a leading '/'
   private[staticcontent] def getSubPath(uri: Uri, pathPrefix: String): String = {
-    if (pathPrefix.isEmpty) uri.path
-    else uri.path.substring(pathPrefix.length)
+    val path = uri.path
+    val index = pathPrefix.length + {
+        if (path.length > pathPrefix.length &&
+            path.charAt(pathPrefix.length) == '/') 1
+        else 0
+      }
+
+    path.substring(index)
   }
 }


### PR DESCRIPTION
Closes #299

It seems that files don't care about having a double '/' in the path,
but getting resources from the classpath happens to be sensitive to this.