### PR TITLE
add missing '&' between multivalued k/v pairs in UrlFormCodec.encode

### DIFF
--- a/core/src/main/scala/org/http4s/util/UrlFormCodec.scala
+++ b/core/src/main/scala/org/http4s/util/UrlFormCodec.scala
@@ -17,10 +17,18 @@ object UrlFormCodec {
       if (sb.nonEmpty) sb.append('&')
 
       if (vs.isEmpty) sb.append(formEncode(k))
-      else vs.foreach { v =>
-        sb.append(formEncode(k))
-          .append('=')
-          .append(formEncode(v))
+      else {
+        def addKvPair(v: String): Unit = {
+          sb.append(formEncode(k))
+            .append('=')
+            .append(formEncode(v))
+        }
+
+        addKvPair(vs.head)
+        vs.tail.foreach { v =>
+          sb.append('&')
+          addKvPair(v)
+        }
       }
     }
 

--- a/core/src/test/scala/org/http4s/util/UrlFormCodecSpec.scala
+++ b/core/src/test/scala/org/http4s/util/UrlFormCodecSpec.scala
@@ -1,0 +1,11 @@
+package org.http4s.util
+
+import org.specs2.{ScalaCheck, Specification}
+
+class UrlFormCodecSpec extends Specification with ScalaCheck {
+  def is = s2"""
+    UrlFormCodec.encode should include & in multi-valued attributes ${
+      UrlFormCodec.encode(Map("foo" -> Seq("a", "b"))) should_== "foo=a&foo=b"
+    }
+  """
+}


### PR DESCRIPTION
`org.http4s.util.UrlFormCodec.encode(Map("foo" -> Seq("a", "b")))` should return `"foo=a&foo=b"`.  Without this patch, it returns `"foo=afoo=b"`.