### PR TITLE
Fix 'Stage has request in progress' leak.

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -43,6 +43,9 @@ final class Http1Connection(val requestKey: RequestKey,
     case _        => false
   }
 
+  override def isRecyclable: Boolean =
+    stageState.get == Idle
+
   override def shutdown(): Unit = stageShutdown()
 
   override def stageShutdown() = shutdownWithError(EOF)

--- a/client/src/main/scala/org/http4s/client/Connection.scala
+++ b/client/src/main/scala/org/http4s/client/Connection.scala
@@ -11,12 +11,13 @@ trait Connection {
 
   def runRequest(req: Request): Task[Response]
 
-  /** Determine if the stage is closed and resources have been freed */
+  /** Determine if the connection is closed and resources have been freed */
   def isClosed: Boolean
 
-  /** Close down the stage
-   *  Freeing resources and potentially aborting a [[Response]]
-   */
+  /** Determine if the connection is in a state that it can be recycled for another request. */
+  def isRecyclable: Boolean
+
+  /** Close down the connection, freeing resources and potentially aborting a [[Response]] */
   def shutdown(): Unit
 
   /** The key for requests we are able to serve */


### PR DESCRIPTION
If the parser is not complete when we return the body, we rely on a cleanup
hook of the body to either reset or shutdown the connection.  If this body is
not run to completion, neither happens.  This leaves the client in the
`Running` state.

Meanwhile, the pooled connection manager happily recycles any connection that
is not closed.  Hilarity ensues.

This exposes a check that the connection is recyleable, which in the blaze case
is true only when the connection has been able to reset itself.