### PR TITLE
Add overloads for `jsonOf` and `as`

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -9,6 +9,15 @@ import org.http4s.argonaut.Parser.facade
 import org.http4s.headers.`Content-Type`
 
 trait ArgonautInstances {
+
+  implicit def http4sArgonautJsonDecoder[F[_]: Sync, A: DecodeJson]: JsonDecoder[F, A] =
+    new JsonDecoder[F, A] {
+      override def decodeJson(message: Message[F]): F[A] =
+        jsonOf[F, A]
+          .decode(message, strict = false)
+          .fold(throw _, identity)
+    }
+
   implicit def jsonDecoder[F[_]: Sync]: EntityDecoder[F, Json] =
     jawn.jawnDecoder
 

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -69,6 +69,20 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     }
   }
 
+  "JsonDecoder instance" should {
+    "decode json from a body" in {
+      val dec = JsonDecoder[IO, Foo]
+      val req = Request[IO]().withBody(foo.asJson)
+      req.flatMap(dec.decodeJson) must returnValue(foo)
+    }
+
+    "fail on invalid json" in {
+      val dec = JsonDecoder[IO, Foo]
+      val req = Request[IO]().withBody(List(13, 14).asJson)
+      req.flatMap(dec.decodeJson).attempt.unsafeRunSync must beLeft
+    }
+  }
+
   "json" should {
     "handle the optionality of jNumber" in {
       // TODO Urgh.  We need to make testing these smoother.

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -14,6 +14,15 @@ import org.http4s.headers.`Content-Type`
 import scodec.bits.ByteVector
 
 trait CirceInstances {
+
+  implicit def http4sCirceJsonDecoder[F[_]: Sync, A](implicit decoder: Decoder[A]) =
+    new JsonDecoder[F, A] {
+      override def decodeJson(message: Message[F]): F[A] =
+        jsonOf[F, A]
+          .decode(message, strict = false)
+          .fold(throw _, identity)
+    }
+
   def jsonDecoderIncremental[F[_]: Sync]: EntityDecoder[F, Json] =
     jawn.jawnDecoder[F, Json]
 

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -15,7 +15,7 @@ import scodec.bits.ByteVector
 
 trait CirceInstances {
 
-  implicit def http4sCirceJsonDecoder[F[_]: Sync, A](implicit decoder: Decoder[A]) =
+  implicit def http4sCirceJsonDecoder[F[_]: Sync, A: Decoder]: JsonDecoder[F, A] =
     new JsonDecoder[F, A] {
       override def decodeJson(message: Message[F]): F[A] =
         jsonOf[F, A]

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -76,6 +76,20 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
     }
   }
 
+  "JsonDecoder instance" should {
+    "decode json from a body" in {
+      val dec = JsonDecoder[IO, Foo]
+      val req = Request[IO]().withBody(foo.asJson)
+      req.flatMap(dec.decodeJson) must returnValue(foo)
+    }
+
+    "fail on invalid json" in {
+      val dec = JsonDecoder[IO, Foo]
+      val req = Request[IO]().withBody(List(13, 14).asJson)
+      req.flatMap(dec.decodeJson).attempt.unsafeRunSync must beLeft
+    }
+  }
+
   "json" should {
     "handle the optionality of asNumber" in {
       // From ArgonautSpec, which tests similar things:

--- a/core/src/main/scala/org/http4s/JsonDecoder.scala
+++ b/core/src/main/scala/org/http4s/JsonDecoder.scala
@@ -1,0 +1,7 @@
+package org.http4s
+
+trait JsonDecoder[F[_], A] {
+
+  def decodeJson(message: Message[F]): F[A]
+
+}

--- a/core/src/main/scala/org/http4s/JsonDecoder.scala
+++ b/core/src/main/scala/org/http4s/JsonDecoder.scala
@@ -5,3 +5,9 @@ trait JsonDecoder[F[_], A] {
   def decodeJson(message: Message[F]): F[A]
 
 }
+
+object JsonDecoder {
+
+  def apply[F[_], A](implicit jsonDecoder: JsonDecoder[F, A]): JsonDecoder[F, A] = jsonDecoder
+
+}

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -123,6 +123,9 @@ sealed trait Message[F[_]] extends MessageOps[F] { self =>
       implicit F: FlatMap[F],
       decoder: EntityDecoder[F, T]): DecodeResult[F, T] =
     decoder.decode(this, strict = false)
+
+  override def decodeJson[T](implicit jsonDecoder: JsonDecoder[F, T], F: FlatMap[F]): F[T] =
+    jsonDecoder.decodeJson(this)
 }
 
 object Message {

--- a/core/src/main/scala/org/http4s/MessageOps.scala
+++ b/core/src/main/scala/org/http4s/MessageOps.scala
@@ -85,6 +85,9 @@ trait MessageOps[F[_]] extends Any {
     */
   final def as[T](implicit F: FlatMap[F], decoder: EntityDecoder[F, T]): F[T] =
     attemptAs.fold(throw _, identity)
+
+  def decodeJson[T](implicit jsonDecoder: JsonDecoder[F, T], F: FlatMap[F]): F[T]
+
 }
 
 trait RequestOps[F[_]] extends Any with MessageOps[F] {

--- a/core/src/main/scala/org/http4s/syntax/EffectMessageSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/EffectMessageSyntax.scala
@@ -25,4 +25,7 @@ trait EffectMessageSyntax[F[_], M <: Message[F]] extends Any with MessageOps[F] 
     EitherT(self.flatMap { msg =>
       decoder.decode(msg, false).value
     })
+
+  override def decodeJson[T](implicit jsonDecoder: JsonDecoder[F, T], F: FlatMap[F]): F[T] =
+    self.flatMap(msg => jsonDecoder.decodeJson(msg))
 }

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -14,6 +14,14 @@ object CustomParser extends Parser(useBigDecimalForDouble = true, useBigIntForLo
 trait Json4sInstances[J] {
   import CustomParser.facade
 
+  implicit def http4sJson4sJsonDecoder[F[_]: Sync, A: Reader]: JsonDecoder[F, A] =
+    new JsonDecoder[F, A] {
+      override def decodeJson(message: Message[F]): F[A] =
+        jsonOf[F, A]
+          .decode(message, strict = false)
+          .fold(throw _, identity)
+    }
+
   implicit def jsonDecoder[F[_]: Sync]: EntityDecoder[F, JValue] =
     jawn.jawnDecoder
 

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -55,6 +55,21 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
     }
   }
 
+  "JsonDecoder instance" should {
+    "decode json from a body" in {
+      val dec = JsonDecoder[IO, Option[Int]]
+      val req = Request[IO]().withBody("42").withContentType(Some(MediaType.`application/json`))
+      req.flatMap(dec.decodeJson) must returnValue(Some(42))
+    }
+
+    "fail on invalid json" in {
+      val dec = JsonDecoder[IO, Int]
+      val req =
+        Request[IO]().withBody(""""horse"""").withContentType(Some(MediaType.`application/json`))
+      req.flatMap(dec.decodeJson).attempt.unsafeRunSync must beLeft
+    }
+  }
+
   "jsonExtract" should {
     implicit val formats = org.json4s.DefaultFormats
 


### PR DESCRIPTION
To allow specifying explicit decoders.