### PR TITLE
Let fallthrough responses through GZip middleware

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -15,7 +15,6 @@ import scodec.bits.ByteVector
 
 object GZip {
   private[this] val logger = getLogger
-  
   // TODO: It could be possible to look for Task.now type bodies, and change the Content-Length header after
   // TODO      zipping and buffering all the input. Just a thought.
   def apply(service: HttpService, bufferSize: Int = 32 * 1024, level: Int = Deflater.DEFAULT_COMPRESSION): HttpService = Service.lift {
@@ -47,7 +46,8 @@ object GZip {
 
   private def isZippable(resp: Response): Boolean = {
     val contentType = resp.headers.get(`Content-Type`)
-    resp.headers.get(`Content-Encoding`).isEmpty &&
+    !Fallthrough[Response].isFallthrough(resp) &&
+      resp.headers.get(`Content-Encoding`).isEmpty &&
       (contentType.isEmpty || contentType.get.mediaType.compressible ||
       (contentType.get.mediaType eq MediaType.`application/octet-stream`))
   }

--- a/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
@@ -1,0 +1,21 @@
+package org.http4s
+package server
+package middleware
+
+import org.http4s.server.syntax._
+import org.http4s.dsl._
+import org.http4s.headers._
+
+class GZipSpec extends Http4sSpec {
+  "GZip" should {
+    "fall through if the route doesn't match" in {
+      val service = GZip(HttpService.empty) || HttpService {
+        case GET -> Root =>
+          Ok("pong")
+      }
+      val req = Request(Method.GET, Uri.uri("/"))
+        .putHeaders(`Accept-Encoding`(ContentCoding.gzip))
+      service.run(req).run.status must_== (Status.Ok)
+    }
+  }
+}

--- a/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
@@ -15,7 +15,9 @@ class GZipSpec extends Http4sSpec {
       }
       val req = Request(Method.GET, Uri.uri("/"))
         .putHeaders(`Accept-Encoding`(ContentCoding.gzip))
-      service.run(req).run.status must_== (Status.Ok)
+      val resp = service.run(req).run
+      resp.status must_== (Status.Ok)
+      resp.get(`Content-Encoding`) must beNone
     }
   }
 }


### PR DESCRIPTION
Fallthrough bites us again.  This bug happened because Fallthrough used to be based on response attributes, which survived a gzipping.  Now it's based on reference equality, which doesn't.

I think I'm going to launch another War on Fallthrough, but this fixes the regression in 0.15.0.

/cc @cquiroz