### PR TITLE
ServerApp should override process

### DIFF
--- a/core/src/main/scala/org/http4s/util/ProcessApp.scala
+++ b/core/src/main/scala/org/http4s/util/ProcessApp.scala
@@ -11,7 +11,7 @@ import scalaz.stream.{async, wye}
 trait ProcessApp {
   private[this] val logger = org.log4s.getLogger
 
-  def process(args: List[String]): Process[Task, Unit]
+  def process(args: List[String]): Process[Task, Nothing]
 
   private[this] val shutdownRequested =
     async.signalOf(false)

--- a/core/src/main/scala/org/http4s/util/Task.scala
+++ b/core/src/main/scala/org/http4s/util/Task.scala
@@ -9,6 +9,10 @@ import scalaz.concurrent.Task
 import org.http4s.internal.compatibility._
 
 trait TaskFunctions {
+  /** A task that never completes */
+  val never: Task[Nothing] =
+    Task.async(_ => ())
+
   def unsafeTaskToFuture[A](task: Task[A]): Future[A] = {
     val p = Promise[A]()
     task.unsafePerformAsync {

--- a/server/src/main/scala/org/http4s/server/ServerApp.scala
+++ b/server/src/main/scala/org/http4s/server/ServerApp.scala
@@ -34,8 +34,8 @@ trait ServerApp extends ProcessApp {
   def shutdown(server: Server): Task[Unit] =
     server.shutdown
 
-  final def main(args: List[String]): Process[Task, Nothing] =
+  final def process(args: List[String]): Process[Task, Unit] =
     Process.bracket(server(args))(s => Process.eval_(s.shutdown)) { s =>
-      Process.eval_(Task.async[Nothing](_ => ()))
+      Process.eval_(Task.async[Unit](_ => ()))
     }
 }

--- a/server/src/main/scala/org/http4s/server/ServerApp.scala
+++ b/server/src/main/scala/org/http4s/server/ServerApp.scala
@@ -34,8 +34,8 @@ trait ServerApp extends ProcessApp {
   def shutdown(server: Server): Task[Unit] =
     server.shutdown
 
-  final def process(args: List[String]): Process[Task, Unit] =
+  final def process(args: List[String]): Process[Task, Nothing] =
     Process.bracket(server(args))(s => Process.eval_(s.shutdown)) { s =>
-      Process.eval_(Task.async[Unit](_ => ()))
+      Process.eval_(Task.async[Nothing](_ => ()))
     }
 }

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -7,6 +7,7 @@ import javax.net.ssl.SSLContext
 
 import org.http4s.internal.compatibility._
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
+import org.http4s.util.task
 import org.http4s.util.threads.DefaultPool
 
 import scala.concurrent.duration._
@@ -48,7 +49,7 @@ trait ServerBuilder {
    */
   final def serve: Process[Task, Nothing] =
     Process.bracket(start)(s => Process.eval_(s.shutdown)) { s: Server =>
-      Process.eval_(Task.async[Unit](_ => ()))
+      Process.eval_(task.never)
     }
 }
 

--- a/tests/src/test/scala/org/http4s/util/ProcessAppSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/ProcessAppSpec.scala
@@ -1,6 +1,7 @@
 package org.http4s
 package util
 
+import org.http4s.util.task.never
 import scalaz.concurrent.Task
 import scalaz.stream.async
 import scalaz.stream.async.mutable.Signal
@@ -61,7 +62,7 @@ class ProcessAppSpec extends Http4sSpec {
     "requestShutdown Shuts Down a Server From A Separate Thread" in {
       val testApp = new TestProcessApp(
         // run forever, emit nothing
-        Process.eval_(Task.async[Nothing]{_ => })
+        Process.eval_(task.never)
       )
       val runApp = Task.unsafeStart(testApp.doMain(Array.empty[String]))
       testApp.requestShutdown.unsafePerformSync

--- a/tests/src/test/scala/org/http4s/util/ProcessAppSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/ProcessAppSpec.scala
@@ -17,9 +17,9 @@ class ProcessAppSpec extends Http4sSpec {
       * and observably cleans up when the process is stopped.
       *
       */
-    class TestProcessApp(process: Process[Task, Unit]) extends ProcessApp {
+    class TestProcessApp(process: Process[Task, Nothing]) extends ProcessApp {
       val cleanedUp : Signal[Boolean] = async.signalOf(false)
-      override def process(args: List[String]): Process[Task, Unit] = {
+      override def process(args: List[String]): Process[Task, Nothing] = {
         process.onComplete(Process.eval_(cleanedUp.set(true)))
       }
     }
@@ -33,28 +33,7 @@ class ProcessAppSpec extends Http4sSpec {
     }
 
     "Terminate Server on a Valid Process" in {
-      val testApp = new TestProcessApp(
-        // emit one unit value
-        Process.emit("Valid Process").map(_ => ())
-      )
-      testApp.doMain(Array.empty[String]) should_== 0
-      testApp.cleanedUp.get.unsafePerformSync should_== true
-    }
-
-    "Terminate Server on a Bad Task" in {
-      val testApp = new TestProcessApp(
-        // fail at task evaluation
-        Process.eval(Task.fail(new Throwable("Bad Task")))
-      )
-      testApp.doMain(Array.empty[String]) should_== -1
-      testApp.cleanedUp.get.unsafePerformSync should_== true
-    }
-
-    "Terminate Server on a Valid Task" in {
-      val testApp = new TestProcessApp(
-        // emit one task evaluated unit value
-        Process.eval(Task("Valid Task").map(_ => ()))
-      )
+      val testApp = new TestProcessApp(Process.halt)
       testApp.doMain(Array.empty[String]) should_== 0
       testApp.cleanedUp.get.unsafePerformSync should_== true
     }


### PR DESCRIPTION
Extending `ServerApp` leaves `process` abstract.  The provided `main` method overrides nothing.  `ServerApp` should only have the one abstract method it ever did.
