### PR TITLE
A better PartialService, for those who like to chain.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ lazy val core = libraryProject("core")
         log4s,
         parboiled,
         scalaReflect(scalaVersion.value) % "provided",
+        scalazCore,
         scalazStream,
         scodecBits
       ),

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -75,6 +75,7 @@ object Http4sBuild extends Build {
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
   lazy val scalameter          = "com.storm-enroute"        %% "scalameter"              % "0.6"
   lazy val scalaXml            = "org.scala-lang.modules"   %% "scala-xml"               % "1.0.3"
+  lazy val scalazCore          = "org.scalaz"               %% "scalaz-core" % "7.1.2"
   lazy val scalazScalacheckBinding = "org.scalaz"           %% "scalaz-scalacheck-binding" % "7.1.2"
   lazy val scalazSpecs2        = "org.typelevel"            %% "scalaz-specs2"           % "0.3.0"
   lazy val scalazStream        = "org.scalaz.stream"        %% "scalaz-stream"           % "0.7.1a"

--- a/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -32,16 +32,16 @@ object FileService {
 
 
   /** Make a new [[org.http4s.server.HttpService]] that serves static files. */
-  private[staticcontent] def apply(config: Config): PartialService[Request, Response] = Service.lift { req =>
+  private[staticcontent] def apply(config: Config): PartialService[Request, Response] = PartialService.lift { req =>
     val uri = req.uri
-    if (!uri.path.startsWith(config.pathPrefix)) Task.now(None)
-    else OptionT(
+    if (!uri.path.startsWith(config.pathPrefix))
+      OptionT.none
+    else
+      OptionT(
         getFile(config.systemPath + '/' + getSubPath(uri, config.pathPrefix))
           .map{ f => config.pathCollector(f, config, req) }
           .getOrElse(Task.now(None))
-      )
-        .flatMapF(config.cacheStartegy.cache(uri, _))
-        .run
+      ).flatMapF(config.cacheStartegy.cache(uri, _))
   }
 
   /* Returns responses for static files.

--- a/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
@@ -26,15 +26,15 @@ object ResourceService {
                     cacheStartegy: CacheStrategy = NoopCacheStrategy)
 
   /** Make a new [[org.http4s.server.HttpService]] that serves static files. */
-  private[staticcontent] def apply(config: Config): PartialService[Request, Response] = Service.lift { req =>
+  private[staticcontent] def apply(config: Config): PartialService[Request, Response] = PartialService.lift { req =>
     val uri = req.uri
-    if (!uri.path.startsWith(config.pathPrefix)) Task.now(None)
-    else OptionT(
-          StaticFile.fromResource(sanitize(config.basePath + '/' + getSubPath(uri, config.pathPrefix)))
+    if (!uri.path.startsWith(config.pathPrefix))
+      OptionT.none
+    else
+      OptionT(
+        StaticFile.fromResource(sanitize(config.basePath + '/' + getSubPath(uri, config.pathPrefix)))
           .map{ f => Task.now(Some(f)) }
           .getOrElse(Task.now(None))
-        )
-          .flatMapF(config.cacheStartegy.cache(uri, _))
-          .run
+      ).flatMapF(config.cacheStartegy.cache(uri, _))
   }
 }

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
@@ -1,13 +1,13 @@
 package org.http4s
-package server.staticcontent
+package server
+package staticcontent
 
-import scalaz.Kleisli.kleisli
 import scalaz.concurrent.Task
 
 class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
   val s = fileService(FileService.Config(System.getProperty("user.dir")))
-    .mapK(_.getOrElse(Response(Status.NotFound)))
+    .or(Task.now(Response(Status.NotFound)))
 
   "FileService" should {
 

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
@@ -7,7 +7,7 @@ import scalaz.concurrent.Task
 class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
   val s = fileService(FileService.Config(System.getProperty("user.dir")))
-    .flatMapK(_.fold(Task.now(Response(Status.NotFound)))(Task.now))
+    .mapK(_.getOrElse(Response(Status.NotFound)))
 
   "FileService" should {
 

--- a/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
@@ -8,7 +8,7 @@ import scalaz.concurrent.Task
 class ResourceServiceSpec extends Http4sSpec with StaticContentShared {
 
   val s = resourceService(ResourceService.Config(""))
-    .flatMapK(_.fold(Task.now(Response(Status.NotFound)))(Task.now))
+    .mapK(_.getOrElse(Response(Status.NotFound)))
 
   "ResourceService" should {
 

--- a/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
@@ -1,14 +1,13 @@
 package org.http4s
-package server.staticcontent
+package server
+package staticcontent
 
-import scalaz.Kleisli.kleisli
 import scalaz.concurrent.Task
-
 
 class ResourceServiceSpec extends Http4sSpec with StaticContentShared {
 
   val s = resourceService(ResourceService.Config(""))
-    .mapK(_.getOrElse(Response(Status.NotFound)))
+    .or(Task.now(Response(Status.NotFound)))
 
   "ResourceService" should {
 


### PR DESCRIPTION
Another experimental offshoot of #332.

A `PartialFunction` can now optionally be lifted into a `PartialService`, which gets back its `or` and `orElse` operations via syntax.  This supports a chaining style for those who want it, but tucks it out of the way because most people won't.

There is probably something clever to be done with middleware here, but I'm done being clever until someone supports this idea.