### PR TITLE
Update Scala Versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
 - 2.12.2
-- 2.11.10
+- 2.11.11
 - 2.10.6
 jdk: oraclejdk8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
-- 2.12.1
-- 2.11.8
+- 2.12.2
+- 2.11.10
 - 2.10.6
 jdk: oraclejdk8
 env:

--- a/build.sbt
+++ b/build.sbt
@@ -489,7 +489,6 @@ lazy val commonSettings = Seq(
     s"-target:jvm-${jvmTarget.value}",
     "-unchecked",
     "-Xfatal-warnings",
-    "-Xlint",
     "-Yinline-warnings",
     "-Yno-adapted-args",
     "-Ywarn-dead-code",

--- a/build.sbt
+++ b/build.sbt
@@ -556,7 +556,7 @@ lazy val commonSettings = Seq(
   },
   coursierVerbosity := 0,
   ivyLoggingLevel := UpdateLogging.Quiet // This doesn't seem to work? We see this in MiMa
-)
+) ++ xlint
 
 lazy val publishSettings = Seq(
   credentials ++= sonatypeEnvCredentials
@@ -617,3 +617,12 @@ def initCommands(additionalImports: String*) =
     "scalaz.concurrent.Task",
     "org.http4s._"
   ) ++ additionalImports).mkString("import ", ", ", "")
+
+lazy val xlint = Seq(
+  scalacOptions += {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) => "-Xlint:-unused,_"
+      case _ => "-Xlint"
+    }
+  }
+)

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -40,7 +40,7 @@ package object http4s { // scalastyle:ignore
   type AuthedService[T] = Service[AuthedRequest[T], Response]
 
   /* Lives here to work around https://issues.scala-lang.org/browse/SI-7139 */
-  object HttpService {
+  object HttpService extends Serializable {
     /**
       * Lifts a total function to an `HttpService`. The function is expected to
       * handle all requests it is given.  If `f` is a `PartialFunction`, use
@@ -63,7 +63,7 @@ package object http4s { // scalastyle:ignore
       Service.const(Response.fallthrough)
   }
 
-  object AuthedService {
+  object AuthedService extends Serializable {
     /**
       * Lifts a total function to an `HttpService`. The function is expected to
       * handle all requests it is given.  If `f` is a `PartialFunction`, use

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/tests/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
@@ -105,7 +105,7 @@ object MultipartParserSpec extends Specification {
         case \/-(bv) => bv
       }
 
-      val (headers, bv) = results.toVector.foldLeft(Headers.empty, ByteVector.empty) {
+      val (headers, bv) = results.toVector.foldLeft((Headers.empty, ByteVector.empty)) {
         case ((hsAcc, bvAcc), \/-(bv)) => (hsAcc, bvAcc ++ bv)
         case ((hsAcc, bvAcc), -\/(hs)) => (hsAcc ++ hs, bvAcc)
       }
@@ -147,7 +147,7 @@ object MultipartParserSpec extends Specification {
 
       val results: Process0[Headers \/ ByteVector] = unspool(input) pipe MultipartParser.parse(boundary)
 
-      val (headers, bv) = results.toVector.foldLeft(Headers.empty, ByteVector.empty) {
+      val (headers, bv) = results.toVector.foldLeft((Headers.empty, ByteVector.empty)) {
         case ((hsAcc, bvAcc), \/-(bv)) => (hsAcc, bvAcc ++ bv)
         case ((hsAcc, bvAcc), -\/(hs)) => (hsAcc ++ hs, ByteVector.empty)
       }


### PR DESCRIPTION
With the release of Scala 2.12.2 and 2.11.10 these changes can be reflected in our builds.

I'm sure I'm missing a location where the primary value is being populated by an sbt file. Picked the furthest upstream branch to proliferate.