### PR TITLE
Extend timeout and wait durations in test to help travis builds

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -12,7 +12,7 @@ object EntityLimiter {
 
   case class EntityTooLarge(limit: Int) extends Exception with NoStackTrace
 
-  val DefaultMaxEntitySize: Int = 2097152
+  val DefaultMaxEntitySize: Int = 2*1024*1024 // 2 MB default
 
   def apply(service: HttpService, limit: Int = DefaultMaxEntitySize): HttpService =
     service.local { req: Request => req.copy(body = req.body |> takeBytes(limit)) }
@@ -23,7 +23,7 @@ object EntityLimiter {
       if (sz > n) fail(EntityTooLarge(n))
       else emit(chunk) ++ receive1(go(sz, _))
     }
-    await(Get[ByteVector])(go(0,_))
+    receive1(go(0,_))
   }
 
   def comsumeUpTo(n: Int): Process1[ByteVector, ByteVector] = {

--- a/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
@@ -10,36 +10,33 @@ class TimeoutSpec extends Http4sSpec {
 
   val myService = HttpService {
     case req if req.uri.path == "/fast" => Response(Status.Ok).withBody("Fast")
-    case req if req.uri.path == "/slow" => Task(Thread.sleep(1000)).flatMap(_ => Response(Status.Ok).withBody("Slow"))
+    case req if req.uri.path == "/slow" => Task(Thread.sleep(10000)).flatMap(_ => Response(Status.Ok).withBody("Slow"))
   }
 
-  val timeoutService = Timeout.apply(500.millis)(myService)
+  val timeoutService = Timeout.apply(5.seconds)(myService)
+  val fastReq = Request(GET, uri("/fast"))
+  val slowReq = Request(GET, uri("/slow"))
 
   "Timeout Middleware" should {
     "Have no effect if the response is not delayed" in {
-      val req = Request(GET, uri("/fast"))
 
-      timeoutService.apply(req).run.status must_== (Status.Ok)
+      timeoutService.apply(fastReq).run.status must_== (Status.Ok)
     }
 
     "return a 500 error if the result takes too long" in {
-      val req = Request(GET, uri("/slow"))
-
-      timeoutService.apply(req).run.status must_== (Status.InternalServerError)
+      timeoutService.apply(slowReq).run.status must_== (Status.InternalServerError)
     }
 
     "return the provided response if the result takes too long" in {
-      val req = Request(GET, uri("/slow"))
       val customTimeout = Response(Status.GatewayTimeout) // some people return 504 here.
       val altTimeoutService = Timeout(500.millis, Task.now(customTimeout))(myService)
 
-      altTimeoutService.apply(req).run.status must_== (customTimeout.status)
+      altTimeoutService.apply(slowReq).run.status must_== (customTimeout.status)
     }
 
     "Handle infinite durations" in {
       val service = Timeout(Duration.Inf)(myService)
-      
-      service.apply(Request(GET, uri("/slow"))).run.status must_== (Status.Ok)
+      service.apply(slowReq).run.status must_== (Status.Ok)
     }
   }
 


### PR DESCRIPTION
Problem: The Travis-ci builds fail relatively often (maybe 1/3 of the time?)
due to timeouts not happening when they should. This is likely caused by the
short timeouts and delays set in the unit tests combined with the heavy load
on the server while running tests concurrently.

Solution: Extend the durations so that threads are more likely to restart in
within their specified duration.

Bonus: make the default max entity size in the `EntityLimiter` easier to
read.