### PR TITLE
Quieter logging of invalid CORS requests

### DIFF
--- a/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
@@ -4,10 +4,9 @@ package middleware
 
 import java.nio.charset.StandardCharsets
 
-import org.http4s.Status._
-import org.http4s.Method._
+import org.http4s.dsl._
 import org.http4s.headers._
-
+import org.http4s.server.syntax._
 import org.specs2.mutable.Specification
 
 import scalaz._
@@ -61,6 +60,11 @@ class CORSSpec extends Specification {
       cors2(req).map(_.headers must not contain(headerCheck _)).run
     }
 
+    "Fall through" in {
+      val req = buildRequest("/2")
+      val s1 = CORS(HttpService { case GET -> Root / "1" => Ok() })
+      val s2 = CORS(HttpService { case GET -> Root / "2" => Ok() })
+      (s1 orElse s2).run(req).run.status must_== Ok
+    }
   }
-
 }


### PR DESCRIPTION
Don't log CORS when no `Origin` header is present, and soften to debug level when it's wrong.  Note that the debug line will still appear multiple times in the example of #932.  The reason for this is that the CORS middleware is invoked twice.  This can be mitigated by composing smaller services and wrapping the result in `CORS`, assuming the config is the same.  Alternatively, using a `Router` supports different CORS configs across prefixes.

Depends on #934.  Helps with #931. /cc @mxl