### PR TITLE
Cookies on Request

### DIFF
--- a/core/src/main/scala/org/http4s/MessageOps.scala
+++ b/core/src/main/scala/org/http4s/MessageOps.scala
@@ -3,6 +3,7 @@ package org.http4s
 import java.time.{ZoneOffset, Instant}
 
 import org.http4s.headers.{`Set-Cookie`, `Content-Type`}
+import org.http4s.util.NonEmptyList._
 
 import scalaz.\/
 import scalaz.concurrent.Task
@@ -114,6 +115,16 @@ trait RequestOps extends Any with MessageOps {
     *               [[MediaType]] is not supported by the provided decoder
     */
   def decodeWith[A](decoder: EntityDecoder[A], strict: Boolean)(f: A => Task[Response]): Task[Response]
+
+  /** Add a Cookie header for the provided [[Cookie]] */
+  final def addCookie(cookie: Cookie): Self =
+    putHeaders(org.http4s.headers.Cookie(nels(cookie)))
+
+  /** Add a Cookie header with the provided values */
+  final def addCookie(name: String,
+                      content: String,
+                      expires: Option[Instant] = None): Self =
+    addCookie(Cookie(name, content, expires))
 }
 
 trait ResponseOps extends Any with MessageOps {

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -6,7 +6,6 @@ import org.http4s.headers.`Content-Type`
 
 import scalaz.concurrent.Task
 
-
 class MessageSpec extends Http4sSpec {
 
   "Request" should {
@@ -50,6 +49,16 @@ class MessageSpec extends Http4sSpec {
 
       "be false if the method is not idempotent" in {
         Request(Method.POST).isIdempotent must beFalse
+      }
+    }
+
+    "support cookies" should {
+      "contain a Cookie header when an explicit cookie is added" in {
+        Request(Method.GET).addCookie(Cookie("token", "value")).headers.get("Cookie".ci).map(_.value) must beSome("token=value")
+      }
+
+      "contain a Cookie header when a name/value pair is added" in {
+        Request(Method.GET).addCookie("token", "value").headers.get("Cookie".ci).map(_.value) must beSome("token=value")
       }
     }
   }


### PR DESCRIPTION
This PR contains methods to easily add `Cookies` to `Request` isomorphic to the ones on `Response`

I thought about adding documentation but couldn't find a good place.