### PR TITLE
Permit recycling of requests with bodies.

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -16,13 +16,13 @@ final class BlazeClient(manager: ConnectionManager, idleTimeout: Duration, reque
   override def shutdown(): Task[Unit] = manager.shutdown()
 
   override def prepare(req: Request): Task[Response] = Task.suspend {
-    def tryClient(client: BlazeClientStage, freshClient: Boolean): Task[Response] = {
+    def tryClient(client: BlazeClientStage, freshClient: Boolean, flushPrelude: Boolean): Task[Response] = {
       // Add the timeout stage to the pipeline
       val ts = new ClientTimeoutStage(idleTimeout, requestTimeout, bits.ClientTickWheel)
       client.spliceBefore(ts)
       ts.initialize()
 
-      client.runRequest(req).attempt.flatMap {
+      client.runRequest(req, flushPrelude).attempt.flatMap {
         case \/-(r)    =>
           val recycleProcess = eval_(Task.delay {
             if (!client.isClosed()) {
@@ -33,7 +33,7 @@ final class BlazeClient(manager: ConnectionManager, idleTimeout: Duration, reque
           Task.now(r.copy(body = r.body.onComplete(recycleProcess)))
 
         case -\/(Command.EOF) if !freshClient =>
-          manager.getClient(req, freshClient = true).flatMap(tryClient(_, true))
+          manager.getClient(req, freshClient = true).flatMap(tryClient(_, true, flushPrelude))
 
         case -\/(e) =>
           if (!client.isClosed()) client.shutdown()
@@ -41,9 +41,8 @@ final class BlazeClient(manager: ConnectionManager, idleTimeout: Duration, reque
       }
     }
 
-    // TODO: Find a better strategy to deal with the potentially mutable body of the Request. Need to make sure the connection isn't stale.
-    val requireFresh = !req.body.isHalt
-    manager.getClient(req, freshClient = requireFresh).flatMap(tryClient(_, requireFresh))
+    val flushPrelude = !req.body.isHalt
+    manager.getClient(req, false).flatMap(tryClient(_, false, flushPrelude))
   }
 }
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientStage.scala
@@ -12,7 +12,7 @@ import scalaz.concurrent.Task
 trait BlazeClientStage extends TailStage[ByteBuffer] {
 
   /** Create a computation that will turn the [[Request]] into a [[Response]] */
-  def runRequest(req: Request): Task[Response]
+  def runRequest(req: Request, preludeFlush: Boolean): Task[Response]
 
   /** Determine if the stage is closed and resources have been freed */
   def isClosed(): Boolean

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
@@ -86,16 +86,16 @@ final class Http1ClientStage(userAgent: Option[`User-Agent`], protected val ec: 
     }
   }
 
-  def runRequest(req: Request): Task[Response] = Task.suspend[Response] {
+  def runRequest(req: Request, flushPrelude: Boolean): Task[Response] = Task.suspend[Response] {
     if (!stageState.compareAndSet(Idle, Running)) Task.fail(InProgressException)
-    else executeRequest(req)
+    else executeRequest(req, flushPrelude)
   }
 
   override protected def doParseContent(buffer: ByteBuffer): Option[ByteBuffer] = parser.doParseContent(buffer)
 
   override protected def contentComplete(): Boolean = parser.contentComplete()
 
-    private def executeRequest(req: Request): Task[Response] = {
+  private def executeRequest(req: Request, flushPrelude: Boolean): Task[Response] = {
     logger.debug(s"Beginning request: $req")
     validateRequest(req) match {
       case Left(e)    => Task.fail(e)
@@ -113,16 +113,24 @@ final class Http1ClientStage(userAgent: Option[`User-Agent`], protected val ec: 
           case None       => getHttpMinor(req) == 0
         }
 
-        val bodyTask = getChunkEncoder(req, mustClose, rr)
-                          .writeProcess(req.body)
-                          .handle { case EOF => () } // If we get a pipeline closed, we might still be good. Check response
+        val next: Task[StringWriter] = if (flushPrelude) {
+          // Write the prelude as a test and feed a ___fresh___ StringWriter forward
+          ???
+
+        } else Task.now(rr)
+
+        next.flatMap{ rr =>
+          val bodyTask = getChunkEncoder(req, mustClose, rr)
+            .writeProcess(req.body)
+            .handle { case EOF => () } // If we get a pipeline closed, we might still be good. Check response
         val respTask =  receiveResponse(mustClose)
 
-        Task.taskInstance.mapBoth(bodyTask, respTask)((_,r) => r)
-            .handleWith { case t => 
-                            fatalError(t, "Error executing request")
-                            Task.fail(t) 
-                        }
+          Task.taskInstance.mapBoth(bodyTask, respTask)((_,r) => r)
+            .handleWith { case t =>
+              fatalError(t, "Error executing request")
+              Task.fail(t)
+            }
+        }
       }
     }
   }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
@@ -1,6 +1,7 @@
 package org.http4s.client.blaze
 
 import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
 
@@ -13,6 +14,7 @@ import org.http4s.blaze.pipeline.Command.EOF
 import org.http4s.blaze.util.ProcessWriter
 import org.http4s.headers.{Host, `Content-Length`, `User-Agent`, Connection}
 import org.http4s.util.{Writer, StringWriter}
+import org.http4s.util.task.futureToTask
 
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
@@ -113,18 +115,28 @@ final class Http1ClientStage(userAgent: Option[`User-Agent`], protected val ec: 
           case None       => getHttpMinor(req) == 0
         }
 
-        val next: Task[StringWriter] = if (flushPrelude) {
-          // Write the prelude as a test and feed a ___fresh___ StringWriter forward
-          ???
+        val next: Task[StringWriter] = 
+          if (!flushPrelude) Task.now(rr)
+          else Task.async[StringWriter] { cb =>
+            val bb = ByteBuffer.wrap(rr.result().getBytes(StandardCharsets.ISO_8859_1))
+            channelWrite(bb).onComplete {
+              case Success(_)    => cb(\/-(new StringWriter))
+              case Failure(EOF)  => stageState.get match {
+                  case Idle | Running => shutdown(); cb(-\/(EOF))
+                  case Error(e)       => cb(-\/(e))
+                }
 
-        } else Task.now(rr)
+              case Failure(t)    =>
+                fatalError(t, s"Error during phase: flush prelude")
+                cb(-\/(t))
+            }(ec)
+          }
 
         next.flatMap{ rr =>
           val bodyTask = getChunkEncoder(req, mustClose, rr)
             .writeProcess(req.body)
             .handle { case EOF => () } // If we get a pipeline closed, we might still be good. Check response
-        val respTask =  receiveResponse(mustClose)
-
+          val respTask = receiveResponse(mustClose)
           Task.taskInstance.mapBoth(bodyTask, respTask)((_,r) => r)
             .handleWith { case t =>
               fatalError(t, "Error executing request")

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -129,7 +129,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 1500.millis)
       val c = mkClient(h, tail)(Duration.Inf, 1.second)
 
-      val result = tail.runRequest(FooRequest).as[String]
+      val result = tail.runRequest(FooRequest, false).as[String]
 
       c.prepare(FooRequest).as[String].run must throwA[TimeoutException]
     }
@@ -140,7 +140,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 1500.millis)
       val c = mkClient(h, tail)(1.second, Duration.Inf)
 
-      val result = tail.runRequest(FooRequest).as[String]
+      val result = tail.runRequest(FooRequest, false).as[String]
 
       c.prepare(FooRequest).as[String].run must throwA[TimeoutException]
     }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -43,7 +43,7 @@ class Http1ClientStageSpec extends Specification {
     })
     LeafBuilder(stage).base(h)
 
-    val result = new String(stage.runRequest(req)
+    val result = new String(stage.runRequest(req, false)
       .run
       .body
       .runLog
@@ -91,8 +91,8 @@ class Http1ClientStageSpec extends Specification {
       LeafBuilder(tail).base(h)
 
       try {
-        tail.runRequest(FooRequest).run  // we remain in the body
-        tail.runRequest(FooRequest).run must throwA[Http1ClientStage.InProgressException.type]
+        tail.runRequest(FooRequest, false).run  // we remain in the body
+        tail.runRequest(FooRequest, false).run must throwA[Http1ClientStage.InProgressException.type]
       }
       finally {
         tail.shutdown()
@@ -106,9 +106,9 @@ class Http1ClientStageSpec extends Specification {
         LeafBuilder(tail).base(h)
 
         // execute the first request and run the body to reset the stage
-        tail.runRequest(FooRequest).run.body.run.run
+        tail.runRequest(FooRequest, false).run.body.run.run
 
-        val result = tail.runRequest(FooRequest).run
+        val result = tail.runRequest(FooRequest, false).run
         tail.shutdown()
 
         result.headers.size must_== 1
@@ -126,7 +126,7 @@ class Http1ClientStageSpec extends Specification {
         val h = new SeqTestHead(List(mkBuffer(resp)))
         LeafBuilder(tail).base(h)
 
-        val result = tail.runRequest(FooRequest).run
+        val result = tail.runRequest(FooRequest, false).run
 
         result.body.run.run must throwA[InvalidBodyException]
       }


### PR DESCRIPTION
For fear of hitting a stale connection after consuming part of the body, we made no attempt to recycle requests with bodies.  With this change, we can verifying the connection health by writing the header before consuming any portion of the body.