### PR TITLE
Correction to watchdog script for older pgrep

### DIFF
--- a/bin/travis
+++ b/bin/travis
@@ -50,7 +50,7 @@ function find_sbt_pid() {
 function start_watchdog() {
     echo "Watchdog will wake up in $1"
     (sleep "$1" && echo "Watchdog launched jstack." && jstack $(find_sbt_pid)) &
-    WATCHDOG_PID=$(pgrep --newest sleep)
+    WATCHDOG_PID=$(pgrep -n sleep)
 }
 
 function stop_watchdog() {


### PR DESCRIPTION
Builds are on Ubuntu Precise where `pgrep --newest` is not a thing yet.

Fixes this ugliness at the end of Travis runs:

    bin/travis: line 57: kill: Usage: pgrep [-cflvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
    [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]: arguments must be process or job IDs

Was not hurting anything; just cluttering the console.