### PR TITLE
Rename `withHeaders` to `replaceAllHeaders`

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -130,7 +130,7 @@ class Http1ClientStageSpec extends Specification {
     "Utilize a provided Host header" in {
       val resp = "HTTP/1.1 200 OK\r\n\r\ndone"
 
-      val req = FooRequest.withHeaders(headers.Host("bar.com"))
+      val req = FooRequest.replaceAllHeaders(headers.Host("bar.com"))
 
       val (request, response) = getSubmission(req, resp, LongDuration)
 
@@ -154,7 +154,7 @@ class Http1ClientStageSpec extends Specification {
     "Use User-Agent header provided in Request" in {
       val resp = "HTTP/1.1 200 OK\r\n\r\ndone"
 
-      val req = FooRequest.withHeaders(Header.Raw("User-Agent".ci, "myagent"))
+      val req = FooRequest.replaceAllHeaders(Header.Raw("User-Agent".ci, "myagent"))
 
       val (request, response) = getSubmission(req, resp, LongDuration)
 

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -203,13 +203,13 @@ class Http1ServerStage(service: HttpService,
 
   final protected def badMessage(debugMessage: String, t: ParserException, req: Request) {
     logger.debug(t)(s"Bad Request: $debugMessage")
-    val resp = Response(Status.BadRequest).withHeaders(Connection("close".ci), `Content-Length`(0))
+    val resp = Response(Status.BadRequest).replaceAllHeaders(Connection("close".ci), `Content-Length`(0))
     renderResponse(req, resp, () => Future.successful(emptyBuffer))
   }
   
   final protected def internalServerError(errorMsg: String, t: Throwable, req: Request, bodyCleanup: () => Future[ByteBuffer]): Unit = {
     logger.error(t)(errorMsg)
-    val resp = Response(Status.InternalServerError).withHeaders(Connection("close".ci), `Content-Length`(0))
+    val resp = Response(Status.InternalServerError).replaceAllHeaders(Connection("close".ci), `Content-Length`(0))
     renderResponse(req, resp, bodyCleanup)  // will terminate the connection due to connection: close header
   }
 

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
@@ -27,7 +27,7 @@ trait WebSocketSupport extends Http1ServerStage {
             logger.info(s"Invalid handshake $code, $msg")
             val resp = Response(Status.BadRequest)
               .withBody(msg)
-              .map(_.withHeaders(
+              .map(_.replaceAllHeaders(
                  Connection("close".ci),
                  Header.Raw(headers.`Sec-WebSocket-Version`.name, "13")
               )).run

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http4sHttp1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http4sHttp1ServerStageSpec.scala
@@ -146,7 +146,7 @@ class Http1ServerStageSpec extends Specification {
     "Honor an explicitly added date header" in {
       val dateHeader = Date(DateTime(4))
       val service = HttpService {
-        case req => Task.now(Response(body = req.body).withHeaders(dateHeader))
+        case req => Task.now(Response(body = req.body).replaceAllHeaders(dateHeader))
       }
 
       // The first request will get split into two chunks, leaving the last byte off

--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -29,7 +29,7 @@ package object oauth1 {
                   verifier: Option[String], token: Option[Token]): Task[Request] = {
     getUserParams(req).map { case (req, params) =>
       val auth = genAuthHeader(req.method, req.uri, params, consumer, callback, verifier, token)
-      req.withHeaders(auth)
+      req.putHeaders(auth)
     }
   }
 

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -12,8 +12,8 @@ class FollowRedirectSpec extends Http4sSpec {
 
   val route = HttpService {
     case r if r.method == GET && r.pathInfo == "/ok"       => Response(Ok).withBody("hello")
-    case r if r.method == GET && r.pathInfo == "/redirect" => Response(MovedPermanently).withHeaders(Location(uri("/ok"))).withBody("Go there.")
-    case r if r.method == GET && r.pathInfo == "/loop"     => Response(MovedPermanently).withHeaders(Location(uri("/loop"))).withBody("Go there.")
+    case r if r.method == GET && r.pathInfo == "/redirect" => Response(MovedPermanently).replaceAllHeaders(Location(uri("/ok"))).withBody("Go there.")
+    case r if r.method == GET && r.pathInfo == "/loop"     => Response(MovedPermanently).replaceAllHeaders(Location(uri("/loop"))).withBody("Go there.")
     case r => sys.error("Path not found: " + r.pathInfo)
   }
 

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -55,7 +55,7 @@ sealed trait Message extends MessageOps {
     * @param headers [[Headers]] containing the desired headers
     * @return a new Request object
     */
-  override def withHeaders(headers: Headers): Self = change(headers = headers)
+  override def replaceAllHeaders(headers: Headers): Self = change(headers = headers)
 
   /** Add the provided headers to the existing headers, replacing those of the same header name */
   override def putHeaders(headers: Header*): Self =

--- a/core/src/main/scala/org/http4s/MessageOps.scala
+++ b/core/src/main/scala/org/http4s/MessageOps.scala
@@ -41,16 +41,27 @@ trait MessageOps extends Any {
   }
 
   def removeHeader(key: HeaderKey): Self = filterHeaders(_ isNot key)
+/** Replaces the [[Header]]s of the incoming Request object
+    *
+    * @param headers [[Headers]] containing the desired headers
+    * @return a new Request object
+    */
+  @deprecated("Use replaceAllHeaders. Will be removed in 0.11.x", "0.10.0")
+  final def withHeaders(headers: Headers): Self = replaceAllHeaders(headers)
 
+  /** Replace the existing headers with those provided */
+  @deprecated("Use replaceAllHeaders. Will be removed in 0.11.x", "0.10.0")
+  final def withHeaders(headers: Header*): Self = replaceAllHeaders(Headers(headers.toList))
+  
   /** Replaces the [[Header]]s of the incoming Request object
     *
     * @param headers [[Headers]] containing the desired headers
     * @return a new Request object
     */
-  def withHeaders(headers: Headers): Self
+  def replaceAllHeaders(headers: Headers): Self
 
   /** Replace the existing headers with those provided */
-  def withHeaders(headers: Header*): Self = withHeaders(Headers(headers.toList))
+  def replaceAllHeaders(headers: Header*): Self = replaceAllHeaders(Headers(headers.toList))
 
   /** Add the provided headers to the existing headers, replacing those of the same header name
     * The passed headers are assumed to contain no duplicate Singleton headers.

--- a/core/src/main/scala/org/http4s/MessageSyntax.scala
+++ b/core/src/main/scala/org/http4s/MessageSyntax.scala
@@ -35,7 +35,7 @@ trait TaskMessageOps[M <: Message] extends Any with MessageOps {
     * @param headers [[Headers]] containing the desired headers
     * @return a new Request object
     */
-  override def withHeaders(headers: Headers): Self = self.map(_.withHeaders(headers))
+  override def replaceAllHeaders(headers: Headers): Self = self.map(_.replaceAllHeaders(headers))
 
   /** Add the provided headers to the existing headers, replacing those of the same header name */
   override def putHeaders(headers: Header*): Self = self.map(_.putHeaders(headers:_*))

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -53,7 +53,7 @@ object ExampleService {
 
     case GET -> Root / "streaming" =>
       // Its also easy to stream responses to clients
-      Ok(dataStream(100)).withHeaders(`Transfer-Encoding`(TransferCoding.chunked))
+      Ok(dataStream(100)).putHeaders(`Transfer-Encoding`(TransferCoding.chunked))
 
     case req @ GET -> Root / "ip" =>
       // Its possible to define an EntityEncoder anywhere so you're not limited to built in types
@@ -67,7 +67,7 @@ object ExampleService {
     case GET -> Root / "content-change" =>
       // EntityEncoder typically deals with appropriate headers, but they can be overridden
       Ok("<h2>This will have an html content type!</h2>")
-          .withHeaders(`Content-Type`(`text/html`))
+          .withContentType(Some(`Content-Type`(`text/html`)))
 
     case req @ GET -> "static" /: path =>
       // captures everything after "/directory" into `path`
@@ -80,7 +80,7 @@ object ExampleService {
     case req @ POST -> Root / "echo" =>
       // The body can be used in the response
       Ok(req.body)
-        .withHeaders(`Content-Type`(`text/plain`), `Transfer-Encoding`(TransferCoding.chunked))
+        .putHeaders(`Content-Type`(`text/plain`), `Transfer-Encoding`(TransferCoding.chunked))
 
     case req @ GET -> Root / "echo" =>
       Ok(html.submissionForm("echo data"))
@@ -88,7 +88,7 @@ object ExampleService {
     case req @ POST -> Root / "echo2" =>
       // Even more useful, the body can be transformed in the response
       Ok(req.body.map(_.drop(6)))
-        .withHeaders(`Content-Type`(`text/plain`))
+        .putHeaders(`Content-Type`(`text/plain`))
 
     case req @ GET -> Root / "echo2" =>
       Ok(html.submissionForm("echo data"))
@@ -128,7 +128,7 @@ object ExampleService {
       // http4s intends to be a forward looking library made with http2.0 in mind
       val data = <html><body><img src="image.jpg"/></body></html>
       Ok(data)
-        .withHeaders(`Content-Type`(`text/html`))
+        .withContentType(Some(`Content-Type`(`text/html`)))
         .push("/image.jpg")(req)
 
     case req @ GET -> Root / "image.jpg" =>

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -32,7 +32,7 @@ object ScienceExperiments {
     case req @ GET -> Root / "date" =>
       val date = DateTime(100)
       Ok(date.toRfc1123DateTimeString)
-        .withHeaders(Date(date))
+        .putHeaders(Date(date))
 
     case req @ GET -> Root / "echo-headers" =>
       Ok(req.headers.mkString("\n"))
@@ -47,7 +47,7 @@ object ScienceExperiments {
     case req@GET -> Root / "bigstring3" => Ok(flatBigString)
 
     case GET -> Root / "zero-chunk" =>
-      Ok(Process("", "foo!")).withHeaders(`Transfer-Encoding`(TransferCoding.chunked))
+      Ok(Process("", "foo!")).putHeaders(`Transfer-Encoding`(TransferCoding.chunked))
 
     case GET -> Root / "bigfile" =>
       val size = 40*1024*1024   // 40 MB
@@ -55,7 +55,7 @@ object ScienceExperiments {
 
     case req @ POST -> Root / "rawecho" =>
       // The body can be used in the response
-      Ok(req.body).withHeaders(`Transfer-Encoding`(TransferCoding.chunked))
+      Ok(req.body).putHeaders(`Transfer-Encoding`(TransferCoding.chunked))
 
     ///////////////// Switch the response based on head of content //////////////////////
 
@@ -98,7 +98,7 @@ object ScienceExperiments {
     ///////////////// Weird Route Failures //////////////////////
     case req @ GET -> Root / "hanging-body" =>
       Ok(Process(Task.now(ByteVector(Seq(' '.toByte))), Task.async[ByteVector] { cb => /* hang */}).eval)
-        .withHeaders(`Transfer-Encoding`(TransferCoding.chunked))
+        .putHeaders(`Transfer-Encoding`(TransferCoding.chunked))
 
     case req @ GET -> Root / "broken-body" =>
       Ok(Process(Task{"Hello "}) ++ Process(Task{sys.error("Boom!")}) ++ Process(Task{"world!"}))
@@ -106,7 +106,7 @@ object ScienceExperiments {
     case req @ GET -> Root / "slow-body" =>
       val resp = "Hello world!".map(_.toString())
       val body = awakeEvery(2.seconds).zipWith(Process.emitAll(resp))((_, c) => c)
-      Ok(body).withHeaders(`Transfer-Encoding`(TransferCoding.chunked))
+      Ok(body).putHeaders(`Transfer-Encoding`(TransferCoding.chunked))
 
     case req @ POST -> Root / "ill-advised-echo" =>
       // Reads concurrently from the input.  Don't do this at home.

--- a/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
@@ -37,7 +37,7 @@ class CORSSpec extends Specification {
     }
 
     "Respect Access-Control-Allow-Credentials" in {
-      val req = Request(uri = Uri(path= "foo")).withHeaders(
+      val req = Request(uri = Uri(path= "foo")).replaceAllHeaders(
         Header("Origin", "http://allowed.com/"),
         Header("Access-Control-Request-Method", "GET")
       )

--- a/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
@@ -42,28 +42,28 @@ class VirtualHostSpec extends Http4sSpec {
 
       "honor the Host header host" in {
         val req = Request(GET, uri("/numbers/1"))
-          .withHeaders(Host("servicea"))
+          .replaceAllHeaders(Host("servicea"))
 
         virtualServices.apply(req).run.as[String].run must equal ("servicea")
       }
 
       "honor the Host header port" in {
         val req = Request(GET, uri("/numbers/1"))
-          .withHeaders(Host("serviceb", Some(80)))
+          .replaceAllHeaders(Host("serviceb", Some(80)))
 
         virtualServices.apply(req).run.as[String].run must equal ("serviceb")
       }
 
       "ignore the Host header port if not specified" in {
         val good = Request(GET, uri("/numbers/1"))
-          .withHeaders(Host("servicea", Some(80)))
+          .replaceAllHeaders(Host("servicea", Some(80)))
 
         virtualServices.apply(good).run.as[String].run must equal ("servicea")
       }
 
       "result in a 404 if the hosts fail to match" in {
         val req = Request(GET, uri("/numbers/1"))
-          .withHeaders(Host("serviceb", Some(8000)))
+          .replaceAllHeaders(Host("serviceb", Some(8000)))
 
         virtualServices.apply(req).run.status must_== NotFound
       }
@@ -78,23 +78,23 @@ class VirtualHostSpec extends Http4sSpec {
 
       "match an exact route" in {
         val req = Request(GET, uri("/numbers/1"))
-          .withHeaders(Host("servicea", Some(80)))
+          .replaceAllHeaders(Host("servicea", Some(80)))
 
         virtualServices.apply(req).run.as[String].run must equal ("servicea")
       }
 
       "allow for a dash in the service" in {
         val req = Request(GET, uri("/numbers/1"))
-          .withHeaders(Host("foo.foo-service", Some(80)))
+          .replaceAllHeaders(Host("foo.foo-service", Some(80)))
 
         virtualServices.apply(req).run.as[String].run must equal ("default")
       }
 
       "match a route with a wildcard route" in {
         val req = Request(GET, uri("/numbers/1"))
-        val reqs = Seq(req.withHeaders(Host("a.service", Some(80))),
-                       req.withHeaders(Host("A.service", Some(80))),
-                       req.withHeaders(Host("b.service", Some(80))))
+        val reqs = Seq(req.replaceAllHeaders(Host("a.service", Some(80))),
+                       req.replaceAllHeaders(Host("A.service", Some(80))),
+                       req.replaceAllHeaders(Host("b.service", Some(80))))
 
         forall(reqs){ req =>
           virtualServices.apply(req).run.as[String].run must equal ("serviceb")
@@ -103,8 +103,8 @@ class VirtualHostSpec extends Http4sSpec {
 
       "not match a route with an abscent wildcard" in {
         val req = Request(GET, uri("/numbers/1"))
-        val reqs = Seq(req.withHeaders(Host(".service", Some(80))),
-                       req.withHeaders(Host("service", Some(80))))
+        val reqs = Seq(req.replaceAllHeaders(Host(".service", Some(80))),
+                       req.replaceAllHeaders(Host("service", Some(80))))
 
         forall(reqs){ req =>
           virtualServices.apply(req).run.status must_== NotFound

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
@@ -52,7 +52,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
     "Return a 206 PartialContent file" in {
       val range = headers.Range(4)
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).withHeaders(range)
+      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(range)
       val rb = runReq(req)
 
       rb._2.status must_== Status.PartialContent
@@ -61,7 +61,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
     "Return a 206 PartialContent file" in {
       val range = headers.Range(-4)
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).withHeaders(range)
+      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(range)
       val rb = runReq(req)
 
       rb._2.status must_== Status.PartialContent
@@ -71,7 +71,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
     "Return a 206 PartialContent file" in {
       val range = headers.Range(2,4)
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).withHeaders(range)
+      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(range)
       val rb = runReq(req)
 
       rb._2.status must_== Status.PartialContent
@@ -87,7 +87,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
                         headers.Range(200, 201),
                         headers.Range(-200)
                        )
-      val reqs = ranges map (r => Request(uri = uri("server/src/test/resources/testresource.txt")).withHeaders(r))
+      val reqs = ranges map (r => Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(r))
       forall(reqs) { req =>
         val rb = runReq(req)
         rb._2.status must_== Status.Ok


### PR DESCRIPTION
Closes #383.

The similarity of `withHeaders` to `putHeaders` has caused unnecessary confusion. Note that this PR also fixes a few bugs, in particular in the client oath1 support, that are due to the confusion.