### PR TITLE
Set HTTPS endpoint identification algorithm when possible

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -72,6 +72,15 @@ final class Http1Support(bufferSize: Int,
     val t = new Http1ClientStage(userAgent, timeout)(ec)
     val builder = LeafBuilder(t)
     uri match {
+      case Uri(Some(Https),Some(auth),_,_,_) =>
+        val eng = sslContext.createSSLEngine(auth.host.value, auth.port getOrElse 443)
+        eng.setUseClientMode(true)
+
+        val sslParams = eng.getSSLParameters
+        sslParams.setEndpointIdentificationAlgorithm("HTTPS")
+        eng.setSSLParameters(sslParams)
+
+        (builder.prepend(new SSLStage(eng)),t)
       case Uri(Some(Https),_,_,_,_) =>
         val eng = sslContext.createSSLEngine()
         eng.setUseClientMode(true)


### PR DESCRIPTION
This enables hostname verification for HTTPS connections.

As it stands, even if we configure a `{Simple|Pooled}HTTP1Client` with a `SSLContext` that will verify certificates, it won't verify that the certificates are for the correct host. This change means that that verification _will_ happen, even for clients using the default configuration. Verification failures are communicated in the same way as with invalid certificates – a `java.net.ssl.SSLHandshakeException` is thrown.

For background, see [fixing hostname verification](https://tersesystems.com/2014/03/23/fixing-hostname-verification/). As the blog details, the `setEndpointIdentificationAlgorithm` method requires constructing the `SSLEngine` with the remote host and port.