### PR TITLE
begin DRYing up library versions used by tuts

### DIFF
--- a/docs/src/hugo/config.toml
+++ b/docs/src/hugo/config.toml
@@ -5,7 +5,9 @@ title = "http4s"
 [params]
 # TODO Render these as part of the build process
 apiVersion = "0.15"
-version = "0.15.8"
+http4sVersion = "0.15.8"
+circeVersion = "0.6.1"
+cryptobitsVersion = "1.1"
 
 [[menu.tut]]
     name = "Scaladoc"

--- a/docs/src/hugo/layouts/shortcodes/circeVersion.html
+++ b/docs/src/hugo/layouts/shortcodes/circeVersion.html
@@ -1,0 +1,1 @@
+{{.Site.Params.circeVersion}}

--- a/docs/src/hugo/layouts/shortcodes/cryptobitsVersion.html
+++ b/docs/src/hugo/layouts/shortcodes/cryptobitsVersion.html
@@ -1,0 +1,1 @@
+{{.Site.Params.cryptobitsVersion}}

--- a/docs/src/hugo/layouts/shortcodes/http4sVersion.html
+++ b/docs/src/hugo/layouts/shortcodes/http4sVersion.html
@@ -1,0 +1,1 @@
+{{.Site.Params.http4sVersion}}

--- a/docs/src/hugo/layouts/shortcodes/version.html
+++ b/docs/src/hugo/layouts/shortcodes/version.html
@@ -1,1 +1,0 @@
-{{.Site.Params.version}}

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -67,7 +67,7 @@ We'll use a small library for the signing/validation of the cookies, which
 basically contains the code used by the Play framework for this specific task.
 
 ```scala
-libraryDependencies += "org.reactormonk" %% "cryptobits" % "1.1"
+libraryDependencies += "org.reactormonk" %% "cryptobits" % "{{< cryptobitsVersion >}}"
 ```
 
 First, we'll need to set the cookie. For the crypto instance, we'll need to

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -16,11 +16,11 @@ basic interop with circe, but to follow this tutorial, install all three:
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-circe" % "{{< version >}}",
+  "org.http4s" %% "http4s-circe" % "{{< http4sVersion >}}",
   // Optional for auto-derivation of JSON codecs
-  "io.circe" %% "circe-generic" % "0.6.1",
+  "io.circe" %% "circe-generic" % "{{< circeVersion >}}",
   // Optional for string interpolation to JSON model
-  "io.circe" %% "circe-literal" % "0.6.1"
+  "io.circe" %% "circe-literal" % "{{< circeVersion >}}"
 )
 ```
 
@@ -31,9 +31,9 @@ community.  The functionality is similar:
 
 ```scala
 libraryDependencies += Seq(
-  "org.http4s" %% "http4s-argonaut" % "{{< version >}}",
+  "org.http4s" %% "http4s-argonaut" % "{{< http4sVersion >}}",
   // Optional for auto-derivation of JSON codecs
-  "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M4"
+  "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M5"
 )
 ```
 
@@ -48,8 +48,8 @@ integrated with many Scala libraries.  It comes with two backends.
 You should pick one of these dependencies:
 
 ```scala
-libraryDependencies += "org.http4s" %% "http4s-json4s-native" % "{{< version >}}"
-libraryDependencies += "org.http4s" %% "http4s-json4s-jackson" % "{{< version >}}"
+libraryDependencies += "org.http4s" %% "http4s-json4s-native" % "{{< http4sVersion >}}"
+libraryDependencies += "org.http4s" %% "http4s-json4s-jackson" % "{{< http4sVersion >}}"
 ```
 
 There is no extra codec derivation library for json4s, as it generally

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -12,7 +12,7 @@ Create a new directory, with the following build.sbt in the root:
 ```scala
 scalaVersion := "2.11.8" // Also supports 2.10.x
 
-val http4sVersion = "{{< version >}}"
+val http4sVersion = "{{< http4sVersion >}}"
 
 // Only necessary for SNAPSHOT releases
 resolvers += Resolver.sonatypeRepo("snapshots")

--- a/docs/src/main/tut/streaming.md
+++ b/docs/src/main/tut/streaming.md
@@ -59,8 +59,8 @@ First, let's assume we want to use [Circe] for JSON support. Please see [json] f
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-circe" % "{{< version >}}",
-  "io.circe" %% "circe-generic" % "0.6.1"
+  "org.http4s" %% "http4s-circe" % "{{< http4sVersion >}}",
+  "io.circe" %% "circe-generic" % "{{< circeVersion >}}"
 )
 ```
 


### PR DESCRIPTION
Add hugo shortcodes[1] for circe and cryptobits versions to
reduce the number of places version numbers are copied.

tut blocks are compiled against library versions in `build.sbt`
and `project/Http4sBuild.scala`, but the versions are also part
of surrounding markdown that is not compiled.  This copypasta
allows the compiled tuts to use version B of a library while a
reader following along at home pastes in older version A.  While
typically not a problem, it may allow the tuts, as rendered in
HTML, to break silently.

This change reduces the version copying, but does not sync the
versions in `Http4sBuild.scala` with the ones displayed in the
rendered HTML.

A good follow-up step might be to generate hugo's `config.toml`
from sbt.  Or, maybe better, export versions from sbt as
environment variables and use getenv[2] in the shortcode templates.

Also updated version for `argonaut-shapeless_6.2` to latest
milestone so all the versions are up-to-date.

[1] https://gohugo.io/extras/shortcodes/
[2] http://gohugo.io/templates/functions/#getenv