### PR TITLE
More cleanup on async-http-client

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -38,7 +38,7 @@ object AsyncHttpClient {
     val client = new DefaultAsyncHttpClient(config)
     Client(Service.lift { req =>
       Task.async[DisposableResponse] { cb =>
-        client.executeRequest(toAsyncRequest(req), asyncHandler(cb, 8))
+        client.executeRequest(toAsyncRequest(req), asyncHandler(cb, bufferSize))
       }
     }, Task(client.close()))
   }

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -7,6 +7,8 @@ import org.asynchttpclient.request.body.generator.{InputStreamBodyGenerator, Bod
 import org.asynchttpclient.{Request => AsyncRequest, Response => _, _}
 import org.asynchttpclient.handler.StreamedAsyncHandler
 
+import org.http4s.util.threads.threadFactory
+
 import org.reactivestreams.Publisher
 import scodec.bits.ByteVector
 
@@ -25,6 +27,7 @@ object AsyncHttpClient {
     .setMaxConnectionsPerHost(200)
     .setMaxConnections(400)
     .setRequestTimeout(30000)
+    .setThreadFactory(threadFactory(name = { i => s"http4s-async-http-client-${i}" }))
     .build()
 
   /**

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -171,7 +171,7 @@ final class Http1Connection(val requestKey: RequestKey,
     Task.async[Response](cb => readAndParsePrelude(cb, close, "Initial Read"))
 
   // this method will get some data, and try to continue parsing using the implicit ec
-  private def readAndParsePrelude(cb: Callback,  closeOnFinish: Boolean, phase: String): Unit = {
+  private def readAndParsePrelude(cb: Callback[Response], closeOnFinish: Boolean, phase: String): Unit = {
     channelRead().onComplete {
       case Success(buff) => parsePrelude(buff, closeOnFinish, cb)
       case Failure(EOF)  => stageState.get match {
@@ -185,7 +185,7 @@ final class Http1Connection(val requestKey: RequestKey,
     }(ec)
   }
 
-  private def parsePrelude(buffer: ByteBuffer, closeOnFinish: Boolean, cb: Callback): Unit = {
+  private def parsePrelude(buffer: ByteBuffer, closeOnFinish: Boolean, cb: Callback[Response]): Unit = {
     try {
       if (!parser.finishedResponseLine(buffer)) readAndParsePrelude(cb, closeOnFinish, "Response Line Parsing")
       else if (!parser.finishedHeaders(buffer)) readAndParsePrelude(cb, closeOnFinish, "Header Parsing")
@@ -278,8 +278,6 @@ final class Http1Connection(val requestKey: RequestKey,
 }
 
 object Http1Connection {
-  private type Callback = Throwable\/Response => Unit
-
   case object InProgressException extends Exception("Stage has request in progress")
 
   // ADT representing the state that the ClientStage can be in

--- a/client/src/main/scala/org/http4s/client/PoolManager.scala
+++ b/client/src/main/scala/org/http4s/client/PoolManager.scala
@@ -10,7 +10,6 @@ import scalaz.syntax.either._
 import scalaz.concurrent.Task
 
 private object PoolManager {
-  type Callback[A] = Throwable \/ A => Unit
   case class Waiting[A <: Connection](key: RequestKey, callback: Callback[A])
 }
 import PoolManager._

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -36,4 +36,6 @@ package object http4s {
     * server backend, such as Blaze, Jetty, or Tomcat.
     */
   type HttpService = Service[Request, Response]
+
+  type Callback[A] = Throwable \/ A => Unit
 }

--- a/core/src/main/scala/org/http4s/util/threads.scala
+++ b/core/src/main/scala/org/http4s/util/threads.scala
@@ -2,7 +2,7 @@ package org.http4s.util
 
 import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.{Executors, ThreadFactory}
+import java.util.concurrent._
 
 object threads {
   final case class ThreadPriority(toInt: Int)
@@ -39,4 +39,14 @@ object threads {
         thread
       }
     }
+
+  /** Marker trait for thread factories we create ourselves, and thus we need to close ourselves. */
+  private[http4s] trait DefaultExecutorService { self: ExecutorService => }
+
+  /** Creates a thread pool marked with the DefaultExecutorService trait, so we know to shut it down. */
+  private[http4s] def newDefaultFixedThreadPool(n: Int, threadFactory: ThreadFactory): ExecutorService with DefaultExecutorService =
+    new ThreadPoolExecutor(n, n,
+      0L, TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue[Runnable],
+      threadFactory) with DefaultExecutorService
 }

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -64,20 +64,18 @@ case class NonBlockingServletIo(chunkSize: Int) extends ServletIo {
   private[this] val RightUnit = ().right
 
   override protected[servlet] def reader(servletRequest: HttpServletRequest): EntityBody = {
-    type Callback = Throwable \/ ByteVector => Unit
-
     sealed trait State
     case object Init extends State
     case object Ready extends State
     case object Complete extends State
     case class Errored(t: Throwable) extends State
-    case class Blocked(cb: Callback) extends State
+    case class Blocked(cb: Callback[ByteVector]) extends State
 
     val in = servletRequest.getInputStream
 
     val state = new AtomicReference[State](Init)
 
-    def read(cb: Callback) = {
+    def read(cb: Callback[ByteVector]) = {
       val buff = new Array[Byte](chunkSize)
       val len = in.read(buff)
 


### PR DESCRIPTION
1. Use the passed in buffer size instead of repeating the parameter.
2. Skip the promise and just use `Task.async`.
3. While we're at it, unify on one callback alias. 
4. Give the async-http-client threads a sensible name.