### PR TITLE
Improve error reporting from parboiled parsers

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -7,6 +7,7 @@ import scala.reflect.macros.whitebox.Context
 
 import macrocompat.bundle
 import org.http4s.Uri._
+import org.http4s.internal.parboiled2.ErrorFormatter
 import org.http4s.parser.{ ScalazDeliverySchemes, RequestUriParser }
 import org.http4s.util.{ Writer, Renderable, CaseInsensitiveString, UrlCodingUtils }
 import org.http4s.syntax.string._
@@ -131,6 +132,7 @@ object Uri extends UriFunctions {
   /** Decodes the String to a [[Uri]] using the RFC 3986 uri decoding specification */
   def fromString(s: String): ParseResult[Uri] = new RequestUriParser(s, StandardCharsets.UTF_8).Uri
     .run()(ScalazDeliverySchemes.Disjunction)
+    .leftMap(e => ParseFailure("Invalid URI", e.format(s)))
 
   /** Parses a String to a [[Uri]] according to RFC 3986.  If decoding
    *  fails, throws a [[ParseFailure]].
@@ -144,6 +146,7 @@ object Uri extends UriFunctions {
   /** Decodes the String to a [[Uri]] using the RFC 7230 section 5.3 uri decoding specification */
   def requestTarget(s: String): ParseResult[Uri] = new RequestUriParser(s, StandardCharsets.UTF_8).RequestUri
     .run()(ScalazDeliverySchemes.Disjunction)
+    .leftMap(e => ParseFailure("Invalid request target", e.format(s)))
 
   type Scheme = CaseInsensitiveString
 

--- a/core/src/main/scala/org/http4s/parser/Http4sHeaderParser.scala
+++ b/core/src/main/scala/org/http4s/parser/Http4sHeaderParser.scala
@@ -10,5 +10,5 @@ private[parser] abstract class Http4sHeaderParser[H <: Header](val input: Parser
 
   def parse: ParseResult[H] =
     entry.run()(ScalazDeliverySchemes.Disjunction)
-      .leftMap(e => ParseFailure("Invalid header", e.format(s)))
+      .leftMap(e => ParseFailure("Invalid header", e.format(input)))
 }

--- a/core/src/main/scala/org/http4s/parser/Http4sHeaderParser.scala
+++ b/core/src/main/scala/org/http4s/parser/Http4sHeaderParser.scala
@@ -8,5 +8,7 @@ private[parser] abstract class Http4sHeaderParser[H <: Header](val input: Parser
 
   def entry: Rule1[H]
 
-  def parse: ParseResult[H] = entry.run()(ScalazDeliverySchemes.Disjunction)
+  def parse: ParseResult[H] =
+    entry.run()(ScalazDeliverySchemes.Disjunction)
+      .leftMap(e => ParseFailure("Invalid header", e.format(s)))
 }

--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -19,7 +19,7 @@ package org.http4s.parser
 
 import scala.reflect.ClassTag
 import scalaz.Validation
-import org.http4s.ParseResult
+import org.http4s.{ParseFailure, ParseResult}
 import org.http4s.internal.parboiled2._
 import org.http4s.internal.parboiled2.support._
 
@@ -88,6 +88,7 @@ private[http4s] object Rfc2616BasicRules {
   def token(in: ParserInput): ParseResult[String] = new Rfc2616BasicRules {
     override def input: ParserInput = in
   }.Token.run()(ScalazDeliverySchemes.Disjunction)
+    .leftMap(e => ParseFailure("Invalid token", e.format(in)))
 
   def isToken(in: ParserInput) = token(in).isRight
 }

--- a/core/src/main/scala/org/http4s/parser/ScalazDeliverySchemes.scala
+++ b/core/src/main/scala/org/http4s/parser/ScalazDeliverySchemes.scala
@@ -14,10 +14,10 @@ private[http4s] object ScalazDeliverySchemes {
   // scalastyle:off public.methods.have.type
   implicit def Disjunction[L <: HList, Out](implicit unpack: Unpack.Aux[L, Out]) =
     new DeliveryScheme[L] {
-      type Result = ParseFailure \/ Out
+      type Result = ParseError \/ Out
       def success(result: L) = \/-(unpack(result))
-      def parseError(error: ParseError) = -\/(ParseFailure("", errorFormattter.formatExpectedAsString(error)))
-      def failure(error: Throwable) = -\/(ParseFailure("Exception during parsing.", error.getMessage))
+      def parseError(error: ParseError) = -\/(error)
+      def failure(error: Throwable) = throw error
     }
   // scalastyle:on public.methods.have.type
 }

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -69,7 +69,9 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
       }
 
       "provide a useful error message if string argument is not url-encoded" in {
-        Uri.fromString("http://example.org/a file") must_=== -\/(ParseFailure("", "'/', 'EOI', '#', '?' or Pchar"))
+        Uri.fromString("http://example.org/a file") must_=== -\/(ParseFailure("Invalid URI", """Invalid input ' ', expected '/', 'EOI', '#', '?' or Pchar (line 1, column 21):
+http://example.org/a file
+                    ^"""))
       }
     }
 


### PR DESCRIPTION
Our existing delivery scheme discards too much information from the parse error.  Nearly every header parser that fails only returns `"entry"` as the detail.  Now we get:

```
scala> HttpHeaderParser.CONTENT_LENGTH("blech").leftMap(_.message)
res4: String \/ org.http4s.headers.Content-Length =
-\/(Invalid header: Invalid input 'b', expected entry (line 1, column 1):
blech
^)
```

All the leftMapping is so we can bring the `ParseError` back to where we have the input.

This will make some of the headers work @wedens is doing on #1143 more useful.