### PR TITLE
Suppress building the main site from non-master branches.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -238,6 +238,10 @@ lazy val docs = http4sProject("docs")
       case _ => Seq.empty
     },
     includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.json" | "*.md" | "CNAME" | "_config.yml",
+    siteMappings := {
+      if (Http4sGhPages.buildMainSite) siteMappings.value
+      else Seq.empty
+    },
     siteMappings <++= (tut, apiVersion) map { case (t, (major, minor)) =>
       for ((f, d) <- t) yield (f, s"docs/$major.$minor/$d")
     },

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,14 @@ repository.
 
 * src/site is a basic Jekyll site that contains mostly static
   information about the project as a whole, and does not pertain to a
-  particular version.
+  particular version.  Travis only updates this on the master branch.
 
 * src/main/tut is a collection of compiler-verified documentation
   built on [tut](http://github.com/tpolecat/tut).  It is a deeper
   walkthrough of the library, and is versioned to remain in sync with
   the code.  These tutorials are published to the [tutdir](docs/x.y)
-  directory of the site.
+  directory of the site.  Travis updates this on the master branch,
+  and any branch named release-*.
 
 * Scaladoc is aggregated by the unidoc plugin and published to
   [api](api/x.y).

--- a/project/Http4sGhPages.scala
+++ b/project/Http4sGhPages.scala
@@ -10,11 +10,20 @@ import Http4sBuild.apiVersion
 // Copied from sbt-ghpages to avoid blowing away the old API
 // https://github.com/sbt/sbt-ghpages/issues/10
 object Http4sGhPages {
+  def buildMainSite: Boolean =
+    // The main site should only build off master.  We don't want maintenance branches
+    // overwriting progress on the master branch that doesn't get merged back.
+    scala.util.Properties.envOrNone("TRAVIS_BRANCH") match {
+      case Some("master") => true // This is the canonical way to publish the site
+      case Some(_) => false // these are the Travis builds we want to suppress
+      case None => true // a less surprising default for local builds.
+    }
+
   def cleanSiteForRealz(dir: File, git: GitRunner, s: TaskStreams, apiVersion: (Int, Int)): Unit ={
     val toClean = IO.listFiles(dir).collect {
       case f if f.getName == "api" => new java.io.File(f, s"${apiVersion._1}.${apiVersion._2}")
       case f if f.getName == "docs" => new java.io.File(f, s"${apiVersion._1}.${apiVersion._2}")
-      case f if f.getName != ".git" => f
+      case f if f.getName != ".git" && buildMainSite => f
     }.map(_.getAbsolutePath).toList
     if (!toClean.isEmpty)
       git(("rm" :: "-r" :: "-f" :: "--ignore-unmatch" :: toClean) :_*)(dir, s.log)


### PR DESCRIPTION
Without this, the maintenance branches with older copies of the main site can overwrite changes, create races, etc.  One branch needs to be canonical for each part of the site.