### PR TITLE
Replace ServerApp with ProcessApp

### DIFF
--- a/core/src/main/scala/org/http4s/util/ProcessApp.scala
+++ b/core/src/main/scala/org/http4s/util/ProcessApp.scala
@@ -1,0 +1,31 @@
+package org.http4s
+package util
+
+import scalaz._
+import scalaz.concurrent._
+import scalaz.stream._
+import scalaz.stream.Process._
+
+trait ProcessApp {
+  def main(args: List[String]): Process[Task, Unit]
+
+  final def main(args: Array[String]): Unit = {
+    val halt = async.signalOf(false)
+    val halted = async.signalOf(false)
+
+    val p = (halt.discrete wye main(args.toList))(wye.interrupt) append eval_(halted set true)
+
+    sys.addShutdownHook {
+      halt.set(true) runAsync { _ => () }
+      halted.discrete.takeWhile(_ == false).run.run
+    }
+
+    p.run.attemptRun match {
+      case -\/(t) =>
+        t.printStackTrace()
+        System.exit(-1)
+      case \/-(_) =>
+        ()
+    }
+  }
+}

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -3,9 +3,11 @@ package com.example.http4s.blaze
 import com.example.http4s.ExampleService
 import org.http4s.server.ServerApp
 import org.http4s.server.blaze.BlazeBuilder
+import org.http4s.util.ProcessApp
 
