### PR TITLE
turn on `showtimes` for specs2 to help diagnose #774

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -414,7 +414,7 @@ def http4sProject(name: String) = Project(name, file(name))
   .settings(publishSettings)
   .settings(
     moduleName := s"http4s-$name",
-    testOptions in Test += Tests.Argument(TestFrameworks.Specs2,"xonly", "failtrace"),
+    testOptions in Test += Tests.Argument(TestFrameworks.Specs2,"showtimes", "failtrace"),
     initCommands()
   )
 


### PR DESCRIPTION
Test output will now include all specs2 expecations and how long
each took to complete.