### PR TITLE
Update jawn module to use jawnfs2 instead of jawnstreamz

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,7 @@ lazy val theDsl = libraryProject("dsl")
 lazy val jawn = libraryProject("jawn")
   .settings(
     description := "Base library to parse JSON to various ASTs for http4s",
-    libraryDependencies += jawnStreamz(scalazVersion.value)
+    libraryDependencies += jawnFs2
   )
   .dependsOn(core % "compile;test->test")
 

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -2,19 +2,24 @@ package org.http4s
 package jawn
 
 import _root_.jawn.{AsyncParser, Facade, ParseException}
-import jawnstreamz._
-
-import scalaz.{-\/, \/-}
-import scalaz.stream.Process.emit
+import fs2.Stream
+import jawnfs2._
+import org.http4s.batteries.right
 
 trait JawnInstances {
   def jawnDecoder[J](implicit facade: Facade[J]): EntityDecoder[J] =
     EntityDecoder.decodeBy(MediaType.`application/json`) { msg =>
       DecodeResult {
-        msg.body.parseJson(AsyncParser.SingleValue).partialAttempt {
-          case pe: ParseException =>
-            emit(MalformedMessageBodyFailure("Invalid JSON", Some(pe)))
-        }.runLastOr(-\/(MalformedMessageBodyFailure("Invalid JSON: empty body")))
+        msg.body.chunks
+          .parseJson(AsyncParser.SingleValue)
+          .map(right)
+          .onError {
+            case pe: ParseException =>
+              Stream.emit(Left(MalformedMessageBodyFailure("Invalid JSON", Some(pe))))
+            case e => Stream.fail(e)
+          }
+          .runLast
+          .map(_.getOrElse(Left(MalformedMessageBodyFailure("Invalid JSON: empty body"))))
       }
     }
 }

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
@@ -2,26 +2,25 @@ package org.http4s
 package jawn
 
 trait JawnDecodeSupportSpec[J] extends Http4sSpec with JawnInstances {
-  def testJsonDecoder(decoder: EntityDecoder[J]) = {
+  def testJsonDecoder(decoder: EntityDecoder[J]) =
     "json decoder" should {
       "return right when the entity is valid" in {
-        val resp = Response(Status.Ok).withBody("""{"valid": true}""").run
-        decoder.decode(resp, strict = false).run.run must beXorRight
+        val resp = Response(Status.Ok).withBody("""{"valid": true}""").unsafeRun
+        decoder.decode(resp, strict = false).value.unsafeRun must beRight
       }
 
       "return a ParseFailure when the entity is invalid" in {
-        val resp = Response(Status.Ok).withBody("""garbage""").run
-        decoder.decode(resp, strict = false).run.run must beXorLeft.like {
+        val resp = Response(Status.Ok).withBody("""garbage""").unsafeRun
+        decoder.decode(resp, strict = false).value.unsafeRun must beLeft.like {
           case MalformedMessageBodyFailure("Invalid JSON", _) => ok
         }
       }
 
       "return a ParseFailure when the entity is empty" in {
-        val resp = Response(Status.Ok).withBody("").run
-        decoder.decode(resp, strict = false).run.run must beXorLeft.like {
+        val resp = Response(Status.Ok).withBody("").unsafeRun
+        decoder.decode(resp, strict = false).value.unsafeRun must beLeft.like {
           case MalformedMessageBodyFailure("Invalid JSON: empty body", _) => ok
         }
       }
     }
-  }
 }

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -74,7 +74,7 @@ object Http4sBuild {
   lazy val javaxServletApi     = "javax.servlet"             % "javax.servlet-api"       % "3.1.0"
   lazy val jawnJson4s          = "org.spire-math"           %% "jawn-json4s"             % jawnParser.revision
   lazy val jawnParser          = "org.spire-math"           %% "jawn-parser"             % "0.8.4"
-  lazy val jawnFs2             = "org.http4s"               %% "jawn-fs2"                % "0.9.0"
+  lazy val jawnFs2             = "org.http4s"               %% "jawn-fs2"                % "0.10.0"
   lazy val jettyServer         = "org.eclipse.jetty"         % "jetty-server"            % "9.3.12.v20160915"
   lazy val jettyServlet        = "org.eclipse.jetty"         % "jetty-servlet"           % jettyServer.revision
   lazy val json4sCore          = "org.json4s"               %% "json4s-core"             % "3.4.0"

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -74,7 +74,7 @@ object Http4sBuild {
   lazy val javaxServletApi     = "javax.servlet"             % "javax.servlet-api"       % "3.1.0"
   lazy val jawnJson4s          = "org.spire-math"           %% "jawn-json4s"             % jawnParser.revision
   lazy val jawnParser          = "org.spire-math"           %% "jawn-parser"             % "0.8.4"
-  def jawnStreamz(scalazVersion: String) = "org.http4s"     %% "jawn-streamz"            % scalazCrossBuild("0.9.0", scalazVersion)
+  lazy val jawnFs2             = "org.http4s"               %% "jawn-fs2"                % "0.9.0"
   lazy val jettyServer         = "org.eclipse.jetty"         % "jetty-server"            % "9.3.12.v20160915"
   lazy val jettyServlet        = "org.eclipse.jetty"         % "jetty-servlet"           % jettyServer.revision
   lazy val json4sCore          = "org.json4s"               %% "json4s-core"             % "3.4.0"


### PR DESCRIPTION
Update the jawn module for #661

This depends on the not-yet released jawn-fs2, so it does not build yet. I just created it to not forget about it :)