### PR TITLE
Pass redacted headers to request and response logger

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -18,8 +18,8 @@ object Logger {
              logBody: Boolean,
              redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
            )(httpService: HttpService)(implicit strategy: Strategy): HttpService =
-    ResponseLogger(logHeaders, logBody)(
-      RequestLogger(logHeaders, logBody)(
+    ResponseLogger(logHeaders, logBody, redactHeadersWhen)(
+      RequestLogger(logHeaders, logBody, redactHeadersWhen)(
         httpService
       )
     )


### PR DESCRIPTION
I want to add a unit test, but we haven't yet developed any means to capture the log output.