### PR TITLE
Log unhandled MessageFailure before backends render them

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -108,9 +108,7 @@ private class Http1ServerStage(service: HttpService,
     parser.collectMessage(body, requestAttrs) match {
       case \/-(req) =>
         Task.fork(serviceFn(req))(pool)
-          .handleWith {
-            case mf: MessageFailure => mf.toHttpResponse(req.httpVersion)
-          }
+          .handleWith(messageFailureHandler(req))
           .runAsync {
             case \/-(resp) => renderResponse(req, resp, cleanup)
             case -\/(t)    => internalServerError(s"Error running route: $req", t, req, cleanup)

--- a/docs/src/main/tut/error-handling.md
+++ b/docs/src/main/tut/error-handling.md
@@ -1,0 +1,36 @@
+---
+menu: error-handling
+title: Error handling
+weight: 320
+---
+
+A `MessageFailure` indicates an error handling an HTTP message.  These
+include:
+
+* `ParsingFailure`: indicative of a malformed HTTP message in the
+  request line or headers.
+* `MalformedMessageBodyFailure`: indicative of a message that has a
+  syntactic error in its body.  For example, trying to decode `{
+  "broken:"` as JSON will result in a `MalforedMessageBodyFailure`.
+* `InvalidMessageBodyFailure`: indicative of a message that is
+  syntactically correct, but semantically incorrect.  A well-formed
+  JSON request that is missing expected fields may generate this
+  failure.
+* `MediaTypeMissing`: indiciates that the message had no media type,
+  and the server wasn't willing to infer it.
+* `MediaTypeMismatch`: indiciates that the server received a media
+  type that it wasn't prepared to handle.
+
+## Logging
+
+If a `MessageFailure` is not handled by your HTTP service, it reaches
+the backend in the form of a failed task, where it is transformed into
+an HTTP response.  To guard against XSS attacks, care is taken in each
+of these renderings to not reflect information back from the request.
+Diagnostic information about syntax errors or missing fields,
+including a full stack trace, is logged to the
+`org.http4s.server.message-failures` category at `DEBUG` level.
+
+## Customizing error handling
+
+TODO

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -48,7 +48,7 @@ package object server {
   private[this] val messageFailureLogger = getLogger("org.http4s.server.message-failures")
   def messageFailureHandler(req: Request): PartialFunction[Throwable, Task[Response]] = {
     case mf: MessageFailure =>
-      messageFailureLogger.debug(mf)(s"Message failure handling request: ${req.method} ${req.pathInfo}")
+      messageFailureLogger.debug(mf)(s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr.getOrElse("<unknown>")}""")
       mf.toHttpResponse(req.httpVersion)
   }
 }

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -1,5 +1,6 @@
 package org.http4s
 
+import org.log4s.getLogger
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
@@ -42,5 +43,12 @@ package object server {
         .local({authed: AuthedRequest[Err \/ T] => authed.authInfo.bimap(err => AuthedRequest(err, authed.req), suc => AuthedRequest(suc, authed.req))})
         .compose(AuthedRequest(authUser))
     }
+  }
+
+  private[this] val messageFailureLogger = getLogger("org.http4s.server.message-failures")
+  def messageFailureHandler(req: Request): PartialFunction[Throwable, Task[Response]] = {
+    case mf: MessageFailure =>
+      messageFailureLogger.debug(mf)(s"Message failure handling request: ${req.method} ${req.pathInfo}")
+      mf.toHttpResponse(req.httpVersion)
   }
 }

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -24,7 +24,6 @@ class Http4sServlet(service: HttpService,
   extends HttpServlet
 {
   private[this] val logger = getLogger
-  private[this] val messageFailureLogger = getLogger("org.http4s.server.message-failures")
 
   private val asyncTimeoutMillis = if (asyncTimeout.isFinite()) asyncTimeout.toMillis else -1 // -1 == Inf
 

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -24,6 +24,7 @@ class Http4sServlet(service: HttpService,
   extends HttpServlet
 {
   private[this] val logger = getLogger
+  private[this] val messageFailureLogger = getLogger("org.http4s.server.message-failures")
 
   private val asyncTimeoutMillis = if (asyncTimeout.isFinite()) asyncTimeout.toMillis else -1 // -1 == Inf
 
@@ -84,13 +85,12 @@ class Http4sServlet(service: HttpService,
                             bodyWriter: BodyWriter): Task[Unit] = {
     ctx.addListener(new AsyncTimeoutHandler(request, bodyWriter))
     val response = Task.fork {
-      try serviceFn(request).handleWith {
+      try serviceFn(request)
         // Handle message failures coming out of the service as failed tasks
-        case mf: MessageFailure => mf.toHttpResponse(request.httpVersion)
-      } catch {
+        .handleWith(messageFailureHandler(request))
+      catch
         // Handle message failures _thrown_ by the service, just in case
-        case mf: MessageFailure => mf.toHttpResponse(request.httpVersion)
-      }
+        messageFailureHandler(request)
     }(threadPool)
     val servletResponse = ctx.getResponse.asInstanceOf[HttpServletResponse]
     renderResponse(response, servletResponse, bodyWriter)


### PR DESCRIPTION
When a server converts a `MessageFailure` to an HTTP response, we're throwing away the diagnostic information that comes in the message.  The response renderings are carefully designed not to reflect request information back to the client to guard against XSS attacks by default, but at the very least the server operator should be able to support clients.  This logs all such failures to `org.http4s.server.message-failures` at DEBUG level.

Fixes #980, starts on #981.

This is binary compatible and can be released as a patch to 0.15.x.

Thanks to @thetrav for reporting this.