### PR TITLE
Revive awaitShutdown

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -180,7 +180,7 @@ class BlazeBuilder(
     val serverChannel = factory.bind(address, pipelineFactory).get
 
     new Server {
-      override def shutdown: Task[Unit] = Task.delay {
+      override protected def destroy: Task[Unit] = Task.delay {
         serverChannel.close()
         factory.closeGroup()
       }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/AwaitShutdownExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/AwaitShutdownExample.scala
@@ -1,0 +1,23 @@
+package com.example.http4s.blaze
+
+import java.util.concurrent._
+import scala.concurrent.duration._
+import scalaz.concurrent._
+import com.example.http4s.ExampleService
+import org.http4s.server.ServerApp
+import org.http4s.server.blaze.BlazeBuilder
+
+object AwaitShutdownExample extends App {
+  val server = BlazeBuilder.bindHttp(8080)
+    .mountService(ExampleService.service, "/http4s")
+    .start
+    .run
+
+  // Some out of band process that shuts down the server
+  server.shutdown.after(1.second).runAsync { _ => }
+
+  server.awaitShutdown()
+
+  // `Task.after` before 7.3 starts a thread inside here
+  Timer.default.stop()
+}

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -184,7 +184,7 @@ sealed class JettyBuilder private (
     jetty.start()
 
     new Server {
-      override def shutdown: Task[Unit] =
+      override protected def destroy: Task[Unit] =
         Task.delay {
           jetty.stop()
         }

--- a/server/src/main/scala/org/http4s/server/Server.scala
+++ b/server/src/main/scala/org/http4s/server/Server.scala
@@ -4,28 +4,30 @@ package server
 import java.net.{InetAddress, InetSocketAddress}
 import java.util.concurrent.{CountDownLatch, ExecutorService}
 
+import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
 trait Server {
-  def shutdown: Task[Unit]
+  private[this] val latch = new CountDownLatch(1)
 
-  def shutdownNow(): Unit =
+  /** A task that triggers a server shutdown when run */
+  final def shutdown: Task[Unit] =
+    destroy >> Task.delay(latch.countDown())
+
+  final def shutdownNow(): Unit =
     shutdown.run
+
+  /** Blocks until the server shuts down. */
+  final def awaitShutdown(): Unit = {
+    println("Waiting")
+    latch.await()
+    println("Done waiting")
+  }
+
+  protected def destroy: Task[Unit]
 
   @deprecated("Compose with the shutdown task instead.", "0.14")
   def onShutdown(f: => Unit): this.type
 
   def address: InetSocketAddress
-
-  /**
-   * Blocks until the server shuts down.
-   */
-  @deprecated("Use ServerApp instead.", "0.14")
-  def awaitShutdown(): Unit = {
-    val latch = new CountDownLatch(1)
-    onShutdown(latch.countDown())
-    latch.await()
-  }
 }
-
-

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -189,7 +189,7 @@ sealed class TomcatBuilder private (
     tomcat.start()
 
     new Server {
-      override def shutdown: Task[Unit] =
+      override protected def destroy: Task[Unit] =
         Task.delay {
           tomcat.stop()
         }


### PR DESCRIPTION
Brings back the `awaitShutdown()` that was removed along with the mutable `onShutdown`.

I'm not convinced that this is a good idea.  It's redundant with, not composed with, `ServerApp` functionality.  Presented in current form for discussion.

/cc @hvesalai 