### PR TITLE
Fix the blaze SSL and http2 examples

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -242,14 +242,8 @@ lazy val examples = http4sProject("examples")
 lazy val examplesBlaze = exampleProject("examples-blaze")
   .settings(
     description := "Examples of http4s server and clients on blaze",
-    libraryDependencies ++= Seq(
-      (javaVersion match {
-        case v if v >= (1, 8) => Seq(alpnBoot)
-        case _ => Seq.empty
-      }),
-      Seq(metricsJson)
-    ).flatten,
-    // ALPN is necessary for HTTP2 support, but requires Java 8
+    fork := true,
+    libraryDependencies ++= Seq(alpnBoot, metricsJson),
     javaOptions in run <++= (managedClasspath in Runtime) map { attList =>
       for {
         file <- attList.map(_.data)

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -43,12 +43,8 @@ object Http4sBuild extends Build {
       None
   }
 
-  lazy val javaVersion = VersionNumber(sys.props("java.specification.version")) match {
-    case VersionNumber(Seq(x, y, _*), _, _) => (x.toInt, y.toInt)
-  }
-
   lazy val argonautSupport     = "org.spire-math"           %% "argonaut-support"        % jawnParser.revision
-  lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               %  "8.0.0.v20140317" // must use Java8!
+  lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               %  "8.1.3.v20150130"
   lazy val base64              = "net.iharder"               % "base64"                  % "2.3.8"
   lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.8.2"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"


### PR DESCRIPTION
Also removed blazeExample build bits for determining if we are running JDK < 1.8.

http2 examples needed a forked JVM.