### PR TITLE
fix ContentLengthSpec exceptions by fixing Rfc2616 rules

### DIFF
--- a/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
+++ b/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
@@ -29,7 +29,7 @@ private[parser] trait AdditionalRules extends Rfc2616BasicRules { this: Parser =
   
   def EOL: Rule0 = rule { OptWS ~ EOI }  // Strip trailing whitespace
 
-  def Digits: Rule1[String] = rule { capture(zeroOrMore( Digit )) }
+  def Digits: Rule1[String] = rule { capture(oneOrMore( Digit )) }
 
   def Value = rule { Token | QuotedString }
 


### PR DESCRIPTION
`Content-Length` requires at least one digit:
https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13

I thought it was safe to change the definition of `Digits` because it only seems to be used in the one place: https://github.com/http4s/http4s/blob/d525219bce17c4d59985e91afd740be1f3fb6d1e/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala#L56