### PR TITLE
Provide a way to retrieve all cookies from a response

### DIFF
--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -37,6 +37,10 @@ final class Headers private (headers: List[Header])
     */
   def get(key: HeaderKey.Extractable): Option[key.HeaderT] = key.from(this)
 
+  @deprecated("Use response.cookies instead. Set-Cookie is unique among HTTP headers in that it can be repeated but can't be joined by a ','. This will return only the first Set-Cookie header. `response.cookies` will return the complete list.", "0.16.0-RC1")
+  def get(key: `Set-Cookie`.type): Option[`Set-Cookie`] =
+    key.from(this).headOption
+
   /** Attempt to get a [[org.http4s.Header]] from this collection of headers
     *
     * @param key name of the header to find

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -304,6 +304,12 @@ final case class Response(
 
   override def toString: String =
     s"""Response(status=${status.code}, headers=$headers)"""
+
+  /** Returns a list of cookies from the [[org.http4s.headers.Set-Cookie]]
+    * headers. Includes expired cookies, such as those that represent cookie
+    * deletion. */
+  def cookies: List[Cookie] =
+    `Set-Cookie`.from(headers).map(_.cookie)
 }
 
 object Response {

--- a/core/src/main/scala/org/http4s/headers/Set-Cookie.scala
+++ b/core/src/main/scala/org/http4s/headers/Set-Cookie.scala
@@ -1,10 +1,22 @@
 package org.http4s
 package headers
 
+import scala.annotation.tailrec
 import org.http4s.parser.HttpHeaderParser
-import org.http4s.util.Writer
+import org.http4s.util.{NonEmptyList, Writer}
 
-object `Set-Cookie` extends HeaderKey.Internal[`Set-Cookie`] with HeaderKey.Singleton {
+object `Set-Cookie` extends HeaderKey.Internal[`Set-Cookie`] {
+  def from(headers: Headers): List[`Set-Cookie`] =
+    headers.toList.map(matchHeader).collect {
+      case Some(h) => h
+    }
+
+  def unapply(headers: Headers): Option[NonEmptyList[`Set-Cookie`]] =
+    from(headers) match {
+      case Nil => None
+      case h :: t => Some(NonEmptyList(h, t:_*))
+    }
+
   override def parse(s: String): ParseResult[`Set-Cookie`] =
     HttpHeaderParser.SET_COOKIE(s)
 }

--- a/tests/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/tests/src/test/scala/org/http4s/ResponderSpec.scala
@@ -74,15 +74,23 @@ class ResponderSpec extends Specification {
       newHeaders.headers.get(Connection) must beNone
     }
 
-    "Set cookie" in {
-      resp.addCookie("foo", "bar").headers.get(`Set-Cookie`) must beSome(`Set-Cookie`(org.http4s.Cookie("foo", "bar")))
-      resp.addCookie(Cookie("foo", "bar")).headers.get(`Set-Cookie`) must beSome(`Set-Cookie`(org.http4s.Cookie("foo", "bar")))
+    "Set cookie from tuple" in {
+      resp.addCookie("foo", "bar").cookies must_== List(org.http4s.Cookie("foo", "bar"))
+    }
+
+    "Set cookie from Cookie" in {
+      resp.addCookie(Cookie("foo", "bar")).cookies must_== List(org.http4s.Cookie("foo", "bar"))
+    }
+
+    "Set multiple cookies" in {
+      resp.addCookie(Cookie("foo", "bar")).addCookie(Cookie("baz", "quux")).cookies must_== List(org.http4s.Cookie("foo", "bar"), org.http4s.Cookie("baz", "quux"))
     }
 
     "Remove cookie" in {
       val cookie = Cookie("foo", "bar")
-      resp.removeCookie(cookie).headers.get(`Set-Cookie`) must
-        beSome(`Set-Cookie`(org.http4s.Cookie("foo", "", expires = Option(Instant.ofEpochSecond(0)), maxAge = Some(0L))))
+      resp.removeCookie(cookie).cookies must_== List(
+        org.http4s.Cookie("foo", "", expires = Option(Instant.ofEpochSecond(0)), maxAge = Some(0L))
+      )
     }
   }
 }


### PR DESCRIPTION
Set-Cookie is such an odd, out-of-spec header, I propose that it ceases to be `Extractable` at all.  We instead provide an accessor for the cookies on the Response that returns the entire list.

Fixes #1299.

/cc @megri 