### PR TITLE
Fix baseURL in hugo, default to 2.12.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,12 +10,10 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 organization in ThisBuild := "org.http4s"
 version      in ThisBuild := scalazCrossBuild("0.15.2-SNAPSHOT", scalazVersion.value)
 apiVersion   in ThisBuild := version.map(extractApiVersion).value
-scalaVersion in ThisBuild := "2.11.8"
 // The build supports both scalaz `7.1.x` and `7.2.x`. Simply run
 // `set scalazVersion in ThisBuild := "7.2.4"` to change which version of scalaz
 // is used to build the project.
 scalazVersion in ThisBuild := "7.1.11"
-crossScalaVersions in ThisBuild := Seq("2.10.6", scalaVersion.value, "2.12.1")
 
 // Root project
 name := "root"
@@ -309,6 +307,10 @@ lazy val docs = http4sProject("docs")
     },
     copySiteToStage <<= copySiteToStage.dependsOn(tutQuick),
     makeSite <<= makeSite.dependsOn(copySiteToStage),
+    baseURL in Hugo := {
+      if (isTravisBuild.value) new URI(s"http://http4s.org")
+      else new URI(s"http://127.0.0.1:${previewFixedPort.value.getOrElse(4000)}")
+    },
     // all .md|markdown files go into `content` dir for hugo processing
     ghpagesNoJekyll := true,
     includeFilter in Hugo := (

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.0.0-M4")
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "2.1.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
@@ -17,5 +18,6 @@ addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.7")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.1.7"


### PR DESCRIPTION
- Fixes the baseURL in hugo for Travis deployments, which will correct
  the pager error that @zarthross identified.
- Uses sbt-travisci plugin to do it
- As a result, our build defaults to 2.12.1 now. This is good, as long
  as we're not relying on anything deprecated.