### PR TITLE
HSTS Support

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
+++ b/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
@@ -9,7 +9,8 @@ import org.http4s.util.Writer
  * Defined by http://tools.ietf.org/html/rfc6797
  */
 object `Strict-Transport-Security` extends HeaderKey.Internal[`Strict-Transport-Security`] with HeaderKey.Singleton {
-  private class StrictTransportSecurityImpl(maxAge: Long, includeSubDomains: Boolean, preload: Boolean)
+  private[headers] class StrictTransportSecurityImpl(maxAge: Long, includeSubDomains: Boolean, preload: Boolean)
+    extends `Strict-Transport-Security`(maxAge, includeSubDomains, preload)
 
   def fromLong(maxAge: Long, includeSubDomains: Boolean = true, preload: Boolean = false): ParseResult[`Strict-Transport-Security`] =
     if (maxAge >= 0) {
@@ -19,22 +20,30 @@ object `Strict-Transport-Security` extends HeaderKey.Internal[`Strict-Transport-
     }
 
   def unsafeFromDuration(maxAge: FiniteDuration, includeSubDomains: Boolean = true, preload: Boolean = false): `Strict-Transport-Security` =
-    fromLong(maxAge.toSeconds).fold(throw _, identity)
+    fromLong(maxAge.toSeconds, includeSubDomains, preload).fold(throw _, identity)
 
   def unsafeFromLong(maxAge: Long, includeSubDomains: Boolean = true, preload: Boolean = false): `Strict-Transport-Security` =
-    fromLong(maxAge).fold(throw _, identity)
+    fromLong(maxAge, includeSubDomains, preload).fold(throw _, identity)
 
   def parse(s: String): ParseResult[`Strict-Transport-Security`] =
     HttpHeaderParser.STRICT_TRANSPORT_SECURITY(s)
 }
 
 sealed abstract case class `Strict-Transport-Security`(maxAge: Long, includeSubDomains: Boolean = true, preload: Boolean = false) extends Header.Parsed {
+
   override def key: `Strict-Transport-Security`.type = `Strict-Transport-Security`
+
   override def renderValue(writer: Writer): writer.type = {
     writer << "max-age=" << maxAge
     if (includeSubDomains) writer << "; includeSubDomains"
     if (preload) writer << "; preload"
     writer
   }
+
+  def withIncludeSubDomains(includeSubDomains: Boolean): `Strict-Transport-Security` =
+    new `Strict-Transport-Security`.StrictTransportSecurityImpl(this.maxAge, includeSubDomains, this.preload)
+
+  def withPreload(preload: Boolean): `Strict-Transport-Security` =
+    new `Strict-Transport-Security`.StrictTransportSecurityImpl(this.maxAge, this.includeSubDomains, preload)
 }
 

--- a/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
+++ b/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
@@ -9,14 +9,29 @@ import org.http4s.util.Writer
  * Defined by http://tools.ietf.org/html/rfc6797
  */
 object `Strict-Transport-Security` extends HeaderKey.Internal[`Strict-Transport-Security`] with HeaderKey.Singleton {
+  private class StrictTransportSecurityImpl(maxAge: Long, includeSubDomains: Boolean, preload: Boolean)
+
+  def fromLong(maxAge: Long, includeSubDomains: Boolean = true, preload: Boolean = false): ParseResult[`Strict-Transport-Security`] =
+    if (maxAge >= 0) {
+      ParseResult.success(new StrictTransportSecurityImpl(maxAge, includeSubDomains, preload))
+    } else {
+      ParseResult.fail("Invalid maxAge value", s"Strict-Transport-Security param $maxAge must be more or equal to 0 seconds")
+    }
+
+  def unsafeFromDuration(maxAge: FiniteDuration, includeSubDomains: Boolean = true, preload: Boolean = false): `Strict-Transport-Security` =
+    fromLong(maxAge.toSeconds).fold(throw _, identity)
+
+  def unsafeFromLong(maxAge: Long, includeSubDomains: Boolean = true, preload: Boolean = false): `Strict-Transport-Security` =
+    fromLong(maxAge).fold(throw _, identity)
+
   def parse(s: String): ParseResult[`Strict-Transport-Security`] =
     HttpHeaderParser.STRICT_TRANSPORT_SECURITY(s)
 }
 
-case class `Strict-Transport-Security`(maxAge: FiniteDuration, includeSubDomains: Boolean = true, preload: Boolean = false) extends Header.Parsed {
+sealed abstract case class `Strict-Transport-Security`(maxAge: Long, includeSubDomains: Boolean = true, preload: Boolean = false) extends Header.Parsed {
   override def key: `Strict-Transport-Security`.type = `Strict-Transport-Security`
   override def renderValue(writer: Writer): writer.type = {
-    writer << "max-age=" << maxAge.toSeconds
+    writer << "max-age=" << maxAge
     if (includeSubDomains) writer << "; includeSubDomains"
     if (preload) writer << "; preload"
     writer

--- a/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
+++ b/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
@@ -1,7 +1,25 @@
 package org.http4s
 package headers
 
+import scala.concurrent.duration.FiniteDuration
+import org.http4s.parser.HttpHeaderParser
+import org.http4s.util.Writer
+
 /**
  * Defined by http://tools.ietf.org/html/rfc6797
  */
-object `Strict-Transport-Security` extends HeaderKey.Default
+object `Strict-Transport-Security` extends HeaderKey.Internal[`Strict-Transport-Security`] with HeaderKey.Singleton {
+  def parse(s: String): ParseResult[`Strict-Transport-Security`] =
+    HttpHeaderParser.STRICT_TRANSPORT_SECURITY(s)
+}
+
+case class `Strict-Transport-Security`(maxAge: FiniteDuration, includeSubDomains: Boolean = true, preload: Boolean = false) extends Header.Parsed {
+  override def key: `Strict-Transport-Security`.type = `Strict-Transport-Security`
+  override def renderValue(writer: Writer): writer.type = {
+    writer << "max-age=" << maxAge.toSeconds
+    if (includeSubDomains) writer << "; includeSubDomains"
+    if (preload) writer << "; preload"
+    writer
+  }
+}
+

--- a/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
+++ b/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
@@ -38,6 +38,7 @@ object HttpHeaderParser extends SimpleHeaders
                     with RangeParser
                     with LocationHeader
                     with RefererHeader
+                    with StrictTransportSecurityHeader
                     with ProxyAuthenticateHeader
                     with WwwAuthenticateHeader
                     with ZipkinHeader {

--- a/core/src/main/scala/org/http4s/parser/StrictTransportSecurityParser.scala
+++ b/core/src/main/scala/org/http4s/parser/StrictTransportSecurityParser.scala
@@ -1,0 +1,27 @@
+package org.http4s
+package parser
+
+import org.http4s.internal.parboiled2._
+import org.http4s.headers.`Strict-Transport-Security`
+import scala.concurrent.duration._
+import org.http4s.internal.parboiled2.support.{HNil, ::}
+
+private[parser] trait StrictTransportSecurityHeader {
+  def STRICT_TRANSPORT_SECURITY(value: String): ParseResult[`Strict-Transport-Security`] =
+    StrictTransportSecurityParser(value).parse
+
+  private case class StrictTransportSecurityParser(override val input: ParserInput) extends Http4sHeaderParser[`Strict-Transport-Security`](input) {
+    def entry: Rule1[`Strict-Transport-Security`] = rule {
+      maxAge ~ zeroOrMore(";" ~ OptWS ~ stsAttributes) ~ EOI
+    }
+
+    def maxAge: Rule1[`Strict-Transport-Security`] = rule {
+      "max-age=" ~ Digits ~> { (age: String) => `Strict-Transport-Security`(maxAge = age.toLong.seconds, includeSubDomains = false, preload = false) }
+    }
+
+    def stsAttributes: Rule[`Strict-Transport-Security`::HNil, `Strict-Transport-Security`::HNil] = rule {
+      capture("includeSubDomains") ~> { (sts: `Strict-Transport-Security`, _: String) => sts.copy(includeSubDomains = true) } |
+      capture("preload")           ~> { (sts: `Strict-Transport-Security`, _: String) => sts.copy(preload = true) }
+    }
+  }
+}

--- a/core/src/main/scala/org/http4s/parser/StrictTransportSecurityParser.scala
+++ b/core/src/main/scala/org/http4s/parser/StrictTransportSecurityParser.scala
@@ -16,12 +16,12 @@ private[parser] trait StrictTransportSecurityHeader {
     }
 
     def maxAge: Rule1[`Strict-Transport-Security`] = rule {
-      "max-age=" ~ Digits ~> { (age: String) => `Strict-Transport-Security`(maxAge = age.toLong.seconds, includeSubDomains = false, preload = false) }
+      "max-age=" ~ Digits ~> { (age: String) => `Strict-Transport-Security`.unsafeFromLong(maxAge = age.toLong, includeSubDomains = false, preload = false) }
     }
 
     def stsAttributes: Rule[`Strict-Transport-Security`::HNil, `Strict-Transport-Security`::HNil] = rule {
-      capture("includeSubDomains") ~> { (sts: `Strict-Transport-Security`, _: String) => sts.copy(includeSubDomains = true) } |
-      capture("preload")           ~> { (sts: `Strict-Transport-Security`, _: String) => sts.copy(preload = true) }
+      capture("includeSubDomains") ~> { (sts: `Strict-Transport-Security`, _: String) => sts.withIncludeSubDomains(true) } |
+      capture("preload")           ~> { (sts: `Strict-Transport-Security`, _: String) => sts.withPreload(true) }
     }
   }
 }

--- a/docs/src/main/tut/hsts.md
+++ b/docs/src/main/tut/hsts.md
@@ -1,0 +1,83 @@
+---
+menu: tut
+title: HSTS
+weight: 126
+---
+
+Http4s provides a [Middleware] giving support for *HTTP Strict Transport Security (HSTS)*.
+The middleware is called `HSTS` and simply adds a header to enable a HSTS security policy.
+Though it is not enforced, HSTS only makes sense for an `https` service.
+
+Examples in this document have the following dependencies.
+
+```scala
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-dsl" % http4sVersion,
+  "org.http4s" %% "http4s-server" % http4sVersion
+)
+```
+
+And we need some imports.
+
+```tut:silent
+import org.http4s._
+import org.http4s.dsl._
+```
+
+Let's make a simple service that will be exposed and wrapped with HSTS.
+
+```tut:book
+val service = HttpService {
+  case _ =>
+    Ok("ok")
+}
+
+val request = Request(Method.GET, uri("/"))
+
+// Do not call 'unsafeRun' in your code
+val response = service.orNotFound(request).unsafeRun
+response.headers
+```
+
+If we were to wrap this on the `HSTS` middleware.
+
+```tut:book
+import org.http4s.server.middleware._
+val hstsService = HSTS(service)
+
+// Do not call 'unsafeRun' in your code
+val response = hstsService.orNotFound(request).unsafeRun
+response.headers
+```
+
+Now the response has the `Strict-Transport-Security` header which will mandate browsers
+supporting HSTS to always connect using `https`.
+
+As described in [Middleware], services and middleware can be composed though HSTS
+is something you may want enabled across all your routes.
+
+## Configuration
+
+By default `HSTS` is configured to indicate that all requests during 1 year
+should be done over `https` and it will contain the `includeSubDomains` directive by default.
+
+If you want to `preload` or change other default values you can pass a custom header, e.g.
+
+```tut:book
+import org.http4s.headers._
+import scala.concurrent.duration._
+
+val hstsHeader = `Strict-Transport-Security`.unsafeFromDuration(30.days, includeSubDomains = true, preload = true)
+val hstsService = HSTS(service, hstsHeader)
+
+// Do not call 'unsafeRun' in your code
+val response = hstsService.orNotFound(request).unsafeRun
+response.headers
+```
+
+## References
+
+* [RFC-6797](https://tools.ietf.org/html/rfc6797)
+* [HSTS Cheat Sheet](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet)
+
+[Middleware]: ../middleware

--- a/docs/src/main/tut/middleware.md
+++ b/docs/src/main/tut/middleware.md
@@ -154,6 +154,7 @@ And a few others.
 [Authentication]: ../auth
 [CORS]: ../cors
 [GZip]: ../gzip
+[HSTS]: ../hsts
 [Service Timeout]: ../api/org/http4s/server/middleware/Timeout$
 [Jsonp]: ../api/org/http4s/server/middleware/Jsonp$
 [Virtual Host]: ../api/org/http4s/server/middleware/VirtualHost$

--- a/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
+++ b/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
@@ -4,10 +4,12 @@ package ssl
 import java.nio.file.Paths
 
 import fs2._
-import org.http4s.server._
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
-import org.http4s.server.{ SSLKeyStoreSupport, ServerBuilder }
+import org.http4s.server.{SSLKeyStoreSupport, ServerBuilder}
+import org.http4s.server.middleware.HSTS
 import org.http4s.util.StreamApp
+
+import scala.concurrent.duration._
 
 trait SslExample extends StreamApp {
   // TODO: Reference server.jks from something other than one child down.
@@ -17,7 +19,7 @@ trait SslExample extends StreamApp {
 
   def stream(args: List[String]) = builder
     .withSSL(StoreInfo(keypath, "password"), keyManagerPassword = "secure")
-    .mountService(ExampleService.service, "/http4s")
+    .mountService(HSTS(ExampleService.service, 10.minutes), "/http4s")
     .bindHttp(8443)
     .serve
 }

--- a/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
+++ b/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
@@ -19,7 +19,7 @@ trait SslExample extends StreamApp {
 
   def stream(args: List[String]) = builder
     .withSSL(StoreInfo(keypath, "password"), keyManagerPassword = "secure")
-    .mountService(HSTS(ExampleService.service, 10.minutes), "/http4s")
+    .mountService(HSTS(ExampleService.service), "/http4s")
     .bindHttp(8443)
     .serve
 }

--- a/server/src/main/scala/org/http4s/server/middleware/HSTS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HSTS.scala
@@ -1,0 +1,27 @@
+package org.http4s
+package server
+package middleware
+
+import org.http4s.headers.`Strict-Transport-Security`
+import fs2._
+import fs2.interop.cats._
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+
+/** [[Middleware]] to add HTTP Strict Transport Security (HSTS) support adding
+  * the Strict Transport Security headers
+  */
+object HSTS {
+
+  def apply(service: HttpService, maxAge: FiniteDuration = 365.days, includeSubDomains: Boolean = true, preload: Boolean = false): HttpService = Service.lift { req =>
+
+    val header = `Strict-Transport-Security`(maxAge, includeSubDomains, preload)
+
+    service.map {
+      case resp: Response =>
+        resp.putHeaders(header)
+      case Pass           => Pass
+    }.apply(req)
+  }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/HSTS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HSTS.scala
@@ -13,15 +13,23 @@ import scala.concurrent.duration._
   * the Strict Transport Security headers
   */
 object HSTS {
+  // Default HSTS policy of waiting for 1 year and include sub domains
+  private val defaultHSTSPolicy = `Strict-Transport-Security`.unsafeFromDuration(365.days, includeSubDomains = true, preload = false)
 
-  def apply(service: HttpService, maxAge: FiniteDuration = 365.days, includeSubDomains: Boolean = true, preload: Boolean = false): HttpService = Service.lift { req =>
+  def apply(service: HttpService): HttpService = apply(service, defaultHSTSPolicy)
 
-    val header = `Strict-Transport-Security`.unsafeFromDuration(maxAge, includeSubDomains, preload)
-
+  def apply(service: HttpService, header: `Strict-Transport-Security`): HttpService = Service.lift { req =>
     service.map {
       case resp: Response =>
         resp.putHeaders(header)
       case Pass           => Pass
     }.apply(req)
   }
+
+  def unsafeFromDuration(service: HttpService, maxAge: FiniteDuration = 365.days, includeSubDomains: Boolean = true, preload: Boolean = false): HttpService = {
+    val header = `Strict-Transport-Security`.unsafeFromDuration(maxAge, includeSubDomains, preload)
+
+    apply(service, header)
+  }
+
 }

--- a/server/src/main/scala/org/http4s/server/middleware/HSTS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HSTS.scala
@@ -16,7 +16,7 @@ object HSTS {
 
   def apply(service: HttpService, maxAge: FiniteDuration = 365.days, includeSubDomains: Boolean = true, preload: Boolean = false): HttpService = Service.lift { req =>
 
-    val header = `Strict-Transport-Security`(maxAge, includeSubDomains, preload)
+    val header = `Strict-Transport-Security`.unsafeFromDuration(maxAge, includeSubDomains, preload)
 
     service.map {
       case resp: Response =>

--- a/server/src/test/scala/org/http4s/server/middleware/HSTSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HSTSSpec.scala
@@ -8,13 +8,29 @@ import org.http4s.headers._
 import scala.concurrent.duration._
 
 class HSTSSpec extends Http4sSpec {
+  val innerService = HttpService {
+      case GET -> Root =>
+        Ok("pong")
+    }
+
+  val req = Request(Method.GET, Uri.uri("/"))
+
   "HSTS" should {
     "add the Strict-Transport-Security header" in {
-      val service = HSTS(HttpService {
-        case GET -> Root =>
-          Ok("pong")
-      }, maxAge = 365.days)
-      val req = Request(Method.GET, Uri.uri("/"))
+      val service = HSTS.unsafeFromDuration(innerService, 365.days)
+      val resp = service.orNotFound(req).unsafeRun
+      resp.status must_== (Status.Ok)
+      resp.headers.get(`Strict-Transport-Security`) must beSome
+    }
+    "support custom headers" in {
+      val hstsHeader = `Strict-Transport-Security`.unsafeFromDuration(365.days, preload = true)
+      val service = HSTS(innerService, hstsHeader)
+      val resp = service.orNotFound(req).unsafeRun
+      resp.status must_== (Status.Ok)
+      resp.headers.get(`Strict-Transport-Security`) must beSome
+    }
+    "have a sensible default" in {
+      val service = HSTS(innerService)
       val resp = service.orNotFound(req).unsafeRun
       resp.status must_== (Status.Ok)
       resp.headers.get(`Strict-Transport-Security`) must beSome

--- a/server/src/test/scala/org/http4s/server/middleware/HSTSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HSTSSpec.scala
@@ -1,0 +1,23 @@
+package org.http4s
+package server
+package middleware
+
+import org.http4s.dsl._
+import org.http4s.headers._
+
+import scala.concurrent.duration._
+
+class HSTSSpec extends Http4sSpec {
+  "HSTS" should {
+    "add the Strict-Transport-Security header" in {
+      val service = HSTS(HttpService {
+        case GET -> Root =>
+          Ok("pong")
+      }, maxAge = 365.days)
+      val req = Request(Method.GET, Uri.uri("/"))
+      val resp = service.orNotFound(req).unsafeRun
+      resp.status must_== (Status.Ok)
+      resp.headers.get(`Strict-Transport-Security`) must beSome
+    }
+  }
+}

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -275,7 +275,7 @@ trait ArbitraryInstances {
       age               <- genFiniteDuration
       includeSubDomains <- Gen.oneOf(true, false)
       preload           <- Gen.oneOf(true, false)
-    } yield headers.`Strict-Transport-Security`(age, includeSubDomains, preload) }
+    } yield headers.`Strict-Transport-Security`.unsafeFromDuration(age, includeSubDomains, preload) }
 
   implicit val arbitraryRawHeader: Arbitrary[Header.Raw] =
     Arbitrary {

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -121,16 +121,19 @@ trait ArbitraryInstances {
       major <- choose(0, 9)
       minor <- choose(0, 9)
     } yield HttpVersion.fromVersion(major, minor).yolo }
+
   implicit val cogenHttpVersion: Cogen[HttpVersion] =
     Cogen[(Int, Int)].contramap(v => (v.major, v.minor))
 
   implicit val arbitraryNioCharset: Arbitrary[NioCharset] =
     Arbitrary(oneOf(NioCharset.availableCharsets.values.asScala.toSeq))
+
   implicit val cogenNioCharset: Cogen[NioCharset] =
     Cogen[String].contramap(_.name)
 
   implicit val arbitraryCharset: Arbitrary[Charset] =
     Arbitrary { arbitrary[NioCharset].map(Charset.fromNioCharset) }
+
   implicit val cogenCharset: Cogen[Charset] =
     Cogen[NioCharset].contramap(_.nioCharset)
 
@@ -146,6 +149,7 @@ trait ArbitraryInstances {
       charsetRange <- genCharsetRangeNoQuality
       q <- arbitrary[QValue]
     } yield charsetRange.withQValue(q) }
+
   implicit val cogenCharsetRange: Cogen[CharsetRange] =
     Cogen[Either[(Charset, QValue), QValue]].contramap {
       case CharsetRange.Atom(charset, qValue) =>
@@ -264,6 +268,14 @@ trait ArbitraryInstances {
       // age is always positive
       age <- genFiniteDuration
     } yield headers.Age.unsafeFromDuration(age) }
+
+  implicit val arbitrarySTS: Arbitrary[headers.`Strict-Transport-Security`] =
+    Arbitrary { for {
+      // age is always positive
+      age               <- genFiniteDuration
+      includeSubDomains <- Gen.oneOf(true, false)
+      preload           <- Gen.oneOf(true, false)
+    } yield headers.`Strict-Transport-Security`(age, includeSubDomains, preload) }
 
   implicit val arbitraryRawHeader: Arbitrary[Header.Raw] =
     Arbitrary {

--- a/tests/src/test/scala/org/http4s/headers/StrictTransportSecuritySpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/StrictTransportSecuritySpec.scala
@@ -2,33 +2,67 @@ package org.http4s.headers
 
 import cats.implicits._
 import java.time.{Instant, ZoneId, ZonedDateTime}
+import org.http4s.{ParseFailure, ParseResult}
 
 import scala.concurrent.duration._
 
 class StrictTransportSecuritySpec extends HeaderLaws {
   checkAll("StrictTransportSecurity", headerLaws(`Strict-Transport-Security`))
 
+  "fromLong" should {
+    "support positive max age in seconds" in {
+      `Strict-Transport-Security`.fromLong(365).map(_.renderString) must beRight("Strict-Transport-Security: max-age=365; includeSubDomains")
+      `Strict-Transport-Security`.fromLong(365, includeSubDomains = false).map(_.renderString) must beRight("Strict-Transport-Security: max-age=365")
+      `Strict-Transport-Security`.fromLong(365, preload = true).map(_.renderString) must beRight("Strict-Transport-Security: max-age=365; includeSubDomains; preload")
+    }
+    "reject negative max age in seconds" in {
+      `Strict-Transport-Security`.fromLong(-365) must beLeft
+    }
+  }
+
+  "unsafeFromDuration" should {
+    "build for valid durations" in {
+      `Strict-Transport-Security`.unsafeFromDuration(10.hours).renderString must_== "Strict-Transport-Security: max-age=36000; includeSubDomains"
+      `Strict-Transport-Security`.unsafeFromDuration(10.hours, includeSubDomains = false).renderString must_== "Strict-Transport-Security: max-age=36000"
+      `Strict-Transport-Security`.unsafeFromDuration(10.hours, preload = true).renderString must_== "Strict-Transport-Security: max-age=36000; includeSubDomains; preload"
+    }
+    "fail for negative durations" in {
+      `Strict-Transport-Security`.unsafeFromDuration(-10.hours).value must throwA[ParseFailure]
+    }
+  }
+
+  "unsafeFromLong" should {
+    "build for valid durations" in {
+      `Strict-Transport-Security`.unsafeFromLong(10).renderString must_== "Strict-Transport-Security: max-age=10; includeSubDomains"
+      `Strict-Transport-Security`.unsafeFromLong(10, includeSubDomains = false).renderString must_== "Strict-Transport-Security: max-age=10"
+      `Strict-Transport-Security`.unsafeFromLong(10, preload = true).renderString must_== "Strict-Transport-Security: max-age=10; includeSubDomains; preload"
+    }
+    "fail for negative durations" in {
+      `Strict-Transport-Security`.unsafeFromLong(-10).value must throwA[ParseFailure]
+    }
+  }
+
   "render" should {
     "include max age in seconds" in {
-      `Strict-Transport-Security`(365.days).renderString must_== "Strict-Transport-Security: max-age=31536000; includeSubDomains"
+      `Strict-Transport-Security`.unsafeFromDuration(365.days).renderString must_== "Strict-Transport-Security: max-age=31536000; includeSubDomains"
     }
     "allow no sub domains" in {
-      `Strict-Transport-Security`(365.days, includeSubDomains = false).renderString must_== "Strict-Transport-Security: max-age=31536000"
+      `Strict-Transport-Security`.unsafeFromDuration(365.days, includeSubDomains = false).renderString must_== "Strict-Transport-Security: max-age=31536000"
     }
     "support preload" in {
-      `Strict-Transport-Security`(365.days, preload = true).renderString must_== "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload"
+      `Strict-Transport-Security`.unsafeFromDuration(365.days, preload = true).renderString must_== "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload"
     }
   }
 
   "parse" should {
     "accept age" in {
-      `Strict-Transport-Security`.parse("max-age=31536000") must beRight(`Strict-Transport-Security`(365.days, false))
+      `Strict-Transport-Security`.parse("max-age=31536000") must beRight(`Strict-Transport-Security`.unsafeFromDuration(365.days, false))
     }
     "accept age and subdomains" in {
-      `Strict-Transport-Security`.parse("max-age=31536000; includeSubDomains") must beRight(`Strict-Transport-Security`(365.days, true))
+      `Strict-Transport-Security`.parse("max-age=31536000; includeSubDomains") must beRight(`Strict-Transport-Security`.unsafeFromDuration(365.days, true))
     }
     "accept age, subdomains and preload" in {
-      `Strict-Transport-Security`.parse("max-age=31536000; includeSubDomains; preload") must beRight(`Strict-Transport-Security`(365.days, true, true))
+      `Strict-Transport-Security`.parse("max-age=31536000; includeSubDomains; preload") must beRight(`Strict-Transport-Security`.unsafeFromDuration(365.days, true, true))
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/headers/StrictTransportSecuritySpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/StrictTransportSecuritySpec.scala
@@ -1,0 +1,34 @@
+package org.http4s.headers
+
+import cats.implicits._
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
+import scala.concurrent.duration._
+
+class StrictTransportSecuritySpec extends HeaderLaws {
+  checkAll("StrictTransportSecurity", headerLaws(`Strict-Transport-Security`))
+
+  "render" should {
+    "include max age in seconds" in {
+      `Strict-Transport-Security`(365.days).renderString must_== "Strict-Transport-Security: max-age=31536000; includeSubDomains"
+    }
+    "allow no sub domains" in {
+      `Strict-Transport-Security`(365.days, includeSubDomains = false).renderString must_== "Strict-Transport-Security: max-age=31536000"
+    }
+    "support preload" in {
+      `Strict-Transport-Security`(365.days, preload = true).renderString must_== "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload"
+    }
+  }
+
+  "parse" should {
+    "accept age" in {
+      `Strict-Transport-Security`.parse("max-age=31536000") must beRight(`Strict-Transport-Security`(365.days, false))
+    }
+    "accept age and subdomains" in {
+      `Strict-Transport-Security`.parse("max-age=31536000; includeSubDomains") must beRight(`Strict-Transport-Security`(365.days, true))
+    }
+    "accept age, subdomains and preload" in {
+      `Strict-Transport-Security`.parse("max-age=31536000; includeSubDomains; preload") must beRight(`Strict-Transport-Security`(365.days, true, true))
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for HSTS in the form of the `Strict-Transport-Security` header and a middleware to activate it

As a reference 
https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet

I was tempted to add it to Blaze as it probably makes more sense as a server feature than a `Middleware` but got lost on the details. Let me know if you think that's an avenue to pursuit