### PR TITLE
Fix for multithreaded xml parsing for fs2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ lazy val client = libraryProject("client")
     description := "Base library for building http4s clients",
     libraryDependencies += jettyServlet % "test"
   )
-  .dependsOn(core, testing % "test->test", server % "test->compile", theDsl % "test->compile")
+  .dependsOn(core, testing % "test->test", server % "test->compile", theDsl % "test->compile", scalaXml % "test->test")
 
 lazy val blazeCore = libraryProject("blaze-core")
   .settings(

--- a/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
@@ -8,7 +8,7 @@ import org.http4s.Method.GET
 
 import scala.xml.Elem
 
-import fs2.{Strategy, Task}
+import fs2.Task
 
 class ClientXmlSpec extends Http4sSpec {
   implicit val decoder = scalaxml.xml
@@ -26,8 +26,7 @@ class ClientXmlSpec extends Http4sSpec {
     }
     "read xml body in parallel" in {
       // https://github.com/http4s/http4s/issues/1209
-      val pool = Strategy.fromFixedDaemonPool(5)
-      val resp = Task.parallelTraverse(0 to 5)(_ => client.expect[Elem](Request(GET)))(pool).unsafeRun
+      val resp = Task.parallelTraverse(0 to 5)(_ => client.expect[Elem](Request(GET)))(testStrategy).unsafeRun
       resp.map(_ must_== body)
     }
   }

--- a/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
@@ -1,0 +1,34 @@
+package org.http4s
+package client
+
+import org.http4s.Http4sSpec
+import org.http4s.scalaxml
+import org.http4s.Status.Ok
+import org.http4s.Method.GET
+
+import scala.xml.Elem
+
+import fs2.{Strategy, Task}
+
+class ClientXmlSpec extends Http4sSpec {
+  implicit val decoder = scalaxml.xml
+  val body = <html><h1>h1</h1></html>
+  val xml = s"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>$body"""
+  val service = HttpService {
+    case r =>
+      Response(Ok).withBody(xml)
+  }
+  val client = Client.fromHttpService(service)
+
+  "mock client" should {
+    "read xml body before dispose" in {
+      client.expect[Elem](Request(GET)).unsafeRun must_== body
+    }
+    "read xml body in parallel" in {
+      // https://github.com/http4s/http4s/issues/1209
+      val pool = Strategy.fromFixedDaemonPool(5)
+      val resp = Task.parallelTraverse(0 to 5)(_ => client.expect[Elem](Request(GET)))(pool).unsafeRun
+      resp.map(_ must_== body)
+    }
+  }
+}

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -10,7 +10,11 @@ import headers.`Content-Type`
 import scala.util.control.NonFatal
 import scala.xml._
 
+import javax.xml.parsers.SAXParserFactory
+
 trait ElemInstances {
+  val spf = SAXParserFactory.newInstance
+  
   implicit def xmlEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[Elem] =
     EntityEncoder.stringEncoder(charset)
       .contramap[Elem](xml => xml.buildString(false))
@@ -24,12 +28,13 @@ trait ElemInstances {
    * @param parser the SAX parser to use to parse the XML
    * @return an XML element
    */
-  implicit def xml(implicit parser: SAXParser = XML.parser): EntityDecoder[Elem] = {
+  implicit val xml: EntityDecoder[Elem] = {
     import EntityDecoder._
     decodeBy(MediaType.`text/xml`, MediaType.`text/html`, MediaType.`application/xml`){ msg =>
       collectBinary(msg).flatMap[DecodeFailure, Elem] { arr =>
         val source = new InputSource(new StringReader(new String(arr.toArray, msg.charset.getOrElse(Charset.`US-ASCII`).nioCharset)))
-        try DecodeResult.success(Task.now(XML.loadXML(source, parser)))
+        val saxParser = spf.newSAXParser()
+        try DecodeResult.success(Task.now(XML.loadXML(source, saxParser)))
         catch {
           case e: SAXParseException =>
             DecodeResult.failure(MalformedMessageBodyFailure("Invalid XML", Some(e)))

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -14,7 +14,7 @@ import javax.xml.parsers.SAXParserFactory
 
 trait ElemInstances {
   val spf = SAXParserFactory.newInstance
-  
+
   implicit def xmlEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder[Elem] =
     EntityEncoder.stringEncoder(charset)
       .contramap[Elem](xml => xml.buildString(false))

--- a/scala-xml/src/main/scala/scalaxml/package.scala
+++ b/scala-xml/src/main/scala/scalaxml/package.scala
@@ -1,3 +1,7 @@
 package org.http4s
 
-package object scalaxml extends ElemInstances
+import javax.xml.parsers.SAXParserFactory
+
+package object scalaxml extends ElemInstances {
+  override val saxFactory = SAXParserFactory.newInstance
+}

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package scalaxml
 
-import fs2.{Stream, Task}
+import fs2.{Strategy, Stream, Task}
 import org.http4s.Status.Ok
 
 import scala.xml.Elem
@@ -14,13 +14,22 @@ class ScalaXmlSpec extends Http4sSpec {
 
   "xml" should {
     val server: Request => Task[Response] = { req =>
-      req.decode { elem: Elem => Response(Ok).withBody(elem.label) }
+      req.decode[Elem] { elem =>
+        Response(Ok).withBody(elem.label) }
     }
 
     "parse the XML" in {
       val resp = server(Request(body = strBody("<html><h1>h1</h1></html>"))).unsafeRun
       resp.status must_==(Ok)
       getBody(resp.body) must_== ("html".getBytes)
+    }
+
+    "parse XML in parallel" in {
+      // https://github.com/http4s/http4s/issues/1209
+      val pool = Strategy.fromFixedDaemonPool(5)
+      val resp = Task.parallelTraverse(0 to 5)(_ => server(Request(body = strBody("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?><html><h1>h1</h1></html>"""))))(pool).unsafeRun
+      resp.forall(_.status must_==(Ok))
+      resp.forall(x => getBody(x.body) must_== ("html".getBytes))
     }
 
     "return 400 on parse error" in {

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package scalaxml
 
-import fs2.{Strategy, Stream, Task}
+import fs2.{Stream, Task}
 import org.http4s.Status.Ok
 
 import scala.xml.Elem
@@ -26,8 +26,7 @@ class ScalaXmlSpec extends Http4sSpec {
 
     "parse XML in parallel" in {
       // https://github.com/http4s/http4s/issues/1209
-      val pool = Strategy.fromFixedDaemonPool(5)
-      val resp = Task.parallelTraverse(0 to 5)(_ => server(Request(body = strBody("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?><html><h1>h1</h1></html>"""))))(pool).unsafeRun
+      val resp = Task.parallelTraverse(0 to 5)(_ => server(Request(body = strBody("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?><html><h1>h1</h1></html>"""))))(testStrategy).unsafeRun
       resp.forall(_.status must_==(Ok))
       resp.forall(x => getBody(x.body) must_== ("html".getBytes))
     }


### PR DESCRIPTION
This is a replay of #1214 for master, basically porting scalaz `Task` usage to fs2 `Task`. 

Fixes #1209 