### PR TITLE
Upgrade parboiled dependency to 2.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,7 @@ lazy val core = libraryProject("core")
       parboiled,
       scalaReflect(v) % "provided",
       scalazCore,
-      scalazStream,
-      shapeless
+      scalazStream
     ) },
     libraryDependencies <++= scalaVersion (
       VersionNumber(_).numbers match {

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -69,15 +69,13 @@ object Http4sBuild extends Build {
   lazy val metricsServlet      = "io.dropwizard.metrics"     % "metrics-servlet"         % metricsCore.revision
   lazy val metricsServlets     = "io.dropwizard.metrics"     % "metrics-servlets"        % metricsCore.revision
   lazy val metricsJson         = "io.dropwizard.metrics"     % "metrics-json"            % metricsCore.revision
-  // Parboiled depends on an ancient Shapeless with _x.y.z compat on Scala 2.10, so we bundle a newer, compatible Shapeless.
-  lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.1.0" exclude ("com.chuusai", "shapeless_2.10.4")
+  lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.1.1"
   lazy val reactiveStreamsTck  = "org.reactivestreams"       % "reactive-streams-tck"    % "1.0.0"
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
   lazy val scalameter          = "com.storm-enroute"        %% "scalameter"              % "0.7"
   lazy val scalaXml            = "org.scala-lang.modules"   %% "scala-xml"               % "1.0.5"
   lazy val scalazCore          = "org.scalaz"               %% "scalaz-core"             % "7.1.7"
   lazy val scalazScalacheckBinding = "org.scalaz"           %% "scalaz-scalacheck-binding" % scalazCore.revision
-  lazy val shapeless           = "com.chuusai"              %% "shapeless"               % "2.2.5"
   lazy val specs2              = "org.specs2"               %% "specs2-core"             % "3.6.6"
   lazy val specs2MatcherExtra  = "org.specs2"               %% "specs2-matcher-extra"    % specs2.revision
   lazy val specs2Scalacheck    = "org.specs2"               %% "specs2-scalacheck"       % specs2.revision


### PR DESCRIPTION
This allows us to get away from the version hacks in the build surrounding shapelss 2.2.5