### PR TITLE
Add a message to the default notFound

### DIFF
--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -85,7 +85,7 @@ package object server {
     def apply(pf: PartialFunction[Request, Task[Response]]): HttpService =
       PartialService.liftPF(pf).or(notFound)
 
-    val notFound: Task[Response] = Task.now(Response(Status.NotFound))
+    val notFound: Task[Response] = Task.now(Response(Status.NotFound).withBody("404 Not Found.").run)
     val empty   : HttpService    = Service.const(notFound)
   }
 


### PR DESCRIPTION
Otherwise web browsers will just render a blank page.

I've done the `Task.now(foo.run)` to fully build the new `Response` so there is less for the backends to needlessly repeat. If that is in poor taste, we can remove it.