### PR TITLE
Fix bug in EOF handling within `BlazeClient`

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -38,7 +38,9 @@ object BlazeClient {
 
           case -\/(Command.EOF) =>
             invalidate(connection).flatMap { _ =>
-              loop(connection, flushPrelude)
+              manager.borrow(key).flatMap { newConn =>
+                loop(newConn, flushPrelude)
+              }
             }
 
           case -\/(e) =>


### PR DESCRIPTION
Old flow:
1. Borrow a request that had closed while idling.  We don't
   know until we write to it.
2. Invalidate the connection and then loop with the *same*
   connection.  The state is now Error.
3. On loop, we get the `InProgressException` and fail.  Invalidate
   the connection again.

In step 2, we need to borrow a new connection, not retry the
invalidated connection.  This is a recent bug.

This prevents us from falling through to step 3, where the
second invalidation of the same connection caused another
decrement in the pool manager, leading to negative connection
values.

Bonus cleanup in `runRequest`: Now an `InProgressException` only
comes from a running request.  If something had moved the
connection into error state and we try to run it, we return the
error, which is now handled appropriately by `BlazeClient`.