### PR TITLE
Move script tags for jQuery and Bootstrap to bottom of page

### DIFF
--- a/docs/src/hugo/layouts/index.html
+++ b/docs/src/hugo/layouts/index.html
@@ -23,5 +23,6 @@
 	</div>
       </div>
     </div>
+    {{ partial "scripts.html" . }}
   </body>
 </html>

--- a/docs/src/hugo/layouts/partials/head.html
+++ b/docs/src/hugo/layouts/partials/head.html
@@ -8,7 +8,4 @@
   <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Share+Tech+Mono" >
   <link rel="stylesheet" type="text/css" href="/css/highlight-github.css">
   <link rel="stylesheet" type="text/css" href="/css/style.css" >
-
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-  <script src="/js/bootstrap.min.js"></script>
 </head>

--- a/docs/src/hugo/layouts/single.html
+++ b/docs/src/hugo/layouts/single.html
@@ -20,5 +20,6 @@
 	</nav>
       </div>
     </footer>
+    {{ partial "scripts.html" . }}
   </body>
 </html>


### PR DESCRIPTION
There might be a slight performance gain[1] for loading the
scripts late in the page.

More importantly, removes conflicting versions of jQuery that
could break some Bootstrap behavior.  For example, it was not
possible to add a (working) Bootstrap dropdown navigation menu
in `/v0.16/index.html` before this change.

[1] http://stackoverflow.com/a/1638705