### PR TITLE
Fix Hugo Publishing

### DIFF
--- a/bin/publishSite.sh
+++ b/bin/publishSite.sh
@@ -6,7 +6,7 @@ checkPublishable "ghPages"
 
 # Install hugo static site generator from GitHub releases page.
 curl -s -L "https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz" | tar xzf -
-mv "hugo_${HUGO_VERSION}_linux_amd64/hugo_${HUGO_VERSION}_linux_amd64" "$HOME/bin/hugo"
+mv "./hugo" "$HOME/bin/hugo"
 
 # Disable Making Sure It's the Real Github
 echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config


### PR DESCRIPTION
New Hugo Distributes Hugo Directly in unpacked folder

If you run the curl command you get a folder like below

```
-rwxr-xr-x  1 davenpcm davenpcm  12M Jun 24 04:27 hugo
-rw-r--r--  1 davenpcm davenpcm  11K Jun 17 04:06 LICENSE.md
-rw-r--r--  1 davenpcm davenpcm 5.8K Jun 21 08:12 README.md
```