### PR TITLE
Add address socket address to Server trait.

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -155,12 +155,12 @@ class BlazeBuilder(
       else
         NIO1SocketServerGroup.fixedGroup(connectorPoolSize, bufferSize)
 
-    var myAddress = socketAddress
-    if (myAddress.isUnresolved)
-      myAddress = new InetSocketAddress(myAddress.getHostString, myAddress.getPort)
+    var address = socketAddress
+    if (address.isUnresolved)
+      address = new InetSocketAddress(address.getHostString, address.getPort)
 
     // if we have a Failure, it will be caught by the Task
-    val serverChannel = factory.bind(myAddress, pipelineFactory).get
+    val serverChannel = factory.bind(address, pipelineFactory).get
 
     new Server {
       override def shutdown: Task[this.type] = Task.delay {
@@ -175,7 +175,7 @@ class BlazeBuilder(
       }
 
       def address: InetSocketAddress =
-        myAddress
+        serverChannel.socketAddress
     }
   }
 

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -155,12 +155,12 @@ class BlazeBuilder(
       else
         NIO1SocketServerGroup.fixedGroup(connectorPoolSize, bufferSize)
 
-    var address = socketAddress
-    if (address.isUnresolved)
-      address = new InetSocketAddress(address.getHostString, address.getPort)
+    var myAddress = socketAddress
+    if (myAddress.isUnresolved)
+      myAddress = new InetSocketAddress(myAddress.getHostString, myAddress.getPort)
 
     // if we have a Failure, it will be caught by the Task
-    val serverChannel = factory.bind(address, pipelineFactory).get
+    val serverChannel = factory.bind(myAddress, pipelineFactory).get
 
     new Server {
       override def shutdown: Task[this.type] = Task.delay {
@@ -173,6 +173,9 @@ class BlazeBuilder(
         serverChannel.addShutdownHook(() => f)
         this
       }
+
+      def address: InetSocketAddress =
+        myAddress
     }
   }
 

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
@@ -1,8 +1,9 @@
-package org.http4s.server.blaze
+package org.http4s
+package server
+package blaze
 
-import org.specs2.mutable.Specification
-
-class BlazeServerSpec extends Specification {
+class BlazeServerSpec extends ServerAddressSpec {
+  def builder = BlazeBuilder
 
   "BlazeServer" should {
 

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val blazeServer = libraryProject("blaze-server")
   .settings(
     description := "blaze implementation for http4s servers"
   )
-  .dependsOn(blazeCore % "compile;test->test", server)
+  .dependsOn(blazeCore % "compile;test->test", server % "compile;test->test")
 
 lazy val blazeClient = libraryProject("blaze-client")
   .settings(
@@ -98,7 +98,7 @@ lazy val jetty = libraryProject("jetty")
       jettyServlet
     )
   )
-  .dependsOn(servlet, theDsl % "test->test")
+  .dependsOn(servlet % "compile;test->test", theDsl % "test->test")
 
 lazy val tomcat = libraryProject("tomcat")
   .settings(
@@ -109,7 +109,7 @@ lazy val tomcat = libraryProject("tomcat")
       tomcatCoyote
     )
   )
-  .dependsOn(servlet)
+  .dependsOn(servlet % "compile;test->test")
 
 // `dsl` name conflicts with modern SBT
 lazy val theDsl = libraryProject("dsl")

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -195,6 +195,12 @@ sealed class JettyBuilder private (
         }}
         this
       }
+
+      lazy val address: InetSocketAddress = {
+        val host = socketAddress.getHostString
+        val port = jetty.getConnectors()(0).asInstanceOf[ServerConnector].getLocalPort
+        new InetSocketAddress(host, port)
+      }
     }
   }
 }

--- a/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
+++ b/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
@@ -1,0 +1,7 @@
+package org.http4s
+package server
+package jetty
+
+class JettyServerSpec extends ServerAddressSpec {
+  val builder = JettyBuilder
+}

--- a/server/src/main/scala/org/http4s/server/Server.scala
+++ b/server/src/main/scala/org/http4s/server/Server.scala
@@ -14,6 +14,8 @@ trait Server {
 
   def onShutdown(f: => Unit): this.type
 
+  def address: InetSocketAddress
+
   /**
    * Blocks until the server shuts down.
    */

--- a/server/src/test/scala/org/http4s/server/ServerAddressSpec.scala
+++ b/server/src/test/scala/org/http4s/server/ServerAddressSpec.scala
@@ -1,0 +1,23 @@
+package org.http4s
+package server
+
+import java.net.InetSocketAddress
+import org.specs2.mutable.After
+import scalaz.{\/-, -\/}
+import scalaz.concurrent.Task
+
+trait ServerAddressSpec extends Http4sSpec {
+  def builder: ServerBuilder
+
+  trait ServerContext extends After {
+    val address = new InetSocketAddress(0)
+    val server = Task.fork(builder.bindSocketAddress(address).start).run
+    def after = server.shutdown.run
+  }
+
+  "A server configured with port 0" should {
+    "know its local port after start" in new ServerContext {
+      server.address.getPort must be_> (0)
+    }
+  }
+}

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -178,7 +178,7 @@ sealed class TomcatBuilder private (
     }
 
     conn.setAttribute("address", socketAddress.getHostString)
-    tomcat.setPort(socketAddress.getPort)
+    conn.setPort(socketAddress.getPort)
     conn.setAttribute("connection_pool_timeout",
       if (idleTimeout.isFinite) idleTimeout.toSeconds.toInt else 0)
 
@@ -203,6 +203,12 @@ sealed class TomcatBuilder private (
         })
         this
       }
+
+      lazy val address: InetSocketAddress = {
+        val host = socketAddress.getHostString
+        val port = tomcat.getConnector.getLocalPort
+        new InetSocketAddress(host, port)
+      }      
     }
   }
 }

--- a/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSpec.scala
+++ b/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSpec.scala
@@ -1,0 +1,7 @@
+package org.http4s
+package server
+package tomcat
+
+class TomcatServerSpec extends ServerAddressSpec {
+  val builder = TomcatBuilder
+}


### PR DESCRIPTION
When binding servers to port 0, it's important to be able to query which port actually got bound.

Fixes #557.