### PR TITLE
Fix corner case of bad hash code in CaseInsensitiveString

### DIFF
--- a/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
+++ b/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
@@ -28,7 +28,7 @@ sealed class CaseInsensitiveString private (val value: String)
         // to go in both directions. A character is not guaranteed to make this
         // round trip, but it doesn't matter as long as all equal characters
         // hash the same.
-        h = h * 31 + Character.toUpperCase(Character.toLowerCase(value.charAt(i)))
+        h = h * 31 + Character.toLowerCase(Character.toUpperCase(value.charAt(i)))
         i += 1
       }
       hash = h

--- a/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
+++ b/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
@@ -23,7 +23,12 @@ sealed class CaseInsensitiveString private (val value: String)
       var i = 0
       val len = value.length
       while (i < len) {
-        h = h * 31 + Character.toLowerCase(value.charAt(i))
+        // Strings are equal igoring case if either their uppercase or lowercase
+        // forms are equal. Equality of one does not imply the other, so we need
+        // to go in both directions. A character is not guaranteed to make this
+        // round trip, but it doesn't matter as long as all equal characters
+        // hash the same.
+        h = h * 31 + Character.toUpperCase(Character.toLowerCase(value.charAt(i)))
         i += 1
       }
       hash = h

--- a/tests/src/test/scala/org/http4s/util/CaseInsensitiveStringSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/CaseInsensitiveStringSpec.scala
@@ -28,9 +28,28 @@ class CaseInsensitiveStringSpec extends Http4sSpec {
   "hashCode" should {
     "be consistent with equality" in {
       prop { s: String =>
-        val lc = s.toLowerCase(Locale.ROOT)
+        val lc = s.toUpperCase(Locale.ROOT)
         (s.ci == lc.ci) ==> (s.ci.## == lc.ci.##)
       }
+    }
+
+    "be consistent with equality for ὈΔΥΣΣΕΎΣ and Ὀδυσσεύς" in {
+      // ς and Σ are equal in their uppercase forms but not their lowercase
+      // forms, so these words are equal ignoring case, but a hashcode based on
+      // lowercase forms is not equal. This is the Greek word for Odysseus.
+      val s = "ὈΔΥΣΣΕΎΣ"
+      val t = "Ὀδυσσεύς"
+      (s.ci == t.ci) && (s.ci.## == t.ci.##)
+    }
+
+    "be consistent with equality for Straße and STRAẞE" in {
+      // ẞ and ß are equal in their lowercase forms but not their uppercase
+      // forms, so these words are equal ignoring case, but a hashcode based on
+      // uppercase forms is not equal. This is the German word for street,
+      // acceptably uppercased for a 2017 orthographical reform.
+      val s = "Straße"
+      val t = "STRAẞE"
+      (s.ci == t.ci) && (s.ci.## == t.ci.##)
     }
   }
 


### PR DESCRIPTION
This is a latent bug finally uncovered by property testing in [this build](https://travis-ci.org/http4s/http4s/jobs/259076280#L3246).