### PR TITLE
finish DRYing up library version used in tuts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 // Global settings
 organization in ThisBuild := "org.http4s"
 version      in ThisBuild := scalazCrossBuild("0.15.10-SNAPSHOT", scalazVersion.value)
-relVersion   in ThisBuild := scalazCrossBuild("0.15.9", scalazVersion.value)
 apiVersion   in ThisBuild := version.map(extractApiVersion).value
 // The build supports both scalaz `7.1.x` and `7.2.x`. Simply run
 // `set scalazVersion in ThisBuild := "7.2.4"` to change which version of scalaz
@@ -318,7 +317,7 @@ lazy val docs = http4sProject("docs")
            |[versions]
            |"http4s.api" = "$major.$minor"
            |"http4s.current" = "${version.value}"
-           |"http4s.release" = "${relVersion.value}"
+           |"http4s.doc" = "${docExampleVersion(version.value)}"
            |scalaz = "${scalazVersion.value}"
            |circe = "${circeJawn.revision}"
            |cryptobits = "${cryptobits.revision}"

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 // Global settings
 organization in ThisBuild := "org.http4s"
 version      in ThisBuild := scalazCrossBuild("0.15.10-SNAPSHOT", scalazVersion.value)
+relVersion   in ThisBuild := scalazCrossBuild("0.15.9", scalazVersion.value)
 apiVersion   in ThisBuild := version.map(extractApiVersion).value
 // The build supports both scalaz `7.1.x` and `7.2.x`. Simply run
 // `set scalazVersion in ThisBuild := "7.2.4"` to change which version of scalaz
@@ -237,6 +238,7 @@ lazy val tutQuick2 = TaskKey[Seq[(File, String)]]("tutQuick2", "Run tut incremen
 val preStageSiteDirectory = SettingKey[File]("pre-stage-site-directory")
 val siteStageDirectory    = SettingKey[File]("site-stage-directory")
 val copySiteToStage       = TaskKey[Unit]("copy-site-to-stage")
+val exportMetadataForSite = TaskKey[File]("export-metadata-for-site", "Export build metadata, like http4s and key dependency versions, for use in tuts and when building site")
 lazy val docs = http4sProject("docs")
   .settings(noPublishSettings)
   .settings(noCoverageSettings)
@@ -306,8 +308,27 @@ lazy val docs = http4sProject("docs")
         targetFile = siteStageDirectory.value / "CHANGELOG.md",
         preserveLastModified = true)
     },
+    exportMetadataForSite := {
+      val dest = (sourceDirectory in Hugo).value / "data" / "build.toml"
+      val (major, minor) = apiVersion.value
+      // Would be more elegant if `[versions.http4s]` was nested, but then
+      // the index lookups in `shortcodes/version.html` get complicated.
+      val buildData: String =
+        s"""
+           |[versions]
+           |"http4s.api" = "$major.$minor"
+           |"http4s.current" = "${version.value}"
+           |"http4s.release" = "${relVersion.value}"
+           |scalaz = "${scalazVersion.value}"
+           |circe = "${circeJawn.revision}"
+           |cryptobits = "${cryptobits.revision}"
+           |"argonaut-shapeless_6.2" = "1.2.0-M5"
+         """.stripMargin
+      IO.write(dest, buildData)
+      dest
+    },
     copySiteToStage := copySiteToStage.dependsOn(tutQuick).value,
