### PR TITLE
Clean up deprecated code

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -76,14 +76,6 @@ final case class Client(open: Service[Request, DisposableResponse], shutdown: Ta
       f(response).onComplete(eval_(dispose))
     }).flatMap(identity)
 
-  @deprecated("Use toHttpService.run for compatibility, or fetch for safety", "0.12")
-  def prepare(req: Request): Task[Response] =
-    toHttpService.run(req)
-
-  @deprecated("Use toHttpService.run for compatibility, or fetch for safety", "0.12")
-  def apply(req: Request): Task[Response] =
-    toHttpService.run(req)
-
   /**
     * Submits a request and decodes the response on success.  On failure, the
     * status code is returned.  The underlying HTTP connection is closed at the
@@ -140,14 +132,6 @@ final case class Client(open: Service[Request, DisposableResponse], shutdown: Ta
   def get[A](s: String)(f: Response => Task[A]): Task[A] =
     Uri.fromString(s).fold(Task.fail, uri => get(uri)(f))
 
-  @deprecated("Use toHttpService.run(Request(Method.GET, uri)).run for compatibility, or get for safety", "0.12")
-  def prepare(uri: Uri): Task[Response] =
-    toHttpService.run(Request(Method.GET, uri))
-
-  @deprecated("Use toHttpService.run(Request(Method.GET, uri)).run for compatibility, or get for safety", "0.12")
-  def apply(uri: Uri): Task[Response] =
-    toHttpService.run(Request(Method.GET, uri))
-
   /**
     * Submits a GET request to the specified URI and decodes the response on
     * success.  On failure, the status code is returned.  The underlying HTTP
@@ -176,10 +160,6 @@ final case class Client(open: Service[Request, DisposableResponse], shutdown: Ta
   def getAs[A](s: String)(implicit d: EntityDecoder[A]): Task[A] =
     Uri.fromString(s).fold(Task.fail, uri => getAs[A](uri))
 
-  @deprecated("Use getAs", "0.12")
-  def prepAs[A](uri: Uri)(implicit d: EntityDecoder[A]): Task[A] =
-    getAs(uri)(d)
-
   /** Submits a request, and provides a callback to process the response.
     *
     * @param req A Task of the request to submit
@@ -190,14 +170,6 @@ final case class Client(open: Service[Request, DisposableResponse], shutdown: Ta
     */
   def fetch[A](req: Task[Request])(f: Response => Task[A]): Task[A] =
     req.flatMap(fetch(_)(f))
-
-  @deprecated("Use toHttpService =<< req for compatibility, or fetch for safety", "0.12")
-  def prepare(req: Task[Request]): Task[Response] =
-    toHttpService =<< req
-
-  @deprecated("Use toHttpService =<< req for compatibility, or fetch for safety", "0.12")
-  def apply(req: Task[Request]): Task[Response] =
-    toHttpService =<< req
 
   def expect[A](req: Task[Request])(implicit d: EntityDecoder[A]): Task[A] =
     req.flatMap(expect(_)(d))

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -29,7 +29,7 @@ final case class DisposableResponse(response: Response, dispose: Task[Unit]) {
   *
   * @param open a service to asynchronously return a [[DisposableResponse]] from
   *             a [[Request]].  This is a low-level operation intended for client
-  *             implementations and middlewares.
+  *             implementations and middleware.
   *
   * @param shutdown a Task to shut down this Shutdown this client, closing any
   *                 open connections and freeing resources

--- a/core/src/main/scala/org/http4s/MessageOps.scala
+++ b/core/src/main/scala/org/http4s/MessageOps.scala
@@ -54,18 +54,6 @@ trait MessageOps extends Any {
     * @param headers [[Headers]] containing the desired headers
     * @return a new Request object
     */
-  @deprecated("Use replaceAllHeaders.", "0.10.0")
-  final def withHeaders(headers: Headers): Self = replaceAllHeaders(headers)
-
-  /** Replace the existing headers with those provided */
-  @deprecated("Use replaceAllHeaders.", "0.10.0")
-  final def withHeaders(headers: Header*): Self = replaceAllHeaders(Headers(headers.toList))
-  
-  /** Replaces the [[Header]]s of the incoming Request object
-    *
-    * @param headers [[Headers]] containing the desired headers
-    * @return a new Request object
-    */
   final def replaceAllHeaders(headers: Headers): Self =
     transformHeaders(_ => headers)
 

--- a/core/src/main/scala/org/http4s/MessageOps.scala
+++ b/core/src/main/scala/org/http4s/MessageOps.scala
@@ -120,7 +120,6 @@ trait ResponseOps extends Any with MessageOps {
   /** Change the status of this response object
     *
     * @param status value to replace on the response object
-    * @tparam S type that can be converted to a [[Status]]
     * @return a new response object with the new status code
     */
   def withStatus(status: Status): Self


### PR DESCRIPTION
As the latest version of http4s is 0.14.x, I think we can remove deprecated methods before 0.14. I also fixed a typo and unnecessary documentation, which should be fine I hope :)