### PR TITLE
show ERROR and WARN messages during specs and tuts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   global:
   - HUGO_VERSION=0.18
   - LOGBACK_ROOT_LEVEL=WARN
+  - LOGBACK_EXCEPTION_PATTERN=%xThrowable{3}
   matrix:
   - SCALAZ_VERSION=7.2.10
   - SCALAZ_VERSION=7.1.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk: oraclejdk8
 env:
   global:
   - HUGO_VERSION=0.18
-  - LOGBACK_ROOT_LEVEL=OFF
+  - LOGBACK_ROOT_LEVEL=WARN
   matrix:
   - SCALAZ_VERSION=7.2.10
   - SCALAZ_VERSION=7.1.12

--- a/docs/src/test/resources/logback-test.xml
+++ b/docs/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <root level="${LOGBACK_ROOT_LEVEL:-OFF}">
+  <root level="${LOGBACK_ROOT_LEVEL:-WARN}">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/testing/src/test/resources/logback-test.xml
+++ b/testing/src/test/resources/logback-test.xml
@@ -4,7 +4,7 @@
     <!-- encoders are assigned the type
          ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n${LOGBACK_EXCEPTION_PATTERN:-%throwable}</pattern>
     </encoder>
   </appender>
 

--- a/testing/src/test/resources/logback-test.xml
+++ b/testing/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <root level="${LOGBACK_ROOT_LEVEL:-OFF}">
+  <root level="${LOGBACK_ROOT_LEVEL:-WARN}">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
Looks like these were at DEBUG for specs and INFO for tuts before commit 17d23f97.  That was too noisy, but OFF is probably too quiet.