### PR TITLE
Eliminate finalizer on BlazeConnection

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeConnection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeConnection.scala
@@ -6,21 +6,8 @@ import java.nio.ByteBuffer
 
 import org.http4s.blaze.pipeline.TailStage
 
-import scala.util.control.NonFatal
 import scalaz.concurrent.Task
 
 private trait BlazeConnection extends TailStage[ByteBuffer] with Connection {
-
   def runRequest(req: Request): Task[Response]
-
-  override protected def finalize(): Unit = {
-    try if (!isClosed) {
-      logger.warn("Client was not shut down and could result in a resource leak")
-      shutdown()
-      super.finalize()
-    } catch {
-      case NonFatal(t) =>
-        logger.error(t)("Failure finalizing the client")
-    }
-  }
 }


### PR DESCRIPTION
Finalizers incur a substantial performance penalty.  _Effective Java_ quotes the damage at 430x to garbage collect a simple object.  We're making everyone pay to warn of a mistake we've made rather difficult to make in the first place.