### PR TITLE
Temporarily allow Travis to use more metaspace

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -7,5 +7,5 @@
 
 -Xms1536M
 -Xmx1536M
--XX:MaxMetaspaceSize=768M
+-XX:MaxMetaspaceSize=1024M
 -Xss6M


### PR DESCRIPTION
Floating this as a temporary measure to get more green out of
Travis until we fix the root causes of metaspace usage under
control.  The build's excessive use metaspace isn't new; it just
became more visible after the recent `.jvmopts` addition (e2fc00aa).

@rossabaker has started some work to improve things in the specs
and I would want to see either a `git revert` on this commit once
we make progress, or perhaps a reduction in the max we allow.

Also worth saying that http4s itself is not a metaspace hog, the
compile and test suite is.

Refs #988