### PR TITLE
In Client.streaming, only call dispose when the stream finalizes.

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -87,8 +87,8 @@ final case class Client(open: Service[Request, DisposableResponse], shutdown: Ta
     Stream.eval(open(req))
       .flatMap {
         case DisposableResponse(response, dispose) =>
-          Stream.eval(dispose)
-            .flatMap(_ => f(response))
+          f(response)
+          .onFinalize(dispose)
       }
   }
 

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -149,7 +149,7 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
 
      "streaming returns a stream" in {
        client.streaming(req)(_.body.through(fs2.text.utf8Decode)).runLog.unsafeRun() must_== Vector("hello")
-     }.pendingUntilFixed
+     }
 
      "streaming disposes of the response on success" in {
        assertDisposes(_.streaming(req)(_.body).run)


### PR DESCRIPTION
Dispose Task is being evaluated before the stream is consumed, which was causing Premature EOF.
This also fixes a pending test

The logic in the master  branch is similar to what I propose here, don't know why in this port the dispose Task is being evaluated before the Stream, but it could exist a very good reason I don't understand.