### PR TITLE
Preserve the original headers when appending

### DIFF
--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -76,12 +76,12 @@ final class Headers private (headers: List[Header])
       else {
         val hs = that.toList.asInstanceOf[List[Header]]
         val acc = new ListBuffer[Header]
-        this.headers.foreach(_.parsed match {
-          case h: Header.Recurring                 => acc += h
-          case h: `Set-Cookie`                     => acc += h
-          case h if !hs.exists(_.name == h.name)   => acc += h
+        this.headers.foreach { orig => orig.parsed match {
+          case h: Header.Recurring                 => acc += orig
+          case h: `Set-Cookie`                     => acc += orig
+          case h if !hs.exists(_.name == h.name)   => acc += orig
           case _                                   => // NOOP, drop non recurring header that already exists
-        })
+        }}
 
         val h =  new Headers(acc.prependToList(hs))
         h.asInstanceOf[That]

--- a/core/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/core/src/test/scala/org/http4s/HeadersSpec.scala
@@ -70,5 +70,12 @@ class HeadersSpec extends Specification {
       base ++ Headers.empty eq base must_== true
       Headers.empty ++ base eq base must_== true
     }
+
+    "Preserve original headers when processing" in {
+      val rawAuth = Header("Authorization", "test this")
+
+      // Mapping to strings because Header equality is based on the *parsed* version
+      (Headers(rawAuth) ++ base).map(_.toString) must contain(===(rawAuth.toString))
+    }
   }
 }


### PR DESCRIPTION
Based on some work done with Bryce today to figure out why our
Authorization header was getting partially quoted. This will preserve
the original header value as headers are modified.