### PR TITLE
Enable configuration of blaze server parser lengths

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerParser.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerParser.scala
@@ -9,7 +9,10 @@ import scala.collection.mutable.ListBuffer
 import scalaz.\/
 
 
-private final class Http1ServerParser(logger: Logger) extends blaze.http.http_parser.Http1ServerParser {
+private final class Http1ServerParser(logger: Logger,
+                                      maxRequestLine: Int,
+                                      maxHeadersLen: Int)
+  extends blaze.http.http_parser.Http1ServerParser(maxRequestLine, maxHeadersLen, 2*1024) {
 
   private var uri: String = null
   private var method: String = null


### PR DESCRIPTION
Now it is possible to configure the max request line length and max headers length. This
is to avoid denial of service attacks where an evil user sends an endless request line
resulting in OOM on the server.

This behavior was already enabled before but utilized hard coded values for the cutoffs.
Some headers may be huge (think cookie session) so its not out of the question that the
headers could be very large in a minority of situations.