### PR TITLE
Bump blaze dependencies to 0.11-SNAPSHOT

### DIFF
--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -44,7 +44,7 @@ object Http4sBuild extends Build {
   }
 
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.4.v20150727"
-  lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.10.0"
+  lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.11.0-SNAPSHOT"
   lazy val circeJawn           = "io.circe"                 %% "circe-jawn"              % "0.2.0"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"
   lazy val gatlingHighCharts   = "io.gatling.highcharts"     % "gatling-charts-highcharts" % gatlingTest.revision


### PR DESCRIPTION
There are quite a few (good) things happening in blaze master to in order to keep track of the fallout I would like to bump http4s master to depend on teh blaze master snapshots.