### PR TITLE
finalize 0.15.9 release and prepare for 0.15.10 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.15.9-SNAPSHOT
+# v0.15.9 (2017-04-19)
 * Terminate `ServerApp` even if the server fails to start
 * Make `ResourceService` respect `If-Modified-Since`
 * Patch-level upgrades to dependencies:

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 // Global settings
 organization in ThisBuild := "org.http4s"
-version      in ThisBuild := scalazCrossBuild("0.15.9-SNAPSHOT", scalazVersion.value)
+version      in ThisBuild := scalazCrossBuild("0.15.10-SNAPSHOT", scalazVersion.value)
 apiVersion   in ThisBuild := version.map(extractApiVersion).value
 // The build supports both scalaz `7.1.x` and `7.2.x`. Simply run
 // `set scalazVersion in ThisBuild := "7.2.4"` to change which version of scalaz

--- a/docs/src/hugo/config.toml
+++ b/docs/src/hugo/config.toml
@@ -5,7 +5,7 @@ title = "http4s"
 [params]
 # TODO Render these as part of the build process
 apiVersion = "0.15"
-version = "0.15.8"
+version = "0.15.9"
 
 [[menu.tut]]
     name = "Scaladoc"

--- a/docs/src/hugo/content/versions.md
+++ b/docs/src/hugo/content/versions.md
@@ -75,7 +75,7 @@ title: Versions
 	    <td>1.8+</td>
 	  </tr>
 	  <tr>
-	    <td>0.15.8a</td>
+	    <td>0.15.9a</td>
 	    <td class="text-center"><span class="label label-primary">Stable</span></td>
 	    <td class="text-center"><i class="fa fa-check"></i></td>
 	    <td class="text-center"><i class="fa fa-check"></i></td>
@@ -85,7 +85,7 @@ title: Versions
 	    <td>1.8+</td>
 	  </tr>
 	  <tr>
-	    <td>0.15.8</td>
+	    <td>0.15.9</td>
 	    <td class="text-center"><span class="label label-primary">Stable</span></td>
 	    <td class="text-center"><i class="fa fa-check"></i></td>
 	    <td class="text-center"><i class="fa fa-check"></i></td>


### PR DESCRIPTION
Update docs references from 0.15.8 to 0.15.9 and bump version to 0.15.10-SNAPSHOT.