### PR TITLE
Avoid Travis OOM by constraining memory usage during build

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,11 @@
+# Make sure JVM resident memory stays below 4gb allowed by Travis
+# container infrastructure.
+# https://docs.travis-ci.com/user/migrating-from-legacy/#More-available-resources
+#
+# With 1536m of heap, 768m of metaspace, and 6m stack size, observed
+# maximum was ~3.2gb with OpenJDK 1.8.0_121.
+
+-Xms1536M
+-Xmx1536M
+-XX:MaxMetaspaceSize=768M
+-Xss6M

--- a/bin/travis
+++ b/bin/travis
@@ -25,6 +25,13 @@ if [[ $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "release-"* ]] && [[ $TRAVIS
   fi
 fi
 
+# Make sure JVM resident memory stays below 4gb allowed by Travis
+# container infrastructure.
+# https://docs.travis-ci.com/user/migrating-from-legacy/#More-available-resources
+#
+# With 1536m of heap, 768m of metaspace, and 6m stack size, observed
+# maximum was ~3.2gb with OpenJDK 1.8.0_121.
+SBT_EXTRA_OPTS="-J-Xms1536M -J-Xmx1536M -J-XX:MaxMetaspaceSize=768M"
 
 # Put JVM options in a file where we can write to it without sudo,
 # for instance to adjust the JVM's entropy source.
@@ -46,7 +53,7 @@ if [[ "$TRAVIS" = "true" ]] && [[ -r "/dev/urandom" ]]; then
     echo
 fi
 
-sbt 'set scalazVersion in ThisBuild := System.getenv("SCALAZ_VERSION")' ++$TRAVIS_SCALA_VERSION -jvm-opts "$JVM_OPTS_FILE" $SBT_COMMAND
+sbt $SBT_EXTRA_OPTS 'set scalazVersion in ThisBuild := System.getenv("SCALAZ_VERSION")' ++$TRAVIS_SCALA_VERSION $SBT_COMMAND
 
 echo "Uploading codecov"
 if [[ $SBT_COMMAND = *";coverage"* ]]; then

--- a/bin/travis
+++ b/bin/travis
@@ -33,10 +33,6 @@ fi
 # maximum was ~3.2gb with OpenJDK 1.8.0_121.
 SBT_EXTRA_OPTS="-J-Xms1536M -J-Xmx1536M -J-XX:MaxMetaspaceSize=768M"
 
-# Put JVM options in a file where we can write to it without sudo,
-# for instance to adjust the JVM's entropy source.
-JVM_OPTS_FILE=/tmp/jvmopts
-cp /etc/sbt/jvmopts "$JVM_OPTS_FILE"
 
 if [[ "$TRAVIS" = "true" ]] && [[ -r "/dev/urandom" ]]; then
     echo
@@ -44,13 +40,7 @@ if [[ "$TRAVIS" = "true" ]] && [[ -r "/dev/urandom" ]]; then
     echo "when VM or container entropy entropy is low.  Additional detail at"
     echo "https://github.com/http4s/http4s/issues/774#issuecomment-273981456 ."
 
-    echo "-Djava.security.egd=file:/dev/./urandom" >> "$JVM_OPTS_FILE"
-    echo
-    echo "JVM_OPTS:"
-    for opt in $(grep -v -e '^#' -e '^$' "$JVM_OPTS_FILE"); do
-        echo "  $opt"
-    done
-    echo
+    SBT_EXTRA_OPTS="$SBT_EXTRA_OPTS -Djava.security.egd=file:/dev/./urandom"
 fi
 
 sbt $SBT_EXTRA_OPTS 'set scalazVersion in ThisBuild := System.getenv("SCALAZ_VERSION")' ++$TRAVIS_SCALA_VERSION $SBT_COMMAND

--- a/bin/travis
+++ b/bin/travis
@@ -25,14 +25,7 @@ if [[ $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "release-"* ]] && [[ $TRAVIS
   fi
 fi
 
-# Make sure JVM resident memory stays below 4gb allowed by Travis
-# container infrastructure.
-# https://docs.travis-ci.com/user/migrating-from-legacy/#More-available-resources
-#
-# With 1536m of heap, 768m of metaspace, and 6m stack size, observed
-# maximum was ~3.2gb with OpenJDK 1.8.0_121.
-SBT_EXTRA_OPTS="-J-Xms1536M -J-Xmx1536M -J-XX:MaxMetaspaceSize=768M"
-
+SBT_EXTRA_OPTS=""
 
 if [[ "$TRAVIS" = "true" ]] && [[ -r "/dev/urandom" ]]; then
     echo


### PR DESCRIPTION
Reduce max heap usage to 1.5gb and max metaspace to 0.75gb to keep
the overal JVM usage safely below the 4gb allowed by Travis[1].

Longer version...

When Travis builds with 2.12.1 and scalaz-7.2 on master, it runs
with:

    ;coverage ;clean ;test ;makeSite ;mimaReportBinaryIssues ;coverageReport ;coverageOff ;publish ;ghpagesPushSite

Locally (with OpenJDK 1.8.0_121), I have seen the JVM for those
builds use more than 3.6gb of resident memory.  Strongly suspect
memory limit, and the kernel OOM killer steps in.

After monitoring several builds with VisualVM, 1.5gb should be
more than enough heap and capping the metaspace at 0.75gb (with
stack size of 6mb), keeps the large builds closer to 3.2gb max.

Fixes #965

[1] https://docs.travis-ci.com/user/migrating-from-legacy/#More-available-resources