### PR TITLE
Add WebSocketSupport to the ServerBuilder mechanism

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -29,9 +29,19 @@ import scalaz.{\/-, -\/}
 import java.util.concurrent.ExecutorService
 
 
+object Http1ServerStage {
+  def apply(service: HttpService,
+            conn: Option[SocketConnection],
+            pool: ExecutorService = Strategy.DefaultExecutorService,
+            enableWebSockets: Boolean = false ): Http1ServerStage = {
+    if (enableWebSockets) new Http1ServerStage(service, conn, pool) with WebSocketSupport
+    else                  new Http1ServerStage(service, conn, pool)
+  }
+}
+
 class Http1ServerStage(service: HttpService,
                        conn: Option[SocketConnection],
-                       pool: ExecutorService = Strategy.DefaultExecutorService)
+                       pool: ExecutorService)
                   extends Http1ServerParser
                   with TailStage[ByteBuffer]
                   with Http1Stage

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http4sHttp1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http4sHttp1ServerStageSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 
-import scalaz.concurrent.Task
+import scalaz.concurrent.{Strategy, Task}
 import scalaz.stream.Process
 
 import scodec.bits.ByteVector
@@ -41,7 +41,7 @@ class Http1ServerStageSpec extends Specification with NoTimeConversions {
 
   def runRequest(req: Seq[String], service: HttpService): Future[ByteBuffer] = {
     val head = new SeqTestHead(req.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
-    val httpStage = new Http1ServerStage(service, None) {
+    val httpStage = new Http1ServerStage(service, None, Strategy.DefaultExecutorService) {
       override def reset(): Unit = head.stageShutdown()     // shutdown the stage after a complete request
     }
     pipeline.LeafBuilder(httpStage).base(head)
@@ -90,7 +90,7 @@ class Http1ServerStageSpec extends Specification with NoTimeConversions {
 
     def httpStage(service: HttpService, requests: Int, input: Seq[String]): Future[ByteBuffer] = {
       val head = new SeqTestHead(input.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
-      val httpStage = new Http1ServerStage(service, None) {
+      val httpStage = new Http1ServerStage(service, None, Strategy.DefaultExecutorService) {
         @volatile var count = 0
 
         override def reset(): Unit = {

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -1,29 +1,21 @@
 package com.example.http4s.blaze
 
-import java.net.InetSocketAddress
-import java.nio.ByteBuffer
-
-import org.http4s.blaze.channel.SocketConnection
-import org.http4s.blaze.channel.nio1.NIO1SocketServerGroup
-import org.http4s.blaze.pipeline.LeafBuilder
 import org.http4s.server.HttpService
-import org.http4s.server.blaze.{Http1ServerStage, WebSocketSupport}
-import org.http4s.server.middleware.URITranslation
+import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.websocket.WebsocketBits._
+import org.http4s.dsl._
+import org.http4s.server.websocket._
 
+import scala.concurrent.duration._
+
+import scalaz.concurrent.Task
 import scalaz.concurrent.Strategy
+import scalaz.stream.async.unboundedQueue
+import scalaz.stream.{Process, Sink}
 import scalaz.stream.{DefaultScheduler, Exchange}
 import scalaz.stream.time.awakeEvery
 
 object BlazeWebSocketExample extends App {
-
-  import org.http4s.dsl._
-  import org.http4s.server.websocket._
-
-import scala.concurrent.duration._
-  import scalaz.concurrent.Task
-  import scalaz.stream.async.unboundedQueue
-  import scalaz.stream.{Process, Sink}
 
 /// code_ref: blaze_websocket_example
 
@@ -48,13 +40,11 @@ import scala.concurrent.duration._
       WS(Exchange(src, q.enqueue))
   }
 
-/// end_code_ref
+  BlazeBuilder.bindHttp(8080)
+    .withWebSockets(true)
+    .mountService(route, "/http4s")
+    .run
+    .awaitShutdown()
 
-  def pipebuilder(conn: SocketConnection): LeafBuilder[ByteBuffer] =
-    new Http1ServerStage(URITranslation.translateRoot("/http4s")(route), Some(conn)) with WebSocketSupport
-
-  NIO1SocketServerGroup.fixedGroup(12, 8*1024)
-    .bind(new InetSocketAddress(8080), pipebuilder)
-    .get  // yolo! Its just an example.
-    .join()
+  /// end_code_ref
 }

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -83,3 +83,8 @@ trait MetricsSupport { this: ServerBuilder =>
 object MetricsSupport {
   val DefaultPrefix = "org.http4s.server"
 }
+
+trait WebSocketSupport { this: ServerBuilder =>
+  /* Enable websocket support */
+  def withWebSockets(enableWebsockets: Boolean): Self
+}


### PR DESCRIPTION
Compatible backends can enable websockets with
```
myBuilder.withWebSockets(true /* or 'false' */)
```

Blaze server builder supports the new mechanism.