### PR TITLE
Make a pluggable error handler for service failures

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
@@ -20,12 +20,13 @@ private object ProtocolSelector {
             maxRequestLineLen: Int,
             maxHeadersLen: Int,
             requestAttributes: AttributeMap,
-            es: ExecutorService): ALPNSelector = {
+            es: ExecutorService,
+            serviceErrorHandler: ServiceErrorHandler): ALPNSelector = {
 
     def http2Stage(): TailStage[ByteBuffer] = {
 
       val newNode = { streamId: Int =>
-        LeafBuilder(new Http2NodeStage(streamId, Duration.Inf, es, requestAttributes, service))
+        LeafBuilder(new Http2NodeStage(streamId, Duration.Inf, es, requestAttributes, service, serviceErrorHandler))
       }
 
       Http2Stage(
@@ -39,7 +40,7 @@ private object ProtocolSelector {
     }
 
     def http1Stage(): TailStage[ByteBuffer] = {
-      Http1ServerStage(service, requestAttributes, es, false, maxRequestLineLen, maxHeadersLen)
+      Http1ServerStage(service, requestAttributes, es, false, maxRequestLineLen, maxHeadersLen, serviceErrorHandler)
     }
 
     def preference(protos: Seq[String]): String = {

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -37,6 +37,12 @@ trait ServerBuilder {
     */
   def start: Task[Server]
 
+  /** Sets the handler for errors thrown invoking the service.  Is not
+    * guaranteed to be invoked on errors on the server backend, such as
+    * parsing a request or handling a context timeout.
+    */
+  def withServiceErrorHandler(serviceErrorHandler: ServiceErrorHandler): Self
+
   /** Convenience method to run a server.  The method blocks
     * until the server is started.
     */
@@ -44,9 +50,9 @@ trait ServerBuilder {
     start.unsafePerformSync
 
   /**
-   * Runs the server as a process that never emits.  Useful for a server
-   * that runs for the rest of the JVM's life.
-   */
+    * Runs the server as a process that never emits.  Useful for a server
+    * that runs for the rest of the JVM's life.
+    */
   final def serve: Process[Task, Nothing] =
     Process.bracket(start)(s => Process.eval_(s.shutdown)) { s: Server =>
       Process.eval_(task.never)

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -1,5 +1,9 @@
 package org.http4s
 
+import scala.util.control.NonFatal
+
+import org.http4s.headers.{Connection, `Content-Length`}
+import org.http4s.syntax.string._
 import org.log4s.getLogger
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
@@ -52,9 +56,20 @@ package object server {
   }
 
   private[this] val messageFailureLogger = getLogger("org.http4s.server.message-failures")
-  def messageFailureHandler(req: Request): PartialFunction[Throwable, Task[Response]] = {
+  private[this] val serviceErrorLogger = getLogger("org.http4s.server.service-errors")
+
+  type ServiceErrorHandler = Request => PartialFunction[Throwable, Task[Response]]
+
+  val DefaultServiceErrorHandler: ServiceErrorHandler = req => {
     case mf: MessageFailure =>
       messageFailureLogger.debug(mf)(s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr.getOrElse("<unknown>")}""")
       mf.toHttpResponse(req.httpVersion)
+    case NonFatal(t) =>
+      serviceErrorLogger.error(t)(s"""Error servicing request: ${req.method} ${req.pathInfo} from ${req.remoteAddr.getOrElse("<unknown>")}""")
+      Task.now(Response(Status.InternalServerError, req.httpVersion,
+                        Headers(
+                          Connection("close".ci),
+                          `Content-Length`.zero
+                        )))
   }
 }

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -4,7 +4,7 @@ package syntax
 
 import javax.servlet.{ServletRegistration, ServletContext}
 
-import org.http4s.server.AsyncTimeoutSupport
+import org.http4s.server.{AsyncTimeoutSupport, DefaultServiceErrorHandler}
 import org.http4s.util.threads.DefaultPool
 
 import scalaz.concurrent.Strategy
@@ -20,7 +20,8 @@ final class ServletContextOps private[syntax](val self: ServletContext) extends 
       service = service,
       asyncTimeout = AsyncTimeoutSupport.DefaultAsyncTimeout,
       threadPool = DefaultPool,
-      servletIo = servletIo
+      servletIo = servletIo,
+      serviceErrorHandler = DefaultServiceErrorHandler
     )
     val reg = self.addServlet(name, servlet)
     reg.setLoadOnStartup(1)


### PR DESCRIPTION
Every `ServerBuilder` gets a `ServiceErrorHandler`, which is invoked when a service returns a failed task and also when a service fails synchronously.  The default is to call `toHttpResponse` on a `MessageFailure` and close the connection with a 500 on `NonFatal` errors.  Fatal errors are left to the server.

In a server end, there are more places things can go wrong, but this will let users customize the handling in _most_ cases, and provide more uniformity across backends.  Most noticeably, Blaze in HTTP/2 was not looking for 4xx errors on `MessageFailure`.

Relates to #1312.