### PR TITLE
Fixed Disposable Request Disposal in FollowRedirect

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -99,7 +99,7 @@ object FollowRedirect {
                 case _ =>
                   pureBody.map(body => nextRequest(method, nextUri, Some(body)))
               }
-              nextReq.fold(dontRedirect)(dr.dispose >> prepareLoop(_, redirects + 1))
+              nextReq.fold(dontRedirect)(req => dr.dispose.flatMap(_ => prepareLoop(req, redirects + 1)))
             }
           }
           else dontRedirect

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -130,7 +130,7 @@ class FollowRedirectSpec extends Http4sSpec with Tables {
       var disposed = 0
       val disposingService = service.map(DisposableResponse(_, Task.delay(disposed = disposed + 1)))
       val client = FollowRedirect(3)(Client(disposingService, Task.now(())))
-      client.expect[String](uri("http://localhost/301")).attemptRun
+      client.expect[String](uri("http://localhost/301")).unsafeRun()
       disposed must_== 2 // one for the original, one for the redirect
     }
   }


### PR DESCRIPTION
Fixes a compilation error as >> is not in Cats. This is replaced with simple flatMapping.