### PR TITLE
Revert to Lightbend compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,19 +28,19 @@ jobs:
   include:
     - &tests
       stage: Test
-      scala: 2.12.3-bin-typelevel-4
+      scala: 2.12.3
       env: SCALAZ_VERSION=7.2.15
       script: $TRAVIS_BUILD_DIR/bin/specialTest.sh
     - <<: *tests
-      scala: 2.12.3-bin-typelevel-4
+      scala: 2.12.3
       env: SCALAZ_VERSION=7.1.13
       script: $TRAVIS_BUILD_DIR/bin/test.sh
     - <<: *tests
-      scala: 2.11.11-bin-typelevel-4
+      scala: 2.11.11
       env: SCALAZ_VERSION=7.2.15
       script: $TRAVIS_BUILD_DIR/bin/test.sh
     - <<: *tests
-      scala: 2.11.11-bin-typelevel-4
+      scala: 2.11.11
       env: SCALAZ_VERSION=7.1.13
       script: $TRAVIS_BUILD_DIR/bin/test.sh
     - <<: *tests
@@ -53,25 +53,25 @@ jobs:
       script: $TRAVIS_BUILD_DIR/bin/test.sh
 
     - stage: Publish Site
-      scala: 2.12.3-bin-typelevel-4
+      scala: 2.12.3
       env: SCALAZ_VERSION=7.2.15
       script: $TRAVIS_BUILD_DIR/bin/publishSite.sh
 
     - &publishSonatype
       stage: Publish Sonatype
-      scala: 2.12.3-bin-typelevel-4
+      scala: 2.12.3
       env: SCALAZ_VERSION=7.2.15
       script: $TRAVIS_BUILD_DIR/bin/publishCentral.sh
     - <<: *publishSonatype
-      scala: 2.12.3-bin-typelevel-4
+      scala: 2.12.3
       env: SCALAZ_VERSION=7.1.13
       script: $TRAVIS_BUILD_DIR/bin/publishCentral.sh
     - <<: *publishSonatype
-      scala: 2.11.11-bin-typelevel-4
+      scala: 2.11.11
       env: SCALAZ_VERSION=7.2.15
       script: $TRAVIS_BUILD_DIR/bin/publishCentral.sh
     - <<: *publishSonatype
-      scala: 2.11.11-bin-typelevel-4
+      scala: 2.11.11
       env: SCALAZ_VERSION=7.1.13
       script: $TRAVIS_BUILD_DIR/bin/publishCentral.sh
     - <<: *publishSonatype

--- a/bin/publish
+++ b/bin/publish
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 for SCALAZ_VERSION in $(sed -ne 's/.*SCALAZ_VERSION=\(.*\)/\1/p' .travis.yml | sort | uniq); do
-    for SCALA_VERSION in 2.12.3-bin-typelevel-4 2.11.11-bin-typelevel-4 2.10.6; do
+    for SCALA_VERSION in 2.12.3 2.11.11 2.10.6; do
 	      env SCALAZ_VERSION=$SCALAZ_VERSION SCALA_VERSION=$SCALA_VERSION sbt +clean +publishSigned
     done
 done

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -27,13 +27,7 @@ object Http4sPlugin extends AutoPlugin {
     releaseVersion := { ver =>
       Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError)
     },
-    scalaVersion := (sys.env.get("TRAVIS_SCALA_VERSION") orElse sys.env.get("SCALA_VERSION") getOrElse "2.12.3-bin-typelevel-4"),
-    scalaOrganization := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n >= 11 => "org.typelevel"
-        case _ => "org.scala-lang"
-      }
-    },
+    scalaVersion := (sys.env.get("TRAVIS_SCALA_VERSION") orElse sys.env.get("SCALA_VERSION") getOrElse "2.12.3"),
 
     // Curiously missing from RigPlugin
     scalacOptions in Compile ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,7 @@ addSbtPlugin("io.gatling"         %  "gatling-sbt"           % "2.1.5")
 addSbtPlugin("io.get-coursier"    %  "sbt-coursier"          % "1.0.0-RC1")
 addSbtPlugin("io.spray"           %  "sbt-revolver"          % "0.8.0")
 addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "2.0.29")
+addSbtPlugin("org.lyranthe.sbt"   %  "partial-unification"   % "1.1.0")
 addSbtPlugin("org.tpolecat"       %  "tut-plugin"            % "0.4.8")
 addSbtPlugin("pl.project13.scala" %  "sbt-jmh"               % "0.2.24")
 


### PR DESCRIPTION
I'd prefer to stay on Typelevel Scala in order to help test it and promote it, but we don't need its extended features yet, and the resulting POMs are causing some pain.  I hope to change back after the dust settles, but it's more important to ship our releases now.

Fixes #1330.