### PR TITLE
Add UrlFormLifter middleware

### DIFF
--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -39,6 +39,8 @@ final class Query private(pairs: Vector[KeyValue])
     else super.:+(elem)
   }
 
+  override def toVector: Vector[(String, Option[String])] = pairs
+
   /** Render the Query as a `String`.
     *
     * Pairs are separated by '&' and keys are separated from values by '='

--- a/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
@@ -1,0 +1,39 @@
+package org.http4s
+package server.middleware
+
+import org.http4s.server.{Service, HttpService}
+
+import scalaz.concurrent.Task
+
+
+object UrlFormLifter {
+
+  def apply(service: HttpService): HttpService =  Service.lift { req =>
+
+    def addUrlForm(form: UrlForm): Task[Response] = {
+      val flatForm = form.values.toVector.flatMap{ case (k, vs) => vs.map(v => (k,Some(v))) }
+      val params = req.uri.query.toVector ++ flatForm: Vector[(String, Option[String])]
+      val newQuery = Query(params :_*)
+
+      val newRequest = req.copy(uri = req.uri.copy(query = newQuery), body = EmptyBody)
+      service(newRequest)
+    }
+
+    req.headers.get(headers.`Content-Type`) match {
+      case Some(headers.`Content-Type`(MediaType.`application/x-www-form-urlencoded`,_)) if checkRequest(req) =>
+        UrlForm.entityDecoder
+          .decode(req)
+          .run
+          .flatMap(_.fold(failure, addUrlForm))
+
+      case None => service(req)
+    }
+  }
+
+  private def failure(failure: ParseFailure): Task[Response] =
+    Response(Status.BadRequest).withBody("400 BadRequest.\n" + failure.sanitized)
+
+  private def checkRequest(req: Request): Boolean = {
+    req.method == Method.POST || req.method == Method.PUT
+  }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
@@ -1,11 +1,16 @@
 package org.http4s
-package server.middleware
-
-import org.http4s.server.{Service, HttpService}
+package server
+package middleware
 
 import scalaz.concurrent.Task
 
-
+/** [[Middleware]] for lifting application/x-www-form-urlencoded bodies into the
+  * request query params.
+  *
+  * The params are merged into the existing paras _after_ the existing query params. This
+  * means that if the query already contains the pair "foo" -> Some("bar"), parameters on
+  * the body must be acessed through `multiParams`.
+  */
 object UrlFormLifter {
 
   def apply(service: HttpService): HttpService =  Service.lift { req =>
@@ -26,7 +31,7 @@ object UrlFormLifter {
           .run
           .flatMap(_.fold(failure, addUrlForm))
 
-      case None => service(req)
+      case _ => service(req)
     }
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSpec.scala
@@ -1,0 +1,41 @@
+package org.http4s
+package server.middleware
+
+import org.http4s.server.HttpService
+
+
+class UrlFormLifterSpec extends Http4sSpec {
+  val urlForm = UrlForm("foo" -> "bar")
+
+  val service = UrlFormLifter(HttpService {
+    case r@Request(Method.POST,_,_,_,_,_) =>
+      r.uri.multiParams.get("foo") match {
+        case Some(ps) => Response(status = Status.Ok).withBody(ps.mkString(","))
+        case None     => Response(status = Status.BadRequest).withBody("No Foo")
+      }
+  })
+
+  "UrlFormLifter" should {
+    "Add application/x-www-form-urlencoded bodies to the query params" in {
+      val req = Request(method = Method.POST).withBody(urlForm).run
+
+      val resp = service(req).run
+      resp.status must_== Status.Ok
+    }
+
+    "Add application/x-www-form-urlencoded bodies after query params" in {
+      val req = Request(method = Method.POST, uri = Uri.uri("/foo?foo=biz")).withBody(urlForm).run
+
+      val resp = service(req).run
+      resp.status must_== Status.Ok
+      resp.as[String].run must_== "biz,bar"
+    }
+
+    "Ignore Requests that don't have application/x-www-form-urlencoded bodies" in {
+      val req = Request(method = Method.POST).withBody("foo").run
+
+      val resp = service(req).run
+      resp.status must_== Status.BadRequest
+    }
+  }
+}


### PR DESCRIPTION
The UrlFormLifter is a middleware that will lift a `application/x-www-form-urlencoded` body into the Query params.

NOTE: this doesn't have tests yet. I envision debating its structure/behavior then I'll write tests and merge it (if we want it merged).