### PR TITLE
Fix for multithreaded xml parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val client = libraryProject("client")
     description := "Base library for building http4s clients",
     libraryDependencies += jettyServlet % "test"
   )
-  .dependsOn(core, testing % "test->test", server % "test->compile", theDsl % "test->compile")
+  .dependsOn(core, testing % "test->test", server % "test->compile", theDsl % "test->compile", scalaXml % "test->compile")
 
 lazy val blazeCore = libraryProject("blaze-core")
   .settings(

--- a/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
@@ -1,8 +1,6 @@
 package org.http4s
 package client
 
-import java.util.concurrent.Executors
-
 import org.http4s.Http4sSpec
 import org.http4s.scalaxml
 import org.http4s.Status.Ok
@@ -23,12 +21,11 @@ class ClientXmlSpec extends Http4sSpec {
   val client = Client.fromHttpService(service)
 
   "mock client" should {
-    "read body before dispose" in {
+    "read xml body before dispose" in {
       client.expect[Elem](Request(GET)).unsafePerformSync must_== body
     }
-    "read body in parallel" in {
-      val pool = Executors.newFixedThreadPool(5)
-      val resp = Task.gatherUnordered((0 to 5).map(_ => Task.fork(client.expect[Elem](Request(GET)))(pool))).unsafePerformSync
+    "read xml body in parallel" in {
+      val resp = Task.gatherUnordered((0 to 5).map(_ => Task.fork(client.expect[Elem](Request(GET)))(testPool))).unsafePerformSync
       resp.map(_ must_== body)
     }
   }

--- a/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
@@ -1,24 +1,19 @@
 package org.http4s
 package client
 
-import java.io.IOException
+import java.util.concurrent.Executors
 
 import org.http4s.Http4sSpec
-import org.http4s.headers.Accept
-import org.http4s.Status.InternalServerError
+import org.http4s.scalaxml
+import org.http4s.Status.Ok
+import org.http4s.Method.GET
+
+import scala.xml.Elem
 
 import scalaz.concurrent.Task
 
-import org.http4s.Status.{Ok, NotFound, Created, BadRequest}
-import org.http4s.Method._
-
-import scala.xml.Elem
-import org.http4s.scalaxml
-
-import java.util.concurrent.Executors
-
 class ClientXmlSpec extends Http4sSpec {
-  implicit val decoder = scalaxml.xml()
+  implicit val decoder = scalaxml.xml
   val body = <html><h1>h1</h1></html>
   val xml = s"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>$body"""
   val service = HttpService {

--- a/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
@@ -1,0 +1,40 @@
+package org.http4s
+package client
+
+import java.io.IOException
+
+import org.http4s.Http4sSpec
+import org.http4s.headers.Accept
+import org.http4s.Status.InternalServerError
+
+import scalaz.concurrent.Task
+
+import org.http4s.Status.{Ok, NotFound, Created, BadRequest}
+import org.http4s.Method._
+
+import scala.xml.Elem
+import org.http4s.scalaxml
+
+import java.util.concurrent.Executors
+
+class ClientXmlSpec extends Http4sSpec {
+  implicit val decoder = scalaxml.xml()
+  val body = <html><h1>h1</h1></html>
+  val xml = s"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>$body"""
+  val service = HttpService {
+    case r =>
+      Response(Ok).withBody(xml)
+  }
+  val client = Client.fromHttpService(service)
+
+  "mock client" should {
+    "read body before dispose" in {
+      client.expect[Elem](Request(GET)).unsafePerformSync must_== body
+    }
+    "read body in parallel" in {
+      val pool = Executors.newFixedThreadPool(5)
+      val resp = Task.gatherUnordered((0 to 5).map(_ => Task.fork(client.expect[Elem](Request(GET)))(pool))).unsafePerformSync
+      resp.map(_ must_== body)
+    }
+  }
+}

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -11,7 +11,8 @@ import scalaz.concurrent.Task
 import javax.xml.parsers.SAXParserFactory
 
 trait ElemInstances {
-  private val spf = SAXParserFactory.newInstance()
+  /* Initialize a sax parser factory, users can override this if needed */
+  protected def saxFactory: SAXParserFactory
 
   implicit def xmlEnocder(implicit charset: Charset = DefaultCharset): EntityEncoder[Elem] =
     EntityEncoder.stringEncoder(charset)
@@ -23,7 +24,6 @@ trait ElemInstances {
    *
    * TODO Not an ideal implementation.  Would be much better with an asynchronous XML parser, such as Aalto.
    *
-   * @param parser the SAX parser to use to parse the XML
    * @return an XML element
    */
   implicit val xml: EntityDecoder[Elem] = {
@@ -31,7 +31,7 @@ trait ElemInstances {
     decodeBy(MediaType.`text/xml`, MediaType.`text/html`, MediaType.`application/xml`){ msg =>
       collectBinary(msg).flatMap[Elem] { arr =>
         val source = new InputSource(new StringReader(new String(arr.toArray, msg.charset.getOrElse(Charset.`US-ASCII`).nioCharset)))
-        val saxParser = spf.newSAXParser()
+        val saxParser = saxFactory.newSAXParser()
         try DecodeResult.success(Task.now(XML.loadXML(source, saxParser)))
         catch {
           case e: SAXParseException =>

--- a/scala-xml/src/main/scala/scalaxml/package.scala
+++ b/scala-xml/src/main/scala/scalaxml/package.scala
@@ -1,3 +1,7 @@
 package org.http4s
 
-package object scalaxml extends ElemInstances
+import javax.xml.parsers.SAXParserFactory
+
+package object scalaxml extends ElemInstances {
+  override val saxFactory = SAXParserFactory.newInstance
+}

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -4,7 +4,8 @@ package scalaxml
 import scodec.bits.ByteVector
 
 import scala.xml.Elem
-import scalaz.concurrent.Task
+import java.util.concurrent.Executors
+import scalaz.concurrent.{Strategy, Task}
 import scalaz.stream.Process
 import scalaz.stream.Process.emit
 import scalaz.stream.text.utf8Decode
@@ -20,13 +21,22 @@ class ScalaXmlSpec extends Http4sSpec {
 
   "xml" should {
     val server: Request => Task[Response] = { req =>
-      req.decode { elem: Elem => Response(Ok).withBody(elem.label) }
+      req.decode[Elem] { elem =>
+        Response(Ok).withBody(elem.label) }
     }
 
     "parse the XML" in {
       val resp = server(Request(body = emit("<html><h1>h1</h1></html>").map(s => ByteVector(s.getBytes)))).unsafePerformSync
       resp.status must_==(Ok)
       getBody(resp.body) must_== ("html".getBytes)
+    }
+
+    "parse XML in parallel" in {
+      // https://github.com/http4s/http4s/issues/1209
+      val pool = Executors.newFixedThreadPool(5)
+      val resp = Task.gatherUnordered((0 to 5).map(_ => Task.fork(server(Request(body = strBody("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?><html><h1>h1</h1></html>"""))))(pool))).unsafePerformSync
+      resp.forall(_.status must_==(Ok))
+      resp.forall(x => getBody(x.body) must_== ("html".getBytes))
     }
 
     "return 400 on parse error" in {


### PR DESCRIPTION
This PR is a fix for #1209 it includes tests and a fix.

The fix is up for discussion as it changes the way an implicit decoder is built. I can see the argument both way of keeping the parser injectable or create one by default, but the approach on this PR gives a saner default and will fix #1209 

If this is accepted I'll port it to the 0.17.x branch

Fixes #1209