### PR TITLE
Order[CharsetRange] is unlawful, so weaken it to Equal

### DIFF
--- a/core/src/main/scala/org/http4s/CharsetRange.scala
+++ b/core/src/main/scala/org/http4s/CharsetRange.scala
@@ -2,7 +2,7 @@ package org.http4s
 
 import util._
 
-import scalaz.{Show, Order}
+import scalaz.{Equal, Show}
 
 sealed abstract class CharsetRange extends HasQValue with Renderable {
   def qValue: QValue
@@ -29,6 +29,6 @@ object CharsetRange extends CharsetRangeInstances {
 }
 
 trait CharsetRangeInstances {
-  implicit val CharacterSetOrder: Order[CharsetRange] = Order[QValue].reverseOrder.contramap(_.qValue)
+  implicit val CharacterSetEqual: Equal[CharsetRange] = Equal.equalA
   implicit val CharsetShow: Show[Charset] = Show.shows(_.toString)
 }

--- a/core/src/test/scala/org/http4s/CharsetRangeSpec.scala
+++ b/core/src/test/scala/org/http4s/CharsetRangeSpec.scala
@@ -39,17 +39,5 @@ class CharsetRangeSpec extends Http4sSpec {
     }
   }
 
-  checkAll(ScalazProperties.order.laws[CharsetRange])
-
-  "sort by descending q-values" in {
-    prop { (x: CharsetRange, y: CharsetRange) =>
-      x.qValue > y.qValue ==> x < y
-    }
-  }
-
-  "have no preference among equal q-values" in {
-    prop { (x: CharsetRange, y: CharsetRange, q: QValue) =>
-      x.withQValue(q) === y.withQValue(q)
-    }
-  }
+  checkAll(ScalazProperties.equal.laws[CharsetRange])
 }


### PR DESCRIPTION
It's based entirely on the QValue.  This makes it possible to write an
`f: CharsetRange => CharsetRange` that determines the QValue by the
charset, and breaks `x eqv y ==> f(x) eqv f(y)`.

We could make it lawful by using the charset to break ties, but this has
no basis in the HTTP spec.  One part of the HTTP spec we missed was to
prefer atoms over splats.  All of this is specific to
content-negotation, and belongs in code there, not a general ordering.

This was uncovered by `Cogen` in cats-0.8.  It will be tested there.

/cc @ceedubs, whose morning I helped ruin with this.