### PR TITLE
Don't add CORS headers to a fallthrough response

### DIFF
--- a/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
@@ -4,10 +4,9 @@ package middleware
 
 import java.nio.charset.StandardCharsets
 
-import org.http4s.Status._
-import org.http4s.Method._
+import org.http4s.dsl._
 import org.http4s.headers._
-
+import org.http4s.server.syntax._
 import org.specs2.mutable.Specification
 
 import scalaz._
@@ -61,6 +60,11 @@ class CORSSpec extends Specification {
       cors2(req).map(_.headers must not contain(headerCheck _)).run
     }
 
+    "Fall through" in {
+      val req = buildRequest("/2")
+      val s1 = CORS(HttpService { case GET -> Root / "1" => Ok() })
+      val s2 = CORS(HttpService { case GET -> Root / "2" => Ok() })
+      (s1 orElse s2).run(req).run.status must_== Ok
+    }
   }
-
 }


### PR DESCRIPTION
The problem is related to #803: we got stricter about what is a fallthrough in 0.15, without making good use of the type system.  The elimination of `Fallthrough` in 0.16 prevents this bug on master.

Fixes #933. /cc @mxl