### PR TITLE
Change StaticFile to use extension to determine MIME type

### DIFF
--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -88,11 +88,14 @@ object StaticFile {
         if (f.length() < end) (halt, 0)
         else (fileToBody(f, start, end, buffsize), (end - start).toInt)
 
-      val contentType = for {
-        mime  <- Option(Files.probeContentType(f.toPath))
-        parts  = mime.split('/') if parts.length == 2
-        mt    <- MediaType.get((parts(0), parts(1)))
-      } yield `Content-Type`(mt)
+      val contentType = {
+        val name = f.getName()
+
+        name.lastIndexOf('.') match {
+          case -1 => None
+          case  i => MediaType.forExtension(name.substring(i + 1)).map(`Content-Type`(_))
+        }
+      }
 
       val hs = `Last-Modified`(lastModified) ::
                `Content-Length`(contentLength) ::

--- a/core/src/test/scala/org/http4s/StaticFileSpec.scala
+++ b/core/src/test/scala/org/http4s/StaticFileSpec.scala
@@ -1,0 +1,27 @@
+package org.http4s
+
+import java.io.File
+import headers.`Content-Type`
+
+
+class StaticFileSpec extends Http4sSpec {
+
+  "StaticFile" should {
+    "Determine the media-type based on the files extension" in {
+
+      def check(path: String, tpe: Option[MediaType]) = {
+        val f = new File(path)
+        val r = StaticFile.fromFile(f)
+
+        r must beSome[Response]
+        r.flatMap(_.headers.get(`Content-Type`)) must_== tpe.map(t => `Content-Type`(t))
+      }
+
+      val tests = Seq("./core/src/test/resources/logback.xml"-> Some(MediaType.`text/xml`),
+                      "./server/src/test/resources/testresource.txt" -> Some(MediaType.`text/plain`),
+                      ".travis.yml" -> None)
+
+      forall(tests){ case (p,om) => check(p, om) }
+    }
+  }
+}


### PR DESCRIPTION
Closes #322

As it turns out `Files.probeContentType` is buggy. Therefor, for the sake of consistent behavior, we will now use the filename extension to determine the media type through the `MediaType.forExtension` function.