### PR TITLE
Fix infinite loop

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
@@ -4,6 +4,7 @@ package blaze
 
 import org.log4s.getLogger
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 import scalaz.{-\/, \/-, \/}
 import scalaz.syntax.either._
@@ -28,17 +29,17 @@ private final class PoolManager(builder: ConnectionBuilder,
   private def stats =
     s"allocated=${allocated} idleQueue.size=${idleQueue.size} waitQueue.size=${waitQueue.size}"
 
-  private def createConnection(key: RequestKey): Unit = {
+  private def createConnection(key: RequestKey, callback: Callback[BlazeClientStage]): Unit = {
     if (allocated < maxTotal) {
       allocated += 1
-      logger.debug(s"Creating connection: ${stats}")
       Task.fork(builder(key)).runAsync {
-        case \/-(stage) =>
-          logger.debug(s"Submitting fresh connection to pool: ${stats}")
-          returnConnection(key, stage)
-        case -\/(t) =>
-          logger.error(t)("Error establishing client connection")
+        case s@ \/-(stage) =>
+          logger.debug(s"Received complete connection from pool: ${stats}")
+          callback(s)
+        case e@ -\/(t) =>
+          logger.error(t)(s"Error establishing client connection for key $key")
           disposeConnection(key, None)
+          callback(e)
       }
     }
     else {
@@ -50,24 +51,30 @@ private final class PoolManager(builder: ConnectionBuilder,
     logger.debug(s"Requesting connection: ${stats}")
     synchronized {
       if (!isClosed) {
+        @tailrec
         def go(): Unit = {
           idleQueue.dequeueFirst(_.requestKey == key) match {
             case Some(stage) if !stage.isClosed =>
               logger.debug(s"Recycling connection: ${stats}")
               callback(stage.right)
+
             case Some(closedStage) =>
               logger.debug(s"Evicting closed connection: ${stats}")
               allocated -= 1
               go()
+
+            case None if allocated < maxTotal =>
+              logger.debug(s"Active connection not found. Creating new one. ${stats}")
+              createConnection(key, callback)
+
             case None if idleQueue.nonEmpty =>
               logger.debug(s"No connections available for the desired key.  Evicting and creating a connection: ${stats}")
               allocated -= 1
               idleQueue.dequeue().shutdown()
-              createConnection(key)
-              waitQueue.enqueue(Waiting(key, callback))
-            case None =>
+              createConnection(key, callback)
+
+            case None => // we're full up. Add to waiting queue.
               logger.debug(s"No connections available.  Waiting on new connection: ${stats}")
-              createConnection(key)
               waitQueue.enqueue(Waiting(key, callback))
           }
         }
@@ -87,19 +94,28 @@ private final class PoolManager(builder: ConnectionBuilder,
             case Some(Waiting(_, callback)) =>
               logger.debug(s"Fulfilling waiting connection request: ${stats}")
               callback(stage.right)
-            case None =>
+            case None if waitQueue.isEmpty =>
               logger.debug(s"Returning idle connection to pool: ${stats}")
               idleQueue.enqueue(stage)
+
+            case None => // this connection didn't match any pending request, kill it and start a new one for a queued request
+              stage.shutdown()
+              allocated -= 1
+              val Waiting(key, callback) = waitQueue.dequeue()
+              createConnection(key, callback)
           }
         }
-        else if (waitQueue.nonEmpty) {
-          logger.debug(s"Replacing closed connection: ${stats}")
+        else { // stage was closed
           allocated -= 1
-          createConnection(key)
-        }
-        else {
-          logger.debug(s"Connection was closed, but nothing to do. Shrinking pool: ${stats}")
-          allocated -= 1
+
+          if (waitQueue.nonEmpty) {
+            logger.debug(s"Connection returned in the close state, new connection needed: ${stats}")
+            val Waiting(key, callback) = waitQueue.dequeue()
+            createConnection(key, callback)
+          }
+          else {
+            logger.debug(s"Connection was closed, but nothing to do. Shrinking pool: ${stats}")
+          }
         }
       }
       else if (!stage.isClosed) {
@@ -114,10 +130,6 @@ private final class PoolManager(builder: ConnectionBuilder,
     synchronized {
       allocated -= 1
       stage.foreach { s => if (!s.isClosed) s.shutdown() }
-      if (!isClosed && waitQueue.nonEmpty) {
-        logger.debug(s"Replacing failed connection: ${stats}")
-        createConnection(key)
-      }
     }
   }
 


### PR DESCRIPTION
When the client is asked to make a request that cannot be opened (say, invalid Uri) it will enter an infinite loop because the failure path creates a new connection with the same key, simply failing again, etc...

This commit changes that behavior by simply discarding the connection at that point and handing the origin that failure.

This commit also changes behavior: previously if the pool received a closed connection it would open a new one to the same endpoint and place it in the idle queue. This commit doesn't do that though it would be trivial to add.

This commit also changes a strange behavior on returning a connection. Previously, if there were waiting connections but they didn't match this endpoint the connection would simply be returned to the idlequeue. This causes a potential deadlock where you saturate the open connections at one endpoint, change endpoint, but the connections from the first endpoint sit in the idle queue while the waiting queue is filled with requests to the second endpoint. This commit fixes that, killing the
connection if there are pending connections that need a different endpoint.