### PR TITLE
v0.17 docs should use 0.17.0-SNAPSHOT as version

### DIFF
--- a/docs/src/hugo/config.toml
+++ b/docs/src/hugo/config.toml
@@ -4,10 +4,10 @@ title = "http4s"
 
 [params]
 # TODO Render these as part of the build process
-apiVersion = "0.16"
-version = "0.16.0-SNAPSHOT"
+apiVersion = "0.17"
+version = "0.17.0-SNAPSHOT"
 
 [[menu.tut]]
     name = "Scaladoc"
     weight = 10000
-    url = "/v0.16/api"
+    url = "/v0.17/api"


### PR DESCRIPTION
Also fixes the "Scaladoc" link at the bottom of the tut menu at
the right of the page.  Looks like the "Edit this page" links are
still broken though.

Follow-up to #1048 .