### PR TITLE
Replace lazy `Raw.parsed` field with a simple null check

### DIFF
--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -82,7 +82,13 @@ object Header {
    * @param value String representation of the header value
    */
   final case class Raw(name: CaseInsensitiveString, override val value: String) extends Header {
-    override lazy val parsed = parser.HttpHeaderParser.parseHeader(this).getOrElse(this)
+    private[this] var _parsed: Header = null
+    final override def parsed: Header = {
+      if (_parsed == null) {
+        _parsed = parser.HttpHeaderParser.parseHeader(this).getOrElse(this)
+      }
+      parsed
+    }
     override def renderValue(writer: Writer): writer.type = writer.append(value)
   }
 

--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -87,7 +87,7 @@ object Header {
       if (_parsed == null) {
         _parsed = parser.HttpHeaderParser.parseHeader(this).getOrElse(this)
       }
-      parsed
+      _parsed
     }
     override def renderValue(writer: Writer): writer.type = writer.append(value)
   }


### PR DESCRIPTION
It's so unlikely that we face thread contention parsing these, we'd
rather pay to parse the same field twice in that rare case than to pay
for the locking on each access.