### PR TITLE
Rename `json` to `jsonDecoder`

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -5,10 +5,10 @@ import _root_.argonaut.{EncodeJson, DecodeJson, Argonaut, Json}
 import org.http4s.headers.`Content-Type`
 
 trait ArgonautInstances {
-  implicit val json: EntityDecoder[Json] = jawn.jawnDecoder(Parser.facade)
+  implicit val jsonDecoder: EntityDecoder[Json] = jawn.jawnDecoder(Parser.facade)
 
   def jsonOf[A](implicit decoder: DecodeJson[A]): EntityDecoder[A] =
-    json.flatMapR { json =>
+    jsonDecoder.flatMapR { json =>
       decoder.decodeJson(json).fold(
         (message, history) =>
           DecodeResult.failure(InvalidMessageBodyFailure(s"Could not decode JSON: $json, error: $message, cursor: $history")),

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -12,7 +12,7 @@ import org.specs2.specification.core.Fragment
 import Status.Ok
 
 class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
-  testJsonDecoder(json)
+  testJsonDecoder(jsonDecoder)
 
   case class Foo(bar: Int)
   val foo = Foo(42)

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -7,10 +7,10 @@ import org.http4s.headers.`Content-Type`
 
 // Originally based on ArgonautInstances
 trait CirceInstances {
-  implicit val json: EntityDecoder[Json] = jawn.jawnDecoder(facade)
+  implicit val jsonDecoder: EntityDecoder[Json] = jawn.jawnDecoder(facade)
 
   def jsonOf[A](implicit decoder: Decoder[A]): EntityDecoder[A] =
-    json.flatMapR { json =>
+    jsonDecoder.flatMapR { json =>
       decoder.decodeJson(json).fold(
         failure =>
           DecodeResult.failure(InvalidMessageBodyFailure(s"Could not decode JSON: $json", Some(failure))),

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -12,7 +12,7 @@ import org.specs2.specification.core.Fragment
 
 // Originally based on ArgonautSpec
 class CirceSpec extends JawnDecodeSupportSpec[Json] {
-  testJsonDecoder(json)
+  testJsonDecoder(jsonDecoder)
 
   case class Foo(bar: Int)
   val foo = Foo(42)

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -10,10 +10,10 @@ import scala.util.control.NonFatal
 import scalaz.{EitherT, \/}
 
 trait Json4sInstances[J] {
-  implicit lazy val json: EntityDecoder[JValue] = jawn.jawnDecoder(facade)
+  implicit lazy val jsonDecoder: EntityDecoder[JValue] = jawn.jawnDecoder(facade)
 
   def jsonOf[A](implicit reader: Reader[A]): EntityDecoder[A] =
-    json.flatMapR { json =>
+    jsonDecoder.flatMapR { json =>
       try DecodeResult.success(reader.read(json))
       catch {
         case e: MappingException => DecodeResult.failure(InvalidMessageBodyFailure("Could not map JSON", Some(e)))
@@ -27,7 +27,7 @@ trait Json4sInstances[J] {
     * idiomatic http4s, than [[jsonOf]].
     */
   def jsonExtract[A](implicit formats: Formats, manifest: Manifest[A]): EntityDecoder[A] =
-    json.flatMapR { json =>
+    jsonDecoder.flatMapR { json =>
       try DecodeResult.success(json.extract[A])
       catch {
         case NonFatal(e) => DecodeResult.failure(InvalidMessageBodyFailure("Could not extract JSON", Some(e)))

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -13,7 +13,7 @@ import scalaz.syntax.std.option._
 trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstances[J] =>
   import Json4sSpec._
 
-  testJsonDecoder(json)
+  testJsonDecoder(jsonDecoder)
 
   "json encoder" should {
     val json: JValue = JObject(JField("test", JString("json4s")))


### PR DESCRIPTION
This avoids a common name clash that shadows the implicit and makes the
library more foreboding to new Scala users.

Fixes #599.