### PR TITLE
update pathinfo when changing uri via Request.copy

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -259,7 +259,7 @@ private final class Http1Connection(val requestKey: RequestKey,
       // If we are HTTP/1.0, make sure HTTP/1.0 has no body or a Content-Length header
     if (minor == 0 && `Content-Length`.from(req.headers).isEmpty) {
       logger.warn(s"Request ${req} is HTTP/1.0 but lacks a length header. Transforming to HTTP/1.1")
-      validateRequest(req.copy(httpVersion = HttpVersion.`HTTP/1.1`))
+      validateRequest(req.withHttpVersion(HttpVersion.`HTTP/1.1`))
     }
       // Ensure we have a host header for HTTP/1.1
     else if (minor == 1 && req.uri.host.isEmpty) { // this is unlikely if not impossible
@@ -269,15 +269,15 @@ private final class Http1Connection(val requestKey: RequestKey,
           case Some(auth) => auth.copy(host = RegName(host.host), port = host.port)
           case None => Authority(host = RegName(host.host), port = host.port)
         }
-        validateRequest(req.copy(uri = req.uri.copy(authority = Some(newAuth))))
+        validateRequest(req.withUri(req.uri.copy(authority = Some(newAuth))))
       }
       else if ( `Content-Length`.from(req.headers).nonEmpty) {  // translate to HTTP/1.0
-        validateRequest(req.copy(httpVersion = HttpVersion.`HTTP/1.0`))
+        validateRequest(req.withHttpVersion(HttpVersion.`HTTP/1.0`))
       } else {
         Either.left(new IllegalArgumentException("Host header required for HTTP/1.1 request"))
       }
     }
