### PR TITLE
Logging Middleware

### DIFF
--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -18,8 +18,9 @@
  */
 package org.http4s
 
-import scala.util.hashing.MurmurHash3
+import cats.Show
 
+import scala.util.hashing.MurmurHash3
 import cats.data.NonEmptyList
 import cats.implicits._
 import org.http4s.syntax.string._
@@ -120,5 +121,9 @@ object Header {
       values.tail.foreach( writer << ", " << _ )
       writer
     }
+  }
+
+  implicit val headerShow : Show[Header] = new Show[Header] {
+    def show(f: Header): String = f.toString
   }
 }

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -1,5 +1,7 @@
 package org.http4s
 
+import cats.Show
+import cats.syntax.show._
 import org.http4s.HeaderKey.StringKey
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.headers.`Set-Cookie`
@@ -115,4 +117,9 @@ object Headers {
 
   private def newBuilder: mutable.Builder[Header, Headers] =
     new mutable.ListBuffer[Header] mapResult (b => new Headers(b))
+
+  implicit val headersShow: Show[Headers] =
+    new Show[Headers]{
+      def show(f: Headers): String = f.iterator.map(_.show).mkString("Headers(", ", ", ")")
+    }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -2,12 +2,49 @@ package org.http4s
 package server
 package middleware
 
-import fs2.Strategy
+import fs2._
+import cats.implicits._
+import fs2.interop.cats._
+import scodec.bits.ByteVector
+import org.log4s.{Logger => SLogger}
 
 /**
   * Simple Middleware for Logging All Requests and Responses
   */
 object Logger {
-  def apply(httpService: HttpService)(implicit strategy: Strategy): HttpService =
-    ResponseLogger(RequestLogger(httpService))
+  def apply(logHeaders: Boolean, logBody: Boolean)(httpService: HttpService)(implicit strategy: Strategy): HttpService =
+    ResponseLogger(logHeaders, logBody)(
+      RequestLogger(logHeaders, logBody)(
+        httpService
+      )
+    )
+
+  def getCharsetFromContentType(m: Message): (Boolean, Option[Charset]) = {
+    val init = m.charset
+    val binary = m.contentType.map(_.mediaType.binary).getOrElse(false)
+    (binary, init)
+  }
+
+  /**
+    * Log Messages As They Pass
+    */
+  def messageLogPipe[A <: Message](logHeaders: Boolean, logBody: Boolean)
+                                  (logger: SLogger): Pipe[Task, A, A] = stream => {
+    stream.flatMap { req =>
+      val (binary, charset) = Logger.getCharsetFromContentType(req)
+      val headers = if (logHeaders) req.headers.toList.mkString("Headers(", ", ", ")") else ""
+      val bodyT: Task[String] = {
+        if (logBody && !binary) {
+          req.bodyAsText(charset.getOrElse(Charset.`UTF-8`))
+        } else if (logBody) {
+          req.body.map(ByteVector.fromByte).map(_.toHex)
+        } else {
+          Stream.empty[Task, String]
+        }
+      }.runFoldMap(identity)
+      Stream.eval(bodyT.flatMap(body =>
+        Task.delay(logger.info(s"$headers + Body: $body"))
+      )) >> Stream.emit(req)
+    }
+  }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -1,0 +1,13 @@
+package org.http4s
+package server
+package middleware
+
+import fs2.Strategy
+
+/**
+  * Simple Middleware for Logging All Requests and Responses
+  */
+object Logger {
+  def apply(httpService: HttpService)(implicit strategy: Strategy): HttpService =
+    ResponseLogger(RequestLogger(httpService))
+}

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -1,0 +1,29 @@
+package org.http4s
+package server
+package middleware
+
+import fs2._
+import org.log4s._
+import cats.implicits._
+import fs2.interop.cats._
+
+/**
+  * Simple Middleware for Logging Requests As They Are Processed
+  */
+object RequestLogger {
+  private[this] val logger = getLogger
+
+  def apply(service: HttpService)(implicit strategy: Strategy): HttpService = Service.lift{ req =>
+    Stream(req)
+      .observe(requestLogSink)
+      .evalMap[Task, Task, MaybeResponse]{req => service(req)}
+      .runFoldMap(identity)
+  }
+
+  def requestLogSink: Sink[Task, Request] = stream => {
+    stream
+      .flatMap(_.body)
+      .through(fs2.text.utf8Decode)
+      .evalMap[Task, Task, Unit]{ str => Task.delay(logger.info(str)) }
+  }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -6,6 +6,7 @@ import fs2._
 import org.log4s._
 import cats.implicits._
 import fs2.interop.cats._
+import scodec.bits._
 
 /**
   * Simple Middleware for Logging Requests As They Are Processed
@@ -13,17 +14,10 @@ import fs2.interop.cats._
 object RequestLogger {
   private[this] val logger = getLogger
 
-  def apply(service: HttpService)(implicit strategy: Strategy): HttpService = Service.lift{ req =>
+  def apply(logHeaders: Boolean, logBody: Boolean)(service: HttpService)(implicit strategy: Strategy): HttpService = Service.lift{ req =>
     Stream(req)
-      .observe(requestLogSink)
+      .through(Logger.messageLogPipe[Request](logHeaders, logBody)(logger))
       .evalMap[Task, Task, MaybeResponse]{req => service(req)}
       .runFoldMap(identity)
-  }
-
-  def requestLogSink: Sink[Task, Request] = stream => {
-    stream
-      .flatMap(_.body)
-      .through(fs2.text.utf8Decode)
-      .evalMap[Task, Task, Unit]{ str => Task.delay(logger.info(str)) }
   }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -1,0 +1,29 @@
+package org.http4s
+package server
+package middleware
+
+import fs2._
+import fs2.interop.cats._
+import cats.implicits._
+import org.log4s.getLogger
+
+/**
+  * Simple Middleware for Logging Responses As They Are Processed
+  */
+object ResponseLogger {
+  private[this] val logger = getLogger
+
+  def apply(service: HttpService): HttpService = Service.lift { req =>
+    service(req).flatMap {
+      case resp: Response =>
+        resp
+          .body
+          .through(fs2.text.utf8Decode)
+          .runFoldMap(identity)
+          .map(logger.info(_))
+          .map(_ => resp)
+      case Pass =>
+        Task.delay(Pass)
+    }
+  }
+}

--- a/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
@@ -13,7 +13,7 @@ class LoggerSpec extends Http4sSpec {
     case req @ GET -> Root / "request" =>
       Ok("request response")
     case req @ POST -> Root / "post" =>
-      Ok("post response")
+      Ok(req.body)
   }
 
   val urlForm = UrlForm("foo" -> "bar")
@@ -28,7 +28,9 @@ class LoggerSpec extends Http4sSpec {
 
     "not effect a Post" in {
       val req = Request(uri = uri("/post"), method = POST).withBody(urlForm)
-      req.flatMap(responseLoggerService.orNotFound) must returnStatus(Status.Ok)
+      val res = req.flatMap(responseLoggerService.orNotFound)
+      res must returnStatus(Status.Ok)
+      res must returnBody(urlForm)
     }
   }
 
@@ -42,7 +44,9 @@ class LoggerSpec extends Http4sSpec {
 
     "not effect a Post" in {
       val req = Request(uri = uri("/post"), method = POST).withBody(urlForm)
-      req.flatMap(requestLoggerService.orNotFound) must returnStatus(Status.Ok)
+      val res = req.flatMap(requestLoggerService.orNotFound)
+      res must returnStatus(Status.Ok)
+      res must returnBody(urlForm)
     }
   }
 
@@ -56,7 +60,9 @@ class LoggerSpec extends Http4sSpec {
 
     "not effect a Post" in {
       val req = Request(uri = uri("/post"), method = POST).withBody(urlForm)
-      req.flatMap(loggerService.orNotFound) must returnStatus(Status.Ok)
+      val res = req.flatMap(loggerService.orNotFound)
+      res must returnStatus(Status.Ok)
+      res must returnBody(urlForm)
     }
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
@@ -1,0 +1,64 @@
+package org.http4s
+package server
+package middleware
+
+import org.http4s.dsl._
+
+/**
+  * Common Tests for Logger, RequestLogger, and ResponseLogger
+  */
+class LoggerSpec extends Http4sSpec {
+
+  val testService = HttpService {
+    case req @ GET -> Root / "request" =>
+      Ok("request response")
+    case req @ POST -> Root / "post" =>
+      Ok("post response")
+  }
+
+  val urlForm = UrlForm("foo" -> "bar")
+
+  "ResponseLogger" should {
+    val responseLoggerService = ResponseLogger(testService)
+
+    "not effect a Get" in {
+      val req = Request(uri = uri("/request"))
+      responseLoggerService.orNotFound(req) must returnStatus(Status.Ok)
+    }
+
+    "not effect a Post" in {
+      val req = Request(uri = uri("/post"), method = POST).withBody(urlForm)
+      req.flatMap(responseLoggerService.orNotFound) must returnStatus(Status.Ok)
+    }
+  }
+
+  "RequestLogger" should {
+    val requestLoggerService = RequestLogger(testService)
+
+    "not effect a Get" in {
+      val req = Request(uri = uri("/request"))
+      requestLoggerService.orNotFound(req) must returnStatus(Status.Ok)
+    }
+
+    "not effect a Post" in {
+      val req = Request(uri = uri("/post"), method = POST).withBody(urlForm)
+      req.flatMap(requestLoggerService.orNotFound) must returnStatus(Status.Ok)
+    }
+  }
+
+  "Logger" should {
+    val loggerService = Logger(testService)
+
+    "not effect a Get" in {
+      val req = Request(uri = uri("/request"))
+      loggerService.orNotFound(req) must returnStatus(Status.Ok)
+    }
+
+    "not effect a Post" in {
+      val req = Request(uri = uri("/post"), method = POST).withBody(urlForm)
+      req.flatMap(loggerService.orNotFound) must returnStatus(Status.Ok)
+    }
+  }
+
+
+}

--- a/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
@@ -19,7 +19,7 @@ class LoggerSpec extends Http4sSpec {
   val urlForm = UrlForm("foo" -> "bar")
 
   "ResponseLogger" should {
-    val responseLoggerService = ResponseLogger(testService)
+    val responseLoggerService = ResponseLogger(true, true)(testService)
 
     "not effect a Get" in {
       val req = Request(uri = uri("/request"))
@@ -33,7 +33,7 @@ class LoggerSpec extends Http4sSpec {
   }
 
   "RequestLogger" should {
-    val requestLoggerService = RequestLogger(testService)
+    val requestLoggerService = RequestLogger(true, true)(testService)
 
     "not effect a Get" in {
       val req = Request(uri = uri("/request"))
@@ -47,7 +47,7 @@ class LoggerSpec extends Http4sSpec {
   }
 
   "Logger" should {
-    val loggerService = Logger(testService)
+    val loggerService = Logger(true, true)(testService)
 
     "not effect a Get" in {
       val req = Request(uri = uri("/request"))


### PR DESCRIPTION
Most version of observe seem to consume to body and creates errors in writing length, these two combinations seem to avoid this.

Not Sure How Valid These Tests are if at all. Recreating the failures of consuming the body is hard. However I found it a couple times in unexpected places.