-    makeSite := makeSite.dependsOn(copySiteToStage).value,
+    makeSite := makeSite.dependsOn(copySiteToStage, exportMetadataForSite).value,
     baseURL in Hugo := {
       if (isTravisBuild.value) new URI(s"http://http4s.org")
       else new URI(s"http://127.0.0.1:${previewFixedPort.value.getOrElse(4000)}")
@@ -427,6 +448,7 @@ def exampleProject(name: String) = http4sProject(name)
 lazy val apiVersion = taskKey[(Int, Int)]("Defines the API compatibility version for the project.")
 lazy val jvmTarget = taskKey[String]("Defines the target JVM version for object files.")
 lazy val scalazVersion = settingKey[String]("The version of Scalaz used for building.")
+lazy val relVersion = taskKey[String]("Last published release of current minor version.")
 
 lazy val projectMetadata = Seq(
   homepage := Some(url("http://http4s.org/")),

--- a/docs/src/hugo/config.toml
+++ b/docs/src/hugo/config.toml
@@ -2,13 +2,6 @@ baseurl = "http://http4s.org/"
 languageCode = "en-us"
 title = "http4s"
 
-[params]
-# TODO Render these as part of the build process
-apiVersion = "0.15"
-http4sVersion = "0.15.9"
-circeVersion = "0.6.1"
-cryptobitsVersion = "1.1"
-
 [[menu.tut]]
     name = "Scaladoc"
     weight = 10000

--- a/docs/src/hugo/layouts/_default/single.html
+++ b/docs/src/hugo/layouts/_default/single.html
@@ -11,12 +11,13 @@
           </div>
           {{ .Content }}
           <footer>
+            {{ $apiVer := index .Site.Data.build.versions "http4s.api" }}
             <nav>
               <ul class="pager">
                 {{ if .NextInSection }}
                 <li class="previous"><a href="{{.NextInSection.Permalink}}"><i class="fa fa-arrow-left"></i> {{.NextInSection.Title}}</a></li>
                 {{ end }}
-                <li><a href="https://github.com/http4s/http4s/edit/release-{{.Site.Params.apiVersion}}.x/docs/src/main/tut{{ replace .File.Path (print "v" .Site.Params.apiVersion) ""}}"><i class="fa fa-pencil"></i> Edit this page</a></li>
+                <li><a href="https://github.com/http4s/http4s/edit/release-{{ $apiVer }}.x/docs/src/main/tut{{ replace .File.Path (print "v" $apiVer) ""}}"><i class="fa fa-pencil"></i> Edit this page</a></li>
                 {{ if .PrevInSection }}
                 <li class="next"><a href="{{.PrevInSection.Permalink}}">{{.PrevInSection.Title}} <i class="fa fa-arrow-right"></i></a></li>
                 {{ end }}

--- a/docs/src/hugo/layouts/shortcodes/circeVersion.html
+++ b/docs/src/hugo/layouts/shortcodes/circeVersion.html
@@ -1,1 +1,0 @@
-{{.Site.Params.circeVersion}}

--- a/docs/src/hugo/layouts/shortcodes/cryptobitsVersion.html
+++ b/docs/src/hugo/layouts/shortcodes/cryptobitsVersion.html
@@ -1,1 +1,0 @@
-{{.Site.Params.cryptobitsVersion}}

--- a/docs/src/hugo/layouts/shortcodes/http4sVersion.html
+++ b/docs/src/hugo/layouts/shortcodes/http4sVersion.html
@@ -1,1 +1,0 @@
-{{.Site.Params.http4sVersion}}

--- a/docs/src/hugo/layouts/shortcodes/version.html
+++ b/docs/src/hugo/layouts/shortcodes/version.html
@@ -13,4 +13,5 @@
          "io.circe" %% "circe-generic" % "{{< version circe >}}",
          "io.circe" %% "circe-literal" % "{{< version circe >}}"
        )
-*/}}{{ index .Site.Data.build.versions (.Get 0) }}
+*/}}
+{{- index .Site.Data.build.versions (.Get 0) -}}

--- a/docs/src/hugo/layouts/shortcodes/version.html
+++ b/docs/src/hugo/layouts/shortcodes/version.html
@@ -9,7 +9,7 @@
   or in a tut:
 
        libraryDependencies ++= Seq(
-         "org.http4s" %% "http4s-circe" % "{{< version "http4s.release" >}}",
+         "org.http4s" %% "http4s-circe" % "{{< version "http4s.doc" >}}",
          "io.circe" %% "circe-generic" % "{{< version circe >}}",
          "io.circe" %% "circe-literal" % "{{< version circe >}}"
        )

