### PR TITLE
merge train to release-0.16.x for DRYing up tuts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -259,6 +259,7 @@ lazy val tutQuick2 = TaskKey[Seq[(File, String)]]("tutQuick2", "Run tut incremen
 val preStageSiteDirectory = SettingKey[File]("pre-stage-site-directory")
 val siteStageDirectory    = SettingKey[File]("site-stage-directory")
 val copySiteToStage       = TaskKey[Unit]("copy-site-to-stage")
+val exportMetadataForSite = TaskKey[File]("export-metadata-for-site", "Export build metadata, like http4s and key dependency versions, for use in tuts and when building site")
 lazy val docs = http4sProject("docs")
   .enablePlugins(DisablePublishingPlugin)
   .settings(noCoverageSettings)
@@ -328,8 +329,27 @@ lazy val docs = http4sProject("docs")
         targetFile = siteStageDirectory.value / "CHANGELOG.md",
         preserveLastModified = true)
     },
+    exportMetadataForSite := {
+      val dest = (sourceDirectory in Hugo).value / "data" / "build.toml"
+      val (major, minor) = apiVersion.value
+      // Would be more elegant if `[versions.http4s]` was nested, but then
+      // the index lookups in `shortcodes/version.html` get complicated.
+      val buildData: String =
+        s"""
+           |[versions]
+           |"http4s.api" = "$major.$minor"
+           |"http4s.current" = "${version.value}"
+           |"http4s.doc" = "${docExampleVersion(version.value)}"
+           |scalaz = "${scalazVersion.value}"
+           |circe = "${circeJawn.revision}"
+           |cryptobits = "${cryptobits.revision}"
+           |"argonaut-shapeless_6.2" = "1.2.0-M5"
+         """.stripMargin
+      IO.write(dest, buildData)
+      dest
+    },
     copySiteToStage := copySiteToStage.dependsOn(tutQuick).value,
-    makeSite := makeSite.dependsOn(copySiteToStage).value,
+    makeSite := makeSite.dependsOn(copySiteToStage, exportMetadataForSite).value,
     baseURL in Hugo := {
       if (isTravisBuild.value) new URI(s"http://http4s.org")
       else new URI(s"http://127.0.0.1:${previewFixedPort.value.getOrElse(4000)}")

--- a/docs/src/hugo/config.toml
+++ b/docs/src/hugo/config.toml
@@ -2,11 +2,6 @@ baseurl = "http://http4s.org/"
 languageCode = "en-us"
 title = "http4s"
 
-[params]
-# TODO Render these as part of the build process
-apiVersion = "0.16"
-version = "0.16.0-M1"
-
 [[menu.tut]]
     name = "Scaladoc"
     weight = 10000

--- a/docs/src/hugo/layouts/_default/single.html
+++ b/docs/src/hugo/layouts/_default/single.html
@@ -11,12 +11,13 @@
           </div>
           {{ .Content }}
           <footer>
+            {{ $apiVer := index .Site.Data.build.versions "http4s.api" }}
             <nav>
               <ul class="pager">
                 {{ if .NextInSection }}
                 <li class="previous"><a href="{{.NextInSection.Permalink}}"><i class="fa fa-arrow-left"></i> {{.NextInSection.Title}}</a></li>
                 {{ end }}
-                <li><a href="https://github.com/http4s/http4s/edit/release-{{.Site.Params.apiVersion}}.x/docs/src/main/tut{{ replace .File.Path (print "v" .Site.Params.apiVersion) ""}}"><i class="fa fa-pencil"></i> Edit this page</a></li>
+                <li><a href="https://github.com/http4s/http4s/edit/release-{{ $apiVer }}.x/docs/src/main/tut{{ replace .File.Path (print "v" $apiVer) ""}}"><i class="fa fa-pencil"></i> Edit this page</a></li>
                 {{ if .PrevInSection }}
                 <li class="next"><a href="{{.PrevInSection.Permalink}}">{{.PrevInSection.Title}} <i class="fa fa-arrow-right"></i></a></li>
                 {{ end }}

--- a/docs/src/hugo/layouts/shortcodes/version.html
+++ b/docs/src/hugo/layouts/shortcodes/version.html
@@ -1,1 +1,17 @@
-{{.Site.Params.version}}
+{{/*
+  Extracts version number of library passed in as first parameter from build.toml.
+  The build.toml file is created by sbt prior to running the Hugo sbt-site plugin.
+
+  Example:
+
+      Site generated for http4s version {{< version "http4s.current" >}}.
+
+  or in a tut:
+
+       libraryDependencies ++= Seq(
+         "org.http4s" %% "http4s-circe" % "{{< version "http4s.doc" >}}",
+         "io.circe" %% "circe-generic" % "{{< version circe >}}",
+         "io.circe" %% "circe-literal" % "{{< version circe >}}"
+       )
+*/}}
+{{- index .Site.Data.build.versions (.Get 0) -}}

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -67,7 +67,7 @@ We'll use a small library for the signing/validation of the cookies, which
 basically contains the code used by the Play framework for this specific task.
 
 ```scala
-libraryDependencies += "org.reactormonk" %% "cryptobits" % "1.1"
+libraryDependencies += "org.reactormonk" %% "cryptobits" % "{{< version cryptobits >}}"
 ```
 
 First, we'll need to set the cookie. For the crypto instance, we'll need to

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -15,12 +15,14 @@ The http4s team recommends circe.  Only http4s-circe is required for
 basic interop with circe, but to follow this tutorial, install all three:
 
 ```scala
+val http4sVersion = "{{< version "http4s.doc" >}}"
+
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-circe" % "{{< version >}}",
+  "org.http4s" %% "http4s-circe" % http4sVersion,
   // Optional for auto-derivation of JSON codecs
-  "io.circe" %% "circe-generic" % "0.6.1",
+  "io.circe" %% "circe-generic" % "{{< version circe >}}",
   // Optional for string interpolation to JSON model
-  "io.circe" %% "circe-literal" % "0.6.1"
+  "io.circe" %% "circe-literal" % "{{< version circe >}}"
 )
 ```
 
@@ -31,9 +33,9 @@ community.  The functionality is similar:
 
 ```scala
 libraryDependencies += Seq(
-  "org.http4s" %% "http4s-argonaut" % "{{< version >}}",
+  "org.http4s" %% "http4s-argonaut" % http4sVersion,
   // Optional for auto-derivation of JSON codecs
-  "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M4"
+  "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "{{< version "argonaut-shapeless_6.2" >}}"
 )
 ```
 
@@ -48,8 +50,8 @@ integrated with many Scala libraries.  It comes with two backends.
 You should pick one of these dependencies:
 
 ```scala
-libraryDependencies += "org.http4s" %% "http4s-json4s-native" % "{{< version >}}"
-libraryDependencies += "org.http4s" %% "http4s-json4s-jackson" % "{{< version >}}"
+libraryDependencies += "org.http4s" %% "http4s-json4s-native" % http4sVersion
+libraryDependencies += "org.http4s" %% "http4s-json4s-jackson" % http4sVersion
 ```
 
 There is no extra codec derivation library for json4s, as it generally

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -12,7 +12,7 @@ Create a new directory, with the following build.sbt in the root:
 ```scala
 scalaVersion := "2.11.8" // Also supports 2.10.x and 2.12.x
 
-val http4sVersion = "{{< version >}}"
+val http4sVersion = "{{< version "http4s.doc" >}}"
 
 // Only necessary for SNAPSHOT releases
 resolvers += Resolver.sonatypeRepo("snapshots")

--- a/docs/src/main/tut/streaming.md
+++ b/docs/src/main/tut/streaming.md
@@ -58,8 +58,8 @@ First, let's assume we want to use [Circe] for JSON support. Please see [json] f
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-circe" % "{{< version >}}",
-  "io.circe" %% "circe-generic" % "0.6.1"
+  "org.http4s" %% "http4s-circe" % "{{< version "http4s.doc" >}}",
+  "io.circe" %% "circe-generic" % "{{< version circe >}}"
 )
 ```
 

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -69,6 +69,33 @@ object Http4sPlugin extends AutoPlugin {
     }
   }
 
