### PR TITLE
Return index.html when a directory is specified for static content

### DIFF
--- a/server/src/test/resources/testDir/index.html
+++ b/server/src/test/resources/testDir/index.html
@@ -1,0 +1,1 @@
+<html>Hello!</html>

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
@@ -45,6 +45,14 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
       rb._2.status must_== Status.Ok
     }
 
+    "Return index.html if request points to a directory" in {
+      val req = Request(uri = uri("testDir/"))
+      val rb = runReq(req)
+
+      rb._2.as[String].unsafePerformSync must_== "<html>Hello!</html>"
+      rb._2.status must_== Status.Ok
+    }
+
     "Not find missing file" in {
       val req = Request(uri = uri("testresource.txtt"))
       runReq(req)._2.status must_== (Status.NotFound)


### PR DESCRIPTION
- Change default behavior of `staticContent` to return the index.html file (when present) when the client asks for a directory
- Make it easier to extend or change the default behavior by removing the `private` modifier so it can be called from external implementations