### PR TITLE
Fix blaze-client tests on windows

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -25,7 +25,7 @@ abstract class ClientRouteTestBattery(name: String, client: Client)
 
   override def runAllTests(): Fragments = {
     val address = initializeServer()
-    val gets = translateTests(address.getPort, Method.GET, getPaths)
+    val gets = translateTests(address, Method.GET, getPaths)
     val frags = gets.map { case (req, resp) => runTest(req, resp, address) }
                     .toSeq
                     .foldLeft(Fragments())(_ ^ _)
@@ -68,9 +68,11 @@ abstract class ClientRouteTestBattery(name: String, client: Client)
     rec.httpVersion must be_==(expected.httpVersion)
   }
 
-  private def translateTests(port: Int, method: Method, paths: Map[String, Response]): Map[Request, Response] = {
+  private def translateTests(address: InetSocketAddress, method: Method, paths: Map[String, Response]): Map[Request, Response] = {
+    val port = address.getPort()
+    val name = address.getHostName()
     paths.map { case (s, r) =>
-      (Request(method, uri = Uri.fromString(s"http://localhost:$port$s").yolo), r)
+      (Request(method, uri = Uri.fromString(s"http://$name:$port$s").yolo), r)
     }
   }
 

--- a/client/src/test/scala/org/http4s/client/JettyScaffold.scala
+++ b/client/src/test/scala/org/http4s/client/JettyScaffold.scala
@@ -1,6 +1,6 @@
 package org.http4s.client
 
-import java.net.{ServerSocket, InetSocketAddress}
+import java.net.{ServerSocket, InetSocketAddress, InetAddress}
 import javax.servlet.http.HttpServlet
 
 import org.eclipse.jetty.server.{Server => JServer, ServerConnector}
@@ -35,7 +35,7 @@ abstract class JettyScaffold(name: String) extends Http4sSpec {
   protected def timeout: Duration = 10.seconds
 
   protected def initializeServer(): InetSocketAddress = {
-    val address = new InetSocketAddress(JettyScaffold.getNextPort())
+    val address = new InetSocketAddress(InetAddress.getLocalHost(), JettyScaffold.getNextPort())
 
     val context = new ServletContextHandler()
     context.setContextPath("/")


### PR DESCRIPTION
closes #294

Windows doens't allow 0.0.0.0 or such things quite the same way as *nix
systems.

Really, this fixes the test battery for all clients on windows, but there
is only one right now.