### PR TITLE
Add documentation for middleware in general, plus CORS and GZip.

### DIFF
--- a/docs/src/hugo/content/cors.md
+++ b/docs/src/hugo/content/cors.md
@@ -1,0 +1,120 @@
+---
+menu: main
+title: Cross Origin Resource Sharing
+weight: 122
+---
+
+Http4s provides [Middleware], named `CORS`, for adding the appropriate headers 
+to responses to allow Cross Origin Resource Sharing.
+
+Examples in this document have the following dependencies.
+
+```scala
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-dsl" % http4sVersion,
+  "org.http4s" %% "http4s-server" % http4sVersion
+)
+```
+
+And we need some imports.
+
+```tut:silent
+import org.http4s._
+import org.http4s.dsl._
+```
+
+Let's start by making a simple service.
+
+```tut:book
+val service = HttpService {
+  case _ =>
+    Ok()
+}
+
+val request = Request(Method.GET, uri("/"))
+
+service(request).run
+```
+
+Now we can wrap the service in the `CORS` middleware.
+
+```tut:book
+import org.http4s.server.middleware._
+val corsService = CORS(service)
+
+corsService(request).run
+```
+
+So far, there was no change. That's because an `Origin` header is required
+in the requests. This, of course, is the responsibility of the caller.
+
+```tut:book
+val originHeader = Header("Origin", "somewhere.com")
+val corsRequest = request.putHeaders(originHeader)
+
+corsService(corsRequest).run
+```
+
+Notice how the response has the CORS headers added. How easy was 
+that? And, as described in [Middleware], services and middleware can be
+composed such that only some of your endpoints are CORS enabled.
+
+## Configuration
+The example above showed the default configuration for CORS, which adds the
+headers to any successul response, regardless of origin or HTTP method. There
+are configuration options to modify that.
+
+First, we'll create some requests to use in our example. We want these requests
+have a variety of origins and methods.
+
+```tut:book
+val googleGet = Request(Method.GET, uri("/"), headers = Headers(Header("Origin", "google.com")))
+val yahooPut = Request(Method.PUT, uri("/"), headers = Headers(Header("Origin", "yahoo.com")))
+val duckPost = Request(Method.POST, uri("/"), headers = Headers(Header("Origin", "duckduckgo.com")))
+```
+
+Now, we'll create a configuration that limits the allowed methods to `GET` 
+and `POST`, pass that to the `CORS` middleware, and try it out on our requests.
+
+```tut:book
+import scala.concurrent.duration._
+
+val methodConfig = CORSConfig(
+  anyOrigin = true,
+  anyMethod = false,
+  allowedMethods = Some(Set("GET", "POST")),
+  allowCredentials = true,
+  maxAge = 1.day.toSeconds)
+
+val corsMethodSvc = CORS(service, methodConfig)
+
+corsMethodSvc(googleGet).run
+corsMethodSvc(yahooPut).run
+corsMethodSvc(duckPost).run
+```
+
+As you can see, the CORS headers were only added to the `GET` and `POST` requests.
+Next, we'll create a configuration that limits the origins to "yahoo.com" and
+"duckduckgo.com".
+
+```tut:book
+val originConfig = CORSConfig(
+  anyOrigin = false,
+  allowedOrigins = Some(Set("yahoo.com", "duckduckgo.com")),
+  allowCredentials = false,
+  maxAge = 1.day.toSeconds)
+
+val corsOriginSvc = CORS(service, originConfig)
+
+corsOriginSvc(googleGet).run
+corsOriginSvc(yahooPut).run
+corsOriginSvc(duckPost).run
+```
+
+Again, the results are as expected. You can, of course, create a configuration that 
+combines limits on both HTTP method and origin.
+
+As described in [Middleware], services and middleware can be composed such 
+that only some of your endpoints are CORS enabled.
+
+[Middleware]: ../middleware

