### PR TITLE
Update xsbt-web-plugin for war example

### DIFF
--- a/examples/war/project/plugins.sbt
+++ b/examples/war/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.earldouglas"    %  "xsbt-web-plugin"       % "3.0.1")
+addSbtPlugin("com.earldouglas"    %  "xsbt-web-plugin"       % "4.0.0")
 addSbtPlugin("com.eed3si9n"       %  "sbt-buildinfo"         % "0.7.0")
 addSbtPlugin("com.eed3si9n"       %  "sbt-unidoc"            % "0.3.3")
 addSbtPlugin("com.github.gseitz"  %  "sbt-release"           % "1.0.4")


### PR DESCRIPTION
Not sure why there was a conflicting version in project/plugins.sbt.  Though maybe that was a good place for it: it would be nice if our example projects descended less from the main build or common modules, and were more self-contained.  To assemble a working example, you need the right plugin, and it refers to a service definition in the parent project.

/cc @AronT-TLV