### PR TITLE
Update SpecialTest for False Positives

### DIFF
--- a/bin/specialTest.sh
+++ b/bin/specialTest.sh
@@ -3,6 +3,9 @@
 . $TRAVIS_BUILD_DIR/bin/setup.sh
 
 sbt "; mimaReportBinaryIssues; coverage; clean; test; coverageReport; coverageOff"
+exitCode=$?
 
 echo "Uploading codecov"
 bash <(curl -s https://codecov.io/bash)
+
+exit exitCode

--- a/bin/specialTest.sh
+++ b/bin/specialTest.sh
@@ -5,7 +5,8 @@
 sbt "; mimaReportBinaryIssues; coverage; clean; test; coverageReport; coverageOff"
 exitCode=$?
 
+
 echo "Uploading codecov"
 bash <(curl -s https://codecov.io/bash)
 
-exit exitCode
+exit ${exitCode}


### PR DESCRIPTION
Needs the exit code to be cached on exit to avoid false positives.