### PR TITLE
Pass content length to InputStreamBodyGenerator in AHC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - SCALAZ_VERSION=7.2.12
   - SCALAZ_VERSION=7.1.13
 before_script:
-- mkdir $HOME/bin
+- mkdir -p $HOME/bin
 - export PATH=$HOME/bin:$PATH
 script: bash bin/travis
 notifications:

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -6,6 +6,7 @@ import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
 import org.http4s.client.testroutes.GetRoutes
 import org.http4s.dsl._
+import org.http4s.headers.{`Content-Length`, `Transfer-Encoding`}
 
 import org.specs2.specification.core.Fragments
 
@@ -54,6 +55,33 @@ abstract class ClientRouteTestBattery(name: String, client: Client)
         length mustNotEqual 0
       }
     }
+
+    "POST an empty body" in {
+      val name = address.getHostName
+      val port = address.getPort
+      val uri = Uri.fromString(s"http://${address.getHostName}:${address.getPort}/echo").yolo
+      val req = POST(uri)
+      val body = client.expect[String](req)
+      body must returnValue("")
+    }
+
+    "POST a normal body" in {
+      val name = address.getHostName
+      val port = address.getPort
+      val uri = Uri.fromString(s"http://${address.getHostName}:${address.getPort}/echo").yolo
+      val req = POST(uri, "This is normal.")
+      val body = client.expect[String](req)
+      body must returnValue("This is normal.")
+    }
+
+    "POST a chunked body" in {
+      val name = address.getHostName
+      val port = address.getPort
+      val uri = Uri.fromString(s"http://${address.getHostName}:${address.getPort}/echo").yolo
+      val req = POST(uri, Process.eval(Task.now("This is chunked.")))
+      val body = client.expect[String](req)
+      body must returnValue("This is chunked.")
+    }
   }
 
   override def map(fs: => Fragments) =
@@ -65,6 +93,13 @@ abstract class ClientRouteTestBattery(name: String, client: Client)
         case Some(r) => renderResponse(srv, r)
         case None    => srv.sendError(404)
       }
+    }
+
+    override def doPost(req: HttpServletRequest, srv: HttpServletResponse): Unit = {
+      srv.setStatus(200)
+      val s = scala.io.Source.fromInputStream(req.getInputStream).mkString
+      srv.getOutputStream.print(s)
+      srv.getOutputStream.flush()
     }
   }
 


### PR DESCRIPTION
Without a content-length, `InputStreamBodyGenerator` assumes chunked transfer encoding.  We pass the content length (or -1 if we can establish chunked transfer encoding).

I did not have a failing test before this change.  I can only reproduce the problem as described against #1264.  This fixes the issue described in #1264.

As stated in #1264, a better solution would be a non-blocking implementation of the body generator based on reactive streams.  Since scalaz-stream is dead and a proper implementation is non-trivial, I propose that this is Good Enough™.

/cc @ktonga

