### PR TITLE
WebjarService should assume pathInfo starts with a `/`

### DIFF
--- a/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceFilterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceFilterSpec.scala
@@ -16,7 +16,7 @@ object WebjarServiceFilterSpec extends Http4sSpec with StaticContentShared {
   "The WebjarService" should {
 
     "Return a 200 Ok file" in {
-      val req = Request(GET, Uri(path = "test-lib/1.0.0/testresource.txt"))
+      val req = Request(GET, Uri(path = "/test-lib/1.0.0/testresource.txt"))
       val rb = runReq(req)
 
       rb._1 must_== testWebjarResource
@@ -24,7 +24,7 @@ object WebjarServiceFilterSpec extends Http4sSpec with StaticContentShared {
     }
 
     "Not find filtered asset" in {
-      val req = Request(GET, Uri(path = "test-lib/1.0.0/sub/testresource.txt"))
+      val req = Request(GET, Uri(path = "/test-lib/1.0.0/sub/testresource.txt"))
       val rb = runReq(req)
 
       rb._2.status must_== Status.NotFound

--- a/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSpec.scala
@@ -13,7 +13,7 @@ object WebjarServiceSpec extends Http4sSpec with StaticContentShared {
   "The WebjarService" should {
 
     "Return a 200 Ok file" in {
-      val req = Request(GET, Uri(path = "test-lib/1.0.0/testresource.txt"))
+      val req = Request(GET, Uri(path = "/test-lib/1.0.0/testresource.txt"))
       val rb = runReq(req)
 
       rb._1 must_== testWebjarResource
@@ -21,7 +21,7 @@ object WebjarServiceSpec extends Http4sSpec with StaticContentShared {
     }
 
     "Return a 200 Ok file in a subdirectory" in {
-      val req = Request(GET, Uri(path = "test-lib/1.0.0/sub/testresource.txt"))
+      val req = Request(GET, Uri(path = "/test-lib/1.0.0/sub/testresource.txt"))
       val rb = runReq(req)
 
       rb._1 must_== testWebjarSubResource
@@ -29,7 +29,7 @@ object WebjarServiceSpec extends Http4sSpec with StaticContentShared {
     }
 
     "Not find missing file" in {
-      val req = Request(uri = uri("test-lib/1.0.0/doesnotexist.txt"))
+      val req = Request(uri = uri("/test-lib/1.0.0/doesnotexist.txt"))
       runReq(req)._2.status must_== Status.NotFound
     }
 
@@ -39,21 +39,19 @@ object WebjarServiceSpec extends Http4sSpec with StaticContentShared {
     }
 
     "Not find missing version" in {
-      val req = Request(uri = uri("test-lib//doesnotexist.txt"))
+      val req = Request(uri = uri("/test-lib//doesnotexist.txt"))
       runReq(req)._2.status must_== Status.NotFound
     }
 
     "Not find missing asset" in {
-      val req = Request(uri = uri("test-lib/1.0.0/"))
+      val req = Request(uri = uri("/test-lib/1.0.0/"))
       runReq(req)._2.status must_== Status.NotFound
     }
 
     "Not match a request with POST" in {
-      val req = Request(POST, Uri(path = "test-lib/1.0.0/testresource.txt"))
+      val req = Request(POST, Uri(path = "/test-lib/1.0.0/testresource.txt"))
 
       runReq(req) must throwA[MatchError]
     }
-
   }
-
 }


### PR DESCRIPTION
In the real world, pathInfo always begins with a '/' unless it's
empty.  In the current implementation, it's assuming no leading slash,
leading to the webjar segments being off by one.

/cc @Busti