### PR TITLE
Improvement to Content-Length header

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -196,13 +196,13 @@ private class Http1ServerStage(service: HttpService,
 
   final protected def badMessage(debugMessage: String, t: ParserException, req: Request): Unit = {
     logger.debug(t)(s"Bad Request: $debugMessage")
-    val resp = Response(Status.BadRequest).replaceAllHeaders(Connection("close".ci), `Content-Length`(0))
+    val resp = Response(Status.BadRequest).replaceAllHeaders(Connection("close".ci), `Content-Length`.zero)
     renderResponse(req, resp, () => Future.successful(emptyBuffer))
   }
 
   final protected def internalServerError(errorMsg: String, t: Throwable, req: Request, bodyCleanup: () => Future[ByteBuffer]): Unit = {
     logger.error(t)(errorMsg)
-    val resp = Response(Status.InternalServerError).replaceAllHeaders(Connection("close".ci), `Content-Length`(0))
+    val resp = Response(Status.InternalServerError).replaceAllHeaders(Connection("close".ci), `Content-Length`.zero)
     renderResponse(req, resp, bodyCleanup)  // will terminate the connection due to connection: close header
   }
 }

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -211,7 +211,7 @@ class Http1ServerStageSpec extends Http4sSpec {
       val buff = Await.result(runRequest(Seq(r11,r12), service), 5.seconds)
 
       // Both responses must succeed
-      parseAndDropDate(buff) must_== ((Ok, Set(H.`Content-Length`(4)), "done"))
+      parseAndDropDate(buff) must_== ((Ok, Set(H.`Content-Length`.unsafeFromLong(4)), "done"))
     }
 
     "Handle routes that consumes the full request body for non-chunked" in {
@@ -226,7 +226,7 @@ class Http1ServerStageSpec extends Http4sSpec {
       val buff = Await.result(runRequest(Seq(r11,r12), service), 5.seconds)
 
       // Both responses must succeed
-      parseAndDropDate(buff) must_== ((Ok, Set(H.`Content-Length`(8 + 4), H.
+      parseAndDropDate(buff) must_== ((Ok, Set(H.`Content-Length`.unsafeFromLong(8 + 4), H.
                                        `Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`)), "Result: done"))
     }
 
@@ -242,7 +242,7 @@ class Http1ServerStageSpec extends Http4sSpec {
 
       val buff = Await.result(runRequest(Seq(req1,req2), service), 5.seconds)
 
-      val hs = Set(H.`Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`), H.`Content-Length`(3))
+      val hs = Set(H.`Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`), H.`Content-Length`.unsafeFromLong(3))
       // Both responses must succeed
       dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, hs, "foo"))
       dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, hs, "foo"))
@@ -262,7 +262,7 @@ class Http1ServerStageSpec extends Http4sSpec {
 
       val buff = Await.result(runRequest(Seq(r11, r12, req2), service), 5.seconds)
 
-      val hs = Set(H.`Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`), H.`Content-Length`(3))
+      val hs = Set(H.`Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`), H.`Content-Length`.unsafeFromLong(3))
       // Both responses must succeed
       dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, hs, "foo"))
       buff.remaining() must_== 0
@@ -281,7 +281,7 @@ class Http1ServerStageSpec extends Http4sSpec {
 
       val buff = Await.result(runRequest(Seq(r11,r12,req2), service), 5.seconds)
 
-      val hs = Set(H.`Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`), H.`Content-Length`(3))
+      val hs = Set(H.`Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`), H.`Content-Length`.unsafeFromLong(3))
       // Both responses must succeed
       dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, hs, "foo"))
       dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, hs, "foo"))
