### PR TITLE
Log error on user output stream terminating with an error

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blaze/websocket/Http4sWSStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blaze/websocket/Http4sWSStage.scala
@@ -78,7 +78,7 @@ class Http4sWSStage(ws: ws4s.Websocket) extends TailStage[WebSocketFrame] {
           sendOutboundCommand(Command.Disconnect)
         }
       case -\/(t) =>
-        logger.trace(t)("WebSocket Exception")
+        logger.error(t)("WebSocket Exception")
         sendOutboundCommand(Command.Disconnect)
     }
     


### PR DESCRIPTION
Is it just me or would it not be more appropriate to log an error if the user stream terminates with an error?