### PR TITLE
Add a lenient flag to the blaze config object

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -20,30 +20,30 @@ import scala.concurrent.duration.Duration
   * @param maxResponseLineSize maximum length of the request line
   * @param maxHeaderLength maximum length of headers
   * @param maxChunkSize maximum size of chunked content chunks
-  * @param isLenient a lenient parser will accept illegal chars but replaces them with � (0xFFFD)
+  * @param lenientParser a lenient parser will accept illegal chars but replaces them with � (0xFFFD)
   * @param bufferSize internal buffer size of the blaze client
   * @param executor thread pool where asynchronous computations will be performed
   * @param group custom `AsynchronousChannelGroup` to use other than the system default
   */
-case class BlazeClientConfig( //
-                              idleTimeout: Duration,
-                              requestTimeout: Duration,
-                              userAgent: Option[`User-Agent`],
+case class BlazeClientConfig(// HTTP properties
+                             idleTimeout: Duration,
+                             requestTimeout: Duration,
+                             userAgent: Option[`User-Agent`],
 
-                              // security options
-                              sslContext: Option[SSLContext],
-                              endpointAuthentication: Boolean,
+                             // security options
+                             sslContext: Option[SSLContext],
+                             endpointAuthentication: Boolean,
 
-                              // parser options
-                              maxResponseLineSize: Int,
-                              maxHeaderLength: Int,
-                              maxChunkSize: Int,
-                              isLenient: Boolean,
+                             // parser options
+                             maxResponseLineSize: Int,
+                             maxHeaderLength: Int,
+                             maxChunkSize: Int,
+                             lenientParser: Boolean,
 
-                              // pipeline management
-                              bufferSize: Int,
-                              executor: ExecutorService,
-                              group: Option[AsynchronousChannelGroup]
+                             // pipeline management
+                             bufferSize: Int,
+                             executor: ExecutorService,
+                             group: Option[AsynchronousChannelGroup]
                             )
 
 object BlazeClientConfig {
@@ -64,7 +64,7 @@ object BlazeClientConfig {
       maxResponseLineSize = 4*1024,
       maxHeaderLength = 40*1024,
       maxChunkSize = Integer.MAX_VALUE,
-      isLenient = false,
+      lenientParser = false,
 
       bufferSize = bits.DefaultBufferSize,
       executor = executor,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -20,6 +20,7 @@ import scala.concurrent.duration.Duration
   * @param maxResponseLineSize maximum length of the request line
   * @param maxHeaderLength maximum length of headers
   * @param maxChunkSize maximum size of chunked content chunks
+  * @param isLenient a lenient parser will accept illegal chars but replaces them with � (0xFFFD)
   * @param bufferSize internal buffer size of the blaze client
   * @param executor thread pool where asynchronous computations will be performed
   * @param group custom `AsynchronousChannelGroup` to use other than the system default
@@ -37,6 +38,7 @@ case class BlazeClientConfig( //
                               maxResponseLineSize: Int,
                               maxHeaderLength: Int,
                               maxChunkSize: Int,
+                              isLenient: Boolean,
 
                               // pipeline management
                               bufferSize: Int,
@@ -62,6 +64,7 @@ object BlazeClientConfig {
       maxResponseLineSize = 4*1024,
       maxHeaderLength = 40*1024,
       maxChunkSize = Integer.MAX_VALUE,
+      isLenient = false,
 
       bufferSize = bits.DefaultBufferSize,
       executor = executor,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeHttp1ClientParser.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeHttp1ClientParser.scala
@@ -10,12 +10,16 @@ import scala.collection.mutable.ListBuffer
 private[blaze] object BlazeHttp1ClientParser {
   def apply(maxRequestLineSize: Int,
             maxHeaderLength: Int,
-            maxChunkSize: Int): BlazeHttp1ClientParser =
-    new BlazeHttp1ClientParser(maxRequestLineSize, maxHeaderLength, maxChunkSize)
+            maxChunkSize: Int,
+            isLenient: Boolean): BlazeHttp1ClientParser =
+    new BlazeHttp1ClientParser(maxRequestLineSize, maxHeaderLength, maxChunkSize, isLenient)
 }
 
-private[blaze] final class BlazeHttp1ClientParser(maxResponseLineSize: Int, maxHeaderLength: Int, maxChunkSize: Int)
-  extends Http1ClientParser(maxResponseLineSize, maxHeaderLength, 2*1024, maxChunkSize) {
+private[blaze] final class BlazeHttp1ClientParser(maxResponseLineSize: Int,
+                                                  maxHeaderLength: Int,
+                                                  maxChunkSize: Int,
+                                                  isLenient: Boolean)
+  extends Http1ClientParser(maxResponseLineSize, maxHeaderLength, 2*1024, maxChunkSize, isLenient) {
   private val headers = new ListBuffer[Header]
   private var status: Status = _
   private var httpVersion: HttpVersion = _

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -37,7 +37,7 @@ private final class Http1Connection(val requestKey: RequestKey,
   override def name: String = getClass.getName
   private val parser =
     new BlazeHttp1ClientParser(config.maxResponseLineSize, config.maxHeaderLength,
-                               config.maxChunkSize, config.isLenient)
+                               config.maxChunkSize, config.lenientParser)
 
   private val stageState = new AtomicReference[State](Idle)
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -35,7 +35,10 @@ private final class Http1Connection(val requestKey: RequestKey,
   import org.http4s.client.blaze.Http1Connection._
 
   override def name: String = getClass.getName
-  private val parser = new BlazeHttp1ClientParser(config.maxResponseLineSize, config.maxHeaderLength, config.maxChunkSize)
+  private val parser =
+    new BlazeHttp1ClientParser(config.maxResponseLineSize, config.maxHeaderLength,
+                               config.maxChunkSize, config.isLenient)
+
   private val stageState = new AtomicReference[State](Idle)
 
   override def isClosed: Boolean = stageState.get match {

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -45,7 +45,7 @@ object Http4sBuild extends Build {
 
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.4.v20150727"
   lazy val asyncHttp           = "org.asynchttpclient"       % "async-http-client"       % "2.0.0-RC7"
-  lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.11.0"
+  lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.12.0-SNAPSHOT"
   lazy val circeJawn           = "io.circe"                 %% "circe-jawn"              % "0.3.0"
   lazy val discipline          = "org.typelevel"            %% "discipline"              % "0.4"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"


### PR DESCRIPTION
The lenient parser will accept illegal chars in header values and the response line but will replace them with the replacement character (0xFFFD).

This PR supersedes #474
