### PR TITLE
Don't render a "/" for an empty path when none is provided

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -76,27 +76,26 @@ case class Uri(
   override lazy val renderString: String =
     super.renderString
 
-  override def render(writer: Writer): writer.type = this match {
-    case Uri(Some(s), Some(a), "/", q, None) if q.isEmpty =>
-      renderSchemeAndAuthority(writer, s, a)
+  override def render(writer: Writer): writer.type = {
+    def renderScheme(s: Scheme): writer.type =
+      writer << s << ':'
 
-    case Uri(Some(s), Some(a), path, params, fragment) =>
-      renderSchemeAndAuthority(writer, s, a)
-      writer.append(path)
-      renderParamsAndFragment(writer, params, fragment)
+    this match {
+      case Uri(Some(s), Some(a), _, _, _) =>
+        renderScheme(s) << "//" << a
 
-    case Uri(Some(s), None, path, params, fragment) =>
-      renderScheme(writer, s)
-      writer.append(path)
-      renderParamsAndFragment(writer, params, fragment)
+      case Uri(Some(s), None, _, _, _) =>
+        renderScheme(s)
 
-    case Uri(None, Some(a), path, params, fragment) =>
-      writer << a << path
-      renderParamsAndFragment(writer, params, fragment)
+      case Uri(None, Some(a), _, _, _) =>
+        writer << a
 
-    case Uri(None, None, path, params, fragment) =>
-      writer.append(path)
-      renderParamsAndFragment(writer, params, fragment)
+      case Uri(None, None, _, _, _) =>
+    }
+    writer << path
+    if (query.nonEmpty) writer << '?' << query
+    fragment.foreach { f => writer << '#' << UrlCodingUtils.urlEncode(f, spaceIsPlus = false) }
+    writer
   }
 
   /////////// Query Operations ///////////////
@@ -175,19 +174,6 @@ object Uri extends UriFunctions {
   object RegName { def apply(name: String) = new RegName(name.ci) }
   object IPv4 { def apply(address: String) = new IPv4(address.ci) }
   object IPv6 { def apply(address: String) = new IPv6(address.ci) }
-
-  private def renderScheme(writer: Writer, s: Scheme): writer.type =
-    writer << s << ':'
-
-  private def renderSchemeAndAuthority(writer: Writer, s: Scheme, a: Authority): writer.type =
-    renderScheme(writer, s) << "//" << a
-
-
-  private def renderParamsAndFragment(writer: Writer, p: Query, f: Option[Fragment]): writer.type = {
-    if (p.nonEmpty) writer << '?' << p
-    if (f.isDefined) writer << '#' << UrlCodingUtils.urlEncode(f.get, spaceIsPlus = false)
-    writer
-  }
 }
 
 trait UriFunctions {

--- a/core/src/test/scala/org/http4s/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/UriSpec.scala
@@ -691,4 +691,10 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       "http:g"        shouldResolveTo "http:g"
     }
   }
+
+  "Uri.equals" should {
+    "be false between an empty path and a trailing slash after an authority" in {
+      uri("http://example.com") must_!= uri("http://example.com/")
+    }
+  }
 }

--- a/core/src/test/scala/org/http4s/UriSpec.scala
+++ b/core/src/test/scala/org/http4s/UriSpec.scala
@@ -168,12 +168,16 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       Uri(Some("http".ci), Some(Authority(host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)))).toString must_==("http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]")
     }
 
+    "not append a '/' unless it's in the path" in {
+      uri("http://www.example.com").toString must_==("http://www.example.com")
+    }
+
     "render email address" in {
       Uri(Some("mailto".ci), path = "John.Doe@example.com").toString must_==("mailto:John.Doe@example.com")
     }
 
     "render an URL with username and password" in {
-      Uri(Some("http".ci), Some(Authority(Some("username:password"), RegName("some.example.com"), None)), "/", Query.empty, None).toString must_==("http://username:password@some.example.com")
+      Uri(Some("http".ci), Some(Authority(Some("username:password"), RegName("some.example.com"), None)), "/", Query.empty, None).toString must_==("http://username:password@some.example.com/")
     }
 
     "render an URL with username and password, path and params" in {


### PR DESCRIPTION
This is a scheme-specific normalization which is further down the
"comparison ladder" in RFC3986 than I think we care to get.

This makes the rendering match the equality semantics.

Fixes #676.