### PR TITLE
Install a fresher JDK in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: scala
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 scala:
 - 2.12.1
 - 2.11.8


### PR DESCRIPTION
I can't reproduce the metaspace problems locally, and the JDK is one
variable.  The one in the Travis container (1.8.0_31) is ancient.
Does this help?