### PR TITLE
Upgrade jawn-fs2

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -113,7 +113,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val http4sWebsocket                  = "org.http4s"             %% "http4s-websocket"          % "0.2.0"
   lazy val javaxServletApi                  = "javax.servlet"          %  "javax.servlet-api"         % "3.1.0"
   lazy val jawnJson4s                       = "org.spire-math"         %% "jawn-json4s"               % "0.11.0"
-  lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "0.12.0-M1"
+  lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "0.12.0-M2"
   lazy val jettyServer                      = "org.eclipse.jetty"      %  "jetty-server"              % "9.4.6.v20170531"
   lazy val jettyServlet                     = "org.eclipse.jetty"      %  "jetty-servlet"             % jettyServer.revision
   lazy val json4sCore                       = "org.json4s"             %% "json4s-core"               % "3.5.3"


### PR DESCRIPTION
This removed a warning with possibly incompatible transitive dependencies.