### PR TITLE
Added option for compatibility with typelevel scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val parboiled2 = libraryProject("parboiled2")
   .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(
-      scalaReflect(scalaVersion.value) % "provided"
+      scalaReflect(scalaOrganization.value, scalaVersion.value) % "provided"
     ),
     unmanagedSourceDirectories in Compile ++= {
       scalaBinaryVersion.value match {
@@ -58,7 +58,7 @@ lazy val core = libraryProject("core")
       http4sWebsocket,
       log4s,
       macroCompat,
-      scalaCompiler(scalaVersion.value) % "provided",
+      scalaCompiler(scalaOrganization.value, scalaVersion.value) % "provided",
       scalazCore(scalazVersion.value),
       scalazStream(scalazVersion.value)
     ),

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -29,7 +29,7 @@ object Http4sBuild {
 
   val macroParadiseSetting =
     libraryDependencies ++= Seq(
-      Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)),
+      Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)),
       VersionNumber(scalaVersion.value).numbers match {
         case Seq(2, 10, _*) => Seq(quasiquotes)
         case _ => Seq.empty

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -80,8 +80,8 @@ object Http4sBuild {
   lazy val quasiquotes         = "org.scalamacros"          %% "quasiquotes"             % "2.1.0"
   lazy val reactiveStreamsTck  = "org.reactivestreams"       % "reactive-streams-tck"    % "1.0.0"
   lazy val scalacheck          = "org.scalacheck"           %% "scalacheck"              % "1.13.4"
-  def scalaCompiler(sv: String) = "org.scala-lang"           % "scala-compiler"          % sv
-  def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
+  def scalaCompiler(so: String, sv: String)     = so                      % "scala-compiler"            % sv
+  def scalaReflect(so: String, sv: String)      = so                      % "scala-reflect"             % sv
   lazy val scalaXml            = "org.scala-lang.modules"   %% "scala-xml"               % "1.0.5"
   def scalazCore(version: String)               = "org.scalaz"           %% "scalaz-core"               % version
   def scalazScalacheckBinding(version: String)  = "org.scalaz"           %% "scalaz-scalacheck-binding" % version


### PR DESCRIPTION
Takes scalaOrganization, but I don't think we have any crossbuild. I think this would be a different publication, and probably should also effect scala xml, but I wanted to put it out there for compatibility. 

typelevel/scala#135