### PR TITLE
Create a config object for the blaze client and allow HTTP/1.X parser configuration

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -8,6 +8,7 @@ import org.asynchttpclient.AsyncHandler.State
 import org.asynchttpclient.request.body.generator.{InputStreamBodyGenerator, BodyGenerator}
 import org.asynchttpclient.{Request => AsyncRequest, Response => _, _}
 import org.asynchttpclient.handler.StreamedAsyncHandler
+import org.http4s.client.impl.DefaultExecutor
 
 import org.http4s.util.threads._
 
@@ -41,7 +42,7 @@ object AsyncHttpClient {
     */
   def apply(config: AsyncHttpClientConfig = defaultConfig,
             bufferSize: Int = 8,
-            executorService: ExecutorService = newDefaultExecutorService): Client = {
+            executorService: ExecutorService = DefaultExecutor.newClientDefaultExecutorService("async-http-client-response")): Client = {
     val client = new DefaultAsyncHttpClient(config)
     val close = executorService match {
       case es: DefaultExecutorService =>
@@ -58,11 +59,6 @@ object AsyncHttpClient {
       }
     }, close)
   }
-
-  private def newDefaultExecutorService =
-    newDefaultFixedThreadPool(
-      (Runtime.getRuntime.availableProcessors * 1.5).ceil.toInt,
-      threadFactory(i => s"http4s-async-http-client-response-$i"))
 
   private def asyncHandler(callback: Callback[DisposableResponse],
                            bufferSize: Int,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -1,0 +1,45 @@
+package org.http4s.client.blaze
+
+import java.nio.channels.AsynchronousChannelGroup
+import java.util.concurrent.ExecutorService
+import javax.net.ssl.SSLContext
+
+import org.http4s.headers.`User-Agent`
+
+import scala.concurrent.duration.Duration
+
+/** Config object for the blaze clients
+  *
+  * @param idleTimeout duration that a connection can wait without traffic before timeout
+  * @param requestTimeout maximum duration for a request to complete before a timeout
+  * @param bufferSize internal buffer size of the blaze client
+  * @param userAgent optional custom user agent header
+  * @param executor thread pool where asynchronous computations will be performed
+  * @param sslContext optional custom `SSLContext` to use to replace the default
+  * @param endpointAuthentication require endpoint authentication for encrypted connections
+  * @param group custom `AsynchronousChannelGroup` to use other than the system default
+  */
+case class BlazeClientConfig(
+                              idleTimeout: Duration,
+                              requestTimeout: Duration,
+                              bufferSize: Int,
+                              userAgent: Option[`User-Agent`],
+                              executor: ExecutorService,
+                              sslContext: Option[SSLContext],
+                              endpointAuthentication: Boolean,
+                              group: Option[AsynchronousChannelGroup]
+                            )
+
+object BlazeClientConfig {
+  /** Default user configuration */
+  val defaultConfig = BlazeClientConfig(
+    idleTimeout = bits.DefaultTimeout,
+    requestTimeout = Duration.Inf,
+    bufferSize = bits.DefaultBufferSize,
+    userAgent = bits.DefaultUserAgent,
+    executor = bits.ClientDefaultEC,
+    sslContext = None,
+    endpointAuthentication = true,
+    group = None
+  )
+}

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -1,9 +1,11 @@
-package org.http4s.client.blaze
+package org.http4s.client
+package blaze
 
 import java.nio.channels.AsynchronousChannelGroup
 import java.util.concurrent.ExecutorService
 import javax.net.ssl.SSLContext
 
+import org.http4s.client.impl.DefaultExecutor
 import org.http4s.headers.`User-Agent`
 
 import scala.concurrent.duration.Duration
@@ -43,21 +45,26 @@ case class BlazeClientConfig( //
                             )
 
 object BlazeClientConfig {
-  /** Default user configuration */
-  val defaultConfig = BlazeClientConfig(
-    idleTimeout = bits.DefaultTimeout,
-    requestTimeout = Duration.Inf,
-    userAgent = bits.DefaultUserAgent,
+  /** Default user configuration
+    *
+    * @param executor executor on which to run computations.
+    *                 If the default `ExecutorService` is used it will be shutdown with the client
+    */
+  def defaultConfig(executor: ExecutorService = DefaultExecutor.newClientDefaultExecutorService("blaze-client")) =
+    BlazeClientConfig(
+      idleTimeout = bits.DefaultTimeout,
+      requestTimeout = Duration.Inf,
+      userAgent = bits.DefaultUserAgent,
 
-    sslContext = None,
-    endpointAuthentication = true,
+      sslContext = None,
+      endpointAuthentication = true,
 
-    maxResponseLineSize = 4*1024,
-    maxHeaderLength = 40*1024,
-    maxChunkSize = Integer.MAX_VALUE,
+      maxResponseLineSize = 4*1024,
+      maxHeaderLength = 40*1024,
+      maxChunkSize = Integer.MAX_VALUE,
 
-    bufferSize = bits.DefaultBufferSize,
-    executor = bits.ClientDefaultEC,
-    group = None
-  )
+      bufferSize = bits.DefaultBufferSize,
+      executor = executor,
+      group = None
+    )
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -12,21 +12,33 @@ import scala.concurrent.duration.Duration
   *
   * @param idleTimeout duration that a connection can wait without traffic before timeout
   * @param requestTimeout maximum duration for a request to complete before a timeout
-  * @param bufferSize internal buffer size of the blaze client
   * @param userAgent optional custom user agent header
-  * @param executor thread pool where asynchronous computations will be performed
   * @param sslContext optional custom `SSLContext` to use to replace the default
   * @param endpointAuthentication require endpoint authentication for encrypted connections
+  * @param maxResponseLineSize maximum length of the request line
+  * @param maxHeaderLength maximum length of headers
+  * @param maxChunkSize maximum size of chunked content chunks
+  * @param bufferSize internal buffer size of the blaze client
+  * @param executor thread pool where asynchronous computations will be performed
   * @param group custom `AsynchronousChannelGroup` to use other than the system default
   */
-case class BlazeClientConfig(
+case class BlazeClientConfig( //
                               idleTimeout: Duration,
                               requestTimeout: Duration,
-                              bufferSize: Int,
                               userAgent: Option[`User-Agent`],
-                              executor: ExecutorService,
+
+                              // security options
                               sslContext: Option[SSLContext],
                               endpointAuthentication: Boolean,
+
+                              // parser options
+                              maxResponseLineSize: Int,
+                              maxHeaderLength: Int,
+                              maxChunkSize: Int,
+
+                              // pipeline management
+                              bufferSize: Int,
+                              executor: ExecutorService,
                               group: Option[AsynchronousChannelGroup]
                             )
 
@@ -35,11 +47,17 @@ object BlazeClientConfig {
   val defaultConfig = BlazeClientConfig(
     idleTimeout = bits.DefaultTimeout,
     requestTimeout = Duration.Inf,
-    bufferSize = bits.DefaultBufferSize,
     userAgent = bits.DefaultUserAgent,
-    executor = bits.ClientDefaultEC,
+
     sslContext = None,
     endpointAuthentication = true,
+
+    maxResponseLineSize = 4*1024,
+    maxHeaderLength = 40*1024,
+    maxChunkSize = Integer.MAX_VALUE,
+
+    bufferSize = bits.DefaultBufferSize,
+    executor = bits.ClientDefaultEC,
     group = None
   )
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeHttp1ClientParser.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeHttp1ClientParser.scala
@@ -6,7 +6,7 @@ import org.http4s._
 import org.http4s.blaze.http.http_parser.Http1ClientParser
 import scala.collection.mutable.ListBuffer
 
-final private class BlazeHttp1ClientParser extends Http1ClientParser {
+private final class BlazeHttp1ClientParser extends Http1ClientParser {
   private val headers = new ListBuffer[Header]
   private var status: Status = _
   private var httpVersion: HttpVersion = _

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeHttp1ClientParser.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeHttp1ClientParser.scala
@@ -6,7 +6,16 @@ import org.http4s._
 import org.http4s.blaze.http.http_parser.Http1ClientParser
 import scala.collection.mutable.ListBuffer
 
-private final class BlazeHttp1ClientParser extends Http1ClientParser {
+/** http/1.x parser for the blaze client */
+private[blaze] object BlazeHttp1ClientParser {
+  def apply(maxRequestLineSize: Int,
+            maxHeaderLength: Int,
+            maxChunkSize: Int): BlazeHttp1ClientParser =
+    new BlazeHttp1ClientParser(maxRequestLineSize, maxHeaderLength, maxChunkSize)
+}
+
+private[blaze] final class BlazeHttp1ClientParser(maxResponseLineSize: Int, maxHeaderLength: Int, maxChunkSize: Int)
+  extends Http1ClientParser(maxResponseLineSize, maxHeaderLength, 2*1024, maxChunkSize) {
   private val headers = new ListBuffer[Header]
   private var status: Status = _
   private var httpVersion: HttpVersion = _

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -28,14 +28,14 @@ import scalaz.{\/, -\/, \/-}
 
 
 private final class Http1Connection(val requestKey: RequestKey,
-                            userAgent: Option[`User-Agent`],
+                            config: BlazeClientConfig,
                             protected val ec: ExecutionContext)
   extends Http1Stage with BlazeConnection
 {
   import org.http4s.client.blaze.Http1Connection._
 
   override def name: String = getClass.getName
-  private val parser = new BlazeHttp1ClientParser
+  private val parser = new BlazeHttp1ClientParser(config.maxResponseLineSize, config.maxHeaderLength, config.maxChunkSize)
   private val stageState = new AtomicReference[State](Idle)
 
   override def isClosed: Boolean = stageState.get match {
@@ -126,8 +126,8 @@ private final class Http1Connection(val requestKey: RequestKey,
         encodeRequestLine(req, rr)
         Http1Stage.encodeHeaders(req.headers, rr, false)
 
-        if (userAgent.nonEmpty && req.headers.get(`User-Agent`).isEmpty) {
-          rr << userAgent.get << "\r\n"
+        if (config.userAgent.nonEmpty && req.headers.get(`User-Agent`).isEmpty) {
+          rr << config.userAgent.get << "\r\n"
         }
 
         val mustClose = H.Connection.from(req.headers) match {

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -27,7 +27,7 @@ import scalaz.stream.Process.{Halt, halt}
 import scalaz.{\/, -\/, \/-}
 
 
-final class Http1Connection(val requestKey: RequestKey,
+private final class Http1Connection(val requestKey: RequestKey,
                             userAgent: Option[`User-Agent`],
                             protected val ec: ExecutionContext)
   extends Http1Stage with BlazeConnection

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -4,13 +4,9 @@ package blaze
 
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
-import java.nio.channels.AsynchronousChannelGroup
-import java.util.concurrent.ExecutorService
-import javax.net.ssl.SSLContext
 
 import org.http4s.Uri.Scheme
 import org.http4s.blaze.channel.nio2.ClientChannelFactory
-import org.http4s.headers.`User-Agent`
 import org.http4s.util.task
 import org.http4s.blaze.pipeline.LeafBuilder
 import org.http4s.blaze.pipeline.stages.SSLStage
@@ -26,20 +22,10 @@ import scalaz.{\/, -\/, \/-}
 object Http1Support {
   /** Create a new [[ConnectionBuilder]]
    *
-   * @param bufferSize buffer size of the socket stages
-   * @param userAgent User-Agent header information
-   * @param es `ExecutorService` on which computations should be run
-   * @param osslContext Optional `SSSContext` for secure requests
-   * @param group `AsynchronousChannelGroup` used to manage socket connections
-   * @return [[ConnectionBuilder]] for creating new requests
+   * @param config The client configuration object
    */
-  def apply(bufferSize: Int,
-             userAgent: Option[`User-Agent`],
-                    es: ExecutorService,
-           osslContext: Option[SSLContext],
-       endpointAuthentication: Boolean,
-                 group: Option[AsynchronousChannelGroup]): ConnectionBuilder[BlazeConnection] = {
-    val builder = new Http1Support(bufferSize, userAgent, es, osslContext, endpointAuthentication, group)
+  def apply(config: BlazeClientConfig): ConnectionBuilder[BlazeConnection] = {
+    val builder = new Http1Support(config)
     builder.makeClient
   }
 
@@ -49,17 +35,12 @@ object Http1Support {
 
 /** Provides basic HTTP1 pipeline building
   */
-final private class Http1Support(bufferSize: Int,
-                          userAgent: Option[`User-Agent`],
-                                 es: ExecutorService,
-                        osslContext: Option[SSLContext],
-             endpointAuthentication: Boolean,
-                              group: Option[AsynchronousChannelGroup]) {
+final private class Http1Support(config: BlazeClientConfig) {
   import Http1Support._
 
-  private val ec = ExecutionContext.fromExecutorService(es)
-  private val sslContext = osslContext.getOrElse(bits.sslContext)
-  private val connectionManager = new ClientChannelFactory(bufferSize, group.orNull)
+  private val ec = ExecutionContext.fromExecutorService(config.executor)
+  private val sslContext = config.sslContext.getOrElse(bits.sslContext)
+  private val connectionManager = new ClientChannelFactory(config.bufferSize, config.group.orNull)
 
 ////////////////////////////////////////////////////
 
@@ -69,7 +50,7 @@ final private class Http1Support(bufferSize: Int,
   }
 
   private def buildPipeline(requestKey: RequestKey, addr: InetSocketAddress): Future[BlazeConnection] = {
-    connectionManager.connect(addr, bufferSize).map { head =>
+    connectionManager.connect(addr, config.bufferSize).map { head =>
       val (builder, t) = buildStages(requestKey)
       builder.base(head)
       t
@@ -77,10 +58,10 @@ final private class Http1Support(bufferSize: Int,
   }
 
   private def buildStages(requestKey: RequestKey): (LeafBuilder[ByteBuffer], BlazeConnection) = {
-    val t = new Http1Connection(requestKey, userAgent, ec)
+    val t = new Http1Connection(requestKey, config.userAgent, ec)
     val builder = LeafBuilder(t)
     requestKey match {
-      case RequestKey(Https, auth) if endpointAuthentication =>
+      case RequestKey(Https, auth) if config.endpointAuthentication =>
         val eng = sslContext.createSSLEngine(auth.host.value, auth.port getOrElse 443)
         eng.setUseClientMode(true)
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -58,7 +58,7 @@ final private class Http1Support(config: BlazeClientConfig) {
   }
 
   private def buildStages(requestKey: RequestKey): (LeafBuilder[ByteBuffer], BlazeConnection) = {
-    val t = new Http1Connection(requestKey, config.userAgent, ec)
+    val t = new Http1Connection(requestKey, config, ec)
     val builder = LeafBuilder(t)
     requestKey match {
       case RequestKey(Https, auth) if config.endpointAuthentication =>

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -2,29 +2,19 @@ package org.http4s
 package client
 package blaze
 
-import java.nio.channels.AsynchronousChannelGroup
-import java.util.concurrent.ExecutorService
-import javax.net.ssl.SSLContext
-
-import org.http4s.headers.`User-Agent`
-
-import scala.concurrent.duration.Duration
 
 /** Create a HTTP1 client which will attempt to recycle connections */
 object PooledHttp1Client {
 
-  /** Construct a new PooledHttp1Client */
+  /** Construct a new PooledHttp1Client
+    *
+    * @param maxTotalConnections maximum connections the client will have at any specific time
+    * @param config blaze client configuration options
+    */
   def apply( maxTotalConnections: Int = 10,
-                     idleTimeout: Duration = bits.DefaultTimeout,
-                  requestTimeout: Duration = Duration.Inf,
-                       userAgent: Option[`User-Agent`] = bits.DefaultUserAgent,
-                      bufferSize: Int = bits.DefaultBufferSize,
-                        executor: ExecutorService = bits.ClientDefaultEC,
-                      sslContext: Option[SSLContext] = None,
-          endpointAuthentication: Boolean = true,
-                           group: Option[AsynchronousChannelGroup] = None) = {
-    val http1 = Http1Support(bufferSize, userAgent, executor, sslContext, endpointAuthentication, group)
-    val pool = ConnectionManager.pool(http1, maxTotalConnections, executor)
-    BlazeClient(pool, idleTimeout, requestTimeout)
+                          config: BlazeClientConfig = BlazeClientConfig.defaultConfig) = {
+    val http1 = Http1Support(config)
+    val pool = ConnectionManager.pool(http1, maxTotalConnections, config.executor)
+    BlazeClient(pool, config.idleTimeout, config.requestTimeout)
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -12,9 +12,9 @@ object PooledHttp1Client {
     * @param config blaze client configuration options
     */
   def apply( maxTotalConnections: Int = 10,
-                          config: BlazeClientConfig = BlazeClientConfig.defaultConfig) = {
+                          config: BlazeClientConfig = BlazeClientConfig.defaultConfig()) = {
     val http1 = Http1Support(config)
     val pool = ConnectionManager.pool(http1, maxTotalConnections, config.executor)
-    BlazeClient(pool, config.idleTimeout, config.requestTimeout)
+    BlazeClient(pool, config)
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
@@ -11,15 +11,12 @@ import scala.concurrent.duration.Duration
 
 /** Create HTTP1 clients which will disconnect on completion of one request */
 object SimpleHttp1Client {
-  def apply(idleTimeout: Duration = bits.DefaultTimeout,
-     requestTimeout: Duration = Duration.Inf,
-         bufferSize: Int = bits.DefaultBufferSize,
-          userAgent: Option[`User-Agent`] = bits.DefaultUserAgent,
-           executor: ExecutorService = bits.ClientDefaultEC,
-         sslContext: Option[SSLContext] = None,
-     endpointAuthentication: Boolean = true,
-              group: Option[AsynchronousChannelGroup] = None) = {
-    val manager = ConnectionManager.basic(Http1Support(bufferSize,  userAgent, executor, sslContext, endpointAuthentication, group))
-    BlazeClient(manager, idleTimeout, requestTimeout)
+  /** create a new simple client
+    *
+    * @param config blaze configuration object
+    */
+  def apply(config: BlazeClientConfig = BlazeClientConfig.defaultConfig) = {
+    val manager = ConnectionManager.basic(Http1Support(config))
+    BlazeClient(manager, config.idleTimeout, config.requestTimeout)
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
@@ -15,8 +15,8 @@ object SimpleHttp1Client {
     *
     * @param config blaze configuration object
     */
-  def apply(config: BlazeClientConfig = BlazeClientConfig.defaultConfig) = {
+  def apply(config: BlazeClientConfig = BlazeClientConfig.defaultConfig()) = {
     val manager = ConnectionManager.basic(Http1Support(config))
-    BlazeClient(manager, config.idleTimeout, config.requestTimeout)
+    BlazeClient(manager, config)
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
@@ -19,11 +19,6 @@ private[blaze] object bits {
   val DefaultTimeout: Duration = 60.seconds
   val DefaultBufferSize: Int = 8*1024
   val DefaultUserAgent = Some(`User-Agent`(AgentProduct("http4s-blaze", Some(BuildInfo.version))))
-  val ClientDefaultEC = {
-    val maxThreads = max(4, (Runtime.getRuntime.availableProcessors * 1.5).ceil.toInt)
-    val threadFactory = threads.threadFactory(name = (i => s"http4s-blaze-client-$i"), daemon = true)
-    Executors.newFixedThreadPool(maxThreads, threadFactory)
-  }
 
   val ClientTickWheel = new TickWheelExecutor()
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
@@ -1,12 +1,6 @@
 package org.http4s
 package client
 
-import java.nio.ByteBuffer
-
-import org.http4s.Uri.{Scheme, Authority}
-import org.http4s.blaze.pipeline.TailStage
-
-import scalaz.concurrent.Task
 
 
 package object blaze {
@@ -14,10 +8,5 @@ package object blaze {
   /** Default blaze client
     *
     * This client will create a new connection for every request. */
-  val defaultClient = SimpleHttp1Client(
-    idleTimeout = bits.DefaultTimeout,
-    bufferSize = bits.DefaultBufferSize,
-    executor = bits.ClientDefaultEC,
-    sslContext = None
-  )
+  lazy val defaultClient: Client = SimpleHttp1Client(BlazeClientConfig.defaultConfig)
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
@@ -8,5 +8,5 @@ package object blaze {
   /** Default blaze client
     *
     * This client will create a new connection for every request. */
-  lazy val defaultClient: Client = SimpleHttp1Client(BlazeClientConfig.defaultConfig)
+  lazy val defaultClient: Client = SimpleHttp1Client(BlazeClientConfig.defaultConfig())
 }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeSimpleHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeSimpleHttp1ClientSpec.scala
@@ -2,4 +2,5 @@ package org.http4s.client.blaze
 
 import org.http4s.client.ClientRouteTestBattery
 
-class BlazeSimpleHttp1ClientSpec extends ClientRouteTestBattery("SimpleHttp1Client", defaultClient)
+class BlazeSimpleHttp1ClientSpec extends
+ClientRouteTestBattery("SimpleHttp1Client", SimpleHttp1Client(BlazeClientConfig.defaultConfig()))

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -24,6 +24,8 @@ class ClientTimeoutSpec extends Http4sSpec {
   val FooRequestKey = RequestKey.fromRequest(FooRequest)
   val resp = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndone"
 
+  private def mkConnection() = new Http1Connection(FooRequestKey, BlazeClientConfig.defaultConfig, ec)
+
   def mkBuffer(s: String): ByteBuffer =
     ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))
   
@@ -36,13 +38,13 @@ class ClientTimeoutSpec extends Http4sSpec {
   "Http1ClientStage responses" should {
     "Timeout immediately with an idle timeout of 0 seconds" in {
       val c = mkClient(new SlowTestHead(List(mkBuffer(resp)), 0.seconds), 
-                       new Http1Connection(FooRequestKey, None, ec))(0.milli, Duration.Inf)
+                       mkConnection())(0.milli, Duration.Inf)
 
       c.fetchAs[String](FooRequest).run must throwA[TimeoutException]
     }
 
     "Timeout immediately with a request timeout of 0 seconds" in {
-      val tail = new Http1Connection(FooRequestKey, None, ec)
+      val tail = mkConnection()
       val h = new SlowTestHead(List(mkBuffer(resp)), 0.seconds)
       val c = mkClient(h, tail)(Duration.Inf, 0.milli)
 
@@ -50,7 +52,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     }
 
     "Idle timeout on slow response" in {
-      val tail = new Http1Connection(FooRequestKey, None, ec)
+      val tail = mkConnection()
       val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds)
       val c = mkClient(h, tail)(1.second, Duration.Inf)
 
@@ -58,7 +60,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     }
 
     "Request timeout on slow response" in {
-      val tail = new Http1Connection(FooRequestKey, None, ec)
+      val tail = mkConnection()
       val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds)
       val c = mkClient(h, tail)(Duration.Inf, 1.second)
 
@@ -77,7 +79,7 @@ class ClientTimeoutSpec extends Http4sSpec {
 
       val req = Request(method = Method.POST, uri = www_foo_com, body = dataStream(4))
 
-      val tail = new Http1Connection(RequestKey.fromRequest(req), None, ec)
+      val tail = new Http1Connection(RequestKey.fromRequest(req), BlazeClientConfig.defaultConfig, ec)
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
       val c = mkClient(h, tail)(Duration.Inf, 1.second)
@@ -97,7 +99,7 @@ class ClientTimeoutSpec extends Http4sSpec {
 
       val req = Request(method = Method.POST, uri = www_foo_com, body = dataStream(4))
 
-      val tail = new Http1Connection(RequestKey.fromRequest(req), None, ec)
+      val tail = new Http1Connection(RequestKey.fromRequest(req), BlazeClientConfig.defaultConfig, ec)
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
       val c = mkClient(h, tail)(1.second, Duration.Inf)
@@ -117,7 +119,7 @@ class ClientTimeoutSpec extends Http4sSpec {
 
       val req = Request(method = Method.POST, uri = www_foo_com, body = dataStream(4))
 
-      val tail = new Http1Connection(RequestKey.fromRequest(req), None, ec)
+      val tail = new Http1Connection(RequestKey.fromRequest(req), BlazeClientConfig.defaultConfig, ec)
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
       val c = mkClient(h, tail)(10.second, 30.seconds)
@@ -126,7 +128,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     }
 
     "Request timeout on slow response body" in {
-      val tail = new Http1Connection(FooRequestKey, None, ec)
+      val tail = mkConnection()
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 1500.millis)
       val c = mkClient(h, tail)(Duration.Inf, 1.second)
@@ -137,7 +139,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     }
 
     "Idle timeout on slow response body" in {
-      val tail = new Http1Connection(FooRequestKey, None, ec)
+      val tail = mkConnection()
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 1500.millis)
       val c = mkClient(h, tail)(1.second, Duration.Inf)

--- a/client/src/main/scala/org/http4s/client/impl/DefaultExecutor.scala
+++ b/client/src/main/scala/org/http4s/client/impl/DefaultExecutor.scala
@@ -1,0 +1,14 @@
+package org.http4s.client.impl
+
+import java.util.concurrent.ExecutorService
+
+import org.http4s.util.threads._
+
+
+private[client] object DefaultExecutor {
+  /** create a new default executor */
+  def newClientDefaultExecutorService(name: String): ExecutorService with DefaultExecutorService =
+    newDefaultFixedThreadPool(
+      (Runtime.getRuntime.availableProcessors * 1.5).ceil.toInt,
+      threadFactory(i => s"http4s-$name-$i"))
+}

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -22,8 +22,8 @@ abstract class ClientRouteTestBattery(name: String, client: Client)
   isolated
 
   override def cleanup() = {
+    super.cleanup() // shuts down the jetty server
     client.shutdown.run
-    super.cleanup()
   }
 
   override def runAllTests(): Fragments = {

--- a/examples/blaze/src/main/resources/logback.xml
+++ b/examples/blaze/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
closes #534

This PR was motivated by commit 05ad145. Each commit is relatively self contained

- 5693cb7: Add the `BlazeClientConfig` class to trim down the number of parameters passed around
- 05ad145: Add the ability to configure the blaze http1 parser for things like max header lengths
- b7a79b2: unify the client `ExecutorService` management

