### PR TITLE
Fix IPv4 parser

### DIFF
--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -80,12 +80,13 @@ private[parser] trait Rfc3986Parser { this: Parser =>
 
   def IpV4Address = rule { 3.times(DecOctet ~ ".") ~ DecOctet }
 
+
   def DecOctet = rule {
-      "1" ~ 2.times(Digit)      |
-      ("1" - "9") ~ Digit       |
-      "2" ~ ("0" - "4") ~ Digit |
-      "25" ~ ("0" - "5")        |
-      Digit
+    "1"         ~ Digit       ~ Digit |
+    "2"         ~ ("0" - "4") ~ Digit |
+    "25"        ~ ("0" - "5")         |
+    ("1" - "9") ~ Digit               |
+    Digit
   }
 
   def RegName: Rule0 = rule { zeroOrMore(Unreserved | PctEncoded | SubDelims) }

--- a/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -8,8 +8,9 @@ import org.http4s._
 import scala.util.Success
 import org.parboiled2._
 
-class IPV6Parser(val input: ParserInput, val charset: NioCharset) extends Parser with Rfc3986Parser {
+class IpParser(val input: ParserInput, val charset: NioCharset) extends Parser with Rfc3986Parser {
   def CaptureIPv6: Rule1[String] = rule { capture(IpV6Address) }
+  def CaptureIPv4: Rule1[String] = rule { capture(IpV4Address) }
 }
 
 class UriParserSpec extends Http4sSpec {
@@ -31,7 +32,14 @@ class UriParserSpec extends Http4sSpec {
       } yield (f + "::" + b))
 
       foreach(v) { s =>
-        new IPV6Parser(s, StandardCharsets.UTF_8).CaptureIPv6.run() must be_==(Success((s)))
+        new IpParser(s, StandardCharsets.UTF_8).CaptureIPv6.run() must be_==(Success(s))
+      }
+    }
+
+    "parse a IPv4 address" in {
+      foreach(0 to 255) { i =>
+        val addr = s"$i.$i.$i.$i"
+        new IpParser(addr, StandardCharsets.UTF_8).CaptureIPv4.run() must_==(Success(addr))
       }
     }
 


### PR DESCRIPTION
closes #320

Order of | elements in the DecOctet rule of Rfc3986 was bad.