### PR TITLE
Return live response body from Client.toHttpService

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -77,12 +77,12 @@ final case class Client(open: Service[Request, DisposableResponse], shutdown: Ta
     * signatures guarantee disposal of the HTTP connection.
     */
   def toHttpService: HttpService = {
-    open.flatMapF{
-      case DisposableResponse(response, dispose) => dispose.flatMap(_ => Task.now(response))
+    open.map { case DisposableResponse(response, dispose) =>
+      response.copy(body = response.body.onFinalize(dispose))
     }
   }
 
-
+n
   def streaming[A](req: Request)(f: Response => Stream[Task, A]): Stream[Task, A] = {
     Stream.eval(open(req))
       .flatMap {

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -82,7 +82,6 @@ final case class Client(open: Service[Request, DisposableResponse], shutdown: Ta
     }
   }
 
-n
   def streaming[A](req: Request)(f: Response => Stream[Task, A]): Stream[Task, A] = {
     Stream.eval(open(req))
       .flatMap {

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -175,6 +175,10 @@ class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
      "toHttpService disposes of the response if the body is run, even if it fails" in {
        assertDisposes(_.toHttpService.flatMapF(_.orNotFound.body.flatMap(_ => Stream.fail(SadTrombone)).run).run(req))
      }
+
+    "toHttpService allows the response to be read" in {
+      client.toHttpService.orNotFound(req).as[String] must returnValue("hello")
+    }
   }
 
   "RequestResponseGenerator" should {


### PR DESCRIPTION
This is tested in #1251, but broken in master.  This contains the fix.  We need to attach `dispose` to the finalizer of the body, not dispose and then return the body.