### PR TITLE
fix mistakes while DRYing up tut versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -447,7 +447,6 @@ def exampleProject(name: String) = http4sProject(name)
 lazy val apiVersion = taskKey[(Int, Int)]("Defines the API compatibility version for the project.")
 lazy val jvmTarget = taskKey[String]("Defines the target JVM version for object files.")
 lazy val scalazVersion = settingKey[String]("The version of Scalaz used for building.")
-lazy val relVersion = taskKey[String]("Last published release of current minor version.")
 
 lazy val projectMetadata = Seq(
   homepage := Some(url("http://http4s.org/")),

--- a/docs/src/hugo/layouts/shortcodes/version.html
+++ b/docs/src/hugo/layouts/shortcodes/version.html
@@ -4,7 +4,7 @@
 
   Example:
 
-      Site generated for http4s version {{< version http4s >}}.
+      Site generated for http4s version {{< version "http4s.current" >}}.
 
   or in a tut:
 

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -22,7 +22,7 @@ object Http4sBuild {
    * scalaz-7.2 "a" versions for 0.15.x and 0.16.x.
    */
   def docExampleVersion(currentVersion: String) = {
-    val MilestoneVersionExtractor = """(0).(16|17).(0)-SNAPSHOT""".r
+    val MilestoneVersionExtractor = """(0).(16|17).(0)a?-SNAPSHOT""".r
     val latestMilestone = "M1"
     val VersionExtractor = """(\d+)\.(\d+)\.(\d+).*""".r
     currentVersion match {


### PR DESCRIPTION
Found several mistakes when doing a dry-run of the merge train.  Fixes:
 * remove `relVersion` that should have been removed in commit 5f11b2de
 * correct sample shortcode
 * allow for "a" qualifier in Scalaz 7.2 version 0.16.0a-SNAPSHOT when calculating version for tut examples

Refs #1131