### PR TITLE
Make the `getChallenge` method of bundled auth middleware public

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
@@ -29,10 +29,10 @@ object BasicAuth {
     * @return
     */
   def apply[A](realm: String, validate: BasicAuthenticator[A]): AuthMiddleware[A] = {
-    challenged(getChallenge(realm, validate))
+    challenged(challenge(realm, validate))
   }
 
-  def getChallenge[A](realm: String, validate: BasicAuthenticator[A]): Service[Request, Challenge \/ AuthedRequest[A]] =
+  def challenge[A](realm: String, validate: BasicAuthenticator[A]): Service[Request, Challenge \/ AuthedRequest[A]] =
     Service.lift { req =>
       validatePassword(validate, req).map {
         case Some(authInfo) =>

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
@@ -34,7 +34,7 @@ object BasicAuth {
     })
   }
 
-  private def getChallenge[A](realm: String, validate: BasicAuthenticator[A], req: Request) =
+  def getChallenge[A](realm: String, validate: BasicAuthenticator[A], req: Request) =
     validatePassword(validate, req).map {
       case Some(authInfo) =>
         \/-(AuthedRequest(authInfo, req))

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
@@ -29,17 +29,17 @@ object BasicAuth {
     * @return
     */
   def apply[A](realm: String, validate: BasicAuthenticator[A]): AuthMiddleware[A] = {
-    challenged(Service.lift { req =>
-      getChallenge(realm, validate, req)
-    })
+    challenged(getChallenge(realm, validate))
   }
 
-  def getChallenge[A](realm: String, validate: BasicAuthenticator[A], req: Request) =
-    validatePassword(validate, req).map {
-      case Some(authInfo) =>
-        \/-(AuthedRequest(authInfo, req))
-      case None =>
-        -\/(Challenge("Basic", realm, Map.empty))
+  def getChallenge[A](realm: String, validate: BasicAuthenticator[A]): Service[Request, Challenge \/ AuthedRequest[A]] =
+    Service.lift { req =>
+      validatePassword(validate, req).map {
+        case Some(authInfo) =>
+          \/-(AuthedRequest(authInfo, req))
+        case None =>
+          -\/(Challenge("Basic", realm, Map.empty))
+      }
     }
 
   private def validatePassword[A](validate: BasicAuthenticator[A], req: Request): Task[Option[A]] = {

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -56,13 +56,13 @@ object DigestAuth {
     nonceBits: Int = 160
   ): AuthMiddleware[A] = {
     val nonceKeeper = new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits)
-    challenged(getChallenge(realm, store, nonceKeeper))
+    challenged(challenge(realm, store, nonceKeeper))
   }
 
   /** Side-effect of running the returned task: If req contains a valid
     * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
     */
-  def getChallenge[A](realm: String, store: AuthenticationStore[A], nonceKeeper: NonceKeeper): Service[Request, Challenge \/ AuthedRequest[A]] =
+  def challenge[A](realm: String, store: AuthenticationStore[A], nonceKeeper: NonceKeeper): Service[Request, Challenge \/ AuthedRequest[A]] =
     Service.lift { req => {
       def paramsToChallenge(params: Map[String, String]) = -\/(Challenge("Digest", realm, params))
 

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -64,7 +64,7 @@ object DigestAuth {
   /** Side-effect of running the returned task: If req contains a valid
     * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
     */
-  private def getChallenge[A](realm: String, store: AuthenticationStore[A], nonceKeeper: NonceKeeper, req: Request): Task[Challenge \/ AuthedRequest[A]] = {
+  def getChallenge[A](realm: String, store: AuthenticationStore[A], nonceKeeper: NonceKeeper, req: Request): Task[Challenge \/ AuthedRequest[A]] = {
     def paramsToChallenge(params: Map[String, String]) = -\/(Challenge("Digest", realm, params))
     checkAuth(realm, store, nonceKeeper, req).flatMap(_ match {
       case OK(authInfo) => Task.now(\/-(AuthedRequest(authInfo, req)))


### PR DESCRIPTION
As the Authentication middleware doesn't "fall through" in a stack, there is no way to allow users to authenticate with multiple different auth sources. In order to enable that kind of functionality, the existing `getChallenge` method of both `BasicAuth` and `DigestAuth` must be public so external integrations can properly invoke them.

For example, consider the use case where users can authenticate either with an api key and secret (using HTTP Basic) _or_ with an OIDC token (using Bearer authentication). Assuming there is already a `BearerAuth` object that parses and validates the OIDC token, a combined authenticator would look something like:

```
object GenericAuth {
  type GenericAuthenticator[A] = Credentials => Task[Option[A]]

  def apply[A](realm: String, validator: GenericAuthenticator[A]): AuthMiddleware[A] = {
    challenged(Service.lift { req =>
      req.headers.get(Authorization) match {
        case Some(Authorization(token: OAuth2BearerToken)) =>
          BearerAuth.getChallenge(realm, validator, req)
        case Some(Authorization(creds: BasicCredentials)) =>
          BasicAuth.getChallenge(realm, validator, req)
        case _ => Task.now(-\/(Challenge("Basic", realm, Map.empty)))
      }
    })
  }
}
```

In order to function properly, the `getChallenge()` method of the underlying authentication middlewares _must_ be public or they cannot be invoked externally in such a way.