### PR TITLE
Fix servlet non-blocking body reader

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -74,6 +74,9 @@ case class NonBlockingServletIo(chunkSize: Int) extends ServletIo {
       if (len == chunkSize) {
         ByteVector.view(buff)
       }
+      else if (len <= 0) {
+        ByteVector.empty
+      }
       else {
         ByteVector.viewI(buff(_), len)
       }


### PR DESCRIPTION
Its possible for a backend to emit a -1 from the InputStream which should be handled appropriately.