### PR TITLE
Add max wait queue for BlazeClient

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PooledHttp1Client.scala
@@ -7,18 +7,26 @@ import cats.effect._
 /** Create a HTTP1 client which will attempt to recycle connections */
 object PooledHttp1Client {
   private val DefaultMaxTotalConnections = 10
+  //Negative value is treated as unbounded.  Default to unbounded for backwards compatibility.
+  private val DefaultMaxWaitConnections = -1
 
   /** Construct a new PooledHttp1Client
     *
     * @param maxTotalConnections maximum connections the client will have at any specific time
+    * @param maxWaitConnections maximum connections in the waiting queue
     * @param config blaze client configuration options
     */
   def apply[F[_]: Effect](
       maxTotalConnections: Int = DefaultMaxTotalConnections,
+      maxWaitConnections: Int = DefaultMaxWaitConnections,
       config: BlazeClientConfig = BlazeClientConfig.defaultConfig): Client[F] = {
 
     val http1: ConnectionBuilder[F, BlazeConnection[F]] = Http1Support(config)
-    val pool = ConnectionManager.pool(http1, maxTotalConnections, config.executionContext)
+    val pool = ConnectionManager.pool(
+      http1,
+      maxTotalConnections,
+      maxWaitConnections,
+      config.executionContext)
     BlazeClient(pool, config, pool.shutdown())
   }
 }

--- a/client/src/main/scala/org/http4s/client/ConnectionManager.scala
+++ b/client/src/main/scala/org/http4s/client/ConnectionManager.scala
@@ -56,5 +56,19 @@ object ConnectionManager {
       builder: ConnectionBuilder[F, A],
       maxTotal: Int,
       executionContext: ExecutionContext): ConnectionManager[F, A] =
-    new PoolManager[F, A](builder, maxTotal, executionContext)
+    pool(builder, maxTotal, -1, executionContext)
+
+  /** Create a [[ConnectionManager]] that will attempt to recycle connections
+    *
+    * @param builder generator of new connections
+    * @param maxTotal max total connections
+    * @param maxWaitSize: max number of requests to wait for a new connection.  Negative value is the same as unbounded.
+    * @param executionContext `ExecutionContext` where async operations will execute
+    */
+  def pool[F[_]: Effect, A <: Connection[F]](
+      builder: ConnectionBuilder[F, A],
+      maxTotal: Int,
+      maxWaitSize: Int,
+      executionContext: ExecutionContext): ConnectionManager[F, A] =
+    new PoolManager[F, A](builder, maxTotal, maxWaitSize, executionContext)
 }


### PR DESCRIPTION
This PR is an attempt to resolve #1043.
One thing to note is I had to break API compatibility for PooledHttp1Client.apply if both parameters are being set without being named, but I don't think there is a way around it.  I did consider adding the value to BlazeClientConfig but the other pool setting is not present there so I did not feel it was a good spot to put the value.