### PR TITLE
Added SBT Import to Client Tut Documentation

### DIFF
--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -7,7 +7,24 @@ title: HTTP Client
 How do we know the server is running?  Let's create a client with
 http4s to try our service.
 
-The service again so tut picks it up:
+A recap of the dependencies for this example, in case you skipped the [service] example. With the following dependencies in your build.sbt:
+
+```scala
+scalaVersion := "2.11.8" // Also supports 2.10.x and 2.12.x
+
+val http4sVersion = "{{< version "http4s.doc" >}}"
+
+// Only necessary for SNAPSHOT releases
+resolvers += Resolver.sonatypeRepo("snapshots")
+
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-dsl" % http4sVersion,
+  "org.http4s" %% "http4s-blaze-server" % http4sVersion,
+  "org.http4s" %% "http4s-blaze-client" % http4sVersion
+)
+```
+
+Then we create the [service] again so tut picks it up:
 
 ```tut:book
 import org.http4s.server.{Server, ServerApp}
@@ -29,15 +46,6 @@ val server = builder.run
 A good default choice is the `PooledHttp1Client`.  As the name
 implies, the `PooledHttp1Client` maintains a connection pool and
 speaks HTTP 1.x.
-
-First, we'll need a dependency on the http4s blaze-client
-
-```scala
-libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-blaze-client" % http4sVersion
-)
-```
-and then we can create the client.
 
 ```tut:book
 import org.http4s.client.blaze._
@@ -143,5 +151,6 @@ Passing it to a `EntityDecoder` is safe.
 client.get[T]("some-url")(response => jsonOf(response.body))
 ```
 
+[service]: ../service
 [entity]: ../entity
 [json]: ../json

--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -30,6 +30,15 @@ A good default choice is the `PooledHttp1Client`.  As the name
 implies, the `PooledHttp1Client` maintains a connection pool and
 speaks HTTP 1.x.
 
+First, we'll need a dependency on the http4s blaze-client
+
+```scala
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-blaze-client" % http4sVersion
+)
+```
+and then we can create the client.
+
 ```tut:book
 import org.http4s.client.blaze._
 

--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -7,7 +7,7 @@ title: HTTP Client
 How do we know the server is running?  Let's create a client with
 http4s to try our service.
 
-A recap of the dependencies for this example, in case you skipped the [service] example. With the following dependencies in your build.sbt:
+A recap of the dependencies for this example, in case you skipped the [service] example. Ensure you have the following dependencies in your build.sbt:
 
 ```scala
 scalaVersion := "2.11.8" // Also supports 2.10.x and 2.12.x


### PR DESCRIPTION
Current documentation did not include the information about sbt dependencies to utilize the client. The additional section remedies this problem.

Fixes #1137 