### PR TITLE
Modified bin/travis to make site using scala 2.12

### DIFF
--- a/bin/travis
+++ b/bin/travis
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ $TRAVIS_SCALA_VERSION == 2.11* ]] && [[ $SCALAZ_VERSION = 7.2* ]]; then
+if [[ $TRAVIS_SCALA_VERSION == 2.12* ]] && [[ $SCALAZ_VERSION = 7.2* ]]; then
   SBT_COMMAND=";coverage ;clean ;test ;makeSite ;mimaReportBinaryIssues ;coverageReport ;coverageOff"
 else
   SBT_COMMAND=";test"

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -174,7 +174,11 @@ def repos(organization: String): Task[List[Repo]] = {
 }
 
 val http4s = repos("http4s")
-http4s.map(_.map(_.stargazers_count).mkString("\n")).run
+
+val stargazers = http4s.map(_.map(_.stargazers_count).mkString("\n"))
+
+// Run has been separated into its own line for tut to compile without hanging. 
+stargazers.run
 httpClient.shutdownNow()
 ```
 


### PR DESCRIPTION
After #853 tut should be able to compile using 2.12. 

Which means this branch should compile and make the new docs and site off of 2.12