### PR TITLE
Turn on -Ypartial-unification

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -32,9 +32,9 @@ object Http4sPlugin extends AutoPlugin {
     scalazVersion := (sys.env.get("SCALAZ_VERSION") getOrElse "7.2.8"),
     unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / VersionNumber(scalazVersion.value).numbers.take(2).mkString("scalaz-", ".", ""),
 
-    // Curiously missing from RigPlugin
     scalacOptions in Compile ++= Seq(
-      "-Yno-adapted-args"
+      "-Yno-adapted-args", // Curiously missing from RigPlugin
+      "-Ypartial-unification" // Needed on 2.11 for Either, good idea in general
     ) ++ {
       // https://issues.scala-lang.org/browse/SI-8340
       CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
This fixes the build failure in version 2.11 of cats, which is caused by the ambiguous implicit and SI-2712.  `-Ypartial-unification` should be standard practice for cats users after the demise of Xor, especially on Scala 2.11.
