### PR TITLE
 Fix blaze-client eager connection closing

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeConnection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeConnection.scala
@@ -10,12 +10,8 @@ import scala.util.control.NonFatal
 import scalaz.concurrent.Task
 
 private trait BlazeConnection extends TailStage[ByteBuffer] with Connection {
-  final def runRequest(req: Request): Task[Response] =
-    runRequest(req, false)
 
-  /** If we flush the prelude, we can detect stale connections before we run the effect
-    * of the body.  This gives us a better retry story. */
-  def runRequest(req: Request, flushPrelude: Boolean): Task[Response]
+  def runRequest(req: Request): Task[Response]
 
   override protected def finalize(): Unit = {
     try if (!isClosed) {

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -50,13 +50,15 @@ private final class Http1Connection(val requestKey: RequestKey,
 
   override def shutdown(): Unit = stageShutdown()
 
-  override def stageShutdown() = shutdownWithError(EOF)
+  override def stageShutdown(): Unit = {
+    shutdownWithError(EOF)
+  }
 
   override protected def fatalError(t: Throwable, msg: String): Unit = {
     val realErr = t match {
       case _: TimeoutException => EOF
       case EOF                 => EOF
-      case t                   => 
+      case t                   =>
         logger.error(t)(s"Fatal Error: $msg")
         t
     }
@@ -154,7 +156,7 @@ private final class Http1Connection(val requestKey: RequestKey,
             }(ec)
           }
 
-        next.flatMap{ rr =>
+        next.flatMap { rr =>
           val bodyTask = getChunkEncoder(req, mustClose, rr)
             .writeProcess(req.body)
             .handle { case EOF => false } // If we get a pipeline closed, we might still be good. Check response

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ReadBufferStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ReadBufferStage.scala
@@ -1,0 +1,67 @@
+package org.http4s.client.blaze
+
+import org.http4s.blaze.pipeline.MidStage
+import org.http4s.blaze.util.Execution
+
+import scala.concurrent.Future
+
+/** Stage that buffers read requests in order to eagerly detect connection close events.
+  *
+  * Among other things, this is useful for helping clients to avoid making
+  * requests against a stale connection when doing so may result in side
+  * effects, and therefore cannot be retried.
+  */
+private final class ReadBufferStage[T] extends MidStage[T, T] {
+
+  override def name: String = "ReadBufferingStage"
+
+  private val lock: Object = this
+  private var buffered: Future[T] = null
+
+  override def writeRequest(data: T): Future[Unit] = channelWrite(data)
+
+  override def writeRequest(data: Seq[T]): Future[Unit] = channelWrite(data)
+
+  override def readRequest(size: Int): Future[T] = lock.synchronized {
+    if (buffered == null) Future.failed(illegalState())
+    else if (buffered.isCompleted) {
+      // What luck: we can schedule a new read right now, without an intermediate future
+      val r = buffered
+      buffered = channelRead()
+      r
+    } else {
+      // Need to schedule a new read for after this one resolves
+      val r = buffered
+      buffered = null
+
+      // We use map as it will introduce some ordering: scheduleRead() will
+      // be called before the new Future resolves, triggering the next read.
+      r.map { v => scheduleRead(); v }(Execution.directec)
+    }
+  }
+
+  // On startup we begin buffering a read event
+  override protected def stageStartup(): Unit = {
+    logger.debug("Stage started up. Beginning read buffering")
+    lock.synchronized {
+      buffered = channelRead()
+    }
+  }
+
+  private def scheduleRead(): Unit = lock.synchronized {
+    if (buffered == null) {
+      buffered = channelRead()
+    } else {
+      // This should never happen, but if it does, lets scream about it
+      val ex = illegalState()
+      logger.error(ex)("Found ourselves in an illegal state, " +
+        "trying to schedule a read when one is already pending")
+      throw ex
+    }
+  }
+
+  private def illegalState(): Exception =
+    new IllegalStateException("Cannot have multiple pending reads")
+}
+
+

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -138,7 +138,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 1500.millis)
       val c = mkClient(h, tail)(Duration.Inf, 1.second)
 
-      val result = tail.runRequest(FooRequest, false).as[String]
+      val result = tail.runRequest(FooRequest).as[String]
 
       c.fetchAs[String](FooRequest).run must throwA[TimeoutException]
     }
@@ -149,7 +149,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 1500.millis)
       val c = mkClient(h, tail)(1.second, Duration.Inf)
 
-      val result = tail.runRequest(FooRequest, false).as[String]
+      val result = tail.runRequest(FooRequest).as[String]
 
       c.fetchAs[String](FooRequest).run must throwA[TimeoutException]
     }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ReadBufferStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ReadBufferStageSpec.scala
@@ -1,0 +1,107 @@
+package org.http4s.client.blaze
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.http4s.Http4sSpec
+import org.http4s.blaze.pipeline.{Command, HeadStage, LeafBuilder, TailStage}
+
+import scala.concurrent.{Await, Awaitable, Future, Promise}
+import scala.concurrent.duration._
+
+class ReadBufferStageSpec extends Http4sSpec {
+  "ReadBufferStage" should {
+    "Launch read request on startup" in {
+      val (readProbe, _) = makePipeline
+
+      readProbe.inboundCommand(Command.Connected)
+      readProbe.readCount.get must_== 1
+    }
+
+    "Trigger a buffered read after a read takes the already resolved read" in {
+      // The ReadProbe class returns futures that are already satisifed,
+      // so buffering happens during each read call
+      val (readProbe, tail) = makePipeline
+
+      readProbe.inboundCommand(Command.Connected)
+      readProbe.readCount.get must_== 1
+
+      awaitResult(tail.channelRead())
+      readProbe.readCount.get must_== 2
+    }
+
+    "Trigger a buffered read after a read command takes a pending read, and that read resolves" in {
+      // The ReadProbe class returns futures that are already satisifed,
+      // so buffering happens during each read call
+      val slowHead = new ReadHead
+      val tail = new NoopTail
+      makePipeline(slowHead, tail)
+
+      slowHead.inboundCommand(Command.Connected)
+      slowHead.readCount.get must_== 1
+
+      val firstRead = slowHead.lastRead
+      val f = tail.channelRead()
+      f.isCompleted must_== false
+      slowHead.readCount.get must_== 1
+
+      firstRead.success(())
+      f.isCompleted must_== true
+
+      // Now we have buffered a second read
+      slowHead.readCount.get must_== 2
+    }
+
+    "Return an IllegalStateException when trying to do two reads at once" in {
+      val slowHead = new ReadHead
+      val tail = new NoopTail
+      makePipeline(slowHead, tail)
+
+      slowHead.inboundCommand(Command.Connected)
+      tail.channelRead()
+      awaitResult(tail.channelRead()) must throwA[IllegalStateException]
+    }
+  }
+
+  def awaitResult[T](f: Awaitable[T]): T = Await.result(f, 5.seconds)
+
+  def makePipeline: (ReadProbe, NoopTail) = {
+    val readProbe = new ReadProbe
+    val noopTail = new NoopTail
+    makePipeline(readProbe, noopTail)
+    readProbe -> noopTail
+  }
+
+  def makePipeline[T](h: HeadStage[T], t: TailStage[T]): Unit = {
+    LeafBuilder(t)
+      .prepend(new ReadBufferStage[T])
+      .base(h)
+    ()
+  }
+
+  class ReadProbe extends HeadStage[Unit] {
+    override def name: String = ""
+    val readCount = new AtomicInteger(0)
+    override def readRequest(size: Int): Future[Unit] = {
+      readCount.incrementAndGet()
+      Future.successful(())
+    }
+
+    override def writeRequest(data: Unit): Future[Unit] = ???
+  }
+
+  class ReadHead extends HeadStage[Unit] {
+    var lastRead: Promise[Unit] = _
+    val readCount = new AtomicInteger(0)
+    override def readRequest(size: Int): Future[Unit] = {
+      lastRead = Promise[Unit]
+      readCount.incrementAndGet()
+      lastRead.future
+    }
+    override def writeRequest(data: Unit): Future[Unit] = ???
+    override def name: String = "SlowHead"
+  }
+
+  class NoopTail extends TailStage[Unit] {
+    override def name: String = "noop"
+  }
+}


### PR DESCRIPTION
Problem

The blaze-client attempts to avoid running the potentially
effectful body of a request by sending only the prelude first,
hoping to get a EOF in return if the connection is stale.
Unfortunately, this doesn't work: we get a success even if
a peer that has sent a FIN (and we have even ACKed it).

Solution

Buffer one read, causing the OS to let us know that the
connection has gone down. This causes the stage to register
as closed as soon as that happens.