### PR TITLE
Add a ServerApp trait.

### DIFF
--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -1,13 +1,11 @@
 package com.example.http4s.blaze
 
-/// code_ref: blaze_server_example
 import com.example.http4s.ExampleService
+import org.http4s.server.ServerApp
 import org.http4s.server.blaze.BlazeBuilder
 
-object BlazeExample extends App {
-  BlazeBuilder.bindHttp(8080)
+object BlazeExample extends ServerApp {
+  def server(args: List[String]) = BlazeBuilder.bindHttp(8080)
     .mountService(ExampleService.service, "/http4s")
-    .run
-    .awaitShutdown()
+    .start
 }
-/// end_code_ref

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeHttp2Example.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeHttp2Example.scala
@@ -18,5 +18,5 @@ import org.http4s.server.blaze.BlazeBuilder
   * https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-9.2.1  *
   */
 object BlazeHttp2Example extends SslExample {
-  go(BlazeBuilder.enableHttp2(true))
+  def builder = BlazeBuilder.enableHttp2(true)
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit
 
 import com.example.http4s.ExampleService
 import org.http4s._
+import org.http4s.server.ServerApp
 import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.server.middleware.Metrics
@@ -16,7 +17,7 @@ import com.codahale.metrics.json.MetricsModule
 
 import com.fasterxml.jackson.databind.ObjectMapper
 
-object BlazeMetricsExample extends App {
+object BlazeMetricsExample extends ServerApp {
 
   val metrics = new MetricRegistry()
   val mapper = new ObjectMapper()
@@ -33,9 +34,8 @@ object BlazeMetricsExample extends App {
     "/metrics" -> metricsService
   )
 
-  BlazeBuilder.bindHttp(8080)
+  def server(args: List[String]) = BlazeBuilder.bindHttp(8080)
     .mountService(srvc, "/http4s")
-    .run
-    .awaitShutdown()
+    .start
 }
 /// end_code_ref

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
@@ -5,5 +5,5 @@ import com.example.http4s.ssl.SslExample
 import org.http4s.server.blaze.BlazeBuilder
 
 object BlazeSslExample extends SslExample {
-  go(BlazeBuilder)
+  def builder = BlazeBuilder
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -1,6 +1,7 @@
 package com.example.http4s.blaze
 
 import org.http4s._
+import org.http4s.server.ServerApp
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.websocket.WebsocketBits._
 import org.http4s.dsl._
@@ -15,9 +16,8 @@ import scalaz.stream.{Process, Sink}
 import scalaz.stream.{DefaultScheduler, Exchange}
 import scalaz.stream.time.awakeEvery
 
-object BlazeWebSocketExample extends App {
+object BlazeWebSocketExample extends ServerApp {
 
-/// code_ref: blaze_websocket_example
   val route = HttpService {
     case GET -> Root / "hello" =>
       Ok("Hello world.")
@@ -39,10 +39,8 @@ object BlazeWebSocketExample extends App {
       WS(Exchange(src, q.enqueue))
   }
 
-  BlazeBuilder.bindHttp(8080)
+  def server(args: List[String]) = BlazeBuilder.bindHttp(8080)
     .withWebSockets(true)
     .mountService(route, "/http4s")
-    .run
-    .awaitShutdown()
-/// end_code_ref
+    .start
 }

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
@@ -5,19 +5,17 @@ import javax.servlet._
 
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.servlets.MetricsServlet
+import org.http4s.server.ServerApp
 import org.http4s.server.jetty.JettyBuilder
 
-/// code_ref: jetty_example
-object JettyExample extends App {
+object JettyExample extends ServerApp {
   val metrics = new MetricRegistry
 
-  JettyBuilder
+  def server(args: List[String]) = JettyBuilder
     .bindHttp(8080)
     .withMetricRegistry(metrics)
     .mountService(ExampleService.service, "/http4s")
     .mountServlet(new MetricsServlet(metrics), "/metrics/*")
     .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
-    .run
-    .awaitShutdown()
+    .start
 }
-/// end_code_ref

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettySslExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettySslExample.scala
@@ -5,6 +5,6 @@ import com.example.http4s.ssl.SslExample
 import org.http4s.server.jetty.JettyBuilder
 
 object JettySslExample extends SslExample {
-  go(JettyBuilder)
+  def builder = JettyBuilder
 }
 

--- a/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
+++ b/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
@@ -4,16 +4,19 @@ import java.nio.file.Paths
 
 import com.example.http4s.ExampleService
 import org.http4s.server.SSLSupport.StoreInfo
-import org.http4s.server.{SSLSupport, ServerBuilder}
+import org.http4s.server.{ SSLSupport, Server, ServerApp, ServerBuilder }
+import scalaz.concurrent.Task
 
-trait SslExample extends App {
+trait SslExample extends ServerApp {
   // TODO: Reference server.jks from something other than one child down.
   val keypath = Paths.get("../server.jks").toAbsolutePath().toString()
-  def go(builder: ServerBuilder with SSLSupport): Unit = builder
+
+  def builder: ServerBuilder with SSLSupport
+
+  def server(args: List[String]): Task[Server] = builder
     .withSSL(StoreInfo(keypath, "password"), keyManagerPassword = "secure")
     .mountService(ExampleService.service, "/http4s")
     .bindHttp(8443)
-    .run
-    .awaitShutdown()
+    .start
 }
 

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
@@ -3,17 +3,17 @@ package com.example.http4s.tomcat
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.servlets.MetricsServlet
 import com.example.http4s.ExampleService
+import org.http4s.server.ServerApp
 import org.http4s.server.tomcat.TomcatBuilder
 
-object TomcatExample extends App {
+object TomcatExample extends ServerApp {
   val metrics = new MetricRegistry
 
-  TomcatBuilder
+  def server(args: List[String]) = TomcatBuilder
     .bindHttp(8080)
     .withMetricRegistry(metrics)
     .mountService(ExampleService.service, "/http4s")
     .mountServlet(new MetricsServlet(metrics), "/metrics/*")
     .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
-    .run
-    .awaitShutdown()
+    .start
 }

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatSslExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatSslExample.scala
@@ -5,5 +5,5 @@ import com.example.http4s.ssl.SslExample
 import org.http4s.server.tomcat.TomcatBuilder
 
 object TomcatSslExample extends SslExample {
-  go(TomcatBuilder)
+  def builder = TomcatBuilder
 }

--- a/server/src/main/scala/org/http4s/server/Server.scala
+++ b/server/src/main/scala/org/http4s/server/Server.scala
@@ -12,6 +12,7 @@ trait Server {
   def shutdownNow(): Unit =
     shutdown.run
 
+  @deprecated("Compose with the shutdown task instead.", "0.14")
   def onShutdown(f: => Unit): this.type
 
   def address: InetSocketAddress
@@ -19,6 +20,7 @@ trait Server {
   /**
    * Blocks until the server shuts down.
    */
+  @deprecated("Use ServerApp instead.", "0.14")
   def awaitShutdown(): Unit = {
     val latch = new CountDownLatch(1)
     onShutdown(latch.countDown())

--- a/server/src/main/scala/org/http4s/server/ServerApp.scala
+++ b/server/src/main/scala/org/http4s/server/ServerApp.scala
@@ -1,0 +1,96 @@
+package org.http4s
+package server
+
+import java.net.ServerSocket
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{ CountDownLatch, RejectedExecutionException }
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{ Executors, ThreadFactory }
+import scala.annotation.tailrec
+import scalaz.concurrent.Task
+import org.http4s.util.threads
+
+/**
+ * Apps extending the server app trait get a graceful shutdown.  The
+ * 
+ */ 
+trait ServerApp {
+  private[this] val logger = org.log4s.getLogger
+
+  /** Return a server to run */
+  def server(args: List[String]): Task[Server]
+
+  /** Return a task to shutdown the application.
+   * 
+   *  This task is run as a JVM shutdown hook, or when
+   *  [[requestShutdown()]] is explicitly called.
+   *  
+   *  The default implementation shuts down the server, and waits for
+   *  it to finish.  Other resources may shutdown by flatMapping this
+   *  task.
+   */
+  def shutdown(server: Server): Task[Unit] =
+    server.shutdown
+
+  sealed trait LifeCycle
+  case object Init extends LifeCycle
+  case object Starting extends LifeCycle
+  case object Started extends LifeCycle
+  case object Stopping extends LifeCycle
+  case object Stopped extends LifeCycle
+
+  /** The current state of the server. */
+  val state =
+    new AtomicReference[LifeCycle](Init)
+
+  @tailrec
+  private def doShutdown(s: Server): Unit =
+    state.get match {
+      case _ if (state.compareAndSet(Started, Stopping)) =>
+        logger.info(s"Shutting down server on ${s.address}")
+        try shutdown(s).run
+        finally state.set(Stopped)
+        logger.info(s"Stopped server on ${s.address}")
+      case Stopping | Stopped =>
+        logger.debug(s"Ignoring duplicate shutdown request for ${s.address}")
+      case state =>
+        logger.warn(s"Tried to shutdown server $s, but was in state $state.  Trying again in 1 second")
+        Thread.sleep(1000)
+        doShutdown(s)
+    }
+
+  private[this] val latch =
+    new CountDownLatch(1)
+
+  /** Explicitly request a graceful shutdown of the service.
+   *  
+   *  There is no operational standard for this, but some common
+   *  implementations include:
+   *  - an admin port receiving a connection
+   *  - a JMX command
+   *  - monitoring a file
+   *  - console input in an interactive session
+   */
+  def requestShutdown() = {
+    logger.info("Received shutdown request")
+    latch.countDown()
+  }
+
+  private def run(args: List[String]): Unit = {
+    val s = server(args.toList).map { s =>
+      state.set(Starting)
+      sys.addShutdownHook {
+        doShutdown(s)
+      }
+      s
+    }.run
+    state.set(Started)
+    logger.info(s"Started server on ${s.address}")
+    latch.await()
+    doShutdown(s)
+  }
+
+  final def main(args: Array[String]): Unit =
+    run(args.toList)
+}
+

--- a/server/src/main/scala/org/http4s/server/ServerApp.scala
+++ b/server/src/main/scala/org/http4s/server/ServerApp.scala
@@ -32,15 +32,15 @@ trait ServerApp {
   def shutdown(server: Server): Task[Unit] =
     server.shutdown
 
-  sealed trait LifeCycle
-  case object Init extends LifeCycle
-  case object Starting extends LifeCycle
-  case object Started extends LifeCycle
-  case object Stopping extends LifeCycle
-  case object Stopped extends LifeCycle
+  private sealed trait LifeCycle
+  private case object Init extends LifeCycle
+  private case object Starting extends LifeCycle
+  private case object Started extends LifeCycle
+  private case object Stopping extends LifeCycle
+  private case object Stopped extends LifeCycle
 
   /** The current state of the server. */
-  val state =
+  private val state =
     new AtomicReference[LifeCycle](Init)
 
   @tailrec

--- a/server/src/main/scala/org/http4s/server/ServerApp.scala
+++ b/server/src/main/scala/org/http4s/server/ServerApp.scala
@@ -34,7 +34,6 @@ trait ServerApp {
 
   private sealed trait LifeCycle
   private case object Init extends LifeCycle
-  private case object Starting extends LifeCycle
   private case object Started extends LifeCycle
   private case object Stopping extends LifeCycle
   private case object Stopped extends LifeCycle
@@ -78,7 +77,6 @@ trait ServerApp {
 
   private def run(args: List[String]): Unit = {
     val s = server(args.toList).map { s =>
-      state.set(Starting)
       sys.addShutdownHook {
         doShutdown(s)
       }

--- a/server/src/main/scala/org/http4s/server/ServerApp.scala
+++ b/server/src/main/scala/org/http4s/server/ServerApp.scala
@@ -71,7 +71,7 @@ trait ServerApp {
    *  - monitoring a file
    *  - console input in an interactive session
    */
-  def requestShutdown() = {
+  def requestShutdown(): Unit = {
     logger.info("Received shutdown request")
     latch.countDown()
   }


### PR DESCRIPTION
Provides a graceful mechanism for starting and stopping an embedded server.

Responds well to kill signals for me.  ^C, which should be a SIGINT, is hit and miss within sbt.  Explicit shutdown requests also work reliably for me.

The exposed lifecycle is imagined to be useful in implementing health check endpoints.
