### PR TITLE
Don't quote cookie values

### DIFF
--- a/core/src/main/scala/org/http4s/Cookie.scala
+++ b/core/src/main/scala/org/http4s/Cookie.scala
@@ -18,7 +18,7 @@
  */
 package org.http4s
 
-import collection.{TraversableOnce, mutable, IterableLike}
+import scala.collection.{TraversableOnce, mutable, IterableLike}
 import collection.generic.CanBuildFrom
 import org.http4s.util.{Renderable, Writer}
 
@@ -98,6 +98,7 @@ class RequestCookieJar(headers: Seq[Cookie]) extends Iterable[Cookie] with Itera
   def valuesIterator: Iterator[Any] = values.iterator
 
   /** Filters this map by retaining only keys satisfying a predicate.
+   *
    *  @param  p   the predicate used to test keys
    *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
    *          the predicate `p`. The resulting map wraps the original map without copying any elements.
@@ -134,7 +135,7 @@ case class Cookie(
   override lazy val renderString: String = super.renderString
 
   override def render(writer: Writer): writer.type = {
-    writer.append(name).append("=\"").append(content).append('"')
+    writer.append(name).append('=').append(content)
     expires.foreach{ e => writer.append("; Expires=").append(e) }
     maxAge.foreach(writer.append("; Max-Age=").append(_))
     domain.foreach(writer.append("; Domain=").append(_))


### PR DESCRIPTION
It turns out that there is no difference between the content
allowed for an unquoted string and a quoted  string. Old
implementations didn't allow double quotes at all so its
best to just remove them all together.

This is in line with the behavior of the cookied parser.