### PR TITLE
Change blaze stage cleanup to use stream `onComplete` as opposed to `append`

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -30,7 +30,7 @@ final class BlazeClient(manager: ConnectionManager, idleTimeout: Duration, reque
               manager.recycleClient(req, client)
             }
           })
-          Task.now(r.copy(body = r.body ++ recycleProcess))
+          Task.now(r.copy(body = r.body.onComplete(recycleProcess)))
 
         case -\/(Command.EOF) if !freshClient =>
           manager.getClient(req, freshClient = true).flatMap(tryClient(_, true))


### PR DESCRIPTION
`append` will not run the process if it terminates abnormally but we want cleanup to occur regardless.
This may be related to a file handle leak observed by some client users.