### PR TITLE
Fix Argonaut string interpolation

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -11,7 +11,7 @@ trait ArgonautInstances {
     json.flatMapR { json =>
       decoder.decodeJson(json).fold(
         (message, history) =>
-          DecodeResult.failure(InvalidMessageBodyFailure("Could not decode JSON: $json, error: $message, cursor: $history")),
+          DecodeResult.failure(InvalidMessageBodyFailure(s"Could not decode JSON: $json, error: $message, cursor: $history")),
         DecodeResult.success(_)
       )
     }


### PR DESCRIPTION
The string was missing the 's' before the quotes resultin in a lack
of string interpolation.