### PR TITLE
Cats - Update fs2 dependency to 0.9.3

### DIFF
--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -47,7 +47,7 @@ object Http4sBuild {
   lazy val cryptobits          = "org.reactormonk"          %% "cryptobits"              % "1.1"
   lazy val discipline          = "org.typelevel"            %% "discipline"              % "0.7.2"
   lazy val fs2Cats             = "co.fs2"                   %% "fs2-cats"                % "0.3.0"
-  lazy val fs2Io               = "co.fs2"                   %% "fs2-io"                  % "0.9.2"
+  lazy val fs2Io               = "co.fs2"                   %% "fs2-io"                  % "0.9.3"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.2.3"
   lazy val gatlingHighCharts   = "io.gatling.highcharts"     % "gatling-charts-highcharts" % gatlingTest.revision
   lazy val http4sWebsocket     = "org.http4s"               %% "http4s-websocket"        % "0.1.6"


### PR DESCRIPTION
fs2 Recently Released version 0.9.3

Seems to work clean out of the gate.