### PR TITLE
Add gzip trailer

### DIFF
--- a/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
@@ -2,10 +2,15 @@ package org.http4s
 package server
 package middleware
 
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPOutputStream
+
 import cats.implicits._
 import org.http4s.server.syntax._
 import org.http4s.dsl._
 import org.http4s.headers._
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
 
 class GZipSpec extends Http4sSpec {
   "GZip" should {
@@ -20,5 +25,21 @@ class GZipSpec extends Http4sSpec {
       resp.status must_== (Status.Ok)
       resp.headers.get(`Content-Encoding`) must beNone
     }
+
+    checkAll("encoding", new Properties("GZip") {
+      property("middleware encoding == GZIPOutputStream encoding") = forAll { value: String =>
+        val service = GZip(HttpService { case GET -> Root => Ok(value) })
+        val req = Request(Method.GET, Uri.uri("/")).putHeaders(`Accept-Encoding`(ContentCoding.gzip))
+        val actual = service.orNotFound(req).unsafeRun.body.runLog.unsafeRun.toArray
+
+        val byteArrayStream = new ByteArrayOutputStream()
+        val gzipStream = new GZIPOutputStream(byteArrayStream)
+        gzipStream.write(value.getBytes)
+        gzipStream.close()
+        val expected = byteArrayStream.toByteArray
+
+        actual === expected
+      }
+    })
   }
 }


### PR DESCRIPTION
Fixes #1167.

This adds the gzip trailer as specified in [RFC 1952](https://www.ietf.org/rfc/rfc1952.txt). It adds a 4 byte CRC32 checksum and 4 bytes to indicate the original size of the data:

```
CRC32 (CRC-32)
    This contains a Cyclic Redundancy Check value of the
    uncompressed data computed according to CRC-32 algorithm
    used in the ISO 3309 standard and in section 8.1.1.6.2 of
    ITU-T recommendation V.42.  (See http://www.iso.ch for
    ordering ISO documents. See gopher://info.itu.ch for an
    online version of ITU-T V.42.)

ISIZE (Input SIZE)
    This contains the size of the original (uncompressed) input
    data modulo 2^32.
```

@rossabaker I can work on adding tests, but wanted to get feedback before moving forward, so let me know what you think. All the tests in the [README of my test repo](https://github.com/mrdziuban/http4s-gzip-test) pass with this change.