### PR TITLE
Remove the Semigroup[F[MaybeResponse[F]]] constraint from classes

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -6,10 +6,8 @@ import java.io.FileInputStream
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.security.{KeyStore, Security}
-import java.util.concurrent.ExecutorService
 import javax.net.ssl.{KeyManagerFactory, SSLContext, SSLEngine, TrustManagerFactory}
 
-import cats._
 import cats.effect._
 import org.http4s.blaze.channel
 import org.http4s.blaze.channel.SocketConnection
@@ -42,8 +40,7 @@ class BlazeBuilder[F[_]](
     with IdleTimeoutSupport[F]
     with SSLKeyStoreSupport[F]
     with SSLContextSupport[F]
-    with server.WebSocketSupport[F]
-    with MaybeResponseInstances {
+    with server.WebSocketSupport[F] {
   type Self = BlazeBuilder[F]
 
   private[this] val logger = getLogger(classOf[BlazeBuilder[F]])
@@ -144,9 +141,7 @@ class BlazeBuilder[F[_]](
     copy(serviceErrorHandler = serviceErrorHandler)
 
   def start: F[Server[F]] = F.delay {
-    val aggregateService = Router(serviceMounts.map { mount =>
-      mount.prefix -> mount.service
-    }: _*)
+    val aggregateService = Router(serviceMounts.map(mount => mount.prefix -> mount.service): _*)
 
     def resolveAddress(address: InetSocketAddress) =
       if (address.isUnresolved) new InetSocketAddress(address.getHostName, address.getPort)

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -37,12 +37,13 @@ class BlazeBuilder[F[_]](
     maxHeadersLen: Int,
     serviceMounts: Vector[ServiceMount[F]],
     serviceErrorHandler: ServiceErrorHandler[F]
-)(implicit F: Effect[F], S: Semigroup[F[MaybeResponse[F]]])
+)(implicit F: Effect[F])
     extends ServerBuilder[F]
     with IdleTimeoutSupport[F]
     with SSLKeyStoreSupport[F]
     with SSLContextSupport[F]
-    with server.WebSocketSupport[F] {
+    with server.WebSocketSupport[F]
+    with MaybeResponseInstances {
   type Self = BlazeBuilder[F]
 
   private[this] val logger = getLogger(classOf[BlazeBuilder[F]])
@@ -281,7 +282,7 @@ class BlazeBuilder[F[_]](
 }
 
 object BlazeBuilder {
-  def apply[F[_]](implicit F: Effect[F], S: Semigroup[F[MaybeResponse[F]]]): BlazeBuilder[F] =
+  def apply[F[_]](implicit F: Effect[F]): BlazeBuilder[F] =
     new BlazeBuilder(
       socketAddress = ServerBuilder.DefaultSocketAddress,
       executionContext = ExecutionContext.global,

--- a/core/src/main/scala/org/http4s/Http4s.scala
+++ b/core/src/main/scala/org/http4s/Http4s.scala
@@ -12,6 +12,7 @@ trait Http4sInstances
     with QValueInstances
     with MethodInstances
     with StatusInstances
+    with MaybeResponseInstances
 
 object Http4sInstances extends Http4sInstances
 

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -1,42 +1,40 @@
 package com.example.http4s.blaze
 
-import java.util.concurrent.Executors
-
 import cats.effect._
+import cats.implicits._
 import fs2._
 import org.http4s._
-import org.http4s.dsl.io._
+import org.http4s.dsl.Http4sDsl
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.server.websocket._
-import org.http4s.util.{StreamApp, _}
+import org.http4s.util.StreamApp
 import org.http4s.websocket.WebsocketBits._
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-object BlazeWebSocketExample extends StreamApp[IO] {
-  val scheduler = Scheduler.allocate[IO](corePoolSize = 2).unsafeRunSync()._1
-  val threadFactory = threads.threadFactory(name = l => s"worker-$l", daemon = true)
-  implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(8, threadFactory))
+object BlazeWebSocketExample extends BlazeWebSocketExampleApp[IO]
 
-  val route = HttpService[IO] {
+class BlazeWebSocketExampleApp[F[_]](implicit F: Effect[F]) extends StreamApp[F] with Http4sDsl[F] {
+
+  def route(scheduler: Scheduler): HttpService[F] = HttpService[F] {
     case GET -> Root / "hello" =>
       Ok("Hello world.")
 
     case GET -> Root / "ws" =>
-      val toClient: Stream[IO, WebSocketFrame] =
-        scheduler.awakeEvery[IO](1.seconds).map(d => Text(s"Ping! $d"))
-      val fromClient: Sink[IO, WebSocketFrame] = _.evalMap { (ws: WebSocketFrame) =>
+      val toClient: Stream[F, WebSocketFrame] =
+        scheduler.awakeEvery[F](1.seconds).map(d => Text(s"Ping! $d"))
+      val fromClient: Sink[F, WebSocketFrame] = _.evalMap { (ws: WebSocketFrame) =>
         ws match {
-          case Text(t, _) => IO(println(t))
-          case f => IO(println(s"Unknown type: $f"))
+          case Text(t, _) => F.delay(println(t))
+          case f => F.delay(println(s"Unknown type: $f"))
         }
       }
       WS(toClient, fromClient)
 
     case GET -> Root / "wsecho" =>
-      val queue = async.unboundedQueue[IO, WebSocketFrame]
-      val echoReply: Pipe[IO, WebSocketFrame, WebSocketFrame] = _.collect {
+      val queue = async.unboundedQueue[F, WebSocketFrame]
+      val echoReply: Pipe[F, WebSocketFrame, WebSocketFrame] = _.collect {
         case Text(msg, _) => Text("You sent the server: " + msg)
         case _ => Text("Something new")
       }
@@ -48,10 +46,13 @@ object BlazeWebSocketExample extends StreamApp[IO] {
       }
   }
 
-  def stream(args: List[String], requestShutdown: IO[Unit]) =
-    BlazeBuilder[IO]
-      .bindHttp(8080)
-      .withWebSockets(true)
-      .mountService(route, "/http4s")
-      .serve
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, Nothing] =
+    Scheduler[F](corePoolSize = 2).flatMap { scheduler =>
+      BlazeBuilder[F]
+        .bindHttp(8080)
+        .withWebSockets(true)
+        .mountService(route(scheduler), "/http4s")
+        .serve
+    }
+
 }

--- a/server/src/main/scala/org/http4s/server/Router.scala
+++ b/server/src/main/scala/org/http4s/server/Router.scala
@@ -4,6 +4,7 @@ package server
 import cats._
 import cats.effect._
 import cats.implicits._
+import org.http4s.Http4sInstances.http4sMonoidForFMaybeResponse
 
 object Router {
 
@@ -13,8 +14,7 @@ object Router {
     * Defines an HttpService based on list of mappings.
     * @see define
     */
-  def apply[F[_]: Sync](mappings: (String, HttpService[F])*)(
-      implicit F: Semigroup[F[MaybeResponse[F]]]): HttpService[F] =
+  def apply[F[_]: Sync](mappings: (String, HttpService[F])*): HttpService[F] =
     define(mappings: _*)(HttpService.empty[F])
 
   /**
@@ -23,8 +23,8 @@ object Router {
     *
     * The mappings are processed in descending order (longest first) of prefix length.
     */
-  def define[F[_]: Sync](mappings: (String, HttpService[F])*)(default: HttpService[F])(
-      implicit F: Semigroup[F[MaybeResponse[F]]]): HttpService[F] =
+  def define[F[_]: Sync](mappings: (String, HttpService[F])*)(
+      default: HttpService[F]): HttpService[F] =
     mappings.sortBy(_._1.length).foldLeft(default) {
       case (acc, (prefix, service)) =>
         if (prefix.isEmpty || prefix == "/") service |+| acc

--- a/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -4,6 +4,7 @@ package middleware
 
 import cats._
 import cats.implicits._
+import org.http4s.Http4sInstances.http4sMonoidForFMaybeResponse
 
 /** Handles HEAD requests as a GET without a body.
   *
@@ -13,8 +14,7 @@ import cats.implicits._
   * requiring more optimization should implement their own HEAD handler.
   */
 object DefaultHead {
-  def apply[F[_]: Functor](service: HttpService[F])(
-      implicit M: Semigroup[F[MaybeResponse[F]]]): HttpService[F] =
+  def apply[F[_]: Monad](service: HttpService[F]): HttpService[F] =
     HttpService.lift { req =>
       req.method match {
         case Method.HEAD =>

--- a/server/src/main/scala/org/http4s/server/syntax/package.scala
+++ b/server/src/main/scala/org/http4s/server/syntax/package.scala
@@ -1,12 +1,12 @@
 package org.http4s
 package server
 
-import cats.Monoid
+import cats.Semigroup
 
 package object syntax {
   @deprecated("Import `cats.syntax.semigroup._` and use `service1 |+| service2` instead", "0.16")
   final implicit class ServiceOps[F[_], A, B](val service: Service[F, A, B])(
-      implicit B: Monoid[F[B]]) {
+      implicit B: Semigroup[F[B]]) {
     def ||(fallback: Service[F, A, B]) = orElse(fallback)
     def orElse(fallback: Service[F, A, B]) = Service.withFallback(fallback)(service)
   }

--- a/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
@@ -6,7 +6,6 @@ import cats.implicits._
 import cats._
 
 class HttpServiceSpec extends Http4sSpec {
-  implicit val asd = Semigroup[HttpService[IO]]
 
   val srvc1 = HttpService[IO] {
     case req if req.pathInfo == "/match" =>

--- a/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/GZipSpec.scala
@@ -8,15 +8,12 @@ import java.util.zip.GZIPOutputStream
 import cats.effect._
 import cats.implicits._
 import fs2._
-import org.http4s.server.syntax._
 import org.http4s.dsl.io._
-import org.http4s.implicits._
 import org.http4s.headers._
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
 
 class GZipSpec extends Http4sSpec {
-  implicit val S = IO.ioSemigroup[MaybeResponse[IO]]
 
   "GZip" should {
     "fall through if the route doesn't match" in {


### PR DESCRIPTION
by re-introducing the implicit `Monoid[F[MaybeResponse[F]]]` in `MaybeResponseInstances`.

This trait is then mixed into the `Http4sInstances` trait, which puts it into scope in most places where a user would need it, i.e. when importing or mixing in the DSL.

To let `BlazeBuilder` pick the right instance, when instantiated with `IO` as the effect type, `BlazeBuilder` now mixes in the `MaybeResponseInstances` trait as well.
