### PR TITLE
Tolerate `[` and `]` in queries parsing URIs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -622,7 +622,19 @@ lazy val mimaSettings = Seq(
       exclude[ReversedMissingMethodProblem]("org.http4s.RequestOps.addCookie$default$3"),
       exclude[DirectMissingMethodProblem]("org.http4s.client.blaze.BlazeConnection.runRequest"),
       exclude[DirectAbstractMethodProblem]("org.http4s.client.blaze.BlazeConnection.runRequest"),
-      exclude[DirectMissingMethodProblem]("org.http4s.client.blaze.Http1Connection.runRequest")
+      exclude[DirectMissingMethodProblem]("org.http4s.client.blaze.Http1Connection.runRequest"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.sb"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.org$parboiled2$StringBuilding$_setter_$sb_="),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.setSB"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.appendSB"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.appendSB"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.appendSB"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.appendSB"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.prependSB"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.prependSB"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.prependSB"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.prependSB"),
+      exclude[InheritedNewAbstractMethodProblem]("org.parboiled2.StringBuilding.clearSB")
     )
   }
 )

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -9,7 +9,7 @@ import scalaz.syntax.std.option._
 import org.http4s.util.CaseInsensitiveString._
 import org.http4s.{ Query => Q }
 
-private[parser] trait Rfc3986Parser { this: Parser =>
+private[parser] trait Rfc3986Parser extends StringBuilding { this: Parser =>
   // scalastyle:off public.methods.have.type
   import CharPredicate.{Alpha, Digit, HexDigit}
 
@@ -113,7 +113,18 @@ private[parser] trait Rfc3986Parser { this: Parser =>
   def Pchar = rule { Unreserved | PctEncoded | SubDelims | ":" | "@" }
 
   // NOTE: The Query is NOT url decoded.
-  def Query = rule { capture(zeroOrMore(Pchar | "/" | "?")) }
+  def Query = rule {
+    clearSB() ~ zeroOrMore(
+      capture(Pchar) ~> { s: String => appendSB(s) } |
+        "/" ~ appendSB() |
+        "?" ~ appendSB() |
+        // These are illegal, but common in the wild.  We will be "conservative
+        // in our sending behavior and liberal in our receiving behavior", and
+        // encode them.
+        "[" ~ appendSB("%5B") |
+        "]" ~ appendSB("%5D")
+    ) ~ push(sb.toString)
+  }
 
   // NOTE: The Fragment is NOT url decoded.
   def Fragment = rule { capture(zeroOrMore(Pchar | "/" | "?")) }

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -258,10 +258,18 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
         "git://github.com/rails/rails.git",
         "crid://broadcaster.com/movies/BestActionMovieEver",
         "http://example.org/absolute/URI/with/absolute/path/to/resource.txt",
-        "/relative/URI/with/absolute/path/to/resource.txt")
+        "/relative/URI/with/absolute/path/to/resource.txt"
+      )
       foreach (examples) { e =>
         Uri.fromString(e).map(_.toString) must be_\/-(e)
       }
+    }
+
+    "handle brackets in query string" in {
+      // These are illegal, but common in the wild.  We will be "conservative
+      // in our sending behavior and liberal in our receiving behavior", and
+      // encode them.
+      Uri.fromString("http://localhost:8080/index?filter[state]=public").map(_.toString) must be_\/-("http://localhost:8080/index?filter%5Bstate%5D=public")
     }
 
     "round trip with toString" in forAll { uri: Uri =>


### PR DESCRIPTION
If we get a `[` or `]` in a query string, parse it by encoding it.  These are the only two reserved characters in RFC 3986 that are neither explicitly permitted in a query string nor preserve special semantics (`#` delimits the fragment).  Parsing them permits real world usage, but encoding them keeps our renderings in strict compliance with the spec.

Fixes #1240 

/cc @TimothyKlim