### PR TITLE
Test that toHttpService returns a live response body

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -175,6 +175,10 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
     "toHttpService disposes of the response if the body is run, even if it fails" in {
       assertDisposes(_.toHttpService.flatMapK(_.orNotFound.body.flatMap(_ => Process.fail(SadTrombone).toSource).run).run(req))
     }
+
+    "toHttpService allows the response to be read" in {
+      client.toHttpService.orNotFound(req).as[String] must returnValue("hello")
+    }
   }
 
   "RequestResponseGenerator" should {


### PR DESCRIPTION
This is what they call foreshadowing.  It's broken in master, but let's put up the safety net here.