### PR TITLE
Topic/default executor

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -38,7 +38,7 @@ object AsyncHttpClient {
     *
     * @param config configuration for the client
     * @param bufferSize body chunks to buffer when reading the body; defaults to 8
-    * @param executorService the executor on which response tasks are run
+    * @param customExecutor custom executor which must be managed externally.
     */
   def apply(config: AsyncHttpClientConfig = defaultConfig,
             bufferSize: Int = 8,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration.Duration
   * @param maxChunkSize maximum size of chunked content chunks
   * @param lenientParser a lenient parser will accept illegal chars but replaces them with � (0xFFFD)
   * @param bufferSize internal buffer size of the blaze client
-  * @param executor thread pool where asynchronous computations will be performed
+  * @param customExecutor custom executor to run async computations. Will not be shutdown with client.
   * @param group custom `AsynchronousChannelGroup` to use other than the system default
   */
 case class BlazeClientConfig(// HTTP properties
@@ -42,17 +42,14 @@ case class BlazeClientConfig(// HTTP properties
 
                              // pipeline management
                              bufferSize: Int,
-                             executor: ExecutorService,
+                             customExecutor: Option[ExecutorService],
                              group: Option[AsynchronousChannelGroup]
                             )
 
 object BlazeClientConfig {
   /** Default user configuration
-    *
-    * @param executor executor on which to run computations.
-    *                 If the default `ExecutorService` is used it will be shutdown with the client
     */
-  def defaultConfig(executor: ExecutorService = DefaultExecutor.newClientDefaultExecutorService("blaze-client")) =
+  val defaultConfig =
     BlazeClientConfig(
       idleTimeout = bits.DefaultTimeout,
       requestTimeout = Duration.Inf,
@@ -67,7 +64,7 @@ object BlazeClientConfig {
       lenientParser = false,
 
       bufferSize = bits.DefaultBufferSize,
-      executor = executor,
+      customExecutor = None,
       group = None
     )
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -4,6 +4,7 @@ package blaze
 
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
+import java.util.concurrent.ExecutorService
 
 import org.http4s.Uri.Scheme
 import org.http4s.blaze.channel.nio2.ClientChannelFactory
@@ -14,18 +15,16 @@ import org.http4s.util.CaseInsensitiveString._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-
 import scalaz.concurrent.Task
-
-import scalaz.{\/, -\/, \/-}
+import scalaz.{-\/, \/, \/-}
 
 private object Http1Support {
   /** Create a new [[ConnectionBuilder]]
    *
    * @param config The client configuration object
    */
-  def apply(config: BlazeClientConfig): ConnectionBuilder[BlazeConnection] = {
-    val builder = new Http1Support(config)
+  def apply(config: BlazeClientConfig, executor: ExecutorService): ConnectionBuilder[BlazeConnection] = {
+    val builder = new Http1Support(config, executor)
     builder.makeClient
   }
 
@@ -35,10 +34,10 @@ private object Http1Support {
 
 /** Provides basic HTTP1 pipeline building
   */
-final private class Http1Support(config: BlazeClientConfig) {
+final private class Http1Support(config: BlazeClientConfig, executor: ExecutorService) {
   import Http1Support._
 
-  private val ec = ExecutionContext.fromExecutorService(config.executor)
+  private val ec = ExecutionContext.fromExecutorService(executor)
   private val sslContext = config.sslContext.getOrElse(bits.sslContext)
   private val connectionManager = new ClientChannelFactory(config.bufferSize, config.group.orNull)
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -17,6 +17,6 @@ object PooledHttp1Client {
     val (ex,shutdown) = bits.getExecutor(config)
     val http1 = Http1Support(config, ex)
     val pool = ConnectionManager.pool(http1, maxTotalConnections, ex)
-    BlazeClient(pool, config, shutdown)
+    BlazeClient(pool, config, pool.shutdown().flatMap(_ =>shutdown))
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -12,9 +12,11 @@ object PooledHttp1Client {
     * @param config blaze client configuration options
     */
   def apply( maxTotalConnections: Int = 10,
-                          config: BlazeClientConfig = BlazeClientConfig.defaultConfig()) = {
-    val http1 = Http1Support(config)
-    val pool = ConnectionManager.pool(http1, maxTotalConnections, config.executor)
-    BlazeClient(pool, config)
+                          config: BlazeClientConfig = BlazeClientConfig.defaultConfig) = {
+
+    val (ex,shutdown) = bits.getExecutor(config)
+    val http1 = Http1Support(config, ex)
+    val pool = ConnectionManager.pool(http1, maxTotalConnections, ex)
+    BlazeClient(pool, config, shutdown)
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
@@ -15,8 +15,11 @@ object SimpleHttp1Client {
     *
     * @param config blaze configuration object
     */
-  def apply(config: BlazeClientConfig = BlazeClientConfig.defaultConfig()) = {
-    val manager = ConnectionManager.basic(Http1Support(config))
-    BlazeClient(manager, config)
+  def apply(config: BlazeClientConfig = BlazeClientConfig.defaultConfig) = {
+
+    val (ex, shutdown) = bits.getExecutor(config)
+
+    val manager = ConnectionManager.basic(Http1Support(config, ex))
+    BlazeClient(manager, config, shutdown)
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/SimpleHttp1Client.scala
@@ -2,13 +2,6 @@ package org.http4s
 package client
 package blaze
 
-import java.nio.channels.AsynchronousChannelGroup
-import java.util.concurrent.ExecutorService
-import javax.net.ssl.SSLContext
-
-import org.http4s.headers.`User-Agent`
-import scala.concurrent.duration.Duration
-
 /** Create HTTP1 clients which will disconnect on completion of one request */
 object SimpleHttp1Client {
   /** create a new simple client
@@ -20,6 +13,6 @@ object SimpleHttp1Client {
     val (ex, shutdown) = bits.getExecutor(config)
 
     val manager = ConnectionManager.basic(Http1Support(config, ex))
-    BlazeClient(manager, config, shutdown)
+    BlazeClient(manager, config, manager.shutdown().flatMap(_ =>shutdown))
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/package.scala
@@ -7,6 +7,7 @@ package object blaze {
 
   /** Default blaze client
     *
-    * This client will create a new connection for every request. */
-  lazy val defaultClient: Client = SimpleHttp1Client(BlazeClientConfig.defaultConfig())
+    * This client will create a new connection for every request.
+    */
+  lazy val defaultClient: Client = SimpleHttp1Client(BlazeClientConfig.defaultConfig)
 }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeSimpleHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeSimpleHttp1ClientSpec.scala
@@ -3,4 +3,4 @@ package org.http4s.client.blaze
 import org.http4s.client.ClientRouteTestBattery
 
 class BlazeSimpleHttp1ClientSpec extends
-ClientRouteTestBattery("SimpleHttp1Client", SimpleHttp1Client(BlazeClientConfig.defaultConfig()))
+ClientRouteTestBattery("SimpleHttp1Client", SimpleHttp1Client(BlazeClientConfig.defaultConfig))

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -25,7 +25,7 @@ class ClientTimeoutSpec extends Http4sSpec {
   val resp = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndone"
 
   // The executor in here needs to be shut down manually because the `BlazeClient` class won't do it for us
-  private val defaultConfig = BlazeClientConfig.defaultConfig()
+  private val defaultConfig = BlazeClientConfig.defaultConfig
 
   private def mkConnection() = new Http1Connection(FooRequestKey, defaultConfig, ec)
 
@@ -35,7 +35,7 @@ class ClientTimeoutSpec extends Http4sSpec {
   private def mkClient(head: => HeadStage[ByteBuffer], tail: => BlazeConnection)
               (idleTimeout: Duration, requestTimeout: Duration): Client = {
     val manager = MockClientBuilder.manager(head, tail)
-    BlazeClient(manager, defaultConfig.copy(idleTimeout = idleTimeout, requestTimeout = requestTimeout))
+    BlazeClient(manager, defaultConfig.copy(idleTimeout = idleTimeout, requestTimeout = requestTimeout), Task.now(()))
   }
 
   "Http1ClientStage responses" should {
@@ -151,10 +151,5 @@ class ClientTimeoutSpec extends Http4sSpec {
 
       c.fetchAs[String](FooRequest).run must throwA[TimeoutException]
     }
-  }
-
-  // shutdown the executor we created
-  step {
-    defaultConfig.executor.shutdown()
   }
 }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable.After
 // TODO: this should have a more comprehensive test suite
 class ExternalBlazeHttp1ClientSpec extends Http4sSpec {
 
-  private val simpleClient = SimpleHttp1Client(BlazeClientConfig.defaultConfig())
+  private val simpleClient = SimpleHttp1Client()
 
   "Blaze Simple Http1 Client" should {
     "Make simple https requests" in {

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -32,7 +32,7 @@ class Http1ClientStageSpec extends Specification {
   val resp = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndone"
 
   // The executor in here needs to be shut down manually because the `BlazeClient` class won't do it for us
-  private val defaultConfig = BlazeClientConfig.defaultConfig()
+  private val defaultConfig = BlazeClientConfig.defaultConfig
 
   private def mkConnection(key: RequestKey) = new Http1Connection(key, defaultConfig, ec)
 
@@ -277,11 +277,6 @@ class Http1ClientStageSpec extends Specification {
         hs.run must throwA[IllegalStateException]
       }
     }
-  }
-
-  // shutdown the executor we created
-  step {
-    defaultConfig.executor.shutdown()
   }
 }
 

--- a/client/src/main/scala/org/http4s/client/impl/DefaultExecutor.scala
+++ b/client/src/main/scala/org/http4s/client/impl/DefaultExecutor.scala
@@ -7,7 +7,7 @@ import org.http4s.util.threads._
 
 private[client] object DefaultExecutor {
   /** create a new default executor */
-  def newClientDefaultExecutorService(name: String): ExecutorService with DefaultExecutorService =
+  def newClientDefaultExecutorService(name: String): ExecutorService =
     newDefaultFixedThreadPool(
       (Runtime.getRuntime.availableProcessors * 1.5).ceil.toInt,
       threadFactory(i => s"http4s-$name-$i"))

--- a/core/src/main/scala/org/http4s/util/threads.scala
+++ b/core/src/main/scala/org/http4s/util/threads.scala
@@ -40,13 +40,10 @@ object threads {
       }
     }
 
-  /** Marker trait for thread factories we create ourselves, and thus we need to close ourselves. */
-  private[http4s] trait DefaultExecutorService { self: ExecutorService => }
-
   /** Creates a thread pool marked with the DefaultExecutorService trait, so we know to shut it down. */
-  private[http4s] def newDefaultFixedThreadPool(n: Int, threadFactory: ThreadFactory): ExecutorService with DefaultExecutorService =
+  private[http4s] def newDefaultFixedThreadPool(n: Int, threadFactory: ThreadFactory): ExecutorService =
     new ThreadPoolExecutor(n, n,
       0L, TimeUnit.MILLISECONDS,
       new LinkedBlockingQueue[Runnable],
-      threadFactory) with DefaultExecutorService
+      threadFactory)
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
@@ -8,7 +8,7 @@ object ClientExample {
     import org.http4s.Http4s._
     import scalaz.concurrent.Task
 
-    val client = org.http4s.client.blaze.defaultClient
+    val client = org.http4s.client.blaze.SimpleHttp1Client()
 
     val page: Task[String] = client.getAs[String](uri("https://www.google.com/"))
 
@@ -36,6 +36,8 @@ object ClientExample {
     }
 
     println(page2.run)
+
+    client.shutdownNow()
 /// end_code_ref
   }
 


### PR DESCRIPTION
closes #569
This PR changes the mode of management of the client `ExecutorService`. Previously we would make our own "special" executor that was tagged with a trait so that we could tell if we made it and then shut it down. After this PR we pass an optional `customExecutor` in and if its `None`, make one and take responsibility for shutting it down.