### PR TITLE
Add a hashCode and equals to Headers

### DIFF
--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -87,6 +87,14 @@ final class Headers private (headers: List[Header])
     }
     else super.++(that)
   }
+
+  override def hashCode(): Int = this.headers.hashCode()
+
+  override def equals(that: Any): Boolean = that match {
+    case otherheaders: Headers =>
+      this.hashCode() == otherheaders.hashCode()
+    case _ => false
+  }
 }
 
 object Headers {

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -92,7 +92,7 @@ final class Headers private (headers: List[Header])
 
   override def equals(that: Any): Boolean = that match {
     case otherheaders: Headers =>
-      this.headers.equals(otherheaders.toList)
+      this.toList.equals(otherheaders.toList)
     case _ => false
   }
 }

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -92,7 +92,7 @@ final class Headers private (headers: List[Header])
 
   override def equals(that: Any): Boolean = that match {
     case otherheaders: Headers =>
-      this.headers.equals(otherheaders.headers)
+      this.headers.equals(otherheaders.toList)
     case _ => false
   }
 }

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -92,7 +92,7 @@ final class Headers private (headers: List[Header])
 
   override def equals(that: Any): Boolean = that match {
     case otherheaders: Headers =>
-      this.hashCode() == otherheaders.hashCode()
+      this.headers.equals(otherheaders.headers)
     case _ => false
   }
 }

--- a/tests/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeadersSpec.scala
@@ -77,5 +77,19 @@ class HeadersSpec extends Specification {
       // Mapping to strings because Header equality is based on the *parsed* version
       (Headers(rawAuth) ++ base).map(_.toString) must contain(===(rawAuth.toString))
     }
+
+    "hash the same when constructed with the same contents" in {
+      val h1 = Headers(Header("Test-Header", "Value"))
+      val h2 = Headers(Header("Test-Header", "Value"))
+      val h3 = Headers(List(Header("Test-Header", "Value"), Header("TestHeader", "other value")))
+      val h4 = Headers(List(Header("TestHeader", "other value"), Header("Test-Header", "Value")))
+      val h5 = Headers(List(Header("Test-Header", "Value"), Header("TestHeader", "other value")))
+      h1.hashCode() must_== h2.hashCode()
+      h1.equals(h2) must_== true
+      h2.equals(h1) must_== true
+      h1.equals(h3) must_== false
+      h3.equals(h4) must_== false
+      h3.equals(h5) must_== true
+    }
   }
 }


### PR DESCRIPTION
* the hashCode passes through to the `List` hashCode, so it is order dependent
* Headers are case classes and already have a sane hashCode, allowing the above to work correctly