### PR TITLE
Http1.0 if body is non empty, but content-length header not provided

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -255,8 +255,8 @@ private final class Http1Connection(val requestKey: RequestKey,
     val minor : Int = getHttpMinor(req)
 
       // If we are HTTP/1.0, make sure HTTP/1.0 has no body or a Content-Length header
-    if (minor == 0 && `Content-Length`.from(req.headers).isEmpty) {
-      logger.warn(s"Request ${req} is HTTP/1.0 but lacks a length header. Transforming to HTTP/1.1")
+    if (minor == 0 && req.body != EmptyBody && `Content-Length`.from(req.headers).isEmpty) {
+      logger.warn(s"Request $req is HTTP/1.0 but lacks a length header. Transforming to HTTP/1.1")
       validateRequest(req.withHttpVersion(HttpVersion.`HTTP/1.1`))
     }
       // Ensure we have a host header for HTTP/1.1

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -228,7 +228,7 @@ class Http1ClientStageSpec extends Http4sSpec {
 
       request must not contain("Host:")
       response must_==("done")
-    }.pendingUntilFixed
+    }
 
     "Support flushing the prelude" in {
       val req = Request(uri = www_foo_test, httpVersion = HttpVersion.`HTTP/1.0`)

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -218,8 +218,7 @@ class Http1ClientStageSpec extends Http4sSpec {
       }
     }
 
-    // TODO fs2 port - Currently is elevating the http version to 1.1 causing this test to fail
-    "Allow an HTTP/1.0 request without a Host header" in {
+    "Allow an HTTP/1.0 request without a Host header and empty body" in {
       val resp = "HTTP/1.0 200 OK\r\n\r\ndone"
 
       val req = Request(uri = www_foo_test, httpVersion = HttpVersion.`HTTP/1.0`)
@@ -227,6 +226,21 @@ class Http1ClientStageSpec extends Http4sSpec {
       val (request, response) = getSubmission(req, resp)
 
       request must not contain("Host:")
+      request must contain("HTTP/1.0")
+      response must_==("done")
+    }
+
+    "Allow an HTTP/1.0 request without a Host header and body present" in {
+      val resp = "HTTP/1.0 200 OK\r\n\r\ndone"
+
+      val req = Request(uri = www_foo_test,
+        httpVersion = HttpVersion.`HTTP/1.0`,
+        body = Stream("request-body").through(fs2.text.utf8Encode))
+
+      val (request, response) = getSubmission(req, resp)
+
+      request must contain("Host:")
+      request must contain("HTTP/1.1")
       response must_==("done")
     }
 


### PR DESCRIPTION
I'm not well versed in the internals of the HTTP spec (or Http4s implementation of it for that sake), but this seemed like one logical fix (based on the history of the conditional). Please correct me if I'm wrong :-)

Refs. https://github.com/http4s/http4s/issues/920