### PR TITLE
Parse XML from an InputStream, not a StringReader

### DIFF
--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -7,6 +7,7 @@ import headers.`Content-Type`
 import scala.util.control.NonFatal
 import scala.xml._
 import scalaz.concurrent.Task
+import scalaz.stream.io.toInputStream
 
 trait ElemInstances {
   implicit def xmlEnocder(implicit charset: Charset = DefaultCharset): EntityEncoder[Elem] =
@@ -17,22 +18,21 @@ trait ElemInstances {
   /**
    * Handles a message body as XML.
    *
-   * TODO Not an ideal implementation.  Would be much better with an asynchronous XML parser, such as Aalto.
-   *
    * @param parser the SAX parser to use to parse the XML
    * @return an XML element
    */
   implicit def xml(implicit parser: SAXParser = XML.parser): EntityDecoder[Elem] = {
     import EntityDecoder._
-    decodeBy(MediaType.`text/xml`, MediaType.`text/html`, MediaType.`application/xml`){ msg =>
-      collectBinary(msg).flatMap[Elem] { arr =>
-        val source = new InputSource(new StringReader(new String(arr.toArray, msg.charset.getOrElse(Charset.`US-ASCII`).nioCharset)))
-        try DecodeResult.success(Task.now(XML.loadXML(source, parser)))
-        catch {
-          case e: SAXParseException =>
-            DecodeResult.failure(MalformedMessageBodyFailure("Invalid XML", Some(e)))
-          case NonFatal(e) => DecodeResult(Task.fail(e))
-        }
+    decodeBy(MediaType.`text/xml`, MediaType.`text/html`, MediaType.`application/xml`) { msg =>
+      val stream = toInputStream(msg.body)
+      val source = new InputSource(stream)
+      msg.charset.foreach(cs => source.setEncoding(cs.nioCharset.name))
+      try DecodeResult.success(XML.loadXML(source, parser))
+      catch {
+        case e: SAXParseException =>
+          DecodeResult.failure(MalformedMessageBodyFailure("Invalid XML", Some(e)))
+        case NonFatal(e) =>
+          DecodeResult(Task.fail(e))
       }
     }
   }

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -27,7 +27,7 @@ trait ElemInstances {
       val stream = toInputStream(msg.body)
       val source = new InputSource(stream)
       msg.charset.foreach(cs => source.setEncoding(cs.nioCharset.name))
-      try DecodeResult.success(XML.loadXML(source, parser))
+      try DecodeResult.success(Http4sXmlLoader.loadXML(source, parser))
       catch {
         case e: SAXParseException =>
           DecodeResult.failure(MalformedMessageBodyFailure("Invalid XML", Some(e)))

--- a/scala-xml/src/main/scala/scalaxml/package.scala
+++ b/scala-xml/src/main/scala/scalaxml/package.scala
@@ -1,3 +1,22 @@
 package org.http4s
 
-package object scalaxml extends ElemInstances
+import scala.xml._
+import scala.xml.factory._
+import scala.xml.parsing._
+
+package object scalaxml extends ElemInstances {
+  /**
+   * Backport of https://github.com/scala/scala-xml/pull/34. Can be
+   * deprecated after we drop Scala < 2.11.5.
+   */
+  val Http4sXmlLoader: XMLLoader[Elem] =
+    new XMLLoader[Elem] {
+      override def adapter: FactoryAdapter =
+        new NoBindingFactoryAdapter {
+          override def processingInstruction(target: String, data: String) {
+            captureText()
+            hStack pushAll createProcInstr(target, data)
+          }
+        }
+    }
+}

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -8,15 +8,15 @@ import scalaz.concurrent.Task
 import scalaz.stream.Process
 import scalaz.stream.Process.emit
 import scalaz.stream.text.utf8Decode
-import Status.Ok
+import org.http4s.Status.Ok
+import org.http4s.util.byteVector._
+import org.specs2.matcher.Matcher
 
-class ScalaXmlSpec extends Http4sSpec {
+class ScalaXmlSpec extends Http4sSpec with XMLGenerators {
 
   def getBody(body: EntityBody): Array[Byte] = body.runLog.run.reduce(_ ++ _).toArray
 
   def strBody(body: String) = emit(body).map(s => ByteVector(s.getBytes))
-
-  implicit val byteVectorMonoid: scalaz.Monoid[ByteVector] = scalaz.Monoid.instance(_ ++ _, ByteVector.empty)
 
   def writeToString[A](a: A)(implicit W: EntityEncoder[A]): String =
     Process.eval(W.toEntity(a))
@@ -43,6 +43,14 @@ class ScalaXmlSpec extends Http4sSpec {
       val tresp = server(Request(body = body))
       tresp.run.status must_== (Status.BadRequest)
     }
+
+    "round trip" in prop { elem: Elem =>
+      EntityEncoder[Elem].toEntity(elem).flatMap { case EntityEncoder.Entity(body, _) =>
+        Response().withBody(body).flatMap { resp =>
+          resp.as[Elem]
+        }
+      }.run must xml_==(elem)
+    }
   }
 
   "htmlEncoder" should {
@@ -50,5 +58,9 @@ class ScalaXmlSpec extends Http4sSpec {
       val html = <html><body>Hello</body></html>
       writeToString(html) must_== "<html><body>Hello</body></html>"
     }
+  }
+
+  def xml_==(e2: Elem): Matcher[Elem] = { e: Elem =>
+    (e xml_== e2, s"$e was not XML-equal to $e2}")
   }
 }

--- a/scala-xml/src/test/scala/scalaxml/XmlGenerators.scala
+++ b/scala-xml/src/test/scala/scalaxml/XmlGenerators.scala
@@ -1,0 +1,122 @@
+/*
+ * Derived from https://raw.githubusercontent.com/arktekk/anti-xml/973068681c74e22bc8c68f4c116720ed543cc0e3/src/test/scala/com/codecommit/antixml/XMLGenerators.scala
+ *
+ * Copyright (c) 2011, Daniel Spiewak
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * - Neither the name of "Anti-XML" nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.http4s
+package scalaxml
+
+import org.scalacheck._
+import scala.io.Source
+import scala.xml._
+
+trait XMLGenerators {
+  import Arbitrary.arbitrary
+  import Gen._
+
+  val MaxGroupDepth = 3
+
+  implicit val arbNode: Arbitrary[Node] = Arbitrary(nodeGenerator(0))
+
+  implicit val arbProcInstr: Arbitrary[ProcInstr] = Arbitrary(procInstrGenerator)
+  implicit val arbElem: Arbitrary[Elem] = Arbitrary(elemGenerator(0))
+  implicit val arbText: Arbitrary[Text] = Arbitrary(textGenerator)
+  implicit val arbEntityRef: Arbitrary[EntityRef] = Arbitrary(entityRefGenerator)
+
+  implicit val arbAttributes: Arbitrary[MetaData] = Arbitrary(genAttributes)
+
+  def nodeGenerator(depth: Int = 0): Gen[Node] = frequency(
+    3 -> procInstrGenerator,
+    30 -> elemGenerator(depth),
+    50 -> textGenerator,
+    0 -> entityRefGenerator)
+
+  lazy val procInstrGenerator: Gen[ProcInstr] = for {
+    target <- genSaneString
+    data <- genSaneString
+  } yield ProcInstr(target, data)
+
+  def elemGenerator(depth: Int = 0): Gen[Elem] = for {
+    ns <- genSaneOptionString
+    name <- genSaneString
+    attrs <- genAttributes
+    bindings <- genBindings // TODO incorporate
+    children <- if (depth > MaxGroupDepth) const(Nil) else (listOf(nodeGenerator(depth + 1)) map { nodes => Group(concatConsecutiveText(nodes)) })
+  } yield {
+    Elem(ns.orNull, name, attrs, TopScope, false, children:_*)
+  }
+
+  // Consecutive Text children are lossy in serialization
+  private def concatConsecutiveText(nodes: List[Node]): List[Node] =
+    nodes match {
+      case Nil => Nil
+      case (h: Text) :: t =>
+        val texts = nodes.takeWhile(_.isInstanceOf[Text])
+        val text = Text(texts.foldLeft(""){_ + _.asInstanceOf[Text].data})
+        text :: concatConsecutiveText(nodes.drop(texts.length))
+      case h :: t =>
+        h :: concatConsecutiveText(t)
+    }
+
+  lazy val textGenerator: Gen[Text] = genSaneString map Text.apply
+
+  lazy val entityRefGenerator: Gen[EntityRef] = genSaneString map EntityRef
+
+  lazy val genSaneString: Gen[String] =
+    // TODO empty is okay in some places here
+    // TODO we can be more clever than alpha
+    nonEmptyListOf(alphaChar).map(_.mkString)
+
+  private lazy val genSaneOptionString: Gen[Option[String]] =
+    frequency(5 -> (genSaneString map { Some(_) }), 1 -> None)
+
+  private lazy val genAttributes: Gen[MetaData] =
+    genAttributeList.map(_.foldLeft[MetaData](Null)(MetaData.concatenate(_, _)))
+
+  lazy val genAttributeList: Gen[List[MetaData]] = {
+    val genTuple = for {
+      prefix <- genSaneOptionString
+      name <- genSaneString
+      value <- genSaneString
+    } yield (prefix match {
+      case Some(p) => new PrefixedAttribute(p, name, value, Null)
+      case None => new UnprefixedAttribute(name, value, Null)
+    })
+
+    listOf(genTuple)
+  }
+
+  private lazy val genBindings: Gen[NamespaceBinding] = {
+    val genTuple = for {
+      prefix <- genSaneString
+      uri <- genSaneString
+    } yield (prefix, uri)
+
+    listOf(genTuple).map(_.foldLeft[NamespaceBinding](TopScope)((parent, child) => NamespaceBinding(child._1, child._2, parent)))
+  }
+}


### PR DESCRIPTION
Instead of reading all the bytes, and then converting that to a String, and then parsing a StringReader to SAX, just pass it an InputStream.  This still builds an `Elem` representation of the entire body, but spares a couple more complete, ephemeral materializations along the way.