### PR TITLE
Fix FollowRedirect client middleware

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -33,7 +33,10 @@ object FollowRedirect {
                 fragment = uri.fragment orElse req.uri.fragment
               )
 
-              prepareLoop(req.copy(uri = nextUri, body = EmptyBody), redirects + 1)
+              prepareLoop(
+                req.copy(method = method, uri = nextUri, body = EmptyBody),
+                redirects + 1
+              )
 
             case _ => Task.now(resp)
           }


### PR DESCRIPTION
Problem: the `method` parameter wasn't being used for redirects which ends up breaking 303 response codes which should redirect with a GET method.
(See https://tools.ietf.org/html/rfc7231#page-57 for why we need to use a GET for 303 redirects)
Solution: use the parameter.