### PR TITLE
Support stopping examples without killing sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ name := "root"
 description := "A minimal, Scala-idiomatic library for HTTP"
 enablePlugins(DisablePublishingPlugin)
 
+cancelable in Global := true
+
 // This defines macros that we use in core, so it needs to be split out
 lazy val parboiled2 = libraryProject("parboiled2")
   .enablePlugins(DisablePublishingPlugin)


### PR DESCRIPTION
Just a small change in sbt. This is useful when working on examples as you can stop them without killing sbt

I'm targeting cats but it could go to master too