### PR TITLE
Add implicitNotFound annotations for Entity{Encoder,Decoder}

### DIFF
--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -9,6 +9,7 @@ import org.http4s.headers.`Content-Type`
 import org.http4s.multipart.{Multipart, MultipartDecoder}
 import scodec.bits.ByteVector
 
+import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
 import scala.util.control.NonFatal
 import scalaz.Liskov.{<~<, refl}
@@ -27,6 +28,7 @@ import util.byteVector._
   * a streaming decoder by having the value of A be some kind of streaming construct.
   * @tparam T result type produced by the decoder
   */
+@implicitNotFound("Cannot decode into a value of type ${T}, because no EntityDecoder[${T}] instance could be found.")
 trait EntityDecoder[T] { self =>
   /** Attempt to decode the body of the [[Message]] */
   def decode(msg: Message, strict: Boolean): DecodeResult[T]
@@ -179,7 +181,7 @@ trait EntityDecoderInstances {
     MultipartDecoder.decoder
 
   /** An entity decoder that ignores the content and returns unit. */
-  implicit val void: EntityDecoder[Unit] = EntityDecoder.decodeBy(MediaRange.`*/*`)(msg => 
+  implicit val void: EntityDecoder[Unit] = EntityDecoder.decodeBy(MediaRange.`*/*`)(msg =>
     DecodeResult.success(msg.body.kill.run)
   )
 }

--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -4,6 +4,7 @@ import java.io.{File, InputStream, Reader}
 import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.file.Path
 
+import scala.annotation.implicitNotFound
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
 
@@ -20,6 +21,7 @@ import scalaz.stream.Process.emit
 import scalaz.syntax.apply._
 import scodec.bits.ByteVector
 
+@implicitNotFound("Cannot convert from ${A} to an Entity, because no EntityEncoder[${A}] instance could be found.")
 trait EntityEncoder[A] { self =>
 
   /** Convert the type `A` to an [[EntityEncoder.Entity]] in the `Task` monad */


### PR DESCRIPTION
As suggested in #800, this adds `implicitNotFound` annotations for `EntityEncoder` and `EntityDecoder` to provide a little bit better error messages.