### PR TITLE
Enforce selection of the first fallthrough reported.

### DIFF
--- a/server/src/main/scala/org/http4s/server/Fallthrough.scala
+++ b/server/src/main/scala/org/http4s/server/Fallthrough.scala
@@ -7,11 +7,15 @@ import scalaz.{Equal, Monoid}
   * Encapsulates the notion of fallthrough orElse for a Service
   * For any given B, if a Fallthrough[B] exists within implicit context
   * then [[Service#orElse]] can be used.
+  * The default Fallthrough implementation will select the first fallthrough
+  * response Whenever a sequence of fallthrough responses is observed.
   */
 trait Fallthrough[B] {
   def isFallthrough(a: B): Boolean
   def fallthrough[A](fst: B, snd: Service[A, B]): Service[A, B] =
-    if (isFallthrough(fst)) snd else Service.constVal(fst)
+    if (isFallthrough(fst)) snd.map { snd =>
+      if (isFallthrough(snd)) fst else snd
+    } else Service.constVal(fst)
 }
 
 /** Houses the principal [[Fallthrough]] typeclass instances. */

--- a/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
@@ -5,6 +5,8 @@ import syntax.ServiceOps
 
 class HttpServiceSpec extends Http4sSpec {
 
+  val notFound = HttpService.notFound.run.as[String].run
+
   val srvc1 = HttpService.lift { _ =>
     Response(Status.NotFound).withBody("srvc1")
   }
@@ -22,19 +24,25 @@ class HttpServiceSpec extends Http4sSpec {
 
   val aggregate1 = srvc1 orElse srvc2
 
-  val aggregate2 = srvc3 || srvc1
+  val aggregate2 = srvc2 orElse srvc1
+
+  val aggregate3 = srvc1 || srvc3
+
+  val aggregate4 = srvc3 || srvc1
 
   "HttpService" should {
     "Fall through to a second service on NotFound" in {
       aggregate1.apply(Request(uri = uri("/match"))).run.as[String].run must equal ("match")
     }
 
-    "Passthrough custom NotFound" in {
-      aggregate1.apply(Request(uri = uri("/wontMatch"))).run.as[String].run must equal ("srvc2")
+    "Use the first Fallthrough (NotFound) when they appear in a chain" in {
+      aggregate1.apply(Request(uri = uri("/wontMatch"))).run.as[String].run must equal ("srvc1")
+      aggregate2.apply(Request(uri = uri("/wontMatch"))).run.as[String].run must equal ("srvc2")
     }
 
-    "Safely skip undefined behavior" in {
-      aggregate2.apply(Request(uri = uri("/wontMatch"))).run.as[String].run must equal ("srvc1")
+    "Safely skip undefined behavior in either position" in {
+      aggregate3.apply(Request(uri = uri("/wontMatch"))).run.as[String].run must equal ("srvc1")
+      aggregate4.apply(Request(uri = uri("/wontMatch"))).run.as[String].run must equal (notFound)
     }
   }
 }


### PR DESCRIPTION
This essentially keeps orElse semantic for Fallthrough cases as well as handled values.
This addresses #416 by inverting the default selection order for 404 responses.