### PR TITLE
Provide an unsafe String => URI function

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -133,6 +133,15 @@ object Uri extends UriFunctions {
   def fromString(s: String): ParseResult[Uri] = new RequestUriParser(s, StandardCharsets.UTF_8).Uri
     .run()(ScalazDeliverySchemes.Disjunction)
 
+  /** Parses a String to a [[Uri]] according to RFC 3986.  If decoding
+   *  fails, throws a [[ParseFailure]].
+   *
+   *  For totality, call [[#fromString]].  For compile-time
+   *  verification of literals, call [[#uri]].
+   */
+  def unsafeFromString(s: String): Uri =
+    fromString(s).valueOr(throw _)
+
   /** Decodes the String to a [[Uri]] using the RFC 7230 section 5.3 uri decoding specification */
   def requestTarget(s: String): ParseResult[Uri] = new RequestUriParser(s, StandardCharsets.UTF_8).RequestUri
     .run()(ScalazDeliverySchemes.Disjunction)


### PR DESCRIPTION
My code is littered with:

```scala
Uri.fromString(s).valueOr(throw _) // YOLO!
```

We have a macro to verify compile-time literals.  We have a safe method that deals with an either.  But it's a frequent use case to read a URI out of configuration and use it as a base for other URIs, and the ParseResult tends to get thrown away in the real world.  :(

A better idea might be a `Uri.apply` that tolerantly parses URIs.  But that digs up old consistency questions like:
- should `apply` on our model parse inputs strictly or tolerantly?
- if strictly, is there a naming convention for a more tolerant one?
- if `apply` is partial, can we still call it `apply`?  I like `unsafe` if it might throw. 

I guess I can live with the yolos through 0.15, but if we agree on a style, we might squeeze improvement in now.  Discuss.