### PR TITLE
Fix Markdown links on community page

### DIFF
--- a/docs/src/hugo/content/community.md
+++ b/docs/src/hugo/content/community.md
@@ -17,6 +17,9 @@ The http4s community is available on [Gitter].  The core developers
 and many of our users are here to provide support, get feedback, and
 discuss the next steps on the project. For those who prefer IRC,
 Gitter provides an [IRC bridge].
+
+[Gitter]: https://gitter.im/http4s/http4s
+[IRC bridge]: https://irc.gitter.im/
 {{% /panel %}}
 
 {{% panel "Issues" %}}
@@ -24,6 +27,8 @@ http4s uses [GitHub issues]. If you think you’ve hit a bug or have an
 idea of what we should do next, please don’t hesitate to submit an
 issue. Your bug reports and request make the project better for
 everyone.
+
+[GitHub issues]: https://github.com/http4s/http4s/issues
 {{% /panel %}}
 
 {{% panel "Twitter" %}}
@@ -34,7 +39,7 @@ or Issues to discuss in depth.
 [@http4s]: https://twitter.com/http4s
 {{% /panel %}}
 
-{{% panel "Contributing" %}} 
+{{% panel "Contributing" %}}
 http4s is an open source project, and depends on its users to continue
 to improve.  Here's how you can help:
 
@@ -54,9 +59,3 @@ to improve.  Here's how you can help:
   [Python WSGI](https://www.python.org/dev/peps/pep-0333/), and
   [Haskell WAI](http://www.yesodweb.com/book/web-application-interface).
 {{% /panel %}}
-
-[Gitter]: https://gitter.im/http4s/http4s
-[IRC bridge]: https://irc.gitter.im/
-[GitHub issues]: https://github.com/http4s/http4s/issues
-[Typelevel]: http://typelevel.org/
-[Typelevel Code of Conduct]: http://typelevel.org/conduct.html


### PR DESCRIPTION
Hugo does not render the reference-style Markdown links if the
reference and the link defintion are not in the same panel.

Before:
![2017-01-04-15 32 57_before](https://cloud.githubusercontent.com/assets/70307/21658143/59997c7e-d293-11e6-8441-37200a97515b.png)

After:
![2017-01-04-15 33 46_after](https://cloud.githubusercontent.com/assets/70307/21658145/5e5ed6be-d293-11e6-802c-ae3b2d4fac30.png)