@@ -301,8 +301,8 @@ class Http1ServerStageSpec extends Http4sSpec {
       val buff = Await.result(runRequest(Seq(req1 + req2), service), 5.seconds)
 
       // Both responses must succeed
-      dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, Set(H.`Content-Length`(4)), "done"))
-      dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, Set(H.`Content-Length`(5)), "total"))
+      dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, Set(H.`Content-Length`.unsafeFromLong(4)), "done"))
+      dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, Set(H.`Content-Length`.unsafeFromLong(5)), "total"))
     }
 
     "Handle using the request body as the response body" in {
@@ -318,8 +318,8 @@ class Http1ServerStageSpec extends Http4sSpec {
       val buff = Await.result(runRequest(Seq(req1, req2), service), 5.seconds)
 
       // Both responses must succeed
-      dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, Set(H.`Content-Length`(4)), "done"))
-      dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, Set(H.`Content-Length`(5)), "total"))
+      dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, Set(H.`Content-Length`.unsafeFromLong(4)), "done"))
+      dropDate(ResponseParser.parseBuffer(buff)) must_== ((Ok, Set(H.`Content-Length`.unsafeFromLong(5)), "total"))
     }
 
     {

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
@@ -21,7 +21,7 @@ object ServerTestRoutes {
   val connKeep = Connection("keep-alive".ci)
   val chunked = `Transfer-Encoding`(TransferCoding.chunked)
 
-  def length(l: Long) = `Content-Length`(l)
+  def length(l: Long): `Content-Length` = `Content-Length`.unsafeFromLong(l)
 
   def testRequestResults: Seq[(String, (Status,Set[Header], String))] = Seq(
     ("GET /get HTTP/1.0\r\n\r\n", (Status.Ok,

--- a/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
+++ b/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
@@ -17,10 +17,10 @@ trait EmptyRequestGenerator extends Any with RequestGenerator {
 trait EntityRequestGenerator extends Any with EmptyRequestGenerator {
   /** Make a [[org.http4s.Request]] using this Method */
   final def apply[A](uri: Uri, body: A)(implicit w: EntityEncoder[A]): Task[Request] = {
-    var h = w.headers
+    val h = w.headers
     w.toEntity(body).flatMap { case Entity(proc, len) =>
-      len foreach { l => h = h put `Content-Length`(l) }
-      Task.now(Request(method = method, uri = uri, headers = h, body = proc))
+      val headers = len.map { l => `Content-Length`(l).fold(_ => h, c => h put c) }.getOrElse(h)
+      Task.now(Request(method = method, uri = uri, headers = headers, body = proc))
     }
   }
 }

--- a/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
+++ b/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
@@ -19,7 +19,7 @@ trait EntityRequestGenerator extends Any with EmptyRequestGenerator {
   final def apply[A](uri: Uri, body: A)(implicit w: EntityEncoder[A]): Task[Request] = {
     val h = w.headers
     w.toEntity(body).flatMap { case Entity(proc, len) =>
-      val headers = len.map { l => `Content-Length`(l).fold(_ => h, c => h put c) }.getOrElse(h)
+      val headers = len.map { l => `Content-Length`.fromLong(l).fold(_ => h, c => h put c) }.getOrElse(h)
       Task.now(Request(method = method, uri = uri, headers = headers, body = proc))
     }
   }

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -66,7 +66,7 @@ sealed trait Message extends MessageOps { self =>
   def withBody[T](b: T)(implicit w: EntityEncoder[T]): Task[Self] = {
     w.toEntity(b).map { entity =>
       val hs = entity.length match {
-        case Some(l) => `Content-Length`(l)::w.headers.toList
+        case Some(l) => `Content-Length`(l).fold(_ => w.headers.toList, _ :: w.headers.toList)
         case None    => w.headers
       }
       change(body = entity.body, headers = headers ++ hs)

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -67,7 +67,7 @@ sealed trait Message extends MessageOps { self =>
   def withBody[T](b: T)(implicit w: EntityEncoder[T]): Task[Self] = {
     w.toEntity(b).flatMap { entity =>
       val hs = entity.length match {
-        case Some(l) => `Content-Length`(l).fold(_ =>
+        case Some(l) => `Content-Length`.fromLong(l).fold(_ =>
           Task.now {
             Message.logger.warn(s"Attempt to provide a negative content length of $l")
             w.headers.toList

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -11,6 +11,7 @@ import fs2.text._
 import org.http4s.headers._
 import org.http4s.util.nonEmptyList._
 import org.http4s.server.ServerSoftware
+import org.log4s.getLogger
 
 /**
  * Represents a HTTP Message. The interesting subclasses are Request and Response
@@ -64,12 +65,17 @@ sealed trait Message extends MessageOps { self =>
     * @return a new message with the new body
     */
   def withBody[T](b: T)(implicit w: EntityEncoder[T]): Task[Self] = {
-    w.toEntity(b).map { entity =>
+    w.toEntity(b).flatMap { entity =>
       val hs = entity.length match {
-        case Some(l) => `Content-Length`(l).fold(_ => w.headers.toList, _ :: w.headers.toList)
-        case None    => w.headers
+        case Some(l) => `Content-Length`(l).fold(_ =>
+          Task.now {
+            Message.logger.warn(s"Attempt to provide a negative content length of $l")
+            w.headers.toList
+          },
+          cl => Task.now(cl :: w.headers.toList))
+        case None    => Task.now(w.headers)
       }
-      change(body = entity.body, headers = headers ++ hs)
+      hs.map(newHeaders => change(body = entity.body, headers = headers ++ newHeaders))
     }
   }
 
@@ -100,6 +106,7 @@ sealed trait Message extends MessageOps { self =>
 }
 
 object Message {
+  private[http4s] val logger = getLogger
   object Keys {
     val TrailerHeaders = AttributeKey.http4s[Task[Headers]]("trailer-headers")
   }

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -92,8 +92,7 @@ object StaticFile {
         }
 
         val hs = `Last-Modified`(lastModified) ::
-          `Content-Length`(contentLength) ::
-          contentType.toList
+          `Content-Length`(contentLength).fold(_ => contentType.toList, _ :: contentType.toList)
 
         val r = Response(
           headers = Headers(hs),

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -92,7 +92,7 @@ object StaticFile {
         }
 
         val hs = `Last-Modified`(lastModified) ::
-          `Content-Length`(contentLength).fold(_ => contentType.toList, _ :: contentType.toList)
+          `Content-Length`.fromLong(contentLength).fold(_ => contentType.toList, _ :: contentType.toList)
 
         val r = Response(
           headers = Headers(hs),

--- a/core/src/main/scala/org/http4s/headers/Content-Length.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Length.scala
@@ -15,15 +15,13 @@ import org.http4s.util.Writer
 sealed abstract case class `Content-Length`(length: Long) extends Header.Parsed {
   override def key: `Content-Length`.type = `Content-Length`
   override def renderValue(writer: Writer): writer.type = writer.append(length)
-  def modify(f: Long => Long): Option[`Content-Length`] = `Content-Length`.apply(f(length)).right.toOption
+  def modify(f: Long => Long): Option[`Content-Length`] = `Content-Length`.fromLong(f(length)).right.toOption
 }
 
 object `Content-Length` extends HeaderKey.Internal[`Content-Length`] with HeaderKey.Singleton {
   private class ContentLengthImpl(length: Long) extends `Content-Length`(length)
 
   val zero: `Content-Length` = new ContentLengthImpl(0) {}
-
-  def apply(length: Long): ParseResult[`Content-Length`] = fromLong(length)
 
   def fromLong(length: Long): ParseResult[`Content-Length`] =
     if (length >= 0L) ParseResult.success(new ContentLengthImpl(length))

--- a/core/src/main/scala/org/http4s/headers/Content-Length.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Length.scala
@@ -9,22 +9,24 @@ import org.http4s.util.Writer
   *
   * The HTTP RFCs do not specify a maximum length.  We have decided that `Long.MaxValue`
   * bytes ought to be good enough for anybody in order to avoid the irritations of `BigInt`.
-  *
+  *t
   * @param length the length; throws an `IllegalArgumentException` if negative
   */
 sealed abstract case class `Content-Length`(length: Long) extends Header.Parsed {
   override def key: `Content-Length`.type = `Content-Length`
   override def renderValue(writer: Writer): writer.type = writer.append(length)
-  def modify(f: Long => Long): `Content-Length` = new `Content-Length`(f(length)) {}
+  def modify(f: Long => Long): Option[`Content-Length`] = `Content-Length`.apply(f(length)).right.toOption
 }
 
 object `Content-Length` extends HeaderKey.Internal[`Content-Length`] with HeaderKey.Singleton {
-  val zero = new `Content-Length`(0) {}
+  private class ContentLengthImpl(length: Long) extends `Content-Length`(length)
+
+  val zero: `Content-Length` = new ContentLengthImpl(0) {}
 
   def apply(length: Long): ParseResult[`Content-Length`] = fromLong(length)
 
   def fromLong(length: Long): ParseResult[`Content-Length`] =
-    if (length >= 0L) ParseResult.success(new `Content-Length`(length) {})
+    if (length >= 0L) ParseResult.success(new ContentLengthImpl(length))
     else ParseResult.fail("Invalid Content-Length", length.toString)
 
   def unsafeFromLong(length: Long): `Content-Length` =

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -57,7 +57,7 @@ private[parser] trait SimpleHeaders {
   }
 
   def CONTENT_LENGTH(value: String): ParseResult[`Content-Length`] = new Http4sHeaderParser[`Content-Length`](value) {
-    def entry = rule { Digits ~ EOL ~> {s: String => `Content-Length`(s.toLong)} }
+    def entry = rule { Digits ~ EOL ~> {s: String => `Content-Length`.unsafeFromLong(s.toLong)} }
   }.parse
 
   def CONTENT_ENCODING(value: String): ParseResult[`Content-Encoding`] = new Http4sHeaderParser[`Content-Encoding`](value) {
@@ -68,7 +68,7 @@ private[parser] trait SimpleHeaders {
 
   def CONTENT_DISPOSITION(value: String): ParseResult[`Content-Disposition`] = new Http4sHeaderParser[`Content-Disposition`](value) {
     def entry = rule {
-     Token ~ zeroOrMore(";" ~ OptWS ~ Parameter) ~ EOL ~> { (token:String, params: Seq[(String, String)]) =>
+     Token ~ zeroOrMore(";" ~ OptWS ~ Parameter) ~ EOL ~> { (token: String, params: Seq[(String, String)]) =>
       `Content-Disposition`(token, params.toMap)}
     }
   }.parse

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -39,7 +39,7 @@ trait EntityResponseGenerator extends Any with EmptyResponseGenerator {
   def apply[A](body: A, headers: Headers)(implicit w: EntityEncoder[A]): Task[Response] = {
     val h = w.headers ++ headers
     w.toEntity(body).flatMap { case Entity(proc, len) =>
-      val headers = len.map { l => `Content-Length`(l).fold(_ => h, c => h put c) }.getOrElse(h)
+      val headers = len.map { l => `Content-Length`.fromLong(l).fold(_ => h, c => h put c) }.getOrElse(h)
       Task.now(Response(status = status, headers = headers, body = proc))
     }
   }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -37,10 +37,10 @@ trait EntityResponseGenerator extends Any with EmptyResponseGenerator {
     apply(body, Headers.empty)(w)
 
   def apply[A](body: A, headers: Headers)(implicit w: EntityEncoder[A]): Task[Response] = {
-    var h = w.headers ++ headers
+    val h = w.headers ++ headers
     w.toEntity(body).flatMap { case Entity(proc, len) =>
-      len foreach { l => h = h put `Content-Length`(l) }
-      Task.now(Response(status = status, headers = h, body = proc))
+      val headers = len.map { l => `Content-Length`(l).fold(_ => h, c => h put c) }.getOrElse(h)
+      Task.now(Response(status = status, headers = headers, body = proc))
     }
   }
 }

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
@@ -13,7 +13,7 @@ class ResponseGeneratorSpec extends Http4sSpec {
       old and (resultheaders.exists(_ == h) must_=== true)
     }
 
-    resultheaders.get(`Content-Length`) must_=== Some(`Content-Length`(body.getBytes.length.toLong))
+    resultheaders.get(`Content-Length`) must_=== `Content-Length`(body.getBytes.length.toLong).right.toOption
   }
 
   "Not duplicate headers when not provided" in {

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
@@ -13,7 +13,7 @@ class ResponseGeneratorSpec extends Http4sSpec {
       old and (resultheaders.exists(_ == h) must_=== true)
     }
 
-    resultheaders.get(`Content-Length`) must_=== `Content-Length`(body.getBytes.length.toLong).right.toOption
+    resultheaders.get(`Content-Length`) must_=== `Content-Length`.fromLong(body.getBytes.length.toLong).right.toOption
   }
 
   "Not duplicate headers when not provided" in {

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -116,17 +116,17 @@ object ExampleService {
 
     // HEAD responses with Content-Lenght, but empty content
     case req @ HEAD -> Root / "head" =>
-      Ok("").putHeaders(`Content-Length`(1024))
+      Ok("").putHeaders(`Content-Length`.unsafeFromLong(1024))
 
     // Response with invalid Content-Length header generates
     // an error (underflow causes the connection to be closed)
     case req @ GET -> Root / "underflow" =>
-      Ok("foo").putHeaders(`Content-Length`(4))
+      Ok("foo").putHeaders(`Content-Length`.unsafeFromLong(4))
 
     // Response with invalid Content-Length header generates
     // an error (overflow causes the extra bytes to be ignored)
     case req @ GET -> Root / "overflow" =>
-      Ok("foo").putHeaders(`Content-Length`(2))
+      Ok("foo").putHeaders(`Content-Length`.unsafeFromLong(2))
 
     ///////////////////////////////////////////////////////////////
     //////////////// Form encoding example ////////////////////////

--- a/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -51,7 +51,7 @@ object Jsonp  {
     val begin = beginJsonp(callback)
     val end = EndJsonp
     val jsonpBody = chunk(begin) ++ resp.body ++ chunk(end)
-    val newLengthHeaderOption = resp.headers.get(`Content-Length`).map { old =>
+    val newLengthHeaderOption = resp.headers.get(`Content-Length`).flatMap { old =>
       old.modify(_ + begin.size + end.size)
     }
     resp.copy(body = jsonpBody).

--- a/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -52,7 +52,7 @@ object Jsonp  {
     val end = EndJsonp
     val jsonpBody = chunk(begin) ++ resp.body ++ chunk(end)
     val newLengthHeaderOption = resp.headers.get(`Content-Length`).map { old =>
-      old.copy(length = begin.size + old.length + end.size)
+      old.modify(_ + begin.size + end.size)
     }
     resp.copy(body = jsonpBody).
       transformHeaders(_ ++ newLengthHeaderOption).

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -196,7 +196,7 @@ trait ArbitraryInstances {
   implicit val arbitraryContentLength: Arbitrary[`Content-Length`] =
     Arbitrary { for {
       long <- arbitrary[Long] if long > 0L
-    } yield `Content-Length`(long) }
+    } yield `Content-Length`.unsafeFromLong(long) }
 
   implicit val arbitraryXB3TraceId: Arbitrary[`X-B3-TraceId`] =
     Arbitrary { for {

--- a/tests/src/test/scala/org/http4s/HeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeaderSpec.scala
@@ -8,23 +8,23 @@ import headers._
 class HeaderSpec extends Specification {
   "Headers" should {
     "Equate same headers" in {
-      val h1 = `Content-Length`(4)
-      val h2 = `Content-Length`(4)
+      val h1 = `Content-Length`.unsafeFromLong(4)
+      val h2 = `Content-Length`.unsafeFromLong(4)
 
       h1 == h2 should beTrue
       h2 == h1 should beTrue
     }
 
     "not equal different headers" in {
-      val h1 = `Content-Length`(4)
-      val h2 = `Content-Length`(5)
+      val h1 = `Content-Length`.unsafeFromLong(4)
+      val h2 = `Content-Length`.unsafeFromLong(5)
 
       h1 == h2 should beFalse
       h2 == h1 should beFalse
     }
 
     "equal same raw headers" in {
-      val h1 = `Content-Length`(44)
+      val h1 = `Content-Length`.unsafeFromLong(44)
       val h2 = Header("Content-Length", "44")
 
       h1 == h2 should beTrue
@@ -38,7 +38,7 @@ class HeaderSpec extends Specification {
     }
 
     "not equal same raw headers" in {
-      val h1 = `Content-Length`(4)
+      val h1 = `Content-Length`.unsafeFromLong(4)
       val h2 = Header("Content-Length", "5")
 
       h1 == h2 should beFalse

--- a/tests/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeadersSpec.scala
@@ -6,7 +6,7 @@ import org.http4s.util.nonEmptyList._
 
 class HeadersSpec extends Http4sSpec {
 
-  val clength = `Content-Length`(10)
+  val clength = `Content-Length`.unsafeFromLong(10)
   val raw = Header.Raw("raw-header".ci, "Raw value")
 
   val base = Headers(clength.toRaw, raw)
@@ -22,7 +22,7 @@ class HeadersSpec extends Http4sSpec {
     }
 
     "Replaces headers" in {
-      val newlen = `Content-Length`(0)
+      val newlen = `Content-Length`.zero
       base.put(newlen).get(newlen.key) should beSome(newlen)
       base.put(newlen.toRaw).get(newlen.key) should beSome (newlen)
     }

--- a/tests/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/tests/src/test/scala/org/http4s/ResponderSpec.scala
@@ -22,7 +22,7 @@ class ResponderSpec extends Specification {
 
     "Replace content type" in {
       resp.contentType should be (None)
-      val c1 = resp.putHeaders(`Content-Length`(4))
+      val c1 = resp.putHeaders(`Content-Length`.unsafeFromLong(4))
         .withContentType(Some(`Content-Type`(MediaType.`text/plain`)))
         .putHeaders(Host("foo"))
 
@@ -48,7 +48,7 @@ class ResponderSpec extends Specification {
     }
 
     "Replace all headers" in {
-      val wHeader = resp.putHeaders(Connection("close".ci), `Content-Length`(10), Host("foo"))
+      val wHeader = resp.putHeaders(Connection("close".ci), `Content-Length`.unsafeFromLong(10), Host("foo"))
       wHeader.headers.toList must have length 3
 
       val newHeaders = wHeader.replaceAllHeaders(Date(Instant.now))
@@ -57,7 +57,7 @@ class ResponderSpec extends Specification {
     }
 
     "Replace all headers II" in {
-      val wHeader = resp.putHeaders(Connection("close".ci), `Content-Length`(10), Host("foo"))
+      val wHeader = resp.putHeaders(Connection("close".ci), `Content-Length`.unsafeFromLong(10), Host("foo"))
       wHeader.headers.toList must have length 3
 
       val newHeaders = wHeader.replaceAllHeaders(Headers(Date(Instant.now)))
@@ -66,7 +66,7 @@ class ResponderSpec extends Specification {
     }
 
     "Filter headers" in {
-      val wHeader = resp.putHeaders(Connection("close".ci), `Content-Length`(10), Host("foo"))
+      val wHeader = resp.putHeaders(Connection("close".ci), `Content-Length`.unsafeFromLong(10), Host("foo"))
       wHeader.headers.toList must have length 3
 
       val newHeaders = wHeader.filterHeaders(_.name != "Connection".ci)

--- a/tests/src/test/scala/org/http4s/headers/ContentLengthSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ContentLengthSpec.scala
@@ -35,5 +35,17 @@ class ContentLengthSpec extends HeaderLaws {
     "be consistent with apply" in prop { length: Long => length >= 0 ==> {
       `Content-Length`.parse(length.toString) must_== `Content-Length`(length)
     }}
+    "roundtrip" in prop { l: Long => (l >= 0) ==> {
+        `Content-Length`(l).right.map(_.value).right.flatMap(`Content-Length`.parse) must_== `Content-Length`(l)
+    }}
+  }
+
+  "modify" should {
+    "update the length if positive" in prop { length: Long => length >= 0 ==> {
+      `Content-Length`.zero.modify(_ + length) must_== `Content-Length`(length).right.toOption
+    }}
+    "fail to update if the result is negative" in prop { length: Long => length > 0 ==> {
+      `Content-Length`.zero.modify(_ - length) must beNone
+    }}
   }
 }

--- a/tests/src/test/scala/org/http4s/headers/ContentLengthSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ContentLengthSpec.scala
@@ -5,11 +5,11 @@ class ContentLengthSpec extends HeaderLaws {
 
   "apply" should {
     "reject negative lengths" in prop { length: Long => length < 0 ==> {
-      `Content-Length`(length) must throwA[IllegalArgumentException]
+      `Content-Length`(length) must beLeft
     }}
 
     "accept non-negative lengths" in prop { length: Long => length >= 0 ==> {
-      `Content-Length`(length).length must_== (length)
+      `Content-Length`(length).right.map(_.length) must beRight(length)
     }}
   }
 
@@ -19,7 +19,7 @@ class ContentLengthSpec extends HeaderLaws {
     }}
 
     "be consistent with apply" in prop { length: Long => length >= 0 ==> {
-      `Content-Length`.fromLong(length) must beRight(`Content-Length`(length))
+      `Content-Length`.fromLong(length) must_== `Content-Length`(length)
     }}
   }
 
@@ -33,7 +33,7 @@ class ContentLengthSpec extends HeaderLaws {
     }}
 
     "be consistent with apply" in prop { length: Long => length >= 0 ==> {
-      `Content-Length`.parse(length.toString) must beRight(`Content-Length`(length))
+      `Content-Length`.parse(length.toString) must_== `Content-Length`(length)
     }}
   }
 }

--- a/tests/src/test/scala/org/http4s/headers/ContentLengthSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ContentLengthSpec.scala
@@ -3,23 +3,12 @@ package org.http4s.headers
 class ContentLengthSpec extends HeaderLaws {
   checkAll("Content-Length", headerLaws(`Content-Length`))
 
-  "apply" should {
-    "reject negative lengths" in prop { length: Long => length < 0 ==> {
-      `Content-Length`(length) must beLeft
-    }}
-
-    "accept non-negative lengths" in prop { length: Long => length >= 0 ==> {
-      `Content-Length`(length).right.map(_.length) must beRight(length)
-    }}
-  }
-
   "fromLong" should {
     "reject negative lengths" in prop { length: Long => length < 0 ==> {
       `Content-Length`.fromLong(length) must beLeft
     }}
-
-    "be consistent with apply" in prop { length: Long => length >= 0 ==> {
-      `Content-Length`.fromLong(length) must_== `Content-Length`(length)
+    "accept non-negative lengths" in prop { length: Long => length >= 0 ==> {
+      `Content-Length`.fromLong(length).right.map(_.length) must beRight(length)
     }}
   }
 
@@ -33,16 +22,16 @@ class ContentLengthSpec extends HeaderLaws {
     }}
 
     "be consistent with apply" in prop { length: Long => length >= 0 ==> {
-      `Content-Length`.parse(length.toString) must_== `Content-Length`(length)
+      `Content-Length`.parse(length.toString) must_== `Content-Length`.fromLong(length)
     }}
     "roundtrip" in prop { l: Long => (l >= 0) ==> {
-        `Content-Length`(l).right.map(_.value).right.flatMap(`Content-Length`.parse) must_== `Content-Length`(l)
+      `Content-Length`.fromLong(l).right.map(_.value).right.flatMap(`Content-Length`.parse) must_== `Content-Length`.fromLong(l)
     }}
   }
 
   "modify" should {
     "update the length if positive" in prop { length: Long => length >= 0 ==> {
-      `Content-Length`.zero.modify(_ + length) must_== `Content-Length`(length).right.toOption
+      `Content-Length`.zero.modify(_ + length) must_== `Content-Length`.fromLong(length).right.toOption
     }}
     "fail to update if the result is negative" in prop { length: Long => length > 0 ==> {
       `Content-Length`.zero.modify(_ - length) must beNone

--- a/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -19,7 +19,7 @@ class SimpleHeadersSpec extends Http4sSpec {
     }
 
     "parse Content-Length" in {
-      val header = `Content-Length`(4)
+      val header = `Content-Length`.unsafeFromLong(4)
       HttpHeaderParser.parseHeader(header.toRaw) must beRight(header)
 
       val bad = Header(header.name.toString, "foo")


### PR DESCRIPTION
After the implementation of the `Age` header it was suggested to review other cases where headers could throw an exception on construction. The other header doing that was `Content-Length`. Given how much more use `Content-Length` has this PR is quite extensive on changes to support this new style

Unfortunately this change breaks the API as the `apply` method now returns a `ParseResult[Content-Length]` value