### PR TITLE
Don't log headers in blaze connection

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -120,7 +120,7 @@ private final class Http1Connection(val requestKey: RequestKey,
   override protected def contentComplete(): Boolean = parser.contentComplete()
 
   private def executeRequest(req: Request, flushPrelude: Boolean): Task[Response] = {
-    logger.debug(s"Beginning request: $req")
+    logger.debug(s"Beginning request: ${req.method} ${req.uri}")
     validateRequest(req) match {
       case Left(e)    => Task.fail(e)
       case Right(req) => Task.suspend {


### PR DESCRIPTION
It's easy to leak authorization information this way.  Any sort of wire logging should be done in a separate category that's easy to disable.

I'll be working on a better overall logging story for blaze, but this scratches today's itch.