### PR TITLE
Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.15.13
+* Patch-level upgrades to dependencies:
+    * async-http-client-2.0.32
+    * blaze-0.12.6 (fixes infinite loop in some SSL handshakes)
+    * jetty-9.3.19.v20170502
+    * json4s-3.5.2
+    * tomcat-8.0.44
+
 # v0.15.12 (2017-05-11)
 * Fix GZip middleware to render a correct stream
 

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -75,8 +75,8 @@ object Http4sBuild {
 
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.11.v20170118"
   lazy val argonaut            = "io.argonaut"              %% "argonaut"                % "6.2"
-  lazy val asyncHttpClient     = "org.asynchttpclient"       % "async-http-client"       % "2.0.31"
-  lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.12.5"
+  lazy val asyncHttpClient     = "org.asynchttpclient"       % "async-http-client"       % "2.0.32"
+  lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.12.6"
   lazy val circeGeneric        = "io.circe"                 %% "circe-generic"           % circeJawn.revision
   lazy val circeJawn           = "io.circe"                 %% "circe-jawn"              % "0.6.1"
   lazy val circeLiteral        = "io.circe"                 %% "circe-literal"           % circeJawn.revision
@@ -88,9 +88,9 @@ object Http4sBuild {
   lazy val javaxServletApi     = "javax.servlet"             % "javax.servlet-api"       % "3.1.0"
   lazy val jawnJson4s          = "org.spire-math"           %% "jawn-json4s"             % "0.10.4"
   def jawnStreamz(scalazVersion: String) = "org.http4s"     %% "jawn-streamz"            % scalazCrossBuild("0.10.1", scalazVersion)
-  lazy val jettyServer         = "org.eclipse.jetty"         % "jetty-server"            % "9.3.18.v20170406"
+  lazy val jettyServer         = "org.eclipse.jetty"         % "jetty-server"            % "9.3.19.v20170502"
   lazy val jettyServlet        = "org.eclipse.jetty"         % "jetty-servlet"           % jettyServer.revision
-  lazy val json4sCore          = "org.json4s"               %% "json4s-core"             % "3.5.1"
+  lazy val json4sCore          = "org.json4s"               %% "json4s-core"             % "3.5.2"
   lazy val json4sJackson       = "org.json4s"               %% "json4s-jackson"          % json4sCore.revision
   lazy val json4sNative        = "org.json4s"               %% "json4s-native"           % json4sCore.revision
   lazy val jspApi              = "javax.servlet.jsp"         % "javax.servlet.jsp-api"   % "2.3.1" // YourKit hack
@@ -112,7 +112,7 @@ object Http4sBuild {
   def specs2MatcherExtra(scalazVersion: String) = "org.specs2"           %% "specs2-matcher-extra"      % specs2Core(scalazVersion).revision
   def specs2Scalacheck(scalazVersion: String)   = "org.specs2"           %% "specs2-scalacheck"         % specs2Core(scalazVersion).revision
   def scalazStream(scalazVersion: String)       = "org.scalaz.stream"    %% "scalaz-stream"             % scalazCrossBuild("0.8.6", scalazVersion)
-  lazy val tomcatCatalina      = "org.apache.tomcat"         % "tomcat-catalina"         % "8.0.43"
+  lazy val tomcatCatalina      = "org.apache.tomcat"         % "tomcat-catalina"         % "8.0.44"
   lazy val tomcatCoyote        = "org.apache.tomcat"         % "tomcat-coyote"           % tomcatCatalina.revision
   lazy val twirlApi            = "com.typesafe.play"        %% "twirl-api"               % "1.3.0"
 }


### PR DESCRIPTION
Round of patch upgrades for 0.15.13.  Blaze is the important one.