### PR TITLE
Add withFragment to remove redundant copy calls

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -34,6 +34,8 @@ final case class Uri(
 
   def withPath(path: Path): Uri = copy(path = path)
 
+  def withFragment(fragment: Option[Fragment]): Uri = copy(fragment = fragment)
+
   def /(newSegment: Path): Uri = {
     val encoded = UrlCodingUtils.pathEncode(newSegment)
     val newPath =

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -36,6 +36,8 @@ final case class Uri(
 
   def withFragment(fragment: Fragment): Uri = copy(fragment = Option(fragment))
 
+  def withoutFragment: Uri = copy(fragment = Option.empty[Fragment])
+
   def /(newSegment: Path): Uri = {
     val encoded = UrlCodingUtils.pathEncode(newSegment)
     val newPath =

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -34,7 +34,7 @@ final case class Uri(
 
   def withPath(path: Path): Uri = copy(path = path)
 
-  def withFragment(fragment: Option[Fragment]): Uri = copy(fragment = fragment)
+  def withFragment(fragment: Fragment): Uri = copy(fragment = Option(fragment))
 
   def /(newSegment: Path): Uri = {
     val encoded = UrlCodingUtils.pathEncode(newSegment)

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -629,6 +629,25 @@ http://example.org/a file
     }
   }
 
+  "Uri.withFragment convenience method" should {
+    "set a Fragment" in {
+      val u = Uri(path = "/")
+      val updated = u.withFragment("nonsense")
+      updated.renderString must_== "/#nonsense"
+    }
+    "set a new Fragment" in {
+      val u = Uri(path = "/", fragment = Some("adjakda"))
+      val updated = u.withFragment("nonsense")
+      updated.renderString must_== "/#nonsense"
+    }
+    "set no Fragment on a null String" in {
+      val u = Uri(path = "/", fragment = Some("adjakda"))
+      val evilString : String = null
+      val updated = u.withFragment(evilString)
+      updated.renderString must_== "/"
+    }
+  }
+
   "Uri.renderString" should {
     "Encode special chars in the query" in {
       val u = Uri(path = "/").withQueryParam("foo", " !$&'()*+,;=:/?@~")

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -648,6 +648,15 @@ http://example.org/a file
     }
   }
 
+  "Uri.withoutFragment convenience method" should {
+    "unset a Fragment" in {
+      val u = Uri(path = "/", fragment = Some("nonsense"))
+      val updated = u.withoutFragment
+      updated.renderString must_== "/"
+    }
+
+  }
+
   "Uri.renderString" should {
     "Encode special chars in the query" in {
       val u = Uri(path = "/").withQueryParam("foo", " !$&'()*+,;=:/?@~")


### PR DESCRIPTION
Follows current convention. However would we prefer an explicit `Fragment` then wrapped in `Some`?