### PR TITLE
Fix various issues with multipart parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
     * argonaut-6.2
     * scalaz-7.2.12
 * Allow preambles and epilogues in multipart bodies
-* Limit multipart headers to 10 kilobytes to avoid unbounded buffering
+* Limit multipart headers to 40 kilobytes to avoid unbounded buffering
   of long lines in a header
 * Remove `' '` and `'?'` from alphabet for generated multipart
   boundaries, as these are not token characters and are known to cause
   trouble for some multipart implementations
+* Fix multipart parsing for unlucky input chunk sizes
 
 # v0.15.9 (2017-04-19)
 * Terminate `ServerApp` even if the server fails to start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 * Patch-level upgrades to dependencies
     * argonaut-6.2
     * scalaz-7.2.12
+* Allow preambles and epilogues in multipart bodies
+* Limit multipart headers to 10 kilobytes to avoid unbounded buffering
+  of long lines in a header
+* Remove `' '` and `'?'` from alphabet for generated multipart
+  boundaries, as these are not token characters and are known to cause
+  trouble for some multipart implementations
 
 # v0.15.9 (2017-04-19)
 * Terminate `ServerApp` even if the server fails to start

--- a/core/src/main/scala/org/http4s/multipart/Multipart.scala
+++ b/core/src/main/scala/org/http4s/multipart/Multipart.scala
@@ -61,7 +61,10 @@ object Boundary {
 
   private val DIGIT = ('0' to '9').toList
   private val ALPHA = ('a' to 'z').toList ++ ('A' to 'Z').toList
-  private val OTHER = """'()+_,-./:=? """.toSeq
+  // ' ' and '?' are also allowed by spec, but mean we need to quote
+  // the boundary in the media type, which causes some implementations
+  // pain.
+  private val OTHER = """'()+_,-./:=""".toSeq
   private val CHARS = (DIGIT ++ ALPHA ++ OTHER).toList
   private val nchars = CHARS.length
   private val rand = new Random()

--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -5,7 +5,7 @@ import scala.language.postfixOps
 
 import scodec.bits.ByteVector
 
-import scalaz.{-\/, \/-, \/}
+import scalaz.{-\/, \/-, \/, State}
 import scalaz.stream.{process1, Process, Process1, Writer1}
 
 /** A low-level multipart-parsing pipe.  Most end users will prefer EntityDecoder[Multipart]. */
@@ -19,7 +19,10 @@ object MultipartParser {
 
   private final case class Out[+A](a: A, tail: Option[ByteVector] = None)
 
-  def parse(boundary: Boundary): Writer1[Headers, ByteVector, ByteVector] = {
+  def parse(boundary: Boundary): Writer1[Headers, ByteVector, ByteVector] =
+    parse(boundary, 10 * 1024)
+
+  def parse(boundary: Boundary, headerLimit: Long): Writer1[Headers, ByteVector, ByteVector] = {
     val boundaryBytes = boundary.toByteVector
     val startLine = DASHDASH ++ boundaryBytes
     val endLine = startLine ++ DASHDASH
@@ -51,6 +54,10 @@ object MultipartParser {
       leading map handle getOrElse receive1(handle)
     }
 
+    def takeUpTo(n: Long, pf: => ParseFailure): Process1[ByteVector, ByteVector] =
+      if (n > 0) receive1(bv => emit(bv) ++ takeUpTo(n - bv.size, pf))
+      else fail(pf)
+
     def receiveCollapsedLine(leading: Option[ByteVector]): Process1[ByteVector, Out[ByteVector]] = {
       receiveLine(leading) pipe process1.fold(Out(ByteVector.empty)) {
         case (acc, -\/(partial)) => acc.copy(acc.a ++ partial)
@@ -59,6 +66,25 @@ object MultipartParser {
     }
 
     def start: Writer1[Headers, ByteVector, ByteVector] = {
+      val partHeaderTooLong =
+        ParseFailure("Invalid multipart entity", s"Part header was longer than ${headerLimit}-byte limit")
+
+      logger.info("Exepected " + expected)
+
+      def preamble(leading: Option[ByteVector]): Process1[ByteVector, Option[ByteVector]] =
+        body(leading.map(_.compact), expected).flatMap {
+          case Out(chunk, None) =>
+            logger.debug(s"preamble chunk: $chunk")
+            halt
+          case Out(ByteVector.empty, tail) =>
+            logger.trace(s"Resuming preamble with $tail.")
+            emit(tail)
+          case Out(chunk, tail) =>
+            logger.debug(s"Last preamble chunk: $chunk.")
+            logger.trace(s"Resuming with $tail.")
+            emit(tail)
+        }
+
       def beginPart(leading: Option[ByteVector]): Process1[ByteVector, Option[ByteVector]] = {
         def isStartLine(line: ByteVector): Boolean =
           line.startsWith(startLine) && isTransportPadding(line.drop(startLine.size))
@@ -78,22 +104,32 @@ object MultipartParser {
             logger.debug("Found end line. Halting.")
             halt
           }
-          else {
-            logger.trace(s"Discarding prelude: $line")
+          else if (line.nonEmpty) {
+            logger.trace(s"Discarding preamble: $line")
             beginPart(tail)
+          }
+          else {
+            halt
           }
         }
       }
 
-      def go(leading: Option[ByteVector]): Writer1[Headers, ByteVector, ByteVector] = {
-        for {
+      def headers(leading: Option[ByteVector]): Process1[ByteVector, Out[Headers]] = {
+        takeUpTo(headerLimit, partHeaderTooLong) pipe (for {
           tail <- beginPart(leading)
           headerPair <- header(tail, expected)
           Out(headers, tail2) = headerPair
           _ = logger.debug(s"Headers: $headers")
           spacePair <- receiveCollapsedLine(tail2)
           tail3 = spacePair.tail // eat the space between header and content
-          part <- emit(-\/(headers)) ++ body(tail3.map(_.compact), expected).flatMap {
+        } yield Out(headers, tail3))
+      }
+
+      def go(leading: Option[ByteVector]): Writer1[Headers, ByteVector, ByteVector] = {
+        for {
+          headerPair <- headers(leading)
+          Out(headers, tail) = headerPair
+          part <- emit(-\/(headers)) ++ body(tail.map(_.compact), expected).flatMap {
             case Out(chunk, None) =>
               logger.debug(s"Chunk: $chunk")
               emit(\/-(chunk))
@@ -108,7 +144,11 @@ object MultipartParser {
         } yield part
       }
 
-      go(None)
+      // RFC1341 says we can tolerate a multipart body that begins
+      // with an enacpsulation line NOT initiated by a CRLF.  If we
+      // supply our own to start the preamble, we are tolerant.  If
+      // it's in the body, it gets eaten as part of the preamble.
+      preamble(Some(CRLF)).flatMap(go)
     }
 
     def header(leading: Option[ByteVector], expected: ByteVector): Process1[ByteVector, Out[Headers]] = {
@@ -165,7 +205,7 @@ object MultipartParser {
        * @param remainder the part of the next boundary we're looking for on the next read.
        */
       def mid(found: ByteVector, remainder: ByteVector): Process1[ByteVector, Out[ByteVector]] = {
-        logger.trace(s"mid: $found remainder")
+        logger.trace(s"mid: $found $remainder")
         if (remainder.isEmpty) {
           // found should start with a CRLF, because mid is called with it.
           emit(Out(ByteVector.empty, Some(found.drop(2))))
@@ -173,6 +213,7 @@ object MultipartParser {
           receive1Or[ByteVector, Out[ByteVector]](
             fail(new MalformedMessageBodyFailure("Part was not terminated"))) { bv =>
             val (remFront, remBack) = remainder splitAt bv.length
+            logger.trace(s"remFront = $remFront; remBack = $remBack; bv = $bv")
             if (bv startsWith remFront) {
               // If remBack is nonEmpty, then the progress toward our match
               // is represented by bv, and we'll loop back to read more to

--- a/tests/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
@@ -19,12 +19,21 @@ object MultipartParserSpec extends Specification {
     case c => c.toString
   }
 
+  def unspool(str: String, limit: Int = Int.MaxValue): Process0[ByteVector] = {
+    if (str.isEmpty) {
+      halt
+    } else if (str.length <= limit) {
+      emit(ByteVector view (str getBytes "ASCII"))
+    } else {
+      val (front, back) = str.splitAt(limit)
+      emit(ByteVector view (front getBytes "ASCII")) ++ unspool(back, limit)
+    }
+  }
+
   "form parsing" should {
-    "produce the body from a single part input" in {
-
-      val Limit = 15
-
-      val unprocessedInput = """--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+    "produce the body from a single part input split across chunks" in {
+      val unprocessedInput = """
+        |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
         |Content-Disposition: form-data; name="upload"; filename="integration.txt"
         |Content-Type: application/octet-stream
         |Content-Transfer-Encoding: binary
@@ -48,20 +57,8 @@ object MultipartParserSpec extends Specification {
               |catch me if you can!
               |""".stripMargin)
 
-      def unspool(str: String): Process0[ByteVector] = {
-        if (str.isEmpty) {
-          halt
-        } else if (str.length <= Limit) {
-          emit(ByteVector view (str getBytes "ASCII"))
-        } else {
-          val front = str.substring(0, Limit)
-          val back = str.substring(Limit)
-
-          emit(ByteVector view (front getBytes "ASCII")) ++ unspool(back)
-        }
-      }
-
-      val results: Process0[Headers \/ ByteVector] = unspool(input) pipe MultipartParser.parse(boundary)
+      val results: Process0[Headers \/ ByteVector] =
+        unspool(input, 15) pipe MultipartParser.parse(boundary)
 
       val (headers, bv) = results.toVector.foldLeft((Headers.empty, ByteVector.empty)) {
         case ((hsAcc, bvAcc), \/-(bv)) => (hsAcc, bvAcc ++ bv)
@@ -72,7 +69,43 @@ object MultipartParserSpec extends Specification {
       bv.decodeAscii mustEqual Right(expected)
     }
 
-    "produce the body from a single part input without limit" in {
+    "produce the body from a single part that doesn't start with a CRLF" in {
+      val unprocessedInput = """--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+        |Content-Disposition: form-data; name="upload"; filename="integration.txt"
+        |Content-Type: application/octet-stream
+        |Content-Transfer-Encoding: binary
+        |
+        |this is a test
+        |here's another test
+        |catch me if you can!
+        |
+        |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI--""".stripMargin
+
+      val input = ruinDelims(unprocessedInput)
+      val results: Process0[Headers \/ ByteVector] =
+        unspool(input, 15) pipe MultipartParser.parse(boundary)
+
+      val expectedHeaders = Headers(
+        `Content-Disposition`("form-data", Map("name" -> "upload", "filename" -> "integration.txt")),
+        `Content-Type`(MediaType.`application/octet-stream`),
+        Header("Content-Transfer-Encoding", "binary")
+      )
+
+      val expected = ruinDelims("""this is a test
+              |here's another test
+              |catch me if you can!
+              |""".stripMargin)
+
+      val (headers, bv) = results.toVector.foldLeft((Headers.empty, ByteVector.empty)) {
+        case ((hsAcc, bvAcc), \/-(bv)) => (hsAcc, bvAcc ++ bv)
+        case ((hsAcc, bvAcc), -\/(hs)) => (hsAcc ++ hs, bvAcc)
+      }
+
+      headers mustEqual (expectedHeaders)
+      bv.decodeAscii mustEqual Right(expected)
+    }
+
+    "discard preamble and epilogue" in {
       val unprocessedInput = """--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
         |Content-Disposition: form-data; name="upload"; filename="integration.txt"
         |Content-Type: application/octet-stream
@@ -97,7 +130,94 @@ object MultipartParserSpec extends Specification {
               |catch me if you can!
               |""".stripMargin)
 
-      def unspool(str: String): Process0[ByteVector] = emit(ByteVector view (str getBytes "ASCII"))
+      val preamble = emit(ByteVector.view("Misery is the river of the world".getBytes("ASCII"))).repeat.take(10)
+      val epilogue = emit(ByteVector.view("Everybody Row!\n".getBytes("ASCII"))).repeat.take(10)
+
+      val results: Process0[Headers \/ ByteVector] =
+        (preamble ++ emit(ByteVector.view("\r\n".getBytes("ASCII"))) ++ unspool(input, 15) ++ epilogue).pipe(MultipartParser.parse(boundary))
+
+      val (headers, bv) = results.toVector.foldLeft((Headers.empty, ByteVector.empty)) {
+        case ((hsAcc, bvAcc), \/-(bv)) => (hsAcc, bvAcc ++ bv)
+        case ((hsAcc, bvAcc), -\/(hs)) => (hsAcc ++ hs, bvAcc)
+      }
+
+      headers mustEqual (expectedHeaders)
+      bv.decodeAscii mustEqual Right(expected)
+    }
+
+    "fail if the header is too large" in {
+      val unprocessedInput = """
+        |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+        |Content-Disposition: form-data; name="upload"; filename="integration.txt"
+        |Content-Type: application/octet-stream
+        |Content-Transfer-Encoding: binary
+        |
+        |this is a test
+        |here's another test
+        |catch me if you can!
+        |
+        |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI--""".stripMargin
+      val input = ruinDelims(unprocessedInput)
+
+      val results: Process0[Headers \/ ByteVector] =
+        unspool(input, 15) pipe MultipartParser.parse(boundary, 100)
+
+      results.toVector must throwA(ParseFailure("Invalid multipart entity", "Part header was longer than 100-byte limit"))
+    }
+
+    "handle an miserably large body on one line" in {
+      val input = ruinDelims("""--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+        |Content-Disposition: form-data; name="upload"; filename="integration.txt"
+        |Content-Type: application/octet-stream
+        |Content-Transfer-Encoding: binary
+        |
+        """.stripMargin)
+      val end = "--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI--"
+
+      val expectedHeaders = Headers(
+        `Content-Disposition`("form-data", Map("name" -> "upload", "filename" -> "integration.txt")),
+        `Content-Type`(MediaType.`application/octet-stream`),
+        Header("Content-Transfer-Encoding", "binary")
+      )
+
+      val body = emit(ByteVector.view("Misery is the river of the world".getBytes("ASCII"))).repeat.take(100000)
+
+      val results: Process0[Headers \/ ByteVector] =
+        (unspool(input) ++ body ++ emit(ByteVector.view("\r\n".getBytes("ASCII"))) ++ unspool(end)).pipe(MultipartParser.parse(boundary))
+
+      val headers = results.toVector.foldLeft(Headers.empty) {
+        case (hsAcc, \/-(_)) => hsAcc
+        case (hsAcc, -\/(hs)) => hsAcc ++ hs
+      }
+
+      headers mustEqual (expectedHeaders)
+    }
+
+    "produce the body from a single part input of one chunk" in {
+      val unprocessedInput = """
+        |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+        |Content-Disposition: form-data; name="upload"; filename="integration.txt"
+        |Content-Type: application/octet-stream
+        |Content-Transfer-Encoding: binary
+        |
+        |this is a test
+        |here's another test
+        |catch me if you can!
+        |
+        |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI--""".stripMargin
+
+      val input = ruinDelims(unprocessedInput)
+
+      val expectedHeaders = Headers(
+        `Content-Disposition`("form-data", Map("name" -> "upload", "filename" -> "integration.txt")),
+        `Content-Type`(MediaType.`application/octet-stream`),
+        Header("Content-Transfer-Encoding", "binary")
+      )
+
+      val expected = ruinDelims("""this is a test
+              |here's another test
+              |catch me if you can!
+              |""".stripMargin)
 
       val results: Process0[Headers \/ ByteVector] = unspool(input) pipe MultipartParser.parse(boundary)
 
@@ -115,7 +235,8 @@ object MultipartParserSpec extends Specification {
     }
 
     "produce the body from a two-part input" in {
-      val unprocessedInput = """--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+      val unprocessedInput = """
+        |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
         |Content-Disposition: form-data; name="upload"; filename="integration.txt"
         |Content-Type: application/octet-stream
         |Content-Transfer-Encoding: binary
@@ -132,19 +253,6 @@ object MultipartParserSpec extends Specification {
 
       val input = ruinDelims(unprocessedInput)
 
-      val expectedHeaders = Headers(
-        `Content-Disposition`("form-data", Map("name" -> "upload", "filename" -> "integration.txt")),
-        `Content-Type`(MediaType.`application/octet-stream`),
-        Header("Content-Transfer-Encoding", "binary")
-      )
-
-      val expected = ruinDelims("""this is a test
-              |here's another test
-              |catch me if you can!
-              |""".stripMargin)
-
-      def unspool(str: String): Process0[ByteVector] = emit(ByteVector view (str getBytes "ASCII"))
-
       val results: Process0[Headers \/ ByteVector] = unspool(input) pipe MultipartParser.parse(boundary)
 
       val (headers, bv) = results.toVector.foldLeft((Headers.empty, ByteVector.empty)) {
@@ -156,7 +264,8 @@ object MultipartParserSpec extends Specification {
     }
 
     "fail with an MalformedMessageBodyFailure without an end line" in {
-      val unprocessedInput = """--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+      val unprocessedInput = """
+        |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
         |Content-Disposition: form-data; name="upload"; filename="integration.txt"
         |Content-Type: application/octet-stream
         |Content-Transfer-Encoding: binary
@@ -166,7 +275,6 @@ object MultipartParserSpec extends Specification {
         |catch me if you can!""".stripMargin
       val input = ruinDelims(unprocessedInput)
 
-      def unspool(str: String): Process0[ByteVector] = emit(ByteVector view (str getBytes "ASCII"))
       val results: Process0[Headers \/ ByteVector] = unspool(input) pipe MultipartParser.parse(boundary)
 
       results.toVector must throwAn[MalformedMessageBodyFailure]


### PR DESCRIPTION
- Skip the preamble
- Bail out after a default of 10240 characters in the header.  This prevents us from buffering an arbitrarily long line in the header.  10240 is the default used by commons-fileupload.
- Skip the epilogue
- Remove non-token characters from the boundary alphabet

Also ensures that we can handle bodies with really long lines.