### PR TITLE
suggest sbt-revolver in documentation

### DIFF
--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -82,10 +82,14 @@ Content-Length: 26
 {"message":"Hello, world"}
 ```
 
-To shut down your server, simply press `^C` in your console.
+To shut down your server, simply press `^C` in your console. Note that
+when running interactive SBT, `^C` will kill the SBT process. For rapid
+application development, you may wish to add the [sbt-resolver] plugin
+to your project and starting the server from the SBT prompt with `re-start`.
 
 With just a few commands, we have a fully functional app for creating
 a simple JSON service.
 
 [giter8 template]: https://github.com/http4s/http4s.g8
 [versions]: /versions/
+[sbt-resolver]: https://github.com/spray/sbt-revolver

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -84,7 +84,7 @@ Content-Length: 26
 
 To shut down your server, simply press `^C` in your console. Note that
 when running interactive SBT, `^C` will kill the SBT process. For rapid
-application development, you may wish to add the [sbt-resolver] plugin
+application development, you may wish to add the [sbt-revolver] plugin
 to your project and starting the server from the SBT prompt with `re-start`.
 
 With just a few commands, we have a fully functional app for creating
@@ -92,4 +92,4 @@ a simple JSON service.
 
 [giter8 template]: https://github.com/http4s/http4s.g8
 [versions]: /versions/
-[sbt-resolver]: https://github.com/spray/sbt-revolver
+[sbt-revolver]: https://github.com/spray/sbt-revolver


### PR DESCRIPTION
For reasons I don't have time to debug, the sbt-site plugin can't find the hugo binary that I just installed, but the GitHub markdown processor implies that I did the right thing. Perhaps this documentation suggestion is obvious to others but it wasn't to me. Hoping to save the maintainers future questions.