### PR TITLE
remove literal null from uri query params: "/foo/bar?null" in jetty backend

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -133,7 +133,7 @@ class Http4sServlet(service: HttpService,
   private def toRequest(req: HttpServletRequest): ParseResult[Request] =
     for {
       method <- Method.fromString(req.getMethod)
-      uri <- Uri.requestTarget(s"${req.getRequestURI}?${req.getQueryString}")
+      uri <- Uri.requestTarget(Option(req.getQueryString).map { q => s"${req.getRequestURI}?$q" }.getOrElse(req.getRequestURI))
       version <- HttpVersion.fromString(req.getProtocol)
     } yield Request(
       method = method,


### PR DESCRIPTION
when printing access logs from the jetty backend we see uris printed with a literal null for the query parameters, eg. "/foo/bar?null". added a check to add the query only if non null