-object BlazeExample extends ServerApp {
-  def server(args: List[String]) = BlazeBuilder.bindHttp(8080)
-    .mountService(ExampleService.service, "/http4s")
-    .start
+object BlazeExample extends ProcessApp {
+  def main(args: List[String]) =
+    BlazeBuilder.bindHttp(8080)
+      .mountService(ExampleService.service, "/http4s")
+      .process
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -4,18 +4,18 @@ import java.util.concurrent.TimeUnit
 
 import com.example.http4s.ExampleService
 import org.http4s._
-import org.http4s.server.ServerApp
 import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.server.middleware.Metrics
 import org.http4s.dsl._
+import org.http4s.util.ProcessApp
 
 import com.codahale.metrics._
 import com.codahale.metrics.json.MetricsModule
 
 import com.fasterxml.jackson.databind.ObjectMapper
 
-object BlazeMetricsExample extends ServerApp {
+object BlazeMetricsExample extends ProcessApp {
 
   val metrics = new MetricRegistry()
   val mapper = new ObjectMapper()
@@ -32,7 +32,7 @@ object BlazeMetricsExample extends ServerApp {
     "/metrics" -> metricsService
   )
 
-  def server(args: List[String]) = BlazeBuilder.bindHttp(8080)
+  def main(args: List[String]) = BlazeBuilder.bindHttp(8080)
     .mountService(srvc, "/http4s")
-    .start
+    .process
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -1,11 +1,11 @@
 package com.example.http4s.blaze
 
 import org.http4s._
-import org.http4s.server.ServerApp
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.websocket.WebsocketBits._
 import org.http4s.dsl._
 import org.http4s.server.websocket._
+import org.http4s.util.ProcessApp
 
 import scala.concurrent.duration._
 
@@ -16,7 +16,7 @@ import scalaz.stream.{Process, Sink}
 import scalaz.stream.{DefaultScheduler, Exchange}
 import scalaz.stream.time.awakeEvery
 
-object BlazeWebSocketExample extends ServerApp {
+object BlazeWebSocketExample extends ProcessApp {
 
   val route = HttpService {
     case GET -> Root / "hello" =>
@@ -39,8 +39,8 @@ object BlazeWebSocketExample extends ServerApp {
       WS(Exchange(src, q.enqueue))
   }
 
-  def server(args: List[String]) = BlazeBuilder.bindHttp(8080)
+  def main(args: List[String]) = BlazeBuilder.bindHttp(8080)
     .withWebSockets(true)
     .mountService(route, "/http4s")
-    .start
+    .process
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/NestedResourceExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/NestedResourceExample.scala
@@ -1,0 +1,31 @@
+package com.example.http4s.blaze
+
+import java.util.concurrent._
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.dsl._
+import org.http4s.server._
+import org.http4s.server.blaze._
+import org.http4s.client.blaze._
+import org.http4s.util.ProcessApp
+import scalaz._
+import scalaz.concurrent._
+import scalaz.stream._, Process._
+
+/** How to manage the lifecycle of a server and its dependent resources */
+object NestedResourceExample extends ProcessApp {
+  // This service depends on a client.
+  def service(client: Client): HttpService = HttpService {
+    case GET -> Root / "proxy" =>
+      client.toHttpService.run(Request(Method.GET, uri("http://http4s.org/")))
+  }
+
+  def main(args: List[String]) =
+    bracket(Task.delay(Executors.newFixedThreadPool(10)))(e => eval_(Task.delay(e.shutdown))) { clientExecutor =>
+      bracket(Task.delay(PooledHttp1Client(config = BlazeClientConfig.defaultConfig.copy(customExecutor = Some(clientExecutor)))))(c => eval_(c.shutdown)) { client =>
+        bracket(Task.delay(Executors.newFixedThreadPool(10)))(e => eval_(Task.delay(e.shutdown))) { serverExecutor =>
+          BlazeBuilder.withServiceExecutor(serverExecutor).mountService(service(client)).process
+        }
+      }
+    }
+}

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
@@ -5,17 +5,17 @@ import javax.servlet._
 
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.servlets.MetricsServlet
-import org.http4s.server.ServerApp
 import org.http4s.server.jetty.JettyBuilder
+import org.http4s.util.ProcessApp
 
-object JettyExample extends ServerApp {
+object JettyExample extends ProcessApp {
   val metrics = new MetricRegistry
 
-  def server(args: List[String]) = JettyBuilder
+  def main(args: List[String]) = JettyBuilder
     .bindHttp(8080)
     .withMetricRegistry(metrics)
     .mountService(ExampleService.service, "/http4s")
     .mountServlet(new MetricsServlet(metrics), "/metrics/*")
     .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
-    .start
+    .process
 }

--- a/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
+++ b/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
@@ -4,19 +4,20 @@ import java.nio.file.Paths
 
 import com.example.http4s.ExampleService
 import org.http4s.server.SSLSupport.StoreInfo
-import org.http4s.server.{ SSLSupport, Server, ServerApp, ServerBuilder }
+import org.http4s.server.{ SSLSupport, Server, ServerBuilder }
+import org.http4s.util.ProcessApp
 import scalaz.concurrent.Task
 
-trait SslExample extends ServerApp {
+trait SslExample extends ProcessApp {
   // TODO: Reference server.jks from something other than one child down.
   val keypath = Paths.get("../server.jks").toAbsolutePath().toString()
 
   def builder: ServerBuilder with SSLSupport
 
-  def server(args: List[String]): Task[Server] = builder
+  def main(args: List[String]) = builder
     .withSSL(StoreInfo(keypath, "password"), keyManagerPassword = "secure")
     .mountService(ExampleService.service, "/http4s")
     .bindHttp(8443)
-    .start
+    .process
 }
 

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
@@ -3,17 +3,17 @@ package com.example.http4s.tomcat
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.servlets.MetricsServlet
 import com.example.http4s.ExampleService
-import org.http4s.server.ServerApp
 import org.http4s.server.tomcat.TomcatBuilder
+import org.http4s.util.ProcessApp
 
-object TomcatExample extends ServerApp {
+object TomcatExample extends ProcessApp {
   val metrics = new MetricRegistry
 
-  def server(args: List[String]) = TomcatBuilder
+  def main(args: List[String]) = TomcatBuilder
     .bindHttp(8080)
     .withMetricRegistry(metrics)
     .mountService(ExampleService.service, "/http4s")
     .mountServlet(new MetricsServlet(metrics), "/metrics/*")
     .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
-    .start
+    .process
 }

--- a/server/src/main/scala/org/http4s/server/ServerApp.scala
+++ b/server/src/main/scala/org/http4s/server/ServerApp.scala
@@ -11,9 +11,9 @@ import scalaz.concurrent.Task
 import org.http4s.util.threads
 
 /**
- * Apps extending the server app trait get a graceful shutdown.  The
- * 
- */ 
+ * Apps extending the server app trait get a graceful shutdown.
+ */
+@deprecated("Use org.http4s.util.ProcessApp", "0.15")
 trait ServerApp {
   private[this] val logger = org.log4s.getLogger
 

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -9,6 +9,8 @@ import org.http4s.server.SSLSupport.StoreInfo
 
 import scala.concurrent.duration._
 import scalaz.concurrent.{Strategy, Task}
+import scalaz.stream.Process
+import scalaz.stream.Process._
 
 trait ServerBuilder {
   import ServerBuilder._
@@ -38,6 +40,14 @@ trait ServerBuilder {
     */
   final def run: Server =
     start.run
+
+  /** Convenience method to start and stop a server as a Process */
+  final def bracket[A](f: Server => Process[Task, A]): Process[Task, A] =
+    Process.bracket(start)(s => eval_(s.shutdown))(f)
+
+  /** Starts this server as an infinite process. */
+  final def process: Process[Task, Nothing] =
+    bracket(_ => eval(Task.async[Nothing] { cb => }))
 }
 
 object ServerBuilder {


### PR DESCRIPTION
Provides a trait for running a general Process, not just a Server.  This takes advantage of `Process.bracket`'s sturdy cleanup.  `ServerApp` works well for trivial servers, but is awkward for winding down nested resources.

`ProcessApp` is based on a gist by @djspiewak.
