### PR TITLE
Upgrade to sbt-1.0

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
@@ -43,9 +43,9 @@ private[util] object ChunkWriter {
     }
     async.unsafeRunAsync(f) {
       case Right(buffer) =>
-        IO(promise.completeWith(pipe.channelWrite(buffer).map(Function.const(false))))
+        IO { promise.completeWith(pipe.channelWrite(buffer).map(Function.const(false))); () }
       case Left(t) =>
-        IO(promise.failure(t))
+        IO { promise.failure(t); () }
     }
     promise.future
   }

--- a/build.sbt
+++ b/build.sbt
@@ -270,9 +270,9 @@ lazy val docs = http4sProject("docs")
         examplesJetty,
         examplesTomcat,
         examplesWar,
-        loadTest
+        loadTest,
+        parboiled2 // internal API, compiled with different flags, generally irritating
       ),
-    // documentation source code linking
     scalacOptions in (Compile,doc) ++= {
       scmInfo.value match {
         case Some(s) =>

--- a/core/src/main/scala/org/http4s/HttpDate.scala
+++ b/core/src/main/scala/org/http4s/HttpDate.scala
@@ -33,6 +33,20 @@ class HttpDate private (val epochSecond: Long) extends Renderable with Ordered[H
 }
 
 object HttpDate {
+  private val MinEpochSecond = -2208988800L
+  private val MaxEpochSecond = 253402300799L
+
+  /** The earliest value reprsentable as an HTTP-date, `Mon, 01 Jan 1900 00:00:00 GMT`.
+    *
+    * The minimum year is specified by RFC5322 as 1900.
+    *
+    * @see https://tools.ietf.org/html/rfc7231#page-65
+    * @see https://tools.ietf.org/html/rfc5322#page-14
+    */
+  val MinValue = HttpDate.unsafeFromEpochSecond(MinEpochSecond)
+
+  /** The latest value reprsentable by RFC1123, `Fri, 31 Dec 9999 23:59:59 GMT`. */
+  val MaxValue = HttpDate.unsafeFromEpochSecond(MaxEpochSecond)
 
   /**
     * Constructs an `HttpDate` from the current time. Starting on January 1,n
@@ -45,22 +59,6 @@ object HttpDate {
   /** The `HttpDate` equal to `Thu, Jan 01 1970 00:00:00 GMT` */
   val Epoch: HttpDate =
     unsafeFromEpochSecond(0)
-
-  private val MinEpochSecond = -2208988800L
-
-  /** The earliest value reprsentable as an HTTP-date, `Mon, 01 Jan 1900 00:00:00 GMT`.
-    *
-    * The minimum year is specified by RFC5322 as 1900.
-    *
-    * @see https://tools.ietf.org/html/rfc7231#page-65
-    * @see https://tools.ietf.org/html/rfc5322#page-14
-    */
-  val MinValue = HttpDate.unsafeFromEpochSecond(MinEpochSecond)
-
-  private val MaxEpochSecond = 253402300799L
-
-  /** The latest value reprsentable by RFC1123, `Fri, 31 Dec 9999 23:59:59 GMT`. */
-  val MaxValue = HttpDate.unsafeFromEpochSecond(MaxEpochSecond)
 
   /** Parses a date according to RFC7321, Section 7.1.1.1
     *

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -26,6 +26,11 @@ object Http4sPlugin extends AutoPlugin {
     },
     scalaVersion := (sys.env.get("TRAVIS_SCALA_VERSION") orElse sys.env.get("SCALA_VERSION") getOrElse "2.12.3"),
 
+    // Rig will take care of this on production builds.  We haven't fully
+    // implemented that machinery yet, so we're going to live without this
+    // one for now.
+    scalacOptions := "-Xcheckinit"
+
     http4sMimaVersion := {
       version.value match {
         case VersionNumber(Seq(major, minor, patch), _, _) if patch.toInt > 0 =>

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -26,10 +26,6 @@ object Http4sPlugin extends AutoPlugin {
     },
     scalaVersion := (sys.env.get("TRAVIS_SCALA_VERSION") orElse sys.env.get("SCALA_VERSION") getOrElse "2.12.3"),
 
-    scalacOptions --= Seq(
-      "-Ywarn-unused:patvars"
-    ),
-
     http4sMimaVersion := {
       version.value match {
         case VersionNumber(Seq(major, minor, patch), _, _) if patch.toInt > 0 =>

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -26,20 +26,9 @@ object Http4sPlugin extends AutoPlugin {
     },
     scalaVersion := (sys.env.get("TRAVIS_SCALA_VERSION") orElse sys.env.get("SCALA_VERSION") getOrElse "2.12.3"),
 
-    scalacOptions in Compile ++= Seq(
-      "-Yno-adapted-args", // Curiously missing from RigPlugin
-      "-Ypartial-unification", // Needed on 2.11 for Either, good idea in general
-      "-Ywarn-unused-import"
-    ) ++ {
-      // https://issues.scala-lang.org/browse/SI-8340
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n >= 11 => Seq("-Ywarn-numeric-widen")
-        case _ => Seq.empty
-      }
-    },
-    scalacOptions in (Compile, console) ~= { xs: Seq[String] =>
-      xs.filterNot(Set("-Xfatal-warnings", "-Ywarn-unused-import"))
-    },
+    scalacOptions --= Seq(
+      "-Ywarn-unused:patvars"
+    ),
 
     http4sMimaVersion := {
       version.value match {
@@ -98,7 +87,7 @@ object Http4sPlugin extends AutoPlugin {
   }
 
   val macroParadiseSetting =
-    libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)
+    libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
 
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.11.v20170118"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2"

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -29,7 +29,7 @@ object Http4sPlugin extends AutoPlugin {
     // Rig will take care of this on production builds.  We haven't fully
     // implemented that machinery yet, so we're going to live without this
     // one for now.
-    scalacOptions := "-Xcheckinit"
+    scalacOptions -= "-Xcheckinit",
 
     http4sMimaVersion := {
       version.value match {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.1
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,20 +1,14 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.earldouglas"    %  "xsbt-web-plugin"       % "4.0.0")
-addSbtPlugin("com.eed3si9n"       %  "sbt-buildinfo"         % "0.7.0")
-addSbtPlugin("com.eed3si9n"       %  "sbt-unidoc"            % "0.3.3")
-addSbtPlugin("com.github.gseitz"  %  "sbt-release"           % "1.0.4")
 addSbtPlugin("com.lucidchart"     %  "sbt-scalafmt-coursier" % "1.12")
-addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.typesafe"       %  "sbt-mima-plugin"       % "0.1.14")
-addSbtPlugin("com.typesafe.sbt"   %  "sbt-ghpages"           % "0.6.2")
-addSbtPlugin("com.typesafe.sbt"   %  "sbt-site"              % "1.2.1")
 addSbtPlugin("com.typesafe.sbt"   %  "sbt-twirl"             % "1.3.7")
-addSbtPlugin("io.gatling"         %  "gatling-sbt"           % "2.1.5")
+addSbtPlugin("io.gatling"         %  "gatling-sbt"           % "2.2.2")
 addSbtPlugin("io.get-coursier"    %  "sbt-coursier"          % "1.0.0-RC11")
-addSbtPlugin("io.spray"           %  "sbt-revolver"          % "0.8.0")
-addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "2.0.29")
-addSbtPlugin("org.tpolecat"       %  "tut-plugin"            % "0.4.8")
+addSbtPlugin("io.spray"           %  "sbt-revolver"          % "0.9.0")
+addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "5.0.0-SNAPSHOT")
 addSbtPlugin("pl.project13.scala" %  "sbt-jmh"               % "0.2.27")
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt"   %  "sbt-twirl"             % "1.3.7")
 addSbtPlugin("io.gatling"         %  "gatling-sbt"           % "2.2.2")
 addSbtPlugin("io.get-coursier"    %  "sbt-coursier"          % "1.0.0-RC11")
 addSbtPlugin("io.spray"           %  "sbt-revolver"          % "0.9.0")
-addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "5.0.73")
+addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "5.0.37")
 addSbtPlugin("pl.project13.scala" %  "sbt-jmh"               % "0.2.27")
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt"   %  "sbt-twirl"             % "1.3.7")
 addSbtPlugin("io.gatling"         %  "gatling-sbt"           % "2.2.2")
 addSbtPlugin("io.get-coursier"    %  "sbt-coursier"          % "1.0.0-RC11")
 addSbtPlugin("io.spray"           %  "sbt-revolver"          % "0.9.0")
-addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "5.0.0-SNAPSHOT")
+addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "5.0.73")
 addSbtPlugin("pl.project13.scala" %  "sbt-jmh"               % "0.2.27")
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"


### PR DESCRIPTION
Won't build yet, because it's based on a snapshot of sbt-rig.

Pulls in sbt-tpolecat, which makes our compiler flags stricter, which cleans up our code more.  That's the meat of this.

Fixes #1401.