### PR TITLE
Improve resource safety of client.

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -1,7 +1,7 @@
 package org.http4s.client.blaze
 
 import org.http4s.blaze.pipeline.Command
-import org.http4s.client.Client
+import org.http4s.client.{DisposableResponse, Client}
 import org.http4s.{Request, Response}
 
 import scala.concurrent.duration.Duration
@@ -15,8 +15,8 @@ final class BlazeClient(manager: ConnectionManager, idleTimeout: Duration, reque
   /** Shutdown this client, closing any open connections and freeing resources */
   override def shutdown(): Task[Unit] = manager.shutdown()
 
-  override def prepare(req: Request): Task[Response] = Task.suspend {
-    def tryClient(client: BlazeClientStage, freshClient: Boolean, flushPrelude: Boolean): Task[Response] = {
+  override def open(req: Request): Task[DisposableResponse] = Task.suspend {
+    def tryClient(client: BlazeClientStage, freshClient: Boolean, flushPrelude: Boolean): Task[DisposableResponse] = {
       // Add the timeout stage to the pipeline
       val ts = new ClientTimeoutStage(idleTimeout, requestTimeout, bits.ClientTickWheel)
       client.spliceBefore(ts)
@@ -24,13 +24,13 @@ final class BlazeClient(manager: ConnectionManager, idleTimeout: Duration, reque
 
       client.runRequest(req, flushPrelude).attempt.flatMap {
         case \/-(r)    =>
-          val recycleProcess = eval_(Task.delay {
+          val dispose = Task.delay {
             if (!client.isClosed()) {
               ts.removeStage
               manager.recycleClient(req, client)
             }
-          })
-          Task.now(r.copy(body = r.body.onComplete(recycleProcess)))
+          }
+          Task.now(DisposableResponse(r, dispose))
 
         case -\/(Command.EOF) if !freshClient =>
           manager.getClient(req, freshClient = true).flatMap(tryClient(_, true, flushPrelude))

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -36,7 +36,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val c = mkClient(new SlowTestHead(List(mkBuffer(resp)), 0.seconds), 
                        new Http1ClientStage(None, ec))(0.milli, Duration.Inf)
 
-      c.prepare(FooRequest).run must throwA[TimeoutException]
+      c.stream(FooRequest).run must throwA[TimeoutException]
     }
 
     "Timeout immediately with a request timeout of 0 seconds" in {
@@ -44,7 +44,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SlowTestHead(List(mkBuffer(resp)), 0.seconds)
       val c = mkClient(h, tail)(Duration.Inf, 0.milli)
 
-      c.prepare(FooRequest).run must throwA[TimeoutException]
+      c.stream(FooRequest).run must throwA[TimeoutException]
     }
 
     "Idle timeout on slow response" in {
@@ -52,7 +52,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds)
       val c = mkClient(h, tail)(1.second, Duration.Inf)
 
-      c.prepare(FooRequest).run must throwA[TimeoutException]
+      c.stream(FooRequest).run must throwA[TimeoutException]
     }
 
     "Request timeout on slow response" in {
@@ -60,7 +60,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds)
       val c = mkClient(h, tail)(Duration.Inf, 1.second)
 
-      c.prepare(FooRequest).run must throwA[TimeoutException]
+      c.stream(FooRequest).run must throwA[TimeoutException]
     }
 
     "Request timeout on slow POST body" in {
@@ -80,7 +80,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
       val c = mkClient(h, tail)(Duration.Inf, 1.second)
 
-      c.prepare(req).run must throwA[TimeoutException]
+      c.stream(req).run must throwA[TimeoutException]
     }
 
     "Idle timeout on slow POST body" in {
@@ -100,7 +100,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
       val c = mkClient(h, tail)(1.second, Duration.Inf)
 
-      c.prepare(req).as[String].run must throwA[TimeoutException]
+      c.fetchAs[String](req).run must throwA[TimeoutException]
     }
 
     "Not timeout on only marginally slow POST body" in {
@@ -120,7 +120,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
       val c = mkClient(h, tail)(10.second, 30.seconds)
 
-      c.prepare(req).as[String].run must_== ("done")
+      c.fetchAs[String](req).run must_== ("done")
     }
 
     "Request timeout on slow response body" in {
@@ -131,7 +131,7 @@ class ClientTimeoutSpec extends Http4sSpec {
 
       val result = tail.runRequest(FooRequest, false).as[String]
 
-      c.prepare(FooRequest).as[String].run must throwA[TimeoutException]
+      c.fetchAs[String](FooRequest).run must throwA[TimeoutException]
     }
 
     "Idle timeout on slow response body" in {
@@ -142,7 +142,7 @@ class ClientTimeoutSpec extends Http4sSpec {
 
       val result = tail.runRequest(FooRequest, false).as[String]
 
-      c.prepare(FooRequest).as[String].run must throwA[TimeoutException]
+      c.fetchAs[String](FooRequest).run must throwA[TimeoutException]
     }
   }
 }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
@@ -13,14 +13,14 @@ class ExternalBlazeHttp1ClientSpec extends Http4sSpec with After {
     def client = defaultClient
 
     "Make simple http requests" in {
-      val resp = client(uri("https://github.com/")).as[String].run
+      val resp = client.getAs[String](uri("https://github.com/")).run
 //      println(resp.copy(body = halt))
 
       resp.length mustNotEqual 0
     }
 
     "Make simple https requests" in {
-      val resp = client(uri("https://github.com/")).as[String].run
+      val resp = client.getAs[String](uri("https://github.com/")).run
 //      println(resp.copy(body = halt))
 //      println("Body -------------------------\n" + gatherBody(resp.body) + "\n--------------------------")
       resp.length mustNotEqual 0
@@ -32,7 +32,7 @@ class ExternalBlazeHttp1ClientSpec extends Http4sSpec with After {
   "RecyclingHttp1Client" should {
 
     "Make simple http requests" in {
-      val resp = client(uri("https://github.com/")).as[String].run
+      val resp = client.getAs[String](uri("https://github.com/")).run
       //      println(resp.copy(body = halt))
 
       resp.length mustNotEqual 0
@@ -41,7 +41,7 @@ class ExternalBlazeHttp1ClientSpec extends Http4sSpec with After {
     "Repeat a simple http request" in {
       val f = (0 until 10).map(_ => Task.fork {
         val req = uri("https://github.com/")
-        val resp = client(req).as[String]
+        val resp = client.getAs[String](req)
         resp.map(_.length)
       })
 
@@ -51,7 +51,7 @@ class ExternalBlazeHttp1ClientSpec extends Http4sSpec with After {
     }
 
     "Make simple https requests" in {
-      val resp = client(uri("https://github.com/")).as[String].run
+      val resp = client.getAs[String](uri("https://github.com/")).run
       //      println(resp.copy(body = halt))
       //      println("Body -------------------------\n" + gatherBody(resp.body) + "\n--------------------------")
       resp.length mustNotEqual 0

--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -17,14 +17,13 @@ object FollowRedirect {
       * @param req [[Request]] containing the headers, URI, etc.
       * @return Task which will generate the Response
       */
-    override def prepare(req: Request): Task[Response] = prepareLoop(req, 0)
+    override def open(req: Request): Task[DisposableResponse] =
+      loop(req, 0)
 
-    private def prepareLoop(req: Request, redirects: Int): Task[Response] = {
-      val t = client.prepare(req)
-      t.flatMap { resp =>
-
-        def doRedirect(method: Method): Task[Response] = {
-          resp.headers.get(headers.Location) match {
+    private def loop(req: Request, redirects: Int): Task[DisposableResponse] = {
+      client.open(req).flatMap { dr =>
+        def doRedirect(method: Method): Task[DisposableResponse] = {
+          dr.response.headers.get(headers.Location) match {
             case Some(headers.Location(uri)) if redirects < maxRedirects =>
               // https://tools.ietf.org/html/rfc7231#section-7.1.2
               val nextUri = uri.copy(
@@ -33,23 +32,26 @@ object FollowRedirect {
                 fragment = uri.fragment orElse req.uri.fragment
               )
 
-              prepareLoop(
+              loop(
                 req.copy(method = method, uri = nextUri, body = EmptyBody),
                 redirects + 1
               )
 
-            case _ => Task.now(resp)
+            case _ => Task.now(dr)
           }
         }
 
-        resp.status.code match {
+        dr.response.status.code match {
           // We cannot be sure what will happen to the request body so we don't attempt to deal with it
-          case 301 | 302 | 307 | 308 if req.body.isHalt => doRedirect(req.method)
+          case 301 | 302 | 307 | 308 if req.body.isHalt =>
+            dr.dispose.flatMap(_ => doRedirect(req.method))
 
           // Often the result of a Post request where the body has been properly consumed
-          case 303 => doRedirect(Method.GET)
+          case 303 =>
+            dr.dispose.flatMap(_ => doRedirect(Method.GET))
 
-          case _ => Task.now(resp)
+          case _ =>
+            Task.now(dr)
         }
       }
     }

--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -3,8 +3,7 @@ package client
 package middleware
 
 import org.http4s.Status.ResponseClass.Successful
-import org.http4s.{Response, Request, EmptyBody}
-import org.http4s.client.Client
+import org.http4s.EmptyBody
 import org.log4s.getLogger
 
 import scala.concurrent.duration._
@@ -21,19 +20,23 @@ object Retry {
 
     def shutdown(): Task[Unit] = client.shutdown()
 
-    def prepare(req: Request): Task[Response] = prepareLoop(req, 1)
+    def open(req: Request): Task[DisposableResponse] =
+      loop(req, 1)
 
-    private def prepareLoop(req: Request, attempts: Int): Task[Response] = {
-      client.prepare(req) flatMap {
-        case Successful(resp) => Task.now(resp)
-        case fail => 
+    private def loop(req: Request, attempts: Int): Task[DisposableResponse] = {
+      client.open(req) flatMap {
+        case dr @ DisposableResponse(Successful(resp), _) =>
+          Task.now(dr)
+        case fail =>
           logger.info(s"Request ${req} has failed attempt ${attempts} with reason ${fail}")
-          backoff(attempts).fold(Task.now(fail))(dur => nextAttempt(req, attempts, dur))
+          fail.dispose.flatMap { _ =>
+            backoff(attempts).fold(Task.now(fail))(dur => nextAttempt(req, attempts, dur))
+          }
       }
     }
 
-    private def nextAttempt(req: Request, attempts: Int, duration: FiniteDuration): Task[Response] =
-      Task.async { (prepareLoop(req.copy(body = EmptyBody), attempts + 1).get after duration).runAsync }
+    private def nextAttempt(req: Request, attempts: Int, duration: FiniteDuration): Task[DisposableResponse] =
+      Task.async { (loop(req.copy(body = EmptyBody), attempts + 1).get after duration).runAsync }
   }
 }
 

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -52,7 +52,7 @@ abstract class ClientRouteTestBattery(name: String, client: Client)
   private def runTest(req: Request, address: InetSocketAddress): Response = {
     val newreq = req.copy(uri = req.uri.copy(authority = Some(Authority(host = RegName(address.getHostName),
       port = Some(address.getPort)))))
-    client.prepare(newreq).runFor(timeout)
+    client.stream(newreq).runFor(timeout)
   }
 
   private def checkResponse(rec: Response, expected: Response) = {

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -33,94 +33,94 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
   "Client" should {
 
     "support Uris" in {
-      client(req.uri).as[String]
+      client.getAs[String](req.uri)
         .run must_== "hello"
     }
 
     "support Requests" in {
-      client(req).as[String]
+      client.fetchAs[String](req)
         .run must_== "hello"
     }
 
     "support Task[Request]s" in {
-      client(Task(req)).as[String]
+      client.fetchAs[String](Task(req))
         .run must_== "hello"
     }
 
     "default to Ok if no Status is mentioned" in {
-      client(req).as[String]
+      client.fetchAs[String](req)
         .run must_== "hello"
     }
 
     "use Status for Response matching and extraction" in {
-      client(req).map {
-        case Ok(resp) => "Ok"
-        case _ => "fail"
+      client.fetch(req) {
+        case Ok(resp) => Task.now("Ok")
+        case _ => Task.now("fail")
       }.run must_== "Ok"
 
-      client(req).map {
-        case NotFound(resp) => "fail"
-        case _ => "nomatch"
+      client.fetch(req) {
+        case NotFound(resp) => Task.now("fail")
+        case _ => Task.now("nomatch")
       }.run must_== "nomatch"
     }
 
     "use Status for Response matching and extraction" in {
-      client(req).flatMap {
+      client.fetch(req) {
         case Successful(resp) => resp.as[String]
         case _                => Task.now("fail")
       }.run must_== "hello"
 
-      client(req).map {
-        case ServerError(resp) => "fail"
-        case _ => "nomatch"
+      client.fetch(req) {
+        case ServerError(resp) => Task.now("fail")
+        case _ => Task.now("nomatch")
       }.run must_== "nomatch"
     }
 
     "implicitly resolve to get headers and body" in {
-      client(req).as[(Headers, String)]
+      client.fetchAs[(Headers, String)](req)
         .run._2 must_== "hello"
     }
 
     "attemptAs with successful result" in {
-      client(req).attemptAs[String]
-        .run.run must be_\/-("hello")
+      client.fetchAs[String](req).attempt
+        .run must be_\/-("hello")
     }
 
     "attemptAs with failed parsing result" in {
       val grouchyEncoder = EntityDecoder.decodeBy[Any](MediaRange.`*/*`) { _ =>
         DecodeResult.failure(ParseFailure("MEH!", "MEH!"))
       }
-      client(req).attemptAs[Any](grouchyEncoder).run.run must be_-\/
+      client.fetchAs[Any](req)(grouchyEncoder).attempt.run must be_-\/
     }
 
     "prepAs must add Accept header" in {
-      client.prepAs(GET(uri("http://www.foo.com/echoheaders")))(EntityDecoder.text)
+      client.fetchAs(GET(uri("http://www.foo.com/echoheaders")))(EntityDecoder.text)
         .run must_== "Accept: text/*"
 
-      client.prepAs[String](GET(uri("http://www.foo.com/echoheaders")))
+      client.fetchAs[String](GET(uri("http://www.foo.com/echoheaders")))
         .run must_== "Accept: text/*"
 
-      client.prepAs[String](uri("http://www.foo.com/echoheaders"))
+      client.getAs[String](uri("http://www.foo.com/echoheaders"))
         .run must_== "Accept: text/*"
 
       // Are we combining our mediatypes correctly? This is more of an EntityDecoder spec
       val edec = EntityDecoder.decodeBy(MediaType.`image/jpeg`)(_ => DecodeResult.success("foo!"))
-      client.prepAs(GET(uri("http://www.foo.com/echoheaders")))(EntityDecoder.text orElse edec)
+      client.fetchAs(GET(uri("http://www.foo.com/echoheaders")))(EntityDecoder.text orElse edec)
         .run must_== "Accept: text/*, image/jpeg"
     }
   }
 
   "RequestResponseGenerator" should {
     "Generate requests based on Method" in {
-      client(GET(uri("http://www.foo.com/"))).as[String]
+      client.fetchAs[String](GET(uri("http://www.foo.com/")))
         .run must_== "hello"
       //      GET("http://www.foo.com/", "cats").on(Ok).as[String].run must_== "hello"  // Doesn't compile, body not allowed
 
       // The PUT: /put path just echos the body
-      client(PUT(uri("http://www.foo.com/put"))).as[String]
+      client.fetchAs[String](PUT(uri("http://www.foo.com/put")))
         .run must_== ""
 
-      client(PUT(uri("http://www.foo.com/put"), "foo")).as[String] // body allowed
+      client.fetchAs[String](PUT(uri("http://www.foo.com/put"), "foo")) // body allowed
         .run must_== "foo"
     }
   }

--- a/client/src/test/scala/org/http4s/client/MockClient.scala
+++ b/client/src/test/scala/org/http4s/client/MockClient.scala
@@ -10,7 +10,8 @@ class MockClient(service: HttpService) extends Client {
     * @param req [[Request]] containing the headers, URI, etc.
     * @return Task which will generate the Response
     */
-  override def prepare(req: Request): Task[Response] = service(req)
+  override def open(req: Request): Task[DisposableResponse] =
+    service(req).map { resp => DisposableResponse(resp, Task.now(())) }
 
   /** Shutdown this client, closing any open connections and freeing resources */
   override def shutdown(): Task[Unit] = Task.now(())

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
@@ -11,7 +11,7 @@ object ClientExample {
 
     val client = org.http4s.client.blaze.defaultClient
 
-    val page: Task[String] = client(uri("https://www.google.com/")).as[String]
+    val page: Task[String] = client.getAs[String](uri("https://www.google.com/"))
 
     for (_ <- 1 to 2)
       println(page.run.take(72))   // each execution of the Task will refetch the page!
@@ -33,7 +33,7 @@ object ClientExample {
     implicit val fooDecoder = jsonOf[Foo]
 
     // Match on response code!
-    val page2 = client(uri("http://http4s.org/resources/foo.json")).flatMap {
+    val page2 = client.get(uri("http://http4s.org/resources/foo.json")) {
       case Successful(resp) => resp.as[Foo].map("Received response: " + _)
       case NotFound(resp)   => Task.now("Not Found!!!")
       case resp             => Task.now("Failed: " + resp.status)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
@@ -7,6 +7,6 @@ import org.http4s.client.blaze.{defaultClient => client}
 
 object ClientPostExample extends App {
   val req = POST(uri("https://duckduckgo.com/"), UrlForm("q" -> "http4s"))
-  val responseBody = client(req).as[String]
+  val responseBody = client.fetchAs[String](req)
   println(responseBody.run)
 }


### PR DESCRIPTION
The abstract method now returns a `DisposableResponse`, which
pairs the response with a dispose Task that must be called to
free the HTTP connection.

The three "userspace" methods are various forms of:
- `stream`: like the old `prepare`, the caller is responsible
  for running the response body to trigger cleanup.
- `fetch`: takes a callback from the response to a Task,
  which provides automatic resource cleanup on termination
  of the Task.
- `fetchAs`: differs from old `prepAs` in that the decoding
  is not strict.  This brings it in line with `Response.as`.