### PR TITLE
Fix Accept-Charset matching

### DIFF
--- a/core/mima.sbt
+++ b/core/mima.sbt
@@ -1,5 +1,10 @@
 import com.typesafe.tools.mima.core._
 
+// This is a new introduction
+mimaBinaryIssueFilters ++= Seq(
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("org.http4s.CharsetRange.matches")
+)
+
 // This is massive because we split out the parboiled2 module in
 // 0.16.1 and 0.17.1.  We are hiding this odious thing from the
 // build, and will eliminate it in the merge to 0.18.

--- a/core/src/main/scala/org/http4s/Charset.scala
+++ b/core/src/main/scala/org/http4s/Charset.scala
@@ -25,6 +25,7 @@ import org.http4s.util._
 import scalaz.{\/, -\/, \/-}
 
 final case class Charset private (nioCharset: NioCharset) extends Renderable {
+  @deprecated("Use `Accept-Charset`.isSatisfiedBy(charset)", "0.16.1")
   def satisfies(charsetRange: CharsetRange): Boolean = charsetRange isSatisfiedBy this
 
   def withQuality(q: QValue): CharsetRange.Atom = CharsetRange.Atom(this, q)

--- a/core/src/main/scala/org/http4s/CharsetRange.scala
+++ b/core/src/main/scala/org/http4s/CharsetRange.scala
@@ -7,13 +7,26 @@ import scalaz.{Equal, Show}
 sealed abstract class CharsetRange extends HasQValue with Renderable {
   def qValue: QValue
   def withQValue(q: QValue): CharsetRange
+
+  @deprecated("Use `isSatisfiedBy` on the `Accept-Charset` header", "0.16.1")
   def isSatisfiedBy(charset: Charset): Boolean
+
+  /** True if this charset range matches the charset.
+    * 
+    * @since 0.16.1
+    */
+  def matches(charset: Charset): Boolean
 }
 
 object CharsetRange extends CharsetRangeInstances {
   sealed case class `*`(qValue: QValue) extends CharsetRange {
     final override def withQValue(q: QValue): CharsetRange.`*` = copy(qValue = q)
+
+    @deprecated("Use `Accept-Charset`.isSatisfiedBy(charset)", "0.16.1")
     final def isSatisfiedBy(charset: Charset): Boolean = qValue.isAcceptable
+
+    final def matches(charset: Charset): Boolean = true
+
     final def render(writer: Writer): writer.type = writer << "*" << qValue
   }
 
@@ -21,7 +34,12 @@ object CharsetRange extends CharsetRangeInstances {
 
   final case class Atom protected[http4s] (charset: Charset, qValue: QValue = QValue.One) extends CharsetRange {
     override def withQValue(q: QValue): CharsetRange.Atom = copy(qValue = q)
+
+    @deprecated("Use `Accept-Charset`.isSatisfiedBy(charset)", "0.16.1")
     def isSatisfiedBy(charset: Charset): Boolean = qValue.isAcceptable && this.charset == charset
+
+    final def matches(charset: Charset): Boolean = this.charset == charset
+
     def render(writer: Writer): writer.type = writer << charset << qValue
   }
 

--- a/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
@@ -14,7 +14,7 @@ final case class `Accept-Charset`(values: NonEmptyList[CharsetRange]) extends He
   type Value = CharsetRange
 
   def qValue(charset: Charset): QValue = {
-    def specific = values.collectFirst { case cs: CharsetRange.Atom => cs.qValue }
+    def specific = values.collectFirst { case cs: CharsetRange.Atom if cs.isSatisfiedBy(charset) => cs.qValue }
     def splatted = values.collectFirst { case cs: CharsetRange.`*` => cs.qValue }
     specific orElse splatted getOrElse QValue.Zero
   }

--- a/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
@@ -14,7 +14,7 @@ final case class `Accept-Charset`(values: NonEmptyList[CharsetRange]) extends He
   type Value = CharsetRange
 
   def qValue(charset: Charset): QValue = {
-    def specific = values.collectFirst { case cs: CharsetRange.Atom if cs.isSatisfiedBy(charset) => cs.qValue }
+    def specific = values.collectFirst { case cs: CharsetRange.Atom if cs.matches(charset) => cs.qValue }
     def splatted = values.collectFirst { case cs: CharsetRange.`*` => cs.qValue }
     specific orElse splatted getOrElse QValue.Zero
   }

--- a/tests/src/test/scala/org/http4s/CharsetRangeSpec.scala
+++ b/tests/src/test/scala/org/http4s/CharsetRangeSpec.scala
@@ -10,29 +10,23 @@ import scalaz.syntax.order._
 
 class CharsetRangeSpec extends Http4sSpec {
   "*" should {
-    "be satisfied by any charset when q > 0" in {
+    "match all charsets" in {
       prop { (range: CharsetRange.`*`, cs: Charset) =>
-        range.qValue > QValue.Zero ==> { range isSatisfiedBy cs }
-      }
-    }
-
-    "not be satisfied when q = 0" in {
-      prop { cs: Charset =>
-        !(`*`.withQValue(QValue.Zero) isSatisfiedBy cs)
+        range.matches(cs)
       }
     }
   }
 
   "atomic charset ranges" should {
-    "be satisfied by themselves if q > 0" in {
-      forAll (arbitrary[CharsetRange.Atom] suchThat (_.qValue > QValue.Zero)) { range =>
-        range isSatisfiedBy range.charset
+    "match their own charsest" in {
+      forAll (arbitrary[CharsetRange.Atom]) { range =>
+        range.matches(range.charset)
       }
     }
 
     "not be satisfied by any other charsets" in {
       prop { (range: CharsetRange.Atom, cs: Charset) =>
-        range.charset != cs ==> { !(range isSatisfiedBy cs) }
+        range.charset != cs ==> { !range.matches(cs) }
       }
     }
   }

--- a/tests/src/test/scala/org/http4s/headers/AcceptCharsetSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptCharsetSpec.scala
@@ -13,4 +13,19 @@ class AcceptCharsetSpec extends HeaderLaws {
   "is not satisfied by a charset if the q value is 0" in {
     prop { (h: `Accept-Charset`, cs: Charset) => !(h.map(_.withQValue(QValue.Zero)) isSatisfiedBy cs) }
   }
+
+  "matches atom before splatted" in {
+    val acceptCharset = `Accept-Charset`(CharsetRange.*, CharsetRange.Atom(Charset.`UTF-8`, QValue.q(0.5)))
+    acceptCharset.qValue(Charset.`UTF-8`) must_== QValue.q(0.5)
+  }
+
+  "matches splatted if atom not present" in {
+    val acceptCharset = `Accept-Charset`(CharsetRange.*, CharsetRange.Atom(Charset.`ISO-8859-1`, QValue.q(0.5)))
+    acceptCharset.qValue(Charset.`UTF-8`) must_== QValue.One
+  }
+
+  "rejects non-matching charsets with no splat" in {
+    val acceptCharset = `Accept-Charset`(CharsetRange.Atom(Charset.`ISO-8859-1`, QValue.q(0.5)))
+    acceptCharset.qValue(Charset.`UTF-8`) must_== QValue.Zero
+  }
 }

--- a/tests/src/test/scala/org/http4s/headers/AcceptCharsetSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptCharsetSpec.scala
@@ -24,7 +24,17 @@ class AcceptCharsetSpec extends HeaderLaws {
     acceptCharset.qValue(Charset.`UTF-8`) must_== QValue.One
   }
 
-  "rejects non-matching charsets with no splat" in {
+  "rejects charset matching atom with q=0" in {
+    val acceptCharset = `Accept-Charset`(CharsetRange.*, CharsetRange.Atom(Charset.`UTF-8`, QValue.Zero))
+    acceptCharset.qValue(Charset.`UTF-8`) must_== QValue.Zero
+  }
+
+  "rejects charset matching splat with q=0" in {
+    val acceptCharset = `Accept-Charset`(CharsetRange.*.withQValue(QValue.Zero), CharsetRange.Atom(Charset.`ISO-8859-1`, QValue.q(0.5)))
+    acceptCharset.qValue(Charset.`UTF-8`) must_== QValue.Zero
+  }
+
+  "rejects unmatched charset" in {
     val acceptCharset = `Accept-Charset`(CharsetRange.Atom(Charset.`ISO-8859-1`, QValue.q(0.5)))
     acceptCharset.qValue(Charset.`UTF-8`) must_== QValue.Zero
   }


### PR DESCRIPTION
`Accept-Charset.qValue` was ignoring the passed in charset and returning the first atom's q-value.