### PR TITLE
Fix Failing UriParserSpec

### DIFF
--- a/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -4,8 +4,8 @@ import java.nio.charset.{Charset => NioCharset, StandardCharsets}
 
 import org.http4s.Uri._
 import org.http4s._
-
 import org.http4s.internal.parboiled2._
+import cats.implicits._
 
 class IpParser(val input: ParserInput, val charset: NioCharset) extends Parser with Rfc3986Parser {
   def CaptureIPv6: Rule1[String] = rule { capture(IpV6Address) }
@@ -36,14 +36,14 @@ class UriParserSpec extends Http4sSpec {
       } yield (f + "::" + b))
 
       foreach(v) { s =>
-        new IpParser(s, StandardCharsets.UTF_8).CaptureIPv6.run().toEither must beRight(s)
+        Either.fromTry(new IpParser(s, StandardCharsets.UTF_8).CaptureIPv6.run()) must beRight(s)
       }
     }
 
     "parse a IPv4 address" in {
       foreach(0 to 255) { i =>
         val addr = s"$i.$i.$i.$i"
-        new IpParser(addr, StandardCharsets.UTF_8).CaptureIPv4.run().toEither must beRight(addr)
+        Either.fromTry(new IpParser(addr, StandardCharsets.UTF_8).CaptureIPv4.run()) must beRight(addr)
       }
     }
 


### PR DESCRIPTION
toEither was a method added in 2.12 to Either to convert from Try. To maintain support for 2.11 utilize the cats Either.fromTry which is present in both versions.

Fixes #1163