### PR TITLE
Instances for QueryParamDecoder/Encoder

### DIFF
--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -2,6 +2,7 @@ package org.http4s
 
 import cats._
 import cats.data._
+import cats.functor.Contravariant
 import cats.implicits._
 
 final case class QueryParameterKey(value: String) extends AnyVal
@@ -41,8 +42,16 @@ object QueryParamKeyLike {
  * Type class defining how to encode a `T` as a [[QueryParameterValue]]s
  * @see QueryParamCodecLaws
  */
-trait QueryParamEncoder[T] {
+trait QueryParamEncoder[T] { outer =>
   def encode(value: T): QueryParameterValue
+
+  /** QueryParamEncoder is a contravariant functor. */
+  def contramap[U](f: U => T): QueryParamEncoder[U] =
+    new QueryParamEncoder[U] {
+      override def encode(value: U) =
+        outer.encode(f(value))
+    }
+
 }
 
 object QueryParamEncoder {
@@ -50,25 +59,41 @@ object QueryParamEncoder {
   /** summon an implicit [[QueryParamEncoder]] */
   def apply[T](implicit ev: QueryParamEncoder[T]): QueryParamEncoder[T] = ev
 
-  def encodeBy[T, U: QueryParamEncoder](f: T => U): QueryParamEncoder[T] = new QueryParamEncoder[T] {
-    def encode(value: T): QueryParameterValue =
-      QueryParamEncoder[U].encode(f(value))
-  }
+  /** QueryParamEncoder is a contravariant functor. */
+  implicit val ContravariantQueryParamEncoder: Contravariant[QueryParamEncoder] =
+    new Contravariant[QueryParamEncoder] {
+      override def contramap[A, B](fa: QueryParamEncoder[A])(f: B => A) =
+        fa.contramap(f)
+    }
 
-  def encode[T](f: T => String): QueryParamEncoder[T] = new QueryParamEncoder[T] {
-    def encode(value: T): QueryParameterValue =
-      QueryParameterValue(f(value))
-  }
+  @deprecated("Use QueryParamEncoder[U].contramap(f)", "0.17")
+  def encodeBy[T, U](f: T => U)(
+    implicit qpe: QueryParamEncoder[U]
+  ): QueryParamEncoder[T] =
+    qpe.contramap(f)
 
-  def fromShow[T: Show]: QueryParamEncoder[T] = encode(Show[T].show)
+  @deprecated("Use QueryParamEncoder[String].contramap(f)", "0.17")
+  def encode[T](f: T => String): QueryParamEncoder[T] =
+    stringQueryParamEncoder.contramap(f)
 
-  implicit val booleanQueryParamEncoder: QueryParamEncoder[Boolean] = fromShow[Boolean]
-  implicit val doubleQueryParamEncoder : QueryParamEncoder[Double]  = fromShow[Double]
-  implicit val floatQueryParamEncoder  : QueryParamEncoder[Float]   = fromShow[Float]
-  implicit val shortQueryParamEncoder  : QueryParamEncoder[Short]   = fromShow[Short]
-  implicit val intQueryParamEncoder    : QueryParamEncoder[Int]     = fromShow[Int]
-  implicit val longQueryParamEncoder   : QueryParamEncoder[Long]    = fromShow[Long]
-  implicit val stringQueryParamEncoder : QueryParamEncoder[String]  = encode(identity)
+  def fromShow[T](
+    implicit sh: Show[T]
+  ): QueryParamEncoder[T] =
+    stringQueryParamEncoder.contramap(sh.show)
+
+  implicit lazy val booleanQueryParamEncoder: QueryParamEncoder[Boolean] = fromShow[Boolean]
+  implicit lazy val doubleQueryParamEncoder : QueryParamEncoder[Double]  = fromShow[Double]
+  implicit lazy val floatQueryParamEncoder  : QueryParamEncoder[Float]   = fromShow[Float]
+  implicit lazy val shortQueryParamEncoder  : QueryParamEncoder[Short]   = fromShow[Short]
+  implicit lazy val intQueryParamEncoder    : QueryParamEncoder[Int]     = fromShow[Int]
+  implicit lazy val longQueryParamEncoder   : QueryParamEncoder[Long]    = fromShow[Long]
+
+  implicit lazy val stringQueryParamEncoder : QueryParamEncoder[String]  =
+    new QueryParamEncoder[String] {
+      override def encode(value: String) =
+        QueryParameterValue(value)
+    }
+
 }
 
 
@@ -76,8 +101,23 @@ object QueryParamEncoder {
  * Type class defining how to decode a [[QueryParameterValue]] into a `T`
  * @see QueryParamCodecLaws
  */
-trait QueryParamDecoder[T] {
+trait QueryParamDecoder[T] { outer =>
   def decode(value: QueryParameterValue): ValidatedNel[ParseFailure, T]
+
+  /** QueryParamDecoder is a covariant functor. */
+  def map[U](f: T => U): QueryParamDecoder[U] =
+    new QueryParamDecoder[U] {
+      override def decode(value: QueryParameterValue) =
+        outer.decode(value).map(f)
+    }
+
+  /** Use another decoder if this one fails. */
+  def orElse[U >: T](qpd: QueryParamDecoder[U]): QueryParamDecoder[U] =
+    new QueryParamDecoder[U] {
+      override def decode(value: QueryParameterValue) =
+        outer.decode(value) orElse qpd.decode(value)
+    }
+
 }
 
 object QueryParamDecoder {
@@ -91,33 +131,56 @@ object QueryParamDecoder {
       ).toValidatedNel
   }
 
-  def decodeBy[T, U: QueryParamDecoder](f: U => T): QueryParamDecoder[T] = new QueryParamDecoder[T] {
-    def decode(value: QueryParameterValue): ValidatedNel[ParseFailure, T] =
-      QueryParamDecoder[U].decode(value) map f
-  }
+  /** QueryParamDecoder is a covariant functor. */
+  implicit val FunctorQueryParamDecoder: Functor[QueryParamDecoder] =
+    new Functor[QueryParamDecoder] {
+      override def map[A, B](fa: QueryParamDecoder[A])(f: A => B) =
+        fa.map(f)
+    }
 
+  /** QueryParamDecoder is a MonoidK. */
+  implicit val MonoidKQueryParamDecoder: MonoidK[QueryParamDecoder] =
+    new MonoidK[QueryParamDecoder] {
+      def empty[A] =
+        nothingQueryParamDecoder.widen[A]
+      def combineK[A](a: QueryParamDecoder[A], b: QueryParamDecoder[A]) =
+        a.orElse(b)
+    }
 
-  implicit val booleanQueryParamDecoder: QueryParamDecoder[Boolean] =
+  @deprecated("Use QueryParamEncoder[T].map(f)", "0.17")
+  def decodeBy[U, T](f: T => U)(
+    implicit qpd: QueryParamDecoder[T]
+  ): QueryParamDecoder[U] =
+    qpd.map(f)
+
+  /** A decoder that always fails. */
+  implicit lazy val nothingQueryParamDecoder: QueryParamDecoder[Nothing] =
+    new QueryParamDecoder[Nothing] {
+      override def decode(value: QueryParameterValue) =
+        Validated.invalidNel(ParseFailure("Failed.", "Nothing decoder always fails."))
+    }
+
+  implicit lazy val booleanQueryParamDecoder: QueryParamDecoder[Boolean] =
     fromUnsafeCast[Boolean](_.value.toBoolean)("Boolean")
-  implicit val doubleQueryParamDecoder: QueryParamDecoder[Double] =
+  implicit lazy val doubleQueryParamDecoder: QueryParamDecoder[Double] =
     fromUnsafeCast[Double](_.value.toDouble)("Double")
-  implicit val floatQueryParamDecoder: QueryParamDecoder[Float] =
+  implicit lazy val floatQueryParamDecoder: QueryParamDecoder[Float] =
     fromUnsafeCast[Float](_.value.toFloat)("Float")
-  implicit val shortQueryParamDecoder: QueryParamDecoder[Short] =
+  implicit lazy val shortQueryParamDecoder: QueryParamDecoder[Short] =
     fromUnsafeCast[Short](_.value.toShort)("Short")
-  implicit val intQueryParamDecoder: QueryParamDecoder[Int] =
+  implicit lazy val intQueryParamDecoder: QueryParamDecoder[Int] =
     fromUnsafeCast[Int](_.value.toInt)("Int")
-  implicit val longQueryParamDecoder: QueryParamDecoder[Long] =
+  implicit lazy val longQueryParamDecoder: QueryParamDecoder[Long] =
     fromUnsafeCast[Long](_.value.toLong)("Long")
 
-  implicit val charQueryParamDecoder: QueryParamDecoder[Char] = new QueryParamDecoder[Char]{
+  implicit lazy val charQueryParamDecoder: QueryParamDecoder[Char] = new QueryParamDecoder[Char]{
     def decode(value: QueryParameterValue): ValidatedNel[ParseFailure, Char] =
       if(value.value.size == 1) value.value.head.validNel
       else ParseFailure("Failed to parse Char query parameter",
                        s"Could not parse ${value.value} as a Char").invalidNel
   }
 
-  implicit val stringQueryParamDecoder: QueryParamDecoder[String] = new QueryParamDecoder[String]{
+  implicit lazy val stringQueryParamDecoder: QueryParamDecoder[String] = new QueryParamDecoder[String]{
     def decode(value: QueryParameterValue): ValidatedNel[ParseFailure, String] =
       value.value.validNel
   }

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
@@ -18,7 +18,7 @@ object PathInHttpServiceSpec extends Http4sSpec {
 
   final case class Limit(l: Long)
   implicit val limitQueryParam = QueryParam.fromKey[Limit]("limit")
-  implicit val limitDecoder    = QueryParamDecoder.decodeBy[Limit, Long](Limit.apply)
+  implicit val limitDecoder    = QueryParamDecoder[Long].map(Limit.apply)
 
   object L extends QueryParamMatcher[Limit]
 

--- a/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
@@ -1,8 +1,13 @@
 package org.http4s
 
+import cats._
+import cats.data._
 import cats.implicits._
+import cats.laws.discipline.{ arbitrary => _, _}
+import org.scalacheck.{ Arbitrary, Cogen }
+import org.scalacheck.Arbitrary._
 
-class QueryParamCodecSpec extends Http4sSpec {
+class QueryParamCodecSpec extends Http4sSpec with QueryParamCodecInstances {
   checkAll("Boolean QueryParamCodec", QueryParamCodecLaws[Boolean])
   checkAll("Double QueryParamCodec" , QueryParamCodecLaws[Double])
   checkAll("Float QueryParamCodec"  , QueryParamCodecLaws[Float])
@@ -10,4 +15,39 @@ class QueryParamCodecSpec extends Http4sSpec {
   checkAll("Int QueryParamCodec"    , QueryParamCodecLaws[Int])
   checkAll("Long QueryParamCodec"   , QueryParamCodecLaws[Long])
   checkAll("String QueryParamCodec" , QueryParamCodecLaws[String])
+
+  // Law checks for instances.
+  checkAll("Functor[QueryParamDecoder]", FunctorTests[QueryParamDecoder].functor[Int, String, Boolean])
+  checkAll("MonoidK[QueryParamDecoder]", MonoidKTests[QueryParamDecoder].monoidK[Int])
+  checkAll("Contravariant[QueryParamEncoder]", ContravariantTests[QueryParamEncoder].contravariant[Int, String, Boolean])
+
+}
+
+trait QueryParamCodecInstances { this: Http4sSpec =>
+
+  // We will assume for the purposes of testing that QueryParamDecoders are equal if they
+  // produce the same result for a bunch of arbitrary strings.
+  implicit def EqQueryParamDecoder[A: Eq]: Eq[QueryParamDecoder[A]] = {
+    val vnp = Eq[Validated[NonEmptyList[ParseFailure], A]]
+    Eq.instance { (x, y) =>
+      val ss = List.fill(100)(arbitrary[String].sample).flatten.map(QueryParameterValue.apply)
+      ss.forall(s => vnp.eqv(x.decode(s), y.decode(s)))
+    }
+  }
+
+  // We will assume for the purposes of testing that QueryParamEncoders are equal if they
+  // produce the same result for a bunch of arbitrary inputs.
+  implicit def EqQueryParamEncoder[A: Arbitrary]: Eq[QueryParamEncoder[A]] = {
+    Eq.instance { (x, y) =>
+      val as = List.fill(100)(arbitrary[A].sample).flatten
+      as.forall(a => x.encode(a) === y.encode(a))
+    }
+  }
+
+  implicit def ArbQueryParamDecoder[A: Arbitrary]: Arbitrary[QueryParamDecoder[A]] =
+    Arbitrary(arbitrary[String => A].map(QueryParamDecoder[String].map))
+
+  implicit def ArbQueryParamEncoder[A: Cogen]: Arbitrary[QueryParamEncoder[A]] =
+    Arbitrary(arbitrary[A => String].map(QueryParamEncoder[String].contramap))
+
 }


### PR DESCRIPTION
This adds some obvious instances for `QueryParam` things and deprecates some now-redundant factory methods.