### PR TITLE
Fix Gitter webhook call from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script: bash bin/travis
 notifications:
   webhooks:
     urls:
-      - $GITTER_WEBHOOK_URL
+      - secure: "aD5b1XnAbGJi6YYofSUdradQngsxkG+xlrbev2kv/xSxD3LtzEiUrewODYmDCPiAL3biTi9/4Ye5mkC7g0ksW1X5ZpW46c5cxpuICE14Ke8EdGF4xK7HW70GvK4We9s8xDddHR4QrNk6G216B+9IPgrnT/VkCaJ327AM5oGWoDY="
     on_success: change
     on_failure: always
     on_start: never


### PR DESCRIPTION
Encrypted blob created with:

    travis encrypt "https://webhooks.gitter.im/e/05****************16" -r http4s/http4s

Adapted from advice here:
https://docs.travis-ci.com/user/notifications/#Configuring-slack-notifications

Will need to run through Travis to confirm it works as expected.