### PR TITLE
Fix deadlock of CharsetRangeSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -587,6 +587,7 @@ lazy val mimaSettings = Seq(
       exclude[ReversedMissingMethodProblem]("org.http4s.testing.ArbitraryInstances.genSubDelims"),
       exclude[ReversedMissingMethodProblem]("org.http4s.testing.ArbitraryInstances.arbitraryUriHost"),
       exclude[ReversedMissingMethodProblem]("org.http4s.testing.ArbitraryInstances.arbitraryAuthority"),
+      exclude[ReversedMissingMethodProblem]("org.http4s.testing.ArbitraryInstances.genCharsetRangeNoQuality"),
       exclude[ReversedMissingMethodProblem]("org.http4s.testing.ArbitraryInstances.genHexDigit"),
       exclude[ReversedMissingMethodProblem]("org.http4s.testing.ArbitraryInstances.genPctEncoded"),
       exclude[ReversedMissingMethodProblem]("org.http4s.testing.ArbitraryInstances.arbitraryUri"),

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -119,7 +119,7 @@ trait ArbitraryInstances {
 
   implicit lazy val arbitraryCharsetRange: Arbitrary[CharsetRange] =
     Arbitrary { for {
-      charsetRange <- charsetRangesNoQuality
+      charsetRange <- genCharsetRangeNoQuality
       q <- arbitrary[QValue]
     } yield charsetRange.withQValue(q) }
 
@@ -132,16 +132,20 @@ trait ArbitraryInstances {
   implicit lazy val arbitraryCharsetSplatRange: Arbitrary[CharsetRange.`*`] =
     Arbitrary { arbitrary[QValue].map(CharsetRange.`*`.withQValue(_)) }
 
-  lazy val charsetRangesNoQuality: Gen[CharsetRange] =
+  def genCharsetRangeNoQuality: Gen[CharsetRange] =
     frequency(
       3 -> arbitrary[Charset].map(CharsetRange.fromCharset),
       1 -> const(CharsetRange.`*`)
     )
 
+  @deprecated("Use genCharsetRangeNoQuality. This one may cause deadlocks.", "0.15.7")
+  lazy val charsetRangesNoQuality: Gen[CharsetRange] =
+    genCharsetRangeNoQuality
+
   implicit lazy val arbitraryAcceptCharset: Arbitrary[`Accept-Charset`] =
     Arbitrary { for {
       // make a set first so we don't have contradictory q-values
-      charsetRanges <- nonEmptyContainerOf[Set, CharsetRange](charsetRangesNoQuality).map(_.toVector)
+      charsetRanges <- nonEmptyContainerOf[Set, CharsetRange](genCharsetRangeNoQuality).map(_.toVector)
       qValues <- containerOfN[Vector, QValue](charsetRanges.size, arbitraryQValue.arbitrary)
       charsetRangesWithQ = charsetRanges.zip(qValues).map { case (range, q) => range.withQValue(q) }
     } yield `Accept-Charset`(charsetRangesWithQ.head, charsetRangesWithQ.tail:_*) }


### PR DESCRIPTION
* `genCharsetRangeNoQuality` -> `arbitraryCharset.arbitrary`
* `arbitraryCharset.arbitrary` -> `arbitraryNioCharset`

Each needs the lock of the other.  This is a "non-circular dependency"
as described in SIP-20.

A better solution based on defs or vals will be designed for 0.16.
This is a binary-compatible mitigation for 0.15.

Fixes #774