### PR TITLE
Re-enables last event id spec

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Last-Event-Id.scala
+++ b/core/src/main/scala/org/http4s/headers/Last-Event-Id.scala
@@ -1,13 +1,13 @@
-/* TODO fs2 port
 package org.http4s
 package headers
 
+import org.http4s
 import org.http4s.ServerSentEvent._
 import org.http4s.parser.HttpHeaderParser
 import org.http4s.util.Writer
 
 final case class `Last-Event-Id`(id: EventId) extends Header.Parsed {
-  override def key = `Last-Event-Id`
+  override def key: http4s.headers.`Last-Event-Id`.type = `Last-Event-Id`
   override def renderValue(writer: Writer): writer.type =
     writer.append(id.value)
 }
@@ -16,4 +16,3 @@ object `Last-Event-Id` extends HeaderKey.Internal[`Last-Event-Id`] with HeaderKe
   def parse(s: String): ParseResult[`Last-Event-Id`] =
     HttpHeaderParser.LAST_EVENT_ID(s)
 }
- */

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -110,7 +110,6 @@ private[parser] trait SimpleHeaders {
     }
   }.parse
 
-  /* TOOO fs2 port
   def LAST_EVENT_ID(value: String): ParseResult[`Last-Event-Id`] =
     new Http4sHeaderParser[`Last-Event-Id`](value) {
       def entry = rule {
@@ -119,7 +118,6 @@ private[parser] trait SimpleHeaders {
         }
       }
     }.parse
-   */
 
   def LAST_MODIFIED(value: String): ParseResult[`Last-Modified`] =
     new Http4sHeaderParser[`Last-Modified`](value) {

--- a/tests/src/test/scala/org/http4s/headers/LastEventIdSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/LastEventIdSpec.scala
@@ -1,8 +1,6 @@
-/* TODO fs2 port
 package org.http4s
 package headers
 
-import scalaz._
 import org.scalacheck._, Arbitrary._
 import org.http4s.ServerSentEvent._
 
@@ -10,11 +8,10 @@ class LastEventIdSpec extends HeaderLaws {
   implicit val arbLastEventId: Arbitrary[`Last-Event-Id`] =
     Arbitrary(for {
       id <- arbitrary[String]
-      if !id.contains("\uffff")      
+      if !id.contains("\uffff")
     } yield {
       `Last-Event-Id`(EventId(id))
     })
 
   checkAll("Last-Event-Id", headerLaws(`Last-Event-Id`))
 }
- */


### PR DESCRIPTION
I dove into the tests to see if I could help out on the fs2-cats port. Discovered this disabled code and figured I could "fix" it. Kind of refs. https://github.com/http4s/http4s/issues/866