### PR TITLE
Modified json.md for tut to Compile

### DIFF
--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -174,7 +174,11 @@ def repos(organization: String): Task[List[Repo]] = {
 }
 
 val http4s = repos("http4s")
-http4s.map(_.map(_.stargazers_count).mkString("\n")).run
+
+val stargazers = http4s.map(_.map(_.stargazers_count).mkString("\n"))
+
+// Run has been separated into its own line for tut to compile without hanging. 
+stargazers.run
 httpClient.shutdownNow()
 ```
 


### PR DESCRIPTION
Scalaz Task is encountering an error when declaring a change to a task and running
that task on the same line. json.md was the only file guilty of this. By modifying
the offending code tut now compiles on 2.12