### PR TITLE
Simple dispatch client impl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,13 @@ lazy val blazeClient = libraryProject("blaze-client")
   )
   .dependsOn(blazeCore % "compile;test->test", client % "compile;test->test")
 
+lazy val dispatchClient = libraryProject("dispatch-client")
+  .settings(
+    description := "dispatch implementation for http4s clients",
+    libraryDependencies += dispatch
+  )
+  .dependsOn(core % "compile;test->test", client % "compile;test->test")
+
 lazy val servlet = libraryProject("servlet")
   .settings(
     description := "Portable servlet implementation for http4s servers",

--- a/dispatch-client/src/main/scala/org/htt4s/client/dispatch/DispatchClient.scala
+++ b/dispatch-client/src/main/scala/org/htt4s/client/dispatch/DispatchClient.scala
@@ -1,0 +1,50 @@
+package org.htt4s.client.dispatch
+
+import dispatch._, Defaults._
+import com.ning.http.client.{Response => DResponse}
+
+import org.http4s._
+import org.http4s.client._
+
+import scala.collection.JavaConverters._
+import scalaz.concurrent.Task
+
+import scalaz._
+import Scalaz._
+
+object DispatchClient {
+  def apply(): Client = {
+    Client(Service.lift { req =>
+      Task.async[DResponse] { register =>
+        Http(toDRequest(req)).onComplete {
+          case scala.util.Success(res) => register(res.right)
+          case scala.util.Failure(ex) => register(ex.left)
+        }
+      }.flatMap(fromDResponse)
+    }, Task.now(()))
+  }
+
+  private def toDRequest(request: Request): Req = {
+    url(request.uri.toString)
+      .setMethod(request.method.toString)
+      .setHeaders(request.headers
+        .groupBy(_.name.toString)
+        .mapValues(_.map(_.value).toSeq)
+      )
+      .setBody(request.bodyAsText.runFoldMap(identity).run)
+  }
+
+  private def fromDResponse(response: DResponse): Task[DisposableResponse] = {
+    Response()
+      .withStatus(Status.fromInt(response.getStatusCode).valueOr(e => throw new ParseException(e)))
+      .withTrailerHeaders(Task.now(Headers(getHeaders(response))))
+      .withBody(response.getResponseBody)
+      .map(response => DisposableResponse(response, Task.now(())))
+  }
+
+  private def getHeaders(response: DResponse): List[Header] = {
+    response.getHeaders.entrySet().asScala.flatMap(entry => {
+      entry.getValue.asScala.map(v => Header(entry.getKey, v)).toList
+    }).toList
+  }
+}

--- a/dispatch-client/src/test/scala/org/http4s/client/dispatch/DispatchClientSpec.scala
+++ b/dispatch-client/src/test/scala/org/http4s/client/dispatch/DispatchClientSpec.scala
@@ -1,0 +1,6 @@
+package org.http4s.client.dispatch
+
+import org.htt4s.client.dispatch.DispatchClient
+import org.http4s.client.ClientRouteTestBattery
+
+class DispatchClientSpec extends ClientRouteTestBattery("Dispatch Client", DispatchClient())

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -46,6 +46,7 @@ object Http4sBuild extends Build {
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.4.v20150727"
   lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.11.0-SNAPSHOT"
   lazy val circeJawn           = "io.circe"                 %% "circe-jawn"              % "0.2.0"
+  lazy val dispatch            = "net.databinder.dispatch"  %% "dispatch-core"           % "0.11.2"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"
   lazy val gatlingHighCharts   = "io.gatling.highcharts"     % "gatling-charts-highcharts" % gatlingTest.revision
   lazy val http4sWebsocket     = "org.http4s"               %% "http4s-websocket"        % "0.1.3"


### PR DESCRIPTION
Really simple implementation of a new http client for http4s - dispatch (as an alternative for blaze). There is no client disposal, shutdown, pool management and streaming.