### PR TITLE
adding Retry client middleware

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -28,7 +28,7 @@ object Retry {
       client.prepare(req) flatMap {
         case Successful(resp) => Task.now(resp)
         case fail => 
-          logger.info(s"Client request failed ${fail}, attempt ${attempt}, retrying ...")
+          logger.info(s"Request ${req} has failed attempt ${attempts} with reason ${fail}")
           backoff flatMap { f =>
             f(attempts).fold(Task.now(fail))(dur => nextAttempt(req, attempts, dur))
           }

--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -1,0 +1,50 @@
+package org.http4s
+package client
+package middleware
+
+import org.http4s.Status.ResponseClass.Successful
+import org.http4s.{Response, Request, EmptyBody}
+import org.http4s.client.Client
+import scala.concurrent.duration._
+import scala.math.{pow, min, random}
+import scalaz.concurrent.Task
+import scala.language.postfixOps
+
+object Retry {
+
+  def apply(backoff: Task[Int => Option[FiniteDuration]])(client: Client) = new Client {
+
+    def shutdown(): Task[Unit] = client.shutdown()
+
+    def prepare(req: Request): Task[Response] = prepareLoop(req, 1)
+
+    private def prepareLoop(req: Request, attempts: Int): Task[Response] = {
+      client.prepare(req) flatMap {
+        case Successful(resp) => Task.now(resp)
+        case fail => backoff flatMap { f =>
+          f(attempts).fold(Task.now(fail))(dur => nextAttempt(req, attempts, dur))
+        }
+      }
+    }
+
+    private def nextAttempt(req: Request, attempts: Int, duration: FiniteDuration): Task[Response] =
+      Task.async { prepareLoop(req.copy(body = EmptyBody), attempts + 1).get after duration runAsync }
+  }
+}
+
+object RetryPolicy {
+
+  def exponentialBackoff(maxWait: Duration, maxRetry: Int): Task[Int => Option[FiniteDuration]] = {
+    val maxInMillis = maxWait.toMillis
+    Task.delay(k =>
+      if (k > maxRetry) None
+      else Some(expBackoff(k, maxInMillis))
+    )
+  }
+
+  private def expBackoff(k: Int, maxInMillis: Long): FiniteDuration = {
+    val millis = (pow(2, k) - 1) * 1000
+    val interval = min(millis, maxInMillis)
+    FiniteDuration((random * interval).toLong, MILLISECONDS)
+  }
+}

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -26,13 +26,13 @@ class RetrySpec extends Http4sSpec {
     "Retry bad requests" in {
       val max = 2
       var attempts = 1
-      val policy = Task.delay((attmpts: Int) => {
+      val policy = (attmpts: Int) => {
         if (attempts >= max) None
         else {
           attempts = attempts + 1
           Some(10 milliseconds)
         }
-      })  
+      }
       val client = Retry(policy)(defaultClient)
       val resp = client(getUri(s"http://localhost/boom")).run
       attempts must_==2 
@@ -41,13 +41,13 @@ class RetrySpec extends Http4sSpec {
     "Not retry successful responses" in {
       val max = 2
       var attempts = 1
-      val policy = Task.delay((attmpts: Int) => {
+      val policy = (attmpts: Int) => {
         if (attempts >= max) None
         else {
           attempts = attempts + 1
           Some(10 milliseconds)
         }
-      })  
+      }
       val client = Retry(policy)(defaultClient)
       val resp = client(getUri(s"http://localhost/ok")).run
       attempts must_==1

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -1,0 +1,58 @@
+package org.http4s.client
+package middleware
+
+import org.http4s.{Uri, Status, Http4sSpec, Response}
+import org.http4s.Status._
+import org.http4s.Method._
+import org.http4s.headers.Location
+import org.http4s.server.HttpService
+
+import scalaz.concurrent.Task
+
+import scala.language.postfixOps
+import scala.concurrent.duration._
+
+class RetrySpec extends Http4sSpec {
+
+  val route = HttpService {
+    case r if r.method == GET && r.pathInfo == "/ok" => Response(Ok).withBody("hello")
+    case r if r.method == GET && r.pathInfo == "/boom" => Task.now(Response(BadRequest))
+    case r => sys.error("Path not found: " + r.pathInfo)
+  }
+
+  val defaultClient = new MockClient(route)
+
+  "Retry Client" should {
+    "Retry bad requests" in {
+      val max = 2
+      var attempts = 1
+      val policy = Task.delay((attmpts: Int) => {
+        if (attempts >= max) None
+        else {
+          attempts = attempts + 1
+          Some(10 milliseconds)
+        }
+      })  
+      val client = Retry(policy)(defaultClient)
+      val resp = client(getUri(s"http://localhost/boom")).run
+      attempts must_==2 
+    }
+
+    "Not retry successful responses" in {
+      val max = 2
+      var attempts = 1
+      val policy = Task.delay((attmpts: Int) => {
+        if (attempts >= max) None
+        else {
+          attempts = attempts + 1
+          Some(10 milliseconds)
+        }
+      })  
+      val client = Retry(policy)(defaultClient)
+      val resp = client(getUri(s"http://localhost/ok")).run
+      attempts must_==1
+    }
+  }
+
+  def getUri(s: String): Uri = Uri.fromString(s).getOrElse(sys.error("Bad uri."))
+}


### PR DESCRIPTION
This pull request includes middleware for a Retry client that takes a RetryPolicy. Currently the only policy implemented is exponential backoff.