### PR TITLE
Make tests log something on failure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -291,7 +291,7 @@ def http4sProject(name: String) = Project(name, file(name))
   .settings(publishSettings)
   .settings(
     moduleName := s"http4s-$name",
-    logLevel := Level.Warn
+    testOptions in Test += Tests.Argument("xonly", "failtrace")
   )
 
 def libraryProject(name: String) = http4sProject(name)

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -43,7 +43,6 @@ abstract class ClientRouteTestBattery(name: String, client: Client)
   }
 
   private def runTest(req: Request, expected: Response, address: InetSocketAddress): Fragment = {
-    println(s"Running $req")
     s"Execute ${req.method}: ${req.uri}" in {
       val received = runTest(req, address)
       checkResponse(received, expected)

--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -171,7 +171,6 @@ trait EntityEncoderInstances extends EntityEncoderInstances0 {
         src => Task.delay(src.close())) { src =>
         Task.now { buf: Array[Char] => Task.delay {
           val m = src.read(buf)
-          println("BUFFER = "+buf.subSequence(0, m))
           if (m == buf.length) buf
           else if (m == -1) throw Terminated(End)
           else buf.slice(0, m)


### PR DESCRIPTION
This PR configures specs2 to only report on test failure while removing loglevel manipulation in the build.

Two println statments where also removed, one was in core which is a no-go.