### PR TITLE
Implement a response header timeout

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -35,7 +35,7 @@ object BlazeClient {
 
       def loop(next: manager.NextConnection): Task[DisposableResponse] = {
         // Add the timeout stage to the pipeline
-        val ts = new ClientTimeoutStage(config.idleTimeout, config.requestTimeout, bits.ClientTickWheel)
+        val ts = new ClientTimeoutStage(config.responseHeaderTimeout, config.idleTimeout, config.requestTimeout, bits.ClientTickWheel)
         next.connection.spliceBefore(ts)
         ts.initialize()
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientConfig.scala
@@ -11,8 +11,14 @@ import scala.concurrent.duration.Duration
 
 /** Config object for the blaze clients
   *
-  * @param idleTimeout duration that a connection can wait without traffic before timeout
-  * @param requestTimeout maximum duration for a request to complete before a timeout
+  * @param responseHeaderTimeout duration between the completion of a request
+  * and the completion of the response header.  Does not include time
+  * to acquire the connection or the time to read the response.
+  * @param idleTimeout duration that a connection can wait without
+  * traffic being read or written before timeout
+  * @param requestTimeout maximum duration for a request to complete
+  * before a timeout.  Does not include time to acquire the the
+  * connection, but does include time to read the response
   * @param userAgent optional custom user agent header
   * @param sslContext optional custom `SSLContext` to use to replace
   * the default, `SSLContext.getDefault`.
@@ -31,6 +37,7 @@ import scala.concurrent.duration.Duration
   * @param group custom `AsynchronousChannelGroup` to use other than the system default
   */
 final case class BlazeClientConfig(// HTTP properties
+                                   responseHeaderTimeout: Duration,
                                    idleTimeout: Duration,
                                    requestTimeout: Duration,
                                    userAgent: Option[`User-Agent`],
@@ -58,6 +65,7 @@ object BlazeClientConfig {
   /** Default configuration of a blaze client. */
   val defaultConfig =
     BlazeClientConfig(
+      responseHeaderTimeout = bits.DefaultResponseHeaderTimeout,
       idleTimeout = bits.DefaultTimeout,
       requestTimeout = Duration.Inf,
       userAgent = bits.DefaultUserAgent,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
@@ -16,6 +16,7 @@ import scalaz.concurrent.Task
 
 private[blaze] object bits {
   // Some default objects
+  val DefaultResponseHeaderTimeout: Duration = 10.seconds
   val DefaultTimeout: Duration = 60.seconds
   val DefaultBufferSize: Int = 8*1024
   val DefaultUserAgent = Some(`User-Agent`(AgentProduct("http4s-blaze", Some(BuildInfo.version))))

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -168,8 +168,8 @@ class ClientTimeoutSpec extends Http4sSpec {
     "No Response head timeout on fast header" in {
       val tail = mkConnection()
       val (f,b) = resp.splitAt(resp.indexOf("\r\n\r\n"+4))
-      val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 500.millis, scheduler)
-      // header is split into two chunks, we wait for 2.5x
+      val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 125.millis, scheduler)
+      // header is split into two chunks, we wait for 10x
       val c = mkClient(h, tail)(responseHeaderTimeout = 1250.millis)
 
       val result = tail.runRequest(FooRequest).as[String]

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -158,9 +158,9 @@ class ClientTimeoutSpec extends Http4sSpec {
     "Response head timeout on slow header" in {
       val tail = mkConnection()
       val (f,b) = resp.splitAt(resp.indexOf("\r\n\r\n"))
-      val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 250.millis, scheduler)
+      val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 500.millis, scheduler)
       // header is split into two chunks, we wait for 1.5x
-      val c = mkClient(h, tail)(responseHeaderTimeout = 375.millis)
+      val c = mkClient(h, tail)(responseHeaderTimeout = 750.millis)
 
       c.fetchAs[String](FooRequest).unsafePerformSync must throwA[TimeoutException]
     }
@@ -168,9 +168,9 @@ class ClientTimeoutSpec extends Http4sSpec {
     "No Response head timeout on fast header" in {
       val tail = mkConnection()
       val (f,b) = resp.splitAt(resp.indexOf("\r\n\r\n"+4))
-      val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 250.millis, scheduler)
+      val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 500.millis, scheduler)
       // header is split into two chunks, we wait for 2.5x
-      val c = mkClient(h, tail)(responseHeaderTimeout = 625.millis)
+      val c = mkClient(h, tail)(responseHeaderTimeout = 1250.millis)
 
       val result = tail.runRequest(FooRequest).as[String]
 

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -39,15 +39,15 @@ class ClientTimeoutSpec extends Http4sSpec {
     ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))
   
   private def mkClient(head: => HeadStage[ByteBuffer], tail: => BlazeConnection)
-              (idleTimeout: Duration, requestTimeout: Duration): Client = {
+              (responseHeaderTimeout: Duration = Duration.Inf, idleTimeout: Duration = Duration.Inf, requestTimeout: Duration = Duration.Inf): Client = {
     val manager = MockClientBuilder.manager(head, tail)
-    BlazeClient(manager, defaultConfig.copy(idleTimeout = idleTimeout, requestTimeout = requestTimeout), Task.now(()))
+    BlazeClient(manager, defaultConfig.copy(responseHeaderTimeout = responseHeaderTimeout, idleTimeout = idleTimeout, requestTimeout = requestTimeout), Task.now(()))
   }
 
   "Http1ClientStage responses" should {
     "Timeout immediately with an idle timeout of 0 seconds" in {
       val c = mkClient(new SlowTestHead(List(mkBuffer(resp)), 0.seconds, scheduler), 
-                       mkConnection())(0.milli, Duration.Inf)
+                       mkConnection())(idleTimeout = Duration.Zero)
 
       c.fetchAs[String](FooRequest).unsafePerformSync must throwA[TimeoutException]
     }
@@ -55,7 +55,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     "Timeout immediately with a request timeout of 0 seconds" in {
       val tail = mkConnection()
       val h = new SlowTestHead(List(mkBuffer(resp)), 0.seconds, scheduler)
-      val c = mkClient(h, tail)(Duration.Inf, 0.milli)
+      val c = mkClient(h, tail)(requestTimeout = 0.milli)
 
       c.fetchAs[String](FooRequest).unsafePerformSync must throwA[TimeoutException]
     }
@@ -63,7 +63,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     "Idle timeout on slow response" in {
       val tail = mkConnection()
       val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds, scheduler)
-      val c = mkClient(h, tail)(1.second, Duration.Inf)
+      val c = mkClient(h, tail)(idleTimeout = 1.second)
 
       c.fetchAs[String](FooRequest).unsafePerformSync must throwA[TimeoutException]
     }
@@ -71,7 +71,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     "Request timeout on slow response" in {
       val tail = mkConnection()
       val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds, scheduler)
-      val c = mkClient(h, tail)(Duration.Inf, 1.second)
+      val c = mkClient(h, tail)(requestTimeout = 1.second)
 
       c.fetchAs[String](FooRequest).unsafePerformSync must throwA[TimeoutException]
     }
@@ -90,7 +90,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val tail = new Http1Connection(RequestKey.fromRequest(req), defaultConfig, testPool, ec)
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
-      val c = mkClient(h, tail)(Duration.Inf, 1.second)
+      val c = mkClient(h, tail)(requestTimeout = 1.second)
 
       c.fetchAs[String](req).unsafePerformSync must throwA[TimeoutException]
     }
@@ -109,7 +109,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val tail = new Http1Connection(RequestKey.fromRequest(req), defaultConfig, testPool, ec)
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
-      val c = mkClient(h, tail)(1.second, Duration.Inf)
+      val c = mkClient(h, tail)(idleTimeout = 1.second)
 
       c.fetchAs[String](req).unsafePerformSync must throwA[TimeoutException]
     }
@@ -128,7 +128,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val tail = new Http1Connection(RequestKey.fromRequest(req), defaultConfig, testPool, ec)
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SeqTestHead(Seq(f,b).map(mkBuffer))
-      val c = mkClient(h, tail)(10.second, 30.seconds)
+      val c = mkClient(h, tail)(idleTimeout = 10.second, requestTimeout = 30.seconds)
 
       c.fetchAs[String](req).unsafePerformSync must_== ("done")
     }
