### PR TITLE
Provides Service.apply methods like HttpService.apply

### DIFF
--- a/core/src/main/scala/org/http4s/Fallthrough.scala
+++ b/core/src/main/scala/org/http4s/Fallthrough.scala
@@ -8,6 +8,7 @@ import scalaz.{Equal, Monoid}
   * then [[Service#orElse]] can be used.
   */
 trait Fallthrough[B] {
+  def fallthroughValue: B
   def isFallthrough(a: B): Boolean
   def fallthrough[A](fst: B, snd: Service[A, B]): Service[A, B] =
     if (isFallthrough(fst)) snd else Service.constVal(fst)
@@ -23,19 +24,15 @@ object Fallthrough {
 
   /** A [[Fallthrough]] for any Monoid with an Equals. */
   implicit def forMonoid[B : Monoid : Equal]: Fallthrough[B] = new Fallthrough[B] {
+    def fallthroughValue: B = Monoid[B].zero
     def isFallthrough(a: B): Boolean = Monoid[B].isMZero(a)
   }
 
   /** A [[Response]] specific [[Fallthrough]] which considers any response with a 404
     * status code as a fallthrough. */
-  implicit def forResponse: Fallthrough[Response] = new Fallthrough[Response] {
+  implicit val forResponse: Fallthrough[Response] = new Fallthrough[Response] {
+    val fallthroughValue: Response = HttpService.notFound.run
     def isFallthrough(r: Response): Boolean =
       r.status.code == 404 && r.attributes.contains(fallthroughKey)
   }
-
-  /** A [[Fallthrough]] which never falls through. */
-  def never[B]: Fallthrough[B] = new Fallthrough[B] {
-    def isFallthrough(a: B): Boolean = false
-  }
-
 }

--- a/core/src/main/scala/org/http4s/Fallthrough.scala
+++ b/core/src/main/scala/org/http4s/Fallthrough.scala
@@ -8,7 +8,7 @@ import scalaz.{Equal, Monoid}
   * then [[Service#orElse]] can be used.
   */
 trait Fallthrough[B] {
-  def fallthroughValue: B
+  def fallthrough: B
   def isFallthrough(a: B): Boolean
   def fallthrough[A](fst: B, snd: Service[A, B]): Service[A, B] =
     if (isFallthrough(fst)) snd else Service.constVal(fst)
@@ -19,20 +19,9 @@ object Fallthrough {
   /** Sintacticl utility for recovering the [[Fallthrough]] currently in scope. */
   def apply[B](implicit F : Fallthrough[B]): Fallthrough[B] = F
 
-  /** Attribute key that signals that a `HttpService` didn't result in a definitive [[Response]] */
-  val fallthroughKey = AttributeKey.http4s[Unit]("fallthroughKey")
-
   /** A [[Fallthrough]] for any Monoid with an Equals. */
   implicit def forMonoid[B : Monoid : Equal]: Fallthrough[B] = new Fallthrough[B] {
-    def fallthroughValue: B = Monoid[B].zero
+    def fallthrough: B = Monoid[B].zero
     def isFallthrough(a: B): Boolean = Monoid[B].isMZero(a)
-  }
-
-  /** A [[Response]] specific [[Fallthrough]] which considers any response with a 404
-    * status code as a fallthrough. */
-  implicit val forResponse: Fallthrough[Response] = new Fallthrough[Response] {
-    val fallthroughValue: Response = HttpService.notFound.run
-    def isFallthrough(r: Response): Boolean =
-      r.status.code == 404 && r.attributes.contains(fallthroughKey)
   }
 }

--- a/core/src/main/scala/org/http4s/Service.scala
+++ b/core/src/main/scala/org/http4s/Service.scala
@@ -12,6 +12,19 @@ object Service {
     */
   def lift[A, B](f: A => Task[B]): Service[A, B] = Kleisli.kleisli(f)
 
+  /** Alternative application which lifts a partial function to a [[Service]],
+    * answering with a [[Response]] with status [[Status.NotFound]] for any requests
+    * where the function is undefined.
+    */
+  def apply[A, B](pf: PartialFunction[A, Task[B]], default: Service[A, B]): Service[A, B] =
+    lift(req => pf.applyOrElse(req, default))
+
+  /** Alternative application which lifts a partial function to an [[Service]],
+    * answering with a [[Response]] as supplied by the default argument.
+    */
+  def apply[A, B](pf: PartialFunction[A, Task[B]], default: Task[B]): Service[A, B] =
+    apply(pf, const[A, B](default))
+
   /**
     * Lifts a Task into a [[Service]].
     *

--- a/core/src/main/scala/org/http4s/Service.scala
+++ b/core/src/main/scala/org/http4s/Service.scala
@@ -16,7 +16,7 @@ object Service {
     * answering with a [[Response]] with status [[Status.NotFound]] for any requests
     * where the function is undefined.
     */
-  def apply[A, B](pf: PartialFunction[A, Task[B]], default: Service[A, B]): Service[A, B] =
+  def apply[A, B](pf: PartialFunction[A, Task[B]], default: Service[A, B] = Service.empty): Service[A, B] =
     lift(req => pf.applyOrElse(req, default))
 
   /** Alternative application which lifts a partial function to an [[Service]],
@@ -43,4 +43,7 @@ object Service {
     */
   def withFallback[A, B : Fallthrough](fallback: Service[A, B])(service: Service[A, B]): Service[A, B] =
     service.flatMap(resp => Fallthrough[B].fallthrough(resp, fallback))
+
+  def empty[A, B: Fallthrough]: Service[A, B] =
+    constVal(Fallthrough[B].fallthroughValue)
 }

--- a/core/src/main/scala/org/http4s/Service.scala
+++ b/core/src/main/scala/org/http4s/Service.scala
@@ -6,24 +6,17 @@ import scalaz.syntax.kleisli._
 
 object Service {
   /**
-    * Lifts an unwrapped function that returns a Task into a [[Service]].
-    *
-    * @see [[HttpService.apply]]
+    * Lifts a total function to a `Service`. The function is expected to handle
+    * all requests it is given.  If `f` is a [[PartialFunction]], use `apply`
+    * instead.
     */
   def lift[A, B](f: A => Task[B]): Service[A, B] = Kleisli.kleisli(f)
 
-  /** Alternative application which lifts a partial function to a [[Service]],
-    * answering with a [[Response]] with status [[Status.NotFound]] for any requests
-    * where the function is undefined.
+  /** Lifts a partial function to an `Service`.  Responds with the
+    * fallthrough instance [B] for any request where `pf` is not defined.
     */
-  def apply[A, B](pf: PartialFunction[A, Task[B]], default: Service[A, B] = Service.empty): Service[A, B] =
-    lift(req => pf.applyOrElse(req, default))
-
-  /** Alternative application which lifts a partial function to an [[Service]],
-    * answering with a [[Response]] as supplied by the default argument.
-    */
-  def apply[A, B](pf: PartialFunction[A, Task[B]], default: Task[B]): Service[A, B] =
-    apply(pf, const[A, B](default))
+  def apply[A, B: Fallthrough](pf: PartialFunction[A, Task[B]]): Service[A, B] =
+    lift(req => pf.applyOrElse(req, Function.const(Task.now(Fallthrough[B].fallthrough))))
 
   /**
     * Lifts a Task into a [[Service]].
@@ -44,6 +37,7 @@ object Service {
   def withFallback[A, B : Fallthrough](fallback: Service[A, B])(service: Service[A, B]): Service[A, B] =
     service.flatMap(resp => Fallthrough[B].fallthrough(resp, fallback))
 
+  /** A service that always falls through */
   def empty[A, B: Fallthrough]: Service[A, B] =
-    constVal(Fallthrough[B].fallthroughValue)
+    constVal(Fallthrough[B].fallthrough)
 }

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -38,53 +38,27 @@ package object http4s { // scalastyle:ignore
   type HttpService = Service[Request, Response]
 
   /* Lives here to work around https://issues.scala-lang.org/browse/SI-7139 */
-  /**
-    * There are 4 HttpService constructors:
-    * <ul>
-    *  <li>(Request => Task[Response]) => HttpService</li>
-    *  <li>PartialFunction[Request, Task[Response]] => HttpService</li>
-    *  <li>(PartialFunction[Request, Task[Response]], HttpService) => HttpService</li>
-    *  <li>(PartialFunction[Request, Task[Response]], Task[Response]) => HttpService</li>
-    * </ul>
-    */
   object HttpService {
-
-    /** Alternative application which lifts a partial function to an `HttpService`,
-      * answering with a [[Response]] with status [[Status.NotFound]] for any requests
-      * where the function is undefined.
-      */
-    def apply(pf: PartialFunction[Request, Task[Response]], default: HttpService = empty): HttpService =
-      Service.lift(req => pf.applyOrElse(req, default))
-
-    /** Alternative application  which lifts a partial function to an `HttpService`,
-      * answering with a [[Response]] as supplied by the default argument.
-      */
-    def apply(pf: PartialFunction[Request, Task[Response]], default: Task[Response]): HttpService =
-      Service.lift(req => pf.applyOrElse(req, (_: Request) => default))
-
     /**
-      * Lifts a (total) function to an `HttpService`. The function is expected to handle
-      * ALL requests it is given.
+      * Lifts a total function to an `HttpService`. The function is expected to
+      * handle all requests it is given.  If `f` is a [[PartialFunction]], use
+      * `apply` instead.
       */
     def lift(f: Request => Task[Response]): HttpService = Service.lift(f)
 
-    /** The default 'Not Found' response used when lifting a partial function
-      * to a [[HttpService]] or general 'not handled' results.
-      *
-      * This [[Response]] is tagged with the [[Fallthrough]] attribute so composed
-      * services will have the opportunity to handle the request.
-      * See [[Fallthrough]] for more details.
+    /** Lifts a partial function to an `HttpService`.  Responds with
+      * [[Repsonse.fallthrough]], which generates a 404, for any request
+      * where `pf` is not defined.
       */
-    val notFound: Task[Response] =
-      Task.now {
-        // Task.now(task.run) looks weird, but this memoizes it so we don't
-        // constantly recreate it.
-        Response(Status.NotFound)
-          .withAttribute(Fallthrough.fallthroughKey, ())
-          .withBody("404 Not Found.").run
-      }
+    def apply(pf: PartialFunction[Request, Task[Response]]): HttpService =
+      lift(req => pf.applyOrElse(req, Function.const(Response.fallthrough)))
 
-    val empty   : HttpService    = Service.const(notFound)
+    @deprecated("Use Response.fallthrough instead", "0.15")    
+    val notFound: Task[Response] =
+      Response.fallthrough
+
+    val empty: HttpService =
+      Service.const(Response.fallthrough)
   }
 
   type Callback[A] = Throwable \/ A => Unit

--- a/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -35,12 +35,12 @@ object FileService {
   private[staticcontent] def apply(config: Config): Service[Request, Response] = Service.lift { req =>
     val uriPath = req.pathInfo
     if (!uriPath.startsWith(config.pathPrefix))
-      HttpService.notFound
+      Response.fallthrough
     else
       getFile(config.systemPath + '/' + getSubPath(uriPath, config.pathPrefix))
         .map { f => config.pathCollector(f, config, req) }
         .getOrElse(Task.now(None))
-        .flatMap(_.fold(HttpService.notFound)(config.cacheStartegy.cache(uriPath, _)))
+        .flatMap(_.fold(Response.fallthrough)(config.cacheStartegy.cache(uriPath, _)))
   }
 
   /* Returns responses for static files.

--- a/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
@@ -30,9 +30,9 @@ object ResourceService {
   private[staticcontent] def apply(config: Config): Service[Request, Response] = Service.lift { req =>
     val uriPath = req.pathInfo
     if (!uriPath.startsWith(config.pathPrefix))
-      HttpService.notFound
+      Response.fallthrough
     else
       StaticFile.fromResource(sanitize(config.basePath + '/' + getSubPath(uriPath, config.pathPrefix)))
-        .fold(HttpService.notFound)(config.cacheStartegy.cache(uriPath, _))
+        .fold(Response.fallthrough)(config.cacheStartegy.cache(uriPath, _))
   }
 }

--- a/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
@@ -45,8 +45,7 @@ class HttpServiceSpec extends Http4sSpec {
 
     "Properly fall through two aggregated service if no path matches" in {
       val resp = aggregate1.apply(Request(uri = uri("/wontMatch"))).run
-      resp.status must_== (Status.NotFound)
-      resp.attributes.contains(Fallthrough.fallthroughKey) must_== (true)
+      Fallthrough[Response].isFallthrough(resp) must beTrue
     }
   }
 }

--- a/server/src/test/scala/org/http4s/server/RouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSpec.scala
@@ -67,10 +67,9 @@ class RouterSpec extends Http4sSpec {
       Router("/foo" -> notFound).apply(Request(uri = uri("/foo/bar"))).run.as[String].run must_== ("Custom NotFound")
     }
 
-    "Return the tagged NotFound response if no route is found" in {
+    "Return the fallthrough response if no route is found" in {
       val resp = Router("/foo" -> notFound).apply(Request(uri = uri("/bar"))).run
-      resp.attributes.contains(Fallthrough.fallthroughKey) must_== (true)
+      Fallthrough[Response].isFallthrough(resp) must beTrue
     }
-
   }
 }


### PR DESCRIPTION
As [imagined here](https://github.com/http4s/http4s/pull/692#discussion_r76735381).

If we just call `Service.lift` on a `PartialFunction`, then match errors
will occur.  It won't fall through nicely.  A default argument is not
yet possible, because there is no `Service.empty`, because `Fallthrough`
doesn't declare a default value.