### PR TITLE
Backport #1168 to scalaz-stream: fixes GZip output

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -28,7 +28,6 @@ object GZip {
             if (isZippable(resp)) {
               logger.trace("GZip middleware encoding content")
               // Need to add the Gzip header and trailer
-              // Need to add the Gzip header
               val b = resp.body
                 .pipe(gzip(
                   level = level,
@@ -68,7 +67,7 @@ object GZip {
           val arr = bytes.toArray
           crc.update(arr)
           length += bytes.length
-          deflater.setInput(bytes.toArray)
+          deflater.setInput(arr)
           val chunks = collect(Deflater.NO_FLUSH)
           emitAll(chunks) ++ go()
         }

--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -2,15 +2,17 @@ package org.http4s
 package server
 package middleware
 
-import java.util.zip.Deflater
+import scala.annotation.tailrec
+
+import java.util.zip.{CRC32, Deflater}
+import javax.xml.bind.DatatypeConverter
 
 import org.http4s.headers.{`Content-Type`, `Content-Length`, `Content-Encoding`, `Accept-Encoding`}
 import org.log4s.getLogger
-
+import scalaz.stream.{ Process0, Process1 }
 import scalaz.stream.Process._
 import scalaz.concurrent.Task
 import scalaz.Kleisli.kleisli
-
 import scodec.bits.ByteVector
 
 object GZip {
@@ -25,13 +27,14 @@ object GZip {
           service.map { resp =>
             if (isZippable(resp)) {
               logger.trace("GZip middleware encoding content")
+              // Need to add the Gzip header and trailer
               // Need to add the Gzip header
-              val b = emit(ByteVector.view(header)) ++
-                        resp.body.pipe(scalaz.stream.compress.deflate(
-                          level = level,
-                          nowrap = true,
-                          bufferSize = bufferSize
-                        ))
+              val b = resp.body
+                .pipe(gzip(
+                  level = level,
+                  nowrap = true,
+                  bufferSize = bufferSize
+                ))
 
               resp.removeHeader(`Content-Length`)
                 .putHeaders(`Content-Encoding`(ContentCoding.gzip))
@@ -44,6 +47,47 @@ object GZip {
       }
   }
 
+  private[http4s] def gzip(level: Int = Deflater.DEFAULT_COMPRESSION,
+              nowrap: Boolean = false,
+              bufferSize: Int = 1024 * 32): Process1[ByteVector,ByteVector] = {
+    suspend {
+      val crc = new CRC32()
+      var length = 0L
+      val deflater = new Deflater(level, nowrap)
+      val buf = Array.ofDim[Byte](bufferSize)
+
+      @tailrec
+      def collect(flush: Int, acc: Vector[ByteVector] = Vector.empty): Vector[ByteVector] =
+        deflater.deflate(buf, 0, buf.length, flush) match {
+          case 0 => acc
+          case n => collect(flush, acc :+ ByteVector.view(buf.take(n)))
+        }
+
+      def go(): Process1[ByteVector,ByteVector] =
+        receive1 { bytes =>
+          val arr = bytes.toArray
+          crc.update(arr)
+          length += bytes.length
+          deflater.setInput(bytes.toArray)
+          val chunks = collect(Deflater.NO_FLUSH)
+          emitAll(chunks) ++ go()
+        }
+
+      def flush(): Process0[ByteVector] = {
+        deflater.finish()
+        val vecs = collect(Deflater.FULL_FLUSH)
+        deflater.end()
+        emitAll(vecs) ++ emit(trailer)
+      }
+
+      def trailer =
+        ByteVector.view(DatatypeConverter.parseHexBinary("%08x".format(crc.getValue)).reverse) ++
+        ByteVector.view(DatatypeConverter.parseHexBinary("%08x".format(length % GZIP_LENGTH_MOD)).reverse)
+
+      emit(header) ++ (go() onComplete flush())
+    }
+  }
+
   private def isZippable(resp: Response): Boolean = {
     val contentType = resp.headers.get(`Content-Type`)
     !Fallthrough[Response].isFallthrough(resp) &&
@@ -52,12 +96,10 @@ object GZip {
       (contentType.get.mediaType eq MediaType.`application/octet-stream`))
   }
 
-
-
   private val GZIP_MAGIC_NUMBER = 0x8b1f
-  private val TRAILER_LENGTH = 8
+  private val GZIP_LENGTH_MOD = Math.pow(2, 32).toLong
 
-  private val header: Array[Byte] = Array(
+  private val header: ByteVector = ByteVector(
     GZIP_MAGIC_NUMBER.toByte,           // Magic number (int16)
     (GZIP_MAGIC_NUMBER >> 8).toByte,    // Magic number  c
     Deflater.DEFLATED.toByte,           // Compression method
@@ -68,5 +110,4 @@ object GZip {
     0.toByte,                           // Modification time  c
     0.toByte,                           // Extra flags
     0.toByte)                           // Operating system
-
 }


### PR DESCRIPTION
`scalaz.stream.compress.deflate` never calls `.finish()` on the deflater, which produces different output from `GZipOutputStream`.  By inhaling scalaz-stream's implementation and adding the `finish` call, we pass the same property test as the fs2 version.

Further simplified by calculating the CRC32 along the way, as long as we already have our own copy.

/cc @mrdziuban