### PR TITLE
Improvements to Expires header

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Expires.scala
+++ b/core/src/main/scala/org/http4s/headers/Expires.scala
@@ -1,5 +1,28 @@
 package org.http4s
 package headers
 
-object Expires extends HeaderKey.Default
+import java.time.Instant
+
+import org.http4s.parser.HttpHeaderParser
+import org.http4s.util.{Renderer, Writer}
+
+object Expires extends HeaderKey.Internal[Expires] with HeaderKey.Singleton {
+  override def parse(s: String): ParseResult[Expires] =
+    HttpHeaderParser.EXPIRES(s)
+}
+
+/**
+  * Constructs an `Expires` header.
+  *
+  * The HTTP RFCs indicate that Expires should be in the range of now to 1 year in the future.
+  * However, it is a usual practice to set it to the past of far in the future
+  * Thus any instant is in practice allowed
+  *
+  * @param expirationDate the date of expiration
+  */
+final case class Expires(expirationDate: Instant) extends Header.Parsed {
+  val key = `Expires`
+  override val value = Renderer.renderString(expirationDate)
+  override def renderValue(writer: Writer): writer.type = writer.append(value)
+}
 

--- a/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
+++ b/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
@@ -113,6 +113,8 @@ private[parser] trait AdditionalRules extends Rfc2616BasicRules { this: Parser =
 
   def Digit4: Rule1[Int] = rule { capture(Digit ~ Digit ~ Digit ~ Digit) ~> {s: String => s.toInt} }
 
+  def NegDigit1: Rule1[Int] = rule { "-" ~ capture(Digit) ~> {s: String => s.toInt} }
+
   def Ip4Number = rule { Digit3 | Digit2 | Digit1 }
 
   def Ip: Rule1[InetAddress] = rule {

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -21,10 +21,11 @@ package parser
 
 import headers._
 import java.net.InetAddress
+import java.time.Instant
+
 import org.http4s.headers.ETag.EntityTag
 import org.http4s.util.CaseInsensitiveString._
 import org.parboiled2.Rule1
-
 import org.http4s.util.NonEmptyList
 
 /**
@@ -72,6 +73,14 @@ private[parser] trait SimpleHeaders {
   def DATE(value: String): ParseResult[Date] = new Http4sHeaderParser[Date](value) {
     def entry = rule {
       HttpDate ~ EOL ~> (Date(_))
+    }
+  }.parse
+
+  def EXPIRES(value: String): ParseResult[Expires] = new Http4sHeaderParser[Expires](value) {
+    def entry = rule {
+      HttpDate ~ EOL ~> (Expires(_)) | // Valid Expires header
+      Digit1 ~ EOL ~> ((t: Int) => Expires(Instant.ofEpochMilli(t))) | // Used for bogus http servers returning 0
+      NegDigit1 ~ EOL ~> ((_: Int) => Expires(Instant.ofEpochMilli(0))) // Used for bogus http servers returning -1
     }
   }.parse
 

--- a/core/src/test/scala/org/http4s/headers/ExpiresSpec.scala
+++ b/core/src/test/scala/org/http4s/headers/ExpiresSpec.scala
@@ -1,0 +1,35 @@
+package org.http4s.headers
+
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
+class ExpiresSpec extends HeaderLaws {
+  checkAll("Expires", headerLaws(Expires))
+
+  val gmtDate = ZonedDateTime.of(1994, 11, 6, 8, 49, 37, 0, ZoneId.of("GMT"))
+  val epoch = Instant.ofEpochMilli(0)
+  val epochString = "Expires: Thu, 01 Jan 1970 00:00:00 GMT"
+
+  "render" should {
+    "format GMT date according to RFC 1123" in {
+      Expires(Instant.from(gmtDate)).renderString must_== "Expires: Sun, 06 Nov 1994 08:49:37 GMT"
+    }
+  }
+
+  "parse" should {
+    "accept format RFC 1123" in {
+      Expires.parse("Sun, 06 Nov 1994 08:49:37 GMT").map(_.expirationDate) must be_\/-(Instant.from(gmtDate))
+    }
+    "accept 0 value (This value is not legal but it used by some servers)" in {
+      // 0 is an illegal value used to denote an expired header, should be
+      // equivalent to expiration set at the epoch
+      Expires.parse("0").map(_.expirationDate) must be_\/-(epoch)
+      Expires.parse("0").map(_.renderString) must be_\/-(epochString)
+    }
+    "accept -1 value (This value is not legal but it used by some servers)" in {
+      // 0 is an illegal value used to denote an expired header, should be
+      // equivalent to expiration set at the epoch
+      Expires.parse("-1").map(_.expirationDate) must be_\/-(epoch)
+      Expires.parse("-1").map(_.renderString) must be_\/-(epochString)
+    }
+  }
+}


### PR DESCRIPTION
This PR lets users easily create the `Expires` header and supports parsing on the usual `Date` format as well as bogus values used by some servers to denote expiration like `0` or `-1`