### PR TITLE
Set 30 second timeout on blaze client requests to github.com

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
@@ -1,19 +1,19 @@
 package org.http4s.client.blaze
 
+import scala.concurrent.duration._
 import scalaz.concurrent.Task
 
 import org.http4s._
 
-import org.specs2.mutable.After
-
 // TODO: this should have a more comprehensive test suite
 class ExternalBlazeHttp1ClientSpec extends Http4sSpec {
+  private val timeout = 30.seconds
 
   private val simpleClient = SimpleHttp1Client()
 
   "Blaze Simple Http1 Client" should {
     "Make simple https requests" in {
-      val resp = simpleClient.expect[String](uri("https://github.com/")).run
+      val resp = simpleClient.expect[String](uri("https://github.com/")).runFor(timeout)
       resp.length mustNotEqual 0
     }
   }
@@ -28,7 +28,7 @@ class ExternalBlazeHttp1ClientSpec extends Http4sSpec {
     def fetchBody = pooledClient.toService(_.as[String]).local { uri: Uri => Request(uri = uri) }
 
     "Make simple https requests" in {
-      val resp = fetchBody.run(uri("https://github.com/")).run
+      val resp = fetchBody.run(uri("https://github.com/")).runFor(timeout)
       resp.length mustNotEqual 0
     }
 
@@ -38,7 +38,7 @@ class ExternalBlazeHttp1ClientSpec extends Http4sSpec {
         resp.map(_.length)
       })
 
-      foreach(Task.gatherUnordered(f).run) { length =>
+      foreach(Task.gatherUnordered(f).runFor(timeout)) { length =>
         length mustNotEqual 0
       }
     }


### PR DESCRIPTION
Thread dumps[1,2] from #897 show `ExternalBlazeHttp1ClientSpec`
running just before `AsyncHttpClientSpec` times out.  Might be
coincidence, but it seems reasonable to have a (long) timeout for
calls to external URLs anyhow.

[1] https://travis-ci.org/http4s/http4s/jobs/197158086#L6885
[2] https://travis-ci.org/http4s/http4s/jobs/198883683#L8345

Refs #858 and #817