### PR TITLE
`f.length()` returns 0 instead of throwing error if f does not exist

### DIFF
--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -67,6 +67,8 @@ object StaticFile {
 
   def fromFile(f: File, start: Long, end: Long, buffsize: Int, req: Option[Request])
                         (implicit es: ExecutorService): Option[Response] = {
+    if(!f.exists()) return None
+    
     require (start >= 0 && end > start && buffsize > 0, s"start: $start, end: $end, buffsize: $buffsize")
 
     if (!f.isFile) return None


### PR DESCRIPTION
Not sure if we should send back a `404` instead, but this change can be
justified given the existing code sends back `None` if `f` is not a
file.