### PR TITLE
Switch to GCE build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ notifications:
     on_success: change
     on_failure: always
     on_start: never
-sudo: false
+sudo: required
 cache:
   directories:
   - "$HOME/.coursier/cache"


### PR DESCRIPTION
tl;dr some tests that took 30 seconds are subsecond

The only thing I can come up with in profiling is synchronization on class loading (`ClasspathUtilities$$anon$1`, which is a `URLClassLoader`), but it's not a major problem in local builds on a powerful MBP, a Chromebook, or @bfritz' [vagrant setup](https://github.com/http4s/http4s/compare/master...rossabaker:gce?expand=1#1035).  Brad and I theorized that if I/O is terrible in Travis, it would explain our woes.

@timperrett suggested a move back to the GCE build environment.  We [switched to containers](https://github.com/http4s/http4s/commit/79db49a673d42202a5118b7b41138886e07b109b) in order to cache dependencies. Subsequently, Travis added [caching on GCE](https://docs.travis-ci.com/user/caching/), which makes this a lot more appealing.

In the troublesome `StreamAppSpec`, the `requestShutdown` test needs to run within 5 seconds.

[Recent failure on container build](https://travis-ci.org/http4s/http4s/jobs/245000789#L2793): 

```
[info] StreamApp should
[info]   + Terminate Server on a Process Failure (32 seconds, 93 ms)
[info]   + Terminate Server on a Valid Process (30 seconds, 310 ms)
[error]   x requestShutdown Shuts Down a Server From A Separate Thread (25 seconds, 347 ms)
[error]    an exception was thrown null (StreamAppSpec.scala:53)
[error] org.http4s.util.StreamAppSpec.$anonfun$new$12(StreamAppSpec.scala:53)
```

[Success on GCE build](https://travis-ci.org/http4s/http4s/jobs/246959488#L3943-L3946):

```
[info] StreamApp should
[info]   + Terminate Server on a Process Failure (271 ms)
[info]   + Terminate Server on a Valid Process (241 ms)
[info]   + requestShutdown Shuts Down a Server From A Separate Thread (65 ms)
```

[fingers crossed]