### PR TITLE
Allown param names to have encoded reserved parameters

### DIFF
--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -1,5 +1,7 @@
 package org.http4s
 
+import java.net.URLEncoder
+
 import org.http4s.Uri.{Authority, Host, IPv4, IPv6, RegName, Scheme}
 import org.http4s.UriTemplate._
 
@@ -108,6 +110,9 @@ object UriTemplate {
   //  protected val reserved = genDelims ::: subDelims
 
   def isUnreserved(s: String): Boolean = s.forall(unreserved.contains)
+
+  def isUnreservedOrEncoded(s: String): Boolean =
+    URLEncoder.encode(s, "UTF-8").forall(c => unreserved.contains(c) || c == '%')
 
   protected def expandPathN(path: Path, name: String, values: List[QueryParameterValue]): Path = {
     val acc = new ArrayBuffer[PathDef]()
@@ -507,7 +512,7 @@ object UriTemplate {
    */
   final case class ParamExp(names: List[String]) extends QueryExp {
     require(names.nonEmpty, "at least one name must be set")
-    require(names forall isUnreserved, "all names must consist of unreserved characters")
+    require(names forall isUnreservedOrEncoded, "all names must consist of unreserved characters or be encoded")
   }
   object ParamExp {
     def apply(names: String*): ParamExp = new ParamExp(names.toList)

--- a/core/src/test/scala/org/http4s/UriTemplateSpec.scala
+++ b/core/src/test/scala/org/http4s/UriTemplateSpec.scala
@@ -46,6 +46,11 @@ object UriTemplateSpec extends Specification {
       val query = List(ParamVarExp("ref", "path"))
       UriTemplate(path = path, query = query).toString must equalTo("/here?ref={path}")
     }
+    "render /here?{ref[name]}" in {
+      val path = List(PathElm("here"))
+      val query = List(ParamExp("ref[name]"))
+      UriTemplate(path = path, query = query).toString must equalTo("/here{?ref[name]}")
+    }
     "render /here?ref={+path}" in {
       val path = List(PathElm("here"))
       val query = List(ParamReservedExp("ref", "path"))


### PR DESCRIPTION
I don't know if we should generalize this to other names like `PathExp`. I am being conservative with just what gets me out my current issue here.

cc @bryce-anderson @rossabaker 