### PR TITLE
Minor text change in documentation.

### DIFF
--- a/docs/src/hugo/content/adopters.md
+++ b/docs/src/hugo/content/adopters.md
@@ -11,7 +11,7 @@ title: Adopters
 : Has about 10 services in production at thousands of requests per second.
 
 [Verizon](http://www.verizon.com)
-: Uses https extensively in its internal services and [open source projects](http://verizon.github.io).
+: Uses http4s extensively in its internal services and [open source projects](http://verizon.github.io).
 	
 ## Open Source
 


### PR DESCRIPTION
Missed the '4' when talking about Version's use of 'http4s'