### PR TITLE
Upgrade builds from Ubuntu Precise to Trusty for newer JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ scala:
 - 2.11.8
 - 2.10.6
 jdk: oraclejdk8
+dist: trusty
 env:
   global:
   - HUGO_VERSION=0.18

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
-- 2.12.1
-- 2.11.8
-- 2.10.6
+  - 2.12.1
+  - 2.11.8
+  - 2.10.6
 jdk: oraclejdk8
 dist: trusty
 env:
@@ -14,10 +14,10 @@ env:
   - SCALAZ_VERSION=7.2.8
   - SCALAZ_VERSION=7.1.11
 before_script:
-- mkdir -p $HOME/.sbt/launchers/$SBT_VERSION/
-- curl -L -o $HOME/.sbt/launchers/$SBT_VERSION/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar
-- mkdir $HOME/bin
-- export PATH=$HOME/bin:$PATH
+  - mkdir -p $HOME/.sbt/launchers/$SBT_VERSION/
+  - curl -L -o $HOME/.sbt/launchers/$SBT_VERSION/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar
+  - mkdir $HOME/bin
+  - export PATH=$HOME/bin:$PATH
 script: bash bin/travis
 notifications:
   webhooks:

--- a/bin/travis
+++ b/bin/travis
@@ -28,13 +28,13 @@ if [[ $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "release-"* ]] && [[ $TRAVIS
   SBT_COMMAND="$SBT_COMMAND ;publish"
   if [[ $TRAVIS_BUILD_NUMBER == 1 ]] && [[ ! -z $encrypted_8735ae5b3321_key ]]; then
     # Record minimal build information via the Git user ident
-    git config --global user.name "Travis CI";
-    git config --global user.email "travis-ci@http4s.org";
+    git config --global user.name "Travis CI"
+    git config --global user.email "travis-ci@http4s.org"
     SBT_GHPAGES_COMMIT_MESSAGE=$(gh_pages_commit_message)
     export SBT_GHPAGES_COMMIT_MESSAGE
     # Add secret deploy key to ssh-agent for deploy
-    eval "$(ssh-agent -s)";
-    openssl aes-256-cbc -d -K $encrypted_8735ae5b3321_key -iv $encrypted_8735ae5b3321_iv -in project/travis-deploy-key.enc | ssh-add -;
+    eval "$(ssh-agent -s)"
+    openssl aes-256-cbc -d -K $encrypted_8735ae5b3321_key -iv $encrypted_8735ae5b3321_iv -in project/travis-deploy-key.enc | ssh-add -
     SBT_COMMAND="$SBT_COMMAND ;ghpagesPushSite"
   fi
 fi


### PR DESCRIPTION
Currently the default OracleJDK on Precise is 1.8.0_31 and the default on Trusty is 1.8.0_111 (one release behind current).

This is an alternate to #988 to in hopes of tracking down metaspace problems.