### PR TITLE
Add HTTP 451 Unavailable For Legal Reasons status

### DIFF
--- a/core/src/main/scala/org/http4s/Status.scala
+++ b/core/src/main/scala/org/http4s/Status.scala
@@ -131,6 +131,7 @@ object Status {
   val PreconditionRequired = register(Status(428)("Precondition Required"))
   val TooManyRequests = register(Status(429)("Too Many Requests"))
   val RequestHeaderFieldsTooLarge = register(Status(431)("Request Header Fields Too Large"))
+  val UnavailableForLegalReasons = register(Status(451)("Unavailable For Legal Reasons"))
 
   val InternalServerError = register(Status(500)("Internal Server Error"))
   val NotImplemented = register(Status(501)("Not Implemented"))

--- a/dsl/src/main/scala/org/http4s/dsl/package.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/package.scala
@@ -129,7 +129,7 @@ package object dsl extends Http4s {
   implicit class PreconditionRequiredSyntax(val status: PreconditionRequired.type) extends AnyVal with EntityResponseGenerator
   implicit class TooManyRequestsSyntax(val status: TooManyRequests.type) extends AnyVal with EntityResponseGenerator
   implicit class RequestHeaderFieldsTooLargeSyntax(val status: RequestHeaderFieldsTooLarge.type) extends AnyVal with EntityResponseGenerator
-  implicit class UnavailableForLegalReasons(val status: UnavailableForLegalReasons.type) extends AnyVal with EntityResponseGenerator
+  implicit class UnavailableForLegalReasonsSyntax(val status: UnavailableForLegalReasons.type) extends AnyVal with EntityResponseGenerator
 
   implicit class InternalServerErrorSyntax(val status: InternalServerError.type) extends AnyVal with EntityResponseGenerator
   implicit class NotImplementedSyntax(val status: NotImplemented.type) extends AnyVal with EntityResponseGenerator

--- a/dsl/src/main/scala/org/http4s/dsl/package.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/package.scala
@@ -63,6 +63,7 @@ package object dsl extends Http4s {
   val PreconditionRequired: Status.PreconditionRequired.type = Status.PreconditionRequired
   val TooManyRequests: Status.TooManyRequests.type = Status.TooManyRequests
   val RequestHeaderFieldsTooLarge: Status.RequestHeaderFieldsTooLarge.type = Status.RequestHeaderFieldsTooLarge
+  val UnavailableForLegalReasons: Status.UnavailableForLegalReasons.type = Status.UnavailableForLegalReasons
 
   val InternalServerError: Status.InternalServerError.type = Status.InternalServerError
   val NotImplemented: Status.NotImplemented.type = Status.NotImplemented

--- a/dsl/src/main/scala/org/http4s/dsl/package.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/package.scala
@@ -129,6 +129,7 @@ package object dsl extends Http4s {
   implicit class PreconditionRequiredSyntax(val status: PreconditionRequired.type) extends AnyVal with EntityResponseGenerator
   implicit class TooManyRequestsSyntax(val status: TooManyRequests.type) extends AnyVal with EntityResponseGenerator
   implicit class RequestHeaderFieldsTooLargeSyntax(val status: RequestHeaderFieldsTooLarge.type) extends AnyVal with EntityResponseGenerator
+  implicit class UnavailableForLegalReasons(val status: UnavailableForLegalReasons.type) extends AnyVal with EntityResponseGenerator
 
   implicit class InternalServerErrorSyntax(val status: InternalServerError.type) extends AnyVal with EntityResponseGenerator
   implicit class NotImplementedSyntax(val status: NotImplemented.type) extends AnyVal with EntityResponseGenerator


### PR DESCRIPTION
HTTP 451was approved by the IESG on December 18, 2015.
https://en.wikipedia.org/wiki/HTTP_451