### PR TITLE
Fix logic to pick Travis job where coverage and mima are run

### DIFF
--- a/bin/travis
+++ b/bin/travis
@@ -2,6 +2,32 @@
 
 set -e
 
+# Extra tasks are run for one build in the Trais matrix.  Currently includes:
+# `makeSite` `mimaReportBinaryIssues` via the `validate` alias and `publish`.
+function primary_build() {
+    if [[ $TRAVIS_SCALA_VERSION == 2.12* ]] && [[ $SCALAZ_VERSION == 7.2* ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Publishing to Sonatype or gh-pages only done from select branches and
+# never from pull requests.
+function publish_site() {
+    if [[ $TRAVIS_BRANCH == "master" || $TRAVIS_BRANCH == "release-"* ]] && [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Install hugo static site generator from GitHub releases page.
+function install_hugo() {
+    curl -s -L "https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz" | tar xzf -
+    mv "hugo_${HUGO_VERSION}_linux_amd64/hugo_${HUGO_VERSION}_linux_amd64" "$HOME/bin/hugo"
+}
+
 # Build git commit message to be used when Travis updates the
 # gh-pages branch to publish a new version of the website.
 function gh_pages_commit_message() {
@@ -15,18 +41,23 @@ Detail: https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID
 EOM
 }
 
-if [[ $TRAVIS_BUILD_NUMBER == 1 ]]; then
-  curl -s -L https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar xzf -
-  mv hugo_${HUGO_VERSION}_linux_amd64/hugo_${HUGO_VERSION}_linux_amd64 $HOME/bin/hugo
+
+
+# Real work starts here.  Configure sbt with the right tasks and
+# options.  If we're going to publish the site, configure git, ssh,
+# and the gh-pages commit message first.
+
+if primary_build; then
+  install_hugo
   SBT_COMMAND=";coverage ;clean ;validate ;coverageReport ;coverageOff"
 else
   SBT_COMMAND=";test"
 fi
 
-if [[ $TRAVIS_BRANCH = "master" || $TRAVIS_BRANCH = "release-"* ]] && [[ $TRAVIS_PULL_REQUEST = "false" ]]; then
+if publish_site; then
   echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
   SBT_COMMAND="$SBT_COMMAND ;publish"
-  if [[ $TRAVIS_BUILD_NUMBER == 1 ]] && [[ ! -z $encrypted_8735ae5b3321_key ]]; then
+  if primary_build && [[ ! -z $encrypted_8735ae5b3321_key ]]; then
     # Record minimal build information via the Git user ident
     git config --global user.name "Travis CI";
     git config --global user.email "travis-ci@http4s.org";
@@ -53,6 +84,6 @@ fi
 sbt $SBT_EXTRA_OPTS 'set scalazVersion in ThisBuild := System.getenv("SCALAZ_VERSION")' ++$TRAVIS_SCALA_VERSION $SBT_COMMAND
 
 echo "Uploading codecov"
-if [[ $TRAVIS_BUILD_NUMBER == 1 ]]; then
+if primary_build; then
    bash <(curl -s https://codecov.io/bash)
 fi


### PR DESCRIPTION
The change to `$TRAVIS_BUILD_NUMBER == 1` in commit 96bb7c5e
did not work as expected.  That value is a counter that
increments for every Travis run.  3817 is a recent example.

This is an example job showing the wrong behavior:
https://travis-ci.org/http4s/http4s/jobs/207603576#L320
Travis is building with Scala 2.12.1 and scalaz 7.2.8, but only
running with `;test ;publish`.

Switched back to checking $TRAVIS_SCALA_VERSION and $SCALAZ_VERSION
because it works and is more explicit.  Looked for a Travis environment
variable for the position in the matrix, but it's not exposed directly.
Would need to use the suffix of $TRAVIS_JOB_NUMBER.

Also extract some of the shell script logic into named functions
so it's easier to follow the guts of the script.  Might make sense
to move those function into a separate file and source them from
bin/travis in a future commit.