### PR TITLE
Replace scalaz default pool with our own

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -9,7 +9,6 @@ import org.asynchttpclient.request.body.generator.{InputStreamBodyGenerator, Bod
 import org.asynchttpclient.{Request => AsyncRequest, Response => _, _}
 import org.asynchttpclient.handler.StreamedAsyncHandler
 import org.reactivestreams.Subscription
-import org.http4s.client.impl.DefaultExecutor
 
 import org.http4s.util.threads._
 
@@ -46,7 +45,7 @@ object AsyncHttpClient {
             bufferSize: Int = 8,
             customExecutor: Option[ExecutorService] = None): Client = {
     val client = new DefaultAsyncHttpClient(config)
-    val executorService = customExecutor.getOrElse(DefaultExecutor.newClientDefaultExecutorService("async-http-client-response"))
+    val executorService = customExecutor.getOrElse(newDaemonPool("http4s-async-http-client-response"))
     val close =
       if (customExecutor.isDefined)
         Task.delay { client.close() }

--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
@@ -1,6 +1,8 @@
 package org.http4s.client.asynchttpclient
 
 import org.http4s.client.ClientRouteTestBattery
+import org.http4s.util.threads.newDaemonPool
 
 class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient",
-  AsyncHttpClient(bufferSize = 1))
+  AsyncHttpClient(bufferSize = 1,
+    customExecutor = Some(newDaemonPool("async-http-client-spec", timeout = true))))

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -5,7 +5,6 @@ import java.nio.channels.AsynchronousChannelGroup
 import java.util.concurrent.ExecutorService
 import javax.net.ssl.SSLContext
 
-import org.http4s.client.impl.DefaultExecutor
 import org.http4s.headers.`User-Agent`
 
 import scala.concurrent.duration.Duration

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
@@ -8,7 +8,6 @@ import java.util.concurrent._
 import org.http4s.BuildInfo
 import org.http4s.headers.{AgentProduct, `User-Agent`}
 import org.http4s.blaze.util.TickWheelExecutor
-import org.http4s.client.impl.DefaultExecutor
 import org.http4s.util.threads
 
 import scala.concurrent.duration._
