### PR TITLE
Don't run MiMa on tests project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,9 @@ lazy val testing = libraryProject("testing")
 // Defined outside core/src/test so it can depend on published testing
 lazy val tests = libraryProject("tests")
   .settings(
-  description := "Tests for core project"
-)
+    description := "Tests for core project",
+    mimaPreviousArtifacts := Set.empty
+  )
   .dependsOn(core, testing % "test->test")
 
 lazy val server = libraryProject("server")


### PR DESCRIPTION
There are not, and will not be, main artifacts in this project.  MiMa goes looking for them, and fails with this message:

`not a directory or jar file: /home/travis/build/http4s/http4s/tests/target/scala-2.11/classes`

This is a fatal error, even though sbt never prints `[error]` and keeps trying to resolve other artifacts.
