### PR TITLE
Fix broken link to code of conduct on the home page.

### DIFF
--- a/docs/src/site/index.md
+++ b/docs/src/site/index.md
@@ -64,6 +64,6 @@ patches will be considered.
 [circe]: https://github.com/travisbrown/circe
 [argonaut]: https://github.com/argonaut.io/argonaut
 [community]: community
-[code of conduct]: conduct.md
+[code of conduct]: community/conduct.html
 [docs/0.13]: docs/0.13
 [docs/0.14]: docs/0.13


### PR DESCRIPTION
The link to the code of conduct on the home page pointed to [/conduct.md](http://http4s.org/conduct.md) instead of [/community/conduct.html](http://http4s.org/community/conduct.html).