### PR TITLE
Allow customization of pretty printers

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package argonaut
 
-import _root_.argonaut.{EncodeJson, DecodeJson, Argonaut, Json}
+import _root_.argonaut.{DecodeResult => _, _}, Argonaut._
 import org.http4s.headers.`Content-Type`
 
 trait ArgonautInstances {
@@ -16,13 +16,28 @@ trait ArgonautInstances {
       )
     }
 
-  implicit val jsonEncoder: EntityEncoder[Json] =
+  protected def defaultPrettyParams: PrettyParams
+
+  implicit def jsonEncoder: EntityEncoder[Json] =
+    jsonEncoderWithPrettyParams(defaultPrettyParams)
+
+  def jsonEncoderWithPrettyParams(prettyParams: PrettyParams): EntityEncoder[Json] =
     EntityEncoder.stringEncoder(Charset.`UTF-8`).contramap[Json] { json =>
-      // TODO naive implementation materializes to a String.
-      // Look into replacing after https://github.com/non/jawn/issues/6#issuecomment-65018736
-      Argonaut.nospace.pretty(json)
+      prettyParams.pretty(json)
     }.withContentType(`Content-Type`(MediaType.`application/json`, Charset.`UTF-8`))
 
   def jsonEncoderOf[A](implicit encoder: EncodeJson[A]): EntityEncoder[A] =
-    jsonEncoder.contramap[A](encoder.encode)
+    jsonEncoderWithPrinterOf(defaultPrettyParams)
+
+  def jsonEncoderWithPrinterOf[A](prettyParams: PrettyParams)
+    (implicit encoder: EncodeJson[A]): EntityEncoder[A] =
+    jsonEncoderWithPrettyParams(prettyParams).contramap[A](encoder.encode)
+}
+
+object ArgonautInstances {
+  def withPrettyParams(pp: PrettyParams): ArgonautInstances = {
+    new ArgonautInstances {
+      def defaultPrettyParams: PrettyParams = pp
+    }
+  }
 }

--- a/argonaut/src/main/scala/org/http4s/argonaut/package.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/package.scala
@@ -1,3 +1,8 @@
 package org.http4s
 
-package object argonaut extends ArgonautInstances
+import _root_.argonaut.PrettyParams
+
+package object argonaut extends ArgonautInstances {
+  protected def defaultPrettyParams: PrettyParams =
+    PrettyParams.nospace
+}

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -1,10 +1,11 @@
 package org.http4s
-package argonaut
+package argonaut.test // Get out of argonaut package so we can import custom instances
 
 import java.nio.charset.StandardCharsets
 
 import _root_.argonaut._
 import org.http4s.MediaType._
+import org.http4s.argonaut._
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSpec
 import org.http4s.EntityEncoderSpec.writeToString
@@ -28,6 +29,23 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     "write compact JSON" in {
       writeToString(json) must_== ("""{"test":"ArgonautSupport"}""")
     }
+
+
+    "write JSON according to custom encoders" in {
+      val custom = ArgonautInstances.withPrettyParams(PrettyParams.spaces2)
+      import custom._
+      writeToString(json) must_== (
+        """{
+          |  "test" : "ArgonautSupport"
+          |}""".stripMargin)
+    }
+
+    "write JSON according to explicit printer" in {
+      writeToString(json)(jsonEncoderWithPrettyParams(PrettyParams.spaces2)) must_== (
+        """{
+          |  "test" : "ArgonautSupport"
+          |}""".stripMargin)
+    }
   }
 
   "jsonEncoderOf" should {
@@ -37,6 +55,22 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
 
     "write compact JSON" in {
       writeToString(foo)(jsonEncoderOf[Foo]) must_== ("""{"bar":42}""")
+    }
+
+    "write JSON according to custom encoders" in {
+      val custom = ArgonautInstances.withPrettyParams(PrettyParams.spaces2)
+      import custom._
+      writeToString(foo)(jsonEncoderOf) must_== (
+        """{
+          |  "bar" : 42
+          |}""".stripMargin)
+    }
+
+    "write JSON according to explicit printer" in {
+      writeToString(foo)(jsonEncoderWithPrinterOf(PrettyParams.spaces2)) must_== (
+        """{
+          |  "bar" : 42
+          |}""".stripMargin)
     }
   }
 

--- a/circe/src/main/scala/org/http4s/circe/package.scala
+++ b/circe/src/main/scala/org/http4s/circe/package.scala
@@ -1,3 +1,8 @@
 package org.http4s
 
-package object circe extends CirceInstances
+import io.circe.Printer
+
+package object circe extends CirceInstances {
+  protected def defaultPrinter: Printer =
+    Printer.noSpaces
+}

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -1,9 +1,10 @@
 package org.http4s
-package circe
+package circe.test // Get out of circe package so we can import custom instances
 
 import java.nio.charset.StandardCharsets
 
 import io.circe._
+import org.http4s.circe._
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSpec
 import org.http4s.EntityEncoderSpec.writeToString
@@ -33,6 +34,22 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
     "write compact JSON" in {
       writeToString(json) must_== ("""{"test":"CirceSupport"}""")
     }
+
+    "write JSON according to custom encoders" in {
+      val custom = CirceInstances.withPrinter(Printer.spaces2)
+      import custom._
+      writeToString(json) must_== (
+        """{
+          |  "test" : "CirceSupport"
+          |}""".stripMargin)
+    }
+
+    "write JSON according to explicit printer" in {
+      writeToString(json)(jsonEncoderWithPrinter(Printer.spaces2)) must_== (
+        """{
+          |  "test" : "CirceSupport"
+          |}""".stripMargin)
+    }
   }
 
   "jsonEncoderOf" should {
@@ -42,6 +59,22 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
 
     "write compact JSON" in {
       writeToString(foo)(jsonEncoderOf[Foo]) must_== ("""{"bar":42}""")
+    }
+
+    "write JSON according to custom encoders" in {
+      val custom = CirceInstances.withPrinter(Printer.spaces2)
+      import custom._
+      writeToString(foo)(jsonEncoderOf) must_== (
+        """{
+          |  "bar" : 42
+          |}""".stripMargin)
+    }
+
+    "write JSON according to explicit printer" in {
+      writeToString(foo)(jsonEncoderWithPrinterOf(Printer.spaces2)) must_== (
+        """{
+          |  "bar" : 42
+          |}""".stripMargin)
     }
   }
 

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -53,7 +53,7 @@ object Http4sBuild {
     }
 
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.9.v20160720"
-  lazy val argonaut            = "io.argonaut"              %% "argonaut"                % "6.2-RC1"
+  lazy val argonaut            = "io.argonaut"              %% "argonaut"                % "6.2-RC2"
   lazy val asyncHttpClient     = "org.asynchttpclient"       % "async-http-client"       % "2.0.12"
   lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.12.4"
   lazy val circeGeneric        = "io.circe"                 %% "circe-generic"           % circeJawn.revision


### PR DESCRIPTION
Goals:

1. Don't break existing code
2. Preserve idiom of "importing package object does something reasonable"
3. Make it relatively easy to change default (e.g., `val custom = CirceInstances.withPrinter(???); import custom._`).  You will get brainteasers if you do this _and_ import the package object.
4. Allow explicit printing case-by-case (e.g., `jsonEncoderWithPrinter`)

I think this scratches most people's itches.

* [x] circe
* [x] argonaut
* ~[ ] json4s~

See #660, #697, #761 for related discussions. 

/cc @ceedubs @jcranky @etorreborre 