### PR TITLE
Change default host to 0.0.0.0 in server builders

### DIFF
--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -43,7 +43,7 @@ trait ServerBuilder {
 object ServerBuilder {
   // Defaults for core server builder functionality
   val LoopbackAddress = InetAddress.getLoopbackAddress.getHostAddress
-  val DefaultHost = LoopbackAddress
+  val DefaultHost = "0.0.0.0"
   val DefaultHttpPort = 8080
   val DefaultSocketAddress = InetSocketAddress.createUnresolved(DefaultHost, DefaultHttpPort)
   val DefaultServiceExecutor = Strategy.DefaultExecutorService


### PR DESCRIPTION
The default of 127.0.0.1 has caught people by surprise.  The wildcard binding matches the defaults of both embedded Jetty and Tomcat.

See #622