### PR TITLE
Remove implicit resolution of Strategy.DefaultExecutor

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -57,7 +57,7 @@ final private class Http1Support(config: BlazeClientConfig, executor: ExecutorSe
   }
 
   private def buildStages(requestKey: RequestKey): (LeafBuilder[ByteBuffer], BlazeConnection) = {
-    val t = new Http1Connection(requestKey, config, ec)
+    val t = new Http1Connection(requestKey, config, executor, ec)
     val builder = LeafBuilder(t)
     requestKey match {
       case RequestKey(Https, auth) if config.endpointAuthentication =>

--- a/build.sbt
+++ b/build.sbt
@@ -454,7 +454,7 @@ lazy val mimaSettings = Seq(
     import com.typesafe.tools.mima.core._
     import com.typesafe.tools.mima.core.ProblemFilters._
     Seq(
-      exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.Http1Stage.encodeHeaders")
+      exclude[DirectMissingMethodProblem]("org.http4s.client.blaze.Http1Connection.this")
     )
   }
 )


### PR DESCRIPTION
There were two calls to `Task.apply` that didn't explicitly take an
ExecutorService.

This resulted in a new mima exception for the constructor method of `Http1Connection`. This class is private so the constructor change shouldn't leak to users.