### PR TITLE
Dispose of redirect responses in FollowRedirect

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -102,7 +102,7 @@ object FollowRedirect {
                 case _ =>
                   pureBody.map(body => nextRequest(method, nextUri, Some(body)))
               }
-              nextReq.fold(dontRedirect)(prepareLoop(_, redirects + 1))
+              nextReq.fold(dontRedirect)(dr.dispose >> prepareLoop(_, redirects + 1))
             }
           }
           else dontRedirect

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -121,5 +121,13 @@ class FollowRedirectSpec extends Http4sSpec with Tables {
         case _ => Task.now(-1)
       }.run must_==(4)
     }
+
+    "Dispose of original response when redirecting" in {
+      var disposed = 0
+      val disposingService = service.map(DisposableResponse(_, Task.delay(disposed = disposed + 1)))
+      val client = FollowRedirect(3)(Client(disposingService, Task.now(())))
+      client.expect[String](uri("http://localhost/301")).attemptRun
+      disposed must_== 2 // one for the original, one for the redirect
+    }
   }
 }


### PR DESCRIPTION
When we redirect, we need to dispose of the original response before issuing another request.  Failure to do so results in n+1 borrows for n redirects before any responses are disposed.  In a tight loop, that deadlocks.

Fixes #796