### PR TITLE
Use UTF-8 by default.

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
@@ -123,7 +123,7 @@ object ServerTestRoutes {
       Response(Ok).withBody("Foo").putHeaders(`Transfer-Encoding`(TransferCoding.chunked))
 
     case req if req.method == Method.POST && req.pathInfo == "/echo" =>
-      Response(Ok).withBody(emit("post") ++ req.body.map(bs => new String(bs.toArray, req.charset.getOrElse(Charset.`ISO-8859-1`).nioCharset)))
+      Response(Ok).withBody(emit("post") ++ req.bodyAsText)
 
       // Kind of cheating, as the real NotModified response should have a Date header representing the current? time?
     case req if req.method == Method.GET && req.pathInfo == "/notmodified" => Task.now(Response(NotModified))

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -5,6 +5,8 @@ import java.net.InetAddress
 import org.http4s.headers._
 import org.http4s.server.ServerSoftware
 import scalaz.concurrent.Task
+import scalaz.stream.Process
+import scalaz.stream.text.utf8Decode
 import scalaz.syntax.monad._
 
 /**
@@ -20,6 +22,16 @@ sealed trait Message extends MessageOps {
   def headers: Headers
   
   def body: EntityBody
+
+  final def bodyAsText(implicit defaultCharset: Charset = DefaultCharset): Process[Task, String] = {
+    (charset getOrElse defaultCharset) match {
+      case Charset.`UTF-8` => body |> utf8Decode
+      case cs =>
+        // TODO broken if multi-byte sequences don't break cleanly on chunk boundaries
+        body map { chunk => new String(chunk.toArray, cs.nioCharset) }
+    }
+
+  }
   
   def attributes: AttributeMap
   
@@ -72,7 +84,9 @@ sealed trait Message extends MessageOps {
 
   def contentType: Option[`Content-Type`] = headers.get(`Content-Type`)
 
-  def charset: Option[Charset] = contentType.map(_.charset)
+  /** Returns the charset parameter of the `Content-Type` header, if present.
+    * Does not introspect the body for media types that define a charset internally. */
+  def charset: Option[Charset] = contentType.flatMap(_.charset)
 
   def isChunked: Boolean = headers.get(`Transfer-Encoding`).exists(_.values.list.contains(TransferCoding.chunked))
 

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -25,10 +25,11 @@ sealed trait Message extends MessageOps {
 
   final def bodyAsText(implicit defaultCharset: Charset = DefaultCharset): Process[Task, String] = {
     (charset getOrElse defaultCharset) match {
-      case Charset.`UTF-8` => body |> utf8Decode
+      case Charset.`UTF-8` =>
+        // suspect this one is more efficient, though this is superstition
+        body |> utf8Decode
       case cs =>
-        // TODO broken if multi-byte sequences don't break cleanly on chunk boundaries
-        body map { chunk => new String(chunk.toArray, cs.nioCharset) }
+        body |> util.decode(cs)
     }
 
   }

--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -41,16 +41,16 @@ object UrlForm {
   def apply(values: (String, String)*): UrlForm =
     values.foldLeft(empty)(_ + _)
 
-  implicit def entityEncoder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[UrlForm] =
+  implicit def entityEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[UrlForm] =
     EntityEncoder.stringEncoder(charset)
       .contramap[UrlForm](encodeString(charset))
       .withContentType(`Content-Type`(MediaType.`application/x-www-form-urlencoded`, charset))
 
-  implicit val entityDecoder: EntityDecoder[UrlForm] =
+  implicit def entityDecoder(implicit defaultCharset: Charset = DefaultCharset): EntityDecoder[UrlForm] =
     EntityDecoder.decodeBy(MediaType.`application/x-www-form-urlencoded`){ m =>
       DecodeResult(
         EntityDecoder.decodeString(m)
-          .map(decodeString(m.charset.getOrElse(Charset.`ISO-8859-1`)))
+          .map(decodeString(m.charset.getOrElse(defaultCharset)))
       )
     }
 

--- a/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
@@ -12,8 +12,7 @@ final case class `Accept-Charset`(values: NonEmptyList[CharsetRange]) extends He
   def qValue(charset: Charset): QValue = {
     def specific = values.list.collectFirst { case cs: CharsetRange.Atom => cs.qValue }
     def splatted = values.list.collectFirst { case cs: CharsetRange.`*` => cs.qValue }
-    def default = if (charset == Charset.`ISO-8859-1`) QValue.One else QValue.Zero
-    specific orElse splatted getOrElse default
+    specific orElse splatted getOrElse QValue.Zero
   }
 
   def isSatisfiedBy(charset: Charset) = qValue(charset) > QValue.Zero

--- a/core/src/main/scala/org/http4s/headers/Content-Type.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Type.scala
@@ -8,9 +8,9 @@ object `Content-Type` extends HeaderKey.Internal[`Content-Type`] with HeaderKey.
   implicit def apply(mediaType: MediaType): `Content-Type` = apply(mediaType, None)
 }
 
-final case class `Content-Type`(mediaType: MediaType, definedCharset: Option[Charset]) extends Header.Parsed {
+final case class `Content-Type`(mediaType: MediaType, charset: Option[Charset]) extends Header.Parsed {
   override def key = `Content-Type`
-  override def renderValue(writer: Writer): writer.type = definedCharset match {
+  override def renderValue(writer: Writer): writer.type = charset match {
     case Some(cs) => writer << mediaType << "; charset=" << cs
     case _        => mediaType.render(writer)
   }
@@ -18,13 +18,11 @@ final case class `Content-Type`(mediaType: MediaType, definedCharset: Option[Cha
   def withMediaType(mediaType: MediaType) =
     if (mediaType != this.mediaType) copy(mediaType = mediaType) else this
   def withCharset(charset: Charset) =
-    if (noCharsetDefined || charset != definedCharset.get) copy(definedCharset = Some(charset)) else this
+    if (noCharsetDefined || charset != this.charset.get) copy(charset = Some(charset)) else this
   def withoutDefinedCharset =
-    if (isCharsetDefined) copy(definedCharset = None) else this
+    if (isCharsetDefined) copy(charset = None) else this
 
-  def isCharsetDefined = definedCharset.isDefined
-  def noCharsetDefined = definedCharset.isEmpty
-
-  def charset: Charset = definedCharset.getOrElse(Charset.`ISO-8859-1`)
+  def isCharsetDefined = charset.isDefined
+  def noCharsetDefined = charset.isEmpty
 }
 

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -20,4 +20,6 @@ package object http4s {
   val ApiVersion: Http4sVersion = Http4sVersion(BuildInfo.apiVersion._1, BuildInfo.apiVersion._2)
 
   type ParseResult[+A] = ParseFailure \/ A
+
+  val DefaultCharset = Charset.`UTF-8`
 }

--- a/core/src/main/scala/org/http4s/util/package.scala
+++ b/core/src/main/scala/org/http4s/util/package.scala
@@ -1,0 +1,46 @@
+package org.http4s
+
+import java.nio.CharBuffer
+import java.nio.charset.CharsetDecoder
+
+import scodec.bits.ByteVector
+
+import scalaz.State
+import scalaz.concurrent.Task
+import scalaz.stream.{process1, Channel, Process, Process1}
+import scalaz.stream.Process._
+import scalaz.stream.io.bufferedChannel
+import scalaz.std.option.none
+
+package object util {
+  /** Temporary.  Contribute back to scalaz-stream. */
+  def decode(charset: Charset): Process1[ByteVector, String] = suspend {
+    val decoder = charset.nioCharset.newDecoder
+    var carryOver = ByteVector.empty
+
+    def push(chunk: ByteVector, eof: Boolean) = {
+      val in = carryOver ++ chunk
+      val byteBuffer = in.toByteBuffer
+      val charBuffer = CharBuffer.allocate(in.size + 1)
+      decoder.decode(byteBuffer, charBuffer, eof)
+      if (eof)
+        decoder.flush(charBuffer)
+      else
+        carryOver = ByteVector.view(byteBuffer.slice)
+      charBuffer.flip().toString
+    }
+
+    def go(): Process1[ByteVector, String] = receive1[ByteVector, String] { chunk =>
+      val s = push(chunk, false)
+      val sChunk = if (s.nonEmpty) emit(s) else halt
+      sChunk ++ go()
+    }
+
+    def flush() = {
+      val s = push(ByteVector.empty, true)
+      if (s.nonEmpty) emit(s) else halt
+    }
+
+    go() onComplete flush()
+  }
+}

--- a/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -196,7 +196,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
                             .withContentType(Some(`Content-Type`(MediaType.`text/plain`, Some(Charset.`UTF-8`))))
                             .run
 
-      EntityDecoder.decodeString(msg, defaultCharset = Some(Charset.`US-ASCII`)).run must_== str
+      EntityDecoder.decodeString(msg)(Charset.`US-ASCII`).run must_== str
     }
 
     "Use the default if the Content-Type header does not define one" in {
@@ -204,7 +204,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
                             .withContentType(Some(`Content-Type`(MediaType.`text/plain`, None)))
                             .run
 
-      EntityDecoder.decodeString(msg, defaultCharset = Some(Charset.`UTF-8`)).run must_== str
+      EntityDecoder.decodeString(msg)(Charset.`UTF-8`).run must_== str
     }
   }
 }

--- a/core/src/test/scala/org/http4s/util/DecodeSpec.scala
+++ b/core/src/test/scala/org/http4s/util/DecodeSpec.scala
@@ -1,0 +1,51 @@
+package org.http4s
+package util
+
+import java.nio.charset.StandardCharsets
+
+import org.specs2.ScalaCheck
+
+import scalaz.stream.Process._
+import scalaz.stream.text.utf8Decode
+import scodec.bits._
+
+import org.http4s.util.byteVector._
+
+class DecodeSpec extends Http4sSpec with ScalaCheck {
+  "decode" should {
+    "be consistent with utf8Decode" in prop { (s: String, chunkSize: Int) =>
+      (chunkSize > 0) ==> {
+        val source = emitAll {
+          s.getBytes(StandardCharsets.UTF_8)
+            .grouped(chunkSize)
+            .map(ByteVector.view)
+            .toSeq
+        }.toSource
+        val utf8Decoded = (source |> utf8Decode).runLog.run
+        val decoded = (source |> decode(Charset.`UTF-8`)).runLog.run
+        decoded must_== utf8Decoded
+      }
+    }
+
+    "be consistent with String constructor over aggregated output" in prop { (cs: Charset, s: String, chunkSize: Int) =>
+      // x-COMPOUND_TEXT fails with a read only buffer.
+      (chunkSize > 0 && cs.nioCharset.canEncode && cs.nioCharset.name != "x-COMPOUND_TEXT") ==> {
+        val source = emitAll {
+          s.getBytes(cs.nioCharset)
+            .grouped(chunkSize)
+            .map(ByteVector.view)
+            .toSeq
+        }.toSource
+        val expected = source.foldMonoid
+          .runLastOr(ByteVector.empty)
+          .map(bs => new String(bs.toArray, cs.nioCharset))
+          .run
+        !expected.contains("\ufffd") ==> {
+          // \ufffd means we generated a String unrepresentable by the charset
+          val decoded = (source |> decode(cs)).foldMonoid.runLastOr("").run
+          decoded must_== expected
+        }
+      }
+    }
+  }
+}

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -9,7 +9,7 @@ import scala.xml._
 import scalaz.concurrent.Task
 
 trait ElemInstances {
-  implicit def xmlEnocder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[Elem] =
+  implicit def xmlEnocder(implicit charset: Charset = DefaultCharset): EntityEncoder[Elem] =
     EntityEncoder.stringEncoder(charset)
       .contramap[Elem](xml => xml.buildString(false))
       .withContentType(`Content-Type`(MediaType.`application/xml`))

--- a/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
+++ b/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
@@ -6,23 +6,23 @@ import MediaType._
 import play.twirl.api._
 
 trait TwirlInstances {
-  implicit def htmlContentEncoder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[Html] =
+  implicit def htmlContentEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[Html] =
     contentEncoder(`text/html`)
 
   /**
    * Note: Twirl uses a media type of `text/javascript`.  This is obsolete, so we instead return
    * [[`application/javascript`]].
    */
-  implicit def jsContentEncoder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[JavaScript] =
+  implicit def jsContentEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[JavaScript] =
     contentEncoder(`application/javascript`)
 
-  implicit def xmlContentEncoder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[Xml] =
+  implicit def xmlContentEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[Xml] =
     contentEncoder(`application/xml`)
 
-  implicit def txtContentEncoder(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[Txt] =
+  implicit def txtContentEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[Txt] =
     contentEncoder(`text/plain`)
 
-  private def contentEncoder[C <: Content](mediaType: MediaType)(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[C] =
+  private def contentEncoder[C <: Content](mediaType: MediaType)(implicit charset: Charset = DefaultCharset): EntityEncoder[C] =
     EntityEncoder.stringEncoder(charset).contramap[C](content => content.body)
       .withContentType(`Content-Type`(mediaType, charset))
 }


### PR DESCRIPTION
Quoth https://tools.ietf.org/html/rfc7231#appendix-B:
> The default charset of ISO-8859-1 for text media types has been
> removed; the default is now whatever the media type definition says.
> Likewise, special treatment of ISO-8859-1 has been removed from the
> Accept-Charset header field.  (Section 3.1.1.3 and Section 5.3.3)

Quoth https://tools.ietf.org/html/rfc6657#page-3:
> Thus, new subtypes of the "text" media type SHOULD NOT define a
> default "charset" value.  If there is a strong reason to do so
> despite this advice, they SHOULD use the "UTF-8" [RFC3629] charset as
> the default. [...]  However, existing "text/*" registrations that fail to specify 
> how the charset is determined still default to US-ASCII.

Downside: This will break things that relied on the deprecated ISO-8859-1 
default, or media types that default to something that is not a proper subset of
UTF-8.  These use cases will need to carefully provide a default charset.

Upside: it's legal, correct by default for JSON, and encourages good citizenship
in the year 2015 and beyond.

Relates to #308, but does not handle payload-defined encodings such as XML
and HTML.