### PR TITLE
Instances for QueryParam codec

### DIFF
--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -2,7 +2,7 @@ package org.http4s
 
 import scalaz.std.anyVal._
 import scalaz.syntax.validation._
-import scalaz.{Show, Validation, ValidationNel}
+import scalaz.{Show, Validation, ValidationNel, Functor, Contravariant, PlusEmpty}
 
 
 final case class QueryParameterKey(value: String) extends AnyVal
@@ -42,8 +42,16 @@ object QueryParamKeyLike {
  * Type class defining how to encode a `T` as a [[QueryParameterValue]]s
  * @see QueryParamCodecLaws
  */
-trait QueryParamEncoder[T] {
+trait QueryParamEncoder[T] { outer =>
   def encode(value: T): QueryParameterValue
+
+  /** QueryParamEncoder is a contravariant functor. */
+  def contramap[U](f: U => T): QueryParamEncoder[U] =
+    new QueryParamEncoder[U] {
+      override def encode(value: U) =
+        outer.encode(f(value))
+    }
+
 }
 
 object QueryParamEncoder {
@@ -51,25 +59,41 @@ object QueryParamEncoder {
   /** summon an implicit [[QueryParamEncoder]] */
   def apply[T](implicit ev: QueryParamEncoder[T]): QueryParamEncoder[T] = ev
 
-  def encodeBy[T, U: QueryParamEncoder](f: T => U): QueryParamEncoder[T] = new QueryParamEncoder[T] {
-    def encode(value: T): QueryParameterValue =
-      QueryParamEncoder[U].encode(f(value))
-  }
+  /** QueryParamEncoder is a contravariant functor. */
+  implicit val ContravariantQueryParamEncoder: Contravariant[QueryParamEncoder] =
+    new Contravariant[QueryParamEncoder] {
+      override def contramap[A, B](fa: QueryParamEncoder[A])(f: B => A) =
+        fa.contramap(f)
+    }
 
-  def encode[T](f: T => String): QueryParamEncoder[T] = new QueryParamEncoder[T] {
-    def encode(value: T): QueryParameterValue =
-      QueryParameterValue(f(value))
-  }
+  @deprecated("Use QueryParamEncoder[U].contramap(f)", "0.17")
+  def encodeBy[T, U](f: T => U)(
+    implicit qpe: QueryParamEncoder[U]
+  ): QueryParamEncoder[T] =
+    qpe.contramap(f)
 
-  def fromShow[T: Show]: QueryParamEncoder[T] = encode(Show[T].shows)
+  @deprecated("Use QueryParamEncoder[String].contramap(f)", "0.17")
+  def encode[T](f: T => String): QueryParamEncoder[T] =
+    stringQueryParamEncoder.contramap(f)
 
-  implicit val booleanQueryParamEncoder: QueryParamEncoder[Boolean] = fromShow[Boolean]
-  implicit val doubleQueryParamEncoder : QueryParamEncoder[Double]  = fromShow[Double]
-  implicit val floatQueryParamEncoder  : QueryParamEncoder[Float]   = fromShow[Float]
-  implicit val shortQueryParamEncoder  : QueryParamEncoder[Short]   = fromShow[Short]
-  implicit val intQueryParamEncoder    : QueryParamEncoder[Int]     = fromShow[Int]
-  implicit val longQueryParamEncoder   : QueryParamEncoder[Long]    = fromShow[Long]
-  implicit val stringQueryParamEncoder : QueryParamEncoder[String]  = encode(identity)
+  def fromShow[T](
+    implicit sh: Show[T]
+  ): QueryParamEncoder[T] =
+    stringQueryParamEncoder.contramap(sh.shows)
+
+  implicit lazy val booleanQueryParamEncoder: QueryParamEncoder[Boolean] = fromShow[Boolean]
+  implicit lazy val doubleQueryParamEncoder : QueryParamEncoder[Double]  = fromShow[Double]
+  implicit lazy val floatQueryParamEncoder  : QueryParamEncoder[Float]   = fromShow[Float]
+  implicit lazy val shortQueryParamEncoder  : QueryParamEncoder[Short]   = fromShow[Short]
+  implicit lazy val intQueryParamEncoder    : QueryParamEncoder[Int]     = fromShow[Int]
+  implicit lazy val longQueryParamEncoder   : QueryParamEncoder[Long]    = fromShow[Long]
+
+  implicit lazy val stringQueryParamEncoder : QueryParamEncoder[String]  =
+    new QueryParamEncoder[String] {
+      override def encode(value: String) =
+        QueryParameterValue(value)
+    }
+
 }
 
 
@@ -77,8 +101,23 @@ object QueryParamEncoder {
  * Type class defining how to decode a [[QueryParameterValue]] into a `T`
  * @see QueryParamCodecLaws
  */
-trait QueryParamDecoder[T] {
+trait QueryParamDecoder[T] { outer =>
   def decode(value: QueryParameterValue): ValidationNel[ParseFailure, T]
+
+  /** QueryParamDecoder is a covariant functor. */
+  def map[U](f: T => U): QueryParamDecoder[U] =
+    new QueryParamDecoder[U] {
+      override def decode(value: QueryParameterValue) =
+        outer.decode(value).map(f)
+    }
+
+  /** Use another decoder if this one fails. */
+  def orElse[U >: T](qpd: QueryParamDecoder[U]): QueryParamDecoder[U] =
+    new QueryParamDecoder[U] {
+      override def decode(value: QueryParameterValue) =
+        outer.decode(value) orElse qpd.decode(value)
+    }
+
 }
 
 object QueryParamDecoder {
@@ -92,33 +131,56 @@ object QueryParamDecoder {
       ).toValidationNel
   }
 
-  def decodeBy[T, U: QueryParamDecoder](f: U => T): QueryParamDecoder[T] = new QueryParamDecoder[T] {
-    def decode(value: QueryParameterValue): ValidationNel[ParseFailure, T] =
-      QueryParamDecoder[U].decode(value) map f
-  }
+  /** QueryParamDecoder is a covariant functor. */
+  implicit val FunctorQueryParamDecoder: Functor[QueryParamDecoder] =
+    new Functor[QueryParamDecoder] {
+      override def map[A, B](fa: QueryParamDecoder[A])(f: A => B) =
+        fa.map(f)
+    }
 
+  /** QueryParamDecoder is a PlusEmpty. */
+  implicit val PlusEmptyQueryParamDecoder: PlusEmpty[QueryParamDecoder] =
+    new PlusEmpty[QueryParamDecoder] {
+      def empty[A] =
+        FunctorQueryParamDecoder.widen[Nothing, A](nothingQueryParamDecoder)
+      def plus[A](a: QueryParamDecoder[A], b: => QueryParamDecoder[A]) =
+        a.orElse(b)
+    }
 
-  implicit val booleanQueryParamDecoder: QueryParamDecoder[Boolean] =
+  @deprecated("Use QueryParamEncoder[T].map(f)", "0.17")
+  def decodeBy[U, T](f: T => U)(
+    implicit qpd: QueryParamDecoder[T]
+  ): QueryParamDecoder[U] =
+    qpd.map(f)
+
+  /** A decoder that always fails. */
+  implicit lazy val nothingQueryParamDecoder: QueryParamDecoder[Nothing] =
+    new QueryParamDecoder[Nothing] {
+      override def decode(value: QueryParameterValue) =
+        Validation.failureNel(ParseFailure("Failed.", "Nothing decoder always fails."))
+    }
+
+  implicit lazy val booleanQueryParamDecoder: QueryParamDecoder[Boolean] =
     fromUnsafeCast[Boolean](_.value.toBoolean)("Boolean")
-  implicit val doubleQueryParamDecoder: QueryParamDecoder[Double] =
+  implicit lazy val doubleQueryParamDecoder: QueryParamDecoder[Double] =
     fromUnsafeCast[Double](_.value.toDouble)("Double")
-  implicit val floatQueryParamDecoder: QueryParamDecoder[Float] =
+  implicit lazy val floatQueryParamDecoder: QueryParamDecoder[Float] =
     fromUnsafeCast[Float](_.value.toFloat)("Float")
-  implicit val shortQueryParamDecoder: QueryParamDecoder[Short] =
+  implicit lazy val shortQueryParamDecoder: QueryParamDecoder[Short] =
     fromUnsafeCast[Short](_.value.toShort)("Short")
-  implicit val intQueryParamDecoder: QueryParamDecoder[Int] =
+  implicit lazy val intQueryParamDecoder: QueryParamDecoder[Int] =
     fromUnsafeCast[Int](_.value.toInt)("Int")
-  implicit val longQueryParamDecoder: QueryParamDecoder[Long] =
+  implicit lazy val longQueryParamDecoder: QueryParamDecoder[Long] =
     fromUnsafeCast[Long](_.value.toLong)("Long")
 
-  implicit val charQueryParamDecoder: QueryParamDecoder[Char] = new QueryParamDecoder[Char]{
+  implicit lazy val charQueryParamDecoder: QueryParamDecoder[Char] = new QueryParamDecoder[Char]{
     def decode(value: QueryParameterValue): ValidationNel[ParseFailure, Char] =
       if(value.value.size == 1) value.value.head.successNel
       else ParseFailure("Failed to parse Char query parameter",
                        s"Could not parse ${value.value} as a Char") .failureNel
   }
 
-  implicit val stringQueryParamDecoder: QueryParamDecoder[String] = new QueryParamDecoder[String]{
+  implicit lazy val stringQueryParamDecoder: QueryParamDecoder[String] = new QueryParamDecoder[String]{
     def decode(value: QueryParameterValue): ValidationNel[ParseFailure, String] =
       value.value.successNel
   }

--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -66,13 +66,13 @@ object QueryParamEncoder {
         fa.contramap(f)
     }
 
-  @deprecated("Use QueryParamEncoder[U].contramap(f)", "0.17")
+  @deprecated("Use QueryParamEncoder[U].contramap(f)", "0.16")
   def encodeBy[T, U](f: T => U)(
     implicit qpe: QueryParamEncoder[U]
   ): QueryParamEncoder[T] =
     qpe.contramap(f)
 
-  @deprecated("Use QueryParamEncoder[String].contramap(f)", "0.17")
+  @deprecated("Use QueryParamEncoder[String].contramap(f)", "0.16")
   def encode[T](f: T => String): QueryParamEncoder[T] =
     stringQueryParamEncoder.contramap(f)
 
@@ -142,24 +142,30 @@ object QueryParamDecoder {
   implicit val PlusEmptyQueryParamDecoder: PlusEmpty[QueryParamDecoder] =
     new PlusEmpty[QueryParamDecoder] {
       def empty[A] =
-        FunctorQueryParamDecoder.widen[Nothing, A](nothingQueryParamDecoder)
+        fail[A]("Decoding failed.", "Empty decoder (always fails).")
       def plus[A](a: QueryParamDecoder[A], b: => QueryParamDecoder[A]) =
         a.orElse(b)
     }
 
-  @deprecated("Use QueryParamEncoder[T].map(f)", "0.17")
+  @deprecated("Use QueryParamEncoder[T].map(f)", "0.16")
   def decodeBy[U, T](f: T => U)(
     implicit qpd: QueryParamDecoder[T]
   ): QueryParamDecoder[U] =
     qpd.map(f)
 
+  /** A decoder that always succeeds. */
+  def success[A](a: A): QueryParamDecoder[A] =
+    fromUnsafeCast[A](_ => a)("Success")
+
   /** A decoder that always fails. */
-  implicit lazy val nothingQueryParamDecoder: QueryParamDecoder[Nothing] =
-    new QueryParamDecoder[Nothing] {
+  def fail[A](sanitized: String, detail: String): QueryParamDecoder[A] =
+    new QueryParamDecoder[A] {
       override def decode(value: QueryParameterValue) =
-        Validation.failureNel(ParseFailure("Failed.", "Nothing decoder always fails."))
+        Validation.failureNel(ParseFailure(sanitized, detail))
     }
 
+  implicit lazy val unitQueryParamDecoder: QueryParamDecoder[Unit] =
+    success(())
   implicit lazy val booleanQueryParamDecoder: QueryParamDecoder[Boolean] =
     fromUnsafeCast[Boolean](_.value.toBoolean)("Boolean")
   implicit lazy val doubleQueryParamDecoder: QueryParamDecoder[Double] =

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
@@ -17,7 +17,7 @@ object PathInHttpServiceSpec extends Http4sSpec {
 
   final case class Limit(l: Long)
   implicit val limitQueryParam = QueryParam.fromKey[Limit]("limit")
-  implicit val limitDecoder    = QueryParamDecoder.decodeBy[Limit, Long](Limit.apply)
+  implicit val limitDecoder    = QueryParamDecoder[Long].map(Limit.apply)
 
   object L extends QueryParamMatcher[Limit]
 

--- a/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
@@ -1,9 +1,13 @@
 package org.http4s
 
-import scalaz.std.string._
-import scalaz.std.anyVal._
+import scalaz.{ Equal, Validation, NonEmptyList }
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazArbitrary._
 
-class QueryParamCodecSpec extends Http4sSpec {
+import org.scalacheck.{ Arbitrary, Cogen }
+import org.scalacheck.Arbitrary._
+
+class QueryParamCodecSpec extends Http4sSpec with QueryParamCodecInstances {
 
   checkAll("Boolean QueryParamCodec", QueryParamCodecLaws[Boolean])
   checkAll("Double QueryParamCodec" , QueryParamCodecLaws[Double])
@@ -12,4 +16,40 @@ class QueryParamCodecSpec extends Http4sSpec {
   checkAll("Int QueryParamCodec"    , QueryParamCodecLaws[Int])
   checkAll("Long QueryParamCodec"   , QueryParamCodecLaws[Long])
   checkAll("String QueryParamCodec" , QueryParamCodecLaws[String])
+
+  // Law checks for instances.
+  checkAll("Functor[QueryParamDecoder]", functor.laws[QueryParamDecoder])
+  checkAll("PlusEmpty[QueryParamDecoder]", plusEmpty.laws[QueryParamDecoder])
+  checkAll("Contravariant[QueryParamEncoder]", contravariant.laws[QueryParamEncoder])
+
+}
+
+trait QueryParamCodecInstances { this: Http4sSpec =>
+
+  // We will assume for the purposes of testing that QueryParamDecoders are equal if they
+  // produce the same result for a bunch of arbitrary strings.
+  implicit def EqQueryParamDecoder[A: Equal]: Equal[QueryParamDecoder[A]] = {
+    val vnp = Equal[Validation[NonEmptyList[ParseFailure], A]]
+    Equal.equal { (x, y) =>
+      val ss = List.fill(50)(arbitrary[String].sample).flatten.map(QueryParameterValue.apply)
+      ss.forall(s => vnp.equal(x.decode(s), y.decode(s)))
+    }
+  }
+
+  // We will assume for the purposes of testing that QueryParamEncoders are equal if they
+  // produce the same result for a bunch of arbitrary inputs.
+  implicit def EqQueryParamEncoder[A: Arbitrary]: Equal[QueryParamEncoder[A]] = {
+    Equal.equal { (x, y) =>
+      val as = List.fill(20)(arbitrary[A].sample).flatten
+      as.forall(a => x.encode(a) === y.encode(a))
+    }
+  }
+
+  implicit def ArbQueryParamDecoder[A: Arbitrary]: Arbitrary[QueryParamDecoder[A]] =
+    Arbitrary(arbitrary[String => A].map(QueryParamDecoder[String].map))
+
+  implicit def ArbQueryParamEncoder[A: Cogen]: Arbitrary[QueryParamEncoder[A]] =
+    Arbitrary(arbitrary[A => String].map(QueryParamEncoder[String].contramap))
+
+
 }


### PR DESCRIPTION
This adds instances for `QueryParamEncoder` and `QueryParamDecoder`. Instances are constructed lazily to avoid initialization issues.