### PR TITLE
Downgrade argonaut to last stable release (6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.14.0 (2016-06-10)
+# v0.14.0
 * Added the possibility to specify custom responses to MessageFailures
 * Address issue with Retry middleware leaking connections
 * Fixed the status code for a semantically invalid request to `422 UnprocessableEntity`
@@ -8,6 +8,7 @@
 * Support for multipart messages
 * The Path extractor for Long now supports negative numbers
 * Upgrade to scalaz-stream-0.8.2(a) for compatibility with scodec-bits-1.1
+* Downgrade to argonaut-6.1 (latest stable release) now that it cross builds for scalaz-7.2
 
 # v0.13.2 (2016-04-13)
 * Fixes the CanBuildFrom for RequestCookieJar to avoid duplicates.

--- a/bin/publish
+++ b/bin/publish
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sbt "set scalazVersion in ThisBuild := \"7.1.7\"" +clean +publishSigned
-sbt "set scalazVersion in ThisBuild := \"7.2.1\"" +clean +publishSigned
+sbt "set scalazVersion in ThisBuild := \"7.1.8\"" +clean +publishSigned
+sbt "set scalazVersion in ThisBuild := \"7.2.4\"" +clean +publishSigned

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import sbtunidoc.Plugin.UnidocKeys._
 
 // Global settings
 organization in ThisBuild := "org.http4s"
-version      in ThisBuild := s"0.14.0${scalazCrossBuildSuffix(scalazVersion.value)}-SNAPSHOT"
+version      in ThisBuild := scalazCrossBuild("0.14.0-SNAPSHOT", scalazVersion.value)
 apiVersion   in ThisBuild <<= version.map(extractApiVersion)
 scalaVersion in ThisBuild := "2.10.6"
 // The build supports both scalaz `7.1.x` and `7.2.x`. Simply run `set scalazVersion in ThiBuild := "7.2.1"` to change
@@ -129,7 +129,7 @@ lazy val argonaut = libraryProject("argonaut")
   .settings(
     description := "Provides Argonaut codecs for http4s",
     libraryDependencies ++= Seq(
-      Http4sBuild.argonaut,
+      Http4sBuild.argonaut(scalazVersion.value),
       jawnParser
     )
   )

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -70,7 +70,7 @@ object Http4sBuild extends Build {
   lazy val javaxServletApi     = "javax.servlet"             % "javax.servlet-api"       % "3.1.0"
   lazy val jawnJson4s          = "org.spire-math"           %% "jawn-json4s"             % jawnParser.revision
   lazy val jawnParser          = "org.spire-math"           %% "jawn-parser"             % "0.8.4"
-  def jawnStreamz(scalazVersion: String) = "org.http4s"     %% "jawn-streamz"            % scalazCrossBuild("0.9", scalazVersion)
+  def jawnStreamz(scalazVersion: String) = "org.http4s"     %% "jawn-streamz"            % scalazCrossBuild("0.9.0", scalazVersion)
   lazy val jettyServer         = "org.eclipse.jetty"         % "jetty-server"            % "9.3.7.v20160115"
   lazy val jettyServlet        = "org.eclipse.jetty"         % "jetty-servlet"           % jettyServer.revision
   lazy val json4sCore          = "org.json4s"               %% "json4s-core"             % "3.3.0"

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -23,7 +23,7 @@ object Http4sBuild extends Build {
   def compatibleVersion(version: String, scalazVersion: String) = {
     val currentVersionWithoutSnapshot = version.replaceAll("-SNAPSHOT$", "")
     val (targetMajor, targetMinor) = extractApiVersion(version)
-    val targetVersion = s"${targetMajor}.${targetMinor}.0${scalazCrossBuildSuffix(scalazVersion)}"
+    val targetVersion = scalazCrossBuild("${targetMajor}.${targetMinor}.0", scalazVersion)
     if (targetVersion != currentVersionWithoutSnapshot)
       Some(targetVersion)
     else
@@ -41,23 +41,24 @@ object Http4sBuild extends Build {
       })
 
   val scalazVersion = settingKey[String]("The version of Scalaz used for building.")
-  def scalazStreamVersion(scalazVersion: String) =
-    "0.8.2" + scalazCrossBuildSuffix(scalazVersion)
-  def scalazCrossBuildSuffix(scalazVersion: String) =
+  def scalazCrossBuild(version: String, scalazVersion: String) =
     VersionNumber(scalazVersion).numbers match {
-      case Seq(7, 1, _*) => ""
-      case Seq(7, 2, _*) => "a"
+      case Seq(7, 1, _*) =>
+        version
+      case Seq(7, 2, _*) =>
+        if (version.endsWith("-SNAPSHOT"))
+          version.replaceFirst("-SNAPSHOT$", "a-SNAPSHOT")
+        else
+          s"${version}a"
     }
   def specs2Version(scalazVersion: String) =
     VersionNumber(scalazVersion).numbers match {
       case Seq(7, 1, _*) => "3.7.2-scalaz-7.1.7"
       case Seq(7, 2, _*) => "3.7.2"
     }
-  def jawnStreamzVersion(scalazVersion: String) =
-    "0.9.0" + scalazCrossBuildSuffix(scalazVersion)
 
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.7.v20160121"
-  lazy val argonaut            = "io.argonaut"              %% "argonaut"                % "6.2-M1"
+  def argonaut(scalazVersion: String) = "io.argonaut"       %% "argonaut"                % scalazCrossBuild("6.1", scalazVersion)
   lazy val asyncHttpClient     = "org.asynchttpclient"       % "async-http-client"       % "2.0.2"
   lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.12.0"
   lazy val circeGeneric        = "io.circe"                 %% "circe-generic"           % circeJawn.revision
@@ -69,7 +70,7 @@ object Http4sBuild extends Build {
   lazy val javaxServletApi     = "javax.servlet"             % "javax.servlet-api"       % "3.1.0"
   lazy val jawnJson4s          = "org.spire-math"           %% "jawn-json4s"             % jawnParser.revision
   lazy val jawnParser          = "org.spire-math"           %% "jawn-parser"             % "0.8.4"
-  def jawnStreamz(scalazVersion: String) = "org.http4s"     %% "jawn-streamz"            % jawnStreamzVersion(scalazVersion)
+  def jawnStreamz(scalazVersion: String) = "org.http4s"     %% "jawn-streamz"            % scalazCrossBuild("0.9", scalazVersion)
   lazy val jettyServer         = "org.eclipse.jetty"         % "jetty-server"            % "9.3.7.v20160115"
   lazy val jettyServlet        = "org.eclipse.jetty"         % "jetty-servlet"           % jettyServer.revision
   lazy val json4sCore          = "org.json4s"               %% "json4s-core"             % "3.3.0"
@@ -92,7 +93,7 @@ object Http4sBuild extends Build {
   def specs2Core(scalazVersion: String)         = "org.specs2"           %% "specs2-core"               % specs2Version(scalazVersion)
   def specs2MatcherExtra(scalazVersion: String) = "org.specs2"           %% "specs2-matcher-extra"      % specs2Core(scalazVersion).revision
   def specs2Scalacheck(scalazVersion: String)   = "org.specs2"           %% "specs2-scalacheck"         % specs2Core(scalazVersion).revision
-  def scalazStream(scalazVersion: String)       = "org.scalaz.stream"    %% "scalaz-stream"             % scalazStreamVersion(scalazVersion)
+  def scalazStream(scalazVersion: String)       = "org.scalaz.stream"    %% "scalaz-stream"             % scalazCrossBuild("0.8.2", scalazVersion)
   lazy val tomcatCatalina      = "org.apache.tomcat"         % "tomcat-catalina"         % "8.0.32"
   lazy val tomcatCoyote        = "org.apache.tomcat"         % "tomcat-coyote"           % tomcatCatalina.revision
   lazy val twirlApi            = "com.typesafe.play"        %% "twirl-api"               % "1.1.1"

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -23,7 +23,7 @@ object Http4sBuild extends Build {
   def compatibleVersion(version: String, scalazVersion: String) = {
     val currentVersionWithoutSnapshot = version.replaceAll("-SNAPSHOT$", "")
     val (targetMajor, targetMinor) = extractApiVersion(version)
-    val targetVersion = scalazCrossBuild("${targetMajor}.${targetMinor}.0", scalazVersion)
+    val targetVersion = scalazCrossBuild(s"${targetMajor}.${targetMinor}.0", scalazVersion)
     if (targetVersion != currentVersionWithoutSnapshot)
       Some(targetVersion)
     else


### PR DESCRIPTION
Most of the argonaut community is still on version 6.1.  The only reason we jumped to 6.2 milestones was to support scalaz-7.2, but this has caused pain for the people who are really using argonaut.  Now that argonaut crossbuilds for scalaz, we can use the standard, and upgrade when the argonaut team blesses 6.2.