### PR TITLE
Make convenient ETag header construct function

### DIFF
--- a/core/src/main/scala/org/http4s/headers/ETag.scala
+++ b/core/src/main/scala/org/http4s/headers/ETag.scala
@@ -10,6 +10,8 @@ object ETag extends HeaderKey.Internal[ETag] with HeaderKey.Singleton {
       else "\"" + tag + '"'
     }
   }
+
+  def apply(tag: String, weak: Boolean = false): ETag = ETag(EntityTag(tag, weak))
 }
 
 final case class ETag(tag: ETag.EntityTag) extends Header.Parsed {

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -98,7 +98,7 @@ private[parser] trait SimpleHeaders {
   }.parse
 
   def ETAG(value: String) = new Http4sHeaderParser[ETag](value) {
-    def entry = rule { EntityTag ~> (ETag(_)) }
+    def entry = rule { EntityTag ~> (ETag(_: ETag.EntityTag)) }
   }.parse
 
   def IF_NONE_MATCH(value: String) = new Http4sHeaderParser[`If-None-Match`](value) {

--- a/core/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -82,8 +82,8 @@ class SimpleHeadersSpec extends Http4sSpec {
       ETag.EntityTag("hash", weak = true).toString() must_== "W/\"hash\""
       ETag.EntityTag("hash", weak = false).toString() must_== "\"hash\""
 
-      val headers = Seq(ETag(ETag.EntityTag("hash")),
-                        ETag(ETag.EntityTag("hash", true)))
+      val headers = Seq(ETag("hash"),
+                        ETag("hash", true))
 
       foreach(headers){ header =>
         HttpHeaderParser.parseHeader(header.toRaw) must be_\/-(header)


### PR DESCRIPTION
Problem: PR #446 (commit 0ce2754eb735d2acb94e2c45758392335a448f99) added the
type `EntityTag` to fix the malformed `ETag` and `If-Modified-Since` headers. In
the process construction of the `ETag` header became more difficult due to it
now containing an inner object instead of a simple `String`.

Fix: Add a simple apply function to the object to give the same behavior we had
before.

This PR should be binary backwards compatible with 0.11.0: it only modifies the
internal of the `ETag` header parser and introduces one new method to the `ETag`
object.