### PR TITLE
Use /dev/urandom in possibly low-entropy Travis CI environments

### DIFF
--- a/bin/travis
+++ b/bin/travis
@@ -32,6 +32,7 @@ JVM_OPTS_FILE=/tmp/jvmopts
 cp /etc/sbt/jvmopts "$JVM_OPTS_FILE"
 
 if [[ "$TRAVIS" = "true" ]] && [[ -r "/dev/urandom" ]]; then
+    echo
     echo "Using /dev/urandom in Travis CI to avoid hanging on /dev/random"
     echo "when VM or container entropy entropy is low.  Additional detail at"
     echo "https://github.com/http4s/http4s/issues/774#issuecomment-273981456 ."

--- a/bin/travis
+++ b/bin/travis
@@ -25,7 +25,27 @@ if [[ $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "release-"* ]] && [[ $TRAVIS
   fi
 fi
 
-sbt 'set scalazVersion in ThisBuild := System.getenv("SCALAZ_VERSION")' ++$TRAVIS_SCALA_VERSION $SBT_COMMAND
+
+# Put JVM options in a file where we can write to it without sudo,
+# for instance to adjust the JVM's entropy source.
+JVM_OPTS_FILE=/tmp/jvmopts
+cp /etc/sbt/jvmopts "$JVM_OPTS_FILE"
+
+if [[ "$TRAVIS" = "true" ]] && [[ -r "/dev/urandom" ]]; then
+    echo "Using /dev/urandom in Travis CI to avoid hanging on /dev/random"
+    echo "when VM or container entropy entropy is low.  Additional detail at"
+    echo "https://github.com/http4s/http4s/issues/774#issuecomment-273981456 ."
+
+    echo "-Djava.security.egd=file:/dev/./urandom" >> "$JVM_OPTS_FILE"
+    echo
+    echo "JVM_OPTS:"
+    for opt in $(grep -v -e '^#' -e '^$' "$JVM_OPTS_FILE"); do
+        echo "  $opt"
+    done
+    echo
+fi
+
+sbt 'set scalazVersion in ThisBuild := System.getenv("SCALAZ_VERSION")' ++$TRAVIS_SCALA_VERSION -jvm-opts "$JVM_OPTS_FILE" $SBT_COMMAND
 
 echo "Uploading codecov"
 if [[ $SBT_COMMAND = *";coverage"* ]]; then


### PR DESCRIPTION
Starting Tomcat in `TomcatServerSpec` seeds a `SecureRandom`
instance.  By default `/dev/random` is used on Linux and, in
low entropy environments like Travis VMs, reading from
`/dev/random` may block for long periods of time.

Reconfigure the Travis build script to point the JVM at
`/dev/urandom` to speed up the CI builds and hopefully prevent
cases of the failed builds described in #774.

References:
  https://github.com/http4s/http4s/issues/774#issuecomment-273981456
  https://github.com/travis-ci/travis-ci/issues/1494#issuecomment-157024534
  https://en.wikipedia.org/wiki//dev/random