### PR TITLE
Update Travis SBT for 0.13.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
   - SCALAZ_VERSION=7.1.11
   - SCALAZ_VERSION=7.2.8
 before_script:
-- mkdir -p $HOME/.sbt/launchers/0.13.8/
-- curl -L -o $HOME/.sbt/launchers/0.13.8/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.8/sbt-launch.jar
+- mkdir -p $HOME/.sbt/launchers/0.13.13/
+- curl -L -o $HOME/.sbt/launchers/0.13.13/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.13/sbt-launch.jar
 - mkdir $HOME/bin
 - export PATH=$HOME/bin:$PATH
 script: bash bin/travis


### PR DESCRIPTION
If this was here for another reason let me know, but project uses 0.13.13 so why don't we pull that?