-    else if (req.uri.path == "") Right(req.copy(uri = req.uri.copy(path = "/")))
+    else if (req.uri.path == "") Right(req.withUri(req.uri.copy(path = "/")))
     else Either.right(req) // All appears to be well
   }
 

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -248,7 +248,7 @@ class Http1ClientStageSpec extends Http4sSpec {
     "Not expect body if request was a HEAD request" in {
       val contentLength = 12345L
       val resp = s"HTTP/1.1 200 OK\r\nContent-Length: $contentLength\r\n\r\n"
-      val headRequest = FooRequest.copy(method = Method.HEAD)
+      val headRequest = FooRequest.withMethod(Method.HEAD)
       val tail = mkConnection(FooRequestKey)
       try {
         val h = new SeqTestHead(List(mkBuffer(resp)))

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -115,7 +115,7 @@ private class Http1ServerStage(service: HttpService,
           case Right(resp) => renderResponse(req, resp, cleanup)
           case Left(t)     => internalServerError(s"Error running route: $req", t, req, cleanup)
         }
-      case Left((e,protocol)) => badMessage(e.details, new BadRequest(e.sanitized), Request().copy(httpVersion = protocol))
+      case Left((e,protocol)) => badMessage(e.details, new BadRequest(e.sanitized), Request().withHttpVersion(protocol))
     }
   }
 

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -242,7 +242,7 @@ object Client {
     def disposableService(service: HttpService): Service[Request, DisposableResponse] =
       Service.lift { req: Request =>
         val disposed = new AtomicBoolean(false)
-        val req0 = req.copy(body = interruptible(req.body, disposed))
+        val req0 = req.withBody(interruptible(req.body, disposed))
         service(req0) map { maybeResp =>
           val resp = maybeResp.orNotFound
           DisposableResponse(

--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -76,14 +76,17 @@ object FollowRedirect {
           bodyOpt match {
             case Some(body) =>
               // Assume that all the headers can be propagated
-              req.copy(method = method, uri = nextUri, body = body)
+              req
+                .withMethod(method)
+                .withUri(nextUri)
+                .withBody(body)
             case None =>
-              req.copy(
-                method = method,
-                uri = nextUri,
-                body = EmptyBody,
+              req
+                .withMethod(method)
+                .withUri(nextUri)
+                .withBody(EmptyBody)
                 // We need to strip all payload headers
-                headers = req.headers.filterNot(h => PayloadHeaderKeys(h.name)))
+                .withHeaders(req.headers.filterNot(h => PayloadHeaderKeys(h.name)))
           }
 
         def doRedirect(method: Method): Task[DisposableResponse] = {

--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -54,7 +54,7 @@ object Retry {
     }
 
     def nextAttempt(req: Request, attempts: Int, duration: FiniteDuration): Task[DisposableResponse] = {
-        prepareLoop(req.copy(body = EmptyBody), attempts + 1)
+        prepareLoop(req.withBody(EmptyBody), attempts + 1)
     }
       // TODO honor Retry-After header
       // Task.async { (prepareLoop(req.copy(body = EmptyBody), attempts + 1)) }

--- a/client/src/test/scala/org/http4s/client/MockClient.scala
+++ b/client/src/test/scala/org/http4s/client/MockClient.scala
@@ -33,7 +33,7 @@ object MockClient {
     def disposableService(service: HttpService): Service[Request, DisposableResponse] =
       Service.lift { req: Request =>
         val disposed = new AtomicBoolean(false)
-        val req0 = req.copy(body = interruptable(req.body, disposed))
+        val req0 = req.withBody(interruptable(req.body, disposed))
         service(req0) map { resp =>
           DisposableResponse(
             resp.orNotFound.copy(body = interruptable(resp.orNotFound.body, disposed)),

--- a/core/src/main/scala/org/http4s/AttributeMap.scala
+++ b/core/src/main/scala/org/http4s/AttributeMap.scala
@@ -59,6 +59,9 @@ final class AttributeMap private(private val backing: Map[AttributeKey[_], Any])
   /** Combines the mappings in `o` with the mappings in this map, with mappings in `o` taking precedence over existing mappings.*/
   def ++(o: AttributeMap): AttributeMap = new AttributeMap(backing ++ o.backing)
 
+  /** Removes an attribute key from the map*/
+  def --(k: AttributeKey[_]): AttributeMap = new AttributeMap(backing - k)
+
   /** All mappings in this map.  The [[AttributeEntry]] type preserves the typesafety of mappings, although the specific types are unknown.*/
   def entries: Iterable[AttributeEntry[_]] =
     for( (k: AttributeKey[kt], v) <- backing) yield AttributeEntry(k, v.asInstanceOf[kt])

--- a/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
@@ -18,7 +18,7 @@ object AutoSlash {
         if (p.isEmpty || p.charAt(p.length - 1) != '/')
           Pass.now
         else {
-          val withSlash = req.copy(uri = req.uri.copy(path = p.substring(0, p.length - 1)))
+          val withSlash = req.withUri(req.uri.copy(path = p.substring(0, p.length - 1)))
           service.apply(withSlash)
         }
       case resp =>

--- a/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -26,7 +26,7 @@ object DefaultHead {
 
   private def headAsTruncatedGet(service: HttpService) =
     HttpService.lift { req =>
-      val getReq = req.copy(method = Method.GET)
+      val getReq = req.withMethod(Method.GET)
       // TODO fs2 port I think .open.close is a fair translation of
       // scalaz-stream's kill, but it doesn't run the cleanup.  Is
       // this a bug?

--- a/server/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -16,7 +16,7 @@ object EntityLimiter {
 
   def apply(service: HttpService, limit: Long = DefaultMaxEntitySize): HttpService =
     service.local { req: Request =>
-      req.copy(body = req.body.pull(takeLimited(limit)))
+      req.withBody(req.body.pull(takeLimited(limit)))
     }
 
   private def takeLimited[F[_]](n: Long)(h: Handle[F, Byte]): Pull[F, Byte, Nothing] =

--- a/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
@@ -20,7 +20,9 @@ object UrlFormLifter {
       val params = req.uri.query.toVector ++ flatForm: Vector[(String, Option[String])]
       val newQuery = Query(params :_*)
 
-      val newRequest = req.copy(uri = req.uri.copy(query = newQuery), body = EmptyBody)
+      val newRequest = req
+        .withUri(req.uri.copy(query = newQuery))
+        .withBody(EmptyBody)
       service(newRequest)
     }
 

--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
@@ -32,7 +32,7 @@ class DefaultHeadSpec extends Http4sSpec {
 
     "retain all headers of corresponding GET on fallthrough" in {
       val get = Request(Method.GET, uri = uri("/hello"))      
-      val head = get.copy(method = Method.HEAD)
+      val head = get.withMethod(Method.HEAD)
       service.orNotFound(get).map(_.headers).unsafeRun must_== service.orNotFound(head).map(_.headers).unsafeRun
     }
 

--- a/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -217,7 +217,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
     }
 
     def mockServe(req: Request)(route: Request => Task[Response]) = {
-      route(req.copy(body = chunk(Chunk.bytes(binData))))
+      route(req.withBody(chunk(Chunk.bytes(binData))))
     }
 
     "Write a text file from a byte string" in {

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -62,6 +62,28 @@ class MessageSpec extends Http4sSpec {
         Request(Method.GET).addCookie("token", "value").headers.get("Cookie".ci).map(_.value) must beSome("token=value")
       }
     }
+
+    "Request.with..." should {
+      val path1 = "/path1"
+      val path2 = "/somethingelse"
+      val attributes = AttributeMap(Seq(AttributeEntry(Request.Keys.PathInfoCaret, 3)))
+
+      "reset pathInfo if uri is changed" in {
+        val originalReq = Request(uri = Uri(path = path1), attributes = attributes)
+        val updatedReq = originalReq.withUri(uri = Uri(path = path2))
+
+        updatedReq.scriptName mustEqual ""
+        updatedReq.pathInfo mustEqual path2
+      }
+
+      "not modify pathInfo if uri is unchanged" in {
+        val originalReq = Request(uri = Uri(path = path1), attributes = attributes)
+        val updatedReq = originalReq.withMethod(method = Method.DELETE)
+
+        originalReq.pathInfo mustEqual updatedReq.pathInfo
+        originalReq.scriptName mustEqual updatedReq.scriptName
+      }
+    }
   }
 
   "Message" should {


### PR DESCRIPTION
https://github.com/http4s/http4s/issues/1183

What would you guys think about changing the lazy vals of scriptName + pathInfo to functions like this:

```
val caret = attributes.get(Request.Keys.PathInfoCaret).getOrElse(0)

def scriptName = {
  uri.path.splitAt(caret)._1
}

def pathInfo = {
  uri.path.splitAt(caret)._2
}
```

That way we wouldn't need to overwrite the copy method and we could avoid the boilerplate