### PR TITLE
Extract getAddress from Http1Support into Uri

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -26,7 +26,7 @@ final class BlazeClient(manager: ConnectionManager) extends Client {
             Task.now(r.copy(body = r.body ++ recycleProcess))
 
           case -\/(Command.EOF) if !freshClient =>
-            manager.getClient(req, fresh = true).flatMap(tryClient(_, true))
+            manager.getClient(req.uri, fresh = true).flatMap(tryClient(_, true))
 
           case -\/(e) =>
             if (!client.isClosed()) {
@@ -36,6 +36,6 @@ final class BlazeClient(manager: ConnectionManager) extends Client {
         }
     }
 
-    manager.getClient(req, fresh = false).flatMap(tryClient(_, false))
+    manager.getClient(req.uri, fresh = false).flatMap(tryClient(_, false))
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionBuilder.scala
@@ -1,6 +1,6 @@
 package org.http4s.client.blaze
 
-import org.http4s.Request
+import org.http4s.Uri
 
 import scalaz.concurrent.Task
 
@@ -10,5 +10,5 @@ trait ConnectionBuilder {
   def shutdown(): Task[Unit]
 
   /** Attempt to make a new client connection */
-  def makeClient(req: Request): Task[BlazeClientStage]
+  def makeClient(req: Uri): Task[BlazeClientStage]
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
@@ -1,6 +1,6 @@
 package org.http4s.client.blaze
 
-import org.http4s.Request
+import org.http4s.{Uri, Request}
 
 import scalaz.concurrent.Task
 
@@ -10,11 +10,11 @@ trait ConnectionManager {
   def shutdown(): Task[Unit]
 
   /** Get a connection to the provided address
-    * @param request [[Request]] to connect too
+    * @param uri [[Uri]] to connect too
     * @param fresh if the client should force a new connection
     * @return a Future with the connected [[BlazeClientStage]] of a blaze pipeline
     */
-  def getClient(request: Request, fresh: Boolean): Task[BlazeClientStage]
+  def getClient(uri: Uri, fresh: Boolean): Task[BlazeClientStage]
   
   /** Recycle or close the connection
     * Allow for smart reuse or simple closing of a connection after the completion of a request

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
@@ -1,11 +1,10 @@
 package org.http4s.client.blaze
 
-import org.http4s.Request
+import org.http4s.{Uri, Request}
 import org.http4s.Uri.{Authority, Scheme}
 import org.log4s.getLogger
 
 import scala.collection.mutable
-import scala.concurrent.Future
 import scalaz.concurrent.Task
 
 
@@ -45,14 +44,14 @@ final class PoolManager(maxPooledConnections: Int,
       }
     }
 
-  override def getClient(request: Request, fresh: Boolean): Task[BlazeClientStage] = Task.suspend {
+  override def getClient(uri: Uri, fresh: Boolean): Task[BlazeClientStage] = Task.suspend {
     cs.synchronized {
       if (closed) Task.fail(new Exception("Client is closed"))
       else cs.dequeueFirst { case Connection(sch, auth, _) =>
-        sch == request.uri.scheme && auth == request.uri.authority
+        sch == uri.scheme && auth == uri.authority
       } match {
         case Some(Connection(_, _, stage)) => Task.now(stage)
-        case None => builder.makeClient(request)
+        case None => builder.makeClient(uri)
       }
     }
   }

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -40,24 +40,24 @@ trait Client {
   /////////////////////////////////////////////////////////////////////////
 
   /** Prepare a single GET request
-    * @param req [[Uri]] of the request
+    * @param uri [[Uri]] of the request
     * @return Task which will generate the Response
     */
-  final def prepare(req: Uri): Task[Response] =
-    prepare(Request(uri = req))
+  final def prepare(uri: Uri): Task[Response] =
+    prepare(Request(uri = uri))
 
   /** Prepare a single GET request
-    * @param req [[Uri]] of the request
+    * @param uri [[Uri]] of the request
     * @return Task which will generate the Response
     */
-  final def apply(req: Uri): Task[Response] = prepare(req)
+  final def apply(uri: Uri): Task[Response] = prepare(uri)
 
   /** Prepare a single GET request
-    * @param req [[Uri]] of the request
+    * @param uri [[Uri]] of the request
     * @return Task which will generate the Response
     */
-  final def prepAs[T](req: Uri)(implicit d: EntityDecoder[T]): Task[T] =
-    prepAs(Request(uri = req))(d)
+  final def prepAs[T](uri: Uri)(implicit d: EntityDecoder[T]): Task[T] =
+    prepAs(Request(uri = uri))(d)
 
   /////////////////////////////////////////////////////////////////////////
 

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -1,5 +1,7 @@
 package org.http4s
 
+import java.io.IOException
+import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
 
 import scala.language.experimental.macros
@@ -11,6 +13,8 @@ import org.http4s.parser.{ ScalazDeliverySchemes, RequestUriParser }
 import org.http4s.util.{ Writer, Renderable, CaseInsensitiveString, UrlCodingUtils, UrlFormCodec }
 import org.http4s.util.string.ToCaseInsensitiveStringSyntax
 import org.http4s.util.option.ToOptionOps
+
+import scalaz.{\/-, -\/, \/}
 
 
 /** Representation of the [[Request]] URI
@@ -102,6 +106,26 @@ case class Uri(
   override protected def self: Self = this
 
   override protected def replaceQuery(query: Query): Self = copy(query = query)
+
+  /**
+   * Converts a [[Uri]] into an [[InetSocketAddress]] as long as this [[Uri]] has an authority.
+   * This conversion is a pretty straightforward translation, most of the work is inserting default port values
+   * if the [[Uri]] does not specify explicit ports.
+   * This method only has knowledge of the Http protocol (including websockets), it does not know how to guess ports
+   * for schemes it has no knowledge of and will return an [[IOException]] if it encounters an unknown scheme.
+   * If the uri does not explicit a scheme, it will assume the [[Http]] scheme.
+   */
+  def asAddress: Throwable \/ InetSocketAddress = {
+    authority.map { auth =>
+      val host = auth.host.value
+      val assumedScheme = scheme.getOrElse(Http)
+      assumedScheme match {
+        case Http | Ws => \/-(new InetSocketAddress(host, 80))
+        case Https | Wss => \/-(new InetSocketAddress(host, 443))
+        case _ => -\/(new IOException("Unknown scheme"))
+      }
+    }.getOrElse(-\/(new IOException("Request must have an authority")))
+  }
 }
 
 object Uri extends UriFunctions {
@@ -135,6 +159,11 @@ object Uri extends UriFunctions {
 
   type Path = String
   type Fragment = String
+
+  val Https: Scheme = "https".ci
+  val Http: Scheme  = "http".ci
+  val Ws: Scheme    = "ws".ci
+  val Wss: Scheme   = "wss".ci
 
   case class Authority(
     userInfo: Option[UserInfo] = None,


### PR DESCRIPTION
I need to access this function in order to avoid code duplication for the websocket client. In any case, it is a pretty general purpose function, case in point being that I would use it if it were available for our own netty based websocket client because we use Http4s' `Uri` in the API and I have the same default port logic lying around there as well.