### PR TITLE
Optimization of body collection for blaze components

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -89,7 +89,8 @@ class Http1ClientStageSpec extends Specification {
 
     "Fail when attempting to get a second request with one in progress" in {
       val tail = new Http1ClientStage(FooRequestKey, DefaultUserAgent, ec)
-      val h = new SeqTestHead(List(mkBuffer(resp), mkBuffer(resp)))
+      val (frag1,frag2) = resp.splitAt(resp.length-1)
+      val h = new SeqTestHead(List(mkBuffer(frag1), mkBuffer(frag2), mkBuffer(resp)))
       LeafBuilder(tail).base(h)
 
       try {


### PR DESCRIPTION
Before this commit the blaze components would see if there wasn't a body and if there is, it would begin a streaming style parsing strategy. This commit changes the second half. The new stragegy examines any remaining bytes to see if that consists of the entire body. If so, wonderful. If not, we go back to the streaming strategy.

This behavior helps the client cleanup more efficiently.