### PR TITLE
Add Support For JDK 9 and Bump Tomcat Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,4 @@ matrix:
     - jar tf $HOME/.sbt/0.13/java9-rt-ext/rt.jar | grep java/lang/Object
     - cd ..
     - echo "sbt.version=0.13.14-RC1" > project/build.properties
-    - sbt -Dscala.ext.dirs=$HOME/.sbt/0.13/java9-rt-ext ++$TRAVIS_SCALA_VERSION test
+    - ./sbt -Dscala.ext.dirs=$HOME/.sbt/0.13/java9-rt-ext ++$TRAVIS_SCALA_VERSION test

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,24 @@ cache:
   - "$HOME/.coursier/cache"
   - "$HOME/.ivy2/cache"
   - "$HOME/.sbt/boot"
+matrix:
+  include:
+  - dist: trusty
+    group: edge
+    sudo: required
+    scala: 2.12.1
+    jdk: oraclejdk9
+    before_script:
+    script:
+    # https://github.com/sbt/sbt/pull/2951
+    - git clone https://github.com/retronym/java9-rt-export
+    - cd java9-rt-export/
+    - git checkout 1019a2873d057dd7214f4135e84283695728395d
+    - jdk_switcher use oraclejdk8
+    - sbt package
+    - jdk_switcher use oraclejdk9
+    - mkdir -p $HOME/.sbt/0.13/java9-rt-ext; java -jar target/java9-rt-export-*.jar $HOME/.sbt/0.13/java9-rt-ext/rt.jar
+    - jar tf $HOME/.sbt/0.13/java9-rt-ext/rt.jar | grep java/lang/Object
+    - cd ..
+    - echo "sbt.version=0.13.14-RC1" > project/build.properties
+    - ./sbt -Dscala.ext.dirs=$HOME/.sbt/0.13/java9-rt-ext ++$TRAVIS_SCALA_VERSION test

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ matrix:
     - jar tf $HOME/.sbt/0.13/java9-rt-ext/rt.jar | grep java/lang/Object
     - cd ..
     - echo "sbt.version=0.13.14-RC1" > project/build.properties
-    - ./sbt -Dscala.ext.dirs=$HOME/.sbt/0.13/java9-rt-ext ++$TRAVIS_SCALA_VERSION test
+    - sbt -Dscala.ext.dirs=$HOME/.sbt/0.13/java9-rt-ext ++$TRAVIS_SCALA_VERSION test

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ matrix:
     sudo: required
     scala: 2.12.1
     jdk: oraclejdk9
-    before_script:
     script:
     # https://github.com/sbt/sbt/pull/2951
     - git clone https://github.com/retronym/java9-rt-export

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -112,7 +112,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val specs2Core                       = "org.specs2"             %% "specs2-core"               % "3.8.6"
   lazy val specs2MatcherExtra               = "org.specs2"             %% "specs2-matcher-extra"      % specs2Core.revision
   lazy val specs2Scalacheck                 = "org.specs2"             %% "specs2-scalacheck"         % specs2Core.revision
-  lazy val tomcatCatalina                   = "org.apache.tomcat"      %  "tomcat-catalina"           % "8.0.43"
+  lazy val tomcatCatalina                   = "org.apache.tomcat"      %  "tomcat-catalina"           % "8.5.13"
   lazy val tomcatCoyote                     = "org.apache.tomcat"      %  "tomcat-coyote"             % tomcatCatalina.revision
   lazy val twirlApi                         = "com.typesafe.play"      %% "twirl-api"                 % "1.3.0"
 }


### PR DESCRIPTION
Java Version 9 is rolling out shortly so ensuring we are capable of moving forward with 0.17 makes sense. 

Tomcat version needed to be upgraded for version 9 support. However, I am open to other ideas if we want to avoid tomcat 9 for some reason.

Versioning was taken from sbt/sbt#2951 and continued coverage of scala support is at scala/scala-dev#139 

