### PR TITLE
Added SBT Import to Client Tut Documentation

### DIFF
--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -30,6 +30,15 @@ A good default choice is the `PooledHttp1Client`.  As the name
 implies, the `PooledHttp1Client` maintains a connection pool and
 speaks HTTP 1.x.
 
+First, we'll need a dependency on the http4s blaze-client
+
+```scala
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-blaze-client" % http4sVersion
+)
+```
+and then we can create the client.
+
 ```tut:book
 import org.http4s.client.blaze._
 


### PR DESCRIPTION
Current documentation did not include the information about sbt dependencies to utilize the client. The additional section remedies this problem.

Fixes #1137