### PR TITLE
Fix read request bug in SlowTestHead

### DIFF
--- a/client/src/main/scala/org/http4s/client/Connection.scala
+++ b/client/src/main/scala/org/http4s/client/Connection.scala
@@ -1,7 +1,6 @@
 package org.http4s
 package client
 
-import scala.util.control.NonFatal
 import scalaz.concurrent.Task
 
 import org.log4s.getLogger


### PR DESCRIPTION
This is a bug in a test...

If the test head serves a chunk it wouldn't reset its state. Then if
it tries to serve another the previous request was still sitting there
and causes a weird error.