### PR TITLE
Adaptive EntityDecoder[Json] for circe (release-0.16.x)

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -7,6 +7,7 @@ import org.openjdk.jmh.annotations._
 import java.util.concurrent.TimeUnit
 import org.http4s._
 import org.http4s.circe._
+import org.http4s.internal.compatibility._
 import scalaz.\/
 
 // sbt "bench/jmh:run -i 10 -wi 10 -f 2 -t 1 org.http4s.bench.CirceJsonBench"

--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -1,0 +1,53 @@
+package org.http4s
+package bench
+
+import io.circe._
+import io.circe.parser._
+import org.openjdk.jmh.annotations._
+import java.util.concurrent.TimeUnit
+import org.http4s._
+import org.http4s.circe._
+import scalaz.\/
+
+// sbt "bench/jmh:run -i 10 -wi 10 -f 2 -t 1 org.http4s.bench.CirceJsonBench"
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class CirceJsonBench {
+  import CirceJsonBench._
+
+  @Benchmark
+  def decode_byte_buffer(in: BenchState): \/[DecodeFailure, Json] =
+    jsonDecoderByteBuffer.decode(in.req, strict = true).run.unsafePerformSync
+
+  @Benchmark
+  def decode_incremental(in: BenchState): \/[DecodeFailure, Json] =
+    jsonDecoderIncremental.decode(in.req, strict = true).run.unsafePerformSync
+
+  @Benchmark
+  def decode_adaptive(in: BenchState): \/[DecodeFailure, Json] =
+    jsonDecoderAdaptive(in.cutoff).decode(in.req, strict = true).run.unsafePerformSync
+}
+
+object CirceJsonBench {
+  // val obj = Json.obj("foo" -> Json.obj("foo2" -> Json.fromString("bar")))
+  val jsonStr = """{"_id":"58fefc19a5eab74376285220","index":0,"guid":"f5740e2b-7bcf-4bb8-9303-774b1ad99f84","isActive":false,"balance":"$1,052.47","picture":"http://placehold.it/32x32","age":34,"eyeColor":"brown","name":"Calhoun Schneider","gender":"male","company":"GEEKMOSIS","email":"calhounschneider@geekmosis.com","phone":"+1 (890) 564-2582","address":"457 Milford Street, Cutter, Nevada, 204","about":"Irure esse sint esse ullamco dolor veniam commodo eiusmod fugiat minim nostrud. Minim occaecat aliquip magna qui ad nisi laboris adipisicing eiusmod amet deserunt ut. Commodo nulla ullamco et esse eu fugiat elit amet nisi dolore id id aliquip qui. In ex excepteur ea labore nulla eu ullamco anim occaecat sint. Consequat do excepteur consequat est.\r\n","registered":"2014-12-04T02:58:51 -06:00","latitude":60.317658,"longitude":-58.313338,"tags":["laboris","ad","ullamco","ea","ex","est","labore"],"friends":[{"id":0,"name":"Angie Johns"},{"id":1,"name":"Francine Mclean"},{"id":2,"name":"Elaine Hebert"}],"greeting":"Hello, Calhoun Schneider! You have 9 unread messages.","favoriteFruit":"apple"}"""
+  val obj = parse(jsonStr).right.get
+
+  @State(Scope.Benchmark)
+  class BenchState {
+    @Param(Array("1100", "5000", "10000", "100000", "500000"))
+    var approxContentLength: Int = _
+    @Param(Array("100000"))
+    var cutoff: Long = _
+    var req: Request = _
+
+    @Setup(Level.Trial)
+    def setup(): Unit = {
+      val arraySize = (approxContentLength.toDouble /
+        jsonStr.getBytes("UTF-8").length.toDouble).round.toInt
+      val json = Json.arr((1 to arraySize).map(_ => obj):_*)
+      req = Request().withBody(json).unsafePerformSync
+      println(s"Array size: $arraySize; Approx. Content-Length: $approxContentLength; Content-Length: ${req.contentLength}")
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -237,9 +237,10 @@ lazy val bench = http4sProject("bench")
   .enablePlugins(DisablePublishingPlugin)
   .settings(noCoverageSettings)
   .settings(
-    description := "Benchmarks for http4s"
+    description := "Benchmarks for http4s",
+    libraryDependencies += circeParser
   )
-  .dependsOn(core)
+  .dependsOn(core, circe)
 
 lazy val loadTest = http4sProject("load-test")
   .enablePlugins(DisablePublishingPlugin)

--- a/circe/src/main/scala/org/http4s/circe/package.scala
+++ b/circe/src/main/scala/org/http4s/circe/package.scala
@@ -1,8 +1,11 @@
 package org.http4s
 
-import io.circe.Printer
+import io.circe.{Json, Printer}
 
 package object circe extends CirceInstances {
-  protected def defaultPrinter: Printer =
+  override val defaultPrinter: Printer =
     Printer.noSpaces
+
+  override val jsonDecoder: EntityDecoder[Json] =
+    CirceInstances.defaultJsonDecoder
 }

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -9,12 +9,14 @@ import scalaz.stream.Process.emit
 
 trait JawnInstances {
   def jawnDecoder[J](implicit facade: Facade[J]): EntityDecoder[J] =
-    EntityDecoder.decodeBy(MediaType.`application/json`) { msg =>
-      DecodeResult {
-        msg.body.parseJson(AsyncParser.SingleValue).partialAttempt {
-          case pe: ParseException =>
-            emit(MalformedMessageBodyFailure("Invalid JSON", Some(pe)))
-        }.runLastOr(-\/(MalformedMessageBodyFailure("Invalid JSON: empty body")))
-      }
+    // EntityDecoder.decodeBy(MediaType.`application/json`)(jawnDecoderImpl[J])
+    EntityDecoder.decodeBy(MediaType.`application/json`)(jawnDecoderImpl[J])
+
+  private[http4s] def jawnDecoderImpl[J](msg: Message)(implicit facade: Facade[J]): DecodeResult[J] =
+    DecodeResult {
+      msg.body.parseJson(AsyncParser.SingleValue).partialAttempt {
+        case pe: ParseException =>
+          emit(MalformedMessageBodyFailure("Invalid JSON", Some(pe)))
+      }.runLastOr(-\/(MalformedMessageBodyFailure("Invalid JSON: empty body")))
     }
 }

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -112,6 +112,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % circeJawn.revision
   lazy val circeJawn                        = "io.circe"               %% "circe-jawn"                % "0.7.1"
   lazy val circeLiteral                     = "io.circe"               %% "circe-literal"             % circeJawn.revision
+  lazy val circeParser                      = "io.circe"               %% "circe-parser"              % circeJawn.revision
   lazy val cryptobits                       = "org.reactormonk"        %% "cryptobits"                % "1.1"
   lazy val discipline                       = "org.typelevel"          %% "discipline"                % "0.7.3"
   lazy val gatlingTest                      = "io.gatling"             %  "gatling-test-framework"    % "2.2.3"


### PR DESCRIPTION
Same as #1142 with release-0.16.x target.
```
[info] Benchmark                          (approxContentLength)  (cutoff)  Mode  Cnt        Score        Error  Units
[info] CirceJsonBench.decode_adaptive                      1100    100000  avgt   20    12273.404 ±    384.060  ns/op
[info] CirceJsonBench.decode_adaptive                      5000    100000  avgt   20    57869.141 ±   2193.909  ns/op
[info] CirceJsonBench.decode_adaptive                     10000    100000  avgt   20   101528.284 ±   2941.912  ns/op
[info] CirceJsonBench.decode_adaptive                    100000    100000  avgt   20   914144.688 ±  20481.076  ns/op
[info] CirceJsonBench.decode_adaptive                    500000    100000  avgt   20  4701151.022 ± 117407.744  ns/op
[info] CirceJsonBench.decode_byte_buffer                   1100    100000  avgt   20    11947.456 ±    274.789  ns/op
[info] CirceJsonBench.decode_byte_buffer                   5000    100000  avgt   20    56818.944 ±   2292.285  ns/op
[info] CirceJsonBench.decode_byte_buffer                  10000    100000  avgt   20    98592.939 ±   1895.418  ns/op
[info] CirceJsonBench.decode_byte_buffer                 100000    100000  avgt   20  1071727.546 ±  40842.539  ns/op
[info] CirceJsonBench.decode_byte_buffer                 500000    100000  avgt   20  5255632.811 ± 123497.299  ns/op
[info] CirceJsonBench.decode_incremental                   1100    100000  avgt   20    36801.777 ±   2742.337  ns/op
[info] CirceJsonBench.decode_incremental                   5000    100000  avgt   20    77018.517 ±   3792.942  ns/op
[info] CirceJsonBench.decode_incremental                  10000    100000  avgt   20   122816.869 ±   6909.232  ns/op
[info] CirceJsonBench.decode_incremental                 100000    100000  avgt   20   941245.294 ±  30284.970  ns/op
[info] CirceJsonBench.decode_incremental                 500000    100000  avgt   20  4936960.637 ± 185787.949  ns/op
```
Just to compare. Benchmark results from #1142 with benchmark executed on the same computer (benchmark results posted in #1142 are from different computer):
```
[info] Benchmark                          (approxContentLength)  (cutoff)  Mode  Cnt        Score       Error  Units
[info] CirceJsonBench.decode_adaptive                      1100    100000  avgt   20    28202.971 ±   381.927  ns/op
[info] CirceJsonBench.decode_adaptive                      5000    100000  avgt   20    74339.225 ±  2496.376  ns/op
[info] CirceJsonBench.decode_adaptive                     10000    100000  avgt   20   122486.480 ±  3720.081  ns/op
[info] CirceJsonBench.decode_adaptive                    100000    100000  avgt   20   973991.958 ± 44714.516  ns/op
[info] CirceJsonBench.decode_adaptive                    500000    100000  avgt   20  4861055.580 ± 53246.377  ns/op
[info] CirceJsonBench.decode_byte_buffer                   1100    100000  avgt   20    27891.493 ±   251.525  ns/op
[info] CirceJsonBench.decode_byte_buffer                   5000    100000  avgt   20    71452.446 ±   460.197  ns/op
[info] CirceJsonBench.decode_byte_buffer                  10000    100000  avgt   20   117383.396 ±   945.563  ns/op
[info] CirceJsonBench.decode_byte_buffer                 100000    100000  avgt   20  1075061.920 ± 63420.034  ns/op
[info] CirceJsonBench.decode_byte_buffer                 500000    100000  avgt   20  5298483.419 ± 55836.618  ns/op
[info] CirceJsonBench.decode_incremental                   1100    100000  avgt   20    64656.237 ±  4267.031  ns/op
[info] CirceJsonBench.decode_incremental                   5000    100000  avgt   20   104110.711 ±  2883.222  ns/op
[info] CirceJsonBench.decode_incremental                  10000    100000  avgt   20   139514.163 ±   952.724  ns/op
[info] CirceJsonBench.decode_incremental                 100000    100000  avgt   20   990475.315 ± 39195.038  ns/op
[info] CirceJsonBench.decode_incremental                 500000    100000  avgt   20  4979513.288 ± 95285.700  ns/op
```