### PR TITLE
More detail in non-literal error msg in URI macro

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -119,7 +119,7 @@ object Uri extends UriFunctions {
             qValue => c.Expr(q"org.http4s.Uri.fromString($s).valueOr(throw _)")
           )
         case _ =>
-          c.abort(c.enclosingPosition, s"only supports literal Strings")
+          c.abort(c.enclosingPosition, s"This method uses a macro to verify that a String literal is a valid URI. Use Uri.fromString if you have a dynamic String that you want to parse as a Uri.")
       }
     }
   }


### PR DESCRIPTION
I think that @rossabaker wants to put some work into Uri such that this
message may become irrelevant. However, I've seen enough people get
tripped up by literals being special-cased that I thought this small
change might be a nice interim solution.