### PR TITLE
Adaptive EntityDecoder[Json] for circe

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -1,0 +1,52 @@
+package org.http4s
+package bench
+
+import io.circe._
+import io.circe.parser._
+import org.openjdk.jmh.annotations._
+import java.util.concurrent.TimeUnit
+import org.http4s._
+import org.http4s.circe._
+
+// sbt "bench/jmh:run -i 10 -wi 10 -f 2 -t 1 org.http4s.bench.CirceJsonBench"
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class CirceJsonBench {
+  import CirceJsonBench._
+
+  @Benchmark
+  def decode_byte_buffer(in: BenchState): Either[DecodeFailure, Json] =
+    jsonDecoderByteBuffer.decode(in.req, strict = true).value.unsafeRun
+
+  @Benchmark
+  def decode_incremental(in: BenchState): Either[DecodeFailure, Json] =
+    jsonDecoderIncremental.decode(in.req, strict = true).value.unsafeRun
+
+  @Benchmark
+  def decode_adaptive(in: BenchState): Either[DecodeFailure, Json] =
+    jsonDecoderAdaptive(in.cutoff).decode(in.req, strict = true).value.unsafeRun
+}
+
+object CirceJsonBench {
+  // val obj = Json.obj("foo" -> Json.obj("foo2" -> Json.fromString("bar")))
+  val jsonStr = """{"_id":"58fefc19a5eab74376285220","index":0,"guid":"f5740e2b-7bcf-4bb8-9303-774b1ad99f84","isActive":false,"balance":"$1,052.47","picture":"http://placehold.it/32x32","age":34,"eyeColor":"brown","name":"Calhoun Schneider","gender":"male","company":"GEEKMOSIS","email":"calhounschneider@geekmosis.com","phone":"+1 (890) 564-2582","address":"457 Milford Street, Cutter, Nevada, 204","about":"Irure esse sint esse ullamco dolor veniam commodo eiusmod fugiat minim nostrud. Minim occaecat aliquip magna qui ad nisi laboris adipisicing eiusmod amet deserunt ut. Commodo nulla ullamco et esse eu fugiat elit amet nisi dolore id id aliquip qui. In ex excepteur ea labore nulla eu ullamco anim occaecat sint. Consequat do excepteur consequat est.\r\n","registered":"2014-12-04T02:58:51 -06:00","latitude":60.317658,"longitude":-58.313338,"tags":["laboris","ad","ullamco","ea","ex","est","labore"],"friends":[{"id":0,"name":"Angie Johns"},{"id":1,"name":"Francine Mclean"},{"id":2,"name":"Elaine Hebert"}],"greeting":"Hello, Calhoun Schneider! You have 9 unread messages.","favoriteFruit":"apple"}"""
+  val obj = parse(jsonStr).right.get
+
+  @State(Scope.Benchmark)
+  class BenchState {
+    @Param(Array("1100", "5000", "10000", "100000", "500000"))
+    var approxContentLength: Int = _
+    @Param(Array("100000"))
+    var cutoff: Long = _
+    var req: Request = _
+
+    @Setup(Level.Trial)
+    def setup(): Unit = {
+      val arraySize = (approxContentLength.toDouble /
+        jsonStr.getBytes("UTF-8").length.toDouble).round.toInt
+      val json = Json.arr((1 to arraySize).map(_ => obj):_*)
+      req = Request().withBody(json).unsafeRun
+      println(s"Array size: $arraySize; Approx. Content-Length: $approxContentLength; Content-Length: ${req.contentLength}")
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -244,9 +244,10 @@ lazy val bench = http4sProject("bench")
   .enablePlugins(DisablePublishingPlugin)
   .settings(noCoverageSettings)
   .settings(
-    description := "Benchmarks for http4s"
+    description := "Benchmarks for http4s",
+    libraryDependencies += circeParser
   )
-  .dependsOn(core)
+  .dependsOn(core, circe)
 
 lazy val loadTest = http4sProject("load-test")
   .enablePlugins(DisablePublishingPlugin)

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -35,9 +35,7 @@ trait CirceInstances {
       }
     }
 
-  // default cutoff value is based on benchmarks results
-  implicit val jsonDecoder: EntityDecoder[Json] =
-    jsonDecoderAdaptive(cutoff = 100000)
+  implicit def jsonDecoder: EntityDecoder[Json]
 
   def jsonDecoderAdaptive(cutoff: Long): EntityDecoder[Json] =
     EntityDecoder.decodeBy(MediaType.`application/json`) { msg =>
@@ -86,7 +84,12 @@ trait CirceInstances {
 object CirceInstances {
   def withPrinter(p: Printer): CirceInstances = {
     new CirceInstances {
-      def defaultPrinter: Printer = p
+      val defaultPrinter: Printer = p
+      val jsonDecoder: EntityDecoder[Json] = defaultJsonDecoder
     }
   }
+
+  // default cutoff value is based on benchmarks results
+  val defaultJsonDecoder: EntityDecoder[Json] =
+    jsonDecoderAdaptive(cutoff = 100000)
 }

--- a/circe/src/main/scala/org/http4s/circe/package.scala
+++ b/circe/src/main/scala/org/http4s/circe/package.scala
@@ -1,8 +1,11 @@
 package org.http4s
 
-import io.circe.Printer
+import io.circe.{Json, Printer}
 
 package object circe extends CirceInstances {
-  protected def defaultPrinter: Printer =
+  override val defaultPrinter: Printer =
     Printer.noSpaces
+
+  override val jsonDecoder: EntityDecoder[Json] =
+    CirceInstances.defaultJsonDecoder
 }

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -108,6 +108,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % circeJawn.revision
   lazy val circeJawn                        = "io.circe"               %% "circe-jawn"                % "0.7.1"
   lazy val circeLiteral                     = "io.circe"               %% "circe-literal"             % circeJawn.revision
+  lazy val circeParser                      = "io.circe"               %% "circe-parser"              % circeJawn.revision
   lazy val cryptobits                       = "org.reactormonk"        %% "cryptobits"                % "1.1"
   lazy val discipline                       = "org.typelevel"          %% "discipline"                % "0.7.3"
   lazy val fs2Cats                          = "co.fs2"                 %% "fs2-cats"                  % "0.3.0"


### PR DESCRIPTION
After doing some benchmarks I've decided to make an instance that combines performance of decoding via `ByteBuffer` for small payloads and via jawn-fs2 for big payloads. 

Default cutoff value of 100000 was chosen by doing benchmarks with different cutoff value. Mesages with `Content-Length` lower than cutoff are handled by `ByteBuffer` parser. Everything higher than cutoff or when `Content-Length` is unknown is handled by incremental decoder.

```
[info] Benchmark                          (approxContentLength)  (cutoff)  Mode  Cnt        Score       Error  Units
[info] CirceJsonBench.decode_adaptive                      1100    100000  avgt   20    28218.335 ±   147.533  ns/op
[info] CirceJsonBench.decode_adaptive                      5000    100000  avgt   20    76649.070 ±  1259.016  ns/op
[info] CirceJsonBench.decode_adaptive                     10000    100000  avgt   20   123584.282 ±   704.567  ns/op
[info] CirceJsonBench.decode_adaptive                    100000    100000  avgt   20  1013073.677 ± 24022.673  ns/op
[info] CirceJsonBench.decode_adaptive                    500000    100000  avgt   20  5211421.634 ± 68338.766  ns/op
[info] CirceJsonBench.decode_byte_buffer                   1100    100000  avgt   20    28265.613 ±    94.894  ns/op
[info] CirceJsonBench.decode_byte_buffer                   5000    100000  avgt   20    75760.460 ±   887.846  ns/op
[info] CirceJsonBench.decode_byte_buffer                  10000    100000  avgt   20   123096.025 ±   667.088  ns/op
[info] CirceJsonBench.decode_byte_buffer                 100000    100000  avgt   20  1088689.815 ± 11907.722  ns/op
[info] CirceJsonBench.decode_byte_buffer                 500000    100000  avgt   20  5534396.999 ± 42943.154  ns/op
[info] CirceJsonBench.decode_incremental                   1100    100000  avgt   20    55218.931 ±   736.221  ns/op
[info] CirceJsonBench.decode_incremental                   5000    100000  avgt   20    95511.884 ±  1571.320  ns/op
[info] CirceJsonBench.decode_incremental                  10000    100000  avgt   20   140359.831 ±  2344.243  ns/op
[info] CirceJsonBench.decode_incremental                 100000    100000  avgt   20  1008533.778 ± 18852.809  ns/op
[info] CirceJsonBench.decode_incremental                 500000    100000  avgt   20  5153683.990 ± 49192.662  ns/op
```