### PR TITLE
Follow the CORS implementation of Jetty and Tomcat

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -58,10 +58,8 @@ object CORS {
    * Currently, you cannot make permissions depend on request details
    */
   def apply(service: HttpService, config: CORSConfig = DefaultCORSConfig): HttpService = Service.lift { req =>
-
-    /**
-     * Always reply with success for an OPTIONS request. The headers to send back are determined by the config.
-     */
+    
+    //Always reply with success for an OPTIONS request. The headers to send back are determined by the config.
     def options(origin: Header, acrm: Header): HttpService = ok.map(corsHeaders(origin.value, acrm.value)(_))
 
     def corsHeaders(origin: String, acrm: String)(resp: Response): Response =

--- a/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
@@ -54,10 +54,10 @@ class CORSSpec extends Http4sSpec {
       cors2.orNotFound(req).map(resp => resp.status.isSuccess && matchHeader(resp.headers, `Access-Control-Allow-Credentials`, "false")).unsafePerformSync
     }
 
-    "Always Respect unsuccesful replies to OPTIONS requests" in {
+    "Always respond with 200 and empty body for OPTIONS request" in {
       val req = buildRequest("/bar", OPTIONS)
-      cors1.orNotFound(req).map(_.headers must not contain(headerCheck _)).unsafePerformSync
-      cors2.orNotFound(req).map(_.headers must not contain(headerCheck _)).unsafePerformSync
+      cors1.orNotFound(req).map(_.headers must contain(headerCheck _)).unsafePerformSync
+      cors2.orNotFound(req).map(_.headers must contain(headerCheck _)).unsafePerformSync
     }
 
     "Fall through" in {


### PR DESCRIPTION
- Fixes #1039
- Changed CORS to reply with ok to OPTIONS request regardless of what it wraps.
