### PR TITLE
Fix Accept-Encoding and Accept-Language

### DIFF
--- a/core/mima.sbt
+++ b/core/mima.sbt
@@ -1,10 +1,5 @@
 import com.typesafe.tools.mima.core._
 
-// This is a new introduction
-mimaBinaryIssueFilters ++= Seq(
-  ProblemFilters.exclude[ReversedMissingMethodProblem]("org.http4s.CharsetRange.matches")
-)
-
 // This is massive because we split out the parboiled2 module in
 // 0.16.1 and 0.17.1.  We are hiding this odious thing from the
 // build, and will eliminate it in the merge to 0.18.

--- a/core/src/main/scala/org/http4s/CharsetRange.scala
+++ b/core/src/main/scala/org/http4s/CharsetRange.scala
@@ -15,7 +15,10 @@ sealed abstract class CharsetRange extends HasQValue with Renderable {
     * 
     * @since 0.16.1
     */
-  def matches(charset: Charset): Boolean
+  final def matches(charset: Charset): Boolean = this match {
+    case CharsetRange.`*`(_) => true
+    case CharsetRange.Atom(cs, _) => charset == cs
+  }
 }
 
 object CharsetRange extends CharsetRangeInstances {
@@ -24,8 +27,6 @@ object CharsetRange extends CharsetRangeInstances {
 
     @deprecated("Use `Accept-Charset`.isSatisfiedBy(charset)", "0.16.1")
     final def isSatisfiedBy(charset: Charset): Boolean = qValue.isAcceptable
-
-    final def matches(charset: Charset): Boolean = true
 
     final def render(writer: Writer): writer.type = writer << "*" << qValue
   }
@@ -37,8 +38,6 @@ object CharsetRange extends CharsetRangeInstances {
 
     @deprecated("Use `Accept-Charset`.isSatisfiedBy(charset)", "0.16.1")
     def isSatisfiedBy(charset: Charset): Boolean = qValue.isAcceptable && this.charset == charset
-
-    final def matches(charset: Charset): Boolean = this.charset == charset
 
     def render(writer: Writer): writer.type = writer << charset << qValue
   }

--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -23,11 +23,18 @@ import org.http4s.syntax.string._
 
 final case class ContentCoding (coding: CaseInsensitiveString, qValue: QValue = QValue.One) extends HasQValue with Renderable {
   def withQValue(q: QValue): ContentCoding = copy(coding, q)
+
+  @deprecated("Use `Accept-Encoding`.isSatisfiedBy(encoding)", "0.16.1")
   def satisfies(encoding: ContentCoding): Boolean = encoding.satisfiedBy(this)
+
+  @deprecated("Use `Accept-Encoding`.isSatisfiedBy(encoding)", "0.16.1")
   def satisfiedBy(encoding: ContentCoding): Boolean = {
     (this.coding.toString == "*" || this.coding == encoding.coding) &&
     qValue.isAcceptable && encoding.qValue.isAcceptable
   }
+
+  def matches(encoding: ContentCoding): Boolean =
+    (this.coding.toString == "*" || this.coding == encoding.coding)
 
   override def render(writer: Writer): writer.type = writer << coding << qValue
 
@@ -56,4 +63,7 @@ object ContentCoding extends Registry {
   // Legacy encodings defined by RFC2616 3.5.
   val `x-compress`   = register("x-compress".ci, compress)
   val `x-gzip`       = register("x-gzip".ci, gzip)
+
+  def registered: Iterable[ContentCoding] =
+    registry.snapshot.values
 }

--- a/core/src/main/scala/org/http4s/LanguageTag.scala
+++ b/core/src/main/scala/org/http4s/LanguageTag.scala
@@ -32,7 +32,10 @@ object LanguageTag {
 }
 
 final case class LanguageTag(primaryTag: String, q: QValue = QValue.One, subTags: Seq[String] = Nil) extends Renderable {
-  def withQuality(q: QValue): LanguageTag = LanguageTag(primaryTag, q, subTags)
+  @deprecated("Use languageTag.withQValue", "0.16.1")
+  def withQuality(q: QValue): LanguageTag = withQValue(q)
+
+  def withQValue(q: QValue): LanguageTag = copy(q = q)
 
   def render(writer: Writer): writer.type = {
     writer.append(primaryTag)
@@ -48,12 +51,19 @@ final case class LanguageTag(primaryTag: String, q: QValue = QValue.One, subTags
     else checkLists(tags1.tail, tags2.tail)
   }
 
+  @deprecated("Use `Accept-Language`.satisfiedBy(encoding)", "0.16.1")
   def satisfies(encoding: LanguageTag): Boolean = encoding.satisfiedBy(this)
+
+  @deprecated("Use `Accept-Language`.satisfiedBy(encoding)", "0.16.1")
   def satisfiedBy(encoding: LanguageTag): Boolean = {
-    (this.primaryTag == "*" || this.primaryTag == encoding.primaryTag) &&
+    matches(encoding) && 
       q.isAcceptable && encoding.q.isAcceptable &&
-      q <= encoding.q &&
-      checkLists(subTags, encoding.subTags)
+      q <= encoding.q
+  }
+
+  def matches(languageTag: LanguageTag): Boolean = {
+    this.primaryTag == "*" || (this.primaryTag == languageTag.primaryTag &&
+      checkLists(subTags, languageTag.subTags))
   }
 }
 

--- a/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
@@ -19,7 +19,10 @@ final case class `Accept-Charset`(values: NonEmptyList[CharsetRange]) extends He
     specific orElse splatted getOrElse QValue.Zero
   }
 
-  def isSatisfiedBy(charset: Charset): Boolean = qValue(charset) > QValue.Zero
+  @deprecated("Use satisfiedBy(charset)", "0.16.1")
+  def isSatisfiedBy(charset: Charset): Boolean = satisfiedBy(charset)
+
+  def satisfiedBy(charset: Charset): Boolean = qValue(charset) > QValue.Zero
 
   def map(f: CharsetRange => CharsetRange): `Accept-Charset` = `Accept-Charset`(values.map(f))
 }

--- a/core/src/main/scala/org/http4s/headers/Accept-Encoding.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Encoding.scala
@@ -2,6 +2,7 @@ package org.http4s
 package headers
 
 import org.http4s.parser.HttpHeaderParser
+import org.http4s.syntax.string._
 import org.http4s.util.NonEmptyList
 
 object `Accept-Encoding` extends HeaderKey.Internal[`Accept-Encoding`] with HeaderKey.Recurring {
@@ -12,6 +13,15 @@ object `Accept-Encoding` extends HeaderKey.Internal[`Accept-Encoding`] with Head
 final case class `Accept-Encoding`(values: NonEmptyList[ContentCoding]) extends Header.RecurringRenderable {
   def key: `Accept-Encoding`.type = `Accept-Encoding`
   type Value = ContentCoding
+
+  @deprecated("Has confusing semantics in the presence of splat. Do not use.", "0.16.1")
   def preferred: ContentCoding = values.tail.fold(values.head)((a, b) => if (a.qValue >= b.qValue) a else b)
-  def satisfiedBy(coding: ContentCoding): Boolean = values.exists(_.satisfiedBy(coding))
+
+  def qValue(coding: ContentCoding): QValue = {
+    def specific = values.collectFirst { case cc: ContentCoding if cc.coding != "*".ci && cc.matches(coding) => cc.qValue }
+    def splatted = values.collectFirst { case cc: ContentCoding if cc.coding == "*".ci => cc.qValue }
+    specific orElse splatted getOrElse QValue.Zero
+  }
+
+  def satisfiedBy(coding: ContentCoding): Boolean = qValue(coding) > QValue.Zero
 }

--- a/core/src/main/scala/org/http4s/headers/Accept-Language.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Language.scala
@@ -12,6 +12,16 @@ object `Accept-Language` extends HeaderKey.Internal[`Accept-Language`] with Head
 final case class `Accept-Language`(values: NonEmptyList[LanguageTag]) extends Header.RecurringRenderable {
   def key: `Accept-Language`.type = `Accept-Language`
   type Value = LanguageTag
+
+  @deprecated("Has confusing semantics in the presence of splat. Do not use.", "0.16.1")  
   def preferred: LanguageTag = values.tail.fold(values.head)((a, b) => if (a.q >= b.q) a else b)
-  def satisfiedBy(languageTag: LanguageTag): Boolean = values.exists(_.satisfiedBy(languageTag))
+
+  def qValue(languageTag: LanguageTag): QValue =
+    values.list.collect {
+      case tag: LanguageTag if tag.matches(languageTag) =>
+        if (tag.primaryTag == "*") (0, tag.q)
+        else (1 + tag.subTags.size, tag.q)
+    }.sortBy(-_._1).headOption.fold(QValue.Zero)(_._2)
+
+  def satisfiedBy(languageTag: LanguageTag): Boolean = qValue(languageTag) > QValue.Zero
 }

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -154,46 +154,6 @@ trait ArbitraryInstances {
       charsetRangesWithQ = charsetRanges.zip(qValues).map { case (range, q) => range.withQValue(q) }
     } yield `Accept-Charset`(charsetRangesWithQ.head, charsetRangesWithQ.tail:_*) }
 
-  def genContentCodingNoQuality: Gen[ContentCoding] =
-    oneOf(ContentCoding.registered.toSeq)
-
-  implicit val arbitraryContentCoding: Arbitrary[ContentCoding] =
-    Arbitrary { for {
-      cc <- genContentCodingNoQuality
-      q <- arbitrary[QValue]
-    } yield cc.withQValue(q) }
-
-  implicit val arbitraryAcceptEncoding: Arbitrary[`Accept-Encoding`] =
-    Arbitrary { for {
-      // make a set first so we don't have contradictory q-values
-      contentCodings <- nonEmptyContainerOf[Set, ContentCoding](genContentCodingNoQuality).map(_.toVector)
-      qValues <- containerOfN[Vector, QValue](contentCodings.size, arbitraryQValue.arbitrary)
-      contentCodingsWithQ = contentCodings.zip(qValues).map { case (coding, q) => coding.withQValue(q) }
-    } yield `Accept-Encoding`(contentCodingsWithQ.head, contentCodingsWithQ.tail:_*) }
-
-  def genLanguageTagNoQuality: Gen[LanguageTag] =
-    frequency(
-      3 -> (for {
-        primaryTag <- genToken
-        subTags <- frequency(4 -> Nil, 1 -> listOf(genToken))
-      } yield LanguageTag(primaryTag, subTags = subTags)),
-      1 -> const(LanguageTag.`*`)
-    )
-
-  implicit val arbitraryLanguageTag: Arbitrary[LanguageTag] =
-    Arbitrary { for {
-      lt <- genLanguageTagNoQuality
-      q <- arbitrary[QValue]
-    } yield lt.copy(q = q) }
-
-  implicit val arbitraryAcceptLanguage: Arbitrary[`Accept-Language`] =
-    Arbitrary { for {
-      // make a set first so we don't have contradictory q-values
-      languageTags <- nonEmptyContainerOf[Set, LanguageTag](genLanguageTagNoQuality).map(_.toVector)
-      qValues <- containerOfN[Vector, QValue](languageTags.size, arbitraryQValue.arbitrary)
-      tagsWithQ = languageTags.zip(qValues).map { case (tag, q) => tag.copy(q = q) }
-    } yield `Accept-Language`(tagsWithQ.head, tagsWithQ.tail:_*) }
-
   implicit val arbitraryUrlForm: Arbitrary[UrlForm] = Arbitrary {
     // new String("\ufffe".getBytes("UTF-16"), "UTF-16") != "\ufffe".
     // Ain't nobody got time for that.
@@ -416,4 +376,49 @@ trait ArbitraryInstances {
     } yield Uri(scheme, authority, path, query, fragment)
   }
 
+}
+
+object ArbitraryInstances extends ArbitraryInstances {
+  // This were introduced after .0 and need to be kept out of the
+  // trait.  We can move them back into the trait in the next .0.
+
+  def genContentCodingNoQuality: Gen[ContentCoding] =
+    oneOf(ContentCoding.registered.toSeq)
+
+  implicit val arbitraryContentCoding: Arbitrary[ContentCoding] =
+    Arbitrary { for {
+      cc <- genContentCodingNoQuality
+      q <- arbitrary[QValue]
+    } yield cc.withQValue(q) }
+
+  implicit val arbitraryAcceptEncoding: Arbitrary[`Accept-Encoding`] =
+    Arbitrary { for {
+      // make a set first so we don't have contradictory q-values
+      contentCodings <- nonEmptyContainerOf[Set, ContentCoding](genContentCodingNoQuality).map(_.toVector)
+      qValues <- containerOfN[Vector, QValue](contentCodings.size, arbitraryQValue.arbitrary)
+      contentCodingsWithQ = contentCodings.zip(qValues).map { case (coding, q) => coding.withQValue(q) }
+    } yield `Accept-Encoding`(contentCodingsWithQ.head, contentCodingsWithQ.tail:_*) }
+
+  def genLanguageTagNoQuality: Gen[LanguageTag] =
+    frequency(
+      3 -> (for {
+        primaryTag <- genToken
+        subTags <- frequency(4 -> Nil, 1 -> listOf(genToken))
+      } yield LanguageTag(primaryTag, subTags = subTags)),
+      1 -> const(LanguageTag.`*`)
+    )
+
+  implicit val arbitraryLanguageTag: Arbitrary[LanguageTag] =
+    Arbitrary { for {
+      lt <- genLanguageTagNoQuality
+      q <- arbitrary[QValue]
+    } yield lt.copy(q = q) }
+
+  implicit val arbitraryAcceptLanguage: Arbitrary[`Accept-Language`] =
+    Arbitrary { for {
+      // make a set first so we don't have contradictory q-values
+      languageTags <- nonEmptyContainerOf[Set, LanguageTag](genLanguageTagNoQuality).map(_.toVector)
+      qValues <- containerOfN[Vector, QValue](languageTags.size, arbitraryQValue.arbitrary)
+      tagsWithQ = languageTags.zip(qValues).map { case (tag, q) => tag.copy(q = q) }
+    } yield `Accept-Language`(tagsWithQ.head, tagsWithQ.tail:_*) }
 }

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -154,6 +154,46 @@ trait ArbitraryInstances {
       charsetRangesWithQ = charsetRanges.zip(qValues).map { case (range, q) => range.withQValue(q) }
     } yield `Accept-Charset`(charsetRangesWithQ.head, charsetRangesWithQ.tail:_*) }
 
