### PR TITLE
Implement mountFilter for servlet backends.

### DIFF
--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
@@ -1,6 +1,8 @@
 package com.example.http4s
 package jetty
 
+import javax.servlet._
+
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.servlets.MetricsServlet
 import org.http4s.server.jetty.JettyBuilder
@@ -14,6 +16,7 @@ object JettyExample extends App {
     .withMetricRegistry(metrics)
     .mountService(ExampleService.service, "/http4s")
     .mountServlet(new MetricsServlet(metrics), "/metrics/*")
+    .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
     .run
     .awaitShutdown()
 }

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/NoneShallPass.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/NoneShallPass.scala
@@ -1,0 +1,10 @@
+package com.example.http4s.jetty
+
+import javax.servlet._
+import javax.servlet.http.{HttpServletResponse, HttpServletRequest}
+import org.http4s.servlet.DefaultFilter
+
+object NoneShallPass extends DefaultFilter {
+  override def doHttpFilter(request: HttpServletRequest, response: HttpServletResponse, chain: FilterChain): Unit =
+    response.setStatus(403)
+}

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -136,5 +136,9 @@ object ScienceExperiments {
       conn.fold(Ok("Couldn't find connection info!")){ case Request.Connection(loc,rem,secure) =>
         Ok(s"Local: $loc, Remote: $rem, secure: $secure")
       }
+
+    case req @ GET -> Root / "black-knight" / _ =>
+      // The servlet examples hide this.
+      InternalServerError("Tis but a scratch")
   }
 }

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/NoneShallPass.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/NoneShallPass.scala
@@ -1,0 +1,11 @@
+package com.example.http4s.tomcat
+
+import javax.servlet._
+import javax.servlet.http._
+
+import org.http4s.servlet.DefaultFilter
+
+object NoneShallPass extends DefaultFilter {
+  override def doHttpFilter(request: HttpServletRequest, response: HttpServletResponse, chain: FilterChain): Unit =
+    response.setStatus(403)
+}

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
@@ -13,6 +13,7 @@ object TomcatExample extends App {
     .withMetricRegistry(metrics)
     .mountService(ExampleService.service, "/http4s")
     .mountServlet(new MetricsServlet(metrics), "/metrics/*")
+    .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
     .run
     .awaitShutdown()
 }

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -2,6 +2,9 @@ package org.http4s
 package server
 package jetty
 
+import java.util
+import javax.servlet.{DispatcherType, Filter}
+
 import com.codahale.metrics.{InstrumentedExecutorService, MetricRegistry}
 import com.codahale.metrics.jetty9.InstrumentedQueuedThreadPool
 import org.eclipse.jetty.util.ssl.SslContextFactory
@@ -20,7 +23,7 @@ import scalaz.concurrent.Task
 import org.eclipse.jetty.util.component.AbstractLifeCycle.AbstractLifeCycleListener
 import org.eclipse.jetty.util.component.LifeCycle
 import org.eclipse.jetty.server.{Server => JServer, _}
