### PR TITLE
Honor connectorPoolSize and bufferSize parametesr in BlazeBuilder

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -151,9 +151,9 @@ class BlazeBuilder(
 
     val factory =
       if (isNio2)
-        NIO2SocketServerGroup.fixedGroup(12, 8 * 1024)
+        NIO2SocketServerGroup.fixedGroup(connectorPoolSize, bufferSize)
       else
-        NIO1SocketServerGroup.fixedGroup(12, 8 * 1024)
+        NIO1SocketServerGroup.fixedGroup(connectorPoolSize, bufferSize)
 
     var address = socketAddress
     if (address.isUnresolved)


### PR DESCRIPTION
closes #450

Problem: The values were hard coded to some reasonable defaults.

Solution: Honor the parameters passed by the user.