### PR TITLE
PooledClient will request a fresh connection for requests with a body

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -26,7 +26,7 @@ final class BlazeClient(manager: ConnectionManager) extends Client {
             Task.now(r.copy(body = r.body ++ recycleProcess))
 
           case -\/(Command.EOF) if !freshClient =>
-            manager.getClient(req, fresh = true).flatMap(tryClient(_, true))
+            manager.getClient(req, freshClient = true).flatMap(tryClient(_, true))
 
           case -\/(e) =>
             if (!client.isClosed()) {
@@ -36,6 +36,8 @@ final class BlazeClient(manager: ConnectionManager) extends Client {
         }
     }
 
-    manager.getClient(req, fresh = false).flatMap(tryClient(_, false))
+    // TODO: Find a better strategy to deal with the potentially mutable body of the Request. Need to make sure the connection isn't stale.
+    val requireFresh = !req.body.isHalt
+    manager.getClient(req, freshClient = requireFresh).flatMap(tryClient(_, requireFresh))
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
@@ -11,10 +11,10 @@ trait ConnectionManager {
 
   /** Get a connection to the provided address
     * @param request [[Request]] to connect too
-    * @param fresh if the client should force a new connection
+    * @param freshClient if the client should force a new connection
     * @return a Future with the connected [[BlazeClientStage]] of a blaze pipeline
     */
-  def getClient(request: Request, fresh: Boolean): Task[BlazeClientStage]
+  def getClient(request: Request, freshClient: Boolean): Task[BlazeClientStage]
   
   /** Recycle or close the connection
     * Allow for smart reuse or simple closing of a connection after the completion of a request

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
@@ -45,9 +45,10 @@ final class PoolManager(maxPooledConnections: Int,
       }
     }
 
-  override def getClient(request: Request, fresh: Boolean): Task[BlazeClientStage] = Task.suspend {
+  override def getClient(request: Request, freshClient: Boolean): Task[BlazeClientStage] = Task.suspend {
     cs.synchronized {
       if (closed) Task.fail(new Exception("Client is closed"))
+      else if (freshClient) builder.makeClient(request)
       else cs.dequeueFirst { case Connection(sch, auth, _) =>
         sch == request.uri.scheme && auth == request.uri.authority
       } match {


### PR DESCRIPTION
This is a quick fix for ensuring that the body of a request isn't perturbed until it is known that a connection is a fresh one.