### PR TITLE
Unseal the EntityDecoder trait

### DIFF
--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -27,7 +27,7 @@ import util.byteVector._
   * a streaming decoder by having the value of A be some kind of streaming construct.
   * @tparam T result type produced by the decoder
   */
-sealed trait EntityDecoder[T] { self =>
+trait EntityDecoder[T] { self =>
   /** Attempt to decode the body of the [[Message]] */
   def decode(msg: Message, strict: Boolean): DecodeResult[T]
 


### PR DESCRIPTION
Problem: The EntityDecoder trait is sealed, making it impossible to create EntityDecoder's that can access the message body.
Solution: Unseal it. The only reason to keep it sealed would be to allow totality checking with pattern matching but considering the problem EntityDecoder is intended to solve that seems like an highly improbably use case.

Mima reports no potential binary compatibilities with this PR.