### PR TITLE
Reduce number of calls to external URLs

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazePooledHttp1ClientRecycleSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazePooledHttp1ClientRecycleSpec.scala
@@ -1,0 +1,46 @@
+package org.http4s.client.blaze
+
+import org.http4s._
+import org.http4s.client.{Client, ClientRouteTestBattery}
+import org.http4s.client.testroutes.GetRoutes
+import org.specs2.specification.core.Fragments
+
+import scalaz.concurrent.Task
+
+class BlazePooledHttp1ClientRecycleSpec(client: Client)
+extends ClientRouteTestBattery("Blaze PooledHttp1Client - recycling", client) with GetRoutes {
+
+  def this() = this(PooledHttp1Client())
+
+  override def runAllTests(): Fragments = {
+    val address = initializeServer()
+    val path = "/simple"
+    val url = Uri.fromString(s"http://${address.getHostName}:${address.getPort}$path").yolo
+
+    Fragments().append {
+      "RecyclingHttp1Client" should {
+        def fetchBody = client.toService(_.as[String]).local { uri: Uri => Request(uri = uri) }
+
+        "Use supported path" in {
+          getPaths.contains(path) must beTrue
+        }
+
+        "Make simple requests" in {
+          val resp = fetchBody.run(url).runFor(timeout)
+          resp.length mustNotEqual 0
+        }
+
+        "Repeat a simple request" in {
+          val f = (0 until 10).map(_ => Task.fork {
+            val resp = fetchBody.run(url)
+            resp.map(_.length)
+          })
+
+          foreach(Task.gatherUnordered(f).runFor(timeout)) { length =>
+            length mustNotEqual 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
@@ -13,7 +13,7 @@ class ExternalBlazeHttp1ClientSpec extends Http4sSpec {
 
   "Blaze Simple Http1 Client" should {
     "Make simple https requests" in {
-      val resp = simpleClient.expect[String](uri("https://github.com/")).runFor(timeout)
+      val resp = simpleClient.expect[String](uri("https://httpbin.org/get")).runFor(timeout)
       resp.length mustNotEqual 0
     }
   }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ExternalBlazeHttp1ClientSpec.scala
@@ -1,7 +1,6 @@
 package org.http4s.client.blaze
 
 import scala.concurrent.duration._
-import scalaz.concurrent.Task
 
 import org.http4s._
 
@@ -20,31 +19,5 @@ class ExternalBlazeHttp1ClientSpec extends Http4sSpec {
 
   step {
     simpleClient.shutdown.run
-  }
-
-  private val pooledClient = PooledHttp1Client()
-
-  "RecyclingHttp1Client" should {
-    def fetchBody = pooledClient.toService(_.as[String]).local { uri: Uri => Request(uri = uri) }
-
-    "Make simple https requests" in {
-      val resp = fetchBody.run(uri("https://github.com/")).runFor(timeout)
-      resp.length mustNotEqual 0
-    }
-
-    "Repeat a simple https request" in {
-      val f = (0 until 10).map(_ => Task.fork {
-        val resp = fetchBody.run(uri("https://github.com/"))
-        resp.map(_.length)
-      })
-
-      foreach(Task.gatherUnordered(f).runFor(timeout)) { length =>
-        length mustNotEqual 0
-      }
-    }
-  }
-
-  step {
-    pooledClient.shutdown.run
   }
 }


### PR DESCRIPTION
Leave one external SSL call, now https://httpbin.org/get instead of https://github.com/, and use Jetty for the looping blaze-client SSL tests.  Theory is fewer external calls will reduce the number of timeouts we're seeing in Travis CI builds.  Specific examples detailed in #909.

Partially implements [suggestions](https://gitter.im/http4s/http4s?at=58a73413aa800ee52cabed70) by @rossabaker.