### PR TITLE
Strip fragment from request target in blaze-client

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -298,7 +298,7 @@ private object Http1Connection {
 
   private def encodeRequestLine(req: Request, writer: Writer): writer.type = {
     val uri = req.uri
-    writer << req.method << ' ' << uri.copy(scheme = None, authority = None) << ' ' << req.httpVersion << "\r\n"
+    writer << req.method << ' ' << uri.copy(scheme = None, authority = None, fragment = None) << ' ' << req.httpVersion << "\r\n"
     if (getHttpMinor(req) == 1 && Host.from(req.headers).isEmpty) { // need to add the host header for HTTP/1.1
       uri.host match {
         case Some(host) =>

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -5,6 +5,7 @@ import java.net.InetSocketAddress
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
 import org.http4s.client.testroutes.GetRoutes
+import org.http4s.dsl._
 
 import org.specs2.specification.core.Fragments
 
@@ -27,6 +28,15 @@ abstract class ClientRouteTestBattery(name: String, client: Client)
   }
 
   name should {
+    "Strip fragments from URI" in {
+      skipped("Can only reproduce against external resource.  Help wanted.")
+      val uri = Uri.uri("https://en.wikipedia.org/wiki/Buckethead_discography#Studio_albums")
+      val body = client.fetch(Request(uri = uri)) {
+        case resp => Task.now(resp.status)
+      }
+      body must returnValue(Ok)
+    }
+
     "Repeat a simple request" in {
       val path = GetRoutes.SimplePath
       def fetchBody = client.toService(_.as[String]).local { uri: Uri =>


### PR DESCRIPTION
A URI fragment is illegal in an HTTP request line.  This irritates sensitive servers, like Wikipedia.  This is difficult to unit test, because both Jetty and Blaze servers tolerate fragments in the request target.  The test failed before the code fix, but is skipped to avoid an external resource dependency in our unit tests.

/cc @gwils