### PR TITLE
Make GenericCredentials less opinionated; add KeyValueCredentials (#921)

### DIFF
--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -6,7 +6,7 @@ import javax.crypto
 
 import org.http4s.headers.Authorization
 import org.http4s.syntax.string._
-import org.http4s.util.UrlCodingUtils
+import org.http4s.util.{ NonEmptyList, UrlCodingUtils }
 
 import scala.collection.mutable.ListBuffer
 import scalaz.concurrent.Task
@@ -52,7 +52,8 @@ package object oauth1 {
 
     val baseString = genBaseString(method, uri, params ++ userParams.map{ case (k,v) => (encode(k), encode(v))})
     val sig = makeSHASig(baseString, consumer, token)
-    val creds = KeyValueCredentials("OAuth".ci, params.toMap + ("oauth_signature" -> encode(sig)))
+    val creds = Credentials.AuthParams("OAuth".ci,
+      NonEmptyList("oauth_signature" -> encode(sig), params: _*))
 
     Authorization(creds)
   }

--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -52,7 +52,7 @@ package object oauth1 {
 
     val baseString = genBaseString(method, uri, params ++ userParams.map{ case (k,v) => (encode(k), encode(v))})
     val sig = makeSHASig(baseString, consumer, token)
-    val creds = GenericCredentials("OAuth".ci, params.toMap + ("oauth_signature" -> encode(sig)))
+    val creds = KeyValueCredentials("OAuth".ci, params.toMap + ("oauth_signature" -> encode(sig)))
 
     Authorization(creds)
   }

--- a/core/src/main/scala/org/http4s/Credentials.scala
+++ b/core/src/main/scala/org/http4s/Credentials.scala
@@ -61,8 +61,17 @@ final case class OAuth2BearerToken(token: String) extends Credentials {
   override def render(writer: Writer): writer.type = writer.append("Bearer ").append(token)
 }
 
+/**
+  * Represents any given authorization value. Will render as `<authScheme> <value>` (with the
+  * included space.
+  */
+final case class GenericCredentials(authScheme: AuthScheme, value: String) extends Credentials {
+  override def render(writer: Writer): writer.type = {
+    writer << authScheme << ' ' << value
+  }
+}
 
-final case class GenericCredentials(authScheme: AuthScheme, params: Map[String, String]) extends Credentials {
+final case class KeyValueCredentials(authScheme: AuthScheme, params: Map[String, String]) extends Credentials {
   override lazy val value = renderString
 
   override def render(writer: Writer): writer.type = {

--- a/core/src/main/scala/org/http4s/Credentials.scala
+++ b/core/src/main/scala/org/http4s/Credentials.scala
@@ -39,21 +39,16 @@ object Credentials {
     def render(writer: Writer): writer.type = {
       writer << authScheme
       writer << ' '
-      var first = true
-      params.foreach { case (k, v) =>
-        if (first) first = false
-        else writer.append(',')
 
-        if (k.isEmpty) writer << '"'
-        else writer<< k << '=' << '"'
-
-        v.foreach {
-          case '"' => writer << '\\' << '"'
-          case '\\' => writer << '\\' << '\\'
-          case c => writer << c
-        }
-        writer << '"'
+      def renderParam(k: String, v: String) = {
+        writer << k << '='
+        writer.quote(v)
         ()
+      }
+      renderParam(params.head._1, params.head._2)
+      params.tail.foreach { case (k, v) =>
+        writer.append(',')
+        renderParam(k, v)
       }
       writer
     }

--- a/core/src/main/scala/org/http4s/Credentials.scala
+++ b/core/src/main/scala/org/http4s/Credentials.scala
@@ -62,8 +62,8 @@ final case class OAuth2BearerToken(token: String) extends Credentials {
 }
 
 /**
-  * Represents any given authorization value. Will render as `<authScheme> <value>` (with the
-  * included space.
+  * Represents any given authorization value. Will render as
+  * `<authScheme> <value>` (with the included space).
   */
 final case class GenericCredentials(authScheme: AuthScheme, value: String) extends Credentials {
   override def render(writer: Writer): writer.type = {

--- a/core/src/main/scala/org/http4s/Credentials.scala
+++ b/core/src/main/scala/org/http4s/Credentials.scala
@@ -53,6 +53,7 @@ object Credentials {
           case c => writer << c
         }
         writer << '"'
+        ()
       }
       writer
     }

--- a/core/src/main/scala/org/http4s/headers/Authorization.scala
+++ b/core/src/main/scala/org/http4s/headers/Authorization.scala
@@ -7,6 +7,9 @@ import org.http4s.util.Writer
 object Authorization extends HeaderKey.Internal[Authorization] with HeaderKey.Singleton {
   override def parse(s: String): ParseResult[Authorization] =
     HttpHeaderParser.AUTHORIZATION(s)
+
+  def apply(basic: BasicCredentials): Authorization =
+    Authorization(Credentials.Token(AuthScheme.Basic, basic.token))
 }
 
 final case class Authorization(credentials: Credentials) extends Header.Parsed {

--- a/core/src/main/scala/org/http4s/parser/AuthorizationHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/AuthorizationHeader.scala
@@ -33,7 +33,10 @@ private[parser] trait AuthorizationHeader {
     }
 
     def CredentialDef = rule {
-      BasicCredentialDef | OAuth2BearerTokenDef | GenericHttpCredentialsDef | KeyValueCredentialsDef
+      BasicCredentialDef |
+      OAuth2BearerTokenDef |
+      KeyValueCredentialsDef |
+      GenericHttpCredentialsDef
     }
 
     def BasicCredentialDef: Rule1[BasicCredentials] = rule {
@@ -49,7 +52,7 @@ private[parser] trait AuthorizationHeader {
     }
 
     def GenericHttpCredentialsDef = rule {
-      Token ~ LWS ~ Token ~> {(scheme: String, value: String) =>
+      Token ~ LWS ~ token68 ~> {(scheme: String, value: String) =>
         GenericCredentials(scheme.ci, value)
       }
     }
@@ -60,9 +63,9 @@ private[parser] trait AuthorizationHeader {
     }
 
     def CredentialParams: Rule1[Map[String, String]] = rule {
-      oneOrMore(AuthParam).separatedBy(ListSep) ~> (_.toMap) |
-        (Token | QuotedString) ~> (param => Map("" -> param)) |
-        push(Map.empty[String, String])
+      oneOrMore(AuthParam).separatedBy(ListSep) ~> {
+        params: Seq[(String, String)] => params.toMap
+      }
     }
 
     def AuthParam: Rule1[(String, String)] = rule {
@@ -75,6 +78,8 @@ private[parser] trait AuthorizationHeader {
     def b64token: Rule1[String] = rule {
       capture(oneOrMore(Alpha | Digit | anyOf("-._~+/")) ~ zeroOrMore('=') )
     }
+
+    def token68: Rule1[String] = b64token
   }
   // scalastyle:on public.methods.have.type
 }

--- a/core/src/main/scala/org/http4s/parser/AuthorizationHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/AuthorizationHeader.scala
@@ -33,7 +33,7 @@ private[parser] trait AuthorizationHeader {
     }
 
     def CredentialDef = rule {
-      BasicCredentialDef | OAuth2BearerTokenDef | GenericHttpCredentialsDef
+      BasicCredentialDef | OAuth2BearerTokenDef | GenericHttpCredentialsDef | KeyValueCredentialsDef
     }
 
     def BasicCredentialDef: Rule1[BasicCredentials] = rule {
@@ -49,8 +49,14 @@ private[parser] trait AuthorizationHeader {
     }
 
     def GenericHttpCredentialsDef = rule {
+      Token ~ LWS ~ Token ~> {(scheme: String, value: String) =>
+        GenericCredentials(scheme.ci, value)
+      }
+    }
+
+    def KeyValueCredentialsDef = rule {
       Token ~ OptWS ~ CredentialParams ~> { (scheme: String, params: Map[String, String]) =>
-        GenericCredentials(scheme.ci, params) }
+        KeyValueCredentials(scheme.ci, params) }
     }
 
     def CredentialParams: Rule1[Map[String, String]] = rule {

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
@@ -44,7 +44,7 @@ object BasicAuth {
 
   private def validatePassword[A](validate: BasicAuthenticator[A], req: Request): Task[Option[A]] = {
     req.headers.get(Authorization) match {
-      case Some(Authorization(creds: BasicCredentials)) =>
+      case Some(Authorization(BasicCredentials(creds))) =>
         validate(creds)
       case _ =>
         Task.now(None)

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -8,7 +8,7 @@ import java.math.BigInteger
 import java.util.Date
 
 import org.http4s.headers.Authorization
-import org.http4s.{AuthedRequest, AuthedService}
+import org.http4s.util.NonEmptyList
 
 import scala.concurrent.duration._
 
@@ -75,7 +75,7 @@ object DigestAuth {
   }
 
   private def checkAuth[A](realm: String, store: AuthenticationStore[A], nonceKeeper: NonceKeeper, req: Request): Task[AuthReply[A]] = req.headers.get(Authorization) match {
-    case Some(Authorization(KeyValueCredentials(AuthScheme.Digest, params))) =>
+    case Some(Authorization(Credentials.AuthParams(AuthScheme.Digest, params))) =>
       checkAuthParams(realm, store, nonceKeeper, req, params)
     case Some(Authorization(_)) =>
       Task.now(NoCredentials)
@@ -92,7 +92,8 @@ object DigestAuth {
       m
   }
 
-  private def checkAuthParams[A](realm: String, store: AuthenticationStore[A], nonceKeeper: NonceKeeper, req: Request, params: Map[String, String]): Task[AuthReply[A]] = {
+  private def checkAuthParams[A](realm: String, store: AuthenticationStore[A], nonceKeeper: NonceKeeper, req: Request, paramsNel: NonEmptyList[(String, String)]): Task[AuthReply[A]] = {
+    val params = paramsNel.list.toMap
     if (!(Set("realm", "nonce", "nc", "username", "cnonce", "qop") subsetOf params.keySet))
       return Task.now(BadParameters)
 

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -75,7 +75,7 @@ object DigestAuth {
   }
 
   private def checkAuth[A](realm: String, store: AuthenticationStore[A], nonceKeeper: NonceKeeper, req: Request): Task[AuthReply[A]] = req.headers.get(Authorization) match {
-    case Some(Authorization(GenericCredentials(AuthScheme.Digest, params))) =>
+    case Some(Authorization(KeyValueCredentials(AuthScheme.Digest, params))) =>
       checkAuthParams(realm, store, nonceKeeper, req, params)
     case Some(Authorization(_)) =>
       Task.now(NoCredentials)

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -138,7 +138,7 @@ class AuthenticationSpec extends Http4sSpec {
       val params: Map[String, String] = Map("username" -> username, "realm" -> realm, "nonce" -> nonce,
         "uri" -> uri, "qop" -> qop, "nc" -> nc, "cnonce" -> cnonce, "response" -> response,
         "method" -> method)
-      val header = Authorization(GenericCredentials(CaseInsensitiveString("Digest"), params))
+      val header = Authorization(KeyValueCredentials(CaseInsensitiveString("Digest"), params))
 
       val req2 = Request(uri = Uri(path = "/"), headers = Headers(header))
       val res2 = digest.orNotFound(req2).unsafePerformSync
@@ -226,7 +226,7 @@ class AuthenticationSpec extends Http4sSpec {
 
       val result = (0 to params.size).map(i => {
         val invalid_params = params.take(i) ++ params.drop(i + 1)
-        val header = Authorization(GenericCredentials(CaseInsensitiveString("Digest"), invalid_params))
+        val header = Authorization(KeyValueCredentials(CaseInsensitiveString("Digest"), invalid_params))
         val req = Request(uri = Uri(path = "/"), headers = Headers(header))
         val res = digestAuthService.orNotFound(req).unsafePerformSync
 

--- a/tests/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
@@ -1,8 +1,8 @@
 package org.http4s.parser
 
-import org.http4s.{Http4sSpec, OAuth2BearerToken}
+import org.http4s.{Http4sSpec, OAuth2BearerToken, GenericCredentials}
 import org.http4s.headers.Authorization
-
+import org.http4s.util.string._
 
 class AuthorizationHeaderSpec extends Http4sSpec {
 
@@ -15,12 +15,19 @@ class AuthorizationHeaderSpec extends Http4sSpec {
       hparse(h.value) must be_\/-(h)
     }
 
-    "Reject an ivalid Oauth2 header" in {
+    "Reject an invalid Oauth2 header" in {
       val invalidTokens = Seq("f!@", "=abc", "abc d")
       forall(invalidTokens) { token =>
         val h = Authorization(OAuth2BearerToken(token))
         hparse(h.value) must be_-\/
       }
+    }
+
+    "Parse a GenericCredential header" in {
+      val scheme = "token"
+      val token = "adsfafsf2332fasdad322332"
+      val h = Authorization(GenericCredentials(scheme.ci, token))
+      hparse(s"$scheme $token") must be_\/-(h)
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
@@ -1,6 +1,6 @@
 package org.http4s.parser
 
-import org.http4s.{Http4sSpec, OAuth2BearerToken, GenericCredentials}
+import org.http4s.{Http4sSpec, OAuth2BearerToken, GenericCredentials, KeyValueCredentials}
 import org.http4s.headers.Authorization
 import org.http4s.util.string._
 
@@ -27,7 +27,14 @@ class AuthorizationHeaderSpec extends Http4sSpec {
       val scheme = "token"
       val token = "adsfafsf2332fasdad322332"
       val h = Authorization(GenericCredentials(scheme.ci, token))
-      hparse(s"$scheme $token") must be_\/-(h)
+      hparse(h.value) must be_\/-(h)
+    }
+
+    "Parse a KeyValueCredentials header" in {
+      val scheme = "foo"
+      val params = Map("abc" -> "123")
+      val h = Authorization(KeyValueCredentials(scheme.ci, params))
+      hparse(h.value) must be_\/-(h)
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AuthorizationHeaderSpec.scala
@@ -1,7 +1,8 @@
-package org.http4s.parser
+package org.http4s
+package parser
 
-import org.http4s.{Http4sSpec, OAuth2BearerToken, GenericCredentials, KeyValueCredentials}
 import org.http4s.headers.Authorization
+import org.http4s.util.NonEmptyList
 import org.http4s.util.string._
 
 class AuthorizationHeaderSpec extends Http4sSpec {
@@ -9,31 +10,24 @@ class AuthorizationHeaderSpec extends Http4sSpec {
   def hparse(value: String) = HttpHeaderParser.AUTHORIZATION(value)
 
   "Authorization header" should {
-    "Parse a valid Oauth2 header" in {
+    "Parse a valid OAuth2 header" in {
       val token = (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ "-._~+/".toSeq).mkString
-      val h = Authorization(OAuth2BearerToken(token + "="))
+      val h = Authorization(Credentials.Token(AuthScheme.Bearer, token + "="))
       hparse(h.value) must be_\/-(h)
     }
 
-    "Reject an invalid Oauth2 header" in {
+    "Reject an invalid OAuth2 header" in {
       val invalidTokens = Seq("f!@", "=abc", "abc d")
       forall(invalidTokens) { token =>
-        val h = Authorization(OAuth2BearerToken(token))
+        val h = Authorization(Credentials.Token(AuthScheme.Bearer, token))
         hparse(h.value) must be_-\/
       }
     }
 
-    "Parse a GenericCredential header" in {
-      val scheme = "token"
-      val token = "adsfafsf2332fasdad322332"
-      val h = Authorization(GenericCredentials(scheme.ci, token))
-      hparse(h.value) must be_\/-(h)
-    }
-
     "Parse a KeyValueCredentials header" in {
       val scheme = "foo"
-      val params = Map("abc" -> "123")
-      val h = Authorization(KeyValueCredentials(scheme.ci, params))
+      val params = NonEmptyList("abc" -> "123")
+      val h = Authorization(Credentials.AuthParams(scheme.ci, params))
       hparse(h.value) must be_\/-(h)
     }
   }


### PR DESCRIPTION
Changes `GenericCredentials` so it holds an `AuthScheme` and a value, nothing else (address #921).

Renamed previous `GenericCredentials` to `KeyValueCredentials` and updated throughout.