### PR TITLE
increase timeout for client tests, like AHC, that connect to Jetty

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -9,6 +9,7 @@ import org.http4s.dsl._
 
 import org.specs2.specification.core.Fragments
 
+import scala.concurrent.duration._
 import scalaz.concurrent.Task
 import scalaz.stream.Process
 
@@ -16,6 +17,8 @@ import scalaz.stream.Process
 abstract class ClientRouteTestBattery(name: String, client: Client)
   extends Http4sSpec with JettyScaffold
 {
+  val timeout = 20.seconds
+
   Fragments.foreach(GetRoutes.getPaths.toSeq) { case (path, expected) =>
     s"Execute GET: $path" in {
       val name = address.getHostName

--- a/client/src/test/scala/org/http4s/client/JettyScaffold.scala
+++ b/client/src/test/scala/org/http4s/client/JettyScaffold.scala
@@ -8,8 +8,6 @@ import org.eclipse.jetty.servlet.{ServletHolder, ServletContextHandler}
 import org.specs2.mutable.SpecificationLike
 import org.specs2.specification.core.Fragments
 
-import scala.concurrent.duration._
-
 trait JettyScaffold extends SpecificationLike {
 
   private val server = new JServer()
@@ -20,8 +18,6 @@ trait JettyScaffold extends SpecificationLike {
   override def map(fs: => Fragments) = {
     step(startServer()) ^ fs ^ step(server.stop())
   }
-
-  protected def timeout: Duration = 20.seconds
 
   private def startServer(): InetSocketAddress = {
     address = new InetSocketAddress(InetAddress.getLocalHost(), JettyScaffold.getNextPort())

--- a/client/src/test/scala/org/http4s/client/JettyScaffold.scala
+++ b/client/src/test/scala/org/http4s/client/JettyScaffold.scala
@@ -21,7 +21,7 @@ trait JettyScaffold extends SpecificationLike {
     step(startServer()) ^ fs ^ step(server.stop())
   }
 
-  protected def timeout: Duration = 10.seconds
+  protected def timeout: Duration = 20.seconds
 
   private def startServer(): InetSocketAddress = {
     address = new InetSocketAddress(InetAddress.getLocalHost(), JettyScaffold.getNextPort())


### PR DESCRIPTION
AsyncHttpClientSpec occasionally exceeds the 10 second timeout when running in 2 core containers on Travis.  Does not happen consistently, so probably the result of a noisy neighbor or other CPU or disk throttling.  10 seconds *should* be enough, and I suspect there is performance still to be had with AsyncHttpClient, but the sporadic CI failures are wasting developer time without any benefit.

Also moves the timeout into `ClientRouteTestBattery` because it's not used by Jetty and that seems like a more appropriate home.

Refs #1055