### PR TITLE
Provide content-length header when serving from a URL

### DIFF
--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -5,8 +5,10 @@ import java.net.URL
 import java.nio.file.{Path, StandardOpenOption}
 import java.time.Instant
 
+import cats.data._
 import fs2._
 import fs2.Stream._
+import fs2.interop.cats._
 import fs2.io._
 import fs2.io.file.{FileHandle, pulls}
 import fs2.util.Suspendable
@@ -22,26 +24,26 @@ object StaticFile {
 
   val DefaultBufferSize = 10240
 
-  def fromString(url: String, req: Option[Request] = None): Option[Response] = {
+  def fromString(url: String, req: Option[Request] = None): OptionT[Task, Response] = {
     fromFile(new File(url), req)
   }
 
-  def fromResource(name: String, req: Option[Request] = None, preferGzipped: Boolean = false): Option[Response] = {
+  def fromResource(name: String, req: Option[Request] = None, preferGzipped: Boolean = false): OptionT[Task, Response] = {
     val tryGzipped = preferGzipped && req.flatMap(_.headers.get(`Accept-Encoding`)).exists { acceptEncoding =>
       acceptEncoding.satisfiedBy(ContentCoding.gzip) || acceptEncoding.satisfiedBy(ContentCoding.`x-gzip`)
     }
 
-    val gzUrl = if (tryGzipped) Option(getClass.getResource(name + ".gz")) else None
-    gzUrl.map { url =>
+    val gzUrl: OptionT[Task, URL] =
+      if (tryGzipped) OptionT.fromOption(Option(getClass.getResource(name + ".gz")))      else OptionT.none
+    gzUrl.flatMap { url =>
       // Guess content type from the name without ".gz"
       val contentType = nameToContentType(name)
       val headers = `Content-Encoding`(ContentCoding.gzip) :: contentType.toList
-
       fromURL(url, req).map(_.removeHeader(`Content-Type`).putHeaders(headers: _*))
-    } getOrElse Option(getClass.getResource(name)).flatMap(fromURL(_, req))
+    } orElse OptionT.fromOption[Task](Option(getClass.getResource(name))).flatMap(fromURL(_, req))
   }
 
-  def fromURL(url: URL, req: Option[Request] = None): Option[Response] = {
+  def fromURL(url: URL, req: Option[Request] = None): OptionT[Task, Response] = OptionT.liftF(Task.delay {
     val lastmod = Instant.ofEpochMilli(url.openConnection.getLastModified)
     val expired = req
       .flatMap(_.headers.get(`If-Modified-Since`)).forall(_.date.compareTo(lastmod) < 0)
@@ -50,25 +52,25 @@ object StaticFile {
       val contentType = nameToContentType(url.getPath)
       val headers = Headers(`Last-Modified`(lastmod) :: contentType.toList)
 
-      Some(Response(
+      Response(
         headers = headers,
         body    = readInputStream[Task](Task.delay(url.openStream), DefaultBufferSize)
           // These chunks wrap a mutable array, and we might be buffering
           // or processing them concurrently later.  Convert to something
           // immutable here for safety.
           .mapChunks(c => ByteVectorChunk(ByteVector(c.toArray)))
-      ))
-    } else Some(Response(NotModified))
-  }
+      )
+    } else Response(NotModified)
+  })
 
-  def fromFile(f: File, req: Option[Request] = None): Option[Response] =
+  def fromFile(f: File, req: Option[Request] = None): OptionT[Task, Response] =
     fromFile(f, DefaultBufferSize, req)
 
-  def fromFile(f: File, buffsize: Int, req: Option[Request]): Option[Response] = {
+  def fromFile(f: File, buffsize: Int, req: Option[Request]): OptionT[Task, Response] = {
     fromFile(f, 0, f.length(), buffsize, req)
   }
 
-  def fromFile(f: File, start: Long, end: Long, buffsize: Int, req: Option[Request]): Option[Response] = {
+  def fromFile(f: File, start: Long, end: Long, buffsize: Int, req: Option[Request]): OptionT[Task, Response] = OptionT(Task.delay {
     if (f.isFile) {
       require (start >= 0 && end >= start && buffsize > 0, s"start: $start, end: $end, buffsize: $buffsize")
 
@@ -105,7 +107,7 @@ object StaticFile {
     } else {
       None
     }
-  }
+  })
 
   private def fileToBody(f: File, start: Long, end: Long, buffsize: Int): EntityBody = {
     // Based on fs2 handling of files
@@ -120,7 +122,7 @@ object StaticFile {
       } yield next
 
     def readAll[F[_]: Suspendable](path: Path, chunkSize: Int): Stream[F, Byte] =
-      pulls.fromPath(path, List(StandardOpenOption.READ)).flatMap(readAllFromFileHandle(chunkSize, start, end)).close
+      pulls.fromPath[F](path, List(StandardOpenOption.READ)).flatMap(readAllFromFileHandle(chunkSize, start, end)).close
 
     readAll[Task](f.toPath, DefaultBufferSize)
   }

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -66,7 +66,10 @@ object StaticFile {
           // immutable here for safety.
           .mapChunks(c => ByteVectorChunk(ByteVector(c.toArray)))
       )
-    } else Response(NotModified)
+    } else {
+      urlConn.getInputStream.close()
+      Response(NotModified)
+    }
   })
 
   def fromFile(f: File, req: Option[Request] = None): OptionT[Task, Response] =

