### PR TITLE
link from typelevel|library badge to http4s section of project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Http4s [![Build Status](https://travis-ci.org/http4s/http4s.svg?branch=master)](https://travis-ci.org/http4s/http4s) [![Gitter chat](https://badges.gitter.im/http4s/http4s.png)](https://gitter.im/http4s/http4s) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.http4s/http4s-core_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.http4s/http4s-core_2.11) [![Typelevel library](https://img.shields.io/badge/typelevel-library-green.svg)](http://typelevel.org/projects/)
+# Http4s [![Build Status](https://travis-ci.org/http4s/http4s.svg?branch=master)](https://travis-ci.org/http4s/http4s) [![Gitter chat](https://badges.gitter.im/http4s/http4s.png)](https://gitter.im/http4s/http4s) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.http4s/http4s-core_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.http4s/http4s-core_2.11) [![Typelevel library](https://img.shields.io/badge/typelevel-library-green.svg)](http://typelevel.org/projects/#http4s)
 
 Http4s is a minimal, idiomatic Scala interface for HTTP services.  Http4s is
 Scala's answer to Ruby's Rack, Python's WSGI, Haskell's WAI, and Java's


### PR DESCRIPTION
Adds `#http4s` to http://typelevel.org/projects/ link.