### PR TITLE
Don't execute request until Task runs.

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -41,9 +41,11 @@ object AsyncHttpClient {
             bufferSize: Int = 8): Client = {
     val client = new DefaultAsyncHttpClient(config)
     Client(Service.lift { req =>
-      val p = Promise[DisposableResponse]
-      client.executeRequest(toAsyncRequest(req), asyncHandler(p, 8))
-      task.futureToTask(p.future)
+      task.futureToTask {
+        val p = Promise[DisposableResponse]
+        client.executeRequest(toAsyncRequest(req), asyncHandler(p, 8))
+        p.future
+      }
     }, Task(client.close()))
   }
 


### PR DESCRIPTION
Take advantage of `task.futureToTask` taking a by-name
parameter to prevent the future from running prematurely.