### PR TITLE
Switch to a default SSL context of SSLContext.getDefault

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -15,8 +15,13 @@ import scala.concurrent.duration.Duration
   * @param idleTimeout duration that a connection can wait without traffic before timeout
   * @param requestTimeout maximum duration for a request to complete before a timeout
   * @param userAgent optional custom user agent header
-  * @param sslContext optional custom `SSLContext` to use to replace the default, `SSLContext.getDefault`
-  * @param endpointAuthentication require endpoint authentication for encrypted connections
+  * @param sslContext optional custom `SSLContext` to use to replace
+  * the default, `SSLContext.getDefault`.
+  * @param endpointAuthentication require endpoint identification for
+  * secure requests.  If the certificate presented does not match the
+  * hostname of the request, the request fails with a CertificateException.
+  * This setting does not affect checking the validity of the cert via the
+  * `sslContext`'s trust managers.
   * @param maxResponseLineSize maximum length of the request line
   * @param maxHeaderLength maximum length of headers
   * @param maxChunkSize maximum size of chunked content chunks

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration.Duration
   * @param idleTimeout duration that a connection can wait without traffic before timeout
   * @param requestTimeout maximum duration for a request to complete before a timeout
   * @param userAgent optional custom user agent header
-  * @param sslContext optional custom `SSLContext` to use to replace the default
+  * @param sslContext optional custom `SSLContext` to use to replace the default, `SSLContext.getDefault`
   * @param endpointAuthentication require endpoint authentication for encrypted connections
   * @param maxResponseLineSize maximum length of the request line
   * @param maxHeaderLength maximum length of headers
@@ -47,8 +47,7 @@ final case class BlazeClientConfig(// HTTP properties
                                   )
 
 object BlazeClientConfig {
-  /** Default user configuration
-    */
+  /** Default configuration of a blaze client. */
   val defaultConfig =
     BlazeClientConfig(
       idleTimeout = bits.DefaultTimeout,
@@ -67,4 +66,13 @@ object BlazeClientConfig {
       customExecutor = None,
       group = None
     )
+
+  /**
+   * Creates an SSLContext that trusts all certificates and disables
+   * endpoint identification.  This is convenient in some development
+   * environments for testing with untrusted certificates, but is
+   * not recommended for production use.
+   */
+  val insecure: BlazeClientConfig =
+    defaultConfig.copy(sslContext = Some(bits.TrustingSslContext), endpointAuthentication = false)
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -5,6 +5,7 @@ package blaze
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.util.concurrent.ExecutorService
+import javax.net.ssl.SSLContext
 
 import org.http4s.Uri.Scheme
 import org.http4s.blaze.channel.nio2.ClientChannelFactory
@@ -38,7 +39,7 @@ final private class Http1Support(config: BlazeClientConfig, executor: ExecutorSe
   import Http1Support._
 
   private val ec = ExecutionContext.fromExecutorService(executor)
-  private val sslContext = config.sslContext.getOrElse(bits.sslContext)
+  private val sslContext = config.sslContext.getOrElse(SSLContext.getDefault)
   private val connectionManager = new ClientChannelFactory(config.bufferSize, config.group.orNull)
 
 ////////////////////////////////////////////////////

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
@@ -23,8 +23,6 @@ private[blaze] object bits {
 
   val ClientTickWheel = new TickWheelExecutor()
 
-
-
   def getExecutor(config: BlazeClientConfig): (ExecutorService, Task[Unit]) = config.customExecutor match {
     case Some(exec) => (exec, Task.now(()))
     case None =>
@@ -32,22 +30,14 @@ private[blaze] object bits {
       (exec, Task { exec.shutdown() })
   }
 
-  /** The sslContext which will generate SSL engines for the pipeline
-    * Override to provide more specific SSL managers */
-  lazy val sslContext = defaultTrustManagerSSLContext()
-
-  private class DefaultTrustManager extends X509TrustManager {
-    def getAcceptedIssuers(): Array[X509Certificate] =  new Array[java.security.cert.X509Certificate](0)
-    def checkClientTrusted(certs: Array[X509Certificate], authType: String): Unit = {}
-    def checkServerTrusted(certs: Array[X509Certificate], authType: String): Unit = {}
-  }
-
-  private def defaultTrustManagerSSLContext(): SSLContext = try {
+  lazy val TrustingSslContext: SSLContext = {
+    val trustManager = new X509TrustManager {
+      def getAcceptedIssuers(): Array[X509Certificate] = Array.empty
+      def checkClientTrusted(certs: Array[X509Certificate], authType: String): Unit = {}
+      def checkServerTrusted(certs: Array[X509Certificate], authType: String): Unit = {}
+    }
     val sslContext = SSLContext.getInstance("TLS")
-    sslContext.init(null, Array(new DefaultTrustManager()), new SecureRandom())
+    sslContext.init(null, Array(trustManager), new SecureRandom)
     sslContext
-  } catch {
-    case e: NoSuchAlgorithmException => throw new ExceptionInInitializerError(e)
-    case e: ExceptionInInitializerError => throw new ExceptionInInitializerError(e)
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
@@ -30,6 +30,7 @@ private[blaze] object bits {
       (exec, Task { exec.shutdown() })
   }
 
+  /** Caution: trusts all certificates and disables endpoint identification */
   lazy val TrustingSslContext: SSLContext = {
     val trustManager = new X509TrustManager {
       def getAcceptedIssuers(): Array[X509Certificate] = Array.empty


### PR DESCRIPTION
The SSL context used by default, when `BlazeClientConfig.sslContext` is `None`, trusts all certificates.  This is a bad production default, leaving users vulnerable to man-in-the-middle attacks.  We should default to `SSLContext.getDefault`.

Because we've all worked in sloppy development environments before, and because the Java SSL APIs are hostile, we provide an "insecure" blaze configuration for people who want things the way they were.