### PR TITLE
Destroy Tomcat after stopping it

### DIFF
--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -153,6 +153,7 @@ sealed class TomcatBuilder private (
       override def shutdown: Task[Unit] =
         Task.delay {
           tomcat.stop()
+          tomcat.destroy()
         }
 
       override def onShutdown(f: => Unit): this.type = {


### PR DESCRIPTION
If we don't do this, it usually leaves the port bound after stop.