### PR TITLE
Run client route test battery sequentially and in isolation.

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -17,6 +17,9 @@ import scalaz.stream.Process
 abstract class ClientRouteTestBattery(name: String, client: Client)
   extends JettyScaffold(name) with GetRoutes
 {
+  // Travis has been timing out intermittently.  Let's see if having All The Threads helps.
+  sequential
+  isolated
 
   override def cleanup() = {
     client.shutdown.run


### PR DESCRIPTION
This is an effort to combat the Travis timeouts.  Intends to fix #529.