### PR TITLE
Catch exceptions thrown from response callback in client

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -20,8 +20,10 @@ final case class DisposableResponse(response: Response, dispose: Task[Unit]) {
     * Returns a task to handle the response, safely disposing of the underlying
     * HTTP connection when the task finishes.
     */
-  def apply[A](f: Response => Task[A]): Task[A] =
-    f(response).onFinish { case _ => dispose }
+  def apply[A](f: Response => Task[A]): Task[A] = {
+    val task = try f(response) catch { case e: Throwable => Task.fail(e) }
+    task.onFinish { case _ => dispose }
+  }
 }
 
 /**

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -80,12 +80,20 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
       assertDisposes(_.get(req.uri) { _ => Task.fail(SadTrombone) })
     }
 
+    "get disposes of the response on uncaught exception" in {
+      assertDisposes(_.get(req.uri) { _ => sys.error("Don't do this at home, kids") })
+    }
+
     "fetch disposes of the response on success" in {
       assertDisposes(_.fetch(req) { _ => Task.now(()) })
     }
 
     "fetch disposes of the response on failure" in {
       assertDisposes(_.fetch(req) { _ => Task.fail(SadTrombone) })
+    }
+
+    "fetch disposes of the response on uncaught exception" in {
+      assertDisposes(_.fetch(req) { _ => sys.error("Don't do this at home, kids") })
     }
 
     "fetch on task disposes of the response on success" in {
@@ -96,8 +104,15 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
       assertDisposes(_.fetch(Task.now(req)) { _ => Task.fail(SadTrombone) })
     }
 
-    "fetch Uris with expect" in {
+    "fetch on task disposes of the response on uncaught exception" in {
+      assertDisposes(_.fetch(Task.now(req)) { _ => sys.error("Don't do this at home, kids") })
+    }
 
+    "fetch on task that does not match results in failed task" in {
+      client.fetch(Task.now(req))(PartialFunction.empty).attempt.run must be_-\/ { e: Throwable => e must beAnInstanceOf[MatchError] }
+    }
+
+    "fetch Uris with expect" in {
       client.expect[String](req.uri) must returnValue("hello")
     }
 


### PR DESCRIPTION
This accomplishes two things:
1. Exceptions end up as failed tasks
2. We don't leak resources

Fixes #664