### PR TITLE
Improve DSL

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -9,7 +9,7 @@ import cats.effect._
 import org.http4s.blaze._
 import org.http4s.blaze.pipeline.{Command => Cmd}
 import org.http4s.blazecore.{ResponseParser, SeqTestHead}
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers.{Date, `Content-Length`, `Transfer-Encoding`}
 import org.http4s.{headers => H, _}
 import org.specs2.specification.core.Fragment

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -9,7 +9,7 @@ import cats.effect._
 import cats.implicits._
 import fs2._
 import org.http4s.client.testroutes.GetRoutes
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers.{`Content-Length`, `Transfer-Encoding`}
 
 import org.specs2.specification.core.Fragments

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic._
 import cats.effect._
 import cats.implicits._
 import fs2._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.specs2.mutable.Tables
 

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -5,7 +5,7 @@ package middleware
 import cats.effect.IO
 import cats.implicits._
 import fs2._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.specs2.specification.Tables
 
 import scala.concurrent.duration._

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -18,7 +18,7 @@ Or in code, using `cats.effect.IO` as the effect type:
 ```tut:book
 import cats._, cats.effect._, cats.implicits._, cats.data._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.server._
 
 case class User(id: Long, name: String)

--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -29,7 +29,7 @@ Then we create the [service] again so tut picks it up:
 ```tut:book
 import cats.effect._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.server.blaze._
 
 val service = HttpService[IO] {

--- a/docs/src/main/tut/cors.md
+++ b/docs/src/main/tut/cors.md
@@ -21,7 +21,7 @@ And we need some imports.
 ```tut:silent
 import cats.effect._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 ```
 
 Let's start by making a simple service.

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -37,7 +37,7 @@ We'll need the following imports to get started:
 
 ```tut:book
 import cats.effect._
-import org.http4s._, org.http4s.dsl._
+import org.http4s._, org.http4s.dsl.io._
 ```
 
 The central concept of http4s-dsl is pattern matching.  An

--- a/docs/src/main/tut/entity.md
+++ b/docs/src/main/tut/entity.md
@@ -46,7 +46,7 @@ determine which of the chained decoders are to be used.
 
 ```tut
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import cats._, cats.effect._, cats.implicits._, cats.data._
 
 sealed trait Resp

--- a/docs/src/main/tut/gzip.md
+++ b/docs/src/main/tut/gzip.md
@@ -21,7 +21,7 @@ And we need some imports.
 ```tut:silent
 import cats.effect._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 ```
 
 Let's start by making a simple service that returns a (relatively) large string

--- a/docs/src/main/tut/hsts.md
+++ b/docs/src/main/tut/hsts.md
@@ -21,7 +21,7 @@ And we need some imports.
 
 ```tut:silent
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import cats.effect.IO
 ```
 

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -68,7 +68,7 @@ import cats.effect._
 import io.circe._
 import io.circe.literal._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 def hello(name: String): Json =
   json"""{"hello": $name}"""
@@ -209,7 +209,7 @@ import io.circe.syntax._
 
 import org.http4s._
 import org.http4s.circe._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 case class User(name: String)
 case class Hello(greeting: String)

--- a/docs/src/main/tut/methods.md
+++ b/docs/src/main/tut/methods.md
@@ -11,7 +11,7 @@ Http4s has a list of all the [methods] you're familiar with, and a few more.
 import cats.effect._
 import io.circe.generic._
 import io.circe.syntax._
-import org.http4s._, org.http4s.dsl._
+import org.http4s._, org.http4s.dsl.io._
 import org.http4s.circe._
 
 @JsonCodec case class TweetWithId(id: Int, message: String)

--- a/docs/src/main/tut/middleware.md
+++ b/docs/src/main/tut/middleware.md
@@ -27,7 +27,7 @@ and some imports.
 import cats.effect._
 import cats.implicits._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 ```
 
 Then, we can create a middleware that adds a header to successful responses from

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -50,7 +50,7 @@ Wherever you are in your studies, let's create our first
 `HttpService`.  Start by pasting these imports into your SBT console:
 
 ```tut:book
-import cats.effect._, org.http4s._, org.http4s.dsl._
+import cats.effect._, org.http4s._, org.http4s.dsl.io._
 ```
 
 Using the [http4s-dsl], we can construct an `HttpService` by pattern

--- a/docs/src/main/tut/static.md
+++ b/docs/src/main/tut/static.md
@@ -19,7 +19,7 @@ Http4s provides a few helpers to handle ETags for you, they're located in [Stati
 ```tut:book
 import cats.effect._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import java.io.File
 
 val service = HttpService[IO] {

--- a/docs/src/main/tut/streaming.md
+++ b/docs/src/main/tut/streaming.md
@@ -22,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import cats.effect._
 import fs2.Scheduler
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 // An infinite stream of the periodic elapsed time
 val seconds = Scheduler[IO](2).flatMap(_.awakeEvery[IO](1.second))

--- a/dsl/src/main/scala/org/http4s/dsl/Auth.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Auth.scala
@@ -1,7 +1,0 @@
-package org.http4s
-package dsl
-
-object as {
-  def unapply[F[_], A](ar: AuthedRequest[F, A]): Option[(Request[F], A)] =
-    Some(ar.req -> ar.authInfo)
-}

--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -1,150 +1,54 @@
 package org.http4s.dsl
 
-import cats.Applicative
-import org.http4s._
 import org.http4s.dsl.impl._
-import org.http4s.headers.`Content-Length`
+import org.http4s.{Http4s, Method}
 
-trait Http4sDsl[F[_]] extends Http4s with Methods with Statuses {
+trait Http4sDsl[F[_]] extends Http4s with Methods with Statuses with Responses[F] with Auth {
   import Http4sDsl._
 
-  implicit def http4sContinueSyntax(status: Continue.type): ContinueOps[F] = new ContinueOps[F](status)
-  implicit def http4sSwitchingProtocolsSyntax(status: SwitchingProtocols.type): SwitchingProtocolsOps[F] = new SwitchingProtocolsOps[F](status)
-  implicit def http4sOkSyntax(status: Ok.type): OkOps[F] = new OkOps[F](status)
+  type Path         = impl.Path
+  type Root         = impl.Root.type
+  type /            = impl./
+  type MethodConcat = impl.MethodConcat
 
-  implicit def http4sCreatedSyntax(status: Created.type): CreatedOps[F] = new CreatedOps[F](status)
-  implicit def http4sAcceptedSyntax(status: Accepted.type): AcceptedOps[F] = new AcceptedOps[F](status)
-  implicit def http4sNonAuthoritativeInformationSyntax(status: NonAuthoritativeInformation.type): NonAuthoritativeInformationOps[F] = new NonAuthoritativeInformationOps[F](status)
-  implicit def http4sNoContentSyntax(status: NoContent.type): NoContentOps[F] = new NoContentOps[F](status)
-  implicit def http4sResetContentSyntax(status: ResetContent.type): ResetContentOps[F] = new ResetContentOps[F](status)
-  implicit def http4sPartialContentSyntax(status: PartialContent.type): PartialContentOps[F] = new PartialContentOps[F](status)
-  implicit def http4sMultiStatusSyntax(status: Status.MultiStatus.type): MultiStatusOps[F] = new MultiStatusOps[F](status)
-  implicit def http4sAlreadyReportedSyntax(status: AlreadyReported.type): AlreadyReportedOps[F] = new AlreadyReportedOps[F](status)
-  implicit def http4sIMUsedSyntax(status: IMUsed.type): IMUsedOps[F] = new IMUsedOps[F](status)
+  val Path: impl.Path.type = impl.Path
+  val Root: impl.Root.type = impl.Root
+  val / : impl./.type      = impl./
+  val :? : impl.:?.type    = impl.:?
+  val ~ : impl.~.type      = impl.~
+  val -> : impl.->.type    = impl.->
+  val /: : impl./:.type    = impl./:
+  val +& : impl.+&.type    = impl.+&
 
-  implicit def http4sMultipleChoicesSyntax(status: MultipleChoices.type): MultipleChoicesOps[F] = new MultipleChoicesOps[F](status)
-  implicit def http4sMovedPermanentlySyntax(status: MovedPermanently.type): MovedPermanentlyOps[F] = new MovedPermanentlyOps[F](status)
-  implicit def http4sFoundSyntax(status: Found.type): FoundOps[F] = new FoundOps[F](status)
-  implicit def http4sSeeOtherSyntax(status: SeeOther.type): SeeOtherOps[F] = new SeeOtherOps[F](status)
-  implicit def http4sNotModifiedSyntax(status: NotModified.type): NotModifiedOps[F] = new NotModifiedOps[F](status)
-  implicit def http4sTemporaryRedirectSyntax(status: TemporaryRedirect.type): TemporaryRedirectOps[F] = new TemporaryRedirectOps[F](status)
-  implicit def http4sPermanentRedirectSyntax(status: PermanentRedirect.type): PermanentRedirectOps[F] = new PermanentRedirectOps[F](status)
+  val IntVar: impl.IntVar.type   = impl.IntVar
+  val LongVar: impl.LongVar.type = impl.LongVar
 
-  implicit def http4sBadRequestSyntax(status: BadRequest.type): BadRequestOps[F] = new BadRequestOps[F](status)
-  implicit def http4sUnauthorizedSyntax(status: Unauthorized.type): UnauthorizedOps[F] = new UnauthorizedOps[F](status)
-  implicit def http4sPaymentRequiredSyntax(status: PaymentRequired.type): PaymentRequiredOps[F] = new PaymentRequiredOps[F](status)
-  implicit def http4sForbiddenSyntax(status: Forbidden.type): ForbiddenOps[F] = new ForbiddenOps[F](status)
-  implicit def http4sNotFoundSyntax(status: NotFound.type): NotFoundOps[F] = new NotFoundOps[F](status)
-  implicit def http4sMethodNotAllowedSyntax(status: MethodNotAllowed.type): MethodNotAllowedOps[F] = new MethodNotAllowedOps[F](status)
-  implicit def http4sNotAcceptableSyntax(status: NotAcceptable.type): NotAcceptableOps[F] = new NotAcceptableOps[F](status)
-  implicit def http4sProxyAuthenticationRequiredSyntax(status: ProxyAuthenticationRequired.type): ProxyAuthenticationRequiredOps[F] = new ProxyAuthenticationRequiredOps[F](status)
-  implicit def http4sRequestTimeoutSyntax(status: RequestTimeout.type): RequestTimeoutOps[F] = new RequestTimeoutOps[F](status)
-  implicit def http4sConflictSyntax(status: Conflict.type): ConflictOps[F] = new ConflictOps[F](status)
-  implicit def http4sGoneSyntax(status: Gone.type): GoneOps[F] = new GoneOps[F](status)
-  implicit def http4sLengthRequiredSyntax(status: LengthRequired.type): LengthRequiredOps[F] = new LengthRequiredOps[F](status)
-  implicit def http4sPreconditionFailedSyntax(status: PreconditionFailed.type): PreconditionFailedOps[F] = new PreconditionFailedOps[F](status)
-  implicit def http4sPayloadTooLargeSyntax(status: PayloadTooLarge.type): PayloadTooLargeOps[F] = new PayloadTooLargeOps[F](status)
-  implicit def http4sUriTooLongSyntax(status: UriTooLong.type): UriTooLongOps[F] = new UriTooLongOps[F](status)
-  implicit def http4sUnsupportedMediaTypeSyntax(status: UnsupportedMediaType.type): UnsupportedMediaTypeOps[F] = new UnsupportedMediaTypeOps[F](status)
-  implicit def http4sRangeNotSatisfiableSyntax(status: RangeNotSatisfiable.type): RangeNotSatisfiableOps[F] = new RangeNotSatisfiableOps[F](status)
-  implicit def http4sExpectationFailedSyntax(status: ExpectationFailed.type): ExpectationFailedOps[F] = new ExpectationFailedOps[F](status)
-  implicit def http4sUnprocessableEntitySyntax(status: UnprocessableEntity.type): UnprocessableEntityOps[F] = new UnprocessableEntityOps[F](status)
-  implicit def http4sLockedSyntax(status: Locked.type): LockedOps[F] = new LockedOps[F](status)
-  implicit def http4sFailedDependencySyntax(status: FailedDependency.type): FailedDependencyOps[F] = new FailedDependencyOps[F](status)
-  implicit def http4sUpgradeRequiredSyntax(status: UpgradeRequired.type): UpgradeRequiredOps[F] = new UpgradeRequiredOps[F](status)
-  implicit def http4sPreconditionRequiredSyntax(status: PreconditionRequired.type): PreconditionRequiredOps[F] = new PreconditionRequiredOps[F](status)
-  implicit def http4sTooManyRequestsSyntax(status: TooManyRequests.type): TooManyRequestsOps[F] = new TooManyRequestsOps[F](status)
-  implicit def http4sRequestHeaderFieldsTooLargeSyntax(status: RequestHeaderFieldsTooLarge.type): RequestHeaderFieldsTooLargeOps[F] = new RequestHeaderFieldsTooLargeOps[F](status)
-  implicit def http4sUnavailableForLegalReasonsSyntax(status: UnavailableForLegalReasons.type): UnavailableForLegalReasonsOps[F] = new UnavailableForLegalReasonsOps[F](status)
+  type QueryParamDecoderMatcher[T]              = impl.QueryParamDecoderMatcher[T]
+  type QueryParamMatcher[T]                     = impl.QueryParamMatcher[T]
+  type OptionalQueryParamDecoderMatcher[T]      = impl.OptionalQueryParamDecoderMatcher[T]
+  type OptionalMultiQueryParamDecoderMatcher[T] = impl.OptionalMultiQueryParamDecoderMatcher[T]
+  type OptionalQueryParamMatcher[T]             = impl.OptionalQueryParamMatcher[T]
+  type ValidatingQueryParamDecoderMatcher[T]    = impl.ValidatingQueryParamDecoderMatcher[T]
+  type OptionalValidatingQueryParamDecoderMatcher[T] =
+    impl.OptionalValidatingQueryParamDecoderMatcher[T]
 
-  implicit def http4sInternalServerErrorSyntax(status: InternalServerError.type): InternalServerErrorOps[F] = new InternalServerErrorOps[F](status)
-  implicit def http4sNotImplementedSyntax(status: NotImplemented.type): NotImplementedOps[F] = new NotImplementedOps[F](status)
-  implicit def http4sBadGatewaySyntax(status: BadGateway.type): BadGatewayOps[F] = new BadGatewayOps[F](status)
-  implicit def http4sServiceUnavailableSyntax(status: ServiceUnavailable.type): ServiceUnavailableOps[F] = new ServiceUnavailableOps[F](status)
-  implicit def http4sGatewayTimeoutSyntax(status: GatewayTimeout.type): GatewayTimeoutOps[F] = new GatewayTimeoutOps[F](status)
-  implicit def http4sHttpVersionNotSupportedSyntax(status: HttpVersionNotSupported.type): HttpVersionNotSupportedOps[F] = new HttpVersionNotSupportedOps[F](status)
-  implicit def http4sVariantAlsoNegotiatesSyntax(status: VariantAlsoNegotiates.type): VariantAlsoNegotiatesOps[F] = new VariantAlsoNegotiatesOps[F](status)
-  implicit def http4sInsufficientStorageSyntax(status: InsufficientStorage.type): InsufficientStorageOps[F] = new InsufficientStorageOps[F](status)
-  implicit def http4sLoopDetectedSyntax(status: LoopDetected.type): LoopDetectedOps[F] = new LoopDetectedOps[F](status)
-  implicit def http4sNotExtendedSyntax(status: NotExtended.type): NotExtendedOps[F] = new NotExtendedOps[F](status)
-  implicit def http4sNetworkAuthenticationRequiredSyntax(status: NetworkAuthenticationRequired.type): NetworkAuthenticationRequiredOps[F] = new NetworkAuthenticationRequiredOps[F](status)
+  implicit def http4sMethodSyntax(method: Method): MethodOps =
+    new MethodOps(method)
+
+  implicit def http4sMethodConcatSyntax(methods: MethodConcat): MethodConcatOps =
+    new MethodConcatOps(methods)
+
 }
 
 object Http4sDsl {
-  final class ContinueOps[F[_]](val status: Continue.type) extends AnyVal with EmptyResponseGenerator[F]
-  // TODO support Upgrade header
-  final class SwitchingProtocolsOps[F[_]](val status: SwitchingProtocols.type) extends AnyVal with EmptyResponseGenerator[F]
-  final class OkOps[F[_]](val status: Ok.type) extends AnyVal with EntityResponseGenerator[F]
 
-  final class CreatedOps[F[_]](val status: Created.type) extends AnyVal with EntityResponseGenerator[F]
-  final class AcceptedOps[F[_]](val status: Accepted.type) extends AnyVal with EntityResponseGenerator[F]
-  final class NonAuthoritativeInformationOps[F[_]](val status: NonAuthoritativeInformation.type) extends AnyVal with EntityResponseGenerator[F]
-  final class NoContentOps[F[_]](val status: NoContent.type) extends AnyVal with EmptyResponseGenerator[F]
-  final class ResetContentOps[F[_]](val status: ResetContent.type) extends AnyVal with EmptyResponseGenerator[F] {
-    override def apply()(implicit F: Applicative[F]): F[Response[F]] =
-      F.pure(Response(ResetContent, headers = Headers(`Content-Length`.zero)))
-  }
-  // TODO helpers for Content-Range and multipart/byteranges
-  final class PartialContentOps[F[_]](val status: PartialContent.type) extends AnyVal with EntityResponseGenerator[F]
-  final class MultiStatusOps[F[_]](val status: Status.MultiStatus.type) extends AnyVal with EntityResponseGenerator[F]
-  final class AlreadyReportedOps[F[_]](val status: AlreadyReported.type) extends AnyVal with EntityResponseGenerator[F]
-  final class IMUsedOps[F[_]](val status: IMUsed.type) extends AnyVal with EntityResponseGenerator[F]
+  def apply[F[_]]: Http4sDsl[F] = new Http4sDsl[F] {}
 
-  final class MultipleChoicesOps[F[_]](val status: MultipleChoices.type) extends AnyVal with LocationResponseGenerator[F]
-  final class MovedPermanentlyOps[F[_]](val status: MovedPermanently.type) extends AnyVal with LocationResponseGenerator[F]
-  final class FoundOps[F[_]](val status: Found.type) extends AnyVal with LocationResponseGenerator[F]
-  final class SeeOtherOps[F[_]](val status: SeeOther.type) extends AnyVal with LocationResponseGenerator[F]
-  final class NotModifiedOps[F[_]](val status: NotModified.type) extends AnyVal with EmptyResponseGenerator[F]
-  // Note: UseProxy is deprecated in RFC7231, so we will not ease its creation here.
-  final class TemporaryRedirectOps[F[_]](val status: TemporaryRedirect.type) extends AnyVal with LocationResponseGenerator[F]
-  final class PermanentRedirectOps[F[_]](val status: PermanentRedirect.type) extends AnyVal with LocationResponseGenerator[F]
-
-  final class BadRequestOps[F[_]](val status: BadRequest.type) extends AnyVal with EntityResponseGenerator[F]
-  final class UnauthorizedOps[F[_]](val status: Unauthorized.type) extends AnyVal with WwwAuthenticateResponseGenerator[F]
-  final class PaymentRequiredOps[F[_]](val status: PaymentRequired.type) extends AnyVal with EntityResponseGenerator[F]
-  final class ForbiddenOps[F[_]](val status: Forbidden.type) extends AnyVal with EntityResponseGenerator[F]
-  final class NotFoundOps[F[_]](val status: NotFound.type) extends AnyVal with EntityResponseGenerator[F]
-  final class MethodNotAllowedOps[F[_]](val status: MethodNotAllowed.type) extends AnyVal with EntityResponseGenerator[F]
-  final class NotAcceptableOps[F[_]](val status: NotAcceptable.type) extends AnyVal with EntityResponseGenerator[F]
-  final class ProxyAuthenticationRequiredOps[F[_]](val status: ProxyAuthenticationRequired.type) extends AnyVal with EntityResponseGenerator[F]
-  // TODO send Connection: close?
-  final class RequestTimeoutOps[F[_]](val status: RequestTimeout.type) extends AnyVal with EntityResponseGenerator[F]
-  final class ConflictOps[F[_]](val status: Conflict.type) extends AnyVal with EntityResponseGenerator[F]
-  final class GoneOps[F[_]](val status: Gone.type) extends AnyVal with EntityResponseGenerator[F]
-  final class LengthRequiredOps[F[_]](val status: LengthRequired.type) extends AnyVal with EntityResponseGenerator[F]
-  final class PreconditionFailedOps[F[_]](val status: PreconditionFailed.type) extends AnyVal with EntityResponseGenerator[F]
-  final class PayloadTooLargeOps[F[_]](val status: PayloadTooLarge.type) extends AnyVal with EntityResponseGenerator[F]
-  final class UriTooLongOps[F[_]](val status: UriTooLong.type) extends AnyVal with EntityResponseGenerator[F]
-  final class UnsupportedMediaTypeOps[F[_]](val status: UnsupportedMediaType.type) extends AnyVal with EntityResponseGenerator[F]
-  final class RangeNotSatisfiableOps[F[_]](val status: RangeNotSatisfiable.type) extends AnyVal with EntityResponseGenerator[F]
-  final class ExpectationFailedOps[F[_]](val status: ExpectationFailed.type) extends AnyVal with EntityResponseGenerator[F]
-  final class UnprocessableEntityOps[F[_]](val status: UnprocessableEntity.type) extends AnyVal with EntityResponseGenerator[F]
-  final class LockedOps[F[_]](val status: Locked.type) extends AnyVal with EntityResponseGenerator[F]
-  final class FailedDependencyOps[F[_]](val status: FailedDependency.type) extends AnyVal with EntityResponseGenerator[F]
-  // TODO Mandatory upgrade field
-  final class UpgradeRequiredOps[F[_]](val status: UpgradeRequired.type) extends AnyVal with EntityResponseGenerator[F]
-  final class PreconditionRequiredOps[F[_]](val status: PreconditionRequired.type) extends AnyVal with EntityResponseGenerator[F]
-  final class TooManyRequestsOps[F[_]](val status: TooManyRequests.type) extends AnyVal with EntityResponseGenerator[F]
-  final class RequestHeaderFieldsTooLargeOps[F[_]](val status: RequestHeaderFieldsTooLarge.type) extends AnyVal with EntityResponseGenerator[F]
-  final class UnavailableForLegalReasonsOps[F[_]](val status: UnavailableForLegalReasons.type) extends AnyVal with EntityResponseGenerator[F]
-
-  final class InternalServerErrorOps[F[_]](val status: InternalServerError.type) extends AnyVal with EntityResponseGenerator[F]
-  final class NotImplementedOps[F[_]](val status: NotImplemented.type) extends AnyVal with EntityResponseGenerator[F]
-  final class BadGatewayOps[F[_]](val status: BadGateway.type) extends AnyVal with EntityResponseGenerator[F]
-  final class ServiceUnavailableOps[F[_]](val status: ServiceUnavailable.type) extends AnyVal with EntityResponseGenerator[F]
-  final class GatewayTimeoutOps[F[_]](val status: GatewayTimeout.type) extends AnyVal with EntityResponseGenerator[F]
-  final class HttpVersionNotSupportedOps[F[_]](val status: HttpVersionNotSupported.type) extends AnyVal with EntityResponseGenerator[F]
-  final class VariantAlsoNegotiatesOps[F[_]](val status: VariantAlsoNegotiates.type) extends AnyVal with EntityResponseGenerator[F]
-  final class InsufficientStorageOps[F[_]](val status: InsufficientStorage.type) extends AnyVal with EntityResponseGenerator[F]
-  final class LoopDetectedOps[F[_]](val status: LoopDetected.type) extends AnyVal with EntityResponseGenerator[F]
-  final class NotExtendedOps[F[_]](val status: NotExtended.type) extends AnyVal with EntityResponseGenerator[F]
-  final class NetworkAuthenticationRequiredOps[F[_]](val status: NetworkAuthenticationRequired.type) extends AnyVal with EntityResponseGenerator[F]
-
-  implicit class MethodOps(val method: Method) extends AnyVal {
-    def | (another: Method) = new MethodConcat(Set(method, another))
+  final class MethodOps(val method: Method) extends AnyVal {
+    def |(another: Method) = new MethodConcat(Set(method, another))
   }
 
-  implicit class MethodConcatOps(val methods: MethodConcat) extends AnyVal {
-    def | (another: Method) = new MethodConcat(methods.methods + another)
+  final class MethodConcatOps(val methods: MethodConcat) extends AnyVal {
+    def |(another: Method) = new MethodConcat(methods.methods + another)
   }
 }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Auth.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Auth.scala
@@ -1,0 +1,10 @@
+package org.http4s.dsl.impl
+
+import org.http4s.{AuthedRequest, Request}
+
+trait Auth {
+  object as {
+    def unapply[F[_], A](ar: AuthedRequest[F, A]): Option[(Request[F], A)] =
+      Some(ar.req -> ar.authInfo)
+  }
+}

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Methods.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Methods.scala
@@ -1,4 +1,4 @@
-package org.http4s.dsl
+package org.http4s.dsl.impl
 
 import org.http4s.Method
 

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
@@ -1,0 +1,143 @@
+package org.http4s.dsl.impl
+
+import cats.Applicative
+import org.http4s.Status._
+import org.http4s.headers.`Content-Length`
+import org.http4s.{Headers, Response, Status}
+
+trait Responses[F[_]] {
+ import Responses._
+
+  implicit def http4sContinueSyntax(status: Continue.type): ContinueOps[F] = new ContinueOps[F](status)
+  implicit def http4sSwitchingProtocolsSyntax(status: SwitchingProtocols.type): SwitchingProtocolsOps[F] = new SwitchingProtocolsOps[F](status)
+  implicit def http4sOkSyntax(status: Ok.type): OkOps[F] = new OkOps[F](status)
+
+  implicit def http4sCreatedSyntax(status: Created.type): CreatedOps[F] = new CreatedOps[F](status)
+  implicit def http4sAcceptedSyntax(status: Accepted.type): AcceptedOps[F] = new AcceptedOps[F](status)
+  implicit def http4sNonAuthoritativeInformationSyntax(status: NonAuthoritativeInformation.type): NonAuthoritativeInformationOps[F] = new NonAuthoritativeInformationOps[F](status)
+  implicit def http4sNoContentSyntax(status: NoContent.type): NoContentOps[F] = new NoContentOps[F](status)
+  implicit def http4sResetContentSyntax(status: ResetContent.type): ResetContentOps[F] = new ResetContentOps[F](status)
+  implicit def http4sPartialContentSyntax(status: PartialContent.type): PartialContentOps[F] = new PartialContentOps[F](status)
+  implicit def http4sMultiStatusSyntax(status: Status.MultiStatus.type): MultiStatusOps[F] = new MultiStatusOps[F](status)
+  implicit def http4sAlreadyReportedSyntax(status: AlreadyReported.type): AlreadyReportedOps[F] = new AlreadyReportedOps[F](status)
+  implicit def http4sIMUsedSyntax(status: IMUsed.type): IMUsedOps[F] = new IMUsedOps[F](status)
+
+  implicit def http4sMultipleChoicesSyntax(status: MultipleChoices.type): MultipleChoicesOps[F] = new MultipleChoicesOps[F](status)
+  implicit def http4sMovedPermanentlySyntax(status: MovedPermanently.type): MovedPermanentlyOps[F] = new MovedPermanentlyOps[F](status)
+  implicit def http4sFoundSyntax(status: Found.type): FoundOps[F] = new FoundOps[F](status)
+  implicit def http4sSeeOtherSyntax(status: SeeOther.type): SeeOtherOps[F] = new SeeOtherOps[F](status)
+  implicit def http4sNotModifiedSyntax(status: NotModified.type): NotModifiedOps[F] = new NotModifiedOps[F](status)
+  implicit def http4sTemporaryRedirectSyntax(status: TemporaryRedirect.type): TemporaryRedirectOps[F] = new TemporaryRedirectOps[F](status)
+  implicit def http4sPermanentRedirectSyntax(status: PermanentRedirect.type): PermanentRedirectOps[F] = new PermanentRedirectOps[F](status)
+
+  implicit def http4sBadRequestSyntax(status: BadRequest.type): BadRequestOps[F] = new BadRequestOps[F](status)
+  implicit def http4sUnauthorizedSyntax(status: Unauthorized.type): UnauthorizedOps[F] = new UnauthorizedOps[F](status)
+  implicit def http4sPaymentRequiredSyntax(status: PaymentRequired.type): PaymentRequiredOps[F] = new PaymentRequiredOps[F](status)
+  implicit def http4sForbiddenSyntax(status: Forbidden.type): ForbiddenOps[F] = new ForbiddenOps[F](status)
+  implicit def http4sNotFoundSyntax(status: NotFound.type): NotFoundOps[F] = new NotFoundOps[F](status)
+  implicit def http4sMethodNotAllowedSyntax(status: MethodNotAllowed.type): MethodNotAllowedOps[F] = new MethodNotAllowedOps[F](status)
+  implicit def http4sNotAcceptableSyntax(status: NotAcceptable.type): NotAcceptableOps[F] = new NotAcceptableOps[F](status)
+  implicit def http4sProxyAuthenticationRequiredSyntax(status: ProxyAuthenticationRequired.type): ProxyAuthenticationRequiredOps[F] = new ProxyAuthenticationRequiredOps[F](status)
+  implicit def http4sRequestTimeoutSyntax(status: RequestTimeout.type): RequestTimeoutOps[F] = new RequestTimeoutOps[F](status)
+  implicit def http4sConflictSyntax(status: Conflict.type): ConflictOps[F] = new ConflictOps[F](status)
+  implicit def http4sGoneSyntax(status: Gone.type): GoneOps[F] = new GoneOps[F](status)
+  implicit def http4sLengthRequiredSyntax(status: LengthRequired.type): LengthRequiredOps[F] = new LengthRequiredOps[F](status)
+  implicit def http4sPreconditionFailedSyntax(status: PreconditionFailed.type): PreconditionFailedOps[F] = new PreconditionFailedOps[F](status)
+  implicit def http4sPayloadTooLargeSyntax(status: PayloadTooLarge.type): PayloadTooLargeOps[F] = new PayloadTooLargeOps[F](status)
+  implicit def http4sUriTooLongSyntax(status: UriTooLong.type): UriTooLongOps[F] = new UriTooLongOps[F](status)
+  implicit def http4sUnsupportedMediaTypeSyntax(status: UnsupportedMediaType.type): UnsupportedMediaTypeOps[F] = new UnsupportedMediaTypeOps[F](status)
+  implicit def http4sRangeNotSatisfiableSyntax(status: RangeNotSatisfiable.type): RangeNotSatisfiableOps[F] = new RangeNotSatisfiableOps[F](status)
+  implicit def http4sExpectationFailedSyntax(status: ExpectationFailed.type): ExpectationFailedOps[F] = new ExpectationFailedOps[F](status)
+  implicit def http4sUnprocessableEntitySyntax(status: UnprocessableEntity.type): UnprocessableEntityOps[F] = new UnprocessableEntityOps[F](status)
+  implicit def http4sLockedSyntax(status: Locked.type): LockedOps[F] = new LockedOps[F](status)
+  implicit def http4sFailedDependencySyntax(status: FailedDependency.type): FailedDependencyOps[F] = new FailedDependencyOps[F](status)
+  implicit def http4sUpgradeRequiredSyntax(status: UpgradeRequired.type): UpgradeRequiredOps[F] = new UpgradeRequiredOps[F](status)
+  implicit def http4sPreconditionRequiredSyntax(status: PreconditionRequired.type): PreconditionRequiredOps[F] = new PreconditionRequiredOps[F](status)
+  implicit def http4sTooManyRequestsSyntax(status: TooManyRequests.type): TooManyRequestsOps[F] = new TooManyRequestsOps[F](status)
+  implicit def http4sRequestHeaderFieldsTooLargeSyntax(status: RequestHeaderFieldsTooLarge.type): RequestHeaderFieldsTooLargeOps[F] = new RequestHeaderFieldsTooLargeOps[F](status)
+  implicit def http4sUnavailableForLegalReasonsSyntax(status: UnavailableForLegalReasons.type): UnavailableForLegalReasonsOps[F] = new UnavailableForLegalReasonsOps[F](status)
+
+  implicit def http4sInternalServerErrorSyntax(status: InternalServerError.type): InternalServerErrorOps[F] = new InternalServerErrorOps[F](status)
+  implicit def http4sNotImplementedSyntax(status: NotImplemented.type): NotImplementedOps[F] = new NotImplementedOps[F](status)
+  implicit def http4sBadGatewaySyntax(status: BadGateway.type): BadGatewayOps[F] = new BadGatewayOps[F](status)
+  implicit def http4sServiceUnavailableSyntax(status: ServiceUnavailable.type): ServiceUnavailableOps[F] = new ServiceUnavailableOps[F](status)
+  implicit def http4sGatewayTimeoutSyntax(status: GatewayTimeout.type): GatewayTimeoutOps[F] = new GatewayTimeoutOps[F](status)
+  implicit def http4sHttpVersionNotSupportedSyntax(status: HttpVersionNotSupported.type): HttpVersionNotSupportedOps[F] = new HttpVersionNotSupportedOps[F](status)
+  implicit def http4sVariantAlsoNegotiatesSyntax(status: VariantAlsoNegotiates.type): VariantAlsoNegotiatesOps[F] = new VariantAlsoNegotiatesOps[F](status)
+  implicit def http4sInsufficientStorageSyntax(status: InsufficientStorage.type): InsufficientStorageOps[F] = new InsufficientStorageOps[F](status)
+  implicit def http4sLoopDetectedSyntax(status: LoopDetected.type): LoopDetectedOps[F] = new LoopDetectedOps[F](status)
+  implicit def http4sNotExtendedSyntax(status: NotExtended.type): NotExtendedOps[F] = new NotExtendedOps[F](status)
+  implicit def http4sNetworkAuthenticationRequiredSyntax(status: NetworkAuthenticationRequired.type): NetworkAuthenticationRequiredOps[F] = new NetworkAuthenticationRequiredOps[F](status)
+}
+
+object Responses {
+  final class ContinueOps[F[_]](val status: Continue.type) extends AnyVal with EmptyResponseGenerator[F]
+  // TODO support Upgrade header
+  final class SwitchingProtocolsOps[F[_]](val status: SwitchingProtocols.type) extends AnyVal with EmptyResponseGenerator[F]
+  final class OkOps[F[_]](val status: Ok.type) extends AnyVal with EntityResponseGenerator[F]
+
+  final class CreatedOps[F[_]](val status: Created.type) extends AnyVal with EntityResponseGenerator[F]
+  final class AcceptedOps[F[_]](val status: Accepted.type) extends AnyVal with EntityResponseGenerator[F]
+  final class NonAuthoritativeInformationOps[F[_]](val status: NonAuthoritativeInformation.type) extends AnyVal with EntityResponseGenerator[F]
+  final class NoContentOps[F[_]](val status: NoContent.type) extends AnyVal with EmptyResponseGenerator[F]
+  final class ResetContentOps[F[_]](val status: ResetContent.type) extends AnyVal with EmptyResponseGenerator[F] {
+    override def apply()(implicit F: Applicative[F]): F[Response[F]] =
+      F.pure(Response(ResetContent, headers = Headers(`Content-Length`.zero)))
+  }
+  // TODO helpers for Content-Range and multipart/byteranges
+  final class PartialContentOps[F[_]](val status: PartialContent.type) extends AnyVal with EntityResponseGenerator[F]
+  final class MultiStatusOps[F[_]](val status: Status.MultiStatus.type) extends AnyVal with EntityResponseGenerator[F]
+  final class AlreadyReportedOps[F[_]](val status: AlreadyReported.type) extends AnyVal with EntityResponseGenerator[F]
+  final class IMUsedOps[F[_]](val status: IMUsed.type) extends AnyVal with EntityResponseGenerator[F]
+
+  final class MultipleChoicesOps[F[_]](val status: MultipleChoices.type) extends AnyVal with LocationResponseGenerator[F]
+  final class MovedPermanentlyOps[F[_]](val status: MovedPermanently.type) extends AnyVal with LocationResponseGenerator[F]
+  final class FoundOps[F[_]](val status: Found.type) extends AnyVal with LocationResponseGenerator[F]
+  final class SeeOtherOps[F[_]](val status: SeeOther.type) extends AnyVal with LocationResponseGenerator[F]
+  final class NotModifiedOps[F[_]](val status: NotModified.type) extends AnyVal with EmptyResponseGenerator[F]
+  // Note: UseProxy is deprecated in RFC7231, so we will not ease its creation here.
+  final class TemporaryRedirectOps[F[_]](val status: TemporaryRedirect.type) extends AnyVal with LocationResponseGenerator[F]
+  final class PermanentRedirectOps[F[_]](val status: PermanentRedirect.type) extends AnyVal with LocationResponseGenerator[F]
+
+  final class BadRequestOps[F[_]](val status: BadRequest.type) extends AnyVal with EntityResponseGenerator[F]
+  final class UnauthorizedOps[F[_]](val status: Unauthorized.type) extends AnyVal with WwwAuthenticateResponseGenerator[F]
+  final class PaymentRequiredOps[F[_]](val status: PaymentRequired.type) extends AnyVal with EntityResponseGenerator[F]
+  final class ForbiddenOps[F[_]](val status: Forbidden.type) extends AnyVal with EntityResponseGenerator[F]
+  final class NotFoundOps[F[_]](val status: NotFound.type) extends AnyVal with EntityResponseGenerator[F]
+  final class MethodNotAllowedOps[F[_]](val status: MethodNotAllowed.type) extends AnyVal with EntityResponseGenerator[F]
+  final class NotAcceptableOps[F[_]](val status: NotAcceptable.type) extends AnyVal with EntityResponseGenerator[F]
+  final class ProxyAuthenticationRequiredOps[F[_]](val status: ProxyAuthenticationRequired.type) extends AnyVal with EntityResponseGenerator[F]
+  // TODO send Connection: close?
+  final class RequestTimeoutOps[F[_]](val status: RequestTimeout.type) extends AnyVal with EntityResponseGenerator[F]
+  final class ConflictOps[F[_]](val status: Conflict.type) extends AnyVal with EntityResponseGenerator[F]
+  final class GoneOps[F[_]](val status: Gone.type) extends AnyVal with EntityResponseGenerator[F]
+  final class LengthRequiredOps[F[_]](val status: LengthRequired.type) extends AnyVal with EntityResponseGenerator[F]
+  final class PreconditionFailedOps[F[_]](val status: PreconditionFailed.type) extends AnyVal with EntityResponseGenerator[F]
+  final class PayloadTooLargeOps[F[_]](val status: PayloadTooLarge.type) extends AnyVal with EntityResponseGenerator[F]
+  final class UriTooLongOps[F[_]](val status: UriTooLong.type) extends AnyVal with EntityResponseGenerator[F]
+  final class UnsupportedMediaTypeOps[F[_]](val status: UnsupportedMediaType.type) extends AnyVal with EntityResponseGenerator[F]
+  final class RangeNotSatisfiableOps[F[_]](val status: RangeNotSatisfiable.type) extends AnyVal with EntityResponseGenerator[F]
+  final class ExpectationFailedOps[F[_]](val status: ExpectationFailed.type) extends AnyVal with EntityResponseGenerator[F]
+  final class UnprocessableEntityOps[F[_]](val status: UnprocessableEntity.type) extends AnyVal with EntityResponseGenerator[F]
+  final class LockedOps[F[_]](val status: Locked.type) extends AnyVal with EntityResponseGenerator[F]
+  final class FailedDependencyOps[F[_]](val status: FailedDependency.type) extends AnyVal with EntityResponseGenerator[F]
+  // TODO Mandatory upgrade field
+  final class UpgradeRequiredOps[F[_]](val status: UpgradeRequired.type) extends AnyVal with EntityResponseGenerator[F]
+  final class PreconditionRequiredOps[F[_]](val status: PreconditionRequired.type) extends AnyVal with EntityResponseGenerator[F]
+  final class TooManyRequestsOps[F[_]](val status: TooManyRequests.type) extends AnyVal with EntityResponseGenerator[F]
+  final class RequestHeaderFieldsTooLargeOps[F[_]](val status: RequestHeaderFieldsTooLarge.type) extends AnyVal with EntityResponseGenerator[F]
+  final class UnavailableForLegalReasonsOps[F[_]](val status: UnavailableForLegalReasons.type) extends AnyVal with EntityResponseGenerator[F]
+
+  final class InternalServerErrorOps[F[_]](val status: InternalServerError.type) extends AnyVal with EntityResponseGenerator[F]
+  final class NotImplementedOps[F[_]](val status: NotImplemented.type) extends AnyVal with EntityResponseGenerator[F]
+  final class BadGatewayOps[F[_]](val status: BadGateway.type) extends AnyVal with EntityResponseGenerator[F]
+  final class ServiceUnavailableOps[F[_]](val status: ServiceUnavailable.type) extends AnyVal with EntityResponseGenerator[F]
+  final class GatewayTimeoutOps[F[_]](val status: GatewayTimeout.type) extends AnyVal with EntityResponseGenerator[F]
+  final class HttpVersionNotSupportedOps[F[_]](val status: HttpVersionNotSupported.type) extends AnyVal with EntityResponseGenerator[F]
+  final class VariantAlsoNegotiatesOps[F[_]](val status: VariantAlsoNegotiates.type) extends AnyVal with EntityResponseGenerator[F]
+  final class InsufficientStorageOps[F[_]](val status: InsufficientStorage.type) extends AnyVal with EntityResponseGenerator[F]
+  final class LoopDetectedOps[F[_]](val status: LoopDetected.type) extends AnyVal with EntityResponseGenerator[F]
+  final class NotExtendedOps[F[_]](val status: NotExtended.type) extends AnyVal with EntityResponseGenerator[F]
+  final class NetworkAuthenticationRequiredOps[F[_]](val status: NetworkAuthenticationRequired.type) extends AnyVal with EntityResponseGenerator[F]
+
+}

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Statuses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Statuses.scala
@@ -1,4 +1,4 @@
-package org.http4s.dsl
+package org.http4s.dsl.impl
 
 import org.http4s.Status
 

--- a/dsl/src/main/scala/org/http4s/dsl/io.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/io.scala
@@ -2,4 +2,4 @@ package org.http4s.dsl
 
 import cats.effect.IO
 
-package object io extends Http4sDsl[IO]
+object io extends Http4sDsl[IO]

--- a/dsl/src/main/scala/org/http4s/dsl/io/package.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/io/package.scala
@@ -1,0 +1,5 @@
+package org.http4s.dsl
+
+import cats.effect.IO
+
+package object io extends Http4sDsl[IO]

--- a/dsl/src/main/scala/org/http4s/dsl/package.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/package.scala
@@ -1,5 +1,0 @@
-package org.http4s
-
-import cats.effect.IO
-
-package object dsl extends Http4sDsl[IO]

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
@@ -3,7 +3,7 @@ package dsl
 
 import cats.data.Validated._
 import cats.effect.IO
-import fs2._
+import org.http4s.dsl.io._
 import org.http4s.util.nonEmptyList._
 
 object PathInHttpServiceSpec extends Http4sSpec {

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -8,6 +8,7 @@ package org.http4s
 package dsl
 
 import cats.effect.IO
+import org.http4s.dsl.io._
 
 class PathSpec extends Http4sSpec {
   "Path" should {

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
@@ -3,6 +3,7 @@ package dsl
 
 import cats._
 import cats.effect.IO
+import org.http4s.dsl.io._
 import org.http4s.headers.{Accept, `Content-Length`, `Content-Type`}
 
 class ResponseGeneratorSpec extends Http4sSpec {

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.Executors
 import cats.effect._
 import fs2._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.server.websocket._
 import org.http4s.util.{StreamApp, _}

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
@@ -6,7 +6,7 @@ import org.http4s.Uri._
 import org.http4s._
 import org.http4s.client._
 import org.http4s.client.blaze.{defaultClient => client}
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.http4s.multipart._
 

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
@@ -4,7 +4,7 @@ import cats.effect._
 import org.http4s._
 import org.http4s.client._
 import org.http4s.client.blaze.{defaultClient => client}
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 object ClientPostExample extends App {
   val req = POST(uri("https://duckduckgo.com/"), UrlForm("q" -> "http4s"))

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -9,7 +9,7 @@ import org.http4s.MediaType._
 import org.http4s._
 import org.http4s.server._
 import org.http4s.circe._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.http4s.server.middleware.authentication.BasicAuth
 import org.http4s.twirl._

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import org.http4s._
 import org.http4s.circe._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers.Date
 import org.http4s.scalaxml._
 import io.circe._

--- a/examples/src/main/scala/com/example/http4s/site/HelloBetterWorld.scala
+++ b/examples/src/main/scala/com/example/http4s/site/HelloBetterWorld.scala
@@ -3,7 +3,7 @@ package site
 
 import cats.effect.IO
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 object HelloBetterWorld {
   val service = HttpService[IO] {

--- a/examples/src/main/scala/com/example/http4s/ssl/SslExampleWithRedirect.scala
+++ b/examples/src/main/scala/com/example/http4s/ssl/SslExampleWithRedirect.scala
@@ -9,7 +9,7 @@ import cats.syntax.option._
 import fs2._
 import org.http4s.HttpService
 import org.http4s.Uri.{Authority, RegName}
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers.Host
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import org.http4s.server.{SSLKeyStoreSupport, ServerBuilder}

--- a/jetty/src/test/scala/org/http4s/server/jetty/Issue454.scala
+++ b/jetty/src/test/scala/org/http4s/server/jetty/Issue454.scala
@@ -6,7 +6,7 @@ package jetty
 import cats.effect.IO
 import org.eclipse.jetty.server.{HttpConfiguration, HttpConnectionFactory, Server, ServerConnector}
 import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.servlet.Http4sServlet
 
 object Issue454 {

--- a/server/src/test/scala/org/http4s/server/RouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSpec.scala
@@ -2,7 +2,7 @@ package org.http4s
 package server
 
 import cats.effect._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 class RouterSpec extends Http4sSpec {
   val numbers  = HttpService[IO] {

--- a/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
@@ -7,7 +7,7 @@ import java.nio.charset.StandardCharsets
 import cats.effect._
 import cats._
 import cats.implicits._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.specs2.mutable.Specification
 

--- a/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
@@ -7,7 +7,7 @@ import cats.instances.vector._
 import cats.syntax.foldable._
 import fs2._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.http4s.util.chunk._
 import org.scalacheck._

--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
@@ -4,7 +4,7 @@ package middleware
 
 import cats.effect._
 import fs2.Stream._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 class DefaultHeadSpec extends Http4sSpec {
   val service = DefaultHead[IO](HttpService[IO] {

--- a/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
@@ -9,7 +9,7 @@ import cats.effect._
 import cats.implicits._
 import fs2._
 import org.http4s.server.syntax._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.http4s.headers._
 import org.scalacheck.Prop.forAll

--- a/server/src/test/scala/org/http4s/server/middleware/HSTSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HSTSSpec.scala
@@ -3,7 +3,7 @@ package server
 package middleware
 
 import cats.effect._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers._
 
 import scala.concurrent.duration._

--- a/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
@@ -4,7 +4,7 @@ package middleware
 
 import cats.effect._
 import fs2.io.readInputStream
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 import scala.io.Source
 

--- a/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
@@ -8,7 +8,7 @@ import cats.effect._
 import cats.implicits._
 import fs2.Scheduler
 import org.http4s.Http4sSpec._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 import scala.concurrent.duration._
 

--- a/server/src/test/scala/org/http4s/server/middleware/UriTranslationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/UriTranslationSpec.scala
@@ -3,7 +3,7 @@ package server
 package middleware
 
 import cats.effect._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 class UriTranslationSpec extends Http4sSpec {
 

--- a/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSpec.scala
@@ -3,7 +3,7 @@ package server
 package middleware
 
 import cats.effect._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 
 class UrlFormLifterSpec extends Http4sSpec {
   val urlForm = UrlForm("foo" -> "bar")

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
@@ -4,7 +4,7 @@ import cats.data.Kleisli
 import cats.effect._
 import cats.implicits._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.server.AuthMiddleware
 
 class AuthMiddlewareSpec extends Http4sSpec {

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 
 import fs2._
 import org.http4s.Status._
-import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.http4s.parser.HttpHeaderParser
 import org.http4s.util.{ CaseInsensitiveString, NonEmptyList }


### PR DESCRIPTION
With a parameterized effect type, the old dsl was not really useful. As an interim solution, `org.http4s.dsl` was fixed to using `cats.effect.IO` as the effect type.

This PR improves on this situation. It still keeps the `IO`-dsl around, so if you are fine with fixing your effect type to `IO`, you can just `import org.http4s.dsl.io._`

If you want a parametric effect type, you will have two options, either

- extend `Http4sDsl[F[_]]` in your service, or
- create a value of `Http4sDsl[F[_]]` and import all members from it

Some examples:

```scala
import org.http4s._
import org.http4s.dsl.Http4sDsl

class MyExtendingService[F[_]: Sync] extends Http4sDsl[F] {
  val service = HttpService[F] {
    case GET -> Root / "hello" / name =>
      Ok(s"Hello, $name")
  }
}
```

```scala
import org.http4s._
import org.http4s.dsl.Http4sDsl

class MyImportingService[F[_]: Sync] {
  val dsl = Http4sDsl[F]
  import dsl._

  val service = HttpService[F] {
    case GET -> Root / "hello" / name =>
      Ok(s"Hello, $name")
  }
}
```