### PR TITLE
UrlForm.fromSeq Added as a Convenience Method

### DIFF
--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -82,6 +82,9 @@ object UrlForm {
   def apply(values: (String, String)*): UrlForm =
     values.foldLeft(empty)(_ + _)
 
+  def fromSeq(values: Seq[(String, String)]): UrlForm =
+    apply(values: _*)
+
   implicit def entityEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[UrlForm] =
     EntityEncoder.stringEncoder(charset)
       .contramap[UrlForm](encodeString(charset))

--- a/tests/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -92,5 +92,14 @@ class UrlFormSpec extends Http4sSpec with ScalaCheck {
         } yield (k -> v)
         UrlForm(flattened: _*) must_== UrlForm(map.mapValues(_.list))
     }
+
+    "construct consistently from Seq of kv-pairs and Map[String, Seq[String]]" in prop {
+      map: Map[String, NonEmptyList[String]] => // non-empty because the kv-constructor can't represent valueless fields
+        val flattened = for {
+          (k, vs) <- map.toSeq
+          v <- vs.list
+        } yield (k -> v)
+        UrlForm.fromSeq(flattened) must_== UrlForm(map.mapValues(_.list))
+    }
   }
 }


### PR DESCRIPTION
Simple Convenience Method for creating a `UrlForm` from a `Seq`