### PR TITLE
Topic/evil fork

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -24,7 +24,7 @@ object PooledHttp1Client {
           endpointAuthentication: Boolean = true,
                            group: Option[AsynchronousChannelGroup] = None) = {
     val http1 = Http1Support(bufferSize, userAgent, executor, sslContext, endpointAuthentication, group)
-    val pool = ConnectionManager.pool(http1, maxTotalConnections)
+    val pool = ConnectionManager.pool(http1, maxTotalConnections, executor)
     BlazeClient(pool, idleTimeout, requestTimeout)
   }
 }

--- a/blaze-core/src/test/scala/org/http4s/blaze/util/FailingWriter.scala
+++ b/blaze-core/src/test/scala/org/http4s/blaze/util/FailingWriter.scala
@@ -1,0 +1,17 @@
+package org.http4s.blaze.util
+
+import org.http4s.blaze.pipeline.Command.EOF
+import scodec.bits.ByteVector
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+
+class FailingWriter() extends ProcessWriter {
+
+  override implicit protected def ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  override protected def writeEnd(chunk: ByteVector): Future[Boolean] = Future.failed(EOF)
+
+  override protected def writeBodyChunk(chunk: ByteVector, flush: Boolean): Future[Unit] = Future.failed(EOF)
+}

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
@@ -3,6 +3,7 @@ package server
 package blaze
 
 import java.util.Locale
+import java.util.concurrent.ExecutorService
 
 import org.http4s.Header.Raw
 import org.http4s.Status._
@@ -30,16 +31,16 @@ import scala.util.{Success, Failure}
 import org.http4s.util.CaseInsensitiveString._
 
 class Http2NodeStage(streamId: Int,
-                      timeout: Duration,
-                           ec: ExecutionContext,
-                   attributes: AttributeMap,
-                      service: HttpService) extends TailStage[NodeMsg.Http2Msg]
+                     timeout: Duration,
+                     executor: ExecutorService,
+                     attributes: AttributeMap,
+                     service: HttpService) extends TailStage[NodeMsg.Http2Msg]
 {
 
   import Http2StageTools._
   import NodeMsg.{ DataFrame, HeadersFrame }
 
-  private implicit def _ec = ec   // for all the onComplete calls
+  private implicit def ec = ExecutionContext.fromExecutor(executor)   // for all the onComplete calls
 
   override def name = "Http2NodeStage"
 
@@ -199,7 +200,7 @@ class Http2NodeStage(streamId: Int,
       val hs = HHeaders(headers.result())
       val req = Request(method, path, HttpVersion.`HTTP/2.0`, hs, body, attributes)
 
-      Task.fork(service(req)).runAsync {
+      Task.fork(service(req))(executor).runAsync {
         case \/-(resp) => renderResponse(req, resp)
         case -\/(t) =>
           val resp = Response(InternalServerError)
@@ -215,7 +216,7 @@ class Http2NodeStage(streamId: Int,
     val hs = new ArrayBuffer[(String, String)](16)
     hs += ((Status, Integer.toString(resp.status.code)))
     resp.headers.foreach{ h => hs += ((h.name.value.toLowerCase(Locale.ROOT), h.value)) }
-    
+
     new Http2Writer(this, hs, ec).writeProcess(resp.body).runAsync {
       case \/-(_)       => shutdownWithCommand(Cmd.Disconnect)
       case -\/(Cmd.EOF) => stageShutdown()

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
@@ -37,11 +37,8 @@ object ProtocolSelector {
   private def http2Stage(service: HttpService, maxHeadersLength: Int,
                          requestAttributes: AttributeMap, es: ExecutorService): TailStage[ByteBuffer] = {
 
-    // Make the objects that will be used for the whole connection
-    val ec = ExecutionContext.fromExecutorService(es)
-
     def newNode(streamId: Int): LeafBuilder[Http2Msg] = {
-      LeafBuilder(new Http2NodeStage(streamId, Duration.Inf, ec, requestAttributes, service))
+      LeafBuilder(new Http2NodeStage(streamId, Duration.Inf, es, requestAttributes, service))
     }
 
     new Http2Stage(
@@ -49,7 +46,7 @@ object ProtocolSelector {
       node_builder = newNode,
       timeout = Duration.Inf,
       maxInboundStreams = 300,
-      ec = ec
+      ec = ExecutionContext.fromExecutor(es)
     )
   }
 }

--- a/client/src/main/scala/org/http4s/client/ConnectionManager.scala
+++ b/client/src/main/scala/org/http4s/client/ConnectionManager.scala
@@ -1,6 +1,8 @@
 package org.http4s
 package client
 
+import java.util.concurrent.ExecutorService
+
 import scalaz.concurrent.Task
 
 /** Type that is responsible for the client lifecycle
@@ -42,8 +44,9 @@ object ConnectionManager {
     *
     * @param builder generator of new connections
     * @param maxTotal max total connections
+    * @param es `ExecutorService` where async operations will execute
     */
-  def pool[A <: Connection](builder: ConnectionBuilder[A], maxTotal: Int): ConnectionManager[A] =
-    new PoolManager[A](builder, maxTotal)
+  def pool[A <: Connection](builder: ConnectionBuilder[A], maxTotal: Int, es: ExecutorService): ConnectionManager[A] =
+    new PoolManager[A](builder, maxTotal, es)
 }
 


### PR DESCRIPTION
This cleans up a few places we are using the scalaz default ExecutorService which is really bad news.

See scalaz/scalaz#1105 for motivation.

I think a fix for the client might in order for the 0.12.x branch but we cannot maintain API compatibility in a reasonable way without just dropping the `.fork` call.