### PR TITLE
Topic/local

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -30,16 +30,16 @@ import java.util.concurrent.ExecutorService
 
 object Http1ServerStage {
   def apply(service: HttpService,
-            conn: Option[SocketConnection],
+            attributes: AttributeMap = AttributeMap.empty,
             pool: ExecutorService = Strategy.DefaultExecutorService,
             enableWebSockets: Boolean = false ): Http1ServerStage = {
-    if (enableWebSockets) new Http1ServerStage(service, conn, pool) with WebSocketSupport
-    else                  new Http1ServerStage(service, conn, pool)
+    if (enableWebSockets) new Http1ServerStage(service, attributes, pool) with WebSocketSupport
+    else                  new Http1ServerStage(service, attributes, pool)
   }
 }
 
 class Http1ServerStage(service: HttpService,
-                       conn: Option[SocketConnection],
+                       requestAttrs: AttributeMap,
                        pool: ExecutorService)
                   extends Http1ServerParser
                   with TailStage[ByteBuffer]
@@ -51,13 +51,6 @@ class Http1ServerStage(service: HttpService,
   protected val ec = ExecutionContext.fromExecutorService(pool)
 
   val name = "Http4sServerStage"
-
-  private val requestAttrs = (
-      for {
-        conn  <- conn
-        raddr <- conn.remoteInetAddress
-      } yield AttributeMap(AttributeEntry(Request.Keys.Remote, raddr))
-    ).getOrElse(AttributeMap.empty)
 
   private var uri: String = null
   private var method: String = null

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http4sHttp1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http4sHttp1ServerStageSpec.scala
@@ -41,7 +41,7 @@ class Http1ServerStageSpec extends Specification with NoTimeConversions {
 
   def runRequest(req: Seq[String], service: HttpService): Future[ByteBuffer] = {
     val head = new SeqTestHead(req.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
-    val httpStage = new Http1ServerStage(service, None, Strategy.DefaultExecutorService) {
+    val httpStage = new Http1ServerStage(service, AttributeMap.empty, Strategy.DefaultExecutorService) {
       override def reset(): Unit = head.stageShutdown()     // shutdown the stage after a complete request
     }
     pipeline.LeafBuilder(httpStage).base(head)
@@ -90,7 +90,7 @@ class Http1ServerStageSpec extends Specification with NoTimeConversions {
 
     def httpStage(service: HttpService, requests: Int, input: Seq[String]): Future[ByteBuffer] = {
       val head = new SeqTestHead(input.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
-      val httpStage = new Http1ServerStage(service, None, Strategy.DefaultExecutorService) {
+      val httpStage = new Http1ServerStage(service, AttributeMap.empty, Strategy.DefaultExecutorService) {
         @volatile var count = 0
 
         override def reset(): Unit = {

--- a/core/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/core/src/test/scala/org/http4s/Http4sSpec.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import org.specs2.matcher.AnyMatchers
+import org.specs2.matcher.{AnyMatchers, OptionMatchers}
 import org.specs2.scalaz.{Spec, ScalazMatchers}
 
 import scalaz.std.AllInstances
@@ -8,4 +8,4 @@ import scalaz.std.AllInstances
 /**
  * Common stack for http4s' own specs.
  */
-trait Http4sSpec extends Spec with AnyMatchers with ScalazMatchers with Http4s with TestInstances with AllInstances
+trait Http4sSpec extends Spec with AnyMatchers with ScalazMatchers with OptionMatchers with Http4s with TestInstances with AllInstances

--- a/core/src/test/scala/org/http4s/MessageSpec.scala
+++ b/core/src/test/scala/org/http4s/MessageSpec.scala
@@ -1,0 +1,39 @@
+package org.http4s
+
+import java.net.InetSocketAddress
+
+
+class MessageSpec extends Http4sSpec {
+
+  "Request" should {
+    "ConnectionInfo" should {
+      val local = InetSocketAddress.createUnresolved("www.local.com", 8080)
+      val remote = InetSocketAddress.createUnresolved("www.remote.com", 45444)
+
+      "get remote connection info when present" in {
+        val r = Request().withAttribute(Request.Keys.ConnectionInfo(Request.Connection(local, remote, false)))
+        r.server must beSome(local)
+        r.remote must beSome(remote)
+      }
+
+      "not contain remote connection info when not present" in {
+        val r = Request()
+        r.server must beNone
+        r.remote must beNone
+      }
+
+      "be utilized to determine the address of server and remote" in {
+        val r = Request().withAttribute(Request.Keys.ConnectionInfo(Request.Connection(local, remote, false)))
+        r.serverAddr must_== local.getHostString
+        r.remoteAddr must beSome(remote.getHostString)
+      }
+
+      "be utilized to determine the port of server and remote" in {
+        val r = Request().withAttribute(Request.Keys.ConnectionInfo(Request.Connection(local, remote, false)))
+        r.serverPort must_== local.getPort
+        r.remotePort must beSome(remote.getPort)
+      }
+    }
+  }
+
+}

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -129,5 +129,12 @@ object ScienceExperiments {
         _    <- Task.delay { Thread.sleep(seconds) }
         resp <- Ok("finally!")
       } yield resp
+
+    case req @ GET -> Root / "connectioninfo" =>
+      val conn = req.attributes.get(Request.Keys.ConnectionInfo)
+
+      conn.fold(Ok("Couldn't find connection info!")){ case Request.Connection(loc,rem,secure) =>
+        Ok(s"Local: $loc, Remote: $rem, secure: $secure")
+      }
   }
 }

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -6,7 +6,7 @@ import org.http4s.headers.`Transfer-Encoding`
 import server._
 
 import javax.servlet.http.{HttpServletResponse, HttpServletRequest, HttpServlet}
-import java.net.InetAddress
+import java.net.{InetSocketAddress, InetAddress}
 
 import scala.collection.JavaConverters._
 import javax.servlet._
@@ -141,7 +141,11 @@ class Http4sServlet(service: HttpService,
       body = servletIo.reader(req),
       attributes = AttributeMap(
         Request.Keys.PathInfoCaret(req.getContextPath.length + req.getServletPath.length),
-        Request.Keys.Remote(InetAddress.getByName(req.getRemoteAddr)),
+        Request.Keys.ConnectionInfo(Request.Connection(
+          InetSocketAddress.createUnresolved(req.getRemoteAddr, req.getRemotePort),
+          InetSocketAddress.createUnresolved(req.getLocalAddr, req.getLocalPort),
+          req.isSecure
+        )),
         Request.Keys.ServerSoftware(serverSoftware)
       )
     )


### PR DESCRIPTION
This pull request adds a greater amount of connection information to the `Request` by way of the request `AttributeMap`. The `InetSocketAddress` of the remote, and server, as well as if the connection is secure are stored together. 

* Helper methods are added to the `Request` to enabler faster lookup of the data.
* Unit tests are added.
* The blaze infrastructure is updated so that code for generation of the `AttributeMap` isn't duplicated and thus is more likely to be uniform.