### PR TITLE
Update Retry-After to follow the coding conventions

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Retry-After.scala
+++ b/core/src/main/scala/org/http4s/headers/Retry-After.scala
@@ -10,6 +10,20 @@ import org.http4s.parser.HttpHeaderParser
 import scala.concurrent.duration.FiniteDuration
 
 object `Retry-After` extends HeaderKey.Internal[`Retry-After`] with HeaderKey.Singleton {
+  private class RetryAfterImpl(retry: Either[Instant, Long]) extends `Retry-After`(retry)
+
+  def apply(retry: Instant): `Retry-After` = new RetryAfterImpl(Left(retry))
+
+  def fromLong(retry: Long): ParseResult[`Retry-After`] =
+    if (retry >= 0) ParseResult.success(new RetryAfterImpl(Right(retry)))
+    else ParseResult.fail("Invalid retry value", s"Retry param $retry must be more or equal than 0 seconds")
+
+  def unsafeFromLong(retry: Long): `Retry-After` =
+    fromLong(retry).fold(throw _, identity)
+
+  def unsafeFromDuration(retry: FiniteDuration): `Retry-After` =
+    fromLong(retry.toSeconds).fold(throw _, identity)
+
   override def parse(s: String): ParseResult[`Retry-After`] =
     HttpHeaderParser.RETRY_AFTER(s)
 }
@@ -21,7 +35,7 @@ object `Retry-After` extends HeaderKey.Internal[`Retry-After`] with HeaderKey.Si
   *
   * @param retry Either the date of expiration or seconds until expiration
   */
-final case class `Retry-After`(retry: Either[Instant, FiniteDuration]) extends Header.Parsed {
+sealed abstract case class `Retry-After`(retry: Either[Instant, Long]) extends Header.Parsed {
   import `Retry-After`._
 
   val key = `Retry-After`

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -89,8 +89,8 @@ private[parser] trait SimpleHeaders {
 
   def RETRY_AFTER(value: String): ParseResult[`Retry-After`] = new Http4sHeaderParser[`Retry-After`](value) {
     def entry = rule {
-      HttpDate ~ EOL ~> ((t: Instant) => `Retry-After`(Left(t))) | // Date value
-      Digits ~ EOL ~> ((t: String) => `Retry-After`(Right(FiniteDuration(t.toLong, SECONDS))))
+      HttpDate ~ EOL ~> ((t: Instant) => `Retry-After`(t)) | // Date value
+      Digits ~ EOL ~> ((t: String) => `Retry-After`.unsafeFromLong(t.toLong))
     }
   }.parse
 

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -256,8 +256,8 @@ trait ArbitraryInstances {
 
   implicit val arbitraryRetryAfterHeader: Arbitrary[headers.`Retry-After`] =
     Arbitrary { for {
-      instant <- Gen.oneOf(genHttpExpireInstant.map(Left(_)), genFiniteDuration.map(Right(_)))
-    } yield headers.`Retry-After`(instant) }
+      retry <- Gen.oneOf(genHttpExpireInstant.map(Left(_)), Gen.posNum[Long].map(Right(_)))
+    } yield retry.fold(headers.`Retry-After`.apply, headers.`Retry-After`.unsafeFromLong) }
 
   implicit val arbitraryAgeHeader: Arbitrary[headers.Age] =
     Arbitrary { for {

--- a/tests/src/test/scala/org/http4s/headers/RetryAfterSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/RetryAfterSpec.scala
@@ -3,6 +3,7 @@ package org.http4s.headers
 import cats.implicits._
 
 import java.time.{Instant, ZoneId, ZonedDateTime}
+import org.http4s.{ParseFailure, ParseResult}
 
 import scala.concurrent.duration._
 
@@ -13,10 +14,27 @@ class RetryAfterSpec extends HeaderLaws {
 
   "render" should {
     "format GMT date according to RFC 1123" in {
-      `Retry-After`(Left(Instant.from(gmtDate))).renderString must_== "Retry-After: Fri, 31 Dec 1999 23:59:59 GMT"
+      `Retry-After`(Instant.from(gmtDate)).renderString must_== "Retry-After: Fri, 31 Dec 1999 23:59:59 GMT"
     }
     "duration in seconds" in {
-      `Retry-After`(Right(120.seconds)).renderString must_== "Retry-After: 120"
+      `Retry-After`.unsafeFromDuration(120.seconds).renderString must_== "Retry-After: 120"
+    }
+  }
+
+  "build" should {
+    "build correctly for positives" in {
+      `Retry-After`.fromLong(0).map(_.value) must beLike { case Right("0") => ok }
+    }
+    "fail for negatives" in {
+      `Retry-After`.fromLong(-10).map(_.value) must beLeft
+    }
+    "build unsafe for positives" in {
+      `Retry-After`.unsafeFromDuration(0.seconds).value must_== "0"
+      `Retry-After`.unsafeFromLong(10).value must_== "10"
+    }
+    "fail unsafe for negatives" in {
+      `Retry-After`.unsafeFromDuration(-10.seconds).value must throwA[ParseFailure]
+      `Retry-After`.unsafeFromLong(-10).value must throwA[ParseFailure]
     }
   }
 
@@ -25,7 +43,7 @@ class RetryAfterSpec extends HeaderLaws {
       `Retry-After`.parse("Fri, 31 Dec 1999 23:59:59 GMT").map(_.retry) must beRight(Left(Instant.from(gmtDate)))
     }
     "accept duration on seconds" in {
-      `Retry-After`.parse("120").map(_.retry) must beRight(Right(120.seconds))
+      `Retry-After`.parse("120").map(_.retry) must beRight(Right(120))
     }
   }
 }


### PR DESCRIPTION
Small update to `Retry-After` to follow the conventions, removing the use of `FiniteDuration` for `Long` instead