### PR TITLE
Don't extend AllInstances in Http4s omnibus import.

### DIFF
--- a/core/src/main/scala/org/http4s/Http4s.scala
+++ b/core/src/main/scala/org/http4s/Http4s.scala
@@ -8,8 +8,7 @@ trait Http4s
 object Http4s extends Http4s
 
 trait Http4sInstances
-  extends scalaz.std.AllInstances
-  with EntityDecoderInstances
+  extends EntityDecoderInstances
   with HttpVersionInstances
   with EntityEncoderInstances
   with CharsetRangeInstances

--- a/core/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/core/src/test/scala/org/http4s/Http4sSpec.scala
@@ -3,7 +3,9 @@ package org.http4s
 import org.specs2.matcher.AnyMatchers
 import org.specs2.scalaz.{Spec, ScalazMatchers}
 
+import scalaz.std.AllInstances
+
 /**
  * Common stack for http4s' own specs.
  */
-trait Http4sSpec extends Spec with AnyMatchers with ScalazMatchers with Http4s with TestInstances
+trait Http4sSpec extends Spec with AnyMatchers with ScalazMatchers with Http4s with TestInstances with AllInstances


### PR DESCRIPTION
This causes pain for Scalaz use.  We still need it in our tests, but it
didn't break any of our examples.

Fixes #323.