### PR TITLE
fix source links from 0.15.x scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -270,7 +270,7 @@ lazy val docs = http4sProject("docs")
           val (major, minor) = apiVersion.value
           val sourceTemplate =
             if (version.value.endsWith("SNAPSHOT"))
-              s"${s.browseUrl}/tree/master€{FILE_PATH}.scala"
+              s"${s.browseUrl}/tree/release-0.15.x€{FILE_PATH}.scala"
             else
               s"${s.browseUrl}/tree/v$major.$minor.0€{FILE_PATH}.scala"
           Seq("-implicits",


### PR DESCRIPTION
Care will be needed when merging to 0.16.x and master.

Edit:  Would be nice if we could pull the correct tree from build metadata rather than hardcoding it.  Any sbt gurus know if that's possible?