### PR TITLE
Remove scalazVersion from makeSite instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ repository.
 You can generate the site with:
 
 ```
-sbt "set scalazVersion in ThisBuild := \"7.2.8\"" docs/makeSite
+sbt docs/makeSite
 ```
 
 The site can be previewed locally by running the bin/local-site script


### PR DESCRIPTION
Not needed in scalaz-stream branch, does not work in cats branch