### PR TITLE
Push as much as we can down to message ops.

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -89,7 +89,7 @@ final case class Request(
     copy(body = body, headers = headers, attributes = attributes)
 
   override def transformUri(f: Uri => Uri): Request =
-    copy(uri = uri)
+    copy(uri = f(uri))
 
   lazy val (scriptName, pathInfo) = {
     val caret = attributes.get(Request.Keys.PathInfoCaret).getOrElse(0)

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -143,8 +143,7 @@ case class Response(
   attributes: AttributeMap = AttributeMap.empty) extends Message with ResponseOps[Id] {
   type Self = Response
 
-  /** Response specific extension methods */
-  override def withStatus[S <% Status](status: S): Self = copy(status = status)
+  override def withStatus(status: Status): Self = copy(status = status)
 
   override protected def change(body: EntityBody, headers: Headers, attributes: AttributeMap): Self =
     copy(body = body, headers = headers, attributes = attributes)

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -4,74 +4,40 @@ import java.io.File
 import java.net.{InetSocketAddress, InetAddress}
 import org.http4s.headers._
 import org.http4s.server.ServerSoftware
+import scalaz.Id.Id
 import scalaz.concurrent.Task
 import scalaz.stream.Process
-import scalaz.stream.text.utf8Decode
 import scalaz.syntax.monad._
 
 /**
  * Represents a HTTP Message. The interesting subclasses are Request and Response
  * while most of the functionality is found in [[MessageSyntax]] and [[ResponseOps]]
- * @see [[MessageSyntax]], [[ResponseOps]]
+  *
+  * @see [[MessageSyntax]], [[ResponseOps]]
  */
-sealed trait Message extends MessageOps { self =>
+sealed trait Message extends MessageOps[Id] { self =>
   type Self <: Message { type Self = self.Self }
 
-  def httpVersion: HttpVersion
-  
-  def headers: Headers
-  
-  def body: EntityBody
+  override protected def map[A, B](fa: A)(f: A => B): B =
+    f(fa)
 
-  final def bodyAsText(implicit defaultCharset: Charset = DefaultCharset): Process[Task, String] = {
-    (charset getOrElse defaultCharset) match {
-      case Charset.`UTF-8` =>
-        // suspect this one is more efficient, though this is superstition
-        body |> utf8Decode
-      case cs =>
-        body |> util.decode(cs)
-    }
+  override protected def taskMap[A, B](fa: A)(f: (A) => Task[B]): Task[B] =
+    f(fa)
 
-  }
-  
-  def attributes: AttributeMap
-  
+  override protected def streamMap[A, B](fa: A)(f: (A) => Process[Task, B]): Process[Task, B] =
+    f(fa)
+
+  override def transformAttributes(f: AttributeMap => AttributeMap): Self =
+    change(attributes = f(attributes))
+
+  override def transformHeaders(f: Headers => Headers): Self =
+    change(headers = f(headers))
+
   protected def change(body: EntityBody = body,
                        headers: Headers = headers,
                        attributes: AttributeMap = attributes): Self
 
-  /** Generates a new message object with the specified key/value pair appended to the [[org.http4s.AttributeMap]]
-    *
-    * @param key [[AttributeKey]] with which to associate the value
-    * @param value value associated with the key
-    * @tparam A type of the value to store
-    * @return a new message object with the key/value pair appended
-    */
-  override def withAttribute[A](key: AttributeKey[A], value: A): Self =
-    change(attributes = attributes.put(key, value))
-
-  /** Replaces the [[Header]]s of the incoming Request object
-    *
-    * @param headers [[Headers]] containing the desired headers
-    * @return a new Request object
-    */
-  override def replaceAllHeaders(headers: Headers): Self = change(headers = headers)
-
-  /** Add the provided headers to the existing headers, replacing those of the same header name */
-  override def putHeaders(headers: Header*): Self =
-    change(headers = this.headers.put(headers:_*))
-
-  override def filterHeaders(f: (Header) => Boolean): Self =
-    change(headers = headers.filter(f))
-
-  /** Replace the body of this message with a new body
-    *
-    * @param b body to attach to this method
-    * @param w [[EntityEncoder]] with which to convert the body to an [[EntityBody]]
-    * @tparam T type of the Body
-    * @return a new message with the new body
-    */
-  def withBody[T](b: T)(implicit w: EntityEncoder[T]): Task[Self] = {
+  override def withBody[T](b: T)(implicit w: EntityEncoder[T]): Task[Self] = {
     w.toEntity(b).map { entity =>
       val hs = entity.length match {
         case Some(l) => `Content-Length`(l)::w.headers.toList
@@ -80,22 +46,6 @@ sealed trait Message extends MessageOps { self =>
       change(body = entity.body, headers = headers ++ hs)
     }
   }
-
-  def contentLength: Option[Long] = headers.get(`Content-Length`).map(_.length)
-
-  def contentType: Option[`Content-Type`] = headers.get(`Content-Type`)
-
-  /** Returns the charset parameter of the `Content-Type` header, if present.
-    * Does not introspect the body for media types that define a charset internally. */
-  def charset: Option[Charset] = contentType.flatMap(_.charset)
-
-  def isChunked: Boolean = headers.get(`Transfer-Encoding`).exists(_.values.list.contains(TransferCoding.chunked))
-
-  /**
-   * The trailer headers, as specified in Section 3.6.1 of RFC 2616.  The resulting
-   * task might not complete unless the entire body has been consumed.
-   */
-  def trailerHeaders: Task[Headers] = attributes.get(Message.Keys.TrailerHeaders).getOrElse(Task.now(Headers.empty))
 
   /** Decode the [[Message]] to the specified type
     *
@@ -125,116 +75,39 @@ object Message {
   * @param body scalaz.stream.Process[Task,Chunk] defining the body of the request
   * @param attributes Immutable Map used for carrying additional information in a type safe fashion
   */
-case class Request(
+final case class Request(
   method: Method = Method.GET,
   uri: Uri = Uri(path = "/"),
   httpVersion: HttpVersion = HttpVersion.`HTTP/1.1`,
   headers: Headers = Headers.empty,
   body: EntityBody = EmptyBody,
   attributes: AttributeMap = AttributeMap.empty
-) extends Message with MessageOps {
-  import Request._
-
+) extends Message with RequestOps[Id] {
   type Self = Request
 
-
-  override protected def change(body: EntityBody, headers: Headers, attributes: AttributeMap): Self =
+  override protected def change(body: EntityBody, headers: Headers, attributes: AttributeMap): Request =
     copy(body = body, headers = headers, attributes = attributes)
 
-  lazy val authType: Option[AuthScheme] = headers.get(Authorization).map(_.credentials.authScheme)
+  override def transformUri(f: Uri => Uri): Request =
+    copy(uri = uri)
 
   lazy val (scriptName, pathInfo) = {
     val caret = attributes.get(Request.Keys.PathInfoCaret).getOrElse(0)
     uri.path.splitAt(caret)
   }
 
-  def withPathInfo(pi: String) = copy(uri = uri.withPath(scriptName + pi))
-
-  lazy val pathTranslated: Option[File] = attributes.get(Keys.PathTranslated)
-
-  def queryString: String = uri.query.renderString
-
-  /**
-   * Representation of the query string as a map
-   *
-   * In case a parameter is available in query string but no value is there the
-   * sequence will be empty. If the value is empty the the sequence contains an
-   * empty string.
-   *
-   * =====Examples=====
-   * <table>
-   * <tr><th>Query String</th><th>Map</th></tr>
-   * <tr><td><code>?param=v</code></td><td><code>Map("param" -> Seq("v"))</code></td></tr>
-   * <tr><td><code>?param=</code></td><td><code>Map("param" -> Seq(""))</code></td></tr>
-   * <tr><td><code>?param</code></td><td><code>Map("param" -> Seq())</code></td></tr>
-   * <tr><td><code>?=value</code></td><td><code>Map("" -> Seq("value"))</code></td></tr>
-   * <tr><td><code>?p1=v1&amp;p1=v2&amp;p2=v3&amp;p2=v3</code></td><td><code>Map("p1" -> Seq("v1","v2"), "p2" -> Seq("v3","v4"))</code></td></tr>
-   * </table>
-   *
-   * The query string is lazily parsed. If an error occurs during parsing
-   * an empty `Map` is returned.
-   */
-  def multiParams: Map[String, Seq[String]] = uri.multiParams
-
-  /**
-   * View of the head elements of the URI parameters in query string.
-   *
-   * In case a parameter has no value the map returns an empty string.
-   *
-   * @see multiParams
-   */
-  def params: Map[String, String] = uri.params
-
-  private lazy val connectionInfo = attributes.get(Keys.ConnectionInfo)
-
-  lazy val remote: Option[InetSocketAddress] = connectionInfo.map(_.remote)
-  lazy val remoteAddr: Option[String] = remote.map(_.getHostString)
-  lazy val remoteHost: Option[String] = remote.map(_.getHostName)
-  lazy val remotePort: Option[Int]    = remote.map(_.getPort)
-
-  lazy val remoteUser: Option[String] = None
-
-  lazy val server: Option[InetSocketAddress] = connectionInfo.map(_.local)
-  lazy val serverAddr: String = {
+  def serverAddr: String =
     server.map(_.getHostString)
       .orElse(uri.host.map(_.value))
       .orElse(headers.get(Host).map(_.host))
       .getOrElse(InetAddress.getLocalHost.getHostName)
-  }
 
-  lazy val serverPort: Int = {
+  def serverPort: Int =
     server.map(_.getPort)
       .orElse(uri.port)
       .orElse(headers.get(Host).flatMap(_.port))
       .getOrElse(80)
-  }
 
-  /** Whether the Request was received over a secure medium */
-  lazy val isSecure: Option[Boolean] = connectionInfo.map(_.secure)
-
-  def serverSoftware: ServerSoftware = attributes.get(Keys.ServerSoftware).getOrElse(ServerSoftware.Unknown)
-
-  /** Helper method for decoding [[Request]]s
-    *
-    * Attempt to decode the [[Request]] and, if successful, execute the continuation to get a [[Response]].
-    * If decoding fails, a BadRequest [[Response]] is generated.
-    */
-  def decode[A](f: A => Task[Response])(implicit decoder: EntityDecoder[A]): Task[Response] =
-    decodeWith(decoder, strict = false)(f)
-
-  /** Helper method for decoding [[Request]]s
-    *
-    * Attempt to decode the [[Request]] and, if successful, execute the continuation to get a [[Response]].
-    * If decoding fails, a BadRequest [[Response]] is generated. If the decoder does not support the
-    * [[MediaType]] of the [[Request]], a `UnsupportedMediaType` [[Response]] is generated instead.
-    */
-  def decodeStrict[A](f: A => Task[Response])(implicit decoder: EntityDecoder[A]): Task[Response] =
-    decodeWith(decoder, true)(f)
-
-  /** Like [[decode]], but with an explicit decoder.
-    * @param strict If strict, will return a [[Status.UnsupportedMediaType]] http Response if this message's
-    *               [[MediaType]] is not supported by the provided decoder
-    */
   def decodeWith[A](decoder: EntityDecoder[A], strict: Boolean)(f: A => Task[Response]): Task[Response] =
     decoder.decode(this, strict = strict).fold(_.toHttpResponse(httpVersion), f).join
 
@@ -267,7 +140,7 @@ case class Response(
   httpVersion: HttpVersion = HttpVersion.`HTTP/1.1`,
   headers: Headers = Headers.empty,
   body: EntityBody = EmptyBody,
-  attributes: AttributeMap = AttributeMap.empty) extends Message with ResponseOps {
+  attributes: AttributeMap = AttributeMap.empty) extends Message with ResponseOps[Id] {
   type Self = Response
 
   /** Response specific extension methods */

--- a/core/src/main/scala/org/http4s/MessageOps.scala
+++ b/core/src/main/scala/org/http4s/MessageOps.scala
@@ -262,10 +262,9 @@ trait ResponseOps[F[_]] extends Any with MessageOps[F] {
   /** Change the status of this response object
     *
     * @param status value to replace on the response object
-    * @tparam S type that can be converted to a [[Status]]
     * @return a new response object with the new status code
     */
-  def withStatus[S <% Status](status: S): F[Self]
+  def withStatus(status: Status): F[Self]
 
   /** Add a Set-Cookie header for the provided [[Cookie]] */
   def addCookie(cookie: Cookie): F[Self] =

--- a/core/src/main/scala/org/http4s/MessageOps.scala
+++ b/core/src/main/scala/org/http4s/MessageOps.scala
@@ -1,21 +1,41 @@
 package org.http4s
 
-import java.time.{ZoneOffset, Instant}
+import java.io.File
+import java.net.InetSocketAddress
+import java.time.Instant
 
-import org.http4s.headers.{`Set-Cookie`, `Content-Type`}
+import org.http4s.Request.Keys
+import org.http4s.headers._
+import org.http4s.server.ServerSoftware
 
-import scalaz.\/
 import scalaz.concurrent.Task
+import scalaz.stream.Process
+import scalaz.stream.text.utf8Decode
 
-trait MessageOps extends Any {
+trait MessageOps[F[_]] extends Any {
   type Self
+
+  protected def map[A, B](fa: F[A])(f: A => B): F[B]
+  protected def taskMap[A, B](fa: F[A])(f: A => Task[B]): Task[B]
+  protected def streamMap[A, B](fa: F[A])(f: A => Process[Task, B]): Process[Task, B]
+
+  def httpVersion: F[HttpVersion]
+
+  def headers: F[Headers]
+
+  def transformHeaders(f: Headers => Headers): F[Self]
 
   /** Remove headers that satisfy the predicate
     *
-    * @param f predicate
+    * @param p predicate
     * @return a new message object which lacks the specified headers
     */
-  def filterHeaders(f: Header => Boolean): Self
+  def filterHeaders(p: Header => Boolean): F[Self] =
+    transformHeaders(_.filter(p))
+
+  def attributes: F[AttributeMap]
+
+  def transformAttributes(f: AttributeMap => AttributeMap): F[Self]
 
   /** Generates a new message object with the specified key/value pair appended to the [[org.http4s.AttributeMap]]
     *
@@ -24,7 +44,8 @@ trait MessageOps extends Any {
     * @tparam A type of the value to store
     * @return a new message object with the key/value pair appended
     */
-  def withAttribute[A](key: AttributeKey[A], value: A): Self
+  def withAttribute[A](key: AttributeKey[A], value: A): F[Self] =
+    transformAttributes(_.put(key, value))
 
   /** Generates a new message object with the specified key/value pair appended to the [[org.http4s.AttributeMap]]
     *
@@ -32,46 +53,83 @@ trait MessageOps extends Any {
     * @tparam V type of the value to store
     * @return a new message object with the key/value pair appended
     */
-  def withAttribute[V](entry: AttributeEntry[V]): Self = withAttribute(entry.key, entry.value)
+  def withAttribute[V](entry: AttributeEntry[V]): F[Self] =
+    withAttribute(entry.key, entry.value)
 
   /** Added the [[`Content-Type`]] header to the response */
-  def withType(t: MediaType): Self = putHeaders(`Content-Type`(t))
+  def withType(t: MediaType): F[Self] =
+    putHeaders(`Content-Type`(t))
 
-  def withContentType(contentType: Option[`Content-Type`]): Self = contentType match {
-    case Some(t) => putHeaders(t)
-    case None => filterHeaders(_.is(`Content-Type`))
-  }
+  def withContentType(contentType: Option[`Content-Type`]): F[Self] =
+    contentType match {
+      case Some(t) => putHeaders(t)
+      case None => filterHeaders(_.is(`Content-Type`))
+    }
 
-  def removeHeader(key: HeaderKey): Self = filterHeaders(_ isNot key)
-/** Replaces the [[Header]]s of the incoming Request object
-    *
-    * @param headers [[Headers]] containing the desired headers
-    * @return a new Request object
-    */
-  @deprecated("Use replaceAllHeaders. Will be removed in 0.11.x", "0.10.0")
-  final def withHeaders(headers: Headers): Self = replaceAllHeaders(headers)
+  def contentLength: F[Option[Long]] =
+    map(headers)(_.get(`Content-Length`).map(_.length))
 
-  /** Replace the existing headers with those provided */
-  @deprecated("Use replaceAllHeaders. Will be removed in 0.11.x", "0.10.0")
-  final def withHeaders(headers: Header*): Self = replaceAllHeaders(Headers(headers.toList))
-  
+  def isChunked: F[Boolean] =
+    map(headers)(_.get(`Transfer-Encoding`).exists(_.values.list.contains(TransferCoding.chunked)))
+
+  def removeHeader(key: HeaderKey): F[Self] =
+    filterHeaders(_ isNot key)
+
   /** Replaces the [[Header]]s of the incoming Request object
     *
     * @param headers [[Headers]] containing the desired headers
     * @return a new Request object
     */
-  def replaceAllHeaders(headers: Headers): Self
+  def replaceAllHeaders(headers: Headers): F[Self] =
+    transformHeaders(_ => headers)
 
   /** Replace the existing headers with those provided */
-  def replaceAllHeaders(headers: Header*): Self = replaceAllHeaders(Headers(headers.toList))
+  def replaceAllHeaders(headers: Header*): F[Self] =
+    replaceAllHeaders(Headers(headers.toList))
 
   /** Add the provided headers to the existing headers, replacing those of the same header name
     * The passed headers are assumed to contain no duplicate Singleton headers.
     */
-  def putHeaders(headers: Header*): Self
+  def putHeaders(headers: Header*): F[Self] =
+    transformHeaders(_.put(headers:_*))
 
-  def withTrailerHeaders(trailerHeaders: Task[Headers]): Self =
+  def contentType: F[Option[`Content-Type`]] =
+    map(headers)(_.get(`Content-Type`))
+
+  /** Returns the charset parameter of the `Content-Type` header, if present.
+    * Does not introspect the body for media types that define a charset internally. */
+  def charset: F[Option[Charset]] =
+    map(contentType)(_.flatMap(_.charset))
+
+  /**
+    * The trailer headers, as specified in Section 3.6.1 of RFC 2616.  The resulting
+    * task might not complete unless the entire body has been consumed.
+    */
+  def trailerHeaders: Task[Headers] =
+    taskMap(attributes)(_.get(Message.Keys.TrailerHeaders).getOrElse(Task.now(Headers.empty)))
+
+  def withTrailerHeaders(trailerHeaders: Task[Headers]): F[Self] =
     withAttribute(Message.Keys.TrailerHeaders, trailerHeaders)
+
+  def body: EntityBody
+
+  def bodyAsText(implicit defaultCharset: Charset = DefaultCharset): Process[Task, String] =
+    streamMap(charset) { _ getOrElse defaultCharset match {
+      case Charset.`UTF-8` =>
+        // suspect this one is more efficient, though this is superstition
+        body |> utf8Decode
+      case cs =>
+        body |> util.decode(cs)
+    } }
+
+  /** Replace the body of this message with a new body
+    *
+    * @param b body to attach to this method
+    * @param w [[EntityEncoder]] with which to convert the body to an [[EntityBody]]
+    * @tparam T type of the Body
+    * @return a new message with the new body
+    */
+  def withBody[T](b: T)(implicit w: EntityEncoder[T]): Task[Self]
 
   /** Decode the [[Message]] to the specified type
     *
@@ -84,6 +142,7 @@ trait MessageOps extends Any {
   /** Decode the [[Message]] to the specified type
     *
     * If no valid [[Status]] has been described, allow Ok
+    *
     * @param decoder [[EntityDecoder]] used to decode the [[Message]]
     * @tparam T type of the result
     * @return the `Task` which will generate the T
@@ -92,7 +151,113 @@ trait MessageOps extends Any {
     attemptAs(decoder).fold(throw _, identity)
 }
 
-trait ResponseOps extends Any with MessageOps {
+trait RequestOps[F[_]] extends Any with MessageOps[F] {
+  def uri: F[Uri]
+  def transformUri(f: Uri => Uri): F[Request]
+
+  def withPathInfo(pi: String): F[Request] =
+    transformUri(_.withPath(scriptName + pi))
+
+  def authType: F[Option[AuthScheme]] =
+    map(headers)(_.get(Authorization).map(_.credentials.authScheme))
+
+  def scriptName: F[String]
+  def pathInfo: F[String]
+
+  def pathTranslated: F[Option[File]] =
+    map(attributes)(_.get(Keys.PathTranslated))
+
+  def queryString: F[String] =
+    map(uri)(_.query.renderString)
+
+  /**
+   * Representation of the query string as a map
+   *
+   * In case a parameter is available in query string but no value is there the
+   * sequence will be empty. If the value is empty the the sequence contains an
+   * empty string.
+   *
+   * =====Examples=====
+   * <table>
+   * <tr><th>Query String</th><th>Map</th></tr>
+   * <tr><td><code>?param=v</code></td><td><code>Map("param" -> Seq("v"))</code></td></tr>
+   * <tr><td><code>?param=</code></td><td><code>Map("param" -> Seq(""))</code></td></tr>
+   * <tr><td><code>?param</code></td><td><code>Map("param" -> Seq())</code></td></tr>
+   * <tr><td><code>?=value</code></td><td><code>Map("" -> Seq("value"))</code></td></tr>
+   * <tr><td><code>?p1=v1&amp;p1=v2&amp;p2=v3&amp;p2=v3</code></td><td><code>Map("p1" -> Seq("v1","v2"), "p2" -> Seq("v3","v4"))</code></td></tr>
+   * </table>
+   *
+   * The query string is lazily parsed. If an error occurs during parsing
+   * an empty `Map` is returned.
+   */
+  def multiParams: F[Map[String, Seq[String]]] =
+    map(uri)(_.multiParams)
+
+  /**
+   * View of the head elements of the URI parameters in query string.
+   *
+   * In case a parameter has no value the map returns an empty string.
+   *
+   * @see multiParams
+   */
+  def params: F[Map[String, String]] =
+    map(uri)(_.params)
+
+  def connectionInfo: F[Option[Request.Connection]] =
+    map(attributes)(_.get(Keys.ConnectionInfo))
+
+  def remote: F[Option[InetSocketAddress]] =
+    map(connectionInfo)(_.map(_.remote))
+
+  def remoteAddr: F[Option[String]] =
+    map(remote)(_.map(_.getHostString))
+
+  def remoteHost: F[Option[String]] =
+    map(remote)(_.map(_.getHostName))
+
+  def remotePort: F[Option[Int]] =
+    map(remote)(_.map(_.getPort))
+
+  def server: F[Option[InetSocketAddress]] =
+    map(connectionInfo)(_.map(_.local))
+
+  def serverAddr: F[String]
+
+  def serverPort: F[Int]
+
+  /** Whether the Request was received over a secure medium */
+  def isSecure: F[Option[Boolean]] =
+    map(connectionInfo)(_.map(_.secure))
+
+  def serverSoftware: F[ServerSoftware] =
+    map(attributes)(_.get(Keys.ServerSoftware).getOrElse(ServerSoftware.Unknown))
+
+  /** Helper method for decoding [[Request]]s
+    *
+    * Attempt to decode the [[Request]] and, if successful, execute the continuation to get a [[Response]].
+    * If decoding fails, a BadRequest [[Response]] is generated.
+    */
+  def decode[A](f: A => Task[Response])(implicit decoder: EntityDecoder[A]): Task[Response] =
+    decodeWith(decoder, strict = false)(f)
+
+  /** Helper method for decoding [[Request]]s
+    *
+    * Attempt to decode the [[Request]] and, if successful, execute the continuation to get a [[Response]].
+    * If decoding fails, a BadRequest [[Response]] is generated. If the decoder does not support the
+    * [[MediaType]] of the [[Request]], a `UnsupportedMediaType` [[Response]] is generated instead.
+    */
+  def decodeStrict[A](f: A => Task[Response])(implicit decoder: EntityDecoder[A]): Task[Response] =
+    decodeWith(decoder, true)(f)
+
+  /** Like [[decode]], but with an explicit decoder.
+    *
+    * @param strict If strict, will return a [[Status.UnsupportedMediaType]] http Response if this message's
+    *               [[MediaType]] is not supported by the provided decoder
+    */
+  def decodeWith[A](decoder: EntityDecoder[A], strict: Boolean)(f: A => Task[Response]): Task[Response]
+}
+
+trait ResponseOps[F[_]] extends Any with MessageOps[F] {
 
   /** Change the status of this response object
     *
@@ -100,23 +265,25 @@ trait ResponseOps extends Any with MessageOps {
     * @tparam S type that can be converted to a [[Status]]
     * @return a new response object with the new status code
     */
-  def withStatus[S <% Status](status: S): Self
+  def withStatus[S <% Status](status: S): F[Self]
 
   /** Add a Set-Cookie header for the provided [[Cookie]] */
-  def addCookie(cookie: Cookie): Self = putHeaders(`Set-Cookie`(cookie))
+  def addCookie(cookie: Cookie): F[Self] =
+    putHeaders(`Set-Cookie`(cookie))
 
   /** Add a Set-Cookie header with the provided values */
   def addCookie(name: String,
                 content: String,
-                expires: Option[Instant] = None): Self = addCookie(Cookie(name, content, expires))
+                expires: Option[Instant] = None): F[Self] =
+    addCookie(Cookie(name, content, expires))
 
   /** Add a [[`Set-Cookie`]] which will remove the specified cookie from the client */
-  def removeCookie(cookie: Cookie): Self = putHeaders(`Set-Cookie`(cookie.copy(content = "",
-    expires = Some(Instant.ofEpochSecond(0)), maxAge = Some(0))))
+  def removeCookie(cookie: Cookie): F[Self] =
+    putHeaders(`Set-Cookie`(cookie.copy(content = "", expires = Some(Instant.ofEpochSecond(0)), maxAge = Some(0))))
 
   /** Add a Set-Cookie which will remove the specified cookie from the client */
-  def removeCookie(name: String): Self = putHeaders(`Set-Cookie`(
-    Cookie(name, "", expires = Some(Instant.ofEpochSecond(0)), maxAge = Some(0))
+  def removeCookie(name: String): F[Self] =
+    putHeaders(`Set-Cookie`(Cookie(name, "", expires = Some(Instant.ofEpochSecond(0)), maxAge = Some(0))
   ))
 }
 

--- a/core/src/main/scala/org/http4s/MessageSyntax.scala
+++ b/core/src/main/scala/org/http4s/MessageSyntax.scala
@@ -1,7 +1,8 @@
 package org.http4s
 
-import scalaz.{EitherT, \/}
+import scalaz.{stream, EitherT}
 import scalaz.concurrent.Task
+import scalaz.stream.Process.eval
 
 object MessageSyntax extends MessageSyntax
 
@@ -11,51 +12,80 @@ trait MessageSyntax {
   implicit def responseSyntax(resp: Task[Response]): TaskResponseOps = new TaskResponseOps(resp)
 }
 
-trait TaskMessageOps[M <: Message] extends Any with MessageOps {
-  type Self = Task[M#Self]
+trait TaskMessageOps[M <: Message] extends Any with MessageOps[Task] {
+  type Self = M#Self
 
   def self: Task[M]
 
-  /** Add a body to the message
-    * @see [[Message]]
-    */
-  def withBody[T](b: T)(implicit w: EntityEncoder[T]): Self = self.flatMap(_.withBody(b)(w))
+  override protected def map[A, B](fa: Task[A])(f: (A) => B): Task[B] =
+    fa.map(f)
 
-  /** Generates a new message object with the specified key/value pair appended to the [[org.http4s.AttributeMap]]
-    *
-    * @param key [[AttributeKey]] with which to associate the value
-    * @param value value associated with the key
-    * @tparam A type of the value to store
-    * @return a new message object with the key/value pair appended
-    */
-  override def withAttribute[A](key: AttributeKey[A], value: A): Self = self.map(_.withAttribute(key, value))
+  override protected def taskMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] =
+    fa.flatMap(f)
 
-  /** Replaces the [[Header]]s of the incoming Request object
-    *
-    * @param headers [[Headers]] containing the desired headers
-    * @return a new Request object
-    */
-  override def replaceAllHeaders(headers: Headers): Self = self.map(_.replaceAllHeaders(headers))
+  override protected def streamMap[A, B](fa: Task[A])(f: A => stream.Process[Task, B]): stream.Process[Task, B] =
+    eval(fa).flatMap(f)
 
-  /** Add the provided headers to the existing headers, replacing those of the same header name */
-  override def putHeaders(headers: Header*): Self = self.map(_.putHeaders(headers:_*))
+  override def httpVersion: Task[HttpVersion] =
+    self.map(_.httpVersion)
 
-  override def filterHeaders(f: (Header) => Boolean): Self = self.map(_.filterHeaders(f))
+  override def body: EntityBody =
+    eval(self).flatMap(_.body)
 
-  /** Decode the [[Message]] to the specified type
-    *
-    * @param decoder [[EntityDecoder]] used to decode the [[Message]]
-    * @tparam T type of the result
-    * @return the `Task` which will generate the `ParseFailure\/T`
-    */
+  override def attributes: Task[AttributeMap] =
+    self.map(_.attributes)
+
+  override def headers: Task[Headers] =
+    self.map(_.headers)
+
+  override def transformAttributes(f: AttributeMap => AttributeMap): Task[Self] =
+    self.map(_.transformAttributes(f))
+
+  override def transformHeaders(f: (Headers) => Headers): Task[Self] =
+    self.map(_.transformHeaders(f))
+
+  override def withBody[T](b: T)(implicit w: EntityEncoder[T]): Task[Self] =
+    self.flatMap(_.withBody(b)(w))
+
   override def attemptAs[T](implicit decoder: EntityDecoder[T]): DecodeResult[T] = EitherT(self.flatMap { msg =>
     decoder.decode(msg, false).run
   })
 }
 
-final class TaskRequestOps(val self: Task[Request]) extends AnyVal with TaskMessageOps[Request]
+final class TaskRequestOps(val self: Task[Request])
+  extends AnyVal with TaskMessageOps[Request] with RequestOps[Task]
+{
+  override def uri: Task[Uri] =
+    self.map(_.uri)
 
-final class TaskResponseOps(val self: Task[Response]) extends AnyVal with TaskMessageOps[Response] with ResponseOps {
-  /** Response specific extension methods */
-  override def withStatus[S <% Status](status: S): Self = self.map(_.withStatus(status))
+  override def transformUri(f: Uri => Uri): Task[Request] =
+    self.map(_.transformUri(f))
+
+  override def scriptName: Task[String] =
+    self.map(_.scriptName)
+
+  override def pathInfo: Task[String] =
+    self.map(_.pathInfo)
+
+  override def serverPort: Task[Int] =
+    self.map(_.serverPort)
+
+  override def serverAddr: Task[String] =
+    self.map(_.serverAddr)
+
+  override def decodeWith[A](decoder: EntityDecoder[A], strict: Boolean)(f: (A) => Task[Response]): Task[Response] =
+    self.flatMap(_.decodeWith(decoder, strict)(f))
+}
+
+final class TaskResponseOps(val self: Task[Response])
+  extends AnyVal with TaskMessageOps[Response] with ResponseOps[Task]
+{
+  /** Change the status of this response object
+    *
+    * @param status value to replace on the response object
+    * @tparam S type that can be converted to a [[Status]]
+    * @return a new response object with the new status code
+    */
+  override def withStatus[S <% Status](status: S): Task[Response] =
+    self.map(_.withStatus(status))
 }

--- a/core/src/main/scala/org/http4s/MessageSyntax.scala
+++ b/core/src/main/scala/org/http4s/MessageSyntax.scala
@@ -80,12 +80,6 @@ final class TaskRequestOps(val self: Task[Request])
 final class TaskResponseOps(val self: Task[Response])
   extends AnyVal with TaskMessageOps[Response] with ResponseOps[Task]
 {
-  /** Change the status of this response object
-    *
-    * @param status value to replace on the response object
-    * @tparam S type that can be converted to a [[Status]]
-    * @return a new response object with the new status code
-    */
-  override def withStatus[S <% Status](status: S): Task[Response] =
+  override def withStatus(status: Status): Task[Response] =
     self.map(_.withStatus(status))
 }


### PR DESCRIPTION
We've been inconsistent about which operations are available as syntax on `Task[Message]` vs. needing to map the `Message`.  This pushes all operations down onto `MessageOps`.

We had several lazy fields on `Request` of dubious value.  These have been converted to defs, which should infrequent calculation for memory on each request.  If this trade proves bad, we can selectively move them back.