### PR TITLE
Get rid of delambdafy on 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -465,21 +465,12 @@ lazy val commonSettings = Seq(
     s"-target:jvm-${jvmTarget.value}"
   ),
   scalacOptions in (Compile, doc) += "-no-link-warnings",
-  scalacOptions ++= scalaVersion.map { v =>
-    if (delambdafyOpts(v)) Seq(
-      "-Ybackend:GenBCode"
-    ) else Seq.empty
-  }.value,
   javacOptions ++= Seq(
     "-source", jvmTarget.value,
     "-target", jvmTarget.value,
     "-Xlint:deprecation",
     "-Xlint:unchecked"
   ),
-  libraryDependencies ++= scalaVersion(v =>
-    if (delambdafyOpts(v)) Seq("org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0")
-    else Seq.empty
-  ).value,
   libraryDependencies ++= scalazVersion(sz => Seq(
     discipline,
     logbackClassic,
@@ -538,14 +529,6 @@ lazy val mimaSettings = Seq(
     )
   }
 )
-
-// Check whether to enable java 8 type lambdas
-// https://github.com/scala/make-release-notes/blob/2.11.x/experimental-backend.md
-// Minimum scala version is 2.11.8 due to sbt/sbt#2076
-def delambdafyOpts(v: String): Boolean = VersionNumber(v).numbers match {
-  case Seq(2, 11, x, _*) if x > 7 => true
-  case _ => false
-}
 
 def initCommands(additionalImports: String*) =
   initialCommands := (List(


### PR DESCRIPTION
This was the cause of some pain in rho between 2.11.7 to 2.11.8,
whereupon @reactormonk and I were advised by the compiler folks that
these flags are exprimental and unmaintained in 2.11.  We'll leave
them in 0.15.x because binary compatibility worries me more than
what's left of these flags, but 0.16.x is a new beginning.