### PR TITLE
Minimal support for hashed passwords in basicAuth

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuthentication.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuthentication.scala
@@ -14,22 +14,56 @@ import scalaz.concurrent.Task
  *              appropriate password.
  */
 object basicAuth {
+  /**
+    * Construct authentication middleware that can validate the client-provided
+    * plaintext password against something else (like a stored, hashed password).
+    * @param realm
+    * @param validate
+    * @return
+    */
+  def apply(realm: String, validate: ValidatePassword): AuthMiddleware[(String, String)] = {
+    challenged(Service.lift { req =>
+      getChallenge(realm, validate, req, validatePassword _)
+    })
+  }
+
+  /**
+    * Construct authentication middleware that compares the client-provided password
+    * to a plaintext password stored on the server.
+    * @param realm
+    * @param store
+    * @return
+    */
   def apply(realm: String, store: AuthenticationStore): AuthMiddleware[(String, String)] =
     challenged(Service.lift { req =>
-      getChallenge(realm, store, req)
+      getChallenge(realm, store, req, comparePasswords _)
     })
 
   private trait AuthReply
   private sealed case class OK(user: String, realm: String) extends AuthReply
   private case object NeedsAuth extends AuthReply
 
-  private def getChallenge(realm: String, store: AuthenticationStore, req: Request) =
-    checkAuth(realm, store, req).map {
+  private def getChallenge[Store](realm: String, store: Store, req: Request, doCheck: (String, Store, Request) => Task[AuthReply]) =
+    doCheck(realm, store, req).map {
       case OK(user, realm) => \/-(AuthedRequest((user, realm), req))
       case NeedsAuth       => -\/(Challenge("Basic", realm, Nil.toMap))
     }
 
-  private def checkAuth(realm: String, store: AuthenticationStore, req: Request): Task[AuthReply] = {
+  private def validatePassword(realm: String, validate: ValidatePassword, req: Request): Task[AuthReply] = {
+    req.headers.get(Authorization) match {
+      case Some(Authorization(BasicCredentials(user, client_pass))) =>
+        validate(realm, user, client_pass).map {
+          case Some(true) => OK(user, realm)
+          case _ => NeedsAuth
+        }
+
+      case Some(Authorization(_)) => Task.now(NeedsAuth)
+
+      case None => Task.now(NeedsAuth)
+    }
+  }
+
+  private def comparePasswords(realm: String, store: AuthenticationStore, req: Request): Task[AuthReply] = {
     req.headers.get(Authorization) match {
       case Some(Authorization(BasicCredentials(user, client_pass))) =>
         store(realm, user).map {

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuthentication.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuthentication.scala
@@ -43,7 +43,7 @@ object basicAuth {
   private sealed case class OK(user: String, realm: String) extends AuthReply
   private case object NeedsAuth extends AuthReply
 
-  private def getChallenge[Store](realm: String, store: Store, req: Request, doCheck: (String, Store, Request) => Task[AuthReply]) =
+  private def getChallenge[A](realm: String, store: A, req: Request, doCheck: (String, A, Request) => Task[AuthReply]) =
     doCheck(realm, store, req).map {
       case OK(user, realm) => \/-(AuthedRequest((user, realm), req))
       case NeedsAuth       => -\/(Challenge("Basic", realm, Nil.toMap))

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
@@ -10,14 +10,16 @@ package object authentication {
   type Realm = String
   type User = String
   type ClientPasssword = String
-  // A function mapping (realm, username) to password, None if no password
-  // exists for that (realm, username) pair.
+  /**
+    * A function mapping (realm, username) to password, None if no password
+    * exists for that (realm, username) pair.
+    */
   type AuthenticationStore = (Realm, User) => Task[Option[String]]
   /**
     *  Validates a plaintext password (presumably by comparing it to a hashed value).
-    *  Some(true) means the password given is valid.
+    *  A Some value indicates success; None indicates the password failed to validate.
     */
-  type ValidatePassword = (Realm, User, ClientPasssword) => Task[Option[Boolean]]
+  type AuthenticationValidator = (Realm, User, ClientPasssword) => Task[Option[Unit]]
 
   def challenged[A](challenge: Service[Request, Challenge \/ AuthedRequest[A]])
                    (service: AuthedService[A]): HttpService =

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
@@ -7,9 +7,17 @@ import scalaz.concurrent.Task
 import org.http4s.headers._
 
 package object authentication {
+  type Realm = String
+  type User = String
+  type ClientPasssword = String
   // A function mapping (realm, username) to password, None if no password
   // exists for that (realm, username) pair.
-  type AuthenticationStore = (String, String) => Task[Option[String]]
+  type AuthenticationStore = (Realm, User) => Task[Option[String]]
+  /**
+    *  Validates a plaintext password (presumably by comparing it to a hashed value).
+    *  Some(true) means the password given is valid.
+    */
+  type ValidatePassword = (Realm, User, ClientPasssword) => Task[Option[Boolean]]
 
   def challenged[A](challenge: Service[Request, Challenge \/ AuthedRequest[A]])
                    (service: AuthedService[A]): HttpService =


### PR DESCRIPTION
Basic Authentication module now supports passing the cleartext password to a function which can validate the password (for example, by comparing it against a hashed value). Previously, the basic authentication middleware require that the password be stored in plaintext on the server.

Closes #730.
