### PR TITLE
Topic/cats

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -81,7 +81,7 @@ final case class Client(open: Service[Request, DisposableResponse], shutdown: Ta
       response.copy(body = response.body.onComplete(eval_(dispose)))
     }
 
-  def streaming[A](req: Request)(f: Response => Process[Task, A]): Process[Task, A] =
+  def streaming[A](req: Request)(f: Response => Stream[Task, A]): Stream[Task, A] =
     eval(open(req).map { case DisposableResponse(response, dispose) =>
       f(response).onComplete(eval_(dispose))
     }).flatMap(identity(_))
@@ -212,7 +212,7 @@ object Client {
     val isShutdown = new AtomicBoolean(false)
 
     def interruptable(body: EntityBody, disposed: AtomicBoolean) = {
-      def loop(reason: String, killed: AtomicBoolean): Process1[ByteVector, ByteVector] = {
+      def loop(reason: String, killed: AtomicBoolean): Stream[ByteVector, ByteVector] = {
         if (killed.get)
           fail(new IOException(reason))
         else

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -7,9 +7,12 @@ import org.http4s.Status.ResponseClass.Successful
 import scala.util.control.NoStackTrace
 
 import java.io.IOException
-import scalaz.concurrent.Task
-import scalaz.stream.{Process, Process1}
-import scalaz.stream.Process._
+// import scalaz.concurrent.Task
+// import scalaz.stream.{Process, Process1}
+// import scalaz.stream.Process._
+
+import fs2._
+
 import scodec.bits.ByteVector
 
 /**
@@ -25,7 +28,7 @@ final case class DisposableResponse(response: Response, dispose: Task[Unit]) {
     */
   def apply[A](f: Response => Task[A]): Task[A] = {
     val task = try f(response) catch { case e: Throwable => Task.fail(e) }
-    task.onFinish { case _ => dispose }
+    task.handleWith { case _ => dispose }
   }
 }
 

--- a/client/src/main/scala/org/http4s/client/Connection.scala
+++ b/client/src/main/scala/org/http4s/client/Connection.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package client
 
-import scalaz.concurrent.Task
+import fs2.Task
 
 import org.log4s.getLogger
 

--- a/client/src/main/scala/org/http4s/client/ConnectionManager.scala
+++ b/client/src/main/scala/org/http4s/client/ConnectionManager.scala
@@ -3,7 +3,7 @@ package client
 
 import java.util.concurrent.ExecutorService
 
-import scalaz.concurrent.Task
+import fs2._
 
 /** Type that is responsible for the client lifecycle
   *

--- a/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
+++ b/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
@@ -4,7 +4,7 @@ import org.http4s.EntityEncoder.Entity
 import org.http4s._
 import org.http4s.headers.`Content-Length`
 
-import scalaz.concurrent.Task
+import fs2.Task
 
 sealed trait RequestGenerator extends Any {
   def method: Method

--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -11,7 +11,10 @@ import fs2._
 // import scalaz.concurrent.Task
 // import scalaz.stream.Process._
 // import scalaz.syntax.monad._
-import scodec.bits.ByteVector
+
+// Replaced with Chunk
+// cue taken from https://github.com/http4s/http4s/pull/661/commits/68f0d712fd482f31991d642c0a4c0575a715b389
+// import scodec.bits.ByteVector
 
 /** 
   * Client middleware to follow redirect responses.

--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -5,10 +5,12 @@ package middleware
 import org.http4s.Method._
 import org.http4s.headers._
 import org.http4s.util.string._
-import scalaz._
-import scalaz.concurrent.Task
-import scalaz.stream.Process._
-import scalaz.syntax.monad._
+import fs2._
+
+// import scalaz._
+// import scalaz.concurrent.Task
+// import scalaz.stream.Process._
+// import scalaz.syntax.monad._
 import scodec.bits.ByteVector
 
 /** 

--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -9,7 +9,10 @@ import org.http4s.util.string._
 import org.http4s.util.UrlCodingUtils
 
 import scala.collection.mutable.ListBuffer
-import scalaz.concurrent.Task
+
+// import scalaz.concurrent.Task
+
+import fs2._
 
 /** Basic OAuth1 message signing support
   * 

--- a/client/src/main/scala/org/http4s/client/package.scala
+++ b/client/src/main/scala/org/http4s/client/package.scala
@@ -6,7 +6,8 @@ import org.http4s.client.impl.{EmptyRequestGenerator, EntityRequestGenerator}
 import Method.{ PermitsBody, NoBody}
 
 import fs2._
-import cats.Functor
+// import cats.Functor
+import cats.Monad
 
 /** Provides extension methods for using the a http4s [[org.http4s.client.Client]]
   * {{{
@@ -37,8 +38,18 @@ package object client {
   implicit class WithBodySyntax(val method: Method with PermitsBody) extends AnyVal with EntityRequestGenerator
   implicit class NoBodySyntax(val method: Method with NoBody) extends AnyVal with EmptyRequestGenerator
 
-  implicit val taskFunctor = new Functor[Task] {
-    def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+  // implicit val taskFunctor = new Functor[Task] {
+  //   def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+  // }
+
+  implicit val taskMonad = new Monad[Task] {
+    def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] =
+      fa.flatMap(f)
+
+    override def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+
+    def pure[A](a: A): Task[A] = Task.now(a)
+
   }
 
 

--- a/client/src/main/scala/org/http4s/client/package.scala
+++ b/client/src/main/scala/org/http4s/client/package.scala
@@ -1,12 +1,12 @@
 // TODO fs2 port
-/*
+
 package org.http4s
 
 import org.http4s.client.impl.{EmptyRequestGenerator, EntityRequestGenerator}
 import Method.{ PermitsBody, NoBody}
 
-import scalaz.concurrent.Task
-
+import fs2._
+import cats.Functor
 
 /** Provides extension methods for using the a http4s [[org.http4s.client.Client]]
   * {{{
@@ -37,6 +37,10 @@ package object client {
   implicit class WithBodySyntax(val method: Method with PermitsBody) extends AnyVal with EntityRequestGenerator
   implicit class NoBodySyntax(val method: Method with NoBody) extends AnyVal with EmptyRequestGenerator
 
+  implicit val taskFunctor = new Functor[Task] {
+    def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+  }
+
 
   implicit def wHeadersDec[T](implicit decoder: EntityDecoder[T]): EntityDecoder[(Headers, T)] = {
     val s = decoder.consumes.toList
@@ -44,4 +48,3 @@ package object client {
   }
 
 }
- */


### PR DESCRIPTION
Various broken imports fixed.

I'm still ignoring the tests.  Some of the remaining compile-time errors below require a better conceptual understanding of HTTP than I have, I think.

Before this PR there were 125 compile-time errors in `main`.  Now there are 30 in `main`. 

```
> project
[info] http4s (in build file:/home/peterbecich/libraries/forks/http4s/)
> compile 
[info] Compiling 13 Scala sources to /home/peterbecich/libraries/forks/http4s/client/target/scala-2.11/classes...
[info] Compiling 8 Scala sources to /home/peterbecich/libraries/forks/http4s/examples/target/scala-2.11/classes...
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:81: value onComplete is not a member of org.http4s.EntityBody
[error]       response.copy(body = response.body.onComplete(eval_(dispose)))
[error]                                          ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:81: not found: value eval_
[error]       response.copy(body = response.body.onComplete(eval_(dispose)))
[error]                                                     ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:85: not found: value eval
[error]     eval(open(req).map { case DisposableResponse(response, dispose) =>
[error]     ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:86: value onComplete is not a member of fs2.Stream[fs2.Task,A]
[error]       f(response).onComplete(eval_(dispose))
[error]                   ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:86: not found: value eval_
[error]       f(response).onComplete(eval_(dispose))
[error]                              ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:202: value run is not a member of fs2.Task[Unit]
[error]     shutdown.run
[error]              ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:215: not found: type ByteVector
[error]       def loop(reason: String, killed: AtomicBoolean): Stream[ByteVector, ByteVector] = {
[error]                                                               ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:215: not found: type ByteVector
[error]       def loop(reason: String, killed: AtomicBoolean): Stream[ByteVector, ByteVector] = {
[error]                                                                           ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:217: not found: value fail
[error]           fail(new IOException(reason))
[error]           ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:219: not found: value await1
[error]           await1[ByteVector] ++ loop(reason, killed)
[error]           ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:219: not found: type ByteVector
[error]           await1[ByteVector] ++ loop(reason, killed)
[error]                  ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/Client.scala:221: value pipe is not a member of org.http4s.EntityBody
[error]       body.pipe(loop("response was disposed", disposed))
[error]            ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/PoolManager.scala:35: value fork is not a member of object fs2.Task
[error]       Task.fork(builder(key))(es).runAsync {
[error]            ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/PoolManager.scala:38: type mismatch;
[error]  found   : fresh.type (with underlying type Any)
[error]  required: A
[error]           callback(NextConnection(fresh, true).right)
[error]                                   ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/PoolManager.scala:40: overloaded method value error with alternatives:
[error]   (msg: String)Unit <and>
[error]   (t: Throwable)(msg: String)Unit
[error]  cannot be applied to (Any)
[error]           logger.error(t)(s"Error establishing client connection for key $key")
[error]                  ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/PoolManager.scala:42: type mismatch;
[error]  found   : scala.util.Left[Any,Any]
[error]  required: fs2.util.Attempt[PoolManager.this.NextConnection]
[error]     (which expands to)  scala.util.Either[Throwable,PoolManager.this.NextConnection]
[error]           callback(e)
[error]                    ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/PoolManager.scala:62: value right is not a member of PoolManager.this.NextConnection
[error]               callback(NextConnection(conn, false).right)
[error]                                                    ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/PoolManager.scala:87: value left is not a member of IllegalStateException
[error]         callback(new IllegalStateException("Connection pool is closed").left)
[error]                                                                         ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/PoolManager.scala:53: could not find implicit value for parameter S: fs2.Strategy
[error]   def borrow(key: RequestKey): Task[NextConnection] = Task.async { callback =>
[error]                                                                  ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/PoolManager.scala:100: value right is not a member of PoolManager.this.NextConnection
[error]               callback(NextConnection(connection, false).right)
[error]                                                          ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala:3: value Entity is not a member of object org.http4s.EntityEncoder
[error] import org.http4s.EntityEncoder.Entity
[error]        ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala:72: value unemit is not a member of org.http4s.EntityBody
[error]           req.body.unemit match {
[error]                    ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala:73: value isHalt is not a member of Any
[error]             case (chunks, p) if p.isHalt =>
[error]                                   ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala:74: value fold is not a member of Any
[error]               Some(chunks.fold(ByteVector.empty)(_ ++ _))
[error]                           ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala:74: not found: value ByteVector
[error]               Some(chunks.fold(ByteVector.empty)(_ ++ _))
[error]                                ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala:83: not found: type ByteVector
[error]         def nextRequest(method: Method, nextUri: Uri, bodyOpt: Option[ByteVector]) =
[error]                                                                       ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala:87: not found: value emit
[error]               req.copy(method = method, uri = nextUri, body = emit(body))
[error]                                                               ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/middleware/Retry.scala:36: value isIdempotent is not a member of org.http4s.Request
[error]         case Right(dr @ DisposableResponse(Response(status, _, _, _, _), _)) if req.isIdempotent && RetriableStatuses(status) =>
[error]                                                                                     ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/middleware/Retry.scala:47: value isIdempotent is not a member of org.http4s.Request
[error]         case Left(e) if req.isIdempotent =>
[error]                             ^
[error] /home/peterbecich/libraries/forks/http4s/client/src/main/scala/org/http4s/client/middleware/Retry.scala:64: value get in class Task cannot be accessed in fs2.Task[org.http4s.client.DisposableResponse]
[error]       Task.async { (prepareLoop(req.copy(body = EmptyBody), attempts + 1).get after duration).runAsync }
[error]                                                                           ^
[error] 30 errors found
[error] /home/peterbecich/libraries/forks/http4s/examples/src/main/scala/com/example/http4s/ExampleService.scala:65: value valueOr is not a member of org.http4s.ParseResult[org.http4s.Uri]
[error]       TemporaryRedirect(uri("/http4s/"))
[error]                            ^
[error] one error found
[error] (client/compile:compileIncremental) Compilation failed
[error] (examples/compile:compileIncremental) Compilation failed
[error] Total time: 3 s, completed Dec 11, 2016 4:23:36 PM
> 
```