### PR TITLE
Change default timeout status code to 500.

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -6,33 +6,37 @@ import scala.concurrent.duration._
 import scalaz.concurrent.Task
 import java.util.concurrent.{TimeUnit, ScheduledThreadPoolExecutor}
 import scalaz.\/-
+import scalaz.syntax.monad._
 
 object Timeout {
 
   // TODO: this should probably be replaced with a low res executor to save clock cycles
   private val ec = new ScheduledThreadPoolExecutor(1)
 
-  private def timeoutResp(timeout: Duration): Task[Response] = Task.async { cb =>
-    val r = new Runnable { override def run(): Unit = cb(\/-(Response(Status.RequestTimeout))) }
-    ec.schedule(r, timeout.toNanos, TimeUnit.NANOSECONDS)
-  }
+  val DefaultTimeoutResponse = Response(Status.InternalServerError)
+    .withBody("The service timed out.")
 
-    /** Transform the service such to return whichever resolves first:
-      * the provided Task[Response], or the result of the service
-      * @param r Task[Response] to race against the result of the service. This will be run for each [[Request]]
-      * @param service [[org.http4s.server.HttpService]] to transform
-      */
+  private def timeoutResp(timeout: Duration, response: Task[Response]): Task[Response] = Task.async[Task[Response]] { cb =>
+    val r = new Runnable { override def run(): Unit = cb(\/-(response)) }
+    ec.schedule(r, timeout.toNanos, TimeUnit.NANOSECONDS)
+  }.join
+
+  /** Transform the service such to return whichever resolves first:
+    * the provided Task[Response], or the result of the service
+    * @param r Task[Response] to race against the result of the service. This will be run for each [[Request]]
+    * @param service [[org.http4s.server.HttpService]] to transform
+    */
   def apply(r: Task[Response])(service: HttpService): HttpService = {
-      val rr = r.map(Some(_))
-      Service.lift{ req: Request => Task.taskInstance.chooseAny(service(req), rr::Nil).map(_._1) }
-    }
+    val rr = r.map(Some(_))
+    Service.lift{ req: Request => Task.taskInstance.chooseAny(service(req), rr::Nil).map(_._1) }
+  }
 
   /** Transform the service to return a RequestTimeOut [[Status]] after the supplied Duration
     * @param timeout Duration to wait before returning the RequestTimeOut
     * @param service [[HttpService]] to transform
     */
-  def apply(timeout: Duration)(service: HttpService): HttpService = {
-    if (timeout.isFinite()) apply(timeoutResp(timeout))(service)
+  def apply(timeout: Duration, response: Task[Response] = DefaultTimeoutResponse)(service: HttpService): HttpService = {
+    if (timeout.isFinite()) apply(timeoutResp(timeout, response))(service)
     else service
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
@@ -10,30 +10,37 @@ import Method._
 
 class TimeoutSpec extends Http4sSpec with NoTimeConversions {
 
-  val myservice = HttpService {
+  val myService = HttpService {
     case req if req.uri.path == "/fast" => Response(Status.Ok).withBody("Fast")
     case req if req.uri.path == "/slow" => Task(Thread.sleep(1000)).flatMap(_ => Response(Status.Ok).withBody("Slow"))
   }
 
-  val timeoutService = Timeout.apply(500.millis)(myservice)
+  val timeoutService = Timeout.apply(500.millis)(myService)
 
   "Timeout Middleware" should {
     "Have no effect if the response is not delayed" in {
       val req = Request(GET, uri("/fast"))
 
-      timeoutService.apply(req).run.get.status must_==(Status.Ok)
+      timeoutService.apply(req).run.get.status must equal (Status.Ok)
     }
 
-    "return a timeout if the result takes too long" in {
+    "return a 500 error if the result takes too long" in {
       val req = Request(GET, uri("/slow"))
 
-      timeoutService.apply(req).run.get.status must_==(Status.RequestTimeout)
+      timeoutService.apply(req).run.get.status must equal (Status.InternalServerError)
+    }
+
+    "return the provided response if the result takes too long" in {
+      val req = Request(GET, uri("/slow"))
+      val customTimeout = Response(Status.GatewayTimeout) // some people return 504 here.
+      val altTimeoutService = Timeout(500.millis, Task.now(customTimeout))(myService)
+      altTimeoutService(req).run.get.status must equal (customTimeout.status)
     }
 
     "Handle infinite durations" in {
-      val service = Timeout(Duration.Inf)(myservice)
+      val service = Timeout(Duration.Inf)(myService)
 
-      service(Request(GET, uri("/slow"))).run.get.status must_==(Status.Ok)
+      service(Request(GET, uri("/slow"))).run.get.status must equal (Status.Ok)
     }
   }
 


### PR DESCRIPTION
Provides method to allow custom response for those who think
of themselves as a proxy or gateway, and should be returning
504.

Fixes #345.