### PR TITLE
Bump scalaz-stream to 0.8

### DIFF
--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -24,7 +24,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     }
 
     "write compact JSON" in {
-      writeToString(json) must equal ("""{"test":"ArgonautSupport"}""")
+      writeToString(json) must_== ("""{"test":"ArgonautSupport"}""")
     }
   }
 
@@ -34,7 +34,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     }
 
     "write compact JSON" in {
-      writeToString(foo)(jsonEncoderOf[Foo]) must equal ("""{"bar":42}""")
+      writeToString(foo)(jsonEncoderOf[Foo]) must_== ("""{"bar":42}""")
     }
   }
 
@@ -52,7 +52,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
   "jsonOf" should {
     "decode JSON from an Argonaut decoder" in {
       val result = jsonOf[Foo].decode(Request().withBody(jObjectFields("bar" -> jNumberOrNull(42))).run)
-      result.run.run must beRightDisjunction(Foo(42))
+      result.run.run must be_\/-(Foo(42))
     }
   }
 }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -121,7 +121,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
       val c = mkClient(h, tail)(10.second, 30.seconds)
 
-      c.prepare(req).as[String].run must equal("done")
+      c.prepare(req).as[String].run must_== ("done")
     }
 
     "Request timeout on slow response body" in {

--- a/blaze-core/src/main/scala/org/http4s/blaze/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blaze/Http1Stage.scala
@@ -174,7 +174,7 @@ trait Http1Stage { self: TailStage[ByteBuffer] =>
         else cb(-\/(Terminated(End)))
       }
 
-      (repeatEval(t), () => drainBody(currentBuffer))
+      (repeatEval(t).onHalt(_.asHalt), () => drainBody(currentBuffer))
     }
   }
 

--- a/blaze-core/src/main/scala/org/http4s/blaze/util/ProcessWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blaze/util/ProcessWriter.scala
@@ -71,7 +71,7 @@ trait ProcessWriter {
         case Failure(t) => bounce(Try(stack.head(Cause.Error(t)).run), stack.tail, cb)
       }
 
-    case Await(t, f) => ec.execute(
+    case Await(t, f, _) => ec.execute(
       new Runnable {
         override def run(): Unit = t.runAsync { // Wait for it to finish, then continue to unwind
           case r@ \/-(_) => bounce(Try(f(r).run), stack, cb)

--- a/blaze-core/src/main/scala/org/http4s/blaze/websocket/Http4sWSStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blaze/websocket/Http4sWSStage.scala
@@ -59,7 +59,7 @@ class Http4sWSStage(ws: ws4s.Websocket) extends TailStage[WebSocketFrame] {
 
       go()
     }
-    Process.repeatEval(t)
+    Process.repeatEval(t).onHalt(_.asHalt)
   }
 
   //////////////////////// Startup and Shutdown ////////////////////////

--- a/blaze-core/src/test/scala/org/http4s/blaze/util/ProcessWriterSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blaze/util/ProcessWriterSpec.scala
@@ -95,7 +95,7 @@ class ProcessWriterSpec extends Specification {
           else throw Cause.Terminated(Cause.End)
         }
       }
-      val p = Process.repeatEval(t) ++ emit(ByteVector("bar".getBytes(StandardCharsets.ISO_8859_1)))
+      val p = Process.repeatEval(t).onHalt(_.asHalt) ++ emit(ByteVector("bar".getBytes(StandardCharsets.ISO_8859_1)))
       writeProcess(p)(builder) must_== "Content-Length: 9\r\n\r\n" + "foofoobar"
     }
   }

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
@@ -122,7 +122,7 @@ class Http2NodeStage(streamId: Int,
       }
     }
 
-    Process.repeatEval(t)
+    Process.repeatEval(t).onHalt(_.asHalt)
   }
 
   private def checkAndRunRequest(hs: Headers, endStream: Boolean): Unit = {

--- a/build.sbt
+++ b/build.sbt
@@ -391,7 +391,8 @@ lazy val commonSettings = Seq(
     scalameter,
     scalazScalacheckBinding,
     scalaCheck,
-    scalazSpecs2
+    specs2,
+    specs2_scalacheck
   ).map(_ % "test")
 )
 

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -83,14 +83,14 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
 
     "attemptAs with successful result" in {
       client(req).attemptAs[String]
-        .run.run must beRightDisjunction("hello")
+        .run.run must be_\/-("hello")
     }
 
     "attemptAs with failed parsing result" in {
       val grouchyEncoder = EntityDecoder.decodeBy[Any](MediaRange.`*/*`) { _ =>
         DecodeResult.failure(ParseFailure("MEH!", "MEH!"))
       }
-      client(req).attemptAs[Any](grouchyEncoder).run.run must beLeftDisjunction
+      client(req).attemptAs[Any](grouchyEncoder).run.run must be_-\/
     }
 
     "prepAs must add Accept header" in {

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -30,12 +30,12 @@ class RetrySpec extends Http4sSpec {
         if (attempts >= max) None
         else {
           attempts = attempts + 1
-          Some(10 milliseconds)
+          Some(10.milliseconds)
         }
       }
       val client = Retry(policy)(defaultClient)
       val resp = client(getUri(s"http://localhost/boom")).run
-      attempts must_==2 
+      attempts must_== 2
     }
 
     "Not retry successful responses" in {
@@ -45,7 +45,7 @@ class RetrySpec extends Http4sSpec {
         if (attempts >= max) None
         else {
           attempts = attempts + 1
-          Some(10 milliseconds)
+          Some(10.milliseconds)
         }
       }
       val client = Retry(policy)(defaultClient)

--- a/core/src/test/scala/org/http4s/CharsetSpec.scala
+++ b/core/src/test/scala/org/http4s/CharsetSpec.scala
@@ -14,11 +14,11 @@ class CharsetSpec extends Http4sSpec {
     }
 
     "work for aliases" in {
-      Charset.fromString("UTF8") must beRightDisjunction(Charset.`UTF-8`)
+      Charset.fromString("UTF8") must be_\/-(Charset.`UTF-8`)
     }
 
     "return InvalidCharset for unregistered names" in {
-      Charset.fromString("blah") must beLeftDisjunction
+      Charset.fromString("blah") must be_-\/
     }
   }
 }

--- a/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -27,7 +27,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
         .flatMapR(s => DecodeResult.success("bar"))
         .decode(req)
         .run
-        .run must beRightDisjunction("bar")
+        .run must be_\/-("bar")
     }
 
     "flatMapR with failure" in {
@@ -35,7 +35,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
         .flatMapR(s => DecodeResult.failure[String](ParseFailure("bummer", "real bummer")))
         .decode(req)
         .run
-        .run must beLeftDisjunction(ParseFailure("bummer", "real bummer"))
+        .run must be_-\/(ParseFailure("bummer", "real bummer"))
     }
   }
 
@@ -46,13 +46,13 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
       val happyDecoder = EntityDecoder.decodeBy(MediaRange.`*/*`)(_ => DecodeResult.success(Task.now("hooray")))
       Task.async[String] { cb =>
         request.decodeWith(happyDecoder) { s => cb(\/-(s)); Task.now(Response()) }.run
-      }.run must equal ("hooray")
+      }.run must_== ("hooray")
     }
 
     "wrap the ParseFailure in a ParseException on failure" in {
       val grumpyDecoder = EntityDecoder.decodeBy(MediaRange.`*/*`)(_ => DecodeResult.failure[String](Task.now(ParseFailure("Bah!", ""))))
       val resp = request.decodeWith(grumpyDecoder) { _ => Task.now(Response())}.run
-      resp.status must equal (Status.BadRequest)
+      resp.status must_== (Status.BadRequest)
     }
   }
 
