### PR TITLE
Remove body from request.toString and response.toString.

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -237,6 +237,9 @@ case class Request(
     */
   def decodeWith[A](decoder: EntityDecoder[A], strict: Boolean)(f: A => Task[Response]): Task[Response] =
     decoder.decode(this, strict = strict).fold(_.toHttpResponse(httpVersion), f).join
+
+  override def toString: String =
+    s"""Request(method=$method, uri=$uri, headers=${headers}"""
 }
 
 object Request {
@@ -272,6 +275,9 @@ case class Response(
 
   override protected def change(body: EntityBody, headers: Headers, attributes: AttributeMap): Self =
     copy(body = body, headers = headers, attributes = attributes)
+
+  override def toString: String =
+    s"""Response(status=${status.code}, headers=$headers)"""
 }
 
 object Response {


### PR DESCRIPTION
The body of a scalaz-stream does not tend to have a very
legible toString.  Ways of making it legible often require
running the body, which should only be done once.

A process of pure Emits of character data can be turned into
a String.  We can do that, for the subset of messages that
are pure emits.  If we *don't* do that, we're still
leaking the contents of the body, but not in a format that
can be sanitized by a reasonable log filter.

We can't anticipate all the things a user wants to log or not,
but we should at least make it obvious to the user what is
being logged.