-import org.eclipse.jetty.servlet.{ServletHolder, ServletContextHandler}
+import org.eclipse.jetty.servlet.{FilterHolder, ServletHolder, ServletContextHandler}
 
 sealed class JettyBuilder private (
   socketAddress: InetSocketAddress,
@@ -66,6 +69,14 @@ sealed class JettyBuilder private (
     copy(mounts = mounts :+ Mount { (context, index, _) =>
       val servletName = name.getOrElse(s"servlet-$index")
       context.addServlet(new ServletHolder(servletName, servlet), urlMapping)
+    })
+
+  override def mountFilter(filter: Filter, urlMapping: String, name: Option[String], dispatches: util.EnumSet[DispatcherType]): JettyBuilder =
+    copy(mounts = mounts :+ Mount { (context, index, _) =>
+      val filterName = name.getOrElse(s"filter-$index")
+      val filterHolder = new FilterHolder(filter)
+      filterHolder.setName(filterName)
+      context.addFilter(filterHolder, urlMapping, dispatches)
     })
 
   override def mountService(service: HttpService, prefix: String): JettyBuilder =

--- a/servlet/src/main/scala/org/http4s/servlet/DefaultFilter.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/DefaultFilter.scala
@@ -1,0 +1,22 @@
+package org.http4s.servlet
+
+import javax.servlet._
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+/**
+  * Mainly a convenience for our servlet examples, but, hey, why not.
+  */
+trait DefaultFilter extends Filter {
+  override def init(filterConfig: FilterConfig): Unit = {}
+
+  override def destroy(): Unit = {}
+
+  override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain): Unit =
+    (request, response) match {
+      case (httpReq: HttpServletRequest, httpRes: HttpServletResponse) =>
+        doHttpFilter(httpReq, httpRes, chain)
+      case _ =>
+    }
+
+  def doHttpFilter(request: HttpServletRequest, response: HttpServletResponse, chain: FilterChain): Unit
+}

--- a/servlet/src/main/scala/org/http4s/servlet/DefaultFilter.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/DefaultFilter.scala
@@ -11,7 +11,7 @@ trait DefaultFilter extends Filter {
 
   override def destroy(): Unit = {}
 
-  override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain): Unit =
+  final override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain): Unit =
     (request, response) match {
       case (httpReq: HttpServletRequest, httpRes: HttpServletResponse) =>
         doHttpFilter(httpReq, httpRes, chain)

--- a/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
@@ -1,5 +1,8 @@
-package org.http4s.servlet
+package org.http4s
+package servlet
 
+import java.util.EnumSet
+import javax.servlet.{DispatcherType, Filter}
 import javax.servlet.http.HttpServlet
 
 import org.http4s.server.{AsyncTimeoutSupport, ServerBuilder}
@@ -10,7 +13,27 @@ trait ServletContainer
 {
   type Self <: ServletContainer
 
+  /**
+    * Mounts a servlet to the server.
+    *
+    * The http4s way is to create an [[HttpService]], which runs not just on servlet containers,
+    * but all supported backends.  This method is good for legacy scenarios, or for reusing parts
+    * of the servlet ecosystem for an app that is committed to running on a servlet container.
+    */
   def mountServlet(servlet: HttpServlet, urlMapping: String, name: Option[String] = None): Self
+
+  /**
+    * Mounts a filter to the server.
+    *
+    * The http4s way is to create a middleware around an  [[HttpService]], which runs not just on
+    * servlet containers, but all supported backends.  This method is good for legacy scenarios,
+    * or for reusing parts of the servlet ecosystem for an app that is committed to running on
+    * a servlet container.
+    */
+  def mountFilter(filter: Filter,
+                  urlMapping: String,
+                  name: Option[String] = None,
+                  dispatches: EnumSet[DispatcherType] = EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD, DispatcherType.INCLUDE, DispatcherType.ASYNC)): Self
 
   /**
    * Sets the servlet I/O mode for reads and writes within the servlet.

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -3,8 +3,8 @@ package server
 package tomcat
 
 import java.net.InetSocketAddress
-import java.util
-import javax.servlet.{ServletContext, ServletContainerInitializer}
+import java.util.EnumSet
+import javax.servlet.{Filter, DispatcherType, ServletContext, ServletContainerInitializer}
 import javax.servlet.http.HttpServlet
 import java.util.concurrent.ExecutorService
 
@@ -15,10 +15,11 @@ import org.http4s.servlet.{ServletIo, ServletContainer, Http4sServlet}
 import org.http4s.server.SSLSupport.{SSLBits, StoreInfo}
 import org.http4s.servlet.{ServletContainer, Http4sServlet}
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scalaz.concurrent.{Strategy, Task}
 import org.apache.catalina.startup.Tomcat
-import org.apache.catalina.{Lifecycle, LifecycleEvent, LifecycleListener}
+import org.apache.catalina.{Context, Lifecycle, LifecycleEvent, LifecycleListener}
 
 
 sealed class TomcatBuilder private (
@@ -63,22 +64,41 @@ sealed class TomcatBuilder private (
     copy(serviceExecutor = serviceExecutor)
 
   override def mountServlet(servlet: HttpServlet, urlMapping: String, name: Option[String] = None): TomcatBuilder =
-    copy(mounts = mounts :+ Mount { (tomcat, index, _) =>
+    copy(mounts = mounts :+ Mount { (ctx, index, _) =>
       val servletName = name.getOrElse(s"servlet-$index")
-      val wrapper = tomcat.addServlet("", servletName, servlet)
+      val wrapper = Tomcat.addServlet(ctx, servletName, servlet)
       wrapper.addMapping(urlMapping)
       wrapper.setAsyncSupported(true)
     })
 
+  override def mountFilter(filter: Filter, urlMapping: String, name: Option[String], dispatches: EnumSet[DispatcherType]): TomcatBuilder =
+    copy(mounts = mounts :+ Mount { (ctx, index, _) =>
+      val filterName = name.getOrElse(s"filter-$index")
+
+      val filterDef = new FilterDef
+      filterDef.setFilterName(filterName)
+      filterDef.setFilter(filter)
+      filterDef.setAsyncSupported(true.toString)
+      ctx.addFilterDef(filterDef)
+
+      val filterMap = new FilterMap
+      filterMap.setFilterName(filterName)
+      filterMap.addURLPattern(urlMapping)
+      dispatches.asScala.foreach { dispatcher =>
+        filterMap.setDispatcher(dispatcher.name)
+      }
+      ctx.addFilterMap(filterMap)
+    })
+
   override def mountService(service: HttpService, prefix: String): TomcatBuilder =
-    copy(mounts = mounts :+ Mount { (tomcat, index, builder) =>
+    copy(mounts = mounts :+ Mount { (ctx, index, builder) =>
       val servlet = new Http4sServlet(
         service = service,
         asyncTimeout = builder.asyncTimeout,
         servletIo = builder.servletIo,
         threadPool = builder.instrumentedServiceExecutor
       )
-      val wrapper = tomcat.addServlet("", s"servlet-$index", servlet)
+      val wrapper = Tomcat.addServlet(ctx, s"servlet-$index", servlet)
       wrapper.addMapping(ServletContainer.prefixMapping(prefix))
       wrapper.setAsyncSupported(true)
     })
@@ -162,8 +182,9 @@ sealed class TomcatBuilder private (
     conn.setAttribute("connection_pool_timeout",
       if (idleTimeout.isFinite) idleTimeout.toSeconds.toInt else 0)
 
+    val rootContext = tomcat.getHost.findChild("").asInstanceOf[Context]
     for ((mount, i) <- mounts.zipWithIndex)
-      mount.f(tomcat, i, this)
+      mount.f(rootContext, i, this)
 
     tomcat.start()
 
@@ -198,5 +219,5 @@ object TomcatBuilder extends TomcatBuilder(
   metricPrefix = MetricsSupport.DefaultPrefix
 )
 
-private case class Mount(f: (Tomcat, Int, TomcatBuilder) => Unit)
+private case class Mount(f: (Context, Int, TomcatBuilder) => Unit)
 


### PR DESCRIPTION
Closes #472.

As noted on #472, it's not "the http4s way," and not recommended for general use, but it is handy for those who are heavily invested in the servlet ecosystem.