### PR TITLE
Fix intermittent failure in async-http-client

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/UnicastSubscriber.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/UnicastSubscriber.scala
@@ -30,7 +30,7 @@ abstract class UnicastSubscriber[A](bufferSize: Int = 8) extends Subscriber[A] {
       // We have to assign it locally before we use it, if we want to be a synchronous `Subscriber`
       // Because according to rule 3.10, the Subscription is allowed to call `onNext` synchronously from within `request`
       subscription = s
-      request(1)
+      request(bufferSize)
     }
   }
 

--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
@@ -2,4 +2,5 @@ package org.http4s.client.asynchttpclient
 
 import org.http4s.client.ClientRouteTestBattery
 
-class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient", AsyncHttpClient())
+class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient",
+  AsyncHttpClient(bufferSize = 1))

--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/QueueSubscriberTest.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/QueueSubscriberTest.scala
@@ -9,19 +9,20 @@ import org.testng.annotations._
 import org.testng.Assert._
 
 import scalaz.-\/
+import scalaz.stream.async.unboundedQueue
 
 class QueueSubscriberTest extends SubscriberWhiteboxVerification[Integer](new TestEnvironment) {
   private lazy val counter = new AtomicInteger
 
   override def createSubscriber(theProbe: WhiteboxSubscriberProbe[Integer]): Subscriber[Integer] = {
-    val subscriber = new QueueSubscriber[Integer](2) with WhiteboxSubscriber[Integer] {
+    val subscriber = new QueueSubscriber[Integer](2, unboundedQueue[Integer]) with WhiteboxSubscriber[Integer] {
       override def probe: WhiteboxSubscriberProbe[Integer] = theProbe
     }
     subscriber
   }
 
   def createSubscriber(): QueueSubscriber[Integer] =
-    new QueueSubscriber[Integer](1)
+    new QueueSubscriber[Integer](1, unboundedQueue[Integer])
 
   override def createElement(element: Int): Integer =
     counter.getAndIncrement

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazePooledHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazePooledHttp1ClientSpec.scala
@@ -2,31 +2,4 @@ package org.http4s
 package client
 package blaze
 
-import org.http4s.client.testroutes.GetRoutes
-import scalaz.concurrent.Task
-
-class BlazePooledHttp1ClientSpec
-  extends { val client = PooledHttp1Client() }
-    with ClientRouteTestBattery("Blaze PooledHttp1Client", client) {
-
-  val path = GetRoutes.SimplePath
-
-  def fetchBody = client.toService(_.as[String]).local { uri: Uri =>
-    Request(uri = uri)
-  }
-
-  "PooledHttp1Client" should {
-    "Repeat a simple request" in {
-      val url = Uri.fromString(s"http://${address.getHostName}:${address.getPort}$path").yolo
-
-      val f = (0 until 10).map(_ => Task.fork {
-        val resp = fetchBody.run(url)
-        resp.map(_.length)
-      })
-
-      foreach(Task.gatherUnordered(f).runFor(timeout)) { length =>
-        length mustNotEqual 0
-      }
-    }
-  }
-}
+class BlazePooledHttp1ClientSpec extends ClientRouteTestBattery("Blaze PooledHttp1Client", PooledHttp1Client())

--- a/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -13,7 +13,7 @@ object GetRoutes {
     import org.http4s.headers._
     Map(
       SimplePath -> Response(Ok).withBody("simple path").run,
-      ChunkedPath -> Response(Ok).withBody(Process.emit("chunk1")).map(_.putHeaders(`Transfer-Encoding`(TransferCoding.chunked))).run
+      ChunkedPath -> Response(Ok).withBody(Process.emitAll("chunk".toSeq.map(_.toString))).run
     )
   }
 }


### PR DESCRIPTION
* Don't block on closing or killing the queue. (Fixes #978)
* Don't trigger `scalaz.concurrent.DefaultStrategy` to dequeue body
* Respect the buffer size on the queue subscriber
* Return response only after subscribing. Should fix sporadic Reactive Streams 3.16 rule.
