### PR TITLE
Call jstack on sbt if sbt runs longer than 13 minutes

### DIFF
--- a/bin/travis
+++ b/bin/travis
@@ -41,6 +41,23 @@ Detail: https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID
 EOM
 }
 
+# Add jstack watchdog timer in case #774 shows itself again.
+WATCHDOG_PID=""
+function find_sbt_pid() {
+    pgrep -f sbt-launch
+}
+
+function start_watchdog() {
+    echo "Watchdog will wake up in $1"
+    (sleep "$1" && echo "Watchdog launched jstack." && jstack $(find_sbt_pid)) &
+    WATCHDOG_PID=$(pgrep --newest sleep)
+}
+
+function stop_watchdog() {
+    ([ -n "$WATCHDOG_PID" ] && kill "$WATCHDOG_PID") || true
+}
+
+
 
 
 # Real work starts here.  Configure sbt with the right tasks and
@@ -81,7 +98,9 @@ if [[ "$TRAVIS" = "true" ]] && [[ -r "/dev/urandom" ]]; then
     SBT_EXTRA_OPTS="$SBT_EXTRA_OPTS -Djava.security.egd=file:/dev/./urandom"
 fi
 
+start_watchdog 13m
 sbt $SBT_EXTRA_OPTS 'set scalazVersion in ThisBuild := System.getenv("SCALAZ_VERSION")' ++$TRAVIS_SCALA_VERSION $SBT_COMMAND
+stop_watchdog
 
 echo "Uploading codecov"
 if primary_build; then


### PR DESCRIPTION
In response to this build:
https://travis-ci.org/http4s/http4s/jobs/207818583#L3278
on the cats branch that hung despite `CharsetRangeSpec` completing.

Hope this will identify source of deadlock if #774 shows itself again.