### PR TITLE
Override getMessage in UnexpectedStatus

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -192,4 +192,6 @@ final case class Client(open: Service[Request, DisposableResponse], shutdown: Ta
     shutdown.run
 }
 
-final case class UnexpectedStatus(status: Status) extends RuntimeException with NoStackTrace
+final case class UnexpectedStatus(status: Status) extends RuntimeException with NoStackTrace {
+  override def getMessage: String = s"unexpected HTTP status: $status"
+}

--- a/client/src/test/scala/org/http4s/client/UnexpectedStatusSpec.scala
+++ b/client/src/test/scala/org/http4s/client/UnexpectedStatusSpec.scala
@@ -1,0 +1,18 @@
+package org.http4s
+package client
+
+class UnexpectedStatusSpec extends Http4sSpec {
+  "UnexpectedStatus" should {
+    "include status in message" in {
+      val e = UnexpectedStatus(Status.NotFound)
+      e.getMessage() must_== "unexpected HTTP status: 404 Not Found"
+    }
+
+    "not return null" in {
+      prop { status: Status =>
+        val e = UnexpectedStatus(status)
+        e.getMessage() must not beNull
+      }
+    }
+  }
+}


### PR DESCRIPTION
Before this change, standard approaches to logging errors would result
in something that looked like `org.http4s.client.UnexpectedStatus:
null`, which is not the most helpful error message in the world. I don't
have strong opinions on what this message should look like and I'm happy
to change it, but I think that it should include the status (at least
its code) in some form.