### PR TITLE
Http Method 'or' extractor

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Path.scala
@@ -109,6 +109,18 @@ object -> {
   }
 }
 
+class MethodConcat(val methods: Set[Method]) {
+  /**
+   * HttpMethod 'or' extractor:
+   *  val request: Request = ???
+   *  request match {
+   *    case (Method.GET | Method.POST) -> Root / "123" => ???
+   *  }
+   */
+  def unapply(method: Method): Option[Method] = 
+    if (methods(method)) Some(method) else None
+}
+
 /**
  * Root extractor:
  *   Path("/") match {

--- a/dsl/src/main/scala/org/http4s/dsl/package.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/package.scala
@@ -140,6 +140,12 @@ package object dsl extends Http4s {
   implicit class LoopDetectedSyntax(val status: LoopDetected.type) extends AnyVal with EntityResponseGenerator
   implicit class NotExtendedSyntax(val status: NotExtended.type) extends AnyVal with EntityResponseGenerator
   implicit class NetworkAuthenticationRequiredSyntax(val status: NetworkAuthenticationRequired.type) extends AnyVal with EntityResponseGenerator
+  
+  implicit class MethodOps(val method: Method) extends AnyVal {
+    def | (another: Method) = new MethodConcat(Set(method, another))
+  }
+  
+  implicit class MethodConcatOps(val methods: MethodConcat) extends AnyVal {
+    def | (another: Method) = new MethodConcat(methods.methods + another)
+  }
 }
-
-


### PR DESCRIPTION
So user can specify multiple Http methods that the request can possibly match, with the same path in one line....

    val request: Request = ??? 

    request match {
      case (Method.GET | Method.POST) -> Root => ???
    }