### PR TITLE
Bump StreamAppSpec timeout to 10 seconds

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -9,3 +9,4 @@
 -Xmx1536M
 -XX:MaxMetaspaceSize=1024M
 -Xss6M
+-XX:+PrintGC

--- a/bin/travis
+++ b/bin/travis
@@ -49,7 +49,7 @@ function find_sbt_pid() {
 
 function start_watchdog() {
     echo "Watchdog will wake up in $1"
-    (sleep "$1" && echo "Watchdog launched jstack." && jstack $(find_sbt_pid)) &
+    (sleep "$1" && echo "Watchdog launched jstack." && jstack -m $(find_sbt_pid)) &
     WATCHDOG_PID=$(pgrep -n sleep)
 }
 

--- a/tests/src/test/scala/org/http4s/util/StreamAppSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/StreamAppSpec.scala
@@ -50,7 +50,7 @@ class StreamAppSpec extends Http4sSpec {
         _ <- testApp.requestShutdown
         exit <- runApp
         cleanedUp <- testApp.cleanedUp.get
-      } yield (exit, cleanedUp)).unsafeTimed(5.seconds) should returnValue((0, true))
+      } yield (exit, cleanedUp)).unsafeTimed(10.seconds) should returnValue((0, true))
     }
   }
 }


### PR DESCRIPTION
A bunch of tests are taking more than 5 seconds to complete.  This raises the technical debt ceiling while we improve the tests.

https://www.youtube.com/watch?v=v5igKuNF1rI
