### PR TITLE
Added Extension Methods for Conversion Between Task And Future

### DIFF
--- a/core/src/main/scala/org/http4s/util/Task.scala
+++ b/core/src/main/scala/org/http4s/util/Task.scala
@@ -30,4 +30,11 @@ trait TaskFunctions {
   }
 }
 
-object task extends TaskFunctions
+object task extends TaskFunctions {
+  implicit class TaskToFutureConverter[A](task: Task[A]){
+    def unsafeToFuture : Future[A] = unsafeTaskToFuture[A](task)
+  }
+  implicit class FutureToTaskConverter[A](future: => Future[A])(implicit ec: ExecutionContext) {
+    def toTask : Task[A] = futureToTask(future)(ec)
+  }
+}


### PR DESCRIPTION
Since conversions between the blaze context Futures and the htt4s context Task happen frequently extension methods would allow us to simply convert between the two. 

This is a simplicity extension so I completely understand if we would prefer explicit function calls rather than extensions.

Closes #913 