### PR TITLE
Second attempt at fixing decodeString

### DIFF
--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -113,7 +113,8 @@ object EntityDecoder extends EntityDecoderInstances {
   def decodeString(msg: Message, defaultCharset: Option[Charset] = None): Task[String] = {
     val buff = new StringBuilder
     (msg.body |> process1.fold(buff) { (b, c) => {
-      b.append(new String(c.toArray, (msg.charset orElse defaultCharset getOrElse(Charset.`ISO-8859-1`)).nioCharset))
+      val charset = msg.contentType.flatMap(_.definedCharset) orElse defaultCharset getOrElse(Charset.`ISO-8859-1`)
+      b.append(new String(c.toArray, charset.nioCharset))
     }}).map(_.result()).runLastOr("")
   }
 }

--- a/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -189,5 +189,22 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
     }
   }
 
+  "decodeString" should {
+    val str = "Oekraïene"
+    "Use an charset defined by the Content-Type header" in {
+      val msg = Response(Ok).withBody(str.getBytes(Charset.`UTF-8`.nioCharset))
+                            .withContentType(Some(`Content-Type`(MediaType.`text/plain`, Some(Charset.`UTF-8`))))
+                            .run
 
+      EntityDecoder.decodeString(msg, defaultCharset = Some(Charset.`US-ASCII`)).run must_== str
+    }
+
+    "Use the default if the Content-Type header does not define one" in {
+      val msg = Response(Ok).withBody(str.getBytes(Charset.`UTF-8`.nioCharset))
+                            .withContentType(Some(`Content-Type`(MediaType.`text/plain`, None)))
+                            .run
+
+      EntityDecoder.decodeString(msg, defaultCharset = Some(Charset.`UTF-8`)).run must_== str
+    }
+  }
 }


### PR DESCRIPTION
See #279, https://github.com/beloglazov/couchdb-scala/issues/4, and https://github.com/beloglazov/couchdb-scala/pull/5

The first attempt at fixing this was tharted by `Content-Type`.charset which will default to ISO-8859-1 if not defined. This PR avoids that default and adds some unit tests to demonstrate.