### PR TITLE
Improve Retry client middleware

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -454,7 +454,8 @@ lazy val mimaSettings = Seq(
     import com.typesafe.tools.mima.core._
     import com.typesafe.tools.mima.core.ProblemFilters._
     Seq(
-      exclude[DirectMissingMethodProblem]("org.http4s.client.blaze.Http1Connection.this")
+      exclude[DirectMissingMethodProblem]("org.http4s.client.blaze.Http1Connection.this"),
+      exclude[ReversedMissingMethodProblem]("org.http4s.Message.isBodyPure")
     )
   }
 )

--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -2,36 +2,55 @@ package org.http4s
 package client
 package middleware
 
-import org.http4s.Status.ResponseClass.Successful
-import org.http4s.{Response, Request, EmptyBody}
-import org.http4s.client.Client
-import org.log4s.getLogger
-
 import scala.concurrent.duration._
 import scala.math.{pow, min, random}
-import scalaz.Kleisli
 
+import scalaz._
 import scalaz.concurrent.Task
+import org.http4s.Status._
+import org.log4s.getLogger
 
 object Retry {
 
   private[this] val logger = getLogger
 
+  private[this] val RetriableStatuses = Set(
+    RequestTimeout,
+    // TODO Leaving PayloadTooLarge out until we model Retry-After
+    InternalServerError,
+    ServiceUnavailable,
+    BadGateway,
+    GatewayTimeout
+  )
+
   def apply(backoff: Int => Option[FiniteDuration])(client: Client) = {
     def prepareLoop(req: Request, attempts: Int): Task[DisposableResponse] = {
-      client.open(req) flatMap {
-        case dr @ DisposableResponse(Successful(resp), _) =>
-          Task.now(dr)
-        case dr @ DisposableResponse(Response(status, _, _, _, _), _) =>
-          logger.info(s"Request ${req} has failed attempt ${attempts} with reason ${status}")
+      client.open(req).attempt flatMap {
+        case \/-(dr @ DisposableResponse(Response(status, _, _, _, _), _)) if req.isIdempotent && RetriableStatuses(status) =>
+          logger.info(s"Request ${req} has failed attempt ${attempts} with reason ${status}. Retrying.")
           backoff(attempts) match {
-            case Some(duration) => dr.dispose.flatMap(_ => nextAttempt(req, attempts, duration))
-            case None => Task.now(dr)
+            case Some(duration) =>
+              dr.dispose.flatMap(_ => nextAttempt(req, attempts, duration))
+            case None =>
+              Task.now(dr)
           }
+        case \/-(dr) =>
+          Task.now(dr)
+        case -\/(e) if req.isIdempotent =>
+          logger.error(e)(s"Request ${req} has failed attempt ${attempts}. Retrying.")
+          backoff(attempts) match {
+            case Some(duration) =>
+              nextAttempt(req, attempts, duration)
+            case None =>
+              Task.fail(e)
+          }
+        case -\/(e) =>
+          Task.fail(e)
       }
     }
 
     def nextAttempt(req: Request, attempts: Int, duration: FiniteDuration): Task[DisposableResponse] =
+      // TODO honor Retry-After header
       Task.async { (prepareLoop(req.copy(body = EmptyBody), attempts + 1).get after duration).runAsync }
 
     client.copy(open = Service.lift(prepareLoop(_, 1)))

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -2,27 +2,28 @@ package org.http4s
 package client
 package middleware
 
-import org.http4s.Status._
-import org.http4s.Method._
-import org.http4s.headers.Location
-
-import scalaz.concurrent.Task
-
-import scala.language.postfixOps
 import scala.concurrent.duration._
 
-class RetrySpec extends Http4sSpec {
+import scalaz.concurrent.Task
+import scalaz.stream.Process
+import scodec.bits.ByteVector
+import org.http4s.dsl._
+import org.http4s.headers.Location
+import org.specs2.specification.Tables
+
+class RetrySpec extends Http4sSpec with Tables {
 
   val route = HttpService {
-    case r if r.method == GET && r.pathInfo == "/ok" => Response(Ok).withBody("hello")
-    case r if r.method == GET && r.pathInfo == "/boom" => Task.now(Response(BadRequest))
-    case r => sys.error("Path not found: " + r.pathInfo)
+    case _ -> Root / status =>
+      Task.now(Response(Status.fromInt(status.toInt).valueOr(throw _)))
+    case _ -> Root / status =>
+      Task.now(Response(BadRequest))
   }
 
   val defaultClient = MockClient(route)
 
   "Retry Client" should {
-    "Retry bad requests" in {
+    def countRetries(client: Client, method: Method, status: Status, body: EntityBody): Int = {
       val max = 2
       var attemptsCounter = 1
       val policy = (attempts: Int) => {
@@ -32,24 +33,39 @@ class RetrySpec extends Http4sSpec {
           Some(10.milliseconds)
         }
       }
-      val client = Retry(policy)(defaultClient)
-      val resp = client.getAs[String](uri("http://localhost/boom")).run
-      attemptsCounter must_== 2
+      val retryClient = Retry(policy)(client)
+      val req = Request(method, uri("http://localhost/") / status.code.toString).withBody(body)
+      val resp = retryClient.fetch(req){ _ => Task.now(()) }.attemptRun
+      attemptsCounter
     }
 
-    "Not retry successful responses" in {
-      val max = 2
-      var attempts = 1
-      val policy = (attmpts: Int) => {
-        if (attempts >= max) None
-        else {
-          attempts = attempts + 1
-          Some(10.milliseconds)
-        }
-      }
-      val client = Retry(policy)(defaultClient)
-      val resp = client.getAs[String](uri("http://localhost/ok")).run
-      attempts must_==1
+    "retry GET based on status code" in {
+      "status"                | "retries" |>
+      Ok                      ! 1         |
+      Found                   ! 1         |
+      BadRequest              ! 1         |
+      NotFound                ! 1         |
+      RequestTimeout          ! 2         |
+      InternalServerError     ! 2         |
+      NotImplemented          ! 1         |
+      BadGateway              ! 2         |
+      ServiceUnavailable      ! 2         |
+      GatewayTimeout          ! 2         |
+      HttpVersionNotSupported ! 1         |
+      { countRetries(defaultClient, GET, _, EmptyBody) must_== _ }
+    }
+
+    "not retry POSTs" in prop { s: Status =>
+      countRetries(defaultClient, POST, s, EmptyBody) must_== 1
+    }
+
+    "not retry effectful bodies" in prop { s: Status =>
+      countRetries(defaultClient, PUT, s, Process.eval_(Task.now(()))) must_== 1
+    }
+
+    "retry exceptions" in {
+      val failClient = Client(Service.const(Task.fail(new Exception("boom"))), Task.now(()))
+      countRetries(failClient, GET, InternalServerError, EmptyBody) must_== 2
     }
   }
 }

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -31,8 +31,12 @@ sealed trait Message extends MessageOps { self =>
       case cs =>
         body |> util.decode(cs)
     }
-
   }
+
+  /** True iff the body is composed solely of Emits and Halt.  This indicates
+    * that the body can be re-run without side-effects. */
+  def isBodyPure: Boolean =
+    body.unemit._2.isHalt
   
   def attributes: AttributeMap
   
@@ -201,6 +205,11 @@ case class Request(
 
   override def toString: String =
     s"""Request(method=$method, uri=$uri, headers=${headers}"""
+
+  /** A request is idempotent iff its method is idempotent and its body is pure.
+    * If true, this request can be submitted multipe times. */
+  def isIdempotent: Boolean =
+    method.isIdempotent && isBodyPure
 }
 
 object Request {

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -33,8 +33,8 @@ sealed trait Message extends MessageOps { self =>
     }
   }
 
-  /** True iff the body is composed solely of Emits and Halt.  This indicates
-    * that the body can be re-run without side-effects. */
+  /** True if and only if the body is composed solely of Emits and Halt.  This
+    * indicates that the body can be re-run without side-effects. */
   def isBodyPure: Boolean =
     body.unemit._2.isHalt
   
@@ -206,8 +206,8 @@ case class Request(
   override def toString: String =
     s"""Request(method=$method, uri=$uri, headers=${headers}"""
 
-  /** A request is idempotent iff its method is idempotent and its body is pure.
-    * If true, this request can be submitted multipe times. */
+  /** A request is idempotent if and only if its method is idempotent and its body
+    * is pure.  If true, this request can be submitted multipe times. */
   def isIdempotent: Boolean =
     method.isIdempotent && isBodyPure
 }

--- a/core/src/test/scala/org/http4s/MessageSpec.scala
+++ b/core/src/test/scala/org/http4s/MessageSpec.scala
@@ -38,6 +38,20 @@ class MessageSpec extends Http4sSpec {
         r.remotePort must beSome(remote.getPort)
       }
     }
+
+    "isIdempotent" should {
+      "be true if the method is idempotent and the body is pure" in {
+        Request(Method.GET).withBody("pure").map(_.isIdempotent) must returnValue(true)
+      }
+
+      "be false if the body is effectful" in {
+        Request(Method.GET).withBody(Task.now("effectful")).map(_.isIdempotent) must returnValue(true)
+      }
+
+      "be false if the method is not idempotent" in {
+        Request(Method.POST).isIdempotent must beFalse
+      }
+    }
   }
 
   "Message" should {


### PR DESCRIPTION
* Only retry idempotent requests with pure bodies
* Only retry when status code is appropriate
* Retry failed tasks from client

Partially addresses #712.  Further fixes (e.g., Retry-After) are binary incompatible and would come in a separate PR.