### PR TITLE
Update examples

### DIFF
--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -2,13 +2,19 @@ package com.example.http4s.blaze
 
 import cats.effect._
 import com.example.http4s.ExampleService
+import fs2.Scheduler
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.util.StreamApp
+import scala.concurrent.ExecutionContext.Implicits.global
 
-object BlazeExample extends StreamApp[IO] {
-  def stream(args: List[String], requestShutdown: IO[Unit]) =
-    BlazeBuilder[IO]
-      .bindHttp(8080)
-      .mountService(ExampleService.service, "/http4s")
-      .serve
+object BlazeExample extends BlazeExampleApp[IO]
+
+class BlazeExampleApp[F[_]: Effect] extends StreamApp[F] {
+  def stream(args: List[String], requestShutdown: F[Unit]) =
+    Scheduler(corePoolSize = 2).flatMap { implicit scheduler =>
+      BlazeBuilder[F]
+        .bindHttp(8080)
+        .mountService(new ExampleService[F].service, "/http4s")
+        .serve
+    }
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeHttp2Example.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeHttp2Example.scala
@@ -5,6 +5,6 @@ import cats.effect._
 import com.example.http4s.ssl.SslExample
 import org.http4s.server.blaze.BlazeBuilder
 
-object BlazeHttp2Example extends SslExample {
-  def builder = BlazeBuilder[IO].enableHttp2(true)
+object BlazeHttp2Example extends SslExample[IO] {
+  def builder: BlazeBuilder[IO] = BlazeBuilder[IO].enableHttp2(true)
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -3,23 +3,30 @@ package com.example.http4s.blaze
 import cats.effect._
 import com.codahale.metrics._
 import com.example.http4s.ExampleService
-import org.http4s.server.Router
+import fs2.Scheduler
+import org.http4s.HttpService
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.server.metrics._
+import org.http4s.server.{HttpMiddleware, Router}
 import org.http4s.util.StreamApp
 
-object BlazeMetricsExample extends StreamApp[IO] {
-  val metricsRegistry = new MetricRegistry()
-  val metrics = Metrics[IO](metricsRegistry)
+object BlazeMetricsExample extends BlazeMetricsExampleApp[IO]
 
-  val srvc = Router(
-    "" -> metrics(ExampleService.service),
-    "/metrics" -> metricsService[IO](metricsRegistry)
-  )
+class BlazeMetricsExampleApp[F[_]: Effect] extends StreamApp[F] {
+  val metricsRegistry: MetricRegistry = new MetricRegistry()
+  val metrics: HttpMiddleware[F] = Metrics[F](metricsRegistry)
 
-  def stream(args: List[String], requestShutdown: IO[Unit]) =
-    BlazeBuilder[IO]
-      .bindHttp(8080)
-      .mountService(srvc, "/http4s")
-      .serve
+  def srvc(implicit scheduler: Scheduler): HttpService[F] =
+    Router(
+      "" -> metrics(new ExampleService[F].service),
+      "/metrics" -> metricsService[F](metricsRegistry)
+    )
+
+  def stream(args: List[String], requestShutdown: F[Unit]): fs2.Stream[F, Nothing] =
+    Scheduler(corePoolSize = 2).flatMap { implicit scheduler =>
+      BlazeBuilder[F]
+        .bindHttp(8080)
+        .mountService(srvc, "/http4s")
+        .serve
+    }
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
@@ -5,6 +5,6 @@ import cats.effect.IO
 import com.example.http4s.ssl.SslExample
 import org.http4s.server.blaze.BlazeBuilder
 
-object BlazeSslExample extends SslExample {
-  def builder = BlazeBuilder[IO]
+object BlazeSslExample extends SslExample[IO] {
+  def builder: BlazeBuilder[IO] = BlazeBuilder[IO]
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
@@ -5,6 +5,6 @@ import cats.effect.IO
 import com.example.http4s.ssl.SslExampleWithRedirect
 import org.http4s.server.blaze.BlazeBuilder
 
-object BlazeSslExampleWithRedirect extends SslExampleWithRedirect {
-  def builder = BlazeBuilder[IO]
+object BlazeSslExampleWithRedirect extends SslExampleWithRedirect[IO] {
+  def builder: BlazeBuilder[IO] = BlazeBuilder[IO]
 }

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
@@ -3,19 +3,26 @@ package jetty
 
 import cats.effect._
 import com.codahale.metrics.MetricRegistry
+import fs2._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.server.HttpMiddleware
 import org.http4s.server.jetty.JettyBuilder
 import org.http4s.server.metrics._
 import org.http4s.util.StreamApp
 
-object JettyExample extends StreamApp[IO] {
-  val metricsRegistry = new MetricRegistry
-  val metrics = Metrics[IO](metricsRegistry)
+object JettyExample extends JettyExampleApp[IO]
 
-  def stream(args: List[String], requestShutdown: IO[Unit]) =
-    JettyBuilder[IO]
-      .bindHttp(8080)
-      .mountService(metrics(ExampleService.service), "/http4s")
-      .mountService(metricsService(metricsRegistry), "/metrics")
-      .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
-      .serve
+class JettyExampleApp[F[_]: Effect] extends StreamApp[F] with Http4sDsl[F] {
+  val metricsRegistry: MetricRegistry = new MetricRegistry
+  val metrics: HttpMiddleware[F] = Metrics[F](metricsRegistry)
+
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, Nothing] =
+    Scheduler(corePoolSize = 2).flatMap { implicit scheduler =>
+      JettyBuilder[F]
+        .bindHttp(8080)
+        .mountService(metrics(new ExampleService[F].service), "/http4s")
+        .mountService(metricsService(metricsRegistry), "/metrics")
+        .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
+        .serve
+    }
 }

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettySslExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettySslExample.scala
@@ -5,6 +5,6 @@ import cats.effect.IO
 import com.example.http4s.ssl.SslExample
 import org.http4s.server.jetty.JettyBuilder
 
-object JettySslExample extends SslExample {
-  def builder = JettyBuilder[IO]
+object JettySslExample extends SslExample[IO] {
+  def builder: JettyBuilder[IO] = JettyBuilder[IO]
 }

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -2,164 +2,172 @@ package com.example.http4s
 
 import _root_.io.circe.Json
 import cats._
-import cats.effect.IO
+import cats.effect._
 import cats.implicits._
 import fs2._
 import org.http4s.MediaType._
 import org.http4s._
 import org.http4s.server._
 import org.http4s.circe._
-import org.http4s.dsl.io._
+import org.http4s.dsl.Http4sDsl
 import org.http4s.headers._
 import org.http4s.server.middleware.authentication.BasicAuth
+import org.http4s.server.middleware.authentication.BasicAuth.BasicAuthenticator
+import org.http4s.syntax.EffectResponseOps
 import org.http4s.twirl._
-
 import scala.concurrent._
 import scala.concurrent.duration._
 
-object ExampleService {
+class ExampleService[F[_]](implicit F: Effect[F]) extends Http4sDsl[F] {
 
   // A Router can mount multiple services to prefixes.  The request is passed to the
   // service with the longest matching prefix.
-  def service(implicit ec: ExecutionContext = ExecutionContext.global): HttpService[IO] =
-    Router[IO](
+  def service(
+      implicit scheduler: Scheduler,
+      executionContext: ExecutionContext = ExecutionContext.global): HttpService[F] =
+    Router[F](
       "" -> rootService,
       "/auth" -> authService,
-      "/science" -> ScienceExperiments.service
+      "/science" -> new ScienceExperiments[F].service
     )
 
-  def rootService(implicit ec: ExecutionContext = ExecutionContext.global) = HttpService[IO] {
-    case GET -> Root =>
-      // Supports Play Framework template -- see src/main/twirl.
-      Ok(html.index())
+  def rootService(
+      implicit scheduler: Scheduler,
+      executionContext: ExecutionContext): HttpService[F] =
+    HttpService[F] {
+      case GET -> Root =>
+        // Supports Play Framework template -- see src/main/twirl.
+        Ok(html.index())
 
-    case _ -> Root =>
-      // The default route result is NotFound. Sometimes MethodNotAllowed is more appropriate.
-      MethodNotAllowed()
+      case _ -> Root =>
+        // The default route result is NotFound. Sometimes MethodNotAllowed is more appropriate.
+        MethodNotAllowed()
 
-    case GET -> Root / "ping" =>
-      // EntityEncoder allows for easy conversion of types to a response body
-      Ok("pong")
+      case GET -> Root / "ping" =>
+        // EntityEncoder allows for easy conversion of types to a response body
+        Ok("pong")
 
-    case GET -> Root / "future" =>
-      // EntityEncoder allows rendering asynchronous results as well
-      Ok(IO.fromFuture(Eval.always(Future("Hello from the future!"))))
+      case GET -> Root / "future" =>
+        // EntityEncoder allows rendering asynchronous results as well
+        Ok(IO.fromFuture(Eval.always(Future("Hello from the future!"))).to[F])
 
-    case GET -> Root / "streaming" =>
-      // It's also easy to stream responses to clients
-      Ok(dataStream(100))
+      case GET -> Root / "streaming" =>
+        // It's also easy to stream responses to clients
+        Ok(dataStream(100))
 
-    case req @ GET -> Root / "ip" =>
-      // It's possible to define an EntityEncoder anywhere so you're not limited to built in types
-      val json = Json.obj("origin" -> Json.fromString(req.remoteAddr.getOrElse("unknown")))
-      Ok(json)
+      case req @ GET -> Root / "ip" =>
+        // It's possible to define an EntityEncoder anywhere so you're not limited to built in types
+        val json = Json.obj("origin" -> Json.fromString(req.remoteAddr.getOrElse("unknown")))
+        Ok(json)
 
-    case GET -> Root / "redirect" =>
-      // Not every response must be Ok using a EntityEncoder: some have meaning only for specific types
-      TemporaryRedirect(uri("/http4s/"))
+      case GET -> Root / "redirect" =>
+        // Not every response must be Ok using a EntityEncoder: some have meaning only for specific types
+        TemporaryRedirect(uri("/http4s/"))
 
-    case GET -> Root / "content-change" =>
-      // EntityEncoder typically deals with appropriate headers, but they can be overridden
-      Ok("<h2>This will have an html content type!</h2>")
-        .withContentType(Some(`Content-Type`(`text/html`)))
+      case GET -> Root / "content-change" =>
+        // EntityEncoder typically deals with appropriate headers, but they can be overridden
+        val resp: F[Response[F]] = Ok("<h2>This will have an html content type!</h2>")
+        val fr: EffectResponseOps[F] = http4sEffectResponseSyntax(resp)
+        val w: F[Response[F]] = fr.withContentType(Some(`Content-Type`(`text/html`)))
+        w
 
-    case req @ GET -> "static" /: path =>
-      // captures everything after "/static" into `path`
-      // Try http://localhost:8080/http4s/static/nasa_blackhole_image.jpg
-      // See also org.http4s.server.staticcontent to create a mountable service for static content
-      StaticFile.fromResource(path.toString, Some(req)).getOrElseF(NotFound())
+      case req @ GET -> "static" /: path =>
+        // captures everything after "/static" into `path`
+        // Try http://localhost:8080/http4s/static/nasa_blackhole_image.jpg
+        // See also org.http4s.server.staticcontent to create a mountable service for static content
+        StaticFile.fromResource(path.toString, Some(req)).getOrElseF(NotFound())
 
-    ///////////////////////////////////////////////////////////////
-    //////////////// Dealing with the message body ////////////////
-    case req @ POST -> Root / "echo" =>
-      // The body can be used in the response
-      Ok(req.body).map(_.putHeaders(`Content-Type`(`text/plain`)))
+      ///////////////////////////////////////////////////////////////
+      //////////////// Dealing with the message body ////////////////
+      case req @ POST -> Root / "echo" =>
+        // The body can be used in the response
+        Ok(req.body).map(_.putHeaders(`Content-Type`(`text/plain`)))
 
-    case GET -> Root / "echo" =>
-      Ok(html.submissionForm("echo data"))
+      case GET -> Root / "echo" =>
+        Ok(html.submissionForm("echo data"))
 
-    case req @ POST -> Root / "echo2" =>
-      // Even more useful, the body can be transformed in the response
-      Ok(req.body.drop(6))
-        .putHeaders(`Content-Type`(`text/plain`))
+      case req @ POST -> Root / "echo2" =>
+        // Even more useful, the body can be transformed in the response
+        Ok(req.body.drop(6))
+          .putHeaders(`Content-Type`(`text/plain`))
 
-    case GET -> Root / "echo2" =>
-      Ok(html.submissionForm("echo data"))
+      case GET -> Root / "echo2" =>
+        Ok(html.submissionForm("echo data"))
 
-    case req @ POST -> Root / "sum" =>
-      // EntityDecoders allow turning the body into something useful
-      req
-        .decode[UrlForm] { data =>
-          data.values.get("sum") match {
-            case Some(Seq(s, _*)) =>
-              val sum = s.split(' ').filter(_.length > 0).map(_.trim.toInt).sum
-              Ok(sum.toString)
+      case req @ POST -> Root / "sum" =>
+        // EntityDecoders allow turning the body into something useful
+        req
+          .decode[UrlForm] { data =>
+            data.values.get("sum") match {
+              case Some(Seq(s, _*)) =>
+                val sum = s.split(' ').filter(_.length > 0).map(_.trim.toInt).sum
+                Ok(sum.toString)
 
-            case None => BadRequest(s"Invalid data: " + data)
+              case None => BadRequest(s"Invalid data: " + data)
+            }
           }
+          .handleErrorWith { // We can handle errors using effect methods
+            case e: NumberFormatException => BadRequest("Not an int: " + e.getMessage)
+          }
+
+      case GET -> Root / "sum" =>
+        Ok(html.submissionForm("sum"))
+
+      ///////////////////////////////////////////////////////////////
+      ////////////////////// Blaze examples /////////////////////////
+
+      // You can use the same service for GET and HEAD. For HEAD request,
+      // only the Content-Length is sent (if static content)
+      case GET -> Root / "helloworld" =>
+        helloWorldService
+      case HEAD -> Root / "helloworld" =>
+        helloWorldService
+
+      // HEAD responses with Content-Lenght, but empty content
+      case HEAD -> Root / "head" =>
+        Ok("").putHeaders(`Content-Length`.unsafeFromLong(1024))
+
+      // Response with invalid Content-Length header generates
+      // an error (underflow causes the connection to be closed)
+      case GET -> Root / "underflow" =>
+        Ok("foo").putHeaders(`Content-Length`.unsafeFromLong(4))
+
+      // Response with invalid Content-Length header generates
+      // an error (overflow causes the extra bytes to be ignored)
+      case GET -> Root / "overflow" =>
+        Ok("foo").putHeaders(`Content-Length`.unsafeFromLong(2))
+
+      ///////////////////////////////////////////////////////////////
+      //////////////// Form encoding example ////////////////////////
+      case GET -> Root / "form-encoded" =>
+        Ok(html.formEncoded())
+
+      case req @ POST -> Root / "form-encoded" =>
+        // EntityDecoders return an F[A] which is easy to sequence
+        req.decode[UrlForm] { m =>
+          val s = m.values.mkString("\n")
+          Ok(s"Form Encoded Data\n$s")
         }
-        .handleErrorWith { // We can handle errors using effect methods
-          case e: NumberFormatException => BadRequest("Not an int: " + e.getMessage)
-        }
 
-    case GET -> Root / "sum" =>
-      Ok(html.submissionForm("sum"))
-
-    ///////////////////////////////////////////////////////////////
-    ////////////////////// Blaze examples /////////////////////////
-
-    // You can use the same service for GET and HEAD. For HEAD request,
-    // only the Content-Length is sent (if static content)
-    case GET -> Root / "helloworld" =>
-      helloWorldService
-    case HEAD -> Root / "helloworld" =>
-      helloWorldService
-
-    // HEAD responses with Content-Lenght, but empty content
-    case HEAD -> Root / "head" =>
-      Ok("").putHeaders(`Content-Length`.unsafeFromLong(1024))
-
-    // Response with invalid Content-Length header generates
-    // an error (underflow causes the connection to be closed)
-    case GET -> Root / "underflow" =>
-      Ok("foo").putHeaders(`Content-Length`.unsafeFromLong(4))
-
-    // Response with invalid Content-Length header generates
-    // an error (overflow causes the extra bytes to be ignored)
-    case GET -> Root / "overflow" =>
-      Ok("foo").putHeaders(`Content-Length`.unsafeFromLong(2))
-
-    ///////////////////////////////////////////////////////////////
-    //////////////// Form encoding example ////////////////////////
-    case GET -> Root / "form-encoded" =>
-      Ok(html.formEncoded())
-
-    case req @ POST -> Root / "form-encoded" =>
-      // EntityDecoders return an F[A] which is easy to sequence
-      req.decode[UrlForm] { m =>
-        val s = m.values.mkString("\n")
-        Ok(s"Form Encoded Data\n$s")
-      }
-
-    ///////////////////////////////////////////////////////////////
-    //////////////////////// Server Push //////////////////////////
-    /*
+      ///////////////////////////////////////////////////////////////
+      //////////////////////// Server Push //////////////////////////
+      /*
   case req @ GET -> Root / "push" =>
     // http4s intends to be a forward looking library made with http2.0 in mind
     val data = <html><body><img src="image.jpg"/></body></html>
     Ok(data)
       .withContentType(Some(`Content-Type`(`text/html`)))
       .push("/image.jpg")(req)
-     */
+       */
 
-    case req @ GET -> Root / "image.jpg" =>
-      StaticFile
-        .fromResource("/nasa_blackhole_image.jpg", Some(req))
-        .getOrElseF(NotFound())
+      case req @ GET -> Root / "image.jpg" =>
+        StaticFile
+          .fromResource("/nasa_blackhole_image.jpg", Some(req))
+          .getOrElseF(NotFound())
 
-    ///////////////////////////////////////////////////////////////
-    //////////////////////// Multi Part //////////////////////////
-    /* TODO fs2 port
+      ///////////////////////////////////////////////////////////////
+      //////////////////////// Multi Part //////////////////////////
+      /* TODO fs2 port
     case req @ GET -> Root / "form" =>
             println("FORM")
       Ok(html.form())
@@ -169,19 +177,17 @@ object ExampleService {
       req.decode[Multipart] { m =>
         Ok(s"""Multipart Data\nParts:${m.parts.length}\n${m.parts.map { case f: Part => f.name }.mkString("\n")}""")
       }
-   */
-  }
+     */
+    }
 
-  val scheduler = Scheduler.allocate[IO](corePoolSize = 1).map(_._1).unsafeRunSync()
-
-  def helloWorldService: IO[Response[IO]] = Ok("Hello World!")
+  def helloWorldService: F[Response[F]] = Ok("Hello World!")
 
   // This is a mock data source, but could be a Process representing results from a database
-  def dataStream(n: Int)(implicit ec: ExecutionContext): Stream[IO, String] = {
+  def dataStream(n: Int)(implicit scheduler: Scheduler, ec: ExecutionContext): Stream[F, String] = {
     val interval = 100.millis
     val stream =
       scheduler
-        .awakeEvery[IO](interval)
+        .awakeEvery[F](interval)
         .map(_ => s"Current system time: ${System.currentTimeMillis()} ms\n")
         .take(n.toLong)
 
@@ -191,18 +197,19 @@ object ExampleService {
   // Services can be protected using HTTP authentication.
   val realm = "testrealm"
 
-  def authStore(creds: BasicCredentials) =
-    if (creds.username == "username" && creds.password == "password") IO.pure(Some(creds.username))
-    else IO.pure(None)
+  val authStore: BasicAuthenticator[F, String] = (creds: BasicCredentials) =>
+    if (creds.username == "username" && creds.password == "password") F.pure(Some(creds.username))
+    else F.pure(None)
 
-  // An AuthedService[A] is a Service[(A, Request), Response] for some
+  // An AuthedService[F, A] is a Service[F, (A, Request[F]), Response[F]] for some
   // user type A.  `BasicAuth` is an auth middleware, which binds an
   // AuthedService to an authentication store.
-  val basicAuth = BasicAuth(realm, authStore)
-  def authService: HttpService[IO] =
-    basicAuth(AuthedService[IO, String] {
+  val basicAuth: AuthMiddleware[F, String] = BasicAuth(realm, authStore)
+
+  def authService: HttpService[F] =
+    basicAuth(AuthedService[F, String] {
       // AuthedServices look like Services, but the user is extracted with `as`.
-      case req @ GET -> Root / "protected" as user =>
+      case GET -> Root / "protected" as user =>
         Ok(s"This page is protected using HTTP authentication; logged in as $user")
     })
 }

--- a/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
+++ b/examples/src/main/scala/com/example/http4s/ScienceExperiments.scala
@@ -1,106 +1,99 @@
 package com.example.http4s
 
-import java.time.Instant
-
-import org.http4s._
-import org.http4s.circe._
-import org.http4s.dsl.io._
-import org.http4s.headers.Date
-import org.http4s.scalaxml._
-import io.circe._
-import io.circe.syntax._
-
-import scala.xml.Elem
-import scala.concurrent.duration._
 import cats.implicits._
-import cats.data._
-import cats._
+import org.http4s.circe._
 import cats.effect._
-import cats.effect.implicits._
+import io.circe._
+import org.http4s.scalaxml._
 import fs2.{text => _, _}
+import org.http4s._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.Date
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.xml.Elem
 import scodec.bits.ByteVector
-import scala.concurrent.ExecutionContext.Implicits.global
 
 /** These are routes that we tend to use for testing purposes
   * and will likely get folded into unit tests later in life */
-object ScienceExperiments {
+class ScienceExperiments[F[_]] extends Http4sDsl[F] {
 
-  val scheduler = Scheduler.allocate[IO](corePoolSize = 2).map(_._1).unsafeRunSync()
+  val flatBigString: String =
+    (0 until 1000)
+      .map(i => s"This is string number $i")
+      .foldLeft("")(_ + _)
 
-  val flatBigString = (0 until 1000)
-    .map { i =>
-      s"This is string number $i"
-    }
-    .foldLeft("") { _ + _ }
-
-  def service = HttpService[IO] {
-    ///////////////// Misc //////////////////////
-    case req @ POST -> Root / "root-element-name" =>
-      req.decode { root: Elem =>
-        Ok(root.label)
-      }
-
-    case req @ GET -> Root / "date" =>
-      val date = HttpDate.now
-      Ok(date.toString()).putHeaders(Date(date))
-
-    case req @ GET -> Root / "echo-headers" =>
-      Ok(req.headers.mkString("\n"))
-
-    ///////////////// Massive Data Loads //////////////////////
-    case GET -> Root / "bigstring" =>
-      Ok((0 until 1000).map(i => s"This is string number $i").mkString("\n"))
-
-    case GET -> Root / "bigstring2" =>
-      Ok(Stream.range(0, 1000).map(i => s"This is string number $i").covary[IO])
-
-    case GET -> Root / "bigstring3" =>
-      Ok(flatBigString)
-
-    case GET -> Root / "zero-chunk" =>
-      Ok(Stream("", "foo!").covary[IO])
-
-    case GET -> Root / "bigfile" =>
-      val size = 40 * 1024 * 1024 // 40 MB
-      Ok(new Array[Byte](size))
-
-    case req @ POST -> Root / "rawecho" =>
-      // The body can be used in the response
-      Ok(req.body)
-
-    ///////////////// Switch the response based on head of content //////////////////////
-
-    case req @ POST -> Root / "challenge1" =>
-      val body = req.bodyAsText
-      def notGo = Stream.emit("Booo!!!")
-      def newBodyP(
-          toPull: Stream.ToPull[IO, String]): Pull[IO, String, Option[Stream[IO, String]]] =
-        toPull.uncons1.flatMap {
-          case Some((s, stream)) =>
-            if (s.startsWith("go")) {
-              Pull.output1(s).as(Some(stream))
-            } else {
-              notGo.pull.echo.as(None)
-            }
-          case None =>
-            Pull.pure(None)
+  def service(
+      implicit F: Effect[F],
+      scheduler: Scheduler,
+      executionContext: ExecutionContext = ExecutionContext.global): HttpService[F] =
+    HttpService[F] {
+      ///////////////// Misc //////////////////////
+      case req @ POST -> Root / "root-element-name" =>
+        req.decode { root: Elem =>
+          Ok(root.label)
         }
-      Ok(body.repeatPull(newBodyP))
 
-    case req @ POST -> Root / "challenge2" =>
-      def parser(stream: Stream[IO, String]): Pull[IO, IO[Response[IO]], Unit] =
-        stream.pull.uncons1.flatMap {
-          case Some((str, stream)) if str.startsWith("Go") =>
-            val body = stream.cons1(str).through(fs2.text.utf8Encode)
-            Pull.output1(IO.pure(Response(body = body)))
-          case Some((str, _)) if str.startsWith("NoGo") =>
-            Pull.output1(BadRequest("Booo!"))
-          case _ =>
-            Pull.output1(BadRequest("no data"))
-        }
-      parser(req.bodyAsText).stream.runLast.flatMap(_.getOrElse(InternalServerError()))
+      case GET -> Root / "date" =>
+        val date = HttpDate.now
+        Ok(date.toString()).putHeaders(Date(date))
 
-    /* TODO
+      case req @ GET -> Root / "echo-headers" =>
+        Ok(req.headers.mkString("\n"))
+
+      ///////////////// Massive Data Loads //////////////////////
+      case GET -> Root / "bigstring" =>
+        Ok((0 until 1000).map(i => s"This is string number $i").mkString("\n"))
+
+      case GET -> Root / "bigstring2" =>
+        Ok(Stream.range(0, 1000).map(i => s"This is string number $i").covary[F])
+
+      case GET -> Root / "bigstring3" =>
+        Ok(flatBigString)
+
+      case GET -> Root / "zero-chunk" =>
+        Ok(Stream("", "foo!").covary[F])
+
+      case GET -> Root / "bigfile" =>
+        val size = 40 * 1024 * 1024 // 40 MB
+        Ok(new Array[Byte](size))
+
+      case req @ POST -> Root / "rawecho" =>
+        // The body can be used in the response
+        Ok(req.body)
+
+      ///////////////// Switch the response based on head of content //////////////////////
+
+      case req @ POST -> Root / "challenge1" =>
+        val body = req.bodyAsText
+        def notGo = Stream.emit("Booo!!!")
+        def newBodyP(toPull: Stream.ToPull[F, String]): Pull[F, String, Option[Stream[F, String]]] =
+          toPull.uncons1.flatMap {
+            case Some((s, stream)) =>
+              if (s.startsWith("go")) {
+                Pull.output1(s).as(Some(stream))
+              } else {
+                notGo.pull.echo.as(None)
+              }
+            case None =>
+              Pull.pure(None)
+          }
+        Ok(body.repeatPull(newBodyP))
+
+      case req @ POST -> Root / "challenge2" =>
+        def parser(stream: Stream[F, String]): Pull[F, F[Response[F]], Unit] =
+          stream.pull.uncons1.flatMap {
+            case Some((str, stream)) if str.startsWith("Go") =>
+              val body = stream.cons1(str).through(fs2.text.utf8Encode)
+              Pull.output1(F.pure(Response(body = body)))
+            case Some((str, _)) if str.startsWith("NoGo") =>
+              Pull.output1(BadRequest("Booo!"))
+            case _ =>
+              Pull.output1(BadRequest("no data"))
+          }
+        parser(req.bodyAsText).stream.runLast.flatMap(_.getOrElse(InternalServerError()))
+
+      /* TODO
     case req @ POST -> Root / "trailer" =>
       trailer(t => Ok(t.headers.length))
 
@@ -109,28 +102,30 @@ object ScienceExperiments {
         body <- text(req.charset)
         trailer <- trailer
       } yield Ok(s"$body\n${trailer.headers("Hi").value}")
-     */
+       */
 
-    ///////////////// Weird Route Failures //////////////////////
-    case GET -> Root / "hanging-body" =>
-      Ok(
-        Stream
-          .eval(IO.pure(ByteVector(Seq(' '.toByte))))
-          .evalMap(_ =>
-            IO.async[Byte] { cb => /* hang */
-          }))
+      ///////////////// Weird Route Failures //////////////////////
+      case GET -> Root / "hanging-body" =>
+        Ok(
+          Stream
+            .eval(F.pure(ByteVector(Seq(' '.toByte))))
+            .evalMap(_ =>
+              F.async[Byte] { cb => /* hang */
+            }))
 
-    case GET -> Root / "broken-body" =>
-      Ok(Stream.eval(IO { "Hello " }) ++ Stream.eval(IO(sys.error("Boom!"))) ++ Stream.eval(IO {
-        "world!"
-      }))
+      case GET -> Root / "broken-body" =>
+        Ok(
+          Stream.eval(F.delay { "Hello " }) ++ Stream.eval(F.delay(sys.error("Boom!"))) ++ Stream
+            .eval(F.delay {
+              "world!"
+            }))
 
-    case GET -> Root / "slow-body" =>
-      val resp = "Hello world!".map(_.toString())
-      val body = scheduler.awakeEvery[IO](2.seconds).zipWith(Stream.emits(resp))((_, c) => c)
-      Ok(body)
+      case GET -> Root / "slow-body" =>
+        val resp = "Hello world!".map(_.toString())
+        val body = scheduler.awakeEvery[F](2.seconds).zipWith(Stream.emits(resp))((_, c) => c)
+        Ok(body)
 
-    /*
+      /*
     case req @ POST -> Root / "ill-advised-echo" =>
       // Reads concurrently from the input.  Don't do this at home.
       implicit val byteVectorMonoidInstance: Monoid[ByteVector] = new Monoid[ByteVector]{
@@ -142,39 +137,39 @@ object ScienceExperiments {
       val result: Stream[IO, Byte] = Stream.eval(IO.traverse(seq)(f))
         .flatMap(v => Stream.emits(v.combineAll.toSeq))
       Ok(result)
-     */
+       */
 
-    case GET -> Root / "fail" / "task" =>
-      IO.raiseError(new RuntimeException)
+      case GET -> Root / "fail" / "task" =>
+        F.raiseError(new RuntimeException)
 
-    case GET -> Root / "fail" / "no-task" =>
-      throw new RuntimeException
+      case GET -> Root / "fail" / "no-task" =>
+        throw new RuntimeException
 
-    case GET -> Root / "fail" / "fatally" =>
-      ???
+      case GET -> Root / "fail" / "fatally" =>
+        ???
 
-    case GET -> Root / "idle" / LongVar(seconds) =>
-      for {
-        _ <- IO(Thread.sleep(seconds))
-        resp <- Ok("finally!")
-      } yield resp
+      case GET -> Root / "idle" / LongVar(seconds) =>
+        for {
+          _ <- F.delay(Thread.sleep(seconds))
+          resp <- Ok("finally!")
+        } yield resp
 
-    case req @ GET -> Root / "connectioninfo" =>
-      val conn = req.attributes.get(Request.Keys.ConnectionInfo)
+      case req @ GET -> Root / "connectioninfo" =>
+        val conn = req.attributes.get(Request.Keys.ConnectionInfo)
 
-      conn.fold(Ok("Couldn't find connection info!")) {
-        case Request.Connection(loc, rem, secure) =>
-          Ok(s"Local: $loc, Remote: $rem, secure: $secure")
-      }
+        conn.fold(Ok("Couldn't find connection info!")) {
+          case Request.Connection(loc, rem, secure) =>
+            Ok(s"Local: $loc, Remote: $rem, secure: $secure")
+        }
 
-    case req @ GET -> Root / "black-knight" / _ =>
-      // The servlet examples hide this.
-      InternalServerError("Tis but a scratch")
+      case GET -> Root / "black-knight" / _ =>
+        // The servlet examples hide this.
+        InternalServerError("Tis but a scratch")
 
-    case req @ POST -> Root / "echo-json" =>
-      req.as[Json].flatMap(Ok(_))
+      case req @ POST -> Root / "echo-json" =>
+        req.as[Json].flatMap(Ok(_))
 
-    case POST -> Root / "dont-care" =>
-      throw InvalidMessageBodyFailure("lol, I didn't even read it")
-  }
+      case POST -> Root / "dont-care" =>
+        throw InvalidMessageBodyFailure("lol, I didn't even read it")
+    }
 }

--- a/examples/src/main/scala/com/example/http4s/ssl/SslExampleWithRedirect.scala
+++ b/examples/src/main/scala/com/example/http4s/ssl/SslExampleWithRedirect.scala
@@ -1,34 +1,30 @@
 package com.example.http4s
 package ssl
 
-import java.nio.file.Paths
-import java.util.concurrent.Executors
-
-import cats.effect.IO
+import cats.effect.Effect
 import cats.syntax.option._
 import fs2._
+import java.nio.file.Paths
 import org.http4s.HttpService
 import org.http4s.Uri.{Authority, RegName}
-import org.http4s.dsl.io._
+import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Host
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import org.http4s.server.{SSLKeyStoreSupport, ServerBuilder}
 import org.http4s.util.StreamApp
-
 import scala.concurrent.ExecutionContext
 
-trait SslExampleWithRedirect extends StreamApp[IO] {
+abstract class SslExampleWithRedirect[F[_]: Effect] extends StreamApp[F] with Http4sDsl[F] {
   val securePort = 8443
 
-  implicit val executionContext: ExecutionContext =
-    ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2))
+  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   // TODO: Reference server.jks from something other than one child down.
-  val keypath = Paths.get("../server.jks").toAbsolutePath.toString
+  val keypath: String = Paths.get("../server.jks").toAbsolutePath.toString
 
-  def builder: ServerBuilder[IO] with SSLKeyStoreSupport[IO]
+  def builder: ServerBuilder[F] with SSLKeyStoreSupport[F]
 
-  val redirectService = HttpService[IO] {
+  val redirectService: HttpService[F] = HttpService[F] {
     case request =>
       request.headers.get(Host) match {
         case Some(Host(host, _)) =>
@@ -45,19 +41,21 @@ trait SslExampleWithRedirect extends StreamApp[IO] {
       }
   }
 
-  def sslStream =
+  def sslStream(implicit scheduler: Scheduler): Stream[F, Nothing] =
     builder
       .withSSL(StoreInfo(keypath, "password"), keyManagerPassword = "secure")
-      .mountService(ExampleService.service, "/http4s")
+      .mountService(new ExampleService[F].service, "/http4s")
       .bindHttp(8443)
       .serve
 
-  def redirectStream =
+  def redirectStream: Stream[F, Nothing] =
     builder
       .mountService(redirectService, "/http4s")
       .bindHttp(8080)
       .serve
 
-  def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, Nothing] =
-    sslStream.mergeHaltBoth(redirectStream)
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, Nothing] =
+    Scheduler[F](corePoolSize = 2).flatMap { implicit scheduler =>
+      sslStream.mergeHaltBoth(redirectStream)
+    }
 }

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
@@ -1,21 +1,27 @@
 package com.example.http4s.tomcat
 
-import cats.effect.IO
+import cats.effect._
 import com.codahale.metrics.MetricRegistry
 import com.example.http4s.ExampleService
+import fs2._
+import org.http4s.server.HttpMiddleware
 import org.http4s.server.metrics._
 import org.http4s.server.tomcat.TomcatBuilder
 import org.http4s.util.StreamApp
 
-object TomcatExample extends StreamApp[IO] {
-  val metricsRegistry = new MetricRegistry
-  val metrics = Metrics[IO](metricsRegistry)
+object TomcatExample extends TomcatExampleApp[IO]
 
-  def stream(args: List[String], requestShutdown: IO[Unit]) =
-    TomcatBuilder[IO]
-      .bindHttp(8080)
-      .mountService(metrics(ExampleService.service), "/http4s")
-      .mountService(metricsService(metricsRegistry), "/metrics/*")
-      .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
-      .serve
+class TomcatExampleApp[F[_]: Effect] extends StreamApp[F] {
+  val metricsRegistry: MetricRegistry = new MetricRegistry
+  val metrics: HttpMiddleware[F] = Metrics[F](metricsRegistry)
+
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, Nothing] =
+    Scheduler(corePoolSize = 2).flatMap { implicit scheduler =>
+      TomcatBuilder[F]
+        .bindHttp(8080)
+        .mountService(metrics(new ExampleService[F].service), "/http4s")
+        .mountService(metricsService(metricsRegistry), "/metrics/*")
+        .mountFilter(NoneShallPass, "/http4s/science/black-knight/*")
+        .serve
+    }
 }

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatSslExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatSslExample.scala
@@ -5,6 +5,6 @@ import cats.effect.IO
 import com.example.http4s.ssl.SslExample
 import org.http4s.server.tomcat.TomcatBuilder
 
-object TomcatSslExample extends SslExample {
-  def builder = TomcatBuilder[IO]
+object TomcatSslExample extends SslExample[IO] {
+  def builder: TomcatBuilder[IO] = TomcatBuilder[IO]
 }

--- a/examples/war/src/main/scala/com/examples/http4s/war/Bootstrap.scala
+++ b/examples/war/src/main/scala/com/examples/http4s/war/Bootstrap.scala
@@ -1,18 +1,24 @@
 package com.examples.http4s.war
 
-import javax.servlet.{ServletContextEvent, ServletContextListener}
-import javax.servlet.annotation.WebListener
-
+import cats.effect.IO
 import com.example.http4s.ExampleService
+import fs2.Scheduler
+import javax.servlet.annotation.WebListener
+import javax.servlet.{ServletContextEvent, ServletContextListener}
 import org.http4s.servlet.syntax._
 
 @WebListener
 class Bootstrap extends ServletContextListener {
+
+  lazy val (scheduler, shutdownSched) = Scheduler.allocate[IO](corePoolSize = 2).unsafeRunSync()
+
   override def contextInitialized(sce: ServletContextEvent): Unit = {
+    implicit val scheduler: Scheduler = this.scheduler
     val ctx = sce.getServletContext
-    ctx.mountService("example", ExampleService.service, "/*")
+    ctx.mountService("example", new ExampleService[IO].service)
     ()
   }
 
-  override def contextDestroyed(sce: ServletContextEvent): Unit = {}
+  override def contextDestroyed(sce: ServletContextEvent): Unit =
+    shutdownSched.unsafeRunSync()
 }


### PR DESCRIPTION
Update examples to use a parametric effect type in the base and extend that with `IO` in the final object.

I have also moved the `Scheduler` needed in `ScienceExperiments` and `ExampleService` out, so it's a parameter. Currently it's an implicit parameter, which looks nice and simple, but it could just as easily be explicit.

This uses #1386, so that should be merged before this.

Once #1384 is merged, I will update this PR for those examples as well.