@@ -175,7 +175,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
   "binary EntityDecoder" should {
     "yield an empty array on a bodyless message" in {
       val msg = Request()
-      binary.decode(msg).run.run must beRightDisjunction.like { case ByteVector.empty => ok }
+      binary.decode(msg).run.run must be_\/-.like { case ByteVector.empty => ok }
     }
 
     "concat ByteVectors" in {

--- a/core/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/core/src/test/scala/org/http4s/Http4sSpec.scala
@@ -1,12 +1,58 @@
+/* checkAll and friends were copied from the scalaz-specs2 project.
+ * Source file: src/main/scala/Spec.scala
+ * Project address: https://github.com/typelevel/scalaz-specs2
+ * Copyright (C) 2013 Lars Hupel
+ * License: MIT. https://github.com/typelevel/scalaz-specs2/blob/master/LICENSE.txt
+ * Commit df921e18cf8bf0fd0bb510133f1ca6e1caea512b
+ * Copied on. 11/1/2015
+ */
+
 package org.http4s
 
-import org.specs2.matcher.{AnyMatchers, OptionMatchers}
-import org.specs2.scalaz.{Spec, ScalazMatchers}
+import org.specs2.ScalaCheck
+import org.specs2.scalacheck.Parameters
+import org.specs2.matcher.{AnyMatchers, OptionMatchers, DisjunctionMatchers}
+import org.specs2.mutable.Specification
 import org.specs2.specification.dsl.FragmentsDsl
+import org.specs2.specification.create.{DefaultFragmentFactory=>ff}
+import org.specs2.specification.core.Fragments
+import org.scalacheck.util.{FreqMap, Pretty}
 
 import scalaz.std.AllInstances
+import org.scalacheck._
 
 /**
  * Common stack for http4s' own specs.
  */
-trait Http4sSpec extends Spec with AnyMatchers with ScalazMatchers with OptionMatchers with Http4s with TestInstances with AllInstances with FragmentsDsl
+trait Http4sSpec extends Specification
+  with ScalaCheck
+  with AnyMatchers
+  with OptionMatchers
+  with DisjunctionMatchers
+  with Http4s
+  with TestInstances
+  with AllInstances
+  with FragmentsDsl
+{
+  def checkAll(name: String, props: Properties)(implicit p: Parameters, f: FreqMap[Set[Any]] => Pretty) {
+    addFragment(ff.text(s"$name  ${props.name} must satisfy"))
+    addFragments(Fragments.foreach(props.properties) { case (name, prop) => 
+      Fragments(name in check(prop, p, f)) 
+    })
+  }
+
+  def checkAll(props: Properties)(implicit p: Parameters, f: FreqMap[Set[Any]] => Pretty) {
+    addFragment(ff.text(s"${props.name} must satisfy"))
+    addFragments(Fragments.foreach(props.properties) { case (name, prop) => 
+      Fragments(name in check(prop, p, f)) 
+    })
+  }
+
+  implicit def enrichProperties(props: Properties) = new {
+    def withProp(propName: String, prop: Prop) = new Properties(props.name) {
+      for {(name, p) <- props.properties} property(name) = p
+        property(propName) = prop
+    }
+  }
+}
+

--- a/core/src/test/scala/org/http4s/HttpVersionSpec.scala
+++ b/core/src/test/scala/org/http4s/HttpVersionSpec.scala
@@ -24,10 +24,10 @@ class HttpVersionSpec extends Http4sSpec {
   }
 
   "fromString is consistent with toString" in {
-    prop { v: HttpVersion => fromString(v.toString) must beRightDisjunction(v) }
+    prop { v: HttpVersion => fromString(v.toString) must be_\/-(v) }
   }
 
   "protocol is case sensitive" in {
-    HttpVersion.fromString("http/1.0") must beLeftDisjunction
+    HttpVersion.fromString("http/1.0") must be_-\/
   }
 }

--- a/core/src/test/scala/org/http4s/MethodSpec.scala
+++ b/core/src/test/scala/org/http4s/MethodSpec.scala
@@ -13,11 +13,11 @@ class MethodSpec extends Http4sSpec {
   import Method._
 
   "parses own string rendering to equal value" in {
-    forAll(tokens) { token => fromString(token).map(_.renderString) must beRightDisjunction(token) }
+    forAll(tokens) { token => fromString(token).map(_.renderString) must be_\/-(token) }
   }
 
   "only tokens are valid methods" in {
-    prop { s: String => fromString(s).isRight must equal (Rfc2616BasicRules.isToken(s)) }
+    prop { s: String => fromString(s).isRight must_== (Rfc2616BasicRules.isToken(s)) }
   }
 
   "name is case sensitive" in {
@@ -31,7 +31,7 @@ class MethodSpec extends Http4sSpec {
   checkAll(ScalazProperties.equal.laws[Method])
 
   "methods are equal by name" in {
-    prop { m: Method => Method.fromString(m.name) must beRightDisjunction(m) }
+    prop { m: Method => Method.fromString(m.name) must be_\/-(m) }
   }
 
   "safety implies idempotence" in {

--- a/core/src/test/scala/org/http4s/QueryParamCodecSpec.scala
+++ b/core/src/test/scala/org/http4s/QueryParamCodecSpec.scala
@@ -1,10 +1,9 @@
 package org.http4s
 
-import org.specs2.scalaz.Spec
 import scalaz.std.string._
 import scalaz.std.anyVal._
 
-class QueryParamCodecSpec extends Spec {
+class QueryParamCodecSpec extends Http4sSpec {
 
   checkAll("Boolean QueryParamCodec", QueryParamCodecLaws[Boolean])
   checkAll("Double QueryParamCodec" , QueryParamCodecLaws[Double])

--- a/core/src/test/scala/org/http4s/StatusSpec.scala
+++ b/core/src/test/scala/org/http4s/StatusSpec.scala
@@ -16,7 +16,7 @@ class StatusSpec extends Http4sSpec {
   }
 
   def responseClassTest(range: Range, responseClass: ResponseClass) =
-    foreach(range) { i => fromInt(i) must beRightDisjunction.like {
+    foreach(range) { i => fromInt(i) must be_\/-.like {
       case s => s.responseClass must_== responseClass
     }}
 

--- a/core/src/test/scala/org/http4s/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/UriSpec.scala
@@ -241,7 +241,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
         "http://example.org/absolute/URI/with/absolute/path/to/resource.txt",
         "/relative/URI/with/absolute/path/to/resource.txt")
       foreach (examples) { e =>
-        Uri.fromString(e) must beRightDisjunction.like { case u => u.toString must be_==(e) }
+        Uri.fromString(e) must be_\/-.like { case u => u.toString must be_==(e) }
       }
     }
 

--- a/core/src/test/scala/org/http4s/parser/AcceptCharsetSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AcceptCharsetSpec.scala
@@ -11,7 +11,7 @@ class AcceptCharsetSpec extends Http4sSpec with HeaderParserHelper[`Accept-Chars
   "Accept-Charset" should {
     "parse any list of CharsetRanges to itself" in {
       prop { h: `Accept-Charset` =>
-        hparse(h.value) must beRightDisjunction(h)
+        hparse(h.value) must be_\/-(h)
       }
     }
 

--- a/core/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
@@ -12,14 +12,14 @@ class AuthorizationHeaderSpec extends Http4sSpec {
     "Parse a valid Oauth2 header" in {
       val token = (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ "-._~+/".toSeq).mkString
       val h = Authorization(OAuth2BearerToken(token + "="))
-      hparse(h.value) must beRightDisjunction(h)
+      hparse(h.value) must be_\/-(h)
     }
 
     "Reject an ivalid Oauth2 header" in {
       val invalidTokens = Seq("f!@", "=abc", "abc d")
       forall(invalidTokens) { token =>
         val h = Authorization(OAuth2BearerToken(token))
-        hparse(h.value) must beLeftDisjunction
+        hparse(h.value) must be_-\/
       }
     }
   }

--- a/core/src/test/scala/org/http4s/parser/QueryParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/QueryParserSpec.scala
@@ -15,52 +15,52 @@ class QueryParserSpec extends Http4sSpec {
   "The QueryParser" should {
 
     "correctly extract complete key value pairs" in {
-      parseQueryString("key=value") must beRightDisjunction(Query("key" -> Some("value")))
-      parseQueryString("key=value&key2=value2") must beRightDisjunction(Query("key" -> Some("value"), "key2" -> Some("value2")))
+      parseQueryString("key=value") must be_\/-(Query("key" -> Some("value")))
+      parseQueryString("key=value&key2=value2") must be_\/-(Query("key" -> Some("value"), "key2" -> Some("value2")))
     }
 
     "decode URL-encoded keys and values" in {
-      parseQueryString("ke%25y=value") must beRightDisjunction(Query("ke%y" -> Some("value")))
-      parseQueryString("key=value%26&key2=value2") must beRightDisjunction(Query("key" -> Some("value&"), "key2" -> Some("value2")))
+      parseQueryString("ke%25y=value") must be_\/-(Query("ke%y" -> Some("value")))
+      parseQueryString("key=value%26&key2=value2") must be_\/-(Query("key" -> Some("value&"), "key2" -> Some("value2")))
     }
 
     "return an empty Map for an empty query string" in {
-      parseQueryString("") must beRightDisjunction(Query.empty)
+      parseQueryString("") must be_\/-(Query.empty)
     }
 
     "return an empty value for keys without a value following the '=' and keys without following '='" in {
-      parseQueryString("key=&key2") must beRightDisjunction(Query("key" -> Some(""), "key2" -> None))
+      parseQueryString("key=&key2") must be_\/-(Query("key" -> Some(""), "key2" -> None))
     }
 
     "accept empty key value pairs" in {
-      parseQueryString("&&b&") must beRightDisjunction(Query("" -> None, "" -> None, "b" -> None, "" -> None))
+      parseQueryString("&&b&") must be_\/-(Query("" -> None, "" -> None, "b" -> None, "" -> None))
     }
 
     "Handle '=' in a query string" in {
-      parseQueryString("a=b=c") must beRightDisjunction(Query("a" -> Some("b=c")))
+      parseQueryString("a=b=c") must be_\/-(Query("a" -> Some("b=c")))
     }
 
 //    "Gracefully handle invalid URL encoding" in {
-//      parseQueryString("a=b%G") must beRightDisjunction(Query("a" -> Some("b%G")))
+//      parseQueryString("a=b%G") must be_\/-(Query("a" -> Some("b%G")))
 //    }
 
     "Allow ';' seperators" in {
-      parseQueryString("a=b;c") must beRightDisjunction(Query("a" -> Some("b"), "c" -> None))
+      parseQueryString("a=b;c") must be_\/-(Query("a" -> Some("b"), "c" -> None))
     }
 
     "Allow PHP-style [] in keys" in {
-      parseQueryString("a[]=b&a[]=c") must beRightDisjunction(Query("a[]" -> Some("b"), "a[]" -> Some("c")))
+      parseQueryString("a[]=b&a[]=c") must be_\/-(Query("a[]" -> Some("b"), "a[]" -> Some("c")))
     }
 
     "QueryParser using QChars doesn't allow PHP-style [] in keys" in {
       val queryString = "a[]=b&a[]=c"
-      new QueryParser(Codec.UTF8, true, QueryParser.QChars).decode(CharBuffer.wrap(queryString), true) must beLeftDisjunction
+      new QueryParser(Codec.UTF8, true, QueryParser.QChars).decode(CharBuffer.wrap(queryString), true) must be_-\/
     }
 
     "Reject a query with invalid char" in {
-      parseQueryString("獾") must beLeftDisjunction
-      parseQueryString("foo獾bar") must beLeftDisjunction
-      parseQueryString("foo=獾") must beLeftDisjunction
+      parseQueryString("獾") must be_-\/
+      parseQueryString("foo獾bar") must be_-\/
+      parseQueryString("foo=獾") must be_-\/
     }
 
     "Keep CharBuffer position if not flushing" in {
@@ -68,22 +68,22 @@ class QueryParserSpec extends Http4sSpec {
       val cs = CharBuffer.wrap(s)
       val r = new QueryParser(Codec.UTF8, true).decode(cs, false)
 
-      r must beRightDisjunction(Query("key" -> Some("value")))
+      r must be_\/-(Query("key" -> Some("value")))
       cs.remaining must_== 9
 
       val r2 = new QueryParser(Codec.UTF8, true).decode(cs, false)
-      r2 must beRightDisjunction(Query())
+      r2 must be_\/-(Query())
       cs.remaining() must_== 9
 
       val r3 = new QueryParser(Codec.UTF8, true).decode(cs, true)
-      r3 must beRightDisjunction(Query("stuff" -> Some("cat")))
+      r3 must be_\/-(Query("stuff" -> Some("cat")))
       cs.remaining() must_== 0
     }
 
     "be stack safe" in {
       val value = Stream.continually('X').take(1000000).mkString
       val query = s"little=x&big=${value}"
-      parseQueryString(query) must beRightDisjunction(Query("little" -> Some("x"), "big" -> Some(value)))
+      parseQueryString(query) must be_\/-(Query("little" -> Some("x"), "big" -> Some(value)))
     }
   }
 }

--- a/core/src/test/scala/org/http4s/parser/RangeParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/RangeParserSpec.scala
@@ -18,7 +18,7 @@ class RangeParserSpec extends Http4sSpec {
       )
 
       forall(headers) { header =>
-        HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+        HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
       }
     }
   }
@@ -34,7 +34,7 @@ class RangeParserSpec extends Http4sSpec {
     )
 
     forall(headers) { header =>
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
     }
   }
 }

--- a/core/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -13,100 +13,100 @@ class SimpleHeadersSpec extends Http4sSpec {
 
     "parse Allow" in {
       val header = Allow(Method.GET, Method.POST)
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
     }
 
     "parse Connection" in {
       val header = Connection("closed".ci)
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
     }
 
     "parse Content-Length" in {
       val header = `Content-Length`(4)
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
 
       val bad = Header(header.name.toString, "foo")
-      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must be_-\/
     }
 
     "parse Content-Encoding" in {
       val header = `Content-Encoding`(ContentCoding.`pack200-gzip`)
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
     }
 
     "parse Content-Disposition" in {
       val header = `Content-Disposition`("foo", Map("one" -> "two", "three" -> "four"))
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
 
       val bad = Header(header.name.toString, "foo; bar")
-      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must be_-\/
     }
 
     "parse Date" in {       // mills are lost, get rid of them
       val header = Date(DateTime.now).toRaw.parsed
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
 
       val bad = Header(header.name.toString, "foo")
-      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must be_-\/
     }
 
     "parse Host" in {
       val header1 = Host("foo", Some(5))
-      HttpHeaderParser.parseHeader(header1.toRaw) must beRightDisjunction(header1)
+      HttpHeaderParser.parseHeader(header1.toRaw) must be_\/-(header1)
 
       val header2 = Host("foo", None)
-      HttpHeaderParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
+      HttpHeaderParser.parseHeader(header2.toRaw) must be_\/-(header2)
 
       val bad = Header(header1.name.toString, "foo:bar")
-      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must be_-\/
     }
 
     "parse Last-Modified" in {
       val header = `Last-Modified`(DateTime.now).toRaw.parsed
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
 
       val bad = Header(header.name.toString, "foo")
-      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must be_-\/
     }
 
     "parse If-Modified-Since" in {
       val header = `If-Modified-Since`(DateTime.now).toRaw.parsed
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
 
       val bad = Header(header.name.toString, "foo")
-      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must be_-\/
     }
 
     "parse ETag" in {
       val header = ETag("hash")
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
     }
 
     "parse If-None-Match" in {
       val header = `If-None-Match`("hash")
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
     }
 
     "parse Transfer-Encoding" in {
       val header = `Transfer-Encoding`(TransferCoding.chunked)
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
 
       val header2 = `Transfer-Encoding`(TransferCoding.compress)
-      HttpHeaderParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
+      HttpHeaderParser.parseHeader(header2.toRaw) must be_\/-(header2)
     }
 
     "parse User-Agent" in {
       val header = `User-Agent`(AgentProduct("foo", Some("bar")), Seq(AgentComment("foo")))
       header.value must_== "foo/bar (foo)"
 
-      HttpHeaderParser.parseHeader(header.toRaw) must beRightDisjunction(header)
+      HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)
 
       val header2 = `User-Agent`(AgentProduct("foo"), Seq(AgentProduct("bar", Some("biz")), AgentComment("blah")))
       header2.value must_== "foo bar/biz (blah)"
-      HttpHeaderParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
+      HttpHeaderParser.parseHeader(header2.toRaw) must be_\/-(header2)
 
       val headerstr = "Mozilla/5.0 (Android; Mobile; rv:30.0) Gecko/30.0 Firefox/30.0"
-      HttpHeaderParser.parseHeader(Header.Raw(`User-Agent`.name, headerstr)) must beRightDisjunction(
+      HttpHeaderParser.parseHeader(Header.Raw(`User-Agent`.name, headerstr)) must be_\/-(
         `User-Agent`(AgentProduct("Mozilla", Some("5.0")), Seq(
             AgentComment("Android; Mobile; rv:30.0"),
             AgentProduct("Gecko", Some("30.0")),
@@ -118,14 +118,14 @@ class SimpleHeadersSpec extends Http4sSpec {
 
     "parse X-Forward-Spec" in {
       val header1 = `X-Forwarded-For`(NonEmptyList(Some(InetAddress.getLocalHost)))
-      HttpHeaderParser.parseHeader(header1.toRaw) must beRightDisjunction(header1)
+      HttpHeaderParser.parseHeader(header1.toRaw) must be_\/-(header1)
 
       val header2 = `X-Forwarded-For`(NonEmptyList(Some(InetAddress.getLocalHost),
                                 Some(InetAddress.getLoopbackAddress)))
-      HttpHeaderParser.parseHeader(header2.toRaw) must beRightDisjunction(header2)
+      HttpHeaderParser.parseHeader(header2.toRaw) must be_\/-(header2)
 
       val bad = Header(header1.name.toString, "foo")
-      HttpHeaderParser.parseHeader(bad) must beLeftDisjunction
+      HttpHeaderParser.parseHeader(bad) must be_-\/
     }
   }
 

--- a/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -19,7 +19,7 @@ class UriParserSpec extends Http4sSpec {
 
     def check(items: Seq[(String, Uri)]) = foreach(items) {
       case (str, uri) =>
-        Uri.requestTarget(str) must beRightDisjunction(uri)
+        Uri.requestTarget(str) must be_\/-(uri)
     }
 
     // RFC 3986 examples
@@ -50,7 +50,7 @@ class UriParserSpec extends Http4sSpec {
 
     "parse a short IPv6 address" in {
       val s = "01ab::32ba:32ba"
-      Uri.requestTarget("01ab::32ba:32ba") must beRightDisjunction(Uri(authority = Some(Authority(host = IPv6("01ab::32ba:32ba")))))
+      Uri.requestTarget("01ab::32ba:32ba") must be_\/-(Uri(authority = Some(Authority(host = IPv6("01ab::32ba:32ba")))))
     }
 
     "handle port configurations" in {
@@ -90,47 +90,47 @@ class UriParserSpec extends Http4sSpec {
 
     "parse absolute URI with fragment" in {
       val u = Uri.requestTarget("http://foo.bar/foo#Examples")
-      u must beRightDisjunction(Uri(Some("http".ci), Some(Authority(host = RegName("foo.bar".ci))), "/foo", Query.empty, Some("Examples")))
+      u must be_\/-(Uri(Some("http".ci), Some(Authority(host = RegName("foo.bar".ci))), "/foo", Query.empty, Some("Examples")))
     }
 
     "parse absolute URI with parameters and fragment" in {
       val u = Uri.requestTarget("http://foo.bar/foo?bar=baz#Example-Fragment")
-      u must beRightDisjunction(Uri(Some("http".ci), Some(Authority(host = RegName("foo.bar".ci))), "/foo", Query.fromPairs("bar" -> "baz"), Some("Example-Fragment")))
+      u must be_\/-(Uri(Some("http".ci), Some(Authority(host = RegName("foo.bar".ci))), "/foo", Query.fromPairs("bar" -> "baz"), Some("Example-Fragment")))
     }
 
     "parse relative URI with empty query string" in {
       val u = Uri.requestTarget("/foo/bar?")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query("" -> None)))
+      u must be_\/-(Uri(path = "/foo/bar", query = Query("" -> None)))
     }
 
     "parse relative URI with empty query string followed by empty fragment" in {
       val u = Uri.requestTarget("/foo/bar?#")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query("" -> None), fragment = Some("")))
+      u must be_\/-(Uri(path = "/foo/bar", query = Query("" -> None), fragment = Some("")))
     }
 
     "parse relative URI with empty query string followed by fragment" in {
       val u = Uri.requestTarget("/foo/bar?#Example_of_Fragment")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query("" -> None), fragment = Some("Example_of_Fragment")))
+      u must be_\/-(Uri(path = "/foo/bar", query = Query("" -> None), fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with fragment" in {
       val u = Uri.requestTarget("/foo/bar#Examples_of_Fragment")
-      u must beRightDisjunction(Uri(path = "/foo/bar", fragment = Some("Examples_of_Fragment")))
+      u must be_\/-(Uri(path = "/foo/bar", fragment = Some("Examples_of_Fragment")))
     }
 
     "parse relative URI with single parameter without a value followed by a fragment" in {
       val u = Uri.requestTarget("/foo/bar?bar#Example_of_Fragment")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query("bar" -> None), fragment = Some("Example_of_Fragment")))
+      u must be_\/-(Uri(path = "/foo/bar", query = Query("bar" -> None), fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with parameters and fragment" in {
       val u = Uri.requestTarget("/foo/bar?bar=baz#Example_of_Fragment")
-      u must beRightDisjunction(Uri(path = "/foo/bar", query = Query.fromPairs("bar" -> "baz"), fragment = Some("Example_of_Fragment")))
+      u must be_\/-(Uri(path = "/foo/bar", query = Query.fromPairs("bar" -> "baz"), fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with slash and fragment" in {
       val u = Uri.requestTarget("/#Example_Fragment")
-      u must beRightDisjunction(Uri(path = "/", fragment = Some("Example_Fragment")))
+      u must be_\/-(Uri(path = "/", fragment = Some("Example_Fragment")))
     }
 
     {
@@ -146,7 +146,7 @@ class UriParserSpec extends Http4sSpec {
     }
 
     "deal with an invalid Query" in {
-      Uri.requestTarget("/hello/world?bad=enc%ode") must beRightDisjunction.like { case u =>
+      Uri.requestTarget("/hello/world?bad=enc%ode") must be_\/-.like { case u =>
         u.params must be_==(Map("bad" -> "enc"))
         u.fragment must be_==(None)
         u.path must be_==("/hello/world")
@@ -154,7 +154,7 @@ class UriParserSpec extends Http4sSpec {
     }
 
     "deal with an invalid Uri" in {
-      Uri.requestTarget("/hello/wo%2rld") must beRightDisjunction.like { case u =>
+      Uri.requestTarget("/hello/wo%2rld") must be_\/-.like { case u =>
         u.path must be_==("/hello/wo")
       }
     }
@@ -165,7 +165,7 @@ class UriParserSpec extends Http4sSpec {
 
     def check(items: Seq[(String, Uri)]) = foreach(items) {
       case (str, uri) =>
-        Uri.fromString(str) must beRightDisjunction(uri)
+        Uri.fromString(str) must be_\/-(uri)
     }
 
     "parse absolute URIs" in {
@@ -186,32 +186,32 @@ class UriParserSpec extends Http4sSpec {
     }
 
     "parse a path-noscheme uri" in {
-      Uri.fromString("q") must beRightDisjunction.like { case u =>
+      Uri.fromString("q") must be_\/-.like { case u =>
         u must_== Uri(path = "q")
       }
-      Uri.fromString("a/b") must beRightDisjunction.like { case u =>
+      Uri.fromString("a/b") must be_\/-.like { case u =>
         u must_== Uri(path = "a/b")
       }
     }
 
     "parse a path-noscheme uri with query" in {
-      Uri.fromString("a/b?foo") must beRightDisjunction.like { case u =>
+      Uri.fromString("a/b?foo") must be_\/-.like { case u =>
         u must_== Uri(path = "a/b", query = Query(("foo", None)))
       }
     }
 
     "parse a path-absolute uri" in {
-      Uri.fromString("/a/b") must beRightDisjunction.like { case u =>
+      Uri.fromString("/a/b") must be_\/-.like { case u =>
         u must_== Uri(path = "/a/b")
       }
     }
     "parse a path-absolute uri with query" in {
-      Uri.fromString("/a/b?foo") must beRightDisjunction.like { case u =>
+      Uri.fromString("/a/b?foo") must be_\/-.like { case u =>
         u must_== Uri(path = "/a/b", query = Query(("foo", None)))
       }
     }
     "parse a path-absolute uri with query and fragment" in {
-      Uri.fromString("/a/b?foo#bar") must beRightDisjunction.like { case u =>
+      Uri.fromString("/a/b?foo#bar") must be_\/-.like { case u =>
         u must_== Uri(path = "/a/b", query = Query(("foo", None)), fragment = Some("bar"))
       }
     }

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
@@ -74,105 +74,105 @@ object PathInHttpServiceSpec extends Http4sSpec {
   "Path DSL within HttpService" should {
     "GET /" in {
       val response = server(Request(GET, Uri(path = "/")))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("(empty)")
     }
     "GET /{id}" in {
       val response = server(Request(GET, Uri(path = "/12345")))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("id: 12345")
     }
     "GET /?{start}" in {
       val response = server(Request(GET, uri("/?start=1")))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("start: 1")
     }
     "GET /?{start,limit}" in {
       val response = server(Request(GET, uri("/?start=1&limit=2")))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("start: 1, limit: 2")
     }
     "GET /calc" in {
       val response = server(Request(GET, Uri(path = "/calc")))
-      response.status must equal (NotFound)
+      response.status must_== (NotFound)
       response.body must equalTo("404 Not Found: /calc")
     }
     "GET /calc?decimal=1.3" in {
       val response = server(Request(GET, Uri(path = "/calc", query = Query.fromString("decimal=1.3"))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo(s"result: 0.65")
     }
     "GET /items?list=1&list=2&list=3&list=4&list=5" in {
       val response = server(Request(GET, Uri(path = "/items", query = Query.fromString("list=1&list=2&list=3&list=4&list=5"))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo(s"items: 1,2,3,4,5")
     }
     "GET /search" in {
       val response = server(Request(GET, Uri(path = "/search")))
-      response.status must equal (NotFound)
+      response.status must_== (NotFound)
       response.body must equalTo("404 Not Found: /search")
     }
     "GET /search?term" in {
       val response = server(Request(GET, Uri(path = "/search", query = Query.fromString("term"))))
-      response.status must equal (NotFound)
+      response.status must_== (NotFound)
       response.body must equalTo("404 Not Found: /search")
     }
     "GET /search?term=" in {
       val response = server(Request(GET, Uri(path = "/search", query = Query.fromString("term="))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("term: ")
     }
     "GET /search?term= http4s  " in {
       val response = server(Request(GET, Uri(path = "/search", query = Query.fromString("term=%20http4s%20%20"))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("term:  http4s  ")
     }
     "GET /search?term=http4s" in {
       val response = server(Request(GET, Uri(path = "/search", query = Query.fromString("term=http4s"))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("term: http4s")
     }
     "optional parameter present" in {
       val response = server(Request(GET, Uri(path = "/app", query = Query.fromString("counter=3"))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("counter: Some(3)")
     }
     "optional parameter absent" in {
       val response = server(Request(GET, Uri(path = "/app", query = Query.fromString("other=john"))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("counter: None")
     }
     "optional parameter present with incorrect format" in {
       val response = server(Request(GET, Uri(path = "/app", query = Query.fromString("counter=john"))))
-      response.status must equal (NotFound)
+      response.status must_== (NotFound)
     }
     "validating parameter present" in {
       val response = server(Request(GET, Uri(path = "/valid", query = Query.fromString("counter=3"))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("counter: 3")
     }
     "validating parameter absent" in {
       val response = server(Request(GET, Uri(path = "/valid", query = Query.fromString("notthis=3"))))
-      response.status must equal (NotFound)
+      response.status must_== (NotFound)
     }
     "validating parameter present with incorrect format" in {
       val response = server(Request(GET, Uri(path = "/valid", query = Query.fromString("counter=foo"))))
-      response.status must equal (BadRequest)
+      response.status must_== (BadRequest)
       response.body must equalTo("Query decoding Int failed")
     }
     "optional validating parameter present" in {
       val response = server(Request(GET, Uri(path = "/optvalid", query = Query.fromString("counter=3"))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("counter: 3")
     }
     "optional validating parameter absent" in {
       val response = server(Request(GET, Uri(path = "/optvalid", query = Query.fromString("notthis=3"))))
-      response.status must equal (Ok)
+      response.status must_== (Ok)
       response.body must equalTo("no counter")
     }
     "optional validating parameter present with incorrect format" in {
       val response = server(Request(GET, Uri(path = "/optvalid", query = Query.fromString("counter=foo"))))
-      response.status must equal (BadRequest)
+      response.status must_== (BadRequest)
       response.body must equalTo("Query decoding Int failed")
     }
 

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
@@ -6,19 +6,19 @@ trait JawnDecodeSupportSpec[J] extends Http4sSpec with JawnInstances {
     "json decoder" should {
       "return right when the entity is valid" in {
         val resp = Response(Status.Ok).withBody("""{"valid": true}""").run
-        decoder.decode(resp).run.run must beRightDisjunction
+        decoder.decode(resp).run.run must be_\/-
       }
 
       "return a ParseFailure when the entity is invalid" in {
         val resp = Response(Status.Ok).withBody("""garbage""").run
-        decoder.decode(resp).run.run must beLeftDisjunction.like {
+        decoder.decode(resp).run.run must be_-\/.like {
           case ParseFailure("Invalid JSON", _) => ok
         }
       }
 
       "return a ParseFailure when the entity is empty" in {
         val resp = Response(Status.Ok).withBody("").run
-        decoder.decode(resp).run.run must beLeftDisjunction.like {
+        decoder.decode(resp).run.run must be_-\/.like {
           case ParseFailure("Invalid JSON", _) => ok
         }
       }

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -21,7 +21,7 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
     }
 
     "write compact JSON" in {
-      writeToString(json) must equal ("""{"test":"json4s"}""")
+      writeToString(json) must_== ("""{"test":"json4s"}""")
     }
   }
 
@@ -31,19 +31,19 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
     }
 
     "write compact JSON with a json4s writer" in {
-      writeToString(42.some)(jsonEncoderOf[Option[Int]]) must equal ("""42""")
+      writeToString(42.some)(jsonEncoderOf[Option[Int]]) must_== ("""42""")
     }
   }
 
   "jsonOf" should {
     "decode JSON from an json4s reader" in {
       val result = jsonOf[Int].decode(Request().withBody("42").run)
-      result.run.run must beRightDisjunction(42)
+      result.run.run must be_\/-(42)
     }
 
     "handle reader failures" in {
       val result = jsonOf[Int].decode(Request().withBody(""""oops"""").run)
-      result.run.run must beLeftDisjunction.like {
+      result.run.run must be_-\/.like {
         case ParseFailure("Could not map JSON", _) => ok
       }
     }

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -73,8 +73,9 @@ object Http4sBuild extends Build {
   lazy val scalazCore          = "org.scalaz"               %% "scalaz-core"             % "7.1.3"
   lazy val scalazScalacheckBinding = "org.scalaz"           %% "scalaz-scalacheck-binding" % scalazCore.revision
   lazy val scalaCheck          = "org.scalacheck"           %% "scalacheck"              % "1.12.4"
-  lazy val scalazSpecs2        = "org.typelevel"            %% "scalaz-specs2"           % "0.4.0"
-  lazy val scalazStream        = "org.scalaz.stream"        %% "scalaz-stream"           % "0.7.3a"
+  lazy val specs2              = "org.specs2"               %% "specs2-core"             % "3.6.5"
+  lazy val specs2_scalacheck   = "org.specs2"               %% "specs2-scalacheck"       % specs2.revision
+  lazy val scalazStream        = "org.scalaz.stream"        %% "scalaz-stream"           % "0.8"
   lazy val scodecBits          = "org.scodec"               %% "scodec-bits"             % "1.0.9"
   lazy val tomcatCatalina      = "org.apache.tomcat"         % "tomcat-catalina"         % "8.0.24"
   lazy val tomcatCoyote        = "org.apache.tomcat"         % "tomcat-coyote"           % tomcatCatalina.revision

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -41,7 +41,7 @@ class ScalaXmlSpec extends Http4sSpec {
     "return 400 on parse error" in {
       val body = strBody("This is not XML.")
       val tresp = server(Request(body = body))
-      tresp.run.status must equal (Status.BadRequest)
+      tresp.run.status must_== (Status.BadRequest)
     }
   }
 

--- a/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
@@ -28,25 +28,25 @@ class HttpServiceSpec extends Http4sSpec {
 
   "HttpService" should {
     "Return a valid Response from the first service of an aggregate" in {
-      aggregate1.apply(Request(uri = uri("/match"))).run.as[String].run must equal ("match")
+      aggregate1.apply(Request(uri = uri("/match"))).run.as[String].run must_== ("match")
     }
 
     "Return a custom NotFound from the first service of an aggregate" in {
-      aggregate1.apply(Request(uri = uri("/notfound"))).run.as[String].run must equal ("notfound")
+      aggregate1.apply(Request(uri = uri("/notfound"))).run.as[String].run must_== ("notfound")
     }
 
     "Accept the first matching route in the case of overlapping paths" in {
-      aggregate1.apply(Request(uri = uri("/conflict"))).run.as[String].run must equal ("srvc1conflict")
+      aggregate1.apply(Request(uri = uri("/conflict"))).run.as[String].run must_== ("srvc1conflict")
     }
 
     "Fall through the first service that doesn't match to a second matching service" in {
-      aggregate1.apply(Request(uri = uri("/srvc2"))).run.as[String].run must equal ("srvc2")
+      aggregate1.apply(Request(uri = uri("/srvc2"))).run.as[String].run must_== ("srvc2")
     }
 
     "Properly fall through two aggregated service if no path matches" in {
       val resp = aggregate1.apply(Request(uri = uri("/wontMatch"))).run
-      resp.status must equal (Status.NotFound)
-      resp.attributes.contains(Fallthrough.fallthroughKey) must equal (true)
+      resp.status must_== (Status.NotFound)
+      resp.attributes.contains(Fallthrough.fallthroughKey) must_== (true)
     }
   }
 }

--- a/server/src/test/scala/org/http4s/server/RouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSpec.scala
@@ -37,40 +37,40 @@ class RouterSpec extends Http4sSpec {
 
   "A router" should {
     "translate mount prefixes" in {
-      service.apply(Request(GET, uri("/numbers/1"))).run.as[String].run must equal ("one")
+      service.apply(Request(GET, uri("/numbers/1"))).run.as[String].run must_== ("one")
     }
 
     "require the correct prefix" in {
       val resp = service.apply(Request(GET, uri("/letters/1"))).run
-      resp.as[String].run must not equal ("bee")
-      resp.as[String].run must not equal ("one")
-      resp.status must equal (NotFound)
+      resp.as[String].run must_!= ("bee")
+      resp.as[String].run must_!= ("one")
+      resp.status must_== (NotFound)
     }
 
     "support root mappings" in {
-      service.apply(Request(GET, uri("/about"))).run.as[String].run must equal ("about")
+      service.apply(Request(GET, uri("/about"))).run.as[String].run must_== ("about")
     }
 
     "match longer prefixes first" in {
-      service.apply(Request(GET, uri("/shadow/shadowed"))).run.as[String].run must equal ("visible")
+      service.apply(Request(GET, uri("/shadow/shadowed"))).run.as[String].run must_== ("visible")
     }
 
     "404 on unknown prefixes" in {
-      service.apply(Request(GET, uri("/symbols/~"))).run.status must equal (NotFound)
+      service.apply(Request(GET, uri("/symbols/~"))).run.status must_== (NotFound)
     }
 
     "Allow passing through of routes with identical prefixes" in {
       Router("" -> letters, "" -> numbers).apply(Request(GET, uri("/1")))
-        .run.as[String].run must equal ("one")
+        .run.as[String].run must_== ("one")
     }
 
     "Serve custom NotFound responses" in {
-      Router("/foo" -> notFound).apply(Request(uri = uri("/foo/bar"))).run.as[String].run must equal ("Custom NotFound")
+      Router("/foo" -> notFound).apply(Request(uri = uri("/foo/bar"))).run.as[String].run must_== ("Custom NotFound")
     }
 
     "Return the tagged NotFound response if no route is found" in {
       val resp = Router("/foo" -> notFound).apply(Request(uri = uri("/bar"))).run
-      resp.attributes.contains(Fallthrough.fallthroughKey) must equal (true)
+      resp.attributes.contains(Fallthrough.fallthroughKey) must_== (true)
     }
 
   }

--- a/server/src/test/scala/org/http4s/server/middleware/AutoSlashSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/AutoSlashSpec.scala
@@ -11,24 +11,24 @@ class AutoSlashSpec extends Http4sSpec {
   "AutoSlash" should {
     "Auto remove a trailing slash" in {
       val req = Request(uri = uri("/ping/"))
-      route.apply(req).run.status must equal (Status.NotFound)
-      AutoSlash(route).apply(req).run.status must equal (Status.Ok)
+      route.apply(req).run.status must_== (Status.NotFound)
+      AutoSlash(route).apply(req).run.status must_== (Status.Ok)
     }
 
     "Match a route defined with a slash" in {
-      AutoSlash(route).apply(Request(uri = uri("/withslash"))).run.status must equal (Status.Ok)
-      AutoSlash(route).apply(Request(uri = uri("/withslash/"))).run.status must equal (Status.Accepted)
+      AutoSlash(route).apply(Request(uri = uri("/withslash"))).run.status must_== (Status.Ok)
+      AutoSlash(route).apply(Request(uri = uri("/withslash/"))).run.status must_== (Status.Accepted)
     }
 
     "Respect an absent trailing slash" in {
       val req = Request(uri = uri("/ping"))
-      route.apply(req).run.status must equal (Status.Ok)
-      AutoSlash(route).apply(req).run.status must equal (Status.Ok)
+      route.apply(req).run.status must_== (Status.Ok)
+      AutoSlash(route).apply(req).run.status must_== (Status.Ok)
     }
 
     "Not crash on empy path" in {
       val req = Request(uri = uri(""))
-      AutoSlash(route).apply(req).run.status must equal (Status.NotFound)
+      AutoSlash(route).apply(req).run.status must_== (Status.NotFound)
     }
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
@@ -19,13 +19,13 @@ class TimeoutSpec extends Http4sSpec {
     "Have no effect if the response is not delayed" in {
       val req = Request(GET, uri("/fast"))
 
-      timeoutService.apply(req).run.status must equal (Status.Ok)
+      timeoutService.apply(req).run.status must_== (Status.Ok)
     }
 
     "return a 500 error if the result takes too long" in {
       val req = Request(GET, uri("/slow"))
 
-      timeoutService.apply(req).run.status must equal (Status.InternalServerError)
+      timeoutService.apply(req).run.status must_== (Status.InternalServerError)
     }
 
     "return the provided response if the result takes too long" in {
@@ -33,13 +33,13 @@ class TimeoutSpec extends Http4sSpec {
       val customTimeout = Response(Status.GatewayTimeout) // some people return 504 here.
       val altTimeoutService = Timeout(500.millis, Task.now(customTimeout))(myService)
 
-      altTimeoutService.apply(req).run.status must equal (customTimeout.status)
+      altTimeoutService.apply(req).run.status must_== (customTimeout.status)
     }
 
     "Handle infinite durations" in {
       val service = Timeout(Duration.Inf)(myService)
       
-      service.apply(Request(GET, uri("/slow"))).run.status must equal(Status.Ok)
+      service.apply(Request(GET, uri("/slow"))).run.status must_== (Status.Ok)
     }
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/UriTranslationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/UriTranslationSpec.scala
@@ -26,24 +26,24 @@ class UriTranslationSpec extends Http4sSpec {
   "UriTranslation" should {
     "match a matching request" in {
       val req = Request(uri = Uri(path = "/http4s/foo"))
-      trans1.apply(req).run.status must equal (Ok)
-      trans2.apply(req).run.status must equal (Ok)
-      service.apply(req).run.status must equal (NotFound)
+      trans1.apply(req).run.status must_== (Ok)
+      trans2.apply(req).run.status must_== (Ok)
+      service.apply(req).run.status must_== (NotFound)
     }
 
     "Not match a request missing the prefix" in {
       val req = Request(uri = Uri(path = "/foo"))
-      trans1.apply(req).run.status must equal (NotFound)
-      trans2.apply(req).run.status must equal (NotFound)
-      service.apply(req).run.status must equal (Ok)
+      trans1.apply(req).run.status must_== (NotFound)
+      trans2.apply(req).run.status must_== (NotFound)
+      service.apply(req).run.status must_== (Ok)
     }
 
     "Split the Uri into scriptName and pathInfo" in {
       val req = Request(uri = Uri(path = "/http4s/checkattr"))
       val resp = trans1.apply(req).run
-      resp.status must equal (Ok)
+      resp.status must_== (Ok)
       val s = new String(resp.body.runLog.run.reduce(_ ++ _).toArray, StandardCharsets.UTF_8)
-      s must equal("/http4s /checkattr")
+      s must_== ("/http4s /checkattr")
     }
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
@@ -44,21 +44,21 @@ class VirtualHostSpec extends Http4sSpec {
         val req = Request(GET, uri("/numbers/1"))
           .replaceAllHeaders(Host("servicea"))
 
-        virtualServices.apply(req).run.as[String].run must equal ("servicea")
+        virtualServices.apply(req).run.as[String].run must_== ("servicea")
       }
 
       "honor the Host header port" in {
         val req = Request(GET, uri("/numbers/1"))
           .replaceAllHeaders(Host("serviceb", Some(80)))
 
-        virtualServices.apply(req).run.as[String].run must equal ("serviceb")
+        virtualServices.apply(req).run.as[String].run must_== ("serviceb")
       }
 
       "ignore the Host header port if not specified" in {
         val good = Request(GET, uri("/numbers/1"))
           .replaceAllHeaders(Host("servicea", Some(80)))
 
-        virtualServices.apply(good).run.as[String].run must equal ("servicea")
+        virtualServices.apply(good).run.as[String].run must_== ("servicea")
       }
 
       "result in a 404 if the hosts fail to match" in {
@@ -80,14 +80,14 @@ class VirtualHostSpec extends Http4sSpec {
         val req = Request(GET, uri("/numbers/1"))
           .replaceAllHeaders(Host("servicea", Some(80)))
 
-        virtualServices.apply(req).run.as[String].run must equal ("servicea")
+        virtualServices.apply(req).run.as[String].run must_== ("servicea")
       }
 
       "allow for a dash in the service" in {
         val req = Request(GET, uri("/numbers/1"))
           .replaceAllHeaders(Host("foo.foo-service", Some(80)))
 
-        virtualServices.apply(req).run.as[String].run must equal ("default")
+        virtualServices.apply(req).run.as[String].run must_== ("default")
       }
 
       "match a route with a wildcard route" in {
@@ -97,7 +97,7 @@ class VirtualHostSpec extends Http4sSpec {
                        req.replaceAllHeaders(Host("b.service", Some(80))))
 
         forall(reqs){ req =>
-          virtualServices.apply(req).run.as[String].run must equal ("serviceb")
+          virtualServices.apply(req).run.as[String].run must_== ("serviceb")
         }
       }
 

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -45,7 +45,7 @@ class AuthenticationSpec extends Http4sSpec {
       val req = Request(uri = Uri(path = "/launch-the-nukes"))
       val res = basic.apply(req).run
       isNuked must_== false
-      res.status must equal (Unauthorized)
+      res.status must_== (Unauthorized)
     }
   }
 
@@ -54,31 +54,31 @@ class AuthenticationSpec extends Http4sSpec {
       val req = Request(uri = Uri(path = "/"))
       val res = basic.apply(req).run
 
-      res.status must equal (Unauthorized)
-      res.headers.get(`WWW-Authenticate`).map(_.value) must equal (Some(Challenge("Basic", realm, Nil.toMap).toString))
+      res.status must_== (Unauthorized)
+      res.headers.get(`WWW-Authenticate`).map(_.value) must_== (Some(Challenge("Basic", realm, Nil.toMap).toString))
     }
 
     "Respond to a request with unknown username with 401" in {
       val req = Request(uri = Uri(path = "/"), headers = Headers(Authorization(BasicCredentials("Wrong User", password))))
       val res = basic.apply(req).run
 
-      res.status must equal (Unauthorized)
-      res.headers.get(`WWW-Authenticate`).map(_.value) must equal (Some(Challenge("Basic", realm, Nil.toMap).toString))
+      res.status must_== (Unauthorized)
+      res.headers.get(`WWW-Authenticate`).map(_.value) must_== (Some(Challenge("Basic", realm, Nil.toMap).toString))
     }
 
     "Respond to a request with wrong password with 401" in {
       val req = Request(uri = Uri(path = "/"), headers = Headers(Authorization(BasicCredentials(username, "Wrong Password"))))
       val res = basic.apply(req).run
 
-      res.status must equal (Unauthorized)
-      res.headers.get(`WWW-Authenticate`).map(_.value) must equal (Some(Challenge("Basic", realm, Nil.toMap).toString))
+      res.status must_== (Unauthorized)
+      res.headers.get(`WWW-Authenticate`).map(_.value) must_== (Some(Challenge("Basic", realm, Nil.toMap).toString))
     }
 
     "Respond to a request with correct credentials" in {
       val req = Request(uri = Uri(path = "/"), headers = Headers(Authorization(BasicCredentials(username, password))))
       val res = basic.apply(req).run
 
-      res.status must equal (Ok)
+      res.status must_== (Ok)
     }
   }
 
@@ -92,7 +92,7 @@ class AuthenticationSpec extends Http4sSpec {
       val req = Request(uri = Uri(path = "/"))
       val res = digest.apply(req).run
 
-      res.status must equal (Status.Unauthorized)
+      res.status must_== (Status.Unauthorized)
       val opt = res.headers.get(`WWW-Authenticate`).map(_.value)
       opt.isDefined must beTrue
       val challenge = parse(opt.get).values.head
@@ -110,7 +110,7 @@ class AuthenticationSpec extends Http4sSpec {
       val req = Request(uri = Uri(path = "/"))
       val res = digest.apply(req).run
 
-      res.status must equal (Unauthorized)
+      res.status must_== (Unauthorized)
       val opt = res.headers.get(`WWW-Authenticate`).map(_.value)
       opt.isDefined must beTrue
       val challenge = parse(opt.get).values.head
@@ -156,10 +156,10 @@ class AuthenticationSpec extends Http4sSpec {
 
       val (res2, res3) = doDigestAuth2(digest, challenge, true)
 
-      res2.status must equal (Ok)
+      res2.status must_== (Ok)
 
       // Digest prevents replay
-      res3.status must equal (Unauthorized)
+      res3.status must_== (Unauthorized)
 
       ok
     }

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
@@ -46,7 +46,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
     "Not find missing file" in {
       val req = Request(uri = uri("server/src/test/resources/testresource.txtt"))
-      runReq(req)._2.status must equal (Status.NotFound)
+      runReq(req)._2.status must_== (Status.NotFound)
     }
 
     "Return a 206 PartialContent file" in {

--- a/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
@@ -46,7 +46,7 @@ class ResourceServiceSpec extends Http4sSpec with StaticContentShared {
 
     "Generate non on missing content" in {
       val req = Request(uri = Uri.fromString("testresource.txtt").yolo)
-      runReq(req)._2.status must equal (Status.NotFound)
+      runReq(req)._2.status must_== (Status.NotFound)
     }
   }
 

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -124,7 +124,7 @@ case class NonBlockingServletIo(chunkSize: Int) extends ServletIo {
             state.set(Blocked(cb))
         }
       }
-    }
+    } onHalt (_.asHalt)
   }
 
   override protected[servlet] def initWriter(servletResponse: HttpServletResponse): BodyWriter = {

--- a/servlet/src/test/scala/org/http4s/servlet/ServletContainerSpec.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/ServletContainerSpec.scala
@@ -7,11 +7,11 @@ class ServletContainerSpec extends Http4sSpec {
     import ServletContainer.prefixMapping
 
     "append /* when prefix does not have trailing slash" in {
-      prefixMapping("/foo") must equal("/foo/*")
+      prefixMapping("/foo") must_== ("/foo/*")
     }
 
     "append * when prefix has trailing slash" in {
-      prefixMapping("/") must equal("/*")
+      prefixMapping("/") must_== ("/*")
     }
   }
 }

--- a/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
+++ b/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
@@ -27,7 +27,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response(Ok).withBody(html.test())
-      text.decode(resp.run).run.run must beRightDisjunction("<h1>test html</h1>")
+      text.decode(resp.run).run.run must be_\/-("<h1>test html</h1>")
     }
   }
 
@@ -39,7 +39,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response(Ok).withBody(js.test())
-      text.decode(resp.run).run.run must beRightDisjunction(""""test js"""")
+      text.decode(resp.run).run.run must be_\/-(""""test js"""")
     }
   }
 
@@ -51,7 +51,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response(Ok).withBody(txt.test())
-      text.decode(resp.run).run.run must beRightDisjunction("""test text""")
+      text.decode(resp.run).run.run must be_\/-("""test text""")
     }
   }
 
@@ -63,7 +63,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response(Ok).withBody(_root_.xml.test())
-      text.decode(resp.run).run.run must beRightDisjunction("<test>test xml</test>")
+      text.decode(resp.run).run.run must be_\/-("<test>test xml</test>")
     }
   }
 }


### PR DESCRIPTION
The version bump of scalaz-stream necessitated a drop of scalaz-specs2 which appears to be a dead project. The reason is specs2 depends on scalaz-stream so the older version of scalaz-specs2 transiently depends on an older version of scalaz-stream.

The most notable changes are the calls to `repeatEval`: they are now followed by `.onHalt(_.asHalt)` in the case that termination was signalled through the exception. See 
https://github.com/scalaz/scalaz-stream/wiki/0.8#terminated-removal
for more details.

Another notable change is the addition of a new field to the `Await` construct of the `Process` type. This only affects the blaze `ProcessWriter` types.