### PR TITLE
_root_-qualify absolute paths in macro expansions.

### DIFF
--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -91,7 +91,7 @@ object QValue extends QValueInstances with QValueFunctions {
         case Literal(Constant(d: Double)) =>
           QValue.fromDouble(d).fold(
             e => c.abort(c.enclosingPosition, e.details),
-            qValue => q"org.http4s.QValue.☠(${qValue.thousandths})"
+            qValue => q"_root_.org.http4s.QValue.☠(${qValue.thousandths})"
           )
         case _ =>
           c.abort(c.enclosingPosition, s"literal Double value required")

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -121,7 +121,7 @@ object Uri extends UriFunctions {
         case Literal(Constant(s: String)) =>
           Uri.fromString(s).fold(
             e => c.abort(c.enclosingPosition, e.details),
-            qValue => q"org.http4s.Uri.fromString($s).valueOr(throw _)"
+            qValue => q"_root_.org.http4s.Uri.fromString($s).valueOr(throw _)"
           )
         case _ =>
           c.abort(c.enclosingPosition, s"This method uses a macro to verify that a String literal is a valid URI. Use Uri.fromString if you have a dynamic String that you want to parse as a Uri.")


### PR DESCRIPTION
This fixes bug #704.

The issue isn't so much using that symbol after `/`, but that scala was picking it up as part of the expansion of the macro quasiquote at `Uri.scala:124`.

Also fixes this bug in `QValue.scala`, just in case.