### PR TITLE
Increase `CharsetRangeSpec` timeout to 4 seconds before thread dump

### DIFF
--- a/tests/src/test/scala/org/http4s/CharsetRangeSpec.scala
+++ b/tests/src/test/scala/org/http4s/CharsetRangeSpec.scala
@@ -11,7 +11,9 @@ import scalaz.syntax.order._
 
 class CharsetRangeSpec extends Http4sSpec with ThreadDumpOnTimeout {
 
-  override def triggerThreadDumpAfter = 2.seconds
+  // wait for completion in 200ms intervals
+  override def triggerThreadDumpAfter = 4.seconds
+  override def slices = 20
 
   "*" should {
     "be satisfied by any charset when q > 0" in {


### PR DESCRIPTION
Wait for up to 20 x 200ms intervals (4 seconds) before triggering
a thread dump.  Spec frequently runs for 1-2 seconds on Travis CI
infrastructure and the 2 second timeout was firing for tests that
were likely not deadlocked.

Would not have been a big deal, but the thread dumps put Travis
over its 4MB log limit and cause the job to fail.  Longer term,
if we keep the dumps, they should be written to a log file and
uploaded to S3 instead of polluting the console output.

Refs #774