### PR TITLE
Date header improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ version      in ThisBuild := scalazCrossBuild("0.15.0-SNAPSHOT", scalazVersion.v
 apiVersion   in ThisBuild <<= version.map(extractApiVersion)
 scalaVersion in ThisBuild := "2.10.6"
 // The build supports both scalaz `7.1.x` and `7.2.x`. Simply run
-// `set scalazVersion in ThiBuild := "7.2.4"` to change which version of scalaz
+// `set scalazVersion in ThisBuild := "7.2.4"` to change which version of scalaz
 // is used to build the project.
 scalazVersion in ThisBuild := "7.1.8"
 crossScalaVersions in ThisBuild <<= scalaVersion(Seq(_, "2.11.8"))

--- a/core/src/main/scala/org/http4s/headers/Date.scala
+++ b/core/src/main/scala/org/http4s/headers/Date.scala
@@ -2,7 +2,6 @@ package org.http4s
 package headers
 
 import java.time.Instant
-import java.time.format.DateTimeFormatter
 
 import org.http4s.parser.HttpHeaderParser
 import org.http4s.util.{Renderer, Writer}
@@ -14,7 +13,7 @@ object Date extends HeaderKey.Internal[Date] with HeaderKey.Singleton {
 
 final case class Date(date: Instant) extends Header.Parsed {
   def key: Date.type = Date
-  override def value: String = Renderer.renderString((date))
+  override def value: String = Renderer.renderString(date)
   override def renderValue(writer: Writer): writer.type = writer.append(value)
 }
 

--- a/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
+++ b/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
@@ -47,14 +47,18 @@ private[parser] trait AdditionalRules extends Rfc2616BasicRules { this: Parser =
     }
   }
 
+  // RFC 850 date string, e.g. `Sunday, 06-Nov-94 08:49:37 GMT`
   def RFC850Date: Rule1[Instant] = rule {
     // TODO: hopefully parboiled2 will get more helpers so we don't need to chain methods to get under 5 args
     Weekday ~ str(", ") ~ Date2 ~ ch(' ') ~ Time ~ ch(' ') ~ ("GMT" | "UTC") ~> {
-      (month: Int, day: Int, wkday: Int, year: Int, hour: Int, min: Int, sec: Int) =>
-        createDateTime(year, month, day, hour, min, sec, wkday)
+      (wkday: Int, day: Int, month: Int, year: Int, hour: Int, min: Int, sec: Int) =>
+        // We'll assume that if the date is less than 100 it is missing the 1900 part
+        val fullYear = if (year < 100) 1900 + year else year
+        createDateTime(fullYear, month, day, hour, min, sec, wkday)
     }
   }
 
+  // ANSI C's asctime() format, e.g. `Sun Nov  6 08:49:37 1994`
   def ASCTimeDate: Rule1[Instant] = rule {
     Wkday ~ ch(' ') ~ Date3 ~ ch(' ') ~ Time ~ ch(' ') ~ Digit4 ~> {
       (wkday:Int, month:Int, day:Int, hour:Int, min:Int, sec:Int, year:Int) =>
@@ -64,7 +68,7 @@ private[parser] trait AdditionalRules extends Rfc2616BasicRules { this: Parser =
 
   def Date1: RuleN[Int::Int::Int::HNil] = rule { (Digit2 | Digit1) ~ ch(' ') ~ Month ~ ch(' ') ~ Digit4 }
 
-  def Date2: RuleN[Int::Int::Int::HNil] = rule { (Digit2 | Digit1) ~ ch('-') ~ Month ~ ch('-') ~ Digit4 }
+  def Date2: RuleN[Int::Int::Int::HNil] = rule { (Digit2 | Digit1) ~ ch('-') ~ Month ~ ch('-') ~ (Digit2 | Digit4) }
 
   def Date3: Rule2[Int, Int] = rule { Month ~ ch(' ') ~ (Digit2 | ch(' ') ~ Digit1) }
 
@@ -82,7 +86,7 @@ private[parser] trait AdditionalRules extends Rfc2616BasicRules { this: Parser =
   def Weekday: Rule1[Int] = rule { ("Sunday"   ~ push(0)) |
                                    ("Monday"   ~ push(1)) |
                                    ("Tuesday"  ~ push(2)) |
-                                   ("Wedsday"  ~ push(3)) |
+                                   ("Wednesday"  ~ push(3)) |
                                    ("Thursday" ~ push(4)) |
                                    ("Friday"   ~ push(5)) |
                                    ("Saturday" ~ push(6)) }

--- a/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
+++ b/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
@@ -83,13 +83,13 @@ private[parser] trait AdditionalRules extends Rfc2616BasicRules { this: Parser =
                                  ("Fri" ~ push(5)) |
                                  ("Sat" ~ push(6)) }
 
-  def Weekday: Rule1[Int] = rule { ("Sunday"   ~ push(0)) |
-                                   ("Monday"   ~ push(1)) |
-                                   ("Tuesday"  ~ push(2)) |
-                                   ("Wednesday"  ~ push(3)) |
-                                   ("Thursday" ~ push(4)) |
-                                   ("Friday"   ~ push(5)) |
-                                   ("Saturday" ~ push(6)) }
+  def Weekday: Rule1[Int] = rule { ("Sunday"    ~ push(0)) |
+                                   ("Monday"    ~ push(1)) |
+                                   ("Tuesday"   ~ push(2)) |
+                                   ("Wednesday" ~ push(3)) |
+                                   ("Thursday"  ~ push(4)) |
+                                   ("Friday"    ~ push(5)) |
+                                   ("Saturday"  ~ push(6)) }
 
   def Month: Rule1[Int] = rule {  ("Jan" ~ push(1))  |
                                   ("Feb" ~ push(2))  |

--- a/core/src/main/scala/org/http4s/util/Renderable.scala
+++ b/core/src/main/scala/org/http4s/util/Renderable.scala
@@ -31,7 +31,7 @@ object Renderer {
     private val dateFormat =
       DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
         .withLocale(Locale.US)
-        .withZone(ZoneId.of("UTC"))
+        .withZone(ZoneId.of("GMT"))
 
     override def render(writer: Writer, t: Instant): writer.type =
       writer << dateFormat.format(t)

--- a/core/src/test/scala/org/http4s/TestInstances.scala
+++ b/core/src/test/scala/org/http4s/TestInstances.scala
@@ -151,12 +151,12 @@ trait TestInstances {
     Arbitrary.arbitrary[Set[Char]].map(_.map(_.toInt)).map(set => BitSet(set.toSeq: _*))
   )
 
-  implicit lazy val arbitararyAllow: Arbitrary[Allow] =
+  implicit lazy val arbitraryAllow: Arbitrary[Allow] =
     Arbitrary { for {
       methods <- nonEmptyContainerOf[Set, Method](arbitrary[Method]).map(_.toList)
     } yield Allow(methods.head, methods.tail:_*) }
 
-  implicit lazy val arbitararyContentLength: Arbitrary[`Content-Length`] =
+  implicit lazy val arbitraryContentLength: Arbitrary[`Content-Length`] =
     Arbitrary { for {
       long <- arbitrary[Long] if long > 0L
     } yield `Content-Length`(long) }

--- a/core/src/test/scala/org/http4s/headers/AllowSpec.scala
+++ b/core/src/test/scala/org/http4s/headers/AllowSpec.scala
@@ -1,7 +1,5 @@
 package org.http4s.headers
 
-import org.http4s.Http4sSpec
-
 class AllowSpec extends HeaderLaws {
   checkAll("Allow", headerLaws(Allow))
 }

--- a/core/src/test/scala/org/http4s/headers/ContentLengthSpec.scala
+++ b/core/src/test/scala/org/http4s/headers/ContentLengthSpec.scala
@@ -1,9 +1,5 @@
 package org.http4s.headers
 
-import org.http4s.Http4sSpec
-
-import scalaz.{\/, -\/}
-
 class ContentLengthSpec extends HeaderLaws {
   checkAll("Content-Length", headerLaws(`Content-Length`))
 

--- a/core/src/test/scala/org/http4s/headers/DateSpec.scala
+++ b/core/src/test/scala/org/http4s/headers/DateSpec.scala
@@ -17,4 +17,17 @@ class DateSpec extends HeaderLaws {
       Date(Instant.from(utcDate)).renderString must_== "Date: Sun, 06 Nov 1994 08:49:37 GMT"
     }
   }
+
+  "fromDate" should {
+    "accept format RFC 1123" in {
+      Date.parse("Sun, 06 Nov 1994 08:49:37 GMT").map(_.date) must be_\/-(Instant.from(gmtDate))
+    }
+    "accept format RFC 1036" in {
+      Date.parse("Sunday, 06-Nov-94 08:49:37 GMT").map(_.date) must be_\/-(Instant.from(gmtDate))
+    }
+    "accept format ANSI date" in {
+      Date.parse("Sun Nov  6 08:49:37 1994").map(_.date) must be_\/-(Instant.from(gmtDate))
+      Date.parse("Sun Nov 16 08:49:37 1994").map(_.date) must be_\/-(Instant.from(gmtDate.plusDays(10)))
+    }
+  }
 }

--- a/core/src/test/scala/org/http4s/headers/DateSpec.scala
+++ b/core/src/test/scala/org/http4s/headers/DateSpec.scala
@@ -1,6 +1,20 @@
 package org.http4s
 package headers
 
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
 class DateSpec extends HeaderLaws {
   checkAll("Date", headerLaws(Date))
+
+  val gmtDate = ZonedDateTime.of(1994, 11, 6, 8, 49, 37, 0, ZoneId.of("GMT"))
+
+  "render" should {
+    "format GMT date according to RFC 1123" in {
+      Date(Instant.from(gmtDate)).renderString must_== "Date: Sun, 06 Nov 1994 08:49:37 GMT"
+    }
+    "format UTC date according to RFC 1123" in {
+      val utcDate = ZonedDateTime.of(1994, 11, 6, 8, 49, 37, 0, ZoneId.of("UTC"))
+      Date(Instant.from(utcDate)).renderString must_== "Date: Sun, 06 Nov 1994 08:49:37 GMT"
+    }
+  }
 }


### PR DESCRIPTION
This PR brings some improvements to the Date header:

* It fixes #669 writing the Date header always using GMT
* It improves the parser of dates for the extra formats indicated in RFC 2616:
```
   HTTP applications have historically allowed three different formats
   for the representation of date/time stamps:

      Sun, 06 Nov 1994 08:49:37 GMT  ; RFC 822, updated by RFC 1123
      Sunday, 06-Nov-94 08:49:37 GMT ; RFC 850, obsoleted by RFC 1036
      Sun Nov  6 08:49:37 1994       ; ANSI C's asctime() format
```
* It contains some small fixes to code found while doing the PR, essentially some typos and unnecessary imports