### PR TITLE
WIP: This doesn't pass tests but starts a discussion about issue #547

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 /.lib/
+_site/
 
 *~
 .ensime

--- a/core/src/main/scala/org/http4s/parser/RequestUriParser.scala
+++ b/core/src/main/scala/org/http4s/parser/RequestUriParser.scala
@@ -10,10 +10,10 @@ private[http4s] class RequestUriParser(val input: ParserInput, val charset: Char
   extends Parser with Rfc3986Parser
 {
   def RequestUri = rule {
-    OriginForm  |
-    AbsoluteUri |
-    Authority ~> (auth => org.http4s.Uri(authority = Some(auth))) |
-    Asterisk
+    (OriginForm  |
+     AbsoluteUri |
+     Authority ~> (auth => org.http4s.Uri(authority = Some(auth))) |
+     Asterisk) ~ EOI
   }
 
   def OriginForm = rule { PathAbsolute ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) ~> { (path, query, fragment) =>

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -14,7 +14,7 @@ private[parser] trait Rfc3986Parser { this: Parser =>
 
   def charset: Charset
 
-  def Uri: Rule1[org.http4s.Uri] = rule { AbsoluteUri | RelativeRef }
+  def Uri: Rule1[org.http4s.Uri] = rule { (AbsoluteUri | RelativeRef) ~ EOI }
 
   def AbsoluteUri = rule {
     Scheme ~ ":" ~ HierPart ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) ~> { (scheme, auth, path, query, fragment) =>

--- a/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/core/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -145,6 +145,14 @@ class UriParserSpec extends Http4sSpec {
       }
     }
 
+    "fail on invalid uri" in {
+      val invalid = Seq("^", "]")
+      forall(invalid) { i =>
+        Uri.fromString("^") must be_-\/
+      }
+    }
+
+    // TODO: why are we allowing invalid Uri's to produce a "valid" result?
     "deal with an invalid Query" in {
       Uri.requestTarget("/hello/world?bad=enc%ode") must be_\/-.like { case u =>
         u.params must be_==(Map("bad" -> "enc"))
@@ -158,7 +166,6 @@ class UriParserSpec extends Http4sSpec {
         u.path must be_==("/hello/wo")
       }
     }
-
   }
 
   "Uri.fromString" should {


### PR DESCRIPTION
Fixes #547

Problem: The Uri parser doesn't demand the entire input satisfy the Uri criteria causing invalid uri's to truncate to "" which appears to be a valid Uri (at least by the parser rules).

Solution: This is solved by adding the `EOI` rule to the end of the parsers requiring the parser to consume all the input to be valid.
    This breaks two tests in UriParserSpec: they allow invalid and invalid uri or query to essentially truncate to the valid portion. This seems wrong to me.