### PR TITLE
XML parsing improved safety

### DIFF
--- a/scala-xml/src/main/scala/scalaxml/package.scala
+++ b/scala-xml/src/main/scala/scalaxml/package.scala
@@ -3,5 +3,14 @@ package org.http4s
 import javax.xml.parsers.SAXParserFactory
 
 package object scalaxml extends ElemInstances {
-  override val saxFactory = SAXParserFactory.newInstance
+  override val saxFactory = {
+    val factory = SAXParserFactory.newInstance
+    // Safer parsing settings to avoid certain class of XML attacks
+    // See https://github.com/scala/scala-xml/issues/17
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false)
+    factory.setXIncludeAware(false)
+    factory
+  }
 }


### PR DESCRIPTION
The default XML parsing settings allows certain classes of attacks like XXE. I propose that by default the parser be set in safer mode with the settings below

if user need the features of parameter entities they can override the `saxParserFactory`

See
https://blog.compass-security.com/2012/08/secure-xml-parser-configuration/
https://github.com/scala/scala-xml/issues/17

Do you think this should target `master`?