### PR TITLE
Remove code_ref tags

### DIFF
--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -1,7 +1,5 @@
 package com.example.http4s.blaze
 
-/// code_ref: blaze_server_example
-
 import java.util.concurrent.TimeUnit
 
 import com.example.http4s.ExampleService
@@ -38,4 +36,3 @@ object BlazeMetricsExample extends ServerApp {
     .mountService(srvc, "/http4s")
     .start
 }
-/// end_code_ref

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
@@ -4,7 +4,6 @@ object ClientExample {
 
   def getSite() = {
 
-/// code_ref: blaze_client_example
     import org.http4s.Http4s._
     import scalaz.concurrent.Task
 
@@ -38,7 +37,6 @@ object ClientExample {
     println(page2.run)
 
     client.shutdownNow()
-/// end_code_ref
   }
 
   def main(args: Array[String]): Unit = getSite()

--- a/examples/src/main/scala/com/example/http4s/site/HelloBetterWorld.scala
+++ b/examples/src/main/scala/com/example/http4s/site/HelloBetterWorld.scala
@@ -5,7 +5,6 @@ import org.http4s._
 import org.http4s.dsl._
 
 object HelloBetterWorld {
-  /// code_ref: service
   val service = HttpService {
     //  We use http4s-dsl to match the path of the Request to the familiar URI form
     case GET -> Root / "hello" =>
@@ -13,5 +12,4 @@ object HelloBetterWorld {
       // EntityResponseGenerator 'Ok' for convenience
       Ok("Hello, better world.")
   }
-  /// end_code_ref
 }


### PR DESCRIPTION
These were from a custom jekyll plugin that is no longer in use.
Compiled documentation belongs in tut.