### PR TITLE
Update to specs2 4.x

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -131,7 +131,7 @@ object Http4sPlugin extends AutoPlugin {
   def scalaReflect(so: String, sv: String)  = so                       %  "scala-reflect"             % sv
   lazy val scalaXml                         = "org.scala-lang.modules" %% "scala-xml"                 % "1.0.6"
   lazy val scodecBits                       = "org.scodec"             %% "scodec-bits"               % "1.1.5"
-  lazy val specs2Core                       = "org.specs2"             %% "specs2-core"               % "3.9.4"
+  lazy val specs2Core                       = "org.specs2"             %% "specs2-core"               % "4.0.0-RC4"
   lazy val specs2MatcherExtra               = "org.specs2"             %% "specs2-matcher-extra"      % specs2Core.revision
   lazy val specs2Scalacheck                 = "org.specs2"             %% "specs2-scalacheck"         % specs2Core.revision
   lazy val tomcatCatalina                   = "org.apache.tomcat"      %  "tomcat-catalina"           % "8.5.20"

--- a/tests/src/test/scala/org/http4s/headers/RetryAfterSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/RetryAfterSpec.scala
@@ -7,7 +7,6 @@ import java.time.{Instant, ZoneId, ZonedDateTime}
 import org.http4s.{ParseFailure, ParseResult}
 
 import scala.concurrent.duration._
-import scalaz.{-\/, \/-}
 
 class RetryAfterSpec extends HeaderLaws {
   checkAll("Retry-After", headerLaws(`Retry-After`))

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -16,7 +16,6 @@ import org.http4s.Status.Ok
 import org.http4s.EntityEncoder._
 import Entity._
 import org.specs2.Specification
-import org.specs2.matcher.DisjunctionMatchers
 
 import cats._
 import cats.implicits._
@@ -25,7 +24,7 @@ import fs2._
 import scodec.bits.BitVector
 import scodec.bits.ByteVector
 
-class MultipartSpec extends Specification with DisjunctionMatchers {
+class MultipartSpec extends Specification {
   sequential
 
   def is = s2"""

--- a/tests/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
@@ -3,7 +3,6 @@ package parser
 
 import org.http4s.headers.`Accept-Encoding`
 import org.specs2.mutable.Specification
-import scalaz.Validation
 import Http4s._
 
 class AcceptEncodingSpec extends Specification with HeaderParserHelper[`Accept-Encoding`] {

--- a/tests/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
@@ -3,7 +3,6 @@ package parser
 
 import org.http4s.headers.`Accept-Language`
 import org.specs2.mutable.Specification
-import scalaz.Validation
 import org.http4s.{LanguageTag, QValue}
 
 class AcceptLanguageSpec

--- a/tests/src/test/scala/org/http4s/parser/HeaderParserHelper.scala
+++ b/tests/src/test/scala/org/http4s/parser/HeaderParserHelper.scala
@@ -1,7 +1,6 @@
 package org.http4s.parser
 
 import org.http4s.{Header, ParseResult}
-import scalaz.Validation
 
 trait HeaderParserHelper[H <: Header] {
 


### PR DESCRIPTION
This PR updates the build to use specs2 4.x. It lets us remove the last bits of scalaz dependency and eventually run tests on scala.js

I don't know if you'd prefer to wait until a final release of specs2 is available