### PR TITLE
Make servlet HTTP session available in Request attributes. Fixes #1173

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -35,7 +35,8 @@ class Http4sServlet(service: HttpService,
   private[this] val serviceFn = service.run
 
   object ServletRequestKeys {
-    val HttpSession: AttributeKey[HttpSession] = AttributeKey.http4s("request.httpSession")
+    val HttpSession: AttributeKey[Option[HttpSession]] =
+      AttributeKey[Option[HttpSession]]
   }
 
   override def init(config: ServletConfig): Unit = {
@@ -163,7 +164,7 @@ class Http4sServlet(service: HttpService,
           req.isSecure
         )),
         Request.Keys.ServerSoftware(serverSoftware),
-        ServletRequestKeys.HttpSession(req.getSession)
+        ServletRequestKeys.HttpSession(Option(req.getSession(false)))
       )
     )
 

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -6,7 +6,7 @@ import org.http4s.headers.`Transfer-Encoding`
 import org.http4s.internal.compatibility._
 import server._
 
-import javax.servlet.http.{HttpServletResponse, HttpServletRequest, HttpServlet}
+import javax.servlet.http.{HttpSession, HttpServletResponse, HttpServletRequest, HttpServlet}
 import java.net.{InetSocketAddress, InetAddress}
 
 import scala.collection.JavaConverters._
@@ -33,6 +33,10 @@ class Http4sServlet(service: HttpService,
 
   // micro-optimization: unwrap the service and call its .run directly
   private[this] val serviceFn = service.run
+
+  object ServletRequestKeys {
+    val HttpSession: AttributeKey[HttpSession] = AttributeKey.http4s("request.httpSession")
+  }
 
   override def init(config: ServletConfig): Unit = {
     val servletContext = config.getServletContext
@@ -158,7 +162,8 @@ class Http4sServlet(service: HttpService,
           InetSocketAddress.createUnresolved(req.getLocalAddr, req.getLocalPort),
           req.isSecure
         )),
-        Request.Keys.ServerSoftware(serverSoftware)
+        Request.Keys.ServerSoftware(serverSoftware),
+        ServletRequestKeys.HttpSession(req.getSession)
       )
     )
 


### PR DESCRIPTION
(remade the PR against 0.15.x branch) 
Please consider this just a draft for discussion as I'm a new contributor.

There might be a better way to name or handle the key definition, for example.

Or would it be more flexible to allow extension by overriding a method that produces the request attribute map?