### PR TITLE
Use MalformedMessageBodyFailure for malformed multiparts

### DIFF
--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -171,7 +171,7 @@ object MultipartParser {
           emit(Out(ByteVector.empty, Some(found.drop(2))))
         } else {
           receive1Or[ByteVector, Out[ByteVector]](
-            fail(new InvalidMessageBodyFailure("Part was not terminated"))) { bv =>
+            fail(new MalformedMessageBodyFailure("Part was not terminated"))) { bv =>
             val (remFront, remBack) = remainder splitAt bv.length
             if (bv startsWith remFront) {
               // If remBack is nonEmpty, then the progress toward our match

--- a/core/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
+++ b/core/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
@@ -155,7 +155,7 @@ object MultipartParserSpec extends Specification {
       bv.decodeAscii mustEqual Right("bar")
     }
 
-    "fail with an InvalidMessageBodyFailure without an end line" in {
+    "fail with an MalformedMessageBodyFailure without an end line" in {
       val unprocessedInput = """--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
         |Content-Disposition: form-data; name="upload"; filename="integration.txt"
         |Content-Type: application/octet-stream
@@ -169,7 +169,7 @@ object MultipartParserSpec extends Specification {
       def unspool(str: String): Process0[ByteVector] = emit(ByteVector view (str getBytes "ASCII"))
       val results: Process0[Headers \/ ByteVector] = unspool(input) pipe MultipartParser.parse(boundary)
 
-      results.toVector must throwAn[InvalidMessageBodyFailure]
+      results.toVector must throwAn[MalformedMessageBodyFailure]
     }
   }
 }


### PR DESCRIPTION
Preserves the distinction between semantic and syntactic failures.

This becomes more important when the status code changes in #625.