### PR TITLE
Run tests with our own test pool/strategy/scheduler

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 import scodec.bits.ByteVector
 
-class Http1ServerStageSpec extends Specification {
+class Http1ServerStageSpec extends Http4sSpec {
   def makeString(b: ByteBuffer): String = {
     val p = b.position()
     val a = new Array[Byte](b.remaining())
@@ -41,7 +41,7 @@ class Http1ServerStageSpec extends Specification {
 
   def runRequest(req: Seq[String], service: HttpService, maxReqLine: Int = 4*1024, maxHeaders: Int = 16*1024): Future[ByteBuffer] = {
     val head = new SeqTestHead(req.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
-    val httpStage = Http1ServerStage(service, AttributeMap.empty, Strategy.DefaultExecutorService, true, maxReqLine, maxHeaders)
+    val httpStage = Http1ServerStage(service, AttributeMap.empty, testPool, true, maxReqLine, maxHeaders)
 
     pipeline.LeafBuilder(httpStage).base(head)
     head.sendInboundCommand(Cmd.Connected)

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
@@ -2,6 +2,7 @@ package org.http4s
 package server
 package staticcontent
 
+import java.io.File
 import org.http4s.server.middleware.URITranslation
 import scodec.bits.ByteVector
 
@@ -9,7 +10,7 @@ import scalaz.concurrent.Task
 
 class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
-  val s = fileService(FileService.Config(System.getProperty("user.dir")))
+  val s = fileService(FileService.Config(new File(getClass.getResource("/").toURI).getPath))
 
   "FileService" should {
 
@@ -23,21 +24,21 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
       }
 
       {
-        val req = Request(uri = uri("foo/server/src/test/resources/testresource.txt"))
+        val req = Request(uri = uri("foo/testresource.txt"))
         val (bv,resp) = runReq(req)
         bv must_== testResource
         resp.status must_== Status.Ok
       }
 
       {
-        val req = Request(uri = uri("server/src/test/resources/testresource.txt"))
+        val req = Request(uri = uri("testresource.txt"))
         val (_,resp) = runReq(req)
         resp.status must_== Status.NotFound
       }
     }
 
     "Return a 200 Ok file" in {
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt"))
+      val req = Request(uri = uri("testresource.txt"))
       val rb = runReq(req)
 
       rb._1 must_== testResource
@@ -45,13 +46,13 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
     }
 
     "Not find missing file" in {
-      val req = Request(uri = uri("server/src/test/resources/testresource.txtt"))
+      val req = Request(uri = uri("testresource.txtt"))
       runReq(req)._2.status must_== (Status.NotFound)
     }
 
     "Return a 206 PartialContent file" in {
       val range = headers.Range(4)
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(range)
+      val req = Request(uri = uri("testresource.txt")).replaceAllHeaders(range)
       val rb = runReq(req)
 
       rb._2.status must_== Status.PartialContent
@@ -60,7 +61,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
     "Return a 206 PartialContent file" in {
       val range = headers.Range(-4)
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(range)
+      val req = Request(uri = uri("testresource.txt")).replaceAllHeaders(range)
       val rb = runReq(req)
 
       rb._2.status must_== Status.PartialContent
@@ -70,7 +71,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
     "Return a 206 PartialContent file" in {
       val range = headers.Range(2,4)
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(range)
+      val req = Request(uri = uri("testresource.txt")).replaceAllHeaders(range)
       val rb = runReq(req)
 
       rb._2.status must_== Status.PartialContent
@@ -86,7 +87,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
                         headers.Range(200, 201),
                         headers.Range(-200)
                        )
-      val reqs = ranges map (r => Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(r))
+      val reqs = ranges map (r => Request(uri = uri("testresource.txt")).replaceAllHeaders(r))
       forall(reqs) { req =>
         val rb = runReq(req)
         rb._2.status must_== Status.Ok

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -9,8 +9,10 @@
 
 package org.http4s
 
+import java.util.concurrent._
 import org.http4s.testing._
 import org.http4s.util.byteVector._
+import org.http4s.util.threads.threadFactory
 import org.specs2.ScalaCheck
 import org.specs2.execute.AsResult
 import org.specs2.scalacheck.Parameters
@@ -24,7 +26,7 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.util.{FreqMap, Pretty}
 import org.typelevel.discipline.Laws
 import scalaz.{ -\/, \/- }
-import scalaz.concurrent.Task
+import scalaz.concurrent.{Strategy, Task}
 import scalaz.std.AllInstances
 import scalaz.stream.Process
 import scalaz.stream.text.utf8Decode
@@ -46,6 +48,13 @@ trait Http4sSpec extends Specification
   with FragmentsDsl
   with TaskMatchers
 {
+  def testPool: ExecutorService =
+    Http4sSpec.TestPool
+  implicit def testStrategy: Strategy =
+    Http4sSpec.TestStrategy
+  implicit def testScheduler: ScheduledExecutorService =
+    Http4sSpec.TestScheduler
+
   implicit val params = Parameters(maxSize = 20)
 
   implicit class ParseResultSyntax[A](self: ParseResult[A]) {
@@ -129,4 +138,20 @@ trait Http4sSpec extends Specification
   }
 }
 
+object Http4sSpec {
+  val TestPool: ExecutorService = {
+    val minThreads = 8
+    val maxThreads = math.max(64, Runtime.getRuntime.availableProcessors * 3)
+    val exec = new ThreadPoolExecutor(minThreads, maxThreads,
+      10, TimeUnit.SECONDS,
+      new LinkedBlockingQueue[Runnable],
+      threadFactory(i => s"http4s-testing-pool-$i", daemon = true))
+    exec
+  }
 
+  val TestStrategy: Strategy =
+    Strategy.Executor(TestPool)
+
+  val TestScheduler: ScheduledExecutorService =
+    Executors.newScheduledThreadPool(2, threadFactory(i => s"http4s-testing-scheduler-$i", daemon = true))
+}

--- a/tests/src/test/resources/test.fiddlefaddle
+++ b/tests/src/test/resources/test.fiddlefaddle
@@ -1,0 +1,1 @@
+This is a test resource with an unknown extension.

--- a/tests/src/test/scala/org/http4s/StaticFileSpec.scala
+++ b/tests/src/test/scala/org/http4s/StaticFileSpec.scala
@@ -9,19 +9,18 @@ class StaticFileSpec extends Http4sSpec {
   "StaticFile" should {
     "Determine the media-type based on the files extension" in {
 
-      def check(path: String, tpe: Option[MediaType]) = {
-        val f = new File(path)
+      def check(f: File, tpe: Option[MediaType]) = {
         val r = StaticFile.fromFile(f)
 
         r must beSome[Response]
         r.flatMap(_.headers.get(`Content-Type`)) must_== tpe.map(t => `Content-Type`(t))
       }
 
-      val tests = Seq("./testing/src/test/resources/logback-test.xml"-> Some(MediaType.`text/xml`),
-                      "./server/src/test/resources/testresource.txt" -> Some(MediaType.`text/plain`),
-                      ".travis.yml" -> None)
-
-      forall(tests){ case (p,om) => check(p, om) }
+      val tests = Seq("/Animated_PNG_example_bouncing_beach_ball.png" -> Some(MediaType.`image/png`),
+                      "/test.fiddlefaddle" -> None)
+      forall(tests) { case (p, om) =>
+        check(new File(getClass.getResource(p).toURI), om)
+      }
     }
 
     "handle an empty file" in {

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -91,9 +91,8 @@ class MultipartSpec extends Specification with DisjunctionMatchers {
 
   def encodeAndDecodeMultipartWithBinaryFormData = {
 
-    val path       = "./tests/src/test/resources/Animated_PNG_example_bouncing_beach_ball.png"
-    val file       = new File(path)
-    
+    val file       = new File(getClass.getResource("/Animated_PNG_example_bouncing_beach_ball.png").toURI)
+
     val field1     = Part.formData("field1", "Text_Field_1")
     
     val ef2        = fileToEntity(file)

--- a/tests/src/test/scala/org/http4s/util/io/IoSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/io/IoSpec.scala
@@ -11,8 +11,6 @@ import scalaz.syntax.foldable._
 import scodec.bits.ByteVector
 
 class IoSpec extends Http4sSpec {
-  implicit val s: Strategy = Strategy.DefaultStrategy
-
   case class ChunkOffsetLen(chunk: ByteVector, offset: Int, len: Int)
 
   implicit val arbitraryChunkOffsetLen = Arbitrary {


### PR DESCRIPTION
- Between 8 and max(64, cpus * 3) threads.  We used to have 3.
- Use our pool, strategy, and scheduler within `Http4sSpec`
- Changes to support running forked. Travis runs out of memory, but I think they're cleaner, so I'm keeping them.