### PR TITLE
Fix broken IP parsing

### DIFF
--- a/core/src/main/scala/org/http4s/headers/X-Forwarded-For.scala
+++ b/core/src/main/scala/org/http4s/headers/X-Forwarded-For.scala
@@ -30,4 +30,3 @@ final case class `X-Forwarded-For`(values: NonEmptyList[Option[InetAddress]]) ex
     else w.append("unknown")
   }
 }
-

--- a/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
+++ b/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
@@ -15,6 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * ip parsing derived from https://github.com/akka/akka-http/blob/5932237a86a432d623fafb1e84eeeff56d7485fe/akka-http-core/src/main/scala/akka/http/impl/model/parser/IpAddressParsing.scala
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package org.http4s
 package parser
 
@@ -114,14 +118,6 @@ private[parser] trait AdditionalRules extends Rfc2616BasicRules { this: Parser =
   def Digit4: Rule1[Int] = rule { capture(Digit ~ Digit ~ Digit ~ Digit) ~> {s: String => s.toInt} }
 
   def NegDigit1: Rule1[Int] = rule { "-" ~ capture(Digit) ~> {s: String => s.toInt} }
-
-  def Ip4Number = rule { Digit3 | Digit2 | Digit1 }
-
-  def Ip: Rule1[InetAddress] = rule {
-    Ip4Number ~ ch('.') ~ Ip4Number ~ ch('.') ~ Ip4Number ~ ch('.') ~ Ip4Number  ~ OptWS ~>
-    { (a:Int,b:Int,c:Int,d:Int) => InetAddress.getByAddress(Array(a.toByte, b.toByte, c.toByte, d.toByte)) }
-  }
-
   private def createDateTime(year: Int, month: Int, day: Int, hour: Int, min: Int, sec: Int, wkday: Int): Instant = {
     Try(ZonedDateTime.of(year, month, day, hour, min, sec, 0, ZoneOffset.UTC).toInstant).getOrElse {
       // TODO Would be better if this message had the real input.

--- a/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
+++ b/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
@@ -15,10 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * ip parsing derived from https://github.com/akka/akka-http/blob/5932237a86a432d623fafb1e84eeeff56d7485fe/akka-http-core/src/main/scala/akka/http/impl/model/parser/IpAddressParsing.scala
- * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
- */
 package org.http4s
 package parser
 

--- a/core/src/main/scala/org/http4s/parser/IpParser.scala
+++ b/core/src/main/scala/org/http4s/parser/IpParser.scala
@@ -1,0 +1,43 @@
+package org.http4s
+package parser
+
+import org.http4s.internal.parboiled2._
+import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit, HexDigit}
+
+private[http4s] trait IpParser { this: Parser =>
+
+  def IpLiteral = rule { "[" ~ capture(IpV6Address | IpVFuture) ~ "]" }
+
+  def IpVFuture = rule { "v" ~ oneOrMore(HexDigit) ~ "." ~ oneOrMore(Unreserved | SubDelims | ":" ) }
+
+  def IpV6Address: Rule0 = rule {
+                                                   6.times(H16 ~ ":") ~ LS32 |
+                                            "::" ~ 5.times(H16 ~ ":") ~ LS32 |
+          optional(H16) ~                   "::" ~ 4.times(H16 ~ ":") ~ LS32 |
+    optional((1 to 2).times(H16).separatedBy(":"))  ~ "::" ~ 3.times(H16 ~ ":") ~ LS32 |
+    optional((1 to 3).times(H16).separatedBy(":"))  ~ "::" ~ 2.times(H16 ~ ":") ~ LS32 |
+    optional((1 to 4).times(H16).separatedBy(":"))  ~ "::" ~         H16 ~ ":"  ~ LS32 |
+    optional((1 to 5).times(H16).separatedBy(":"))  ~ "::" ~                      LS32 |
+    optional((1 to 6).times(H16).separatedBy(":"))  ~ "::" ~                      H16  |
+    optional((1 to 7).times(H16).separatedBy(":"))  ~ "::"
+  }
+
+  def H16 = rule { (1 to 4).times(HexDigit) }
+
+  def LS32 = rule { (H16 ~ ":" ~ H16) | IpV4Address }
+
+  def IpV4Address = rule { 3.times(DecOctet ~ ".") ~ DecOctet }
+
+
+  def DecOctet = rule {
+    "1"         ~ Digit       ~ Digit |
+    "2"         ~ ("0" - "4") ~ Digit |
+    "25"        ~ ("0" - "5")         |
+    ("1" - "9") ~ Digit               |
+    Digit
+  }
+
+  def Unreserved = rule { Alpha | Digit | "-" | "." | "_" | "~" }
+
+  def SubDelims = rule { "!" | "$" | "&" | "'" | "(" | ")" | "*" | "+" | "," | ";" | "=" }
+}

--- a/core/src/main/scala/org/http4s/parser/IpParser.scala
+++ b/core/src/main/scala/org/http4s/parser/IpParser.scala
@@ -6,10 +6,6 @@ import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit, HexDigit}
 
 private[http4s] trait IpParser { this: Parser =>
 
-  def IpLiteral = rule { "[" ~ capture(IpV6Address | IpVFuture) ~ "]" }
-
-  def IpVFuture = rule { "v" ~ oneOrMore(HexDigit) ~ "." ~ oneOrMore(Unreserved | SubDelims | ":" ) }
-
   def IpV6Address: Rule0 = rule {
                                                    6.times(H16 ~ ":") ~ LS32 |
                                             "::" ~ 5.times(H16 ~ ":") ~ LS32 |
@@ -36,8 +32,4 @@ private[http4s] trait IpParser { this: Parser =>
     ("1" - "9") ~ Digit               |
     Digit
   }
-
-  def Unreserved = rule { Alpha | Digit | "-" | "." | "_" | "~" }
-
-  def SubDelims = rule { "!" | "$" | "&" | "'" | "(" | ")" | "*" | "+" | "," | ";" | "=" }
 }

--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -17,8 +17,6 @@
  */
 package org.http4s.parser
 
-import scala.reflect.ClassTag
-import scalaz.Validation
 import org.http4s.{ParseFailure, ParseResult}
 import org.http4s.internal.parboiled2._
 

--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -21,7 +21,6 @@ import scala.reflect.ClassTag
 import scalaz.Validation
 import org.http4s.{ParseFailure, ParseResult}
 import org.http4s.internal.parboiled2._
-import org.http4s.internal.parboiled2.CharPredicate.{ HexDigit => HEXDIG }
 
 // direct implementation of http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2
 private[http4s] trait Rfc2616BasicRules extends Parser {
@@ -76,64 +75,6 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
   def ListSep = rule { oneOrMore("," ~ OptWS) }
 
   def LASTCHAR: Rule1[Char] = rule { push(input.charAt(cursor - 1)) }
-
-  private val DIGIT = CharPredicate.Digit
-  private val DIGIT04 = CharPredicate('0' to '4')
-  private val DIGIT05 = CharPredicate('0' to '5')
-  private val DIGIT19 = CharPredicate.Digit19
-
-  def IPNumber = rule {
-    capture(
-      '2' ~ (DIGIT04 ~ DIGIT | '5' ~ DIGIT05)
-        | '1' ~ DIGIT ~ DIGIT
-        | DIGIT19 ~ DIGIT
-        | DIGIT) ~> (java.lang.Integer.parseInt(_).toByte)
-  }
-
-  def IPv4Address = {
-    rule {
-      IPNumber ~ '.' ~ IPNumber ~ '.' ~ IPNumber ~ '.' ~ IPNumber ~> (Array[Byte](_, _, _, _))
-    }
-  }
-
-  def IPv6Address: Rule1[Array[Byte]] = {
-    import CharUtils.{ hexValue ⇒ hv }
-    var a: Array[Byte] = null
-    def zero(ix: Int) = rule { run(a(ix) = 0.toByte) }
-    def zero2(ix: Int) = rule { run { a(ix) = 0.toByte; a(ix + 1) = 0.toByte; } }
-    def h4(ix: Int) = rule { HEXDIG ~ run(a(ix) = hv(lastChar).toByte) }
-    def h8(ix: Int) = rule { HEXDIG ~ HEXDIG ~ run(a(ix) = (hv(charAt(-2)) * 16 + hv(lastChar)).toByte) }
-    def h16(ix: Int) = rule { h8(ix) ~ h8(ix + 1) | h4(ix) ~ h8(ix + 1) | zero(ix) ~ h8(ix + 1) | zero(ix) ~ h4(ix + 1) }
-    def h16c(ix: Int) = rule { h16(ix) ~ ':' ~ !':' }
-    def ch16o(ix: Int) = rule { optional(':' ~ !':') ~ (h16(ix) | zero2(ix)) }
-    def ls32 = rule { h16(12) ~ ':' ~ h16(14) | IPv4Address ~> (System.arraycopy(_, 0, a, 12, 4)) }
-    def cc(ix: Int) = rule { ':' ~ ':' ~ zero2(ix) }
-    def tail2 = rule { h16c(2) ~ tail4 }
-    def tail4 = rule { h16c(4) ~ tail6 }
-    def tail6 = rule { h16c(6) ~ tail8 }
-    def tail8 = rule { h16c(8) ~ tail10 }
-    def tail10 = rule { h16c(10) ~ ls32 }
-    rule {
-      !(':' ~ HEXDIG) ~ push { a = new Array[Byte](16); a } ~ (
-        h16c(0) ~ tail2
-        | cc(0) ~ tail2
-        | ch16o(0) ~ (
-          cc(2) ~ tail4
-          | ch16o(2) ~ (
-            cc(4) ~ tail6
-            | ch16o(4) ~ (
-              cc(6) ~ tail8
-              | ch16o(6) ~ (
-                cc(8) ~ tail10
-                | ch16o(8) ~ (
-                  cc(10) ~ ls32
-                  | ch16o(10) ~ (
-                    cc(12) ~ h16(14)
-                      | ch16o(12) ~ cc(14))))))))
-    }
-  }
-
-  def IPv6Reference: Rule1[String] = rule { capture("[" ~ oneOrMore(HEXDIG | anyOf(":.")) ~ "]") }
 }
 
 private[http4s] object Rfc2616BasicRules {

--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -17,8 +17,11 @@
  */
 package org.http4s.parser
 
+import scala.reflect.ClassTag
+import scalaz.Validation
 import org.http4s.{ParseFailure, ParseResult}
 import org.http4s.internal.parboiled2._
+import org.http4s.internal.parboiled2.CharPredicate.{ HexDigit => HEXDIG }
 
 // direct implementation of http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2
 private[http4s] trait Rfc2616BasicRules extends Parser {
@@ -74,11 +77,63 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
 
   def LASTCHAR: Rule1[Char] = rule { push(input.charAt(cursor - 1)) }
 
-  // we don't match scoped IPv6 addresses
-  def IPv6Address = rule { oneOrMore(Hex | anyOf(":.")) }
+  private val DIGIT = CharPredicate.Digit
+  private val DIGIT04 = CharPredicate('0' to '4')
+  private val DIGIT05 = CharPredicate('0' to '5')
+  private val DIGIT19 = CharPredicate.Digit19
 
-  def IPv6Reference: Rule1[String] = rule { capture("[" ~ IPv6Address ~ "]") }
-  // scalastyle:on public.methods.have.type
+  def IPNumber = rule {
+    capture(
+      '2' ~ (DIGIT04 ~ DIGIT | '5' ~ DIGIT05)
+        | '1' ~ DIGIT ~ DIGIT
+        | DIGIT19 ~ DIGIT
+        | DIGIT) ~> (java.lang.Integer.parseInt(_).toByte)
+  }
+
+  def IPv4Address = {
+    rule {
+      IPNumber ~ '.' ~ IPNumber ~ '.' ~ IPNumber ~ '.' ~ IPNumber ~> (Array[Byte](_, _, _, _))
+    }
+  }
+
+  def IPv6Address: Rule1[Array[Byte]] = {
+    import CharUtils.{ hexValue ⇒ hv }
+    var a: Array[Byte] = null
+    def zero(ix: Int) = rule { run(a(ix) = 0.toByte) }
+    def zero2(ix: Int) = rule { run { a(ix) = 0.toByte; a(ix + 1) = 0.toByte; } }
+    def h4(ix: Int) = rule { HEXDIG ~ run(a(ix) = hv(lastChar).toByte) }
+    def h8(ix: Int) = rule { HEXDIG ~ HEXDIG ~ run(a(ix) = (hv(charAt(-2)) * 16 + hv(lastChar)).toByte) }
+    def h16(ix: Int) = rule { h8(ix) ~ h8(ix + 1) | h4(ix) ~ h8(ix + 1) | zero(ix) ~ h8(ix + 1) | zero(ix) ~ h4(ix + 1) }
+    def h16c(ix: Int) = rule { h16(ix) ~ ':' ~ !':' }
+    def ch16o(ix: Int) = rule { optional(':' ~ !':') ~ (h16(ix) | zero2(ix)) }
+    def ls32 = rule { h16(12) ~ ':' ~ h16(14) | IPv4Address ~> (System.arraycopy(_, 0, a, 12, 4)) }
+    def cc(ix: Int) = rule { ':' ~ ':' ~ zero2(ix) }
+    def tail2 = rule { h16c(2) ~ tail4 }
+    def tail4 = rule { h16c(4) ~ tail6 }
+    def tail6 = rule { h16c(6) ~ tail8 }
+    def tail8 = rule { h16c(8) ~ tail10 }
+    def tail10 = rule { h16c(10) ~ ls32 }
+    rule {
+      !(':' ~ HEXDIG) ~ push { a = new Array[Byte](16); a } ~ (
+        h16c(0) ~ tail2
+        | cc(0) ~ tail2
+        | ch16o(0) ~ (
+          cc(2) ~ tail4
+          | ch16o(2) ~ (
+            cc(4) ~ tail6
+            | ch16o(4) ~ (
+              cc(6) ~ tail8
+              | ch16o(6) ~ (
+                cc(8) ~ tail10
+                | ch16o(8) ~ (
+                  cc(10) ~ ls32
+                  | ch16o(10) ~ (
+                    cc(12) ~ h16(14)
+                      | ch16o(12) ~ cc(14))))))))
+    }
+  }
+
+  def IPv6Reference: Rule1[String] = rule { capture("[" ~ oneOrMore(HEXDIG | anyOf(":.")) ~ "]") }
 }
 
 private[http4s] object Rfc2616BasicRules {

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -9,7 +9,11 @@ import scalaz.syntax.std.option._
 import org.http4s.{ Query => Q }
 import org.http4s.syntax.string._
 
-private[parser] trait Rfc3986Parser extends StringBuilding { this: Parser =>
+private[parser] trait Rfc3986Parser
+    extends IpParser
+    with StringBuilding {
+  this: Parser =>
+
   // scalastyle:off public.methods.have.type
   import CharPredicate.{Alpha, Digit, HexDigit}
 
@@ -59,37 +63,6 @@ private[parser] trait Rfc3986Parser extends StringBuilding { this: Parser =>
 
   def Port = rule { ":" ~ (capture(oneOrMore(Digit)) ~> {s: String => (Some(s.toInt))} |  push(None)) |  push(None) }
 
-  def IpLiteral = rule { "[" ~ capture(IpV6Address | IpVFuture) ~ "]" }
-
-  def IpVFuture = rule { "v" ~ oneOrMore(HexDigit) ~ "." ~ oneOrMore(Unreserved | SubDelims | ":" ) }
-
-  def IpV6Address: Rule0 = rule {
-                                                   6.times(H16 ~ ":") ~ LS32 |
-                                            "::" ~ 5.times(H16 ~ ":") ~ LS32 |
-          optional(H16) ~                   "::" ~ 4.times(H16 ~ ":") ~ LS32 |
-    optional((1 to 2).times(H16).separatedBy(":"))  ~ "::" ~ 3.times(H16 ~ ":") ~ LS32 |
-    optional((1 to 3).times(H16).separatedBy(":"))  ~ "::" ~ 2.times(H16 ~ ":") ~ LS32 |
-    optional((1 to 4).times(H16).separatedBy(":"))  ~ "::" ~         H16 ~ ":"  ~ LS32 |
-    optional((1 to 5).times(H16).separatedBy(":"))  ~ "::" ~                      LS32 |
-    optional((1 to 6).times(H16).separatedBy(":"))  ~ "::" ~                      H16  |
-    optional((1 to 7).times(H16).separatedBy(":"))  ~ "::"
-  }
-
-  def H16 = rule { (1 to 4).times(HexDigit) }
-
-  def LS32 = rule { (H16 ~ ":" ~ H16) | IpV4Address }
-
-  def IpV4Address = rule { 3.times(DecOctet ~ ".") ~ DecOctet }
-
-
-  def DecOctet = rule {
-    "1"         ~ Digit       ~ Digit |
-    "2"         ~ ("0" - "4") ~ Digit |
-    "25"        ~ ("0" - "5")         |
-    ("1" - "9") ~ Digit               |
-    Digit
-  }
-
   def RegName: Rule0 = rule { zeroOrMore(Unreserved | PctEncoded | SubDelims) }
 
   def Path: Rule1[String] = rule { (PathAbempty | PathAbsolute | PathNoscheme | PathRootless | PathEmpty) ~> { s: String => decode(s)} }
@@ -131,13 +104,9 @@ private[parser] trait Rfc3986Parser extends StringBuilding { this: Parser =>
 
   def PctEncoded = rule { "%" ~ 2.times(HexDigit) }
 
-  def Unreserved = rule { Alpha | Digit | "-" | "." | "_" | "~" }
-
   def Reserved = rule { GenDelims | SubDelims }
 
   def GenDelims = rule { ":" | "/" | "?" | "#" | "[" | "]" | "@" }
-
-  def SubDelims = rule { "!" | "$" | "&" | "'" | "(" | ")" | "*" | "+" | "," | ";" | "=" }
 
   private[this] def decode(s: String) = URLDecoder.decode(s, charset.name)
   // scalastyle:on public.methods.have.type

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -63,6 +63,10 @@ private[parser] trait Rfc3986Parser
 
   def Port = rule { ":" ~ (capture(oneOrMore(Digit)) ~> {s: String => (Some(s.toInt))} |  push(None)) |  push(None) }
 
+  def IpLiteral = rule { "[" ~ capture(IpV6Address | IpVFuture) ~ "]" }
+
+  def IpVFuture = rule { "v" ~ oneOrMore(HexDigit) ~ "." ~ oneOrMore(Unreserved | SubDelims | ":" ) }
+
   def RegName: Rule0 = rule { zeroOrMore(Unreserved | PctEncoded | SubDelims) }
 
   def Path: Rule1[String] = rule { (PathAbempty | PathAbsolute | PathNoscheme | PathRootless | PathEmpty) ~> { s: String => decode(s)} }
@@ -106,7 +110,11 @@ private[parser] trait Rfc3986Parser
 
   def Reserved = rule { GenDelims | SubDelims }
 
+  def Unreserved = rule { Alpha | Digit | "-" | "." | "_" | "~" }
+
   def GenDelims = rule { ":" | "/" | "?" | "#" | "[" | "]" | "@" }
+
+  def SubDelims = rule { "!" | "$" | "&" | "'" | "(" | ")" | "*" | "+" | "," | ";" | "=" }
 
   private[this] def decode(s: String) = URLDecoder.decode(s, charset.name)
   // scalastyle:on public.methods.have.type

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -164,9 +164,10 @@ private[parser] trait SimpleHeaders {
 
   def X_FORWARDED_FOR(value: String): ParseResult[`X-Forwarded-For`] = new Http4sHeaderParser[`X-Forwarded-For`](value) {
     def entry = rule {
-      oneOrMore((Ip ~> (Some(_))) |
-                (capture(IPv6Address) ~> { s: String => Some(InetAddress.getByName(s)) }) |
-                ("unknown" ~ push(None))).separatedBy(ListSep) ~
+      oneOrMore(
+        (IPv4Address ~> { b: Array[Byte] => Some(InetAddress.getByAddress(b)) }) |
+        (IPv6Address ~> { b: Array[Byte] => Some(InetAddress.getByAddress(b)) }) |
+        ("unknown" ~ push(None))).separatedBy(ListSep) ~
         EOL ~> { xs: Seq[Option[InetAddress]] =>
         `X-Forwarded-For`(xs.head, xs.tail: _*)
       }

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -20,6 +20,7 @@ package parser
 
 import headers._
 import java.net.InetAddress
+import java.nio.charset.StandardCharsets
 import java.time.Instant
 
 import org.http4s.headers.ETag.EntityTag
@@ -96,10 +97,12 @@ private[parser] trait SimpleHeaders {
 //  // see also https://issues.apache.org/bugzilla/show_bug.cgi?id=35122 (WONTFIX in Apache 2 issue) and
 //  // https://bugzilla.mozilla.org/show_bug.cgi?id=464162 (FIXED in mozilla)
   def HOST(value: String): ParseResult[Host] =
-    new Http4sHeaderParser[Host](value) with IpParser {
+    new Http4sHeaderParser[Host](value) with Rfc3986Parser {
+      def charset = StandardCharsets.UTF_8
+
       def entry = rule {
         (Token | IpLiteral) ~ OptWS ~
-          optional(":" ~ capture(oneOrMore(Digit)) ~> (_.toInt)) ~ EOL ~> (Host(_:String, _:Option[Int]))
+          optional(":" ~ capture(oneOrMore(Digit)) ~> (_.toInt)) ~ EOL ~> (org.http4s.headers.Host(_:String, _:Option[Int]))
       }
     }.parse
 

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -170,8 +170,7 @@ private[parser] trait SimpleHeaders {
     new Http4sHeaderParser[`X-Forwarded-For`](value) with IpParser {
       def entry = rule {
         oneOrMore(
-          (capture(IpV4Address) ~> { s: String => Some(InetAddress.getByName(s)) }) |
-            (capture(IpV6Address) ~> { s: String => Some(InetAddress.getByName(s)) }) |
+          (capture(IpV4Address | IpV6Address) ~> { s: String => Some(InetAddress.getByName(s)) }) |
             ("unknown" ~ push(None))).separatedBy(ListSep) ~
           EOL ~> { xs: Seq[Option[InetAddress]] =>
             `X-Forwarded-For`(xs.head, xs.tail: _*)

--- a/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -127,7 +127,7 @@ class SimpleHeadersSpec extends Http4sSpec {
       )
     }
 
-    "parse X-Forward-For" in {
+    "parse X-Forwarded-For" in {
       // ipv4
       val header2 = `X-Forwarded-For`(NonEmptyList(
         Some(InetAddress.getLocalHost),
@@ -146,7 +146,9 @@ class SimpleHeadersSpec extends Http4sSpec {
 
       val bad = Header("x-forwarded-for", "foo")
       HttpHeaderParser.parseHeader(bad) must be_-\/
+
+      val bad2 = Header("x-forwarded-for", "256.56.56.56")
+      HttpHeaderParser.parseHeader(bad2) must be_-\/
     }
   }
-
 }

--- a/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -8,7 +8,7 @@ import org.http4s._
 import scala.util.Success
 import org.http4s.internal.parboiled2._
 
-class IpParser(val input: ParserInput, val charset: NioCharset) extends Parser with Rfc3986Parser {
+class IpParserImpl(val input: ParserInput, val charset: NioCharset) extends Parser with IpParser {
   def CaptureIPv6: Rule1[String] = rule { capture(IpV6Address) }
   def CaptureIPv4: Rule1[String] = rule { capture(IpV4Address) }
 }
@@ -37,14 +37,14 @@ class UriParserSpec extends Http4sSpec {
       } yield (f + "::" + b))
 
       foreach(v) { s =>
-        new IpParser(s, StandardCharsets.UTF_8).CaptureIPv6.run() must be_==(Success(s))
+        new IpParserImpl(s, StandardCharsets.UTF_8).CaptureIPv6.run() must be_==(Success(s))
       }
     }
 
     "parse a IPv4 address" in {
       foreach(0 to 255) { i =>
         val addr = s"$i.$i.$i.$i"
-        new IpParser(addr, StandardCharsets.UTF_8).CaptureIPv4.run() must_==(Success(addr))
+        new IpParserImpl(addr, StandardCharsets.UTF_8).CaptureIPv4.run() must_==(Success(addr))
       }
     }
 


### PR DESCRIPTION
* Old IPv4 parser allowed invalid octets
* IPv6 parser allowed invalid addresses, threw exceptions

Not sure why #1284 didn't get a PR build to uncover this, but I think this fixes release-0.16.x.