### PR TITLE
Extract webhook URL for Gitter into Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script: bash bin/travis
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/053866704df09e101f16
+      - $GITTER_WEBHOOK_URL
     on_success: change
     on_failure: always
     on_start: never


### PR DESCRIPTION
Prevents Traivs builds in repos other than http4s/http4s from posting to the http4s Gitter channel.