### PR TITLE
Add a `bug` constructor for when the type system lets us down.

### DIFF
--- a/core/src/main/scala/org/http4s/util/package.scala
+++ b/core/src/main/scala/org/http4s/util/package.scala
@@ -43,4 +43,8 @@ package object util {
 
     go() onComplete flush()
   }
+
+  /** Constructs an assertion error with a reference back to our issue tracker. Use only with head hung low. */
+  def bug(message: String): AssertionError =
+    new AssertionError(s"This is a bug. Please report to https://github.com/http4s/http4s/issues: ${message}")
 }


### PR DESCRIPTION
Instead of throwing IllegalStateExceptions, make them more
fatal in nature, with a nice link to our bug tracker.

Bonus: get rid of the null sentinel in the servlet reader.