### PR TITLE
Delete an unused string interpolation.

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -29,7 +29,7 @@ trait CirceInstances {
             DecodeResult.success(Task.now(json))
           case Left(pf) =>
             DecodeResult.failure(MalformedMessageBodyFailure(
-              s"Invalid JSON", Some(pf.underlying)))
+              "Invalid JSON", Some(pf.underlying)))
         }
       } else {
         DecodeResult.failure(MalformedMessageBodyFailure(


### PR DESCRIPTION
Change `s"Invalid JSON"` to `"Invalid JSON"`