### PR TITLE
Empty EntityEncoder

### DIFF
--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -95,6 +95,11 @@ trait EntityEncoderInstances0 {
     simple[A](hdr)(a => ByteVector.view(show.shows(a).getBytes(charset.nioCharset)))
   }
 
+  def emptyEncoder[A]: EntityEncoder[A] = new EntityEncoder[A] {
+    def toEntity(a: A): Task[Entity] = Task.now(Entity.empty)
+    def headers: Headers = Headers.empty
+  }
+
   implicit def futureEncoder[A](implicit W: EntityEncoder[A], ec: ExecutionContext): EntityEncoder[Future[A]] =
     new EntityEncoder[Future[A]] {
       override def toEntity(a: Future[A]): Task[Entity] = util.task.futureToTask(a).flatMap(W.toEntity)
@@ -131,6 +136,8 @@ trait EntityEncoderInstances0 {
 
 trait EntityEncoderInstances extends EntityEncoderInstances0 {
   private val DefaultChunkSize = 4096
+
+  implicit val unitEncoder: EntityEncoder[Unit] = emptyEncoder[Unit]
 
   implicit def stringEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[String] = {
     val hdr = `Content-Type`(MediaType.`text/plain`).withCharset(charset)


### PR DESCRIPTION
Add parametric empty EntityEncoder, and use it to give an instance for Unit.

I would like to add an Option EntityEncoder as well, which uses this empty encoder in case of None, but I can't write an EntityEncoder that alters the headers based on the given A. This would be possible if toEntity had type (A => (Entity, Headers)) or something like that, but it's not possible now.
This would also let us create an EitherEncoder.