### PR TITLE
 Flush header while awaiting first chunk

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ReadBufferStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ReadBufferStageSpec.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import org.http4s.Http4sSpec
 import org.http4s.blaze.pipeline.{Command, HeadStage, LeafBuilder, TailStage}
+import org.http4s.blazecore.util.FutureUnit
 
 import scala.concurrent.{Await, Awaitable, Future, Promise}
 import scala.concurrent.duration._
@@ -83,7 +84,7 @@ class ReadBufferStageSpec extends Http4sSpec {
     val readCount = new AtomicInteger(0)
     override def readRequest(size: Int): Future[Unit] = {
       readCount.incrementAndGet()
-      Future.successful(())
+      FutureUnit
     }
 
     override def writeRequest(data: Unit): Future[Unit] = ???

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
@@ -13,6 +13,7 @@ import fs2.Stream._
 import fs2.interop.cats._
 import fs2.util.Attempt
 import org.http4s.blaze.pipeline._
+import org.http4s.util.StringWriter
 
 /** Discards the body, killing it so as to clean up resources
   *
@@ -20,26 +21,24 @@ import org.http4s.blaze.pipeline._
   * @param pipe the blaze `TailStage`, which takes ByteBuffers which will send the data downstream
   * @param ec an ExecutionContext which will be used to complete operations
   */
-class BodylessWriter(headers: ByteBuffer, pipe: TailStage[ByteBuffer], close: Boolean)
-                    (implicit protected val ec: ExecutionContext) extends EntityBodyWriter {
+class BodylessWriter(pipe: TailStage[ByteBuffer], close: Boolean)
+  (implicit protected val ec: ExecutionContext) extends Http1Writer {
+  private[this] var headers: ByteBuffer = null
 
-  private lazy val doneFuture = Future.successful( () )
+  def writeHeader(headerWriter: StringWriter): Future[Unit] =
+    pipe.channelWrite(Http1Writer.headersToByteBuffer(headerWriter.result))
 
   /** Doesn't write the entity body, just the headers. Kills the stream, if an error if necessary
     *
     * @param p an entity body that will be killed
     * @return the Task which, when run, will send the headers and kill the entity body
     */
-  override def writeEntityBody(p: EntityBody): Task[Boolean] = Task.async { cb =>
-    val callback = cb.compose((t: Attempt[Unit]) => t.map(_ => close))
+  override def writeEntityBody(p: EntityBody): Task[Boolean] =
+    p.drain.run.map(_ => close)
 
-    pipe.channelWrite(headers).onComplete {
-      case Success(_) => p.open.close.run.unsafeRunAsync(callback)
-      case Failure(t) => p.pull(_ => Pull.fail(t)).run.unsafeRunAsync(callback)
-    }
-  }
+  override protected def writeEnd(chunk: Chunk[Byte]): Future[Boolean] =
+    Future.successful(close)
 
-  override protected def writeEnd(chunk: Chunk[Byte]): Future[Boolean] = doneFuture.map(_ => close)
-
-  override protected def writeBodyChunk(chunk: Chunk[Byte], flush: Boolean): Future[Unit] = doneFuture
+  override protected def writeBodyChunk(chunk: Chunk[Byte], flush: Boolean): Future[Unit] =
+    FutureUnit
 }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
@@ -21,11 +21,11 @@ import org.http4s.util.StringWriter
   * @param pipe the blaze `TailStage`, which takes ByteBuffers which will send the data downstream
   * @param ec an ExecutionContext which will be used to complete operations
   */
-class BodylessWriter(pipe: TailStage[ByteBuffer], close: Boolean)
+private[http4s] class BodylessWriter(pipe: TailStage[ByteBuffer], close: Boolean)
   (implicit protected val ec: ExecutionContext) extends Http1Writer {
   private[this] var headers: ByteBuffer = null
 
-  def writeHeader(headerWriter: StringWriter): Future[Unit] =
+  def writeHeaders(headerWriter: StringWriter): Future[Unit] =
     pipe.channelWrite(Http1Writer.headersToByteBuffer(headerWriter.result))
 
   /** Doesn't write the entity body, just the headers. Kills the stream, if an error if necessary

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
@@ -3,21 +3,24 @@ package blazecore
 package util
 
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.ISO_8859_1
 
 import scala.concurrent._
 
 import fs2._
 import org.http4s.Headers
 import org.http4s.blaze.pipeline.TailStage
+import org.http4s.util.chunk._
 import org.http4s.util.StringWriter
 
 private[http4s] class CachingChunkWriter(pipe: TailStage[ByteBuffer],
                          trailer: Task[Headers],
-                         bufferMaxSize: Int = 10*1024)(implicit ec: ExecutionContext)
-              extends ChunkEntityBodyWriter(pipe, trailer) {
+                         bufferMaxSize: Int = 10*1024)(implicit val ec: ExecutionContext)
+    extends Http1Writer {
+  import ChunkWriter._
 
-  private var bodyBuffer: Chunk[Byte] = null
+  private[this] var pendingHeaders: StringWriter = null
+  private[this] var bodyBuffer: Chunk[Byte] = null
 
   override def writeHeaders(headerWriter: StringWriter): Future[Unit] = {
     pendingHeaders = headerWriter
@@ -34,22 +37,58 @@ private[http4s] class CachingChunkWriter(pipe: TailStage[ByteBuffer],
   override protected def exceptionFlush(): Future[Unit] = {
     val c = bodyBuffer
     bodyBuffer = null
-    if (c != null && !c.isEmpty) super.writeBodyChunk(c, true)  // TODO: would we want to writeEnd?
+    if (c != null && !c.isEmpty) pipe.channelWrite(encodeChunk(c, Nil))
     else FutureUnit
   }
 
-  override protected def writeEnd(chunk: Chunk[Byte]): Future[Boolean] = {
+  def writeEnd(chunk: Chunk[Byte]): Future[Boolean] = {
     val b = addChunk(chunk)
     bodyBuffer = null
-    super.writeEnd(b)
+    doWriteEnd(b)
+  }
+
+  private def doWriteEnd(chunk: Chunk[Byte]): Future[Boolean] = {
+    val f = if (pendingHeaders != null) {  // This is the first write, so we can add a body length instead of chunking
+      val h = pendingHeaders
+      pendingHeaders = null
+
+      if (!chunk.isEmpty) {
+        val body = chunk.toByteBuffer
+        h << s"Content-Length: ${body.remaining()}\r\n\r\n"
+        
+        // Trailers are optional, so dropping because we have no body.
+        val hbuff = ByteBuffer.wrap(h.result.getBytes(ISO_8859_1))
+        pipe.channelWrite(hbuff::body::Nil)
+      }
+      else {
+        h << s"Content-Length: 0\r\n\r\n"
+        val hbuff = ByteBuffer.wrap(h.result.getBytes(ISO_8859_1))
+        pipe.channelWrite(hbuff)
+      }
+    } else {
+      if (!chunk.isEmpty) writeBodyChunk(chunk, true).flatMap { _ => writeTrailer(pipe, trailer) }
+      else writeTrailer(pipe, trailer)
+    }
+
+    f.map(Function.const(false))
   }
 
   override protected def writeBodyChunk(chunk: Chunk[Byte], flush: Boolean): Future[Unit] = {
     val c = addChunk(chunk)
     if (c.size >= bufferMaxSize || flush) { // time to flush
       bodyBuffer = null
-      super.writeBodyChunk(c, true)
+      pipe.channelWrite(encodeChunk(c, Nil))
     }
     else FutureUnit    // Pretend to be done.
   }
+
+  private def encodeChunk(chunk: Chunk[Byte], last: List[ByteBuffer]): List[ByteBuffer] = {
+    val list = ChunkEntityBodyWriter.encodeChunk(chunk, last)
+    if (pendingHeaders != null) {
+      pendingHeaders << TransferEncodingChunkedString
+      val b = ByteBuffer.wrap(pendingHeaders.result.getBytes(ISO_8859_1))
+      pendingHeaders = null
+      b::list
+    } else list
+  }  
 }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
@@ -12,14 +12,14 @@ import org.http4s.Headers
 import org.http4s.blaze.pipeline.TailStage
 import org.http4s.util.StringWriter
 
-class CachingChunkWriter(pipe: TailStage[ByteBuffer],
+private[http4s] class CachingChunkWriter(pipe: TailStage[ByteBuffer],
                          trailer: Task[Headers],
                          bufferMaxSize: Int = 10*1024)(implicit ec: ExecutionContext)
               extends ChunkEntityBodyWriter(pipe, trailer) {
 
   private var bodyBuffer: Chunk[Byte] = null
 
-  override def writeHeader(headerWriter: StringWriter): Future[Unit] = {
+  override def writeHeaders(headerWriter: StringWriter): Future[Unit] = {
     pendingHeaders = headerWriter
     FutureUnit
   }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingStaticWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingStaticWriter.scala
@@ -12,16 +12,23 @@ import org.http4s.blaze.pipeline.TailStage
 import org.http4s.util.StringWriter
 import org.log4s.getLogger
 
-class CachingStaticWriter(writer: StringWriter, out: TailStage[ByteBuffer],
+class CachingStaticWriter(out: TailStage[ByteBuffer],
                           bufferSize: Int = 8*1024)
                          (implicit val ec: ExecutionContext)
-                          extends EntityBodyWriter {
+                          extends Http1Writer {
   private[this] val logger = getLogger
 
   @volatile
   private var _forceClose = false
   private var bodyBuffer: Chunk[Byte] = null
+
+  private var writer: StringWriter = null
   private var innerWriter: InnerWriter = null
+
+  def writeHeader(headerWriter: StringWriter): Future[Unit] = {
+    this.writer = headerWriter
+    FutureUnit
+  }
 
   private def addChunk(b: Chunk[Byte]): Chunk[Byte] = {
     if (bodyBuffer == null) bodyBuffer = b
@@ -35,8 +42,7 @@ class CachingStaticWriter(writer: StringWriter, out: TailStage[ByteBuffer],
 
     if (innerWriter == null) {  // We haven't written anything yet
       writer << "\r\n"
-      val b = ByteBuffer.wrap(writer.result.getBytes(StandardCharsets.ISO_8859_1))
-      new InnerWriter(b).writeBodyChunk(c, flush = true)
+      new InnerWriter().writeBodyChunk(c, flush = true)
     }
     else writeBodyChunk(c, flush = true)    // we are already proceeding
   }
@@ -47,9 +53,7 @@ class CachingStaticWriter(writer: StringWriter, out: TailStage[ByteBuffer],
       val c = addChunk(chunk)
       writer << "Content-Length: " << c.size << "\r\nConnection: keep-alive\r\n\r\n"
 
-      val b = ByteBuffer.wrap(writer.result.getBytes(StandardCharsets.ISO_8859_1))
-
-      new InnerWriter(b).writeEnd(c).map(_ || _forceClose)
+      new InnerWriter().writeEnd(c).map(_ || _forceClose)
     }
   }
 
@@ -60,16 +64,15 @@ class CachingStaticWriter(writer: StringWriter, out: TailStage[ByteBuffer],
       if (flush || c.size >= bufferSize) { // time to just abort and stream it
         _forceClose = true
         writer << "\r\n"
-        val b = ByteBuffer.wrap(writer.result.getBytes(StandardCharsets.ISO_8859_1))
-        innerWriter = new InnerWriter(b)
+        innerWriter = new InnerWriter
         innerWriter.writeBodyChunk(chunk, flush)
       }
-      else Future.successful(())
+      else FutureUnit
     }
   }
 
   // Make the write stuff public
-  private class InnerWriter(buffer: ByteBuffer) extends IdentityWriter(buffer, -1, out) {
+  private class InnerWriter extends IdentityWriter(-1, out) {
     override def writeEnd(chunk: Chunk[Byte]): Future[Boolean] = super.writeEnd(chunk)
     override def writeBodyChunk(chunk: Chunk[Byte], flush: Boolean): Future[Unit] = super.writeBodyChunk(chunk, flush)
   }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingStaticWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingStaticWriter.scala
@@ -12,7 +12,7 @@ import org.http4s.blaze.pipeline.TailStage
 import org.http4s.util.StringWriter
 import org.log4s.getLogger
 
-class CachingStaticWriter(out: TailStage[ByteBuffer],
+private[http4s] class CachingStaticWriter(out: TailStage[ByteBuffer],
                           bufferSize: Int = 8*1024)
                          (implicit val ec: ExecutionContext)
                           extends Http1Writer {
@@ -25,7 +25,7 @@ class CachingStaticWriter(out: TailStage[ByteBuffer],
   private var writer: StringWriter = null
   private var innerWriter: InnerWriter = null
 
-  def writeHeader(headerWriter: StringWriter): Future[Unit] = {
+  def writeHeaders(headerWriter: StringWriter): Future[Unit] = {
     this.writer = headerWriter
     FutureUnit
   }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkEntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkEntityBodyWriter.scala
@@ -13,7 +13,7 @@ import org.http4s.blaze.pipeline.TailStage
 import org.http4s.util.chunk._
 import org.http4s.util.StringWriter
 
-abstract class ChunkEntityBodyWriter(
+private[http4s] abstract class ChunkEntityBodyWriter(
                          pipe: TailStage[ByteBuffer],
                          trailer: Task[Headers])
                          (implicit val ec: ExecutionContext) extends Http1Writer {
@@ -93,7 +93,7 @@ abstract class ChunkEntityBodyWriter(
   }
 }
 
-object ChunkEntityBodyWriter {
+private[http4s] object ChunkEntityBodyWriter {
   private val CRLFBytes = "\r\n".getBytes(ISO_8859_1)
 
   private def CRLF = CRLFBuffer.duplicate()

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
@@ -13,7 +13,7 @@ import org.http4s.blaze.pipeline.TailStage
 import org.http4s.util.chunk._
 import org.http4s.util.StringWriter
 
-private[util] object ChunkEntityBodyWriter {
+private[util] object ChunkWriter {
   val CRLFBytes = "\r\n".getBytes(ISO_8859_1)
   private[this] val CRLFBuffer = ByteBuffer.wrap(CRLFBytes).asReadOnlyBuffer()
   def CRLF = CRLFBuffer.duplicate()
@@ -22,6 +22,7 @@ private[util] object ChunkEntityBodyWriter {
     ByteBuffer.wrap("0\r\n\r\n".getBytes(ISO_8859_1)).asReadOnlyBuffer()
   def ChunkEndBuffer = chunkEndBuffer.duplicate()
 
+  val TransferEncodingChunkedString = "Transfer-Encoding: chunked\r\n\r\n"
   private[this] val TransferEncodingChunkedBytes = "Transfer-Encoding: chunked\r\n\r\n".getBytes(ISO_8859_1)
   private[this] val transferEncodingChunkedBuffer = ByteBuffer.wrap(TransferEncodingChunkedBytes).asReadOnlyBuffer
   def TransferEncodingChunked = transferEncodingChunkedBuffer.duplicate()

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 import fs2._
 import fs2.Stream._
 import fs2.interop.cats._
+import org.http4s.util.StringWriter
 
 trait EntityBodyWriter {
 
@@ -37,7 +38,7 @@ trait EntityBodyWriter {
   protected def writeEnd(chunk: Chunk[Byte]): Future[Boolean]
 
   /** Called in the event of an Await failure to alert the pipeline to cleanup */
-  protected def exceptionFlush(): Future[Unit] = Future.successful(())
+  protected def exceptionFlush(): Future[Unit] = FutureUnit
 
   /** Creates a Task that writes the contents of the EntityBody to the output.
     * Cancelled exceptions fall through to the Task cb
@@ -52,7 +53,7 @@ trait EntityBodyWriter {
     val writeBodyEnd : Task[Boolean] = Task.fromFuture(writeEnd(Chunk.empty))
     writeBody >> writeBodyEnd
   }
-  
+
   /** Writes each of the body chunks, if the write fails it returns
     * the failed future which throws an error.
     * If it errors the error stream becomes the stream, which performs an

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
@@ -10,7 +10,7 @@ import fs2.Stream._
 import fs2.interop.cats._
 import org.http4s.util.StringWriter
 
-trait EntityBodyWriter {
+private[http4s] trait EntityBodyWriter {
 
   /** The `ExecutionContext` on which to run computations, assumed to be stack safe. */
   implicit protected def ec: ExecutionContext

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/FlushingChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/FlushingChunkWriter.scala
@@ -1,0 +1,26 @@
+package org.http4s
+package blazecore
+package util
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+import scala.concurrent._
+
+import fs2._
+import org.http4s.Headers
+import org.http4s.blaze.pipeline.TailStage
+import org.http4s.util.StringWriter
+
+class FlushingChunkWriter(pipe: TailStage[ByteBuffer],
+                         trailer: Task[Headers])(implicit ec: ExecutionContext)
+              extends ChunkEntityBodyWriter(pipe, trailer) {
+  override def writeHeader(headerWriter: StringWriter): Future[Unit] = {
+    // It may be a while before we get another chunk, so we flush now
+    pipe.channelWrite(Http1Writer.headersToByteBuffer(headerWriter.result)).map { _ =>
+      // Set to non-null to indicate that the headers aren't closed yet.  We still
+      // need to write a Content-Length or Transfer-Encoding
+      pendingHeaders = new StringWriter
+    }
+  }
+}

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/FlushingChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/FlushingChunkWriter.scala
@@ -12,10 +12,10 @@ import org.http4s.Headers
 import org.http4s.blaze.pipeline.TailStage
 import org.http4s.util.StringWriter
 
-class FlushingChunkWriter(pipe: TailStage[ByteBuffer],
+private[http4s] class FlushingChunkWriter(pipe: TailStage[ByteBuffer],
                          trailer: Task[Headers])(implicit ec: ExecutionContext)
               extends ChunkEntityBodyWriter(pipe, trailer) {
-  override def writeHeader(headerWriter: StringWriter): Future[Unit] = {
+  override def writeHeaders(headerWriter: StringWriter): Future[Unit] = {
     // It may be a while before we get another chunk, so we flush now
     pipe.channelWrite(Http1Writer.headersToByteBuffer(headerWriter.result)).map { _ =>
       // Set to non-null to indicate that the headers aren't closed yet.  We still

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/FlushingChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/FlushingChunkWriter.scala
@@ -3,24 +3,33 @@ package blazecore
 package util
 
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.ISO_8859_1
 
 import scala.concurrent._
 
 import fs2._
 import org.http4s.Headers
 import org.http4s.blaze.pipeline.TailStage
+import org.http4s.util.chunk._
 import org.http4s.util.StringWriter
 
 private[http4s] class FlushingChunkWriter(pipe: TailStage[ByteBuffer],
-                         trailer: Task[Headers])(implicit ec: ExecutionContext)
-              extends ChunkEntityBodyWriter(pipe, trailer) {
-  override def writeHeaders(headerWriter: StringWriter): Future[Unit] = {
-    // It may be a while before we get another chunk, so we flush now
-    pipe.channelWrite(Http1Writer.headersToByteBuffer(headerWriter.result)).map { _ =>
-      // Set to non-null to indicate that the headers aren't closed yet.  We still
-      // need to write a Content-Length or Transfer-Encoding
-      pendingHeaders = new StringWriter
-    }
+                         trailer: Task[Headers])(implicit val ec: ExecutionContext)
+    extends Http1Writer {
+  import ChunkWriter._
+
+  protected def writeBodyChunk(chunk: Chunk[Byte], flush: Boolean): Future[Unit] = {
+    if (chunk.isEmpty) FutureUnit
+    else pipe.channelWrite(encodeChunk(chunk, Nil))
   }
+
+  protected def writeEnd(chunk: Chunk[Byte]): Future[Boolean] =
+    {
+      if (!chunk.isEmpty) writeBodyChunk(chunk, true).flatMap { _ => writeTrailer(pipe, trailer) }
+      else writeTrailer(pipe, trailer)
+    }.map(_ => false)
+
+  override def writeHeaders(headerWriter: StringWriter): Future[Unit] =
+    // It may be a while before we get another chunk, so we flush now
+    pipe.channelWrite(List(Http1Writer.headersToByteBuffer(headerWriter.result), TransferEncodingChunked))
 }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
@@ -1,0 +1,28 @@
+package org.http4s
+package blazecore
+package util
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import scala.concurrent._
+
+import fs2._
+import org.http4s.blaze.http.Headers
+import org.http4s.blaze.pipeline.TailStage
+import org.http4s.blaze.http.http20.NodeMsg._
+import org.http4s.util.StringWriter
+import org.http4s.util.chunk._
+
+trait Http1Writer extends EntityBodyWriter {
+  final def write(headerWriter: StringWriter, body: EntityBody): Task[Boolean] =
+    Task.fromFuture(writeHeader(headerWriter)).flatMap(_ => writeEntityBody(body))
+
+  /* Writes the header.  It is up to the writer whether to flush immediately or to
+   * buffer the header with a subsequent chunk. */
+  def writeHeader(headerWriter: StringWriter): Future[Unit]
+}
+
+object Http1Writer {
+  def headersToByteBuffer(headers: String): ByteBuffer =
+    ByteBuffer.wrap(headers.getBytes(StandardCharsets.ISO_8859_1))
+}

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/Http2Writer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/Http2Writer.scala
@@ -27,7 +27,7 @@ class Http2Writer(tail: TailStage[Http2Msg],
   }
 
   override protected def writeBodyChunk(chunk: Chunk[Byte], flush: Boolean): Future[Unit] = {
-    if (chunk.isEmpty) Future.successful(())
+    if (chunk.isEmpty) FutureUnit
     else {
       if (headers == null) tail.channelWrite(DataFrame(false, chunk.toByteBuffer))
       else {

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/Http2Writer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/Http2Writer.scala
@@ -10,7 +10,7 @@ import org.http4s.blaze.http.Headers
 import org.http4s.blaze.pipeline.TailStage
 import org.http4s.blaze.http.http20.NodeMsg._
 
-class Http2Writer(tail: TailStage[Http2Msg],
+private[http4s] class Http2Writer(tail: TailStage[Http2Msg],
                   private var headers: Headers,
                   protected val ec: ExecutionContext) extends EntityBodyWriter {
 

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
@@ -12,7 +12,7 @@ import org.http4s.util.chunk._
 import org.http4s.util.StringWriter
 import org.log4s.getLogger
 
-class IdentityWriter(size: Long, out: TailStage[ByteBuffer])
+private[http4s] class IdentityWriter(size: Long, out: TailStage[ByteBuffer])
                     (implicit val ec: ExecutionContext)
     extends Http1Writer {
 
@@ -24,9 +24,7 @@ class IdentityWriter(size: Long, out: TailStage[ByteBuffer])
   private def willOverflow(count: Long) =
     if (size < 0L) false else (count + bodyBytesWritten > size)
 
-  def writeHeader(headerWriter: StringWriter): Future[Unit] = {
-
-
+  def writeHeaders(headerWriter: StringWriter): Future[Unit] = {
     headers = Http1Writer.headersToByteBuffer(headerWriter.result)
     FutureUnit
   }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/package.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/package.scala
@@ -1,11 +1,15 @@
 package org.http4s
 package blazecore
 
+import scala.concurrent.Future
 import fs2._
 
 package object util {
   /** Used as a terminator for streams built from repeatEval */
   private[http4s] val End = Right(None)
+
+  private[http4s] val FutureUnit =
+    Future.successful(())
 
   private[http4s] def unNoneTerminateChunks[F[_],I]: Stream[F,Option[Chunk[I]]] => Stream[F,I] =
     pipe.unNoneTerminate(_) repeatPull { _ receive1 {

--- a/blaze-core/src/test/scala/org/http4s/blazecore/TestHead.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/TestHead.scala
@@ -27,7 +27,7 @@ abstract class TestHead(val name: String) extends HeadStage[ByteBuffer] {
       val cpy = new Array[Byte](data.remaining())
       data.get(cpy)
       acc :+= cpy
-      Future.successful(())
+      util.FutureUnit
     }
   }
 

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/DumpingWriter.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/DumpingWriter.scala
@@ -36,6 +36,6 @@ class DumpingWriter extends EntityBodyWriter {
 
   override protected def writeBodyChunk(chunk: Chunk[Byte], flush: Boolean): Future[Unit] = {
     buffers += chunk
-    Future.successful(())
+    FutureUnit
   }
 }

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
@@ -19,7 +19,7 @@ import org.http4s.util.StringWriter
 class Http1WriterSpec extends Http4sSpec {
   case object Failed extends RuntimeException
 
-  def writeEntityBody(p: EntityBody)(builder: TailStage[ByteBuffer] => Http1Writer): String = {
+  final def writeEntityBody(p: EntityBody)(builder: TailStage[ByteBuffer] => Http1Writer): String = {
     val tail = new TailStage[ByteBuffer] {
       override def name: String = "TestTail"
     }
@@ -34,7 +34,7 @@ class Http1WriterSpec extends Http4sSpec {
 
     val hs = new StringWriter() << "Content-Type: text/plain\r\n"
     (for {
-      _ <- Task.fromFuture(w.writeHeader(hs))
+      _ <- Task.fromFuture(w.writeHeaders(hs))
       _ <- w.writeEntityBody(p)
     } yield ()).unsafeRun
     head.stageShutdown()
@@ -45,7 +45,7 @@ class Http1WriterSpec extends Http4sSpec {
   val message = "Hello world!"
   val messageBuffer = Chunk.bytes(message.getBytes(StandardCharsets.ISO_8859_1))
 
-  def runNonChunkedTests(builder: TailStage[ByteBuffer] => Http1Writer) = {
+  final def runNonChunkedTests(builder: TailStage[ByteBuffer] => Http1Writer) = {
     "Write a single emit" in {
       writeEntityBody(chunk(messageBuffer))(builder) must_== "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n" + message
     }

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
@@ -16,10 +16,10 @@ import org.http4s.blaze.pipeline.{LeafBuilder, TailStage}
 import org.http4s.blazecore.TestHead
 import org.http4s.util.StringWriter
 
-class EntityBodyWriterSpec extends Http4sSpec {
+class Http1WriterSpec extends Http4sSpec {
   case object Failed extends RuntimeException
 
-  def writeEntityBody(p: EntityBody)(builder: TailStage[ByteBuffer] => EntityBodyWriter): String = {
+  def writeEntityBody(p: EntityBody)(builder: TailStage[ByteBuffer] => Http1Writer): String = {
     val tail = new TailStage[ByteBuffer] {
       override def name: String = "TestTail"
     }
@@ -32,7 +32,11 @@ class EntityBodyWriterSpec extends Http4sSpec {
     LeafBuilder(tail).base(head)
     val w = builder(tail)
 
-    w.writeEntityBody(p).unsafeRun
+    val hs = new StringWriter() << "Content-Type: text/plain\r\n"
+    (for {
+      _ <- Task.fromFuture(w.writeHeader(hs))
+      _ <- w.writeEntityBody(p)
+    } yield ()).unsafeRun
     head.stageShutdown()
     Await.ready(head.result, Duration.Inf)
     new String(head.getBytes(), StandardCharsets.ISO_8859_1)
@@ -41,37 +45,37 @@ class EntityBodyWriterSpec extends Http4sSpec {
   val message = "Hello world!"
   val messageBuffer = Chunk.bytes(message.getBytes(StandardCharsets.ISO_8859_1))
 
-  def runNonChunkedTests(builder: TailStage[ByteBuffer] => EntityBodyWriter) = {
+  def runNonChunkedTests(builder: TailStage[ByteBuffer] => Http1Writer) = {
     "Write a single emit" in {
-      writeEntityBody(chunk(messageBuffer))(builder) must_== "Content-Length: 12\r\n\r\n" + message
+      writeEntityBody(chunk(messageBuffer))(builder) must_== "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n" + message
     }
 
     "Write two emits" in {
       val p = chunk(messageBuffer) ++ chunk(messageBuffer)
-      writeEntityBody(p.covary[Task])(builder) must_== "Content-Length: 24\r\n\r\n" + message + message
+      writeEntityBody(p.covary[Task])(builder) must_== "Content-Type: text/plain\r\nContent-Length: 24\r\n\r\n" + message + message
     }
 
     "Write an await" in {
       val p = eval(Task.delay(messageBuffer)).flatMap(chunk)
-      writeEntityBody(p.covary[Task])(builder) must_== "Content-Length: 12\r\n\r\n" + message
+      writeEntityBody(p.covary[Task])(builder) must_== "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n" + message
     }
 
     "Write two awaits" in {
       val p = eval(Task.delay(messageBuffer)).flatMap(chunk)
-      writeEntityBody(p ++ p)(builder) must_== "Content-Length: 24\r\n\r\n" + message + message
+      writeEntityBody(p ++ p)(builder) must_== "Content-Type: text/plain\r\nContent-Length: 24\r\n\r\n" + message + message
     }
 
     "Write a body that fails and falls back" in {
       val p = eval(Task.fail(Failed)).onError { _ =>
         chunk(messageBuffer)
       }
-      writeEntityBody(p)(builder) must_== "Content-Length: 12\r\n\r\n" + message
+      writeEntityBody(p)(builder) must_== "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n" + message
     }
 
     "execute cleanup" in {
       var clean = false
       val p = chunk(messageBuffer).covary[Task].onFinalize[Task]( Task.delay(clean = true) )
-      writeEntityBody(p.covary[Task])(builder) must_== "Content-Length: 12\r\n\r\n" + message
+      writeEntityBody(p.covary[Task])(builder) must_== "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n" + message
       clean must_== true
     }
 
@@ -85,29 +89,30 @@ class EntityBodyWriterSpec extends Http4sSpec {
         }
       }
       val p = repeatEval(t).unNoneTerminate.flatMap(chunk) ++ chunk(Chunk.bytes("bar".getBytes(StandardCharsets.ISO_8859_1)))
-      writeEntityBody(p)(builder) must_== "Content-Length: 9\r\n\r\n" + "foofoobar"
+      writeEntityBody(p)(builder) must_== "Content-Type: text/plain\r\nContent-Length: 9\r\n\r\n" + "foofoobar"
     }
   }
 
 
   "CachingChunkWriter" should {
-    runNonChunkedTests(tail => new CachingChunkWriter(new StringWriter(), tail, Task.now(Headers())))
+    runNonChunkedTests(tail => new CachingChunkWriter(tail, Task.now(Headers())))
   }
 
   "CachingStaticWriter" should {
-    runNonChunkedTests(tail => new CachingChunkWriter(new StringWriter(), tail, Task.now(Headers())))
+    runNonChunkedTests(tail => new CachingChunkWriter(tail, Task.now(Headers())))
   }
 
-  "ChunkEntityBodyWriter" should {
+  "FlushingChunkWriter" should {
     def builder(tail: TailStage[ByteBuffer]) =
-      new ChunkEntityBodyWriter(new StringWriter(), tail, Task.now(Headers()))
+      new FlushingChunkWriter(tail, Task.now(Headers()))
 
     "Write a strict chunk" in {
       // n.b. in the scalaz-stream version, we could introspect the
       // stream, note the lack of effects, and write this with a
       // Content-Length header.  In fs2, this must be chunked.
       writeEntityBody(chunk(messageBuffer))(builder) must_==
-        """Transfer-Encoding: chunked
+        """Content-Type: text/plain
+          |Transfer-Encoding: chunked
           |
           |c
           |Hello world!
@@ -119,7 +124,8 @@ class EntityBodyWriterSpec extends Http4sSpec {
     "Write two strict chunks" in {
       val p = chunk(messageBuffer) ++ chunk(messageBuffer)
       writeEntityBody(p.covary[Task])(builder) must_==
-        """Transfer-Encoding: chunked
+        """Content-Type: text/plain
+          |Transfer-Encoding: chunked
           |
           |c
           |Hello world!
@@ -136,7 +142,8 @@ class EntityBodyWriterSpec extends Http4sSpec {
       // with a Content-Length header.  In fs2, this must be chunked.
       val p = eval(Task.delay(messageBuffer)).flatMap(chunk)
       writeEntityBody(p.covary[Task])(builder) must_==
-        """Transfer-Encoding: chunked
+        """Content-Type: text/plain
+          |Transfer-Encoding: chunked
           |
           |c
           |Hello world!
@@ -148,7 +155,8 @@ class EntityBodyWriterSpec extends Http4sSpec {
     "Write two effectful chunks" in {
       val p = eval(Task.delay(messageBuffer)).flatMap(chunk)
       writeEntityBody(p ++ p)(builder) must_==
-        """Transfer-Encoding: chunked
+        """Content-Type: text/plain
+          |Transfer-Encoding: chunked
           |
           |c
           |Hello world!
@@ -164,7 +172,8 @@ class EntityBodyWriterSpec extends Http4sSpec {
       // fs2, but it's important enough we should check it here.
       val p = chunk(Chunk.empty) ++ chunk(messageBuffer)
       writeEntityBody(p.covary[Task])(builder) must_==
-        """Transfer-Encoding: chunked
+        """Content-Type: text/plain
+          |Transfer-Encoding: chunked
           |
           |c
           |Hello world!
@@ -178,7 +187,8 @@ class EntityBodyWriterSpec extends Http4sSpec {
         chunk(messageBuffer)
       }
       writeEntityBody(p)(builder) must_==
-        """Transfer-Encoding: chunked
+        """Content-Type: text/plain
+          |Transfer-Encoding: chunked
           |
           |c
           |Hello world!
@@ -193,7 +203,8 @@ class EntityBodyWriterSpec extends Http4sSpec {
         Task.delay(clean = true)
       }
       writeEntityBody(p)(builder) must_==
-        """Transfer-Encoding: chunked
+        """Content-Type: text/plain
+          |Transfer-Encoding: chunked
           |
           |c
           |Hello world!
@@ -231,7 +242,7 @@ class EntityBodyWriterSpec extends Http4sSpec {
       (new DumpingWriter).writeEntityBody(p).unsafeAttemptRun must beRight
     }
 
-    "Execute cleanup on a failing EntityBodyWriter" in {
+    "Execute cleanup on a failing Http1Writer" in {
       {
         var clean = false
         val p = chunk(messageBuffer).onFinalize(Task.delay {

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -152,13 +152,12 @@ private class Http1ServerStage(service: HttpService,
         // add KeepAlive to Http 1.0 responses if the header isn't already present
         rr << (if (!closeOnFinish && parser.minorVersion == 0 && respConn.isEmpty) "Connection: keep-alive\r\n\r\n" else "\r\n")
 
-        val b = ByteBuffer.wrap(rr.result.getBytes(StandardCharsets.ISO_8859_1))
-        new BodylessWriter(b, this, closeOnFinish)(executionContext)
+        new BodylessWriter(this, closeOnFinish)(executionContext)
       }
       else getEncoder(respConn, respTransferCoding, lengthHeader, resp.trailerHeaders, rr, parser.minorVersion, closeOnFinish)
     }
 
-    bodyEncoder.writeEntityBody(resp.body).unsafeRunAsync {
+    bodyEncoder.write(rr, resp.body).unsafeRunAsync {
       case Right(requireClose) =>
         if (closeOnFinish || requireClose) {
           closeConnection()

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -176,12 +176,12 @@ object ExampleService {
 
   // This is a mock data source, but could be a Process representing results from a database
   def dataStream(n: Int): Stream[Task, String] = {
-    val interval = 100.millis
+    val interval = 1000.millis
     val stream = time.awakeEvery[Task](interval)(Task.asyncInstance, defaultScheduler)
       .map(_ => s"Current system time: ${System.currentTimeMillis()} ms\n")
       .take(n.toLong)
 
-    Stream.emit(s"Starting $interval stream intervals, taking $n results\n\n") ++ stream
+    stream // Stream.emit(s"Starting $interval stream intervals, taking $n results\n\n") ++ stream
   }
 
   // Services can be protected using HTTP authentication.

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -176,12 +176,12 @@ object ExampleService {
 
   // This is a mock data source, but could be a Process representing results from a database
   def dataStream(n: Int): Stream[Task, String] = {
-    val interval = 1000.millis
+    val interval = 100.millis
     val stream = time.awakeEvery[Task](interval)(Task.asyncInstance, defaultScheduler)
       .map(_ => s"Current system time: ${System.currentTimeMillis()} ms\n")
       .take(n.toLong)
 
-    stream // Stream.emit(s"Starting $interval stream intervals, taking $n results\n\n") ++ stream
+    Stream.emit(s"Starting $interval stream intervals, taking $n results\n\n") ++ stream
   }
 
   // Services can be protected using HTTP authentication.


### PR DESCRIPTION
A message might have a header substantially before the first chunk is calculated.  We should render the header, sans Content-Length or Transfer-Encoding header, as soon as it's available.  We call a `writeHeader` method with the header buffer, which gives each encoder the discretion to flush the header immediately or to hold it to be flushed with the beginning of the entity.

/cc @scottcarey, who mentioned this behavior on Gitter