### PR TITLE
Improve error message for unsupported media type decoding error

### DIFF
--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -106,11 +106,19 @@ object EntityDecoder extends EntityDecoderInstances {
       msg.headers.get(`Content-Type`) match {
         case Some(contentType) =>
           if (a.matchesMediaType(contentType.mediaType)) a.decode(msg, strict)
-          else b.decode(msg, strict)
+          else b.decode(msg, strict).leftMap{
+            case MediaTypeMismatch(actual, expected) =>
+              MediaTypeMismatch(actual, expected ++ a.consumes)
+            case other => other
+          }
 
         case None =>
           if (a.matchesMediaType(UndefinedMediaType)) a.decode(msg, strict)
-          else b.decode(msg, strict)
+          else b.decode(msg, strict).leftMap{
+            case MediaTypeMissing(expected) =>
+              MediaTypeMissing(expected ++ a.consumes)
+            case other => other
+          }
       }
     }
 

--- a/core/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/src/main/scala/org/http4s/MessageFailure.scala
@@ -84,7 +84,7 @@ sealed case class InvalidMessageBodyFailure(details: String, override val cause:
 sealed abstract class UnsupportedMediaTypeFailure(expected: Set[MediaRange]) extends DecodeFailure with NoStackTrace {
   override def toHttpResponse(httpVersion: HttpVersion): Task[Response] =
     Response(Status.UnsupportedMediaType, httpVersion)
-      .withBody(s"""Please specify a media type in the following ranges: ${expected.mkString(",")}""")
+      .withBody(message)
 }
 
 /** Indicates that a [[Message]] attempting to be decoded has no [[MediaType]] and no
@@ -92,12 +92,17 @@ sealed abstract class UnsupportedMediaTypeFailure(expected: Set[MediaRange]) ext
 final case class MediaTypeMissing(expected: Set[MediaRange])
   extends UnsupportedMediaTypeFailure(expected)
 {
-  val message = s"Decoder is unable to decode a Message without a MediaType. Expected media ranges: $expected"
+  val expectedMsg = expected.map(_.renderString).mkString(", ")
+  val message = s"No media type specified in Content-Type header. Expected one of the following media ranges: $expectedMsg"
 }
 
 /** Indicates that no [[EntityDecoder]] matches the [[MediaType]] of the [[Message]] being decoded */
 final case class MediaTypeMismatch(messageType: MediaType, expected: Set[MediaRange])
   extends UnsupportedMediaTypeFailure(expected)
 {
-  def message = s"$messageType is not a supported media type. Decoder accepts one of the following media ranges: $expected"
+  def message = {
+    val actual = messageType.renderString
+    val expectedMsg = expected.map(_.renderString).mkString(", ")
+    s"$actual is not a supported media type. Expected one of the following media ranges: $expectedMsg"
+  }
 }

--- a/core/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/src/main/scala/org/http4s/MessageFailure.scala
@@ -82,9 +82,14 @@ sealed case class InvalidMessageBodyFailure(details: String, override val cause:
 
 /** Indicates that a [[Message]] came with no supported [[MediaType]]. */
 sealed abstract class UnsupportedMediaTypeFailure(expected: Set[MediaRange]) extends DecodeFailure with NoStackTrace {
+  def sanitizedResponsePrefix: String
+
+  val expectedMsg = s"Expected one of the following media ranges: ${expected.map(_.renderString).mkString(", ")}"
+  val responseMsg = s"$sanitizedResponsePrefix. $expectedMsg"
+
   override def toHttpResponse(httpVersion: HttpVersion): Task[Response] =
     Response(Status.UnsupportedMediaType, httpVersion)
-      .withBody(message)
+      .withBody(responseMsg)
 }
 
 /** Indicates that a [[Message]] attempting to be decoded has no [[MediaType]] and no
@@ -92,17 +97,14 @@ sealed abstract class UnsupportedMediaTypeFailure(expected: Set[MediaRange]) ext
 final case class MediaTypeMissing(expected: Set[MediaRange])
   extends UnsupportedMediaTypeFailure(expected)
 {
-  val expectedMsg = expected.map(_.renderString).mkString(", ")
-  val message = s"No media type specified in Content-Type header. Expected one of the following media ranges: $expectedMsg"
+  def sanitizedResponsePrefix = "No media type specified in Content-Type header"
+  val message = responseMsg
 }
 
 /** Indicates that no [[EntityDecoder]] matches the [[MediaType]] of the [[Message]] being decoded */
 final case class MediaTypeMismatch(messageType: MediaType, expected: Set[MediaRange])
   extends UnsupportedMediaTypeFailure(expected)
 {
-  def message = {
-    val actual = messageType.renderString
-    val expectedMsg = expected.map(_.renderString).mkString(", ")
-    s"$actual is not a supported media type. Expected one of the following media ranges: $expectedMsg"
-  }
+  def sanitizedResponsePrefix = "Media type supplied in Content-Type header is not supported"
+  def message = s"${messageType.renderString} is not a supported media type. $expectedMsg"
 }

--- a/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/core/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -97,6 +97,16 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
         (catchAllDecoder orElse decoder1).decode(reqSomeOtherMediaType, strict = true).run.run must_== DecodeResult.success(3).run.run
         (catchAllDecoder orElse decoder1).decode(reqNoMediaType, strict = true).run.run must_== DecodeResult.success(3).run.run
       }
+      "if decode is called with strict, will produce a MediaTypeMissing or MediaTypeMismatch " +
+      "with ALL supported media types of the composite decoder" in {
+        val reqMediaType = MediaType.`text/x-h`
+        val expectedMediaRanges = decoder1.consumes ++ decoder2.consumes ++ failDecoder.consumes
+        val reqSomeOtherMediaType = Request(headers = Headers(`Content-Type`(reqMediaType)))
+        (decoder1 orElse decoder2 orElse failDecoder).decode(reqSomeOtherMediaType, strict = true).run.run must_==
+          DecodeResult.failure(MediaTypeMismatch(reqMediaType, expectedMediaRanges)).run.run
+        (decoder1 orElse decoder2 orElse failDecoder).decode(Request(), strict = true).run.run must_==
+          DecodeResult.failure(MediaTypeMissing(expectedMediaRanges)).run.run
+      }
     }
   }
 


### PR DESCRIPTION
- List ALL supported media types when failing to decode using a composite decoder (build with `orElse`)
- changes to message wording
- use renderString on MediaRanges instead of standard case class to String to produce nicer message for logging
- use logging message for http response since it does not contain any sensitive information (I think?)