### PR TITLE
Improve blaze-client's PooledManager

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BasicManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BasicManager.scala
@@ -8,7 +8,7 @@ import scalaz.concurrent.Task
 /* implementation bits for the basic client manager */
 private final class BasicManager (builder: ConnectionBuilder) extends ConnectionManager {
   override def getClient(request: Request, freshClient: Boolean): Task[BlazeClientStage] =
-    builder(request)
+    builder(RequestKey.fromRequest(request))
 
   override def shutdown(): Task[Unit] = Task(())
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BasicManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BasicManager.scala
@@ -7,12 +7,16 @@ import scalaz.concurrent.Task
 
 /* implementation bits for the basic client manager */
 private final class BasicManager (builder: ConnectionBuilder) extends ConnectionManager {
-  override def getClient(request: Request, freshClient: Boolean): Task[BlazeClientStage] =
-    builder(RequestKey.fromRequest(request))
+  override def withClient[A](request: Request)(f: BlazeClientStage => Task[A]): Task[A] = {
+    builder(RequestKey.fromRequest(request)).flatMap { stage =>
+      f(stage).onFinish { _ => Task.delay {
+        if (!stage.isClosed)
+          stage.shutdown()
+      }}
+    }
+  }
 
-  override def shutdown(): Task[Unit] = Task(())
-
-  override def recycleClient(request: Request, stage: BlazeClientStage): Unit = stage.shutdown()
+  override def shutdown(): Task[Unit] = Task.now(())
 }
 
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -16,7 +16,7 @@ final class BlazeClient(manager: ConnectionManager, idleTimeout: Duration, reque
   override def shutdown(): Task[Unit] = manager.shutdown()
 
   override def prepare(req: Request): Task[Response] = Task.suspend {
-    def tryClient(client: BlazeClientStage, freshClient: Boolean, flushPrelude: Boolean): Task[Response] = {
+    def tryClient(flushPrelude: Boolean)(client: BlazeClientStage): Task[Response] = {
       // Add the timeout stage to the pipeline
       val ts = new ClientTimeoutStage(idleTimeout, requestTimeout, bits.ClientTickWheel)
       client.spliceBefore(ts)
@@ -27,13 +27,12 @@ final class BlazeClient(manager: ConnectionManager, idleTimeout: Duration, reque
           val recycleProcess = eval_(Task.delay {
             if (!client.isClosed()) {
               ts.removeStage
-              manager.recycleClient(req, client)
             }
           })
           Task.now(r.copy(body = r.body.onComplete(recycleProcess)))
 
-        case -\/(Command.EOF) if !freshClient =>
-          manager.getClient(req, freshClient = true).flatMap(tryClient(_, true, flushPrelude))
+        case -\/(Command.EOF) =>
+          manager.withClient(req)(tryClient(flushPrelude))
 
         case -\/(e) =>
           if (!client.isClosed()) client.shutdown()
@@ -42,7 +41,7 @@ final class BlazeClient(manager: ConnectionManager, idleTimeout: Duration, reque
     }
 
     val flushPrelude = !req.body.isHalt
-    manager.getClient(req, false).flatMap(tryClient(_, false, flushPrelude))
+    manager.withClient(req)(tryClient(flushPrelude))
   }
 }
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientStage.scala
@@ -10,7 +10,6 @@ import org.http4s.{Request, Response}
 import scalaz.concurrent.Task
 
 trait BlazeClientStage extends TailStage[ByteBuffer] {
-
   /** Create a computation that will turn the [[Request]] into a [[Response]] */
   @deprecated("0.11.2", "Overload preserved for binary compatibility. Use runRequest(Request, Boolean).")
   def runRequest(req: Request): Task[Response]

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
@@ -1,6 +1,7 @@
 package org.http4s.client.blaze
 
 import org.http4s.Request
+import org.http4s.Uri.{Scheme, Authority}
 
 import scalaz.concurrent.Task
 
@@ -12,7 +13,6 @@ import scalaz.concurrent.Task
   * must have a mechanism to free resources associated with it.
   */
 trait ConnectionManager {
-
   /** Shutdown this client, closing any open connections and freeing resources */
   def shutdown(): Task[Unit]
 
@@ -41,9 +41,10 @@ object ConnectionManager {
 
   /** Create a [[ConnectionManager]] that will attempt to recycle connections
     *
-    * @param maxPooledConnections max pool size before connections are closed
     * @param builder generator of new connections
+    * @param maxTotal max total connections
+    * @param maxPerKey max connections per request key
     */
-  def pool(maxPooledConnections: Int, builder: ConnectionBuilder): ConnectionManager =
-    new PoolManager(maxPooledConnections, builder)
+  def pool(builder: ConnectionBuilder, maxTotal: Int, maxPerKey: Int): ConnectionManager =
+    new PoolManager(builder, maxTotal, maxPerKey)
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
@@ -16,19 +16,9 @@ trait ConnectionManager {
   /** Shutdown this client, closing any open connections and freeing resources */
   def shutdown(): Task[Unit]
 
-  /** Get a connection to the provided address
-    * @param request [[Request]] to connect too
-    * @param freshClient if the client should force a new connection
-    * @return a Future with the connected [[BlazeClientStage]] of a blaze pipeline
+   /** Execute a block of code with a (possibly pooled) blaze client stage.
     */
-  def getClient(request: Request, freshClient: Boolean): Task[BlazeClientStage]
-  
-  /** Recycle or close the connection
-    * Allow for smart reuse or simple closing of a connection after the completion of a request
-    * @param request [[Request]] to connect too
-    * @param stage the [[BlazeClientStage]] which to deal with
-    */
-  def recycleClient(request: Request, stage: BlazeClientStage): Unit
+  def withClient[A](request: Request)(f: BlazeClientStage => Task[A]): Task[A]
 }
 
 object ConnectionManager {
@@ -43,8 +33,7 @@ object ConnectionManager {
     *
     * @param builder generator of new connections
     * @param maxTotal max total connections
-    * @param maxPerKey max connections per request key
     */
-  def pool(builder: ConnectionBuilder, maxTotal: Int, maxPerKey: Int): ConnectionManager =
-    new PoolManager(builder, maxTotal, maxPerKey)
+  def pool(builder: ConnectionBuilder, maxTotal: Int): ConnectionManager =
+    new PoolManager(builder, maxTotal)
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
@@ -1,62 +1,146 @@
 package org.http4s.client.blaze
 
-import java.nio.ByteBuffer
+import java.util
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
-import org.apache.commons.pool2.{PooledObject, BaseKeyedPooledObjectFactory}
-import org.apache.commons.pool2.impl.{GenericKeyedObjectPoolConfig, DefaultPooledObject, GenericKeyedObjectPool}
 import org.http4s.Request
-import org.http4s.Uri.{Authority, Scheme}
-import org.http4s.blaze.pipeline.Command.InboundCommand
 import org.log4s.getLogger
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future, Promise}
-import scalaz.concurrent.Task
+import scala.collection.mutable
+import scalaz.{-\/, \/-, \/}
+import scalaz.syntax.either._
+import scalaz.concurrent.{Actor, Task}
 
-/* implementation bits for the pooled client manager */
+private object PoolManager {
+  type Callback[A] = Throwable \/ A => Unit
+  sealed trait Protocol
+  case class RequestConnection(key: RequestKey, callback: Callback[BlazeClientStage]) extends Protocol
+  case class ReturnConnection(key: RequestKey, stage: BlazeClientStage) extends Protocol
+  case class DisposeConnection(key: RequestKey) extends Protocol
+  case class Shutdown(callback: Callback[Unit]) extends Protocol
+}
+import PoolManager._
+
 private final class PoolManager(builder: ConnectionBuilder,
-                                maxTotal: Int,
-                                maxTotalPerKey: Int)
-  extends ConnectionManager
-{
+                                maxTotal: Int)
+  extends ConnectionManager {
+
   private[this] val logger = getLogger
+  private var isClosed = false
+  private var allocated = 0
+  private val idleQueue = new mutable.Queue[BlazeClientStage]
+  private val waitQueue = new mutable.Queue[Callback[BlazeClientStage]]()
 
-  private def closed = pool.isClosed
+  private def stats =
+    s"allocated=${allocated} idleQueue.size=${idleQueue.size} waitQueue.size=${waitQueue.size}"
 
-  private val pool = {
-    val factory = new BaseKeyedPooledObjectFactory[RequestKey, BlazeClientStage] {
-      override def wrap(value: BlazeClientStage) = new DefaultPooledObject(value)
-      override def create(key: RequestKey) = builder(key)./*gulp*/run/*gulp*/
-      override def validateObject(key: RequestKey, p: PooledObject[BlazeClientStage]): Boolean =
-        !p.getObject.isClosed
-      override def destroyObject(key: RequestKey, p: PooledObject[BlazeClientStage]): Unit =
-        p.getObject.shutdown()
+  private def createConnection(key: RequestKey): Unit = {
+    if (allocated < maxTotal) {
+      allocated += 1
+      logger.debug(s"Creating connection: ${stats}")
+      Task.fork(builder(key)).runAsync {
+        case \/-(stage) =>
+          logger.debug(s"Submitting fresh connection to pool: ${stats}")
+          actor ! ReturnConnection(key, stage)
+        case -\/(t) =>
+          logger.error(t)("Error establishing client connection")
+          actor ! DisposeConnection(key)
+      }
     }
-    val config = new GenericKeyedObjectPoolConfig
-    config.setMaxTotal(maxTotal)
-    config.setMaxTotalPerKey(maxTotalPerKey)
-    config.setTestOnBorrow(true)
-    new GenericKeyedObjectPool[RequestKey, BlazeClientStage](factory)
+    else {
+      logger.debug(s"Too many connections open.  Can't create a connection: ${stats}")
+    }
+  }
+
+  private val actor = Actor[Protocol] {
+    case RequestConnection(key, callback) =>
+      logger.debug(s"Requesting connection: ${stats}")
+      if (!isClosed) {
+        def go(): Unit = {
+          if (idleQueue.nonEmpty) {
+            idleQueue.dequeue() match {
+              case stage if !stage.isClosed =>
+                logger.debug(s"Recycling connection: ${stats}")
+                callback(stage.right)
+              case closedStage =>
+                logger.debug(s"Evicting closed connection: ${stats}")
+                allocated -= 1
+                go()
+            }
+          }
+          else {
+            logger.debug(s"No connections available.  Waiting on new connection: ${stats}")
+            createConnection(key)
+            waitQueue.enqueue(callback)
+          }
+        }
+        go()
+      }
+      else
+        callback(new IllegalStateException("Connection pool is closed").left)
+
+    case ReturnConnection(key, stage) =>
+      logger.debug(s"Reallocating connection: ${stats}")
+      if (!isClosed) {
+        if (!stage.isClosed) {
+          if (waitQueue.nonEmpty) {
+            logger.debug(s"Fulfilling waiting connection request: ${stats}")
+            waitQueue.dequeue.apply(stage.right)
+          }
+          else {
+            logger.debug(s"Returning idle connection to pool: ${stats}")
+            idleQueue.enqueue(stage)
+          }
+        }
+        else if (waitQueue.nonEmpty) {
+          logger.debug(s"Replacing closed connection: ${stats}")
+          allocated -= 1
+          createConnection(key)
+        }
+        else {
+          logger.debug(s"Connection was closed, but nothing to do. Shrinking pool: ${stats}")
+          allocated -= 1
+        }
+      }
+      else if (!stage.isClosed) {
+        logger.debug(s"Shutting down connection after pool closure: ${stats}")
+        stage.shutdown()
+        allocated -= 1
+      }
+
+    case DisposeConnection(key) =>
+      logger.debug(s"Disposing of connection after failure: ${stats}")
+      allocated -= 1
+      if (!isClosed && waitQueue.nonEmpty) {
+        logger.debug(s"Replacing failed connection: ${stats}")
+        createConnection(key)
+      }
+
+    case Shutdown(callback) =>
+      callback(\/.fromTryCatchNonFatal {
+        logger.info(s"Shutting down connection pool: ${stats}")
+        if (!isClosed) {
+          isClosed = true
+          idleQueue.foreach(_.shutdown())
+          allocated = 0
+        }
+      })
   }
 
   /** Shutdown this client, closing any open connections and freeing resources */
-  override def shutdown(): Task[Unit] = Task.delay {
-    pool.close()
-  }
+  override def shutdown(): Task[Unit] =
+    Task.async(actor ! Shutdown(_))
 
-  override def recycleClient(request: Request, stage: BlazeClientStage): Unit = {
+  /** Execute a block of code with a (possibly pooled) blaze client stage.
+    */
+  override def withClient[A](request: Request)(f: (BlazeClientStage) => Task[A]): Task[A] = {
     val key = RequestKey.fromRequest(request)
-    logger.debug(s"Returning connection to ${key}.")
-    pool.returnObject(key, stage)
-  }
-
-  override def getClient(request: Request, ignored: Boolean): Task[BlazeClientStage] = Task.suspend {
-    if (closed) Task.fail(new Exception("Client is closed"))
-    else {
-      val key = RequestKey.fromRequest(request)
-      Task {
-        logger.debug(s"Borrowing connection to ${key}.")
-        pool.borrowObject(key)
+    Task.async[BlazeClientStage](actor ! RequestConnection(key, _)).flatMap { stage =>
+      f(stage).onFinish {
+        case None =>
+          Task.delay(actor ! ReturnConnection(key, stage))
+        case Some(t) =>
+          Task.delay(actor ! DisposeConnection(key))
       }
     }
   }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -13,7 +13,8 @@ import scala.concurrent.duration.Duration
 object PooledHttp1Client {
 
   /** Construct a new PooledHttp1Client */
-  def apply(maxPooledConnections: Int = 10,
+  def apply(maxConnectionsPerKey: Int = 10,
+             maxTotalConnections: Int = 10,
                      idleTimeout: Duration = bits.DefaultTimeout,
                   requestTimeout: Duration = Duration.Inf,
                        userAgent: Option[`User-Agent`] = bits.DefaultUserAgent,
@@ -23,7 +24,7 @@ object PooledHttp1Client {
           endpointAuthentication: Boolean = true,
                            group: Option[AsynchronousChannelGroup] = None) = {
     val http1 = Http1Support(bufferSize, userAgent, executor, sslContext, endpointAuthentication, group)
-    val pool = ConnectionManager.pool(maxPooledConnections, http1)
+    val pool = ConnectionManager.pool(http1, maxTotalConnections, maxConnectionsPerKey)
     new BlazeClient(pool, idleTimeout, requestTimeout)
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -13,8 +13,7 @@ import scala.concurrent.duration.Duration
 object PooledHttp1Client {
 
   /** Construct a new PooledHttp1Client */
-  def apply(maxConnectionsPerKey: Int = 10,
-             maxTotalConnections: Int = 10,
+  def apply( maxTotalConnections: Int = 10,
                      idleTimeout: Duration = bits.DefaultTimeout,
                   requestTimeout: Duration = Duration.Inf,
                        userAgent: Option[`User-Agent`] = bits.DefaultUserAgent,
@@ -24,7 +23,7 @@ object PooledHttp1Client {
           endpointAuthentication: Boolean = true,
                            group: Option[AsynchronousChannelGroup] = None) = {
     val http1 = Http1Support(bufferSize, userAgent, executor, sslContext, endpointAuthentication, group)
-    val pool = ConnectionManager.pool(http1, maxTotalConnections, maxConnectionsPerKey)
+    val pool = ConnectionManager.pool(http1, maxTotalConnections)
     new BlazeClient(pool, idleTimeout, requestTimeout)
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/RequestKey.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/RequestKey.scala
@@ -1,0 +1,17 @@
+package org.http4s.client.blaze
+
+import org.http4s.Request
+import org.http4s.Uri.{Authority, Scheme}
+import org.http4s.util.string._
+
+/**
+  * Created by ross on 12/8/15.
+  */
+case class RequestKey(scheme: Scheme, authority: Authority)
+
+object RequestKey {
+  def fromRequest(request: Request): RequestKey = {
+    val uri = request.uri
+    RequestKey(uri.scheme.getOrElse("http".ci), uri.authority.getOrElse(Authority()))
+  }
+}

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
@@ -1,18 +1,22 @@
 package org.http4s
 package client
 
+import java.nio.ByteBuffer
+
+import org.http4s.Uri.{Scheme, Authority}
+import org.http4s.blaze.pipeline.TailStage
+
 import scalaz.concurrent.Task
 
 
 package object blaze {
-
   /** Factory function for new client connections.
     *
     * The connections must be 'fresh' in the sense that they are newly created
     * and failure of the resulting client stage is a sign of connection trouble
     * not due to typical timeouts etc.
     */
-  type ConnectionBuilder = Request => Task[BlazeClientStage]
+  type ConnectionBuilder = RequestKey => Task[BlazeClientStage]
 
   /** Default blaze client
     *

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,6 @@ lazy val blazeServer = libraryProject("blaze-server")
 lazy val blazeClient = libraryProject("blaze-client")
   .settings(
     description := "blaze implementation for http4s clients",
-    libraryDependencies += commonsPool2
   )
   .dependsOn(blazeCore % "compile;test->test", client % "compile;test->test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val blazeServer = libraryProject("blaze-server")
 
 lazy val blazeClient = libraryProject("blaze-client")
   .settings(
-    description := "blaze implementation for http4s clients",
+    description := "blaze implementation for http4s clients"
   )
   .dependsOn(blazeCore % "compile;test->test", client % "compile;test->test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,8 @@ lazy val blazeServer = libraryProject("blaze-server")
 
 lazy val blazeClient = libraryProject("blaze-client")
   .settings(
-    description := "blaze implementation for http4s clients"
+    description := "blaze implementation for http4s clients",
+    libraryDependencies += commonsPool2
   )
   .dependsOn(blazeCore % "compile;test->test", client % "compile;test->test")
 

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -46,6 +46,7 @@ object Http4sBuild extends Build {
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.4.v20150727"
   lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.10.0"
   lazy val circeJawn           = "io.circe"                 %% "circe-jawn"              % "0.2.0"
+  lazy val commonsPool2        = "org.apache.commons"        % "commons-pool2"           % "2.4.2"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"
   lazy val gatlingHighCharts   = "io.gatling.highcharts"     % "gatling-charts-highcharts" % gatlingTest.revision
   lazy val http4sWebsocket     = "org.http4s"               %% "http4s-websocket"        % "0.1.3"

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -22,8 +22,9 @@ object Http4sBuild extends Build {
 
   def nexusRepoFor(version: String): Resolver = {
     val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot(version))
-      "snapshots" at s"$nexus/content/repositories/snapshots"
+    if (isSnapshot(version)) 
+      //"snapshots" at s"$nexus/content/repositories/snapshots"
+      Resolver.file("file", new File(Path.userHome.absolutePath+"/.m2/repository"))
     else
       "releases" at s"$nexus/service/local/staging/deploy/maven2"
   }
@@ -46,7 +47,6 @@ object Http4sBuild extends Build {
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.4.v20150727"
   lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.10.0"
   lazy val circeJawn           = "io.circe"                 %% "circe-jawn"              % "0.2.0"
-  lazy val commonsPool2        = "org.apache.commons"        % "commons-pool2"           % "2.4.2"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"
   lazy val gatlingHighCharts   = "io.gatling.highcharts"     % "gatling-charts-highcharts" % gatlingTest.revision
   lazy val http4sWebsocket     = "org.http4s"               %% "http4s-websocket"        % "0.1.3"


### PR DESCRIPTION
This uses a Scalaz Actor to maintain a pool with a strict cap on connections.  The wait queue is unbounded, which is probably not desirable.

The next step would be to maintain a sub pool per key to restrict connections to a particular client.