### PR TITLE
Better author and commit message when Travis publishes to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ cache:
   - "$HOME/.sbt/boot"
 before_install:
   # Record minimal build information via the Git user ident
-  - git config --global user.name "$USER"
-  - git config --global user.email "$TRAVIS_BUILD_NUMBER@$TRAVIS_COMMIT"
+  - git config --global user.name "Travis CI"
+  - git config --global user.email "travis-ci@http4s.org"
   # Add secret deploy key to ssh-agent for deploy
   - eval "$(ssh-agent -s)"
   - openssl aes-256-cbc -d -K $encrypted_8735ae5b3321_key -iv $encrypted_8735ae5b3321_iv -in project/travis-deploy-key.enc | ssh-add -

--- a/bin/travis
+++ b/bin/travis
@@ -2,6 +2,21 @@
 
 set -e
 
+# Build git commit message to be used when Travis updates the
+# gh-pages branch to publish a new version of the website.
+function gh_pages_commit_message() {
+    local SHORT_COMMIT=$(printf "%.8s" "$TRAVIS_COMMIT")
+    cat <<EOM
+updated site
+
+   Job: $TRAVIS_JOB_NUMBER
+Commit: $SHORT_COMMIT
+Detail: $TRAVIS_BUILD_ID
+EOM
+}
+
+
+
 if [[ $TRAVIS_SCALA_VERSION == 2.11* ]] && [[ $SCALAZ_VERSION = 7.2* ]]; then
   SBT_COMMAND=";coverage ;clean ;test ;makeSite ;mimaReportBinaryIssues ;coverageReport ;coverageOff"
 else
@@ -18,6 +33,7 @@ if [[ $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "release-"* ]] && [[ $TRAVIS
   SBT_COMMAND="$SBT_COMMAND ;publish"
   if [[ $SBT_COMMAND == *"makeSite"* ]]; then
     SBT_COMMAND="$SBT_COMMAND ;ghpagesPushSite"
+    export SBT_GHPAGES_COMMIT_MESSAGE=$(gh_pages_update_commit_message)
   fi
 fi
 

--- a/bin/travis
+++ b/bin/travis
@@ -33,7 +33,8 @@ if [[ $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "release-"* ]] && [[ $TRAVIS
   SBT_COMMAND="$SBT_COMMAND ;publish"
   if [[ $SBT_COMMAND == *"makeSite"* ]]; then
     SBT_COMMAND="$SBT_COMMAND ;ghpagesPushSite"
-    export SBT_GHPAGES_COMMIT_MESSAGE=$(gh_pages_update_commit_message)
+    SBT_GHPAGES_COMMIT_MESSAGE=$(gh_pages_commit_message)
+    export SBT_GHPAGES_COMMIT_MESSAGE
   fi
 fi
 

--- a/bin/travis
+++ b/bin/travis
@@ -11,7 +11,7 @@ updated site
 
    Job: $TRAVIS_JOB_NUMBER
 Commit: $SHORT_COMMIT
-Detail: $TRAVIS_BUILD_ID
+Detail: https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID
 EOM
 }
 


### PR DESCRIPTION
Revert to author to `Travis CI <travis-ci@http4s.org>` after change
in #970.  Include build metadata in the git commit message.

Example:

    updated site
    
       Job: 3748.6
    Commit: 90626678
    Detail: https://travis-ci.org/http4s/http4s/jobs/206466634