### PR TITLE
Make parboiled2 an actual module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,8 +20,8 @@ enablePlugins(DisablePublishingPlugin)
 
 // This defines macros that we use in core, so it needs to be split out
 lazy val parboiled2 = libraryProject("parboiled2")
-  .enablePlugins(DisablePublishingPlugin)
   .settings(
+    description := "Internal fork of parboiled2 to remove shapeless dependency",    
     libraryDependencies ++= Seq(
       scalaReflect(scalaOrganization.value, scalaVersion.value) % "provided"
     ),
@@ -51,12 +51,7 @@ lazy val core = libraryProject("core")
       scalazCore(scalazVersion.value),
       scalazStream(scalazVersion.value)
     ),
-    macroParadiseSetting,
-    mappings in (Compile, packageBin) ++= (mappings in (parboiled2.project, Compile, packageBin)).value,
-    mappings in (Compile, packageSrc) ++= (mappings in (parboiled2.project, Compile, packageSrc)).value,
-    mappings in (Compile, packageDoc) ++= (mappings in (parboiled2.project, Compile, packageDoc)).value,
-    mappings in (Compile, packageBin) ~= (_.groupBy(_._2).toSeq.map(_._2.head)), // filter duplicate outputs
-    mappings in (Compile, packageDoc) ~= (_.groupBy(_._2).toSeq.map(_._2.head)) // filter duplicate outputs
+    macroParadiseSetting
   )
   .dependsOn(parboiled2)
 
@@ -507,8 +502,6 @@ lazy val commonSettings = Seq(
         override def transform(node: xml.Node): Seq[xml.Node] = node match {
           case e: xml.Elem
               if e.label == "dependency" && e.child.exists(child => child.label == "groupId" && child.text == "org.scoverage") => Nil
-          case e: xml.Elem
-              if e.label == "dependency" && e.child.exists(child => child.label == "artifactId" && child.text.contains("parboiled2")) => Nil
           case _ => Seq(node)
         }
       }).transform(node).head


### PR DESCRIPTION
This solves the problem of being unable to publishLocal and then depend on that when testing http4s.

I was reluctant to do this, because it appears to be another dependency, which is used in negative marketing.  All code in this newly published module is internal and was already in core.  Haters gonna hate.  This just simplifies our build and makes a better story for local development.

Alternatively, I tried `ivyXML` in addition to `pomPostProcess`, but I couldn't get it to affect the delivered Ivy file.