### PR TITLE
Make F in Effect*Syntax invariant

### DIFF
--- a/core/src/main/scala/org/http4s/syntax/EffectMessageSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/EffectMessageSyntax.scala
@@ -5,7 +5,7 @@ import cats._
 import cats.data.EitherT
 import cats.implicits._
 
-trait EffectMessageSyntax[F[+ _], M <: Message[F]] extends Any with MessageOps[F] {
+trait EffectMessageSyntax[F[_], M <: Message[F]] extends Any with MessageOps[F] {
   type Self = F[M#Self]
 
   def self: F[M]
@@ -14,7 +14,7 @@ trait EffectMessageSyntax[F[+ _], M <: Message[F]] extends Any with MessageOps[F
     self.map(_.transformHeaders(f))
 
   def withBody[T](b: T)(implicit F: Monad[F], w: EntityEncoder[F, T]): Self =
-    self.flatMap(_.withBody(b))
+    self.flatMap(_.withBody(b).widen[M#Self])
 
   override def withAttribute[A](key: AttributeKey[A], value: A)(implicit F: Functor[F]): Self =
     self.map(_.withAttribute(key, value))

--- a/core/src/main/scala/org/http4s/syntax/EffectRequestSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/EffectRequestSyntax.scala
@@ -5,11 +5,11 @@ import cats._
 import cats.implicits._
 
 trait EffectRequestSyntax extends Any {
-  implicit def http4sEffectRequestSyntax[F[+ _]](req: F[Request[F]]): EffectRequestOps[F] =
+  implicit def http4sEffectRequestSyntax[F[_]](req: F[Request[F]]): EffectRequestOps[F] =
     new EffectRequestOps[F](req)
 }
 
-final class EffectRequestOps[F[+ _]](val self: F[Request[F]])
+final class EffectRequestOps[F[_]](val self: F[Request[F]])
     extends AnyVal
     with EffectMessageSyntax[F, Request[F]]
     with RequestOps[F] {

--- a/core/src/main/scala/org/http4s/syntax/EffectResponseSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/EffectResponseSyntax.scala
@@ -5,11 +5,11 @@ import cats._
 import cats.implicits._
 
 trait EffectResponseSyntax extends Any {
-  implicit def http4sEffectResponseSyntax[F[+ _]](resp: F[Response[F]]): EffectResponseOps[F] =
+  implicit def http4sEffectResponseSyntax[F[_]](resp: F[Response[F]]): EffectResponseOps[F] =
     new EffectResponseOps[F](resp)
 }
 
-final class EffectResponseOps[F[+ _]](val self: F[Response[F]])
+final class EffectResponseOps[F[_]](val self: F[Response[F]])
     extends AnyVal
     with EffectMessageSyntax[F, Response[F]]
     with ResponseOps[F] {


### PR DESCRIPTION
Currently all `F`s that use syntax on `F[Message[F]]` must be covariant. This removes that requirement at the cost of a `.widen`.