### PR TITLE
BlazeBuilder is now setting the custom execution context passed in.

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -88,7 +88,7 @@ class BlazeBuilder(
     copy(socketAddress = socketAddress)
 
   override def withExecutionContext(ec: ExecutionContext): Self =
-    copy(executionContext = executionContext)
+    copy(executionContext = ec)
 
   override def withIdleTimeout(idleTimeout: Duration): BlazeBuilder = copy(idleTimeout = idleTimeout)
 

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
@@ -2,6 +2,10 @@ package org.http4s
 package server
 package blaze
 
+import java.util.concurrent.Executors
+
+import scala.concurrent.ExecutionContext
+
 class BlazeServerSpec extends ServerAddressSpec {
   def builder = BlazeBuilder
 
@@ -11,6 +15,20 @@ class BlazeServerSpec extends ServerAddressSpec {
     "Startup and shutdown without blocking" in {
       val s = BlazeBuilder
         .bindAny()
+        .run
+
+      s.shutdownNow()
+
+      true must_== true
+    }
+
+    "Startup with a custom ExecutionContext" in {
+      val s = BlazeBuilder
+        .bindAny()
+        .withExecutionContext(
+          ExecutionContext.
+            fromExecutorService(
+              Executors.newFixedThreadPool(5)))
         .run
 
       s.shutdownNow()


### PR DESCRIPTION
This closes #1345.