### PR TITLE
Add documentation dropdown menu to website navbar

### DIFF
--- a/docs/src/hugo/content/versions.md
+++ b/docs/src/hugo/content/versions.md
@@ -1,6 +1,5 @@
 ---
 type: common
-menu: main
 weight: 100
 title: Versions
 ---

--- a/docs/src/hugo/layouts/index.html
+++ b/docs/src/hugo/layouts/index.html
@@ -23,5 +23,6 @@
 	</div>
       </div>
     </div>
+    {{ partial "scripts.html" . }}
   </body>
 </html>

--- a/docs/src/hugo/layouts/partials/head.html
+++ b/docs/src/hugo/layouts/partials/head.html
@@ -8,7 +8,4 @@
   <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Share+Tech+Mono" >
   <link rel="stylesheet" type="text/css" href="/css/highlight-github.css">
   <link rel="stylesheet" type="text/css" href="/css/style.css" >
-
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-  <script src="/js/bootstrap.min.js"></script>
 </head>

--- a/docs/src/hugo/layouts/partials/nav-docs.html
+++ b/docs/src/hugo/layouts/partials/nav-docs.html
@@ -3,6 +3,8 @@
     Documentation <span class="caret"></span>
   </a>
   <ul class="dropdown-menu" aria-labelledby="doc-menu-item">
+    <li><a href="/versions/">Versions</a></li>
+    <li role="separator" class="divider"></li>
     <li class="dropdown-header">v0.16 (unreleased)</li>
     <li><a href="/v0.16/">Tutorial</a></li>
     <li><a href="/v0.16/api/org/http4s/">Scaladoc</a></li>

--- a/docs/src/hugo/layouts/partials/nav-docs.html
+++ b/docs/src/hugo/layouts/partials/nav-docs.html
@@ -1,0 +1,14 @@
+<li class="dropdown">
+  <a class="dropdown-toggle" id="doc-menu-item" data-toggle="dropdown" data-target="#" href="http://http4s.org/" role="button" aria-haspopup="true" aria-expanded="false">
+    Documentation <span class="caret"></span>
+  </a>
+  <ul class="dropdown-menu" aria-labelledby="doc-menu-item">
+    <li class="dropdown-header">v0.16 (unreleased)</li>
+    <li><a href="/v0.16/">Tutorial</a></li>
+    <li><a href="/v0.16/api/org/http4s/">Scaladoc</a></li>
+    <li role="separator" class="divider"></li>
+    <li class="dropdown-header">v0.15</li>
+    <li><a href="/v0.15/">Tutorial</a></li>
+    <li><a href="/v0.15/api/">Scaladoc</a></li>
+  </ul>
+</li>

--- a/docs/src/hugo/layouts/partials/nav.html
+++ b/docs/src/hugo/layouts/partials/nav.html
@@ -19,6 +19,7 @@
 	    <a href="{{ .URL }}">{{ .Name }}</a>
 	  </li>
 	{{ end }}
+	{{ partial "nav-docs.html" . }}
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li><a href="https://github.com/http4s/http4s" title="http4s/http4s on GitHub"><span class="icon-github-circled"></span></a></li>	

--- a/docs/src/hugo/layouts/single.html
+++ b/docs/src/hugo/layouts/single.html
@@ -20,5 +20,6 @@
 	</nav>
       </div>
     </footer>
+    {{ partial "scripts.html" . }}
   </body>
 </html>


### PR DESCRIPTION
Introduces "Documentation" dropdown with direct links to the v0.15
and v0.16 tuts and scaladocs.  Relocated "Versions" menu item under
"Documentation".

![http4s_docs_dropdown_menu](https://cloud.githubusercontent.com/assets/70307/23345918/247afa28-fc63-11e6-8992-aade35e4e30a.png)

Fixes #819 and #903