### PR TITLE
Add a finalizer to the BlazeClientStage trait

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientStage.scala
@@ -2,6 +2,8 @@ package org.http4s.client.blaze
 
 import java.nio.ByteBuffer
 
+import scala.util.control.NonFatal
+
 import org.http4s.blaze.pipeline.TailStage
 import org.http4s.{Request, Response}
 
@@ -13,4 +15,15 @@ trait BlazeClientStage extends TailStage[ByteBuffer] {
   def isClosed(): Boolean
 
   def shutdown(): Unit
+
+  override protected def finalize(): Unit = {
+    try if (!isClosed()) {
+      logger.warn("BlazeClientStage was not disconnected and could result in a resource leak")
+      shutdown()
+      super.finalize()
+    } catch {
+      case NonFatal(t) =>
+        logger.error(t)("Failure finalizing the client stage")
+    }
+  }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientStage.scala
@@ -10,10 +10,16 @@ import org.http4s.{Request, Response}
 import scalaz.concurrent.Task
 
 trait BlazeClientStage extends TailStage[ByteBuffer] {
+
+  /** Create a computation that will turn the [[Request]] into a [[Response]] */
   def runRequest(req: Request): Task[Response]
 
+  /** Determine if the stage is closed and resources have been freed */
   def isClosed(): Boolean
 
+  /** Close down the stage
+   *  Freeing resources and potentially aborting a [[Response]]
+   */
   def shutdown(): Unit
 
   override protected def finalize(): Unit = {

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
@@ -97,6 +97,7 @@ final class Http1ClientStage(userAgent: Option[`User-Agent`], protected val ec: 
         val respTask =  receiveResponse(mustClose)
 
         Task.taskInstance.mapBoth(bodyTask, respTask)((_,r) => r)
+            .handleWith { case t => stageShutdown(); Task.fail(t) }
       }
     }
   }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -33,9 +33,8 @@ class ClientTimeoutSpec extends Http4sSpec {
 
   "Http1ClientStage responses" should {
     "Timeout immediately with an idle timeout of 0 seconds" in {
-      val tail = new Http1ClientStage(None, ec)
-      val h = new SlowTestHead(List(mkBuffer(resp)), 0.seconds)
-      val c = mkClient(h, tail)(0.milli, Duration.Inf)
+      val c = mkClient(new SlowTestHead(List(mkBuffer(resp)), 0.seconds), 
+                       new Http1ClientStage(None, ec))(0.milli, Duration.Inf)
 
       c.prepare(FooRequest).run must throwA[TimeoutException]
     }


### PR DESCRIPTION
Problem: If a body isn't used the socket may never be released.
Solution: Adding a finalizer will ensure that the stage shuts down and presumably performs resource cleanup.