### PR TITLE
#828 - Add details when JSON decode failure occurs

### DIFF
--- a/core/src/main/scala/org/http4s/DecodeFailure.scala
+++ b/core/src/main/scala/org/http4s/DecodeFailure.scala
@@ -27,7 +27,10 @@ final case class DecodeFailureException(failure: DecodeFailure) extends RuntimeE
   *                version of the error.  This may freely echo a Request.
   */
 final case class ParseFailure(sanitized: String, details: String) extends DecodeFailure {
-  val msg = details
+  def msg: String =
+    if (sanitized.isEmpty) details
+    else if (details.isEmpty) sanitized
+    else s"$sanitized: $details"
 }
 
 final case class ParseException(failure: ParseFailure) extends RuntimeException(failure.sanitized)

--- a/core/src/main/scala/org/http4s/DecodeFailure.scala
+++ b/core/src/main/scala/org/http4s/DecodeFailure.scala
@@ -27,7 +27,7 @@ final case class DecodeFailureException(failure: DecodeFailure) extends RuntimeE
   *                version of the error.  This may freely echo a Request.
   */
 final case class ParseFailure(sanitized: String, details: String) extends DecodeFailure {
-  val msg = sanitized
+  val msg = details
 }
 
 final case class ParseException(failure: ParseFailure) extends RuntimeException(failure.sanitized)


### PR DESCRIPTION
change ParseFailure msg value to details instead of sanitized version