### PR TITLE
Bump to v0.17.0-SNAPSHOT

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -19,8 +19,6 @@ object Http4sPlugin extends AutoPlugin {
   override def requires = RigPlugin && MimaPlugin
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    version := s"${(version in ThisBuild).value}-cats",
-
     // Override rig's default of the Travis build number being the bugfix number
     releaseVersion := { ver =>
       Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.16.0-SNAPSHOT"
+version in ThisBuild := "0.17.0-SNAPSHOT"


### PR DESCRIPTION
Starts publishing cats branch as `0.17.0-SNAPSHOT`, sans `-cats` qualifier.