### PR TITLE
Remove the 'name: String' param from AttributeKey

### DIFF
--- a/core/src/main/scala/org/http4s/AttributeMap.scala
+++ b/core/src/main/scala/org/http4s/AttributeMap.scala
@@ -19,6 +19,9 @@ object AttributeKey {
 
   /** Construct a new [[AttributeKey]] */
   def apply[T]: AttributeKey[T] = new AttributeKey()
+
+  @deprecated("Removed because `name` suggests equality between keys with the same name", "0.17")
+  def apply[T](name: String): AttributeKey[T] = apply
 }
 
 /** An immutable map where an [[AttributeKey]]  for a fixed type `T` can only be associated with values of type `T`.

--- a/core/src/main/scala/org/http4s/AttributeMap.scala
+++ b/core/src/main/scala/org/http4s/AttributeMap.scala
@@ -11,22 +11,14 @@ package org.http4s
 /** A key in an [[AttributeMap]] that constrains its associated value to be of type `T`.
   * The key is uniquely defined by its reference: there are no duplicate keys, even
   * those with the same name and type. */
-final class AttributeKey[T] private (val name: String) {
+final class AttributeKey[T] private {
   def apply(value: T): AttributeEntry[T] = AttributeEntry(this, value)
-
-  override def toString: String = name
 }
 
 object AttributeKey {
 
-  /** Construct an [[AttributeKey]] */
-  def apply[T](name: String): AttributeKey[T] = new AttributeKey(name)
-
-  /**
-   * Encourage greater consistency in internal keys by imposing a universal prefix.
-   */
-  private[http4s] def http4s[T](name: String): AttributeKey[T] =
-    apply(s"org.http4s.$name")
+  /** Construct a new [[AttributeKey]] */
+  def apply[T]: AttributeKey[T] = new AttributeKey()
 }
 
 /** An immutable map where an [[AttributeKey]]  for a fixed type `T` can only be associated with values of type `T`.
@@ -85,6 +77,6 @@ object AttributeMap
 // type inference required less generality
 /** A map entry where `key` is constrained to only be associated with a fixed value of type `T`. */
 final case class AttributeEntry[T](key: AttributeKey[T], value: T) {
-  override def toString: String = key.name + ": " + value
+  override def toString: String = s"$key: $value"
 }
 

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -108,7 +108,7 @@ sealed trait Message extends MessageOps { self =>
 object Message {
   private[http4s] val logger = getLogger
   object Keys {
-    val TrailerHeaders = AttributeKey.http4s[Task[Headers]]("trailer-headers")
+    val TrailerHeaders = AttributeKey[Task[Headers]]
   }
 }
 
@@ -293,10 +293,10 @@ object Request {
   final case class Connection(local: InetSocketAddress, remote: InetSocketAddress, secure: Boolean)
 
   object Keys {
-    val PathInfoCaret = AttributeKey.http4s[Int]("request.pathInfoCaret")
-    val PathTranslated = AttributeKey.http4s[File]("request.pathTranslated")
-    val ConnectionInfo = AttributeKey.http4s[Connection]("request.remote")
-    val ServerSoftware = AttributeKey.http4s[ServerSoftware]("request.serverSoftware")
+    val PathInfoCaret = AttributeKey[Int]
+    val PathTranslated = AttributeKey[File]
+    val ConnectionInfo = AttributeKey[Connection]
+    val ServerSoftware = AttributeKey[ServerSoftware]
   }
 }
 

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -126,5 +126,5 @@ object StaticFile {
     readAll[Task](f.toPath, DefaultBufferSize)
   }
 
-  private[http4s] val staticFileKey = AttributeKey.http4s[File]("staticFile")
+  private[http4s] val staticFileKey = AttributeKey[File]
 }

--- a/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
@@ -91,7 +91,7 @@ object PushSupport {
   private [PushSupport] final case class PushLocation(location: String, cascade: Boolean)
   private [http4s] final case class PushResponse(location: String, resp: Response)
 
-  private[PushSupport] val pushLocationKey = AttributeKey.http4s[Vector[PushLocation]]("pushLocation")
-  private[http4s] val pushResponsesKey = AttributeKey.http4s[Task[Vector[PushResponse]]]("pushResponses")
+  private[PushSupport] val pushLocationKey = AttributeKey[Vector[PushLocation]]
+  private[http4s] val pushResponsesKey = AttributeKey[Task[Vector[PushResponse]]]
 }
 

--- a/server/src/main/scala/org/http4s/server/websocket/package.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/package.scala
@@ -7,7 +7,7 @@ import org.http4s.websocket.WebsocketBits.WebSocketFrame
 import fs2._
 
 package object websocket {
-  val websocketKey = AttributeKey.http4s[Websocket]("websocket")
+  val websocketKey = AttributeKey[Websocket]
 
   /**
    * Build a response which will accept an HTTP websocket upgrade request and initiate a websocket connection using the

--- a/tests/src/test/scala/org/http4s/AttributeMapSpec.scala
+++ b/tests/src/test/scala/org/http4s/AttributeMapSpec.scala
@@ -6,10 +6,10 @@ class AttributeMapSpec extends Specification {
 
   "AttributeMap" should {
 
-    val k1 = AttributeKey.apply[Int]("int")
-    val k2 = AttributeKey.apply[String]("string")
-    val k3 = AttributeKey.apply[Int]("missing")
-    val k1imposter = AttributeKey.apply[Int]("int")
+    val k1 = AttributeKey[Int]
+    val k2 = AttributeKey[String]
+    val k3 = AttributeKey[Int]
+    val k1imposter = AttributeKey[Int]
 
     val m = AttributeMap.empty ++ Seq(k1(1), k2("foo"))
 
@@ -29,7 +29,7 @@ class AttributeMapSpec extends Specification {
     // This is a compile test
     "Maintain the correct static type for keys" in {
       sealed case class Foo(stuff: String)
-      val mismatchedKey = AttributeKey.apply[Foo]("mismatched")
+      val mismatchedKey = AttributeKey[Foo]
 //      val ii = m(mismatchedKey) + 5   // FAILS TO COMPILE: Foo doesn't `+` with 5
 
       val i: Int = m.get(k1).get + 4


### PR DESCRIPTION
The name parameter gives the false hope that the key
is based on something other than referential equality.
Right now, it's only purpose is to override the
`toString` method, and even that is dangerous because
`toString` doesn't allude that it's an `AttributeKey`.