+  def genContentCodingNoQuality: Gen[ContentCoding] =
+    oneOf(ContentCoding.registered.toSeq)
+
+  implicit val arbitraryContentCoding: Arbitrary[ContentCoding] =
+    Arbitrary { for {
+      cc <- genContentCodingNoQuality
+      q <- arbitrary[QValue]
+    } yield cc.withQValue(q) }
+
+  implicit val arbitraryAcceptEncoding: Arbitrary[`Accept-Encoding`] =
+    Arbitrary { for {
+      // make a set first so we don't have contradictory q-values
+      contentCodings <- nonEmptyContainerOf[Set, ContentCoding](genContentCodingNoQuality).map(_.toVector)
+      qValues <- containerOfN[Vector, QValue](contentCodings.size, arbitraryQValue.arbitrary)
+      contentCodingsWithQ = contentCodings.zip(qValues).map { case (coding, q) => coding.withQValue(q) }
+    } yield `Accept-Encoding`(contentCodingsWithQ.head, contentCodingsWithQ.tail:_*) }
+
+  def genLanguageTagNoQuality: Gen[LanguageTag] =
+    frequency(
+      3 -> (for {
+        primaryTag <- genToken
+        subTags <- frequency(4 -> Nil, 1 -> listOf(genToken))
+      } yield LanguageTag(primaryTag, subTags = subTags)),
+      1 -> const(LanguageTag.`*`)
+    )
+
+  implicit val arbitraryLanguageTag: Arbitrary[LanguageTag] =
+    Arbitrary { for {
+      lt <- genLanguageTagNoQuality
+      q <- arbitrary[QValue]
+    } yield lt.copy(q = q) }
+
+  implicit val arbitraryAcceptLanguage: Arbitrary[`Accept-Language`] =
+    Arbitrary { for {
+      // make a set first so we don't have contradictory q-values
+      languageTags <- nonEmptyContainerOf[Set, LanguageTag](genLanguageTagNoQuality).map(_.toVector)
+      qValues <- containerOfN[Vector, QValue](languageTags.size, arbitraryQValue.arbitrary)
+      tagsWithQ = languageTags.zip(qValues).map { case (tag, q) => tag.copy(q = q) }
+    } yield `Accept-Language`(tagsWithQ.head, tagsWithQ.tail:_*) }
+
   implicit val arbitraryUrlForm: Arbitrary[UrlForm] = Arbitrary {
     // new String("\ufffe".getBytes("UTF-16"), "UTF-16") != "\ufffe".
     // Ain't nobody got time for that.

--- a/tests/src/test/scala/org/http4s/headers/AcceptCharsetSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptCharsetSpec.scala
@@ -6,12 +6,12 @@ class AcceptCharsetSpec extends HeaderLaws {
 
   "is satisfied by a charset if the q value is > 0" in {
     prop { (h: `Accept-Charset`, cs: Charset) =>
-      h.qValue(cs) > QValue.Zero ==> { h isSatisfiedBy cs }
+      h.qValue(cs) > QValue.Zero ==> { h.satisfiedBy(cs) }
     }
   }
 
   "is not satisfied by a charset if the q value is 0" in {
-    prop { (h: `Accept-Charset`, cs: Charset) => !(h.map(_.withQValue(QValue.Zero)) isSatisfiedBy cs) }
+    prop { (h: `Accept-Charset`, cs: Charset) => !(h.map(_.withQValue(QValue.Zero)).satisfiedBy(cs)) }
   }
 
   "matches atom before splatted" in {

--- a/tests/src/test/scala/org/http4s/headers/AcceptEncodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptEncodingSpec.scala
@@ -1,6 +1,8 @@
 package org.http4s
 package headers
 
+import org.http4s.testing.ArbitraryInstances._
+
 class AcceptEncodingSpec extends HeaderLaws {
   checkAll("Accept-Encoding", headerLaws(`Accept-Encoding`))
 

--- a/tests/src/test/scala/org/http4s/headers/AcceptEncodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptEncodingSpec.scala
@@ -1,0 +1,41 @@
+package org.http4s
+package headers
+
+class AcceptEncodingSpec extends HeaderLaws {
+  checkAll("Accept-Encoding", headerLaws(`Accept-Encoding`))
+
+  "is satisfied by a content coding if the q value is > 0" in {
+    prop { (h: `Accept-Encoding`, cc: ContentCoding) =>
+      h.qValue(cc) > QValue.Zero ==> { h.satisfiedBy(cc) }
+    }
+  }
+
+  "is not satisfied by a content coding if the q value is 0" in {
+    prop { (h: `Accept-Encoding`, cc: ContentCoding) => !(`Accept-Encoding`(h.values.map(_.withQValue(QValue.Zero))).satisfiedBy(cc)) }
+  }
+
+  "matches atom before splatted" in {
+    val acceptEncoding = `Accept-Encoding`(ContentCoding.*, ContentCoding.gzip.withQValue(QValue.q(0.5)))
+    acceptEncoding.qValue(ContentCoding.gzip) must_== QValue.q(0.5)
+  }
+
+  "matches splatted if atom not present" in {
+    val acceptEncoding = `Accept-Encoding`(ContentCoding.*, ContentCoding.compress.withQValue(QValue.q(0.5)))
+    acceptEncoding.qValue(ContentCoding.gzip) must_== QValue.One
+  }
+
+  "rejects content coding matching atom with q=0" in {
+    val acceptEncoding = `Accept-Encoding`(ContentCoding.*, ContentCoding.gzip.withQValue(QValue.Zero))
+    acceptEncoding.qValue(ContentCoding.gzip) must_== QValue.Zero
+  }
+
+  "rejects content coding matching splat with q=0" in {
+    val acceptEncoding = `Accept-Encoding`(ContentCoding.*.withQValue(QValue.Zero), ContentCoding.compress.withQValue(QValue.q(0.5)))
+    acceptEncoding.qValue(ContentCoding.gzip) must_== QValue.Zero
+  }
+
+  "rejects unmatched content coding" in {
+    val acceptEncoding = `Accept-Encoding`(ContentCoding.compress.withQValue(QValue.q(0.5)))
+    acceptEncoding.qValue(ContentCoding.gzip) must_== QValue.Zero
+  }
+}

--- a/tests/src/test/scala/org/http4s/headers/AcceptLanguageSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptLanguageSpec.scala
@@ -1,0 +1,49 @@
+package org.http4s
+package headers
+
+class AcceptLanguageSpec extends HeaderLaws {
+  val english = LanguageTag("en")
+  val spanish = LanguageTag("es")
+
+  "is satisfied by a language tag if the q value is > 0" in {
+    prop { (h: `Accept-Language`, cc: LanguageTag) =>
+      h.qValue(cc) > QValue.Zero ==> { h.satisfiedBy(cc) }
+    }
+  }
+
+  "is not satisfied by a language tag if the q value is 0" in {
+    prop { (h: `Accept-Language`, cc: LanguageTag) => !(`Accept-Language`(h.values.map(_.copy(q = QValue.Zero))).satisfiedBy(cc)) }
+  }
+
+  "matches most specific tag" in {
+    val acceptLanguage = `Accept-Language`(
+      LanguageTag.*,
+      LanguageTag("de", QValue.q(0.3), Seq("DE", "1996")),
+      LanguageTag("de", QValue.q(0.1)),
+      LanguageTag("de", QValue.q(0.2), Seq("DE")))
+    acceptLanguage.qValue(LanguageTag("de")) must_== QValue.q(0.1)
+    acceptLanguage.qValue(LanguageTag("de", subTags = List("DE"))) must_== QValue.q(0.2)
+    acceptLanguage.qValue(LanguageTag("de", subTags = List("DE", "1996"))) must_== QValue.q(0.3)
+    acceptLanguage.qValue(LanguageTag("de", subTags = List("DE", "2017"))) must_== QValue.q(0.2)
+  }
+
+  "matches splatted if primary tag not present" in {
+    val acceptLanguage = `Accept-Language`(LanguageTag.*, spanish.withQValue(QValue.q(0.5)))
+    acceptLanguage.qValue(english) must_== QValue.One
+  }
+
+  "rejects language tag matching primary tag with q=0" in {
+    val acceptLanguage = `Accept-Language`(LanguageTag.*, english.withQValue(QValue.Zero))
+    acceptLanguage.qValue(english) must_== QValue.Zero
+  }
+
+  "rejects language tag matching splat with q=0" in {
+    val acceptLanguage = `Accept-Language`(LanguageTag.*.withQValue(QValue.Zero), spanish.withQValue(QValue.q(0.5)))
+    acceptLanguage.qValue(english) must_== QValue.Zero
+  }
+
+  "rejects unmatched language tag" in {
+    val acceptLanguage = `Accept-Language`(spanish.withQValue(QValue.q(0.5)))
+    acceptLanguage.qValue(english) must_== QValue.Zero
+  }
+}

--- a/tests/src/test/scala/org/http4s/headers/AcceptLanguageSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptLanguageSpec.scala
@@ -1,6 +1,8 @@
 package org.http4s
 package headers
 
+import org.http4s.testing.ArbitraryInstances._
+
 class AcceptLanguageSpec extends HeaderLaws {
   val english = LanguageTag("en")
   val spanish = LanguageTag("es")

--- a/tests/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
@@ -43,19 +43,4 @@ class AcceptEncodingSpec extends Specification with HeaderParserHelper[`Accept-E
 
     parse(gzip1.value) must be_==(gzip)
   }
-
-  "Offer preferred" in {
-    val unordered = `Accept-Encoding`(ContentCoding.gzip.withQValue(q(0.5)),
-      ContentCoding.compress.withQValue(q(0.1)),
-      ContentCoding.deflate)
-
-    unordered.preferred must be_==(ContentCoding.deflate)
-  }
-
-  "Be satisfied correctly" in {
-    `Accept-Encoding`(ContentCoding.`*`) satisfiedBy ContentCoding.gzip should beTrue
-    `Accept-Encoding`(ContentCoding.`*` withQValue QValue.Zero) satisfiedBy ContentCoding.gzip should beFalse
-    gzip satisfiedBy ContentCoding.gzip should beTrue
-    gzip satisfiedBy ContentCoding.deflate should beFalse
-  }
 }

--- a/tests/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
@@ -12,11 +12,11 @@ class AcceptLanguageSpec extends Specification with HeaderParserHelper[`Accept-L
 
   val en = `Accept-Language`(LanguageTag("en"))
   val fr = `Accept-Language`(LanguageTag("fr"))
-  val enq5 = `Accept-Language`(LanguageTag("en").withQuality(q(0.5)))
+  val enq5 = `Accept-Language`(LanguageTag("en").withQValue(q(0.5)))
   val en_cool = `Accept-Language`(LanguageTag("en", "cool"))
 
   val all = `Accept-Language`(LanguageTag.`*`)
-  val ninguno = `Accept-Language`(LanguageTag.`*`.withQuality(QValue.Zero))
+  val ninguno = `Accept-Language`(LanguageTag.`*`.withQValue(QValue.Zero))
 
   "Accept-Language" should {
     "Give correct value" in {
@@ -28,23 +28,6 @@ class AcceptLanguageSpec extends Specification with HeaderParserHelper[`Accept-L
       parse(en.value) must be_==(en)
       parse(enq5.value) must be_==(enq5)
       parse(en_cool.value) must be_==(en_cool)
-    }
-
-    "Offer preferred" in {
-      val unordered = `Accept-Language`(en.values.head.withQuality(q(0.2)),
-                                        fr.values.head.withQuality(q(0.1)),
-                                        en_cool.values.head)
-      unordered.preferred must be_==(en_cool.values.head)
-    }
-
-    "Be satisfied correctly" in {
-      all satisfiedBy en.values.head must be_== (true)
-      ninguno satisfiedBy en.values.head must be_== (false)
-
-      en satisfiedBy en_cool.values.head must be_== (true)
-      en_cool satisfiedBy en.values.head must be_== (false)
-
-      en satisfiedBy fr.values.head must be_== (false)
     }
   }
 }


### PR DESCRIPTION
* `satisfiedBy` on the values makes little sense and is deprecated
* `satisfiedBy` on the headers did not understand priority
* made more consistent with `Accept-Charset`

`LanguageTag` and `ContentCoding` are still broken in that they are both values (in the `Content-*` headers) and ranges (in the `Accept-*` headers).  These should be split into different types, but there's no reasonable way to do that without breaking binary compatibility.  We'll address that in a later version.