### PR TITLE
Upgrade Shapeless to shelter users from bincompat woes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ lazy val core = libraryProject("core")
       scalaReflect(v) % "provided",
       scalazCore,
       scalazStream,
-      scodecBits
+      scodecBits,
+      shapeless
     ) },
     libraryDependencies <++= scalaVersion (
       VersionNumber(_).numbers match {

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -67,13 +67,15 @@ object Http4sBuild extends Build {
   lazy val metricsServlet      = "io.dropwizard.metrics"     % "metrics-servlet"         % metricsCore.revision
   lazy val metricsServlets     = "io.dropwizard.metrics"     % "metrics-servlets"        % metricsCore.revision
   lazy val metricsJson         = "io.dropwizard.metrics"     % "metrics-json"            % metricsCore.revision
-  lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.1.0"
+  // Parboiled depends on an ancient Shapeless with _x.y.z compat on Scala 2.10, so we bundle a newer, compatible Shapeless.
+  lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.1.0" exclude ("com.chuusai", "shapeless_2.10.4")
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
   lazy val scalameter          = "com.storm-enroute"        %% "scalameter"              % "0.6"
   lazy val scalaXml            = "org.scala-lang.modules"   %% "scala-xml"               % "1.0.5"
   lazy val scalazCore          = "org.scalaz"               %% "scalaz-core"             % "7.1.3"
   lazy val scalazScalacheckBinding = "org.scalaz"           %% "scalaz-scalacheck-binding" % scalazCore.revision
   lazy val scalaCheck          = "org.scalacheck"           %% "scalacheck"              % "1.12.4"
+  lazy val shapeless           = "com.chuusai"              %% "shapeless"               % "2.2.5"
   lazy val specs2              = "org.specs2"               %% "specs2-core"             % "3.6.5"
   lazy val specs2MatcherExtra  = "org.specs2"               %% "specs2-matcher-extra"    % specs2.revision
   lazy val specs2Scalacheck    = "org.specs2"               %% "specs2-scalacheck"       % specs2.revision


### PR DESCRIPTION
Parboiled brings in an old version of shapeless that was published against the _2.10.x scheme.  Newer shapeless versions are published against _2.10.  Parboiled still works with the latest shapeless, but it irritates sbt:

```
[error] Modules were resolved with conflicting cross-version suffixes in {file:/redacted/}core:
[error]    com.chuusai:shapeless _2.10, _2.10.4
```

This hides the transitive _2.10.4 dependency from downstream users, and should allow projects to use newer shapelesses without any fuss.

/cc @stew