### PR TITLE
Replace `fetchAs` and `getAs` with `expect`

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -3,7 +3,9 @@ package client
 
 import org.http4s.Http4sSpec
 import org.http4s.headers.Accept
+import org.http4s.Status.InternalServerError
 
+import scalaz.-\/
 import scalaz.concurrent.Task
 import scalaz.stream.Process
 
@@ -15,13 +17,16 @@ import org.specs2.matcher.MustThrownMatchers
 class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
 
   val route = HttpService {
-    case r if r.method == GET && r.pathInfo == "/"            => Response(Ok).withBody("hello")
-    case r if r.method == PUT && r.pathInfo == "/put"         => Response(Created).withBody(r.body)
+    case r if r.method == GET && r.pathInfo == "/"            =>
+      Response(Ok).withBody("hello")
+    case r if r.method == PUT && r.pathInfo == "/put"         =>
+      Response(Created).withBody(r.body)
     case r if r.method == GET && r.pathInfo == "/echoheaders" =>
       r.headers.get(Accept).fold(Task.now(Response(BadRequest))){ m =>
          Response(Ok).withBody(m.toString)
       }
-
+    case r if r.pathInfo == "/status/500" =>
+      Response(InternalServerError).withBody("Oops")
     case r => sys.error("Path not found: " + r.pathInfo)
   }
 
@@ -91,34 +96,39 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
       assertDisposes(_.fetch(Task.now(req)) { _ => Task.fail(SadTrombone) })
     }
 
-    "fetch Uris with getAs" in {
-      client.getAs[String](req.uri) must returnValue("hello")
+    "fetch Uris with expect" in {
+
+      client.expect[String](req.uri) must returnValue("hello")
     }
 
-    "fetch requests with fetchAs" in {
-      client.fetchAs[String](req) must returnValue("hello")
+    "fetch requests with expect" in {
+      client.expect[String](req) must returnValue("hello")
     }
 
-    "fetch request tasks with fetchAs" in {
-      client.fetchAs[String](Task.now(req)) must returnValue("hello")
+    "fetch request tasks with expect" in {
+      client.expect[String](Task.now(req)) must returnValue("hello")
     }
 
-    "add Accept header on getAs" in {
-      client.getAs[String](uri("http://www.foo.com/echoheaders")) must returnValue("Accept: text/*")
+    "return an unexpected status when expect returns unsuccessful status" in {
+      client.expect[String](uri("http://www.foo.com/status/500")).attempt must returnValue(-\/(UnexpectedStatus(Status.InternalServerError)))
     }
 
-    "add Accept header on fetchAs for requests" in {
-      client.fetchAs[String](Request(GET, uri("http://www.foo.com/echoheaders"))) must returnValue("Accept: text/*")
+    "add Accept header on expect" in {
+      client.expect[String](uri("http://www.foo.com/echoheaders")) must returnValue("Accept: text/*")
     }
 
-    "add Accept header on fetchAs for requests" in {
-      client.fetchAs[String](GET(uri("http://www.foo.com/echoheaders"))) must returnValue("Accept: text/*")
+    "add Accept header on expect for requests" in {
+      client.expect[String](Request(GET, uri("http://www.foo.com/echoheaders"))) must returnValue("Accept: text/*")
+    }
+
+    "add Accept header on expect for requests" in {
+      client.expect[String](GET(uri("http://www.foo.com/echoheaders"))) must returnValue("Accept: text/*")
     }
 
     "combine entity decoder media types correctly" in {
       // This is more of an EntityDecoder spec
       val edec = EntityDecoder.decodeBy(MediaType.`image/jpeg`)(_ => DecodeResult.success("foo!"))
-      client.fetchAs(GET(uri("http://www.foo.com/echoheaders")))(EntityDecoder.text orElse edec) must returnValue("Accept: text/*, image/jpeg")
+      client.expect(GET(uri("http://www.foo.com/echoheaders")))(EntityDecoder.text orElse edec) must returnValue("Accept: text/*, image/jpeg")
     }
 
     "streaming returns a stream" in {
@@ -152,10 +162,10 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
 
   "RequestResponseGenerator" should {
     "Generate requests based on Method" in {
-      client.fetchAs[String](GET(uri("http://www.foo.com/"))) must returnValue("hello")
+      client.expect[String](GET(uri("http://www.foo.com/"))) must returnValue("hello")
 
       // The PUT: /put path just echoes the body
-      client.fetchAs[String](PUT(uri("http://www.foo.com/put"), "hello?")) must returnValue("hello?")
+      client.expect[String](PUT(uri("http://www.foo.com/put"), "hello?")) must returnValue("hello?")
     }
   }
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
@@ -10,7 +10,7 @@ object ClientExample {
 
     val client = org.http4s.client.blaze.SimpleHttp1Client()
 
-    val page: Task[String] = client.getAs[String](uri("https://www.google.com/"))
+    val page: Task[String] = client.expect[String](uri("https://www.google.com/"))
 
     for (_ <- 1 to 2)
       println(page.map(_.take(72)).run)   // each execution of the Task will refetch the page!

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
@@ -33,7 +33,7 @@ object ClientMultipartPostExample {
                                 ))
 
     val request = Method.POST(url,multipart).map(_.replaceAllHeaders(multipart.headers))
-    client.fetchAs[String](request).run
+    client.expect[String](request).run
   }
 
   def main(args: Array[String]): Unit = println(go)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
@@ -7,6 +7,6 @@ import org.http4s.client.blaze.{defaultClient => client}
 
 object ClientPostExample extends App {
   val req = POST(uri("https://duckduckgo.com/"), UrlForm("q" -> "http4s"))
-  val responseBody = client.fetchAs[String](req)
+  val responseBody = client.expect[String](req)
   println(responseBody.run)
 }


### PR DESCRIPTION
`fetchAs` and `getAs` have quirky semantics when the response is not
successful.  It is unusual that the body of a 4xx or 5xx response will
decode to the same type as desired in the successful case.  This returns
the unexpected status code in a failed task.

Fixes #587