### PR TITLE
Topic/blaze server cleanup

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
@@ -28,7 +28,7 @@ import scalaz.{\/, -\/, \/-}
 
 
 final class Http1ClientStage(userAgent: Option[`User-Agent`], protected val ec: ExecutionContext)
-  extends Http1Stage(-1) with BlazeClientStage
+  extends Http1Stage with BlazeClientStage
 {
   import org.http4s.client.blaze.Http1ClientStage._
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1ClientStage.scala
@@ -28,7 +28,7 @@ import scalaz.{\/, -\/, \/-}
 
 
 final class Http1ClientStage(userAgent: Option[`User-Agent`], protected val ec: ExecutionContext)
-  extends BlazeClientStage with Http1Stage
+  extends Http1Stage(-1) with BlazeClientStage
 {
   import org.http4s.client.blaze.Http1ClientStage._
 

--- a/blaze-core/src/test/scala/org/http4s/blaze/TestHead.scala
+++ b/blaze-core/src/test/scala/org/http4s/blaze/TestHead.scala
@@ -43,6 +43,7 @@ class SeqTestHead(body: Seq[ByteBuffer]) extends TestHead("SeqTestHead") {
   override def readRequest(size: Int): Future[ByteBuffer] = synchronized {
     if (!closed && bodyIt.hasNext) Future.successful(bodyIt.next())
     else {
+      stageShutdown()
       sendInboundCommand(Disconnected)
       Future.failed(EOF)
     }

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -119,7 +119,7 @@ class BlazeBuilder(
 
           val l1 =
             if (isHttp2Enabled) LeafBuilder(ProtocolSelector(eng, aggregateService, 4*1024, requestAttrs, serviceExecutor))
-            else LeafBuilder(Http1ServerStage(aggregateService, requestAttrs, serviceExecutor, enableWebSockets))
+            else LeafBuilder(Http1ServerStage(aggregateService, requestAttrs, Http1ServerStage.defaultMaxDrain, serviceExecutor, enableWebSockets))
 
           val l2 = if (idleTimeout.isFinite) l1.prepend(new QuietTimeoutStage[ByteBuffer](idleTimeout))
                    else l1
@@ -143,7 +143,7 @@ class BlazeBuilder(
             }
             requestAttrs
           }
-          val leaf = LeafBuilder(Http1ServerStage(aggregateService, requestAttrs, serviceExecutor, enableWebSockets))
+          val leaf = LeafBuilder(Http1ServerStage(aggregateService, requestAttrs, Http1ServerStage.defaultMaxDrain, serviceExecutor, enableWebSockets))
           if (idleTimeout.isFinite) leaf.prepend(new QuietTimeoutStage[ByteBuffer](idleTimeout))
           else leaf
         }

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -119,7 +119,7 @@ class BlazeBuilder(
 
           val l1 =
             if (isHttp2Enabled) LeafBuilder(ProtocolSelector(eng, aggregateService, 4*1024, requestAttrs, serviceExecutor))
-            else LeafBuilder(Http1ServerStage(aggregateService, requestAttrs, Http1ServerStage.defaultMaxDrain, serviceExecutor, enableWebSockets))
+            else LeafBuilder(Http1ServerStage(aggregateService, requestAttrs, serviceExecutor, enableWebSockets))
 
           val l2 = if (idleTimeout.isFinite) l1.prepend(new QuietTimeoutStage[ByteBuffer](idleTimeout))
                    else l1
@@ -143,7 +143,7 @@ class BlazeBuilder(
             }
             requestAttrs
           }
-          val leaf = LeafBuilder(Http1ServerStage(aggregateService, requestAttrs, Http1ServerStage.defaultMaxDrain, serviceExecutor, enableWebSockets))
+          val leaf = LeafBuilder(Http1ServerStage(aggregateService, requestAttrs, serviceExecutor, enableWebSockets))
           if (idleTimeout.isFinite) leaf.prepend(new QuietTimeoutStage[ByteBuffer](idleTimeout))
           else leaf
         }

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerParser.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerParser.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable.ListBuffer
 import scalaz.\/
 
 
-final class Http1ServerParser(logger: Logger) extends blaze.http.http_parser.Http1ServerParser {
+private final class Http1ServerParser(logger: Logger) extends blaze.http.http_parser.Http1ServerParser {
 
   private var uri: String = null
   private var method: String = null

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerParser.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerParser.scala
@@ -1,0 +1,64 @@
+package org.http4s
+package server.blaze
+
+import java.nio.ByteBuffer
+
+import org.log4s.Logger
+
+import scala.collection.mutable.ListBuffer
+import scalaz.\/
+
+
+final class Http1ServerParser(logger: Logger) extends blaze.http.http_parser.Http1ServerParser {
+
+  private var uri: String = null
+  private var method: String = null
+  private var minor: Int = -1
+  private var major: Int = -1
+  private val headers = new ListBuffer[Header]
+
+  def minorVersion(): Int = minor
+
+  def doParseRequestLine(buff: ByteBuffer): Boolean = parseRequestLine(buff)
+
+  def doParseHeaders(buff: ByteBuffer): Boolean = parseHeaders(buff)
+
+  def doParseContent(buff: ByteBuffer): Option[ByteBuffer] = Option(parseContent(buff))
+
+  def collectMessage(body: EntityBody, attrs: AttributeMap): (ParseFailure,HttpVersion)\/Request = {
+    val h = Headers(headers.result())
+    headers.clear()
+    val protocol = if (minorVersion() == 1) HttpVersion.`HTTP/1.1` else HttpVersion.`HTTP/1.0`
+
+    (for {
+      method <- Method.fromString(this.method)
+      uri <- Uri.requestTarget(this.uri)
+    } yield Request(method, uri, protocol, h, body, attrs)
+    ).leftMap(_ -> protocol)
+  }
+
+  override def submitRequestLine(methodString: String, uri: String, scheme: String, majorversion: Int, minorversion: Int): Boolean = {
+    logger.trace(s"Received request($methodString $uri $scheme/$majorversion.$minorversion)")
+    this.uri = uri
+    this.method = methodString
+    this.major = majorversion
+    this.minor = minorversion
+    false
+  }
+
+  /////////////////// Stateful methods for the HTTP parser ///////////////////
+  override protected def headerComplete(name: String, value: String) = {
+    logger.trace(s"Received header '$name: $value'")
+    headers += Header(name, value)
+    false
+  }
+
+  override def reset(): Unit = {
+    uri = null
+    method = null
+    minor = -1
+    major = -1
+    headers.clear()
+    super.reset()
+  }
+}

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -10,8 +10,6 @@ import org.http4s.blaze.util.BodylessWriter
 import org.http4s.blaze.util.Execution._
 import org.http4s.blaze.util.BufferTools.emptyBuffer
 import org.http4s.blaze.http.http_parser.BaseExceptions.{BadRequest, ParserException}
-import org.http4s.blaze.http.http_parser.Http1ServerParser
-import org.http4s.blaze.channel.SocketConnection
 
 import org.http4s.util.StringWriter
 import org.http4s.util.CaseInsensitiveString._
@@ -20,7 +18,6 @@ import org.http4s.headers.{Connection, `Content-Length`}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{Try, Success, Failure}
 
@@ -42,26 +39,23 @@ object Http1ServerStage {
 class Http1ServerStage(service: HttpService,
                        requestAttrs: AttributeMap,
                        pool: ExecutorService)
-                  extends Http1ServerParser
-                  with TailStage[ByteBuffer]
+                  extends TailStage[ByteBuffer]
                   with Http1Stage
 {
   // micro-optimization: unwrap the service and call its .run directly
   private[this] val serviceFn = service.run
+  private[this] val parser = new Http1ServerParser(logger)
 
   protected val ec = ExecutionContext.fromExecutorService(pool)
 
   val name = "Http4sServerStage"
 
-  private var uri: String = null
-  private var method: String = null
-  private var minor: Int = -1
-  private var major: Int = -1
-  private val headers = new ListBuffer[Header]
-
   logger.trace(s"Http4sStage starting up")
 
-  final override protected def doParseContent(buffer: ByteBuffer): Option[ByteBuffer] = Option(parseContent(buffer))
+  final override protected def doParseContent(buffer: ByteBuffer): Option[ByteBuffer] =
+    parser.doParseContent(buffer)
+
+  final override protected def contentComplete(): Boolean = parser.contentComplete()
 
   // Will act as our loop
   override def stageStartup() {
@@ -84,11 +78,11 @@ class Http1ServerStage(service: HttpService,
       }
 
       try {
-        if (!requestLineComplete() && !parseRequestLine(buff)) {
+        if (!parser.requestLineComplete() && !parser.doParseRequestLine(buff)) {
           requestLoop()
           return
         }
-        if (!headersComplete() && !parseHeaders(buff)) {
+        if (!parser.headersComplete() && !parser.doParseHeaders(buff)) {
           requestLoop()
           return
         }
@@ -104,33 +98,18 @@ class Http1ServerStage(service: HttpService,
     case Failure(t)       => fatalError(t, "Error in requestLoop()")
   }
 
-  final protected def collectMessage(body: EntityBody): Option[Request] = {
-    val h = Headers(headers.result())
-    headers.clear()
-    val protocol = if (minor == 1) HttpVersion.`HTTP/1.1` else HttpVersion.`HTTP/1.0`
-
-    (for {
-      method <- Method.fromString(this.method)
-      uri <- Uri.requestTarget(this.uri)
-    } yield Some(Request(method, uri, protocol, h, body, requestAttrs))
-    ).valueOr { e =>
-      badMessage(e.details, new BadRequest(e.sanitized), Request().copy(httpVersion = protocol))
-      None
-    }
-  }
-
   private def runRequest(buffer: ByteBuffer): Unit = {
     val (body, cleanup) = collectBodyFromParser(buffer, () => InvalidBodyException("Received premature EOF."))
 
-    collectMessage(body) match {
-      case Some(req) =>
+    parser.collectMessage(body, requestAttrs) match {
+      case \/-(req) =>
         Task.fork(serviceFn(req))(pool)
           .runAsync {
           case \/-(resp) => renderResponse(req, resp, cleanup)
           case -\/(t)    => internalServerError(s"Error running route: $req", t, req, cleanup)
         }
 
-      case None => // NOOP, this should be handled in the collectMessage method
+      case -\/((e,protocol)) => badMessage(e.details, new BadRequest(e.sanitized), Request().copy(httpVersion = protocol))
     }
   }
 
@@ -144,7 +123,7 @@ class Http1ServerStage(service: HttpService,
     // Need to decide which encoder and if to close on finish
     val closeOnFinish = respConn.map(_.hasClose).orElse {
                           Connection.from(req.headers).map(checkCloseConnection(_, rr))
-                        }.getOrElse(minor == 0)   // Finally, if nobody specifies, http 1.0 defaults to close
+                        }.getOrElse(parser.minorVersion() == 0)   // Finally, if nobody specifies, http 1.0 defaults to close
 
     // choose a body encoder. Will add a Transfer-Encoding header if necessary
     val lengthHeader = `Content-Length`.from(resp.headers)
@@ -161,13 +140,13 @@ class Http1ServerStage(service: HttpService,
         }
 
         // add KeepAlive to Http 1.0 responses if the header isn't already present
-        if (!closeOnFinish && minor == 0 && respConn.isEmpty) rr << "Connection:keep-alive\r\n\r\n"
+        if (!closeOnFinish && parser.minorVersion() == 0 && respConn.isEmpty) rr << "Connection:keep-alive\r\n\r\n"
         else rr << "\r\n"
 
         val b = ByteBuffer.wrap(rr.result().getBytes(StandardCharsets.ISO_8859_1))
         new BodylessWriter(b, this, closeOnFinish)(ec)
       }
-      else getEncoder(respConn, respTransferCoding, lengthHeader, resp.trailerHeaders, rr, minor, closeOnFinish)
+      else getEncoder(respConn, respTransferCoding, lengthHeader, resp.trailerHeaders, rr, parser.minorVersion(), closeOnFinish)
     }
 
     bodyEncoder.writeProcess(resp.body).runAsync {
@@ -177,7 +156,7 @@ class Http1ServerStage(service: HttpService,
           logger.trace("Request/route requested closing connection.")
         } else bodyCleanup().onComplete {
           case s@ Success(_) => // Serve another request using s
-            reset()
+            parser.reset()
             reqLoopCallback(s)
 
           case Failure(EOF) => closeConnection()
@@ -202,7 +181,7 @@ class Http1ServerStage(service: HttpService,
 
   override protected def stageShutdown(): Unit = {
     logger.debug("Shutting down HttpPipeline")
-    shutdownParser()
+    parser.shutdownParser()
     super.stageShutdown()
   }
 
@@ -218,25 +197,5 @@ class Http1ServerStage(service: HttpService,
     logger.error(t)(errorMsg)
     val resp = Response(Status.InternalServerError).replaceAllHeaders(Connection("close".ci), `Content-Length`(0))
     renderResponse(req, resp, bodyCleanup)  // will terminate the connection due to connection: close header
-  }
-
-  /////////////////// Stateful methods for the HTTP parser ///////////////////
-  final override protected def headerComplete(name: String, value: String) = {
-    logger.trace(s"Received header '$name: $value'")
-    headers += Header(name, value)
-    false
-  }
-
-  final override protected def submitRequestLine(methodString: String,
-                                                          uri: String,
-                                                       scheme: String,
-                                                 majorversion: Int,
-                                                 minorversion: Int) = {
-    logger.trace(s"Received request($methodString $uri $scheme/$majorversion.$minorversion)")
-    this.uri = uri
-    this.method = methodString
-    this.major = majorversion
-    this.minor = minorversion
-    false
   }
 }

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -28,23 +28,19 @@ import java.util.concurrent.ExecutorService
 
 object Http1ServerStage {
 
-  val defaultMaxDrain: Long = 256*1024
-
   def apply(service: HttpService,
             attributes: AttributeMap = AttributeMap.empty,
-            maxDrainSize: Long = defaultMaxDrain,
             pool: ExecutorService = Strategy.DefaultExecutorService,
             enableWebSockets: Boolean = false ): Http1ServerStage = {
-    if (enableWebSockets) new Http1ServerStage(service, attributes, maxDrainSize, pool) with WebSocketSupport
-    else                  new Http1ServerStage(service, attributes, maxDrainSize, pool)
+    if (enableWebSockets) new Http1ServerStage(service, attributes, pool) with WebSocketSupport
+    else                  new Http1ServerStage(service, attributes, pool)
   }
 }
 
 class Http1ServerStage(service: HttpService,
                        requestAttrs: AttributeMap,
-                       maxDrainSize: Long,
                        pool: ExecutorService)
-                  extends Http1Stage(maxDrainSize)
+                  extends Http1Stage
                   with TailStage[ByteBuffer]
 {
   // micro-optimization: unwrap the service and call its .run directly

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
@@ -30,7 +30,7 @@ object ProtocolSelector {
 
     def select(s: String): LeafBuilder[ByteBuffer] = s match {
       case "h2" | "h2-14" | "h2-15" => LeafBuilder(http2Stage(service, maxHeaderLen, requestAttributes, es))
-      case _                        => LeafBuilder(Http1ServerStage(service, requestAttributes, Http1ServerStage.defaultMaxDrain, es))
+      case _                        => LeafBuilder(Http1ServerStage(service, requestAttributes, es))
     }
 
     new ALPNSelector(engine, preference, select)

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
@@ -30,7 +30,7 @@ object ProtocolSelector {
 
     def select(s: String): LeafBuilder[ByteBuffer] = s match {
       case "h2" | "h2-14" | "h2-15" => LeafBuilder(http2Stage(service, maxHeaderLen, requestAttributes, es))
-      case _                        => LeafBuilder(new Http1ServerStage(service, requestAttributes, es))
+      case _                        => LeafBuilder(Http1ServerStage(service, requestAttributes, Http1ServerStage.defaultMaxDrain, es))
     }
 
     new ALPNSelector(engine, preference, select)

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -16,7 +16,6 @@ import org.specs2.specification.core.Fragment
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
-import scala.concurrent.duration.FiniteDuration
 
 import scalaz.concurrent.{Strategy, Task}
 import scalaz.stream.Process
@@ -43,9 +42,8 @@ class Http1ServerStageSpec extends Specification {
 
   def runRequest(req: Seq[String], service: HttpService): Future[ByteBuffer] = {
     val head = new SeqTestHead(req.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
-    val httpStage = new Http1ServerStage(service, AttributeMap.empty, Strategy.DefaultExecutorService) {
-      override def reset(): Unit = head.stageShutdown()     // shutdown the stage after a complete request
-    }
+    val httpStage = new Http1ServerStage(service, AttributeMap.empty, Strategy.DefaultExecutorService)
+
     pipeline.LeafBuilder(httpStage).base(head)
     head.sendInboundCommand(Cmd.Connected)
     head.result
@@ -93,17 +91,8 @@ class Http1ServerStageSpec extends Specification {
   "Http1ServerStage: routes" should {
 
     def httpStage(service: HttpService, requests: Int, input: Seq[String]): Future[ByteBuffer] = {
-      val head = new SeqTestHead(input.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
-      val httpStage = new Http1ServerStage(service, AttributeMap.empty, Strategy.DefaultExecutorService) {
-        @volatile var count = 0
-
-        override def reset(): Unit = {
-          // shutdown the stage after it completes two requests
-          count += 1
-          if (count < requests) super.reset()
-          else head.stageShutdown()
-        }
-      }
+      val head = new SeqTestHead(input.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8))))
+      val httpStage = new Http1ServerStage(service, AttributeMap.empty, Strategy.DefaultExecutorService)
 
       pipeline.LeafBuilder(httpStage).base(head)
       head.sendInboundCommand(Cmd.Connected)


### PR DESCRIPTION
This PR consists of two commits that both fall under the umbrella of 'cleanup'.

Commit c4dd4fd:
Move the http1 parsing bits into its own class resulting in cleanup of the `Http1ServerStage`. Functionally the behavior of the library is unchanged by this commit.

Commit 03a0be1:
Allow the `drainBody` function of `Http1Stage` to 'give up' on draining the body after a parameterized number of bytes. This allows the server to avoid reading,parsing, and then simply discarding an excessive number of bytes that the client may have left on the wire.