### PR TITLE
Dependency patch upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   - LOGBACK_ROOT_LEVEL=OFF
   - SBT_VERSION=0.13.13
   matrix:
-  - SCALAZ_VERSION=7.2.9
-  - SCALAZ_VERSION=7.1.11
+  - SCALAZ_VERSION=7.2.10
+  - SCALAZ_VERSION=7.1.12
 before_script:
 - mkdir -p $HOME/.sbt/launchers/$SBT_VERSION/
 - curl -L -o $HOME/.sbt/launchers/$SBT_VERSION/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -80,10 +80,10 @@ object Http4sPlugin extends AutoPlugin {
 
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.11.v20170118"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2-RC2"
-  lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.0.30"
+  lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.0.31"
   lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.12.4"
   lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % circeJawn.revision
-  lazy val circeJawn                        = "io.circe"               %% "circe-jawn"                % "0.7.0"
+  lazy val circeJawn                        = "io.circe"               %% "circe-jawn"                % "0.7.1"
   lazy val circeLiteral                     = "io.circe"               %% "circe-literal"             % circeJawn.revision
   lazy val cryptobits                       = "org.reactormonk"        %% "cryptobits"                % "1.1"
   lazy val discipline                       = "org.typelevel"          %% "discipline"                % "0.7.3"
@@ -93,22 +93,22 @@ object Http4sPlugin extends AutoPlugin {
   lazy val javaxServletApi                  = "javax.servlet"          %  "javax.servlet-api"         % "3.1.0"
   lazy val jawnJson4s                       = "org.spire-math"         %% "jawn-json4s"               % "0.10.4"
   def jawnStreamz(scalazVersion: String)    = "org.http4s"             %% "jawn-streamz"              % "0.10.1" forScalaz scalazVersion
-  lazy val jettyServer                      = "org.eclipse.jetty"      %  "jetty-server"              % "9.4.2.v20170220"
+  lazy val jettyServer                      = "org.eclipse.jetty"      %  "jetty-server"              % "9.4.3.v20170317"
   lazy val jettyServlet                     = "org.eclipse.jetty"      %  "jetty-servlet"             % jettyServer.revision
-  lazy val json4sCore                       = "org.json4s"             %% "json4s-core"               % "3.5.0"
+  lazy val json4sCore                       = "org.json4s"             %% "json4s-core"               % "3.5.1"
   lazy val json4sJackson                    = "org.json4s"             %% "json4s-jackson"            % json4sCore.revision
   lazy val json4sNative                     = "org.json4s"             %% "json4s-native"             % json4sCore.revision
   lazy val jspApi                           = "javax.servlet.jsp"      %  "javax.servlet.jsp-api"     % "2.3.1" // YourKit hack
   lazy val log4s                            = "org.log4s"              %% "log4s"                     % "1.3.4"
-  lazy val logbackClassic                   = "ch.qos.logback"         %  "logback-classic"           % "1.2.1"
+  lazy val logbackClassic                   = "ch.qos.logback"         %  "logback-classic"           % "1.2.3"
   lazy val macroCompat                      = "org.typelevel"          %% "macro-compat"              % "1.1.1"
   lazy val metricsCore                      = "io.dropwizard.metrics"  %  "metrics-core"              % "3.2.0"
   lazy val metricsJson                      = "io.dropwizard.metrics"  %  "metrics-json"              % metricsCore.revision
   lazy val quasiquotes                      = "org.scalamacros"        %% "quasiquotes"               % "2.1.0"
   lazy val reactiveStreamsTck               = "org.reactivestreams"    %  "reactive-streams-tck"      % "1.0.0"
-  lazy val scalacheck                       = "org.scalacheck"         %% "scalacheck"                % "1.13.4"
+  lazy val scalacheck                       = "org.scalacheck"         %% "scalacheck"                % "1.13.5"
   def scalaCompiler(so: String, sv: String) = so                       %  "scala-compiler"            % sv
-  def scalaReflect(so: String, sv: String)  = so                %  "scala-reflect"             % sv
+  def scalaReflect(so: String, sv: String)  = so                       %  "scala-reflect"             % sv
   lazy val scalaXml                         = "org.scala-lang.modules" %% "scala-xml"                 % "1.0.6"
   def scalazCore(szv: String)               = "org.scalaz"             %% "scalaz-core"               % szv
   def scalazScalacheckBinding(szv: String)  = "org.scalaz"             %% "scalaz-scalacheck-binding" % szv
@@ -116,7 +116,7 @@ object Http4sPlugin extends AutoPlugin {
   def specs2MatcherExtra(szv: String)       = "org.specs2"             %% "specs2-matcher-extra"      % specs2Core(szv).revision
   def specs2Scalacheck(szv: String)         = "org.specs2"             %% "specs2-scalacheck"         % specs2Core(szv).revision
   def scalazStream(szv: String)             = "org.scalaz.stream"      %% "scalaz-stream"             % "0.8.6" forScalaz szv
-  lazy val tomcatCatalina                   = "org.apache.tomcat"      %  "tomcat-catalina"           % "8.0.41"
+  lazy val tomcatCatalina                   = "org.apache.tomcat"      %  "tomcat-catalina"           % "8.0.43"
   lazy val tomcatCoyote                     = "org.apache.tomcat"      %  "tomcat-coyote"             % tomcatCatalina.revision
   lazy val twirlApi                         = "com.typesafe.play"      %% "twirl-api"                 % "1.3.0"
 }

--- a/project/ScalazPlugin.scala
+++ b/project/ScalazPlugin.scala
@@ -19,7 +19,7 @@ object ScalazPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override lazy val projectSettings = Seq(
-    scalazVersion := sys.env.get("SCALAZ_VERSION").getOrElse("7.2.9"),
+    scalazVersion := sys.env.get("SCALAZ_VERSION").getOrElse("7.2.10"),
     scalazVersionRewriter := scalazVersionRewriters.default,
     version := scalazVersionRewriter.value(version.value, scalazVersion.value),
     unmanagedSourceDirectories in Compile +=


### PR DESCRIPTION
Get 'em while they're hot.

- async-http-client-2.0.31
- circe-0.7.1
- jetty-9.4.3.v20170317
- json4s-3.5.1
- scalacheck-1.13.5
- scalaz-7.2.10 or 7.1.12
- tomcat-8.0.43