@@ -28,7 +27,7 @@ private[blaze] object bits {
   def getExecutor(config: BlazeClientConfig): (ExecutorService, Task[Unit]) = config.customExecutor match {
     case Some(exec) => (exec, Task.now(()))
     case None =>
-      val exec = DefaultExecutor.newClientDefaultExecutorService("blaze-client")
+      val exec = threads.newDaemonPool("http4s-blaze-client")
       (exec, Task { exec.shutdown() })
   }
 

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazePooledHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazePooledHttp1ClientSpec.scala
@@ -2,4 +2,8 @@ package org.http4s
 package client
 package blaze
 
-class BlazePooledHttp1ClientSpec extends ClientRouteTestBattery("Blaze PooledHttp1Client", PooledHttp1Client())
+import org.http4s.util.threads.newDaemonPool
+
+class BlazePooledHttp1ClientSpec extends ClientRouteTestBattery("Blaze PooledHttp1Client",
+  PooledHttp1Client(config = BlazeClientConfig.defaultConfig.copy(customExecutor =
+    Some(newDaemonPool("blaze-pooled-http1-client-spec", timeout = true)))))

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeSimpleHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeSimpleHttp1ClientSpec.scala
@@ -1,6 +1,9 @@
 package org.http4s.client.blaze
 
 import org.http4s.client.ClientRouteTestBattery
+import org.http4s.util.threads.newDaemonPool
 
 class BlazeSimpleHttp1ClientSpec extends
-ClientRouteTestBattery("SimpleHttp1Client", SimpleHttp1Client(BlazeClientConfig.defaultConfig))
+    ClientRouteTestBattery("SimpleHttp1Client",
+      SimpleHttp1Client(BlazeClientConfig.defaultConfig.copy(customExecutor =
+        Some(newDaemonPool("blaze-simple-http1-client-spec", timeout = true)))))

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer
 import org.http4s.blaze.SeqTestHead
 import org.http4s.blaze.pipeline.LeafBuilder
 import org.http4s.util.CaseInsensitiveString._
+import org.http4s.util.threads.DefaultPool
 import bits.DefaultUserAgent
 import org.specs2.mutable.Specification
 import scodec.bits.ByteVector
@@ -21,7 +22,7 @@ import scalaz.concurrent.{Strategy, Task}
 class Http1ClientStageSpec extends Specification {
 
   val ec = org.http4s.blaze.util.Execution.trampoline
-  val es = Strategy.DefaultExecutorService
+  val es = DefaultPool
 
   val www_foo_test = Uri.uri("http://www.foo.test")
   val FooRequest = Request(uri = www_foo_test)

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -17,6 +17,7 @@ import org.http4s.blaze.channel.SocketConnection
 import org.http4s.blaze.channel.nio1.NIO1SocketServerGroup
 import org.http4s.blaze.channel.nio2.NIO2SocketServerGroup
 import org.http4s.server.SSLSupport.{StoreInfo, SSLBits}
+import org.http4s.util.threads.DefaultPool
 
 import org.log4s.getLogger
 
@@ -233,7 +234,7 @@ class BlazeBuilder(
 
 object BlazeBuilder extends BlazeBuilder(
   socketAddress = ServerBuilder.DefaultSocketAddress,
-  serviceExecutor = Strategy.DefaultExecutorService,
+  serviceExecutor = DefaultPool,
   idleTimeout = IdleTimeoutSupport.DefaultIdleTimeout,
   isNio2 = false,
   connectorPoolSize = channel.defaultPoolSize,

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 import scodec.bits.ByteVector
 
-class Http1ServerStageSpec extends Specification {
+class Http1ServerStageSpec extends Http4sSpec {
   def makeString(b: ByteBuffer): String = {
     val p = b.position()
     val a = new Array[Byte](b.remaining())
@@ -41,7 +41,7 @@ class Http1ServerStageSpec extends Specification {
 
   def runRequest(req: Seq[String], service: HttpService, maxReqLine: Int = 4*1024, maxHeaders: Int = 16*1024): Future[ByteBuffer] = {
     val head = new SeqTestHead(req.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
-    val httpStage = Http1ServerStage(service, AttributeMap.empty, Strategy.DefaultExecutorService, true, maxReqLine, maxHeaders)
+    val httpStage = Http1ServerStage(service, AttributeMap.empty, testPool, true, maxReqLine, maxHeaders)
 
     pipeline.LeafBuilder(httpStage).base(head)
     head.sendInboundCommand(Cmd.Connected)

--- a/client/src/main/scala/org/http4s/client/impl/DefaultExecutor.scala
+++ b/client/src/main/scala/org/http4s/client/impl/DefaultExecutor.scala
@@ -4,9 +4,9 @@ import java.util.concurrent.ExecutorService
 
 import org.http4s.util.threads._
 
-
 private[client] object DefaultExecutor {
   /** create a new default executor */
+  @deprecated("Use org.http4s.util.threads.newDaemonPool instead", "0.15.7")
   def newClientDefaultExecutorService(name: String): ExecutorService =
     newDefaultFixedThreadPool(
       (Runtime.getRuntime.availableProcessors * 1.5).ceil.toInt,

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -17,6 +17,7 @@ import Process._
 
 import org.http4s.headers._
 import org.http4s.Status.NotModified
+import org.http4s.util.threads.DefaultPool
 import org.log4s.getLogger
 import scodec.bits.ByteVector
 
@@ -27,17 +28,17 @@ object StaticFile {
   val DefaultBufferSize = 10240
 
   def fromString(url: String, req: Option[Request] = None)
-                (implicit es: ExecutorService = Strategy.DefaultExecutorService): Option[Response] = {
+                (implicit es: ExecutorService = DefaultPool): Option[Response] = {
     fromFile(new File(url), req)
   }
 
   def fromResource(name: String, req: Option[Request] = None)
-             (implicit es: ExecutorService = Strategy.DefaultExecutorService): Option[Response] = {
+             (implicit es: ExecutorService = DefaultPool): Option[Response] = {
     Option(getClass.getResource(name)).flatMap(fromURL(_, req))
   }
 
   def fromURL(url: URL, req: Option[Request] = None)
-             (implicit es: ExecutorService = Strategy.DefaultExecutorService): Option[Response] = {
+             (implicit es: ExecutorService = DefaultPool): Option[Response] = {
     val lastmod = Instant.ofEpochMilli(url.openConnection.getLastModified())
     val expired = req
       .flatMap(_.headers.get(`If-Modified-Since`))
@@ -57,7 +58,7 @@ object StaticFile {
     } else Some(Response(NotModified))
   }
 
-  def fromFile(f: File, req: Option[Request] = None)(implicit es: ExecutorService = Strategy.DefaultExecutorService): Option[Response] =
+  def fromFile(f: File, req: Option[Request] = None)(implicit es: ExecutorService = DefaultPool): Option[Response] =
     fromFile(f, DefaultBufferSize, req)
 
   def fromFile(f: File, buffsize: Int, req: Option[Request])

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -5,6 +5,7 @@ import java.net.{InetAddress, InetSocketAddress}
 import java.util.concurrent.ExecutorService
 
 import org.http4s.server.SSLSupport.StoreInfo
+import org.http4s.util.threads.DefaultPool
 
 import scala.concurrent.duration._
 import scalaz.concurrent.{Strategy, Task}
@@ -45,7 +46,7 @@ object ServerBuilder {
   val DefaultHost = LoopbackAddress
   val DefaultHttpPort = 8080
   val DefaultSocketAddress = InetSocketAddress.createUnresolved(DefaultHost, DefaultHttpPort)
-  val DefaultServiceExecutor = Strategy.DefaultExecutorService
+  val DefaultServiceExecutor: ExecutorService = DefaultPool
 }
 
 trait IdleTimeoutSupport { this: ServerBuilder =>

--- a/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -10,6 +10,7 @@ import org.http4s.headers.Range.SubRange
 
 import scalaz.concurrent.{Strategy, Task}
 import org.http4s.util._
+import org.http4s.util.threads.DefaultPool
 
 
 object FileService {
@@ -27,7 +28,7 @@ object FileService {
                           pathPrefix: String = "",
                           pathCollector: (File, Config, Request) => Task[Option[Response]] = filesOnly,
                           bufferSize: Int = 50*1024,
-                          executor: ExecutorService = Strategy.DefaultExecutorService,
+                          executor: ExecutorService = DefaultPool,
                           cacheStrategy: CacheStrategy = NoopCacheStrategy)
 
 

--- a/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.ExecutorService
 
 import org.http4s.server._
 import org.http4s.{Response, Request, StaticFile}
+import org.http4s.util.threads.DefaultPool
 
 import scalaz.concurrent.{Strategy, Task}
 
@@ -23,7 +24,7 @@ object ResourceService {
   final case class Config(basePath: String,
                           pathPrefix: String = "",
                           bufferSize: Int = 50*1024,
-                          executor: ExecutorService = Strategy.DefaultExecutorService,
+                          executor: ExecutorService = DefaultPool,
                           cacheStrategy: CacheStrategy = NoopCacheStrategy)
 
   /** Make a new [[org.http4s.HttpService]] that serves static files. */

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
@@ -2,6 +2,7 @@ package org.http4s
 package server
 package staticcontent
 
+import java.io.File
 import org.http4s.server.middleware.URITranslation
 import scodec.bits.ByteVector
 
@@ -9,7 +10,7 @@ import scalaz.concurrent.Task
 
 class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
-  val s = fileService(FileService.Config(System.getProperty("user.dir")))
+  val s = fileService(FileService.Config(new File(getClass.getResource("/").toURI).getPath))
 
   "FileService" should {
 
@@ -23,21 +24,21 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
       }
 
       {
-        val req = Request(uri = uri("foo/server/src/test/resources/testresource.txt"))
+        val req = Request(uri = uri("foo/testresource.txt"))
         val (bv,resp) = runReq(req)
         bv must_== testResource
         resp.status must_== Status.Ok
       }
 
       {
-        val req = Request(uri = uri("server/src/test/resources/testresource.txt"))
+        val req = Request(uri = uri("testresource.txt"))
         val (_,resp) = runReq(req)
         resp.status must_== Status.NotFound
       }
     }
 
     "Return a 200 Ok file" in {
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt"))
+      val req = Request(uri = uri("testresource.txt"))
       val rb = runReq(req)
 
       rb._1 must_== testResource
@@ -45,13 +46,13 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
     }
 
     "Not find missing file" in {
-      val req = Request(uri = uri("server/src/test/resources/testresource.txtt"))
+      val req = Request(uri = uri("testresource.txtt"))
       runReq(req)._2.status must_== (Status.NotFound)
     }
 
     "Return a 206 PartialContent file" in {
       val range = headers.Range(4)
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(range)
+      val req = Request(uri = uri("testresource.txt")).replaceAllHeaders(range)
       val rb = runReq(req)
 
       rb._2.status must_== Status.PartialContent
@@ -60,7 +61,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
     "Return a 206 PartialContent file" in {
       val range = headers.Range(-4)
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(range)
+      val req = Request(uri = uri("testresource.txt")).replaceAllHeaders(range)
       val rb = runReq(req)
 
       rb._2.status must_== Status.PartialContent
@@ -70,7 +71,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
 
     "Return a 206 PartialContent file" in {
       val range = headers.Range(2,4)
-      val req = Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(range)
+      val req = Request(uri = uri("testresource.txt")).replaceAllHeaders(range)
       val rb = runReq(req)
 
       rb._2.status must_== Status.PartialContent
@@ -86,7 +87,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
                         headers.Range(200, 201),
                         headers.Range(-200)
                        )
-      val reqs = ranges map (r => Request(uri = uri("server/src/test/resources/testresource.txt")).replaceAllHeaders(r))
+      val reqs = ranges map (r => Request(uri = uri("testresource.txt")).replaceAllHeaders(r))
       forall(reqs) { req =>
         val rb = runReq(req)
         rb._2.status must_== Status.Ok

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -15,11 +15,12 @@ import scala.concurrent.duration.Duration
 import scalaz.concurrent.{Strategy, Task}
 import scalaz.{-\/, \/-}
 import scala.util.control.NonFatal
+import org.http4s.util.threads.DefaultPool
 import org.log4s.getLogger
 
 class Http4sServlet(service: HttpService,
                     asyncTimeout: Duration = Duration.Inf,
-                    threadPool: ExecutorService = Strategy.DefaultExecutorService,
+                    threadPool: ExecutorService = DefaultPool,
                     private[this] var servletIo: ServletIo = BlockingServletIo(DefaultChunkSize))
   extends HttpServlet
 {

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -5,6 +5,7 @@ package syntax
 import javax.servlet.{ServletRegistration, ServletContext}
 
 import org.http4s.server.AsyncTimeoutSupport
+import org.http4s.util.threads.DefaultPool
 
 import scalaz.concurrent.Strategy
 
@@ -18,7 +19,7 @@ final class ServletContextOps private[syntax](val self: ServletContext) extends 
     val servlet = new Http4sServlet(
       service = service,
       asyncTimeout = AsyncTimeoutSupport.DefaultAsyncTimeout,
-      threadPool = Strategy.DefaultExecutorService,
+      threadPool = DefaultPool,
       servletIo = servletIo
     )
     val reg = self.addServlet(name, servlet)

--- a/tests/src/test/resources/test.fiddlefaddle
+++ b/tests/src/test/resources/test.fiddlefaddle
@@ -1,0 +1,1 @@
+This is a test resource with an unknown extension.

--- a/tests/src/test/scala/org/http4s/StaticFileSpec.scala
+++ b/tests/src/test/scala/org/http4s/StaticFileSpec.scala
@@ -9,19 +9,18 @@ class StaticFileSpec extends Http4sSpec {
   "StaticFile" should {
     "Determine the media-type based on the files extension" in {
 
-      def check(path: String, tpe: Option[MediaType]) = {
-        val f = new File(path)
+      def check(f: File, tpe: Option[MediaType]) = {
         val r = StaticFile.fromFile(f)
 
         r must beSome[Response]
         r.flatMap(_.headers.get(`Content-Type`)) must_== tpe.map(t => `Content-Type`(t))
       }
 
-      val tests = Seq("./testing/src/test/resources/logback-test.xml"-> Some(MediaType.`text/xml`),
-                      "./server/src/test/resources/testresource.txt" -> Some(MediaType.`text/plain`),
-                      ".travis.yml" -> None)
-
-      forall(tests){ case (p,om) => check(p, om) }
+      val tests = Seq("/Animated_PNG_example_bouncing_beach_ball.png" -> Some(MediaType.`image/png`),
+                      "/test.fiddlefaddle" -> None)
+      forall(tests) { case (p, om) =>
+        check(new File(getClass.getResource(p).toURI), om)
+      }
     }
 
     "handle an empty file" in {

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -91,9 +91,8 @@ class MultipartSpec extends Specification with DisjunctionMatchers {
 
   def encodeAndDecodeMultipartWithBinaryFormData = {
 
-    val path       = "./tests/src/test/resources/Animated_PNG_example_bouncing_beach_ball.png"
-    val file       = new File(path)
-    
+    val file       = new File(getClass.getResource("/Animated_PNG_example_bouncing_beach_ball.png").toURI)
+
     val field1     = Part.formData("field1", "Text_Field_1")
     
     val ef2        = fileToEntity(file)

--- a/tests/src/test/scala/org/http4s/util/io/IoSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/io/IoSpec.scala
@@ -11,8 +11,6 @@ import scalaz.syntax.foldable._
 import scodec.bits.ByteVector
 
 class IoSpec extends Http4sSpec {
-  implicit val s: Strategy = Strategy.DefaultStrategy
-
   case class ChunkOffsetLen(chunk: ByteVector, offset: Int, len: Int)
 
   implicit val arbitraryChunkOffsetLen = Arbitrary {

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -12,6 +12,7 @@ import org.apache.tomcat.util.descriptor.web.{FilterMap, FilterDef}
 import org.http4s.servlet.{ServletIo, ServletContainer, Http4sServlet}
 import org.http4s.server.SSLSupport.{SSLBits, StoreInfo}
 import org.http4s.servlet.{ServletContainer, Http4sServlet}
+import org.http4s.util.threads.DefaultPool
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._


### PR DESCRIPTION
What's better:
- Default pools have minimum of 4 threads, vs. scalaz-7.1's `availableProcessors`.
- Our default test pools will evaporate in long-running sbt sessions.

What might be better:
- Scale up to `availableProcessors * 3` on demand.

What's not yet:
- Clients and servers still default to running on a daemon threads.
- scalaz pools still leak in sbt, because `Strategy` creates them eagerly.

What I hope to achieve:
- The end of #978