### PR TITLE
Render SSE with the leading optional space.

### DIFF
--- a/core/src/main/scala/org/http4s/ServerSentEvent.scala
+++ b/core/src/main/scala/org/http4s/ServerSentEvent.scala
@@ -1,4 +1,3 @@
-
 package org.http4s
 
 import java.util.regex.Pattern
@@ -25,7 +24,7 @@ case class ServerSentEvent(
     id match {
       case None =>
       case Some(EventId.reset) => writer << "id\n"
-      case Some(EventId(id)) => writer << "id:" << id << "\n"
+      case Some(EventId(id)) => writer << "id: " << id << "\n"
     }
     retry.foreach { writer << "retry:" << _ << "\n" }
     writer << "\n"

--- a/core/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/core/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -84,6 +84,12 @@ class ServerSentEventSpec extends Http4sSpec {
         .run
       roundTrip must_== sses
     }
+
+    "handle events that begin with a space" in {
+      // This is a pathological case uncovered by scalacheck
+      val sse = ServerSentEvent("meh",None,Some(EventId(" begins_with_space")),None)
+      emit(sse).toSource.pipe(ServerSentEvent.encoder).pipe(ServerSentEvent.decoder).runLast.run must beSome(sse)
+    }
   }
 
   "EntityEncoder[ServerSentEvent]" should {


### PR DESCRIPTION
Up to one space gets trimmed.  If data actually begins with a space,
which is a horrible thing to rely on but the kind of thing property
testing finds, then the optional space becomes mandatory.  It's simpler
just to always render it.

Fixes the Travis failure in #691 .