### PR TITLE
Add circe module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,6 +136,13 @@ lazy val argonaut = libraryProject("argonaut")
   )
   .dependsOn(core % "compile;test->test", jawn % "compile;test->test")
 
+lazy val circe = libraryProject("circe")
+  .settings(
+    description := "Provides Circe codecs for http4s",
+    libraryDependencies += circeJawn
+  )
+  .dependsOn(core % "compile;test->test", jawn % "compile;test->test")
+
 lazy val json4s = libraryProject("json4s")
   .settings(
     description := "Base library for json4s codecs for http4s",

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -1,0 +1,34 @@
+package org.http4s
+package circe
+
+import io.circe.{Encoder, Decoder, Json, Printer}
+import io.circe.jawn.CirceSupportParser.facade
+import org.http4s.headers.`Content-Type`
+
+// Originally based on ArgonautInstances
+trait CirceInstances {
+  implicit val json: EntityDecoder[Json] = jawn.jawnDecoder(facade)
+
+  def jsonOf[A](implicit decoder: Decoder[A]): EntityDecoder[A] =
+    json.flatMapR { json =>
+      decoder.decodeJson(json).fold(
+        failure =>
+          DecodeResult.failure(ParseFailure(
+            "Could not decode JSON",
+            s"json: $json, error: ${failure.message}, cursor: ${failure.history}"
+          )),
+        DecodeResult.success(_)
+      )
+    }
+
+  implicit val jsonEncoder: EntityEncoder[Json] =
+    EntityEncoder[String].contramap[Json] { json =>
+      // Comment from ArgonautInstances (which this code is based on):
+      // TODO naive implementation materializes to a String.
+      // See https://github.com/non/jawn/issues/6#issuecomment-65018736
+      Printer.noSpaces.pretty(json)
+    }.withContentType(`Content-Type`(MediaType.`application/json`))
+
+  def jsonEncoderOf[A](implicit encoder: Encoder[A]): EntityEncoder[A] =
+    jsonEncoder.contramap[A](encoder.apply)
+}

--- a/circe/src/main/scala/org/http4s/circe/package.scala
+++ b/circe/src/main/scala/org/http4s/circe/package.scala
@@ -1,0 +1,3 @@
+package org.http4s
+
+package object circe extends CirceInstances

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -1,0 +1,63 @@
+package org.http4s
+package circe
+
+import java.nio.charset.StandardCharsets
+
+import io.circe._
+import org.http4s.headers.`Content-Type`
+import org.http4s.jawn.JawnDecodeSupportSpec
+import org.http4s.EntityEncoderSpec.writeToString
+import Status.Ok
+
+// Originally based on ArgonautSpec
+class CirceSpec extends JawnDecodeSupportSpec[Json] {
+  testJsonDecoder(json)
+
+  case class Foo(bar: Int)
+  val foo = Foo(42)
+  // Beware of possible conflicting shapeless versions if using the circe-generic module
+  // to derive these.
+  implicit val FooDecoder = Decoder.instance(_.get("bar")(Decoder[Int]).map(Foo))
+  implicit val FooEncoder = Encoder.instance[Foo](foo => Json.obj("bar" -> Encoder[Int].apply(foo.bar)))
+
+  "json encoder" should {
+    val json = Json.obj("test" -> Json.string("CirceSupport"))
+
+    "have json content type" in {
+      jsonEncoder.headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.`application/json`))
+    }
+
+    "write compact JSON" in {
+      writeToString(json) must equal ("""{"test":"CirceSupport"}""")
+    }
+  }
+
+  "jsonEncoderOf" should {
+    "have json content type" in {
+      jsonEncoderOf[Foo].headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.`application/json`))
+    }
+
+    "write compact JSON" in {
+      writeToString(foo)(jsonEncoderOf[Foo]) must equal ("""{"bar":42}""")
+    }
+  }
+
+  "json" should {
+    "handle the optionality of asNumber" in {
+      // From ArgonautSpec, which tests similar things:
+      // TODO Urgh.  We need to make testing these smoother.
+      // https://github.com/http4s/http4s/issues/157
+      def getBody(body: EntityBody): Array[Byte] = body.runLog.run.reduce(_ ++ _).toArray
+      val req = Request().withBody(Json.numberOrNull(157)).run
+      val body = req.decode { json: Json => Response(Ok).withBody(json.asNumber.flatMap(_.toLong).getOrElse(0L).toString)}.run.body
+      new String(getBody(body), StandardCharsets.UTF_8) must_== "157"
+    }
+  }
+
+  "jsonOf" should {
+    "decode JSON from a Circe decoder" in {
+      val result = jsonOf[Foo].decode(Request().withBody(Json.obj("bar" -> Json.numberOrNull(42))).run)
+      result.run.run must beRightDisjunction(Foo(42))
+    }
+  }
+}

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -45,6 +45,7 @@ object Http4sBuild extends Build {
 
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.4.v20150727"
   lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.10.0"
+  lazy val circeJawn           = "io.circe"                 %% "circe-jawn"              % "0.2.0"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"
   lazy val gatlingHighCharts   = "io.gatling.highcharts"     % "gatling-charts-highcharts" % gatlingTest.revision
   lazy val http4sWebsocket     = "org.http4s"               %% "http4s-websocket"        % "0.1.3"


### PR DESCRIPTION
This PR adds a module for circe, similar to the one for argonaut. It depends on the current *snapshot* version of circe (0.2.0-SNAPSHOT).

Users should be aware that in practice, when they're using the circe-generic module from circe along with http4s-circe, they are pulling a shapeless version (currently 2.3.0-SNAPSHOT) that is not fully binary compatible with the one parboiled depends on here (2.1.0). A small test server of mine was fine with it though (no `ClassDefNotFound` and the like).