### PR TITLE
Call toHttpResponse on MessageFailures failed/thrown by HttpService

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -7,10 +7,9 @@ import java.time.Instant
 
 import org.http4s.headers.{`Transfer-Encoding`, Date, `Content-Length`}
 import org.http4s.{headers => H, _}
-import org.http4s.Status._
 import org.http4s.blaze._
 import org.http4s.blaze.pipeline.{Command => Cmd}
-import org.http4s.util.CaseInsensitiveString._
+import org.http4s.dsl._
 import org.specs2.mutable.Specification
 import org.specs2.specification.core.Fragment
 
@@ -81,8 +80,10 @@ class Http1ServerStageSpec extends Specification {
 
   "Http1ServerStage: Errors" should {
     val exceptionService = HttpService {
-      case r if r.uri.path == "/sync" => sys.error("Synchronous error!")
-      case r if r.uri.path == "/async" => Task.fail(new Exception("Asynchronous error!"))
+      case GET -> Root / "sync" => sys.error("Synchronous error!")
+      case GET -> Root / "async" => Task.fail(new Exception("Asynchronous error!"))
+      case GET -> Root / "sync" / "422" => throw InvalidMessageBodyFailure("lol, I didn't even look")
+      case GET -> Root / "async" / "422" => Task.fail(new InvalidMessageBodyFailure("lol, I didn't even look"))
     }
 
     def runError(path: String) = runRequest(List(path), exceptionService)
@@ -95,17 +96,29 @@ class Http1ServerStageSpec extends Specification {
     "Deal with synchronous errors" in {
       val path = "GET /sync HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
       val (s,c,_) = Await.result(runError(path), 10.seconds)
-
       s must_== InternalServerError
       c must_== true
+    }
+
+    "Call toHttpResponse on synchronous errors" in {
+      val path = "GET /sync/422 HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
+      val (s,c,_) = Await.result(runError(path), 10.seconds)
+      s must_== UnprocessableEntity
+      c must_== false
     }
 
     "Deal with asynchronous errors" in {
       val path = "GET /async HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
       val (s,c,_) = Await.result(runError(path), 10.seconds)
-
       s must_== InternalServerError
       c must_== true
+    }
+
+    "Call toHttpResponse on asynchronous errors" in {
+      val path = "GET /async/422 HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
+      val (s,c,_) = Await.result(runError(path), 10.seconds)
+      s must_== UnprocessableEntity
+      c must_== false
     }
   }
 

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -3,11 +3,13 @@ package com.example.http4s
 import java.time.Instant
 
 import org.http4s._
+import org.http4s.circe._
 import org.http4s.dsl._
 import org.http4s.headers.Date
 import org.http4s.scalaxml._
-import scodec.bits.ByteVector
 
+import io.circe._
+import io.circe.syntax._
 import scala.xml.Elem
 import scala.concurrent.duration._
 import scalaz.{Reducer, Monoid}
@@ -16,6 +18,7 @@ import scalaz.stream.Process
 import scalaz.stream.Process._
 import scalaz.stream.text.utf8Encode
 import scalaz.stream.time.awakeEvery
+import scodec.bits.ByteVector
 
 /** These are routes that we tend to use for testing purposes
   * and will likely get folded into unit tests later in life */
@@ -140,5 +143,11 @@ object ScienceExperiments {
     case req @ GET -> Root / "black-knight" / _ =>
       // The servlet examples hide this.
       InternalServerError("Tis but a scratch")
+
+    case req @ POST -> Root / "echo-json" =>
+      req.as[Json].flatMap(Ok(_))
+
+    case req @ POST -> Root / "dont-care" =>
+      throw new InvalidMessageBodyFailure("lol, I didn't even read it")
   }
 }


### PR DESCRIPTION
```
case POST -> Root =>
  req.as[Json].flatMap(Ok(_))
```

If we post `NOT JSON` to that, it should return a 400, not a 500.

This is a change in behavior, but I was quite surprised by the old behavior.  I would like to release this as a patch to 0.15.