--- a/docs/src/hugo/content/gzip.md
+++ b/docs/src/hugo/content/gzip.md
@@ -24,8 +24,7 @@ import org.http4s.dsl._
 ```
 
 Let's start by making a simple service that returns a (relatively) large string
-in it's body. We'll use `as[String]` to examine the body. The body is returned
-as a `Task[String]`, so we need to call `run` to get the string itself.
+in its body. We'll use `as[String]` to examine the body. 
 
 ```tut:book
 val service = HttpService {
@@ -35,6 +34,7 @@ val service = HttpService {
 
 val request = Request(Method.GET, uri("/"))
 
+// Do not call 'run' in your code - see note at bottom.
 val response = service(request).run
 val body = response.as[String].run
 body.length
@@ -46,6 +46,7 @@ Now we can wrap the service in the `GZip` middleware.
 import org.http4s.server.middleware._
 val zipService = GZip(service)
 
+// Do not call 'run' in your code - see note at bottom.
 val response = zipService(request).run
 val body = response.as[String].run
 body.length
@@ -59,6 +60,7 @@ values for the `Accept-Encoding` header are **"gzip"**, **"x-gzip"**, and **"*"*
 val acceptHeader = Header("Accept-Encoding", "gzip")
 val zipRequest = request.putHeaders(acceptHeader)
 
+// Do not call 'run' in your code - see note at bottom.
 val response = zipService(zipRequest).run
 val body = response.as[String].run
 body.length
@@ -70,5 +72,11 @@ of **"gzip"**.
 
 As described in [Middleware], services and middleware can be composed such 
 that only some of your endpoints are GZip enabled.
+
+**NOTE:** In this documentation, we are calling `run` to extract values out of a
+`Task` so that they will be printed out. You should **not** call `run` in your 
+service or middleware code. You can work with values while keeping them inside the 
+Task using `map`, `flatMap` and/or `for`. Remember, your service returns a 
+`Task[Response]`.
 
 [Middleware]: ../middleware

--- a/docs/src/hugo/content/gzip.md
+++ b/docs/src/hugo/content/gzip.md
@@ -1,0 +1,74 @@
+---
+menu: main
+title: GZip Compression
+weight: 124
+---
+
+Http4s provides [Middleware], named `GZip`, for allowing for the compression of the `Response`
+body using GZip.
+
+Examples in this document have the following dependencies.
+
+```scala
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-dsl" % http4sVersion,
+  "org.http4s" %% "http4s-server" % http4sVersion
+)
+```
+
+And we need some imports.
+
+```tut:silent
+import org.http4s._
+import org.http4s.dsl._
+```
+
+Let's start by making a simple service that returns a (relatively) large string
+in it's body. We'll use `as[String]` to examine the body. The body is returned
+as a `Task[String]`, so we need to call `run` to get the string itself.
+
+```tut:book
+val service = HttpService {
+  case _ =>
+    Ok("I repeat myself when I'm under stress. " * 3)
+}
+
+val request = Request(Method.GET, uri("/"))
+
+val response = service(request).run
+val body = response.as[String].run
+body.length
+```
+
+Now we can wrap the service in the `GZip` middleware.
+
+```tut:book
+import org.http4s.server.middleware._
+val zipService = GZip(service)
+
+val response = zipService(request).run
+val body = response.as[String].run
+body.length
+```
+
+So far, there was no change. That's because the caller needs to inform us that
+they will accept GZipped responses via an `Accept-Encoding` header. Acceptable 
+values for the `Accept-Encoding` header are **"gzip"**, **"x-gzip"**, and **"*"**.
+
+```tut:book
+val acceptHeader = Header("Accept-Encoding", "gzip")
+val zipRequest = request.putHeaders(acceptHeader)
+
+val response = zipService(zipRequest).run
+val body = response.as[String].run
+body.length
+```
+
+Notice how the response no longer looks very String-like and it's shorter in 
+length. Also, there is a `Content-Encoding` header in the response with a value
+of **"gzip"**.
+
+As described in [Middleware], services and middleware can be composed such 
+that only some of your endpoints are GZip enabled.
+
+[Middleware]: ../middleware

--- a/docs/src/hugo/content/middleware.md
+++ b/docs/src/hugo/content/middleware.md
@@ -9,9 +9,9 @@ the `Request` sent to service, and/or the `Response` returned by the service. In
 some cases, such as [Authentication], middleware may even prevent the service
 from being called.
 
-At it's most basic, middleware is simply a function that takes one `Service` as a
+At its most basic, middleware is simply a function that takes one `Service` as a
 parameter and returns another `Service`. In addition to the `Service`, the middleware
-function can take any additional parameters it needs to perform it's task. Let's look 
+function can take any additional parameters it needs to perform its task. Let's look 
 at a simple example.
 
 For this, we'll need a dependency on the http4s [dsl].
@@ -75,7 +75,8 @@ val wrappedService = myMiddle(service, Header("SomeKey", "SomeValue"));
 wrappedService(goodRequest).run
 wrappedService(badRequest).run
 ```
-Note that the successful response has our header added to it.
+
+Note that the successful response has your header added to it.
 
 If you intend to use you middleware in multiple places,  you may want to implement 
 it as an `object` and use the `apply` method.
@@ -97,7 +98,7 @@ newService(badRequest).run
 ```
 
 It is possible for the wrapped `Service` to have different `Request` and `Response`
-types than the middleware. Authorization is, again, a good example. Authorization 
+types than the middleware. Authentication is, again, a good example. Authentication 
 middleware is an `HttpService` (an alias for `Service[Request, Response]`) that wraps an `
 AuthedService` (an alias for `Service[AuthedRequest[T], Response]`. There is a type 
 defined for this in the `http4s.server` package:

--- a/docs/src/hugo/content/middleware.md
+++ b/docs/src/hugo/content/middleware.md
@@ -1,0 +1,152 @@
+---
+menu: main
+title: Middleware
+weight: 115
+---
+
+A middleware is a wrapper around a [service] that provides a means of manipulating
+the `Request` sent to service, and/or the `Response` returned by the service. In 
+some cases, such as [Authentication], middleware may even prevent the service
+from being called.
+
+At it's most basic, middleware is simply a function that takes one `Service` as a
+parameter and returns another `Service`. In addition to the `Service`, the middleware
+function can take any additional parameters it needs to perform it's task. Let's look 
+at a simple example.
+
+For this, we'll need a dependency on the http4s [dsl].
+
+```scala
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-dsl" % http4sVersion
+)
+```
+and some imports.
+
+```tut:silent
+import org.http4s._
+import org.http4s.dsl._
+```
+
+Then, we can create a middleware that adds a header to successful responses from
+the wrapped service like this. 
+
+```tut:book
+def myMiddle(service: HttpService, header: Header): HttpService = Service.lift { req =>
+  service(req).map {resp =>
+    if (resp.status.isSuccess)
+      resp.putHeaders(header)
+    else
+      resp
+  }
+}
+```
+
+All we do here is pass the request to the service,
+which returns a `Task[Rresponse]`. So, we use `map` to get the request out of the task,
+add the header if the response is a success, and then pass the response on. We could
+just as easily modify the request before we passed it to the service.
+
+Now, let's create a simple service. As mentioned in [service], because `Service` 
+is implemented as a `Kleisli`, which is just a function at heart, we can test a
+service without a server. Because an `HttpService` returns a `Task[Response]`, 
+we need to call `run` on the result of the function to extract the `Response`.
+
+```tut:book
+val service = HttpService {
+  case GET -> Root / "bad" =>
+    BadRequest()
+  case _ =>
+    Ok()
+}
+
+val goodRequest = Request(Method.GET, uri("/"))
+val badRequest = Request(Method.GET, uri("/bad"))
+
+service(goodRequest).run
+service(badRequest).run
+```
+
+Now, we'll wrap the service in our middleware to create a new service, and try it out.
+
+```tut:book
+val wrappedService = myMiddle(service, Header("SomeKey", "SomeValue"));
+
+wrappedService(goodRequest).run
+wrappedService(badRequest).run
+```
+Note that the successful response has our header added to it.
+
+If you intend to use you middleware in multiple places,  you may want to implement 
+it as an `object` and use the `apply` method.
+
+```tut:book
+object MyMiddle {
+  def addHeader(resp: Response, header: Header) =
+    if (resp.status.isSuccess) resp.putHeaders(header)
+    else resp
+
+  def apply(service: HttpService, header: Header) =
+    service.map(addHeader(_, header))
+}
+
+val newService = MyMiddle(service, Header("SomeKey", "SomeValue"))
+
+newService(goodRequest).run
+newService(badRequest).run
+```
+
+It is possible for the wrapped `Service` to have different `Request` and `Response`
+types than the middleware. Authorization is, again, a good example. Authorization 
+middleware is an `HttpService` (an alias for `Service[Request, Response]`) that wraps an `
+AuthedService` (an alias for `Service[AuthedRequest[T], Response]`. There is a type 
+defined for this in the `http4s.server` package:
+
+```scala
+type AuthMiddleware[T] = Middleware[AuthedRequest[T], Response, Request, Response]
+```
+See the [Authentication] documentation for more details.
+ 
+## Composing Services with Middleware
+Because middleware returns a `Service`, you can compose services wrapped in 
+middleware with other, unwrapped, services, or services wrapped in other middleware.
+You can also wrap a single service in multiple layers of middleware. For example:
+
+```tut:book
+val apiService = HttpService {
+  case GET -> Root / "api" =>
+    Ok()
+}
+
+import org.http4s.server.syntax._
+val aggregateService = apiService orElse MyMiddle(service, Header("SomeKey", "SomeValue"))
+
+val apiRequest = Request(Method.GET, uri("/api"))
+
+aggregateService(goodRequest).run
+aggregateService(apiRequest).run
+```
+
+Note that `goodRequest` ran through the `MyMiddle` middleware and the `Result` had
+our header added to it. But, `apiRequest` did not go through the middleware and did
+not have the header added to it's `Result`.
+
+## Included Middleware
+Http4s includes some middleware Out of the Box in the `org.http4s.server.middleware`
+package. These include:
+
+* [Authentication]
+* Cross Origin Resource Sharing ([CORS])
+* Response Compression ([GZip])
+* Service Timeout
+* Jsonp
+* Virtual Host
+
+And a few others.
+
+[service]: ../service
+[dsl]: ../dsl
+[Authentication]: ../auth
+[CORS]: ../cors
+[GZip]: ../gzip
+


### PR DESCRIPTION
Relates to documentation meta-ticket #679 and the hugo reboot issue #782. 

I set the Hugo **weight** to values that put the new documentation into what I thought were reasonable places in the navigation. The inter-documentation links are also relative to the new Hugo directory/file structure. So, if we don't go with Hugo, those will need to be re-jiggered.