### PR TITLE
Create `scalazVersion` sbt `SettingKey` in order to avoid relying on Java Properties

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sbt -Dscalaz.version=7.1.7 +clean +publishSigned
-sbt -Dscalaz.version=7.2.1 +clean +publishSigned
+sbt "set scalazVersion in ThisBuild := \"7.1.7\"" +clean +publishSigned
+sbt "set scalazVersion in ThisBuild := \"7.2.1\"" +clean +publishSigned

--- a/bin/travis
+++ b/bin/travis
@@ -3,9 +3,9 @@
 set -e
 
 if [[ $TRAVIS_SCALA_VERSION == 2.11* ]] && [[ $SCALAZ_VERSION = 7.2* ]]; then
-  SBT_COMMAND="\"set scalazVersion in ThisBuild := \\\"7.2.1\\\"\" ;coverage ;clean ;test ;makeSite ;coverageOff"
+  SBT_COMMAND=";coverage ;clean ;test ;makeSite ;coverageOff"
 elif [[ $TRAVIS_SCALA_VERSION = 2.10* ]] && [[ $SCALAZ_VERSION = 7.2* ]]; then
-  SBT_COMMAND="\"set scalazVersion in ThisBuild := \\\"7.2.1\\\"\" ;test ;mimaReportBinaryIssues"
+  SBT_COMMAND=";test ;mimaReportBinaryIssues"
 else
   SBT_COMMAND=";test"
 fi
@@ -22,7 +22,7 @@ if [[ $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "release-"* ]] && [[ $TRAVIS
   fi
 fi
 
-sbt ++$TRAVIS_SCALA_VERSION $SBT_COMMAND
+sbt 'set scalazVersion in ThisBuild := System.getenv("SCALAZ_VERSION")' ++$TRAVIS_SCALA_VERSION $SBT_COMMAND
 
 if [[ $SBT_COMMAND = *";coverage"* ]]; then
    bash <(curl -s https://codecov.io/bash)

--- a/bin/travis
+++ b/bin/travis
@@ -3,9 +3,9 @@
 set -e
 
 if [[ $TRAVIS_SCALA_VERSION == 2.11* ]] && [[ $SCALAZ_VERSION = 7.2* ]]; then
-  SBT_COMMAND=";coverage ;clean ;test ;makeSite ;coverageOff"
+  SBT_COMMAND="\"set scalazVersion in ThisBuild := \\\"7.2.1\\\"\" ;coverage ;clean ;test ;makeSite ;coverageOff"
 elif [[ $TRAVIS_SCALA_VERSION = 2.10* ]] && [[ $SCALAZ_VERSION = 7.2* ]]; then
-  SBT_COMMAND=";test ;mimaReportBinaryIssues"
+  SBT_COMMAND="\"set scalazVersion in ThisBuild := \\\"7.2.1\\\"\" ;test ;mimaReportBinaryIssues"
 else
   SBT_COMMAND=";test"
 fi
@@ -22,7 +22,7 @@ if [[ $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "release-"* ]] && [[ $TRAVIS
   fi
 fi
 
-sbt -Dscalaz.version=$SCALAZ_VERSION ++$TRAVIS_SCALA_VERSION $SBT_COMMAND
+sbt ++$TRAVIS_SCALA_VERSION $SBT_COMMAND
 
 if [[ $SBT_COMMAND = *";coverage"* ]]; then
    bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This makes it easier (IMO) to change the scalazVersion. Instead of failing silently if there is a typo in the Java Property key, you get autocomplete in the sbt console!