@@ -137,7 +137,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       val tail = mkConnection()
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 1500.millis, scheduler)
-      val c = mkClient(h, tail)(Duration.Inf, 1.second)
+      val c = mkClient(h, tail)(requestTimeout = 1.second)
 
       val result = tail.runRequest(FooRequest).as[String]
 
@@ -148,11 +148,33 @@ class ClientTimeoutSpec extends Http4sSpec {
       val tail = mkConnection()
       val (f,b) = resp.splitAt(resp.length - 1)
       val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 1500.millis, scheduler)
-      val c = mkClient(h, tail)(1.second, Duration.Inf)
+      val c = mkClient(h, tail)(idleTimeout = 1.second)
 
       val result = tail.runRequest(FooRequest).as[String]
 
       c.fetchAs[String](FooRequest).unsafePerformSync must throwA[TimeoutException]
+    }
+
+    "Response head timeout on slow header" in {
+      val tail = mkConnection()
+      val (f,b) = resp.splitAt(resp.indexOf("\r\n\r\n"))
+      val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 250.millis, scheduler)
+      // header is split into two chunks, we wait for 1.5x
+      val c = mkClient(h, tail)(responseHeaderTimeout = 375.millis)
+
+      c.fetchAs[String](FooRequest).unsafePerformSync must throwA[TimeoutException]
+    }
+
+    "No Response head timeout on fast header" in {
+      val tail = mkConnection()
+      val (f,b) = resp.splitAt(resp.indexOf("\r\n\r\n"+4))
+      val h = new SlowTestHead(Seq(f,b).map(mkBuffer), 250.millis, scheduler)
+      // header is split into two chunks, we wait for 2.5x
+      val c = mkClient(h, tail)(responseHeaderTimeout = 625.millis)
+
+      val result = tail.runRequest(FooRequest).as[String]
+
+      c.fetchAs[String](FooRequest).unsafePerformSync must_== "done"
     }
   }
 }


### PR DESCRIPTION
Adds a timeout between the completion of the request and the completion of the response header.

Addresses #1349.  The original request was for time-to-first-byte, but I think this satisfies @scottcarey's use case, and I've seen this in other APIs.