--- a/docs/src/main/tut/static.md
+++ b/docs/src/main/tut/static.md
@@ -21,12 +21,12 @@ import org.http4s._
 import org.http4s.dsl._
 import java.io.File
 import fs2.Task
+import fs2.interop.cats._
 
 val service = HttpService {
   case request @ GET -> Root / "index.html" =>
     StaticFile.fromFile(new File("relative/path/to/index.html"), Some(request))
-      .map(Task.now) // This one is require to make the types match up
-      .getOrElse(NotFound()) // In case the file doesn't exist
+      .getOrElseF(NotFound()) // In case the file doesn't exist
 }
 ```
 
@@ -36,7 +36,7 @@ deliver them from there. Append to the `List` as needed.
 
 ```tut:book
 def static(file: String, request: Request) =
-  StaticFile.fromResource("/" + file, Some(request)).map(Task.now).getOrElse(NotFound())
+  StaticFile.fromResource("/" + file, Some(request)).getOrElseF(NotFound())
 
 val service = HttpService {
   case request @ GET -> Root / path if List(".js", ".css", ".map", ".html", ".webm").exists(path.endsWith) =>

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -5,6 +5,7 @@ import scala.concurrent._
 import scala.concurrent.duration._
 
 import fs2._
+import fs2.interop.cats._
 import _root_.io.circe.Json
 import org.http4s._
 import org.http4s.MediaType._
@@ -68,7 +69,7 @@ object ExampleService {
       // captures everything after "/static" into `path`
       // Try http://localhost:8080/http4s/static/nasa_blackhole_image.jpg
       // See also org.http4s.server.staticcontent to create a mountable service for static content
-      StaticFile.fromResource(path.toString, Some(req)).fold(NotFound())(Task.now)
+      StaticFile.fromResource(path.toString, Some(req)).getOrElseF(NotFound())
 
     ///////////////////////////////////////////////////////////////
     //////////////// Dealing with the message body ////////////////
@@ -151,8 +152,7 @@ object ExampleService {
 
     case req @ GET -> Root / "image.jpg" =>
       StaticFile.fromResource("/nasa_blackhole_image.jpg", Some(req))
-        .map(Task.now)
-        .getOrElse(NotFound())
+        .getOrElseF(NotFound())
 
     ///////////////////////////////////////////////////////////////
     //////////////////////// Multi Part //////////////////////////

--- a/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
@@ -2,6 +2,8 @@ package org.http4s
 package server
 package staticcontent
 
+import cats.implicits._
+import fs2.interop.cats._
 import scala.concurrent.ExecutionContext
 
 object ResourceService {
@@ -35,5 +37,6 @@ object ResourceService {
           preferGzipped = config.preferGzipped
         )
         .fold(Pass.now)(config.cacheStrategy.cache(uriPath, _))
+        .flatten
   }
 }

--- a/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -2,7 +2,9 @@ package org.http4s
 package server
 package staticcontent
 
+import cats.implicits._
 import fs2.Task
+import fs2.interop.cats._
 
 /**
   * Constructs new services to serve assets from Webjars
@@ -99,4 +101,5 @@ object WebjarService {
     StaticFile
       .fromResource(webjarAsset.pathInJar, Some(request))
       .fold(Pass.now)(config.cacheStrategy.cache(request.pathInfo, _))
+      .flatten
 }

--- a/tests/src/test/scala/org/http4s/StaticFileSpec.scala
+++ b/tests/src/test/scala/org/http4s/StaticFileSpec.scala
@@ -109,5 +109,12 @@ class StaticFileSpec extends Http4sSpec {
       // things like CachingChunkWriter that buffer the chunks.
       new String(Chunk.concat(s.chunks.runLog.unsafeRun).toArray, "utf-8") must_== expected
     }
+
+    "Set content-length header from a URL" in {
+      val url = getClass.getResource("/lorem-ipsum.txt")
+      val len = StaticFile.fromURL(getClass.getResource("/lorem-ipsum.txt"))
+        .value.map(_.flatMap(_.contentLength))
+      len must returnValue(Some(24005L))
+    }
   }
 }

--- a/tests/src/test/scala/org/http4s/StaticFileSpec.scala
+++ b/tests/src/test/scala/org/http4s/StaticFileSpec.scala
@@ -100,7 +100,7 @@ class StaticFileSpec extends Http4sSpec {
     "Read from a URL" in {
       val url = getClass.getResource("/lorem-ipsum.txt")
       val expected = scala.io.Source.fromURL(url, "utf-8").mkString
-      val s = StaticFile.fromURL(getClass.getResource("/lorem-ipsum.txt"))
+      val s = StaticFile.fromURL(url)
         .value.unsafeRun
         .fold[EntityBody](sys.error("Couldn't find resource"))(_.body)
       // Expose problem with readInputStream recycling buffer.  chunks.runLog
@@ -112,7 +112,7 @@ class StaticFileSpec extends Http4sSpec {
 
     "Set content-length header from a URL" in {
       val url = getClass.getResource("/lorem-ipsum.txt")
-      val len = StaticFile.fromURL(getClass.getResource("/lorem-ipsum.txt"))
+      val len = StaticFile.fromURL(url)
         .value.map(_.flatMap(_.contentLength))
       len must returnValue(Some(24005L))
     }


### PR DESCRIPTION
A bunch of file I/O operations are unguarded by task, so sweep all of `StaticFile` into an `OptionT`.

Then, once safely tucked away, we can call `getContentLengthLong` on the `URLConnection`.

Fixes #1295.

/cc @ZizhengTai 