+  /**
+   * @return the version we want to document, for example in tuts,
+   * given the version being built.
+   *
+   * For snapshots after a stable release, return the previous stable
+   * release.  For snapshots of 0.16.0 and 0.17.0, return the latest
+   * milestone.  Otherwise, just return the current version.  Favors
+   * scalaz-7.2 "a" versions for 0.15.x and 0.16.x.
+   */
+  def docExampleVersion(currentVersion: String) = {
+    val MilestoneVersionExtractor = """(0).(16|17).(0)a?-SNAPSHOT""".r
+    val latestMilestone = "M1"
+    val VersionExtractor = """(\d+)\.(\d+)\.(\d+).*""".r
+    currentVersion match {
+      case MilestoneVersionExtractor(major, minor, patch) if minor.toInt == 16 =>
+        s"${major.toInt}.${minor.toInt}.${patch.toInt}a-$latestMilestone" // scalaz-7.2 for 0.16.x
+      case MilestoneVersionExtractor(major, minor, patch) =>
+        s"${major.toInt}.${minor.toInt}.${patch.toInt}-$latestMilestone"
+      case VersionExtractor(major, minor, patch) if minor.toInt == 15 =>
+        s"${major.toInt}.${minor.toInt}.${patch.toInt - 1}a"              // scalaz-7.2 for 0.15.x
+      case VersionExtractor(major, minor, patch) if patch.toInt > 0 =>
+        s"${major.toInt}.${minor.toInt}.${patch.toInt - 1}"
+      case _ =>
+        currentVersion
+    }
+  }
+
   val macroParadiseSetting =
     libraryDependencies ++= Seq(
       Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)),


### PR DESCRIPTION
No hurry to merge this.  Offering it because there were some merge conflicts in `config.toml` and `project/Http4sBuild.scala` and probably easier for me to resolve them than anyone else.

Two user-facing changes in the v0.16 tuts:
* Refer to http4s 0.16.0a-M1.  The "a" for Scalaz 7.2 is new.
* Refer to circe 0.7.1 in `libraryDependencies` examples.  Was 0.6.1 despite tut compilation using 0.7.1.