--- a/docs/src/hugo/layouts/shortcodes/version.html
+++ b/docs/src/hugo/layouts/shortcodes/version.html
@@ -9,7 +9,7 @@
   or in a tut:
 
        libraryDependencies ++= Seq(
-         "org.http4s" %% "http4s-circe" % "{{< version http4s >}}",
+         "org.http4s" %% "http4s-circe" % "{{< version "http4s.release" >}}",
          "io.circe" %% "circe-generic" % "{{< version circe >}}",
          "io.circe" %% "circe-literal" % "{{< version circe >}}"
        )

--- a/docs/src/hugo/layouts/shortcodes/version.html
+++ b/docs/src/hugo/layouts/shortcodes/version.html
@@ -1,0 +1,16 @@
+{{/*
+  Extracts version number of library passed in as first parameter from build.toml.
+  The build.toml file is created by sbt prior to running the Hugo sbt-site plugin.
+
+  Example:
+
+      Site generated for http4s version {{< version http4s >}}.
+
+  or in a tut:
+
+       libraryDependencies ++= Seq(
+         "org.http4s" %% "http4s-circe" % "{{< version http4s >}}",
+         "io.circe" %% "circe-generic" % "{{< version circe >}}",
+         "io.circe" %% "circe-literal" % "{{< version circe >}}"
+       )
+*/}}{{ index .Site.Data.build.versions (.Get 0) }}

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -67,7 +67,7 @@ We'll use a small library for the signing/validation of the cookies, which
 basically contains the code used by the Play framework for this specific task.
 
 ```scala
-libraryDependencies += "org.reactormonk" %% "cryptobits" % "{{< cryptobitsVersion >}}"
+libraryDependencies += "org.reactormonk" %% "cryptobits" % "{{< version cryptobits >}}"
 ```
 
 First, we'll need to set the cookie. For the crypto instance, we'll need to

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -15,7 +15,7 @@ The http4s team recommends circe.  Only http4s-circe is required for
 basic interop with circe, but to follow this tutorial, install all three:
 
 ```scala
-val http4sVersion = "{{< version "http4s.release" >}}"
+val http4sVersion = "{{< version "http4s.doc" >}}"
 
 libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-circe" % http4sVersion,

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -15,12 +15,14 @@ The http4s team recommends circe.  Only http4s-circe is required for
 basic interop with circe, but to follow this tutorial, install all three:
 
 ```scala
+val http4sVersion = "{{< version "http4s.release" >}}"
+
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-circe" % "{{< http4sVersion >}}",
+  "org.http4s" %% "http4s-circe" % http4sVersion,
   // Optional for auto-derivation of JSON codecs
-  "io.circe" %% "circe-generic" % "{{< circeVersion >}}",
+  "io.circe" %% "circe-generic" % "{{< version circe >}}",
   // Optional for string interpolation to JSON model
-  "io.circe" %% "circe-literal" % "{{< circeVersion >}}"
+  "io.circe" %% "circe-literal" % "{{< version circe >}}"
 )
 ```
 
@@ -31,9 +33,9 @@ community.  The functionality is similar:
 
 ```scala
 libraryDependencies += Seq(
-  "org.http4s" %% "http4s-argonaut" % "{{< http4sVersion >}}",
+  "org.http4s" %% "http4s-argonaut" % http4sVersion,
   // Optional for auto-derivation of JSON codecs
-  "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M5"
+  "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "{{< version "argonaut-shapeless_6.2" >}}"
 )
 ```
 
@@ -48,8 +50,8 @@ integrated with many Scala libraries.  It comes with two backends.
 You should pick one of these dependencies:
 
 ```scala
-libraryDependencies += "org.http4s" %% "http4s-json4s-native" % "{{< http4sVersion >}}"
-libraryDependencies += "org.http4s" %% "http4s-json4s-jackson" % "{{< http4sVersion >}}"
+libraryDependencies += "org.http4s" %% "http4s-json4s-native" % http4sVersion
+libraryDependencies += "org.http4s" %% "http4s-json4s-jackson" % http4sVersion
 ```
 
 There is no extra codec derivation library for json4s, as it generally

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -12,7 +12,7 @@ Create a new directory, with the following build.sbt in the root:
 ```scala
 scalaVersion := "2.11.8" // Also supports 2.10.x
 
-val http4sVersion = "{{< http4sVersion >}}"
+val http4sVersion = "{{< version "http4s.release" >}}"
 
 // Only necessary for SNAPSHOT releases
 resolvers += Resolver.sonatypeRepo("snapshots")

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -12,7 +12,7 @@ Create a new directory, with the following build.sbt in the root:
 ```scala
 scalaVersion := "2.11.8" // Also supports 2.10.x
 
-val http4sVersion = "{{< version "http4s.release" >}}"
+val http4sVersion = "{{< version "http4s.doc" >}}"
 
 // Only necessary for SNAPSHOT releases
 resolvers += Resolver.sonatypeRepo("snapshots")

--- a/docs/src/main/tut/streaming.md
+++ b/docs/src/main/tut/streaming.md
@@ -59,7 +59,7 @@ First, let's assume we want to use [Circe] for JSON support. Please see [json] f
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-circe" % "{{< version "http4s.release" >}}",
+  "org.http4s" %% "http4s-circe" % "{{< version "http4s.doc" >}}",
   "io.circe" %% "circe-generic" % "{{< version circe >}}"
 )
 ```

--- a/docs/src/main/tut/streaming.md
+++ b/docs/src/main/tut/streaming.md
@@ -59,8 +59,8 @@ First, let's assume we want to use [Circe] for JSON support. Please see [json] f
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-circe" % "{{< http4sVersion >}}",
-  "io.circe" %% "circe-generic" % "{{< circeVersion >}}"
+  "org.http4s" %% "http4s-circe" % "{{< version "http4s.release" >}}",
+  "io.circe" %% "circe-generic" % "{{< version circe >}}"
 )
 ```
 

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -12,6 +12,28 @@ object Http4sBuild {
     }
   }
 
+  /**
+   * @return the version we want to document, for example in tuts,
+   * given the version being built.
+   *
+   * For snapshots after a stable release, return the previous stable
+   * release.  For snapshots of 0.16.0 and 0.17.0, return the latest
+   * milestone.  Otherwise, just return the current version.
+   */
+  def docExampleVersion(currentVersion: String) = {
+    val MilestoneVersionExtractor = """(0).(16|17).(0)-SNAPSHOT""".r
+    val latestMilestone = "M1"
+    val VersionExtractor = """(\d+)\.(\d+)\.(\d+).*""".r
+    currentVersion match {
+      case MilestoneVersionExtractor(major, minor, patch) =>
+        s"${major.toInt}.${minor.toInt}.${patch.toInt}-$latestMilestone"
+      case VersionExtractor(major, minor, patch) if patch.toInt > 0 =>
+        s"${major.toInt}.${minor.toInt}.${patch.toInt - 1}"
+      case _ =>
+        currentVersion
+    }
+  }
+
   lazy val sonatypeEnvCredentials = (for {
     user <- envOrNone("SONATYPE_USERNAME")
     pass <- envOrNone("SONATYPE_PASSWORD")


### PR DESCRIPTION
Follow-up to #1127 [as promised](https://github.com/http4s/http4s/pull/1127#issuecomment-296238572)...

Instead of duplicating key library versions in `config.toml`, write them to a Hugo data file, `build.toml`, from sbt using the same values the compiler is using.

Also made the Hugo version shortcode more generic, so there is a single shortcode for retrieving versions instead of one for each of the key dependencies used in tuts.

Example usage:

    val http4sVersion = "{{< version "http4s.release" >}}"

or:

    ```scala
    libraryDependencies ++= Seq(
      "org.http4s" %% "http4s-circe" % http4sVersion,
      "io.circe" %% "circe-generic" % "{{< version circe >}}",
      "io.circe" %% "circe-literal" % "{{< version circe >}}"
    )
    ```

Potential gotchas:

 * Argument to the version shortcode needs to be quoted if it contains periods or other characters outside `[A-Za-z0-9]`.

 * Quotes are also required for TOML keys with periods.