### PR TITLE
cats 1.0.0-MF, fs2 0.10.0-M5

### DIFF
--- a/core/src/main/scala/org/http4s/Entity.scala
+++ b/core/src/main/scala/org/http4s/Entity.scala
@@ -9,7 +9,7 @@ object Entity {
   implicit def entityInstance[F[_]]: Monoid[Entity[F]] =
     new Monoid[Entity[F]] {
       def combine(a1: Entity[F], a2: Entity[F]): Entity[F] =
-        Entity(a1.body ++ a2.body, (a1.length |@| a2.length).map(_ + _))
+        Entity(a1.body ++ a2.body, (a1.length, a2.length).mapN(_ + _))
       val empty: Entity[F] =
         Entity.empty
     }

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -254,11 +254,11 @@ power here.  This stream emits the elapsed time every 100 milliseconds
 for one second:
 
 ```tut:book
-implicit val scheduler = fs2.Scheduler.fromFixedDaemonPool(2, threadName = "scheduler")
-val drip = {
-  import scala.concurrent.duration._
-  fs2.time.awakeEvery[IO](100.millis).map(_.toString).take(10)
-}
+val drip: fs2.Stream[IO, String] =
+  fs2.Scheduler[IO](2).flatMap { s =>
+    import scala.concurrent.duration._
+    s.awakeEvery[IO](100.millis).map(_.toString).take(10)
+  }
 ```
 
 We can see it for ourselves in the REPL:

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -162,7 +162,7 @@ import org.http4s.server.blaze._
 import org.http4s.util.StreamApp
 
 object Main extends StreamApp[IO] {
-  override def stream(args: List[String]): Stream[IO, Nothing] = {
+  override def stream(args: List[String], requestShutdown: IO[Unit]) = {
     BlazeBuilder[IO]
       .bindHttp(8080, "localhost")
       .mountService(helloWorldService, "/")

--- a/docs/src/main/tut/streaming.md
+++ b/docs/src/main/tut/streaming.md
@@ -20,16 +20,12 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import cats.effect._
-import fs2.time
 import fs2.Scheduler
 import org.http4s._
 import org.http4s.dsl._
 
-// fs2's `time` module needs an implicit `Scheduler`
-implicit val scheduler = Scheduler.fromFixedDaemonPool(2)
-
 // An infinite stream of the periodic elapsed time
-val seconds = time.awakeEvery[IO](1.second)
+val seconds = Scheduler[IO](2).flatMap(_.awakeEvery[IO](1.second))
 
 val service = HttpService[IO] {
   case GET -> Root / "seconds" =>
@@ -127,7 +123,7 @@ object twstream {
     val s   = stream("<consumerKey>", "<consumerSecret>", "<accessToken>", "<accessSecret>")(req)
     s.map(_.spaces2).through(lines).through(utf8Encode).to(stdout).onFinalize(client.shutdown).run
   }
-  
+
   // Uncomment To Run App
   // def main(args: Array[String]): Unit = runc.unsafeRunSync()
 }

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -100,14 +100,14 @@ object Http4sPlugin extends AutoPlugin {
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.0.32"
   lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.12.5"
   lazy val catsKernelLaws                   = "org.typelevel"          %% "cats-kernel-laws"          % catsLaws.revision
-  lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % "0.9.0"
+  lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % "1.0.0-MF"
   lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % circeJawn.revision
   lazy val circeJawn                        = "io.circe"               %% "circe-jawn"                % "0.8.0"
   lazy val circeLiteral                     = "io.circe"               %% "circe-literal"             % circeJawn.revision
   lazy val circeParser                      = "io.circe"               %% "circe-parser"              % circeJawn.revision
   lazy val cryptobits                       = "org.reactormonk"        %% "cryptobits"                % "1.1"
   lazy val discipline                       = "org.typelevel"          %% "discipline"                % "0.7.3"
-  lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "0.10.0-M4"
+  lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "0.10.0-M5"
   lazy val fs2ReactiveStreams               = "com.github.zainab-ali"  %% "fs2-reactive-streams"      % "0.2.0"
   lazy val fs2Scodec                        = "co.fs2"                 %% "fs2-scodec"                % fs2Io.revision
   lazy val gatlingTest                      = "io.gatling"             %  "gatling-test-framework"    % "2.2.3"


### PR DESCRIPTION
As it says on the tin. Note that circe hasn't been updated to 1.0.0-MF yet … the test pass but it's probably flaky in real life. Options include turning that module off for the milestone or saying  `¯\_(ツ)_/¯` which is what I would probably do.