### PR TITLE
Remove EntityEncoder[Char] and EntityEncoder[Byte]

### DIFF
--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -143,17 +143,12 @@ trait EntityEncoderInstances extends EntityEncoderInstances0 {
   implicit def charArrayEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[Array[Char]] =
     stringEncoder.contramap(new String(_))
 
-  implicit val charEncoder: EntityEncoder[Char] =
-    stringEncoder.contramap(Character.toString)
-
   implicit val byteVectorEncoder: EntityEncoder[ByteVector] =
     simple(`Content-Type`(MediaType.`application/octet-stream`))(identity)
 
   implicit val byteArrayEncoder: EntityEncoder[Array[Byte]] = byteVectorEncoder.contramap(ByteVector.apply)
 
   implicit val byteBufferEncoder: EntityEncoder[ByteBuffer] = byteVectorEncoder.contramap(ByteVector.apply)
-
-  implicit val byteEncoder: EntityEncoder[Byte] = byteVectorEncoder.contramap(ByteVector.apply(_))
 
   implicit def taskEncoder[A](implicit W: EntityEncoder[A]): EntityEncoder[Task[A]] = new EntityEncoder[Task[A]] {
     override def toEntity(a: Task[A]): Task[Entity] = a.flatMap(W.toEntity)

--- a/core/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/core/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -42,10 +42,6 @@ class EntityEncoderSpec extends Http4sSpec {
       writeToString("pong") must_== "pong"
     }
 
-    "render single characters" in {
-      prop { char: Char => writeToString(char) must_== Character.toString(char) }
-    }
-
     "calculate the content length of strings" in {
       implicitly[EntityEncoder[String]].toEntity("pong").map(_.length) must returnValue(Some(4))
     }
@@ -53,10 +49,6 @@ class EntityEncoderSpec extends Http4sSpec {
     "render byte arrays" in {
       val hello = "hello"
       writeToString(hello.getBytes(StandardCharsets.UTF_8)) must_== hello
-    }
-
-    "render bytes" in {
-      prop { byte: Byte => writeToByteVector(byte) must_== ByteVector(byte) }
     }
 
     "render futures" in {


### PR DESCRIPTION
Just because they're possible doesn't mean they're useful.  It's
doubtful anybody is encoding a single char or byte in this way, so let's
not tempt the Ambiguous Implicit Fates.

Proposed by @bryce-anderson in #711.