### PR TITLE
Also space-pad data, event, and retry fields.

### DIFF
--- a/core/src/main/scala/org/http4s/ServerSentEvent.scala
+++ b/core/src/main/scala/org/http4s/ServerSentEvent.scala
@@ -19,14 +19,14 @@ case class ServerSentEvent(
   retry: Option[Long] = None
 ) extends Renderable {
   def render(writer: Writer): writer.type = {
-    writer << "data:" << data << "\n"
-    eventType.foreach { writer << "event:" << _ << "\n" }
+    writer << "data: " << data << "\n"
+    eventType.foreach { writer << "event: " << _ << "\n" }
     id match {
       case None =>
       case Some(EventId.reset) => writer << "id\n"
       case Some(EventId(id)) => writer << "id: " << id << "\n"
     }
-    retry.foreach { writer << "retry:" << _ << "\n" }
+    retry.foreach { writer << "retry: " << _ << "\n" }
     writer << "\n"
   }
 

--- a/core/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/core/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -85,9 +85,9 @@ class ServerSentEventSpec extends Http4sSpec {
       roundTrip must_== sses
     }
 
-    "handle events that begin with a space" in {
+    "handle leading spaces" in {
       // This is a pathological case uncovered by scalacheck
-      val sse = ServerSentEvent("meh",None,Some(EventId(" begins_with_space")),None)
+      val sse = ServerSentEvent(" a",Some(" b"),Some(EventId(" c")),Some(1L))
       emit(sse).toSource.pipe(ServerSentEvent.encoder).pipe(ServerSentEvent.decoder).runLast.run must beSome(sse)
     }
   }


### PR DESCRIPTION
data and event for correctness, retry for consistency.

This was meant to be part of #693, but I gitted too fast.