### PR TITLE
Add Content-Length header to empty response generators

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -46,15 +46,22 @@ trait EntityResponseGenerator extends Any with EmptyResponseGenerator {
 }
 
 trait LocationResponseGenerator extends Any with ResponseGenerator {
-  def apply(location: Uri): Task[Response] = Task.now(Response(status).putHeaders(Location(location)))
+  def apply(location: Uri): Task[Response] =
+    Task.now(Response(status = status, headers = Headers(`Content-Length`.zero, Location(location))))
 }
 
 trait WwwAuthenticateResponseGenerator extends Any with ResponseGenerator {
   def apply(challenge: Challenge, challenges: Challenge*): Task[Response] =
-    Task.now(Response(status).putHeaders(`WWW-Authenticate`(challenge, challenges: _*)))
+    Task.now(Response(
+      status = status,
+      headers = Headers(`Content-Length`.zero, `WWW-Authenticate`(challenge, challenges: _*))
+    ))
 }
 
 trait ProxyAuthenticateResponseGenerator extends Any with ResponseGenerator {
   def apply(challenge: Challenge, challenges: Challenge*): Task[Response] =
-    Task.now(Response(status).putHeaders(`Proxy-Authenticate`(challenge, challenges: _*)))
+    Task.now(Response(
+      status = status,
+      headers = Headers(`Content-Length`.zero, `Proxy-Authenticate`(challenge, challenges: _*))
+    ))
 }


### PR DESCRIPTION
Added the `Content-Length: 0` header for responses with an obviously empty body.

I didn't touch `EmptyResponseGenerator`, because I don't know if it's intended to be used with status codes forbidden to have a body.