### PR TITLE
Run tests with our own default strategy

### DIFF
--- a/testing/src/main/scala/org/http4s/testing/concurrent.scala
+++ b/testing/src/main/scala/org/http4s/testing/concurrent.scala
@@ -1,0 +1,25 @@
+package org.http4s.testing
+
+import java.util.concurrent.{ExecutorService, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+import scalaz.concurrent.Strategy
+import org.http4s.util.threads.threadFactory
+
+object concurrent {
+  private[this] val poolCounter = new AtomicInteger(0)
+
+  val TestPool: ExecutorService = {
+    val poolNumber = poolCounter.incrementAndGet
+    val minThreads = 4
+    val maxThreads = math.max(16, Runtime.getRuntime.availableProcessors)
+    val exec = new ThreadPoolExecutor(minThreads, maxThreads,
+      10, TimeUnit.SECONDS,
+      new LinkedBlockingQueue[Runnable],
+      threadFactory(i => s"http4s-testing-${poolNumber}-$i", daemon = true))
+    exec.allowCoreThreadTimeOut(true) // don't leak threads on multiple test runs
+    exec
+  }
+
+  implicit val TestStrategy: Strategy =
+    Strategy.Executor(TestPool)
+}

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -10,7 +10,9 @@
 package org.http4s
 
 import org.http4s.testing._
+import org.http4s.testing.concurrent.TestStrategy
 import org.http4s.util.byteVector._
+import org.http4s.util.threads._
 import org.specs2.ScalaCheck
 import org.specs2.execute.AsResult
 import org.specs2.scalacheck.Parameters
@@ -24,7 +26,7 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.util.{FreqMap, Pretty}
 import org.typelevel.discipline.Laws
 import scalaz.{ -\/, \/- }
-import scalaz.concurrent.Task
+import scalaz.concurrent.{Strategy, Task}
 import scalaz.std.AllInstances
 import scalaz.stream.Process
 import scalaz.stream.text.utf8Decode
@@ -46,6 +48,8 @@ trait Http4sSpec extends Specification
   with FragmentsDsl
   with TaskMatchers
 {
+  implicit def strategy: Strategy = TestStrategy
+
   implicit val params = Parameters(maxSize = 20)
 
   implicit class ParseResultSyntax[A](self: ParseResult[A]) {
@@ -128,5 +132,3 @@ trait Http4sSpec extends Specification
     }
   }
 }
-
-

--- a/tests/src/test/scala/org/http4s/util/io/IoSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/io/IoSpec.scala
@@ -11,8 +11,6 @@ import scalaz.syntax.foldable._
 import scodec.bits.ByteVector
 
 class IoSpec extends Http4sSpec {
-  implicit val s: Strategy = Strategy.DefaultStrategy
-
   case class ChunkOffsetLen(chunk: ByteVector, offset: Int, len: Int)
 
   implicit val arbitraryChunkOffsetLen = Arbitrary {


### PR DESCRIPTION
- Between 4 and 16 threads. (Or more, on a _huge_ box.)
- All daemon threads for clean exit
- Core threads timeout so we don't leak between tests
- Remove DefaultStrategy in IoSpec
