### PR TITLE
Fix parsing of `entity-tag` rule

### DIFF
--- a/core/src/main/scala/org/http4s/headers/ETag.scala
+++ b/core/src/main/scala/org/http4s/headers/ETag.scala
@@ -3,11 +3,19 @@ package headers
 
 import org.http4s.util.Writer
 
-object ETag extends HeaderKey.Internal[ETag] with HeaderKey.Singleton
+object ETag extends HeaderKey.Internal[ETag] with HeaderKey.Singleton {
+  case class EntityTag(tag: String, weak: Boolean = false) {
+    override def toString() = {
+      if (weak) "W/\"" + tag + '"'
+      else "\"" + tag + '"'
+    }
+  }
+}
 
-final case class ETag(tag: String) extends Header.Parsed {
+final case class ETag(tag: ETag.EntityTag) extends Header.Parsed {
   def key: HeaderKey = ETag
-  override def value: String = tag
+  override def value: String = tag.toString()
   override def renderValue(writer: Writer): writer.type = writer.append(value)
 }
+
 

--- a/core/src/main/scala/org/http4s/headers/If-None-Match.scala
+++ b/core/src/main/scala/org/http4s/headers/If-None-Match.scala
@@ -3,11 +3,24 @@ package headers
 
 import org.http4s.util.Writer
 
-object `If-None-Match` extends HeaderKey.Internal[`If-None-Match`] with HeaderKey.Singleton
+import scalaz.NonEmptyList
 
-case class `If-None-Match`(tag: String) extends Header.Parsed {
+object `If-None-Match` extends HeaderKey.Internal[`If-None-Match`] with HeaderKey.Singleton {
+
+  /** Match any existing entity */
+  val `*` = `If-None-Match`(None)
+
+  def apply(first: ETag.EntityTag, rest: ETag.EntityTag*): `If-None-Match` = {
+    `If-None-Match`(Some(NonEmptyList(first, rest:_*)))
+  }
+}
+
+case class `If-None-Match`(tags: Option[NonEmptyList[ETag.EntityTag]]) extends Header.Parsed {
   override def key: HeaderKey = `If-None-Match`
-  override def value: String = tag
+  override def value: String = tags match {
+    case None       => "*"
+    case Some(tags) => tags.list.mkString(",")
+  }
   override def renderValue(writer: Writer): writer.type = writer.append(value)
 }
 


### PR DESCRIPTION
fixes #446

Parsing of the `entity-tag` rule was previously malformed and only
accepted alpha-numeric characters.

Changes include ETAG and IF_MODIFIED_SINCE parsers. Notably, the
IF_MATCH header doesn't exhist and would use the same parsing bits.