### PR TITLE
Add decodeJson to Message

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -54,6 +54,11 @@ trait ArgonautInstances {
               .fromString(str)
               .fold(err => ArgDecodeResult.fail(err.toString, c.history), ArgDecodeResult.ok))
   )
+
+  implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
+    def decodeJson[A](implicit decoder: DecodeJson[A]): F[A] =
+      self.as(implicitly, jsonOf[F, A])
+  }
 }
 
 object ArgonautInstances {

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -114,4 +114,16 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
       uri.asJson.as[Uri].result must beRight(uri)
     }
   }
+
+  "Message[F].decodeJson[A]" should {
+    "decode json from a message" in {
+      val req = Request[IO]().withBody(foo.asJson)
+      req.flatMap(_.decodeJson[Foo]) must returnValue(foo)
+    }
+
+    "fail on invalid json" in {
+      val req = Request[IO]().withBody(List(13, 14).asJson)
+      req.flatMap(_.decodeJson[Foo]).attempt.unsafeRunSync must beLeft
+    }
+  }
 }

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -88,6 +88,11 @@ trait CirceInstances {
     Decoder.decodeString.emap { str =>
       Uri.fromString(str).leftMap(_ => "Uri")
     }
+
+  implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
+    def decodeJson[A](implicit decoder: Decoder[A]): F[A] =
+      self.as(implicitly, jsonOf[F, A])
+  }
 }
 
 object CirceInstances {

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -121,4 +121,16 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
       uri.asJson.as[Uri] must beRight(uri)
     }
   }
+
+  "Message[F].decodeJson[A]" should {
+    "decode json from a message" in {
+      val req = Request[IO]().withBody(foo.asJson)
+      req.flatMap(_.decodeJson[Foo]) must returnValue(foo)
+    }
+
+    "fail on invalid json" in {
+      val req = Request[IO]().withBody(List(13, 14).asJson)
+      req.flatMap(_.decodeJson[Foo]).attempt.unsafeRunSync must beLeft
+    }
+  }
 }

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -76,4 +76,9 @@ trait Json4sInstances[J] {
       def write(uri: Uri): JValue =
         JString(uri.toString)
     }
+
+  implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
+    def decodeJson[A](implicit decoder: Reader[A]): F[A] =
+      self.as(implicitly, jsonOf[F, A])
+  }
 }

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -81,6 +81,19 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
       format.read(format.write(uri)) must_== uri
     }
   }
+
+  "Message[F].decodeJson[A]" should {
+    "decode json from a message" in {
+      val req = Request[IO]().withBody("42").withContentType(Some(MediaType.`application/json`))
+      req.flatMap(_.decodeJson[Option[Int]]) must returnValue(Some(42))
+    }
+
+    "fail on invalid json" in {
+      val req =
+        Request[IO]().withBody("not a number").withContentType(Some(MediaType.`application/json`))
+      req.flatMap(_.decodeJson[Int]).attempt.unsafeRunSync must beLeft
+    }
+  }
 }
 
 object Json4sSpec {


### PR DESCRIPTION
This is the continuation of #1351.

By moving the constraint on `F[_]` to the implicit class, we can do:
```scala
msg.decodeJson[A]
// or
msg.decodeJson(customDecoder)
```
without any `implicitly`.