### PR TITLE
Bring Age header up to standard

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Age.scala
+++ b/core/src/main/scala/org/http4s/headers/Age.scala
@@ -10,18 +10,20 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 object Age extends HeaderKey.Internal[Age] with HeaderKey.Singleton {
-  def apply(age: Long): ParseResult[Age] =
+  private class AgeImpl(age: Long) extends Age(age)
+
+  def fromLong(age: Long): ParseResult[Age] =
     if (age >= 0) {
-      ParseResult.success(new Age(age) {})
+      ParseResult.success(new AgeImpl(age))
     } else {
       ParseResult.fail("Invalid age value", s"Age param $age must be more or equal to 0 seconds")
     }
 
   def unsafeFromDuration(age: FiniteDuration): Age =
-    apply(age.toSeconds).fold(throw _, identity)
+    fromLong(age.toSeconds).fold(throw _, identity)
 
   def unsafeFromLong(age: Long): Age =
-    apply(age).fold(throw _, identity)
+    fromLong(age).fold(throw _, identity)
 
   override def parse(s: String): ParseResult[Age] =
     HttpHeaderParser.AGE(s)

--- a/tests/src/test/scala/org/http4s/headers/AgeSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AgeSpec.scala
@@ -12,16 +12,16 @@ class AgeSpec extends HeaderLaws {
 
   "render" should {
     "age in seconds" in {
-      Age(120).map(_.renderString) must_== ParseResult.success("Age: 120")
+      Age.fromLong(120).map(_.renderString) must_== ParseResult.success("Age: 120")
     }
   }
 
   "build" should {
     "build correctly for positives" in {
-      Age(0).map(_.value) must beLike { case Right("0") => ok }
+      Age.fromLong(0).map(_.value) must beLike { case Right("0") => ok }
     }
     "fail for negatives" in {
-      Age(-10).map(_.value) must beLeft
+      Age.fromLong(-10).map(_.value) must beLeft
     }
     "build unsafe for positives" in {
       Age.unsafeFromDuration(0.seconds).value must_== "0"
@@ -51,7 +51,7 @@ class AgeSpec extends HeaderLaws {
     }
     "roundtrip" in {
       forAll { l: Long => (l >= 0) ==> {
-        Age(l).map(_.value).flatMap(Age.parse) must_== Age(l)
+        Age.fromLong(l).map(_.value).flatMap(Age.parse) must_== Age.fromLong(l)
       }}
     }
   }


### PR DESCRIPTION
After the changes on `Content-Length` on #1244, I'm updating the `Age` header in the same way, removing the partial `apply` constructor and the anonymous class

This is an API break but given that `Age` was add very recently I'd expect the impact to be minimal