### PR TITLE
Grudgingly disable scalafmt on compile

### DIFF
--- a/bin/specialTest.sh
+++ b/bin/specialTest.sh
@@ -3,7 +3,7 @@ set -e
 
 . $TRAVIS_BUILD_DIR/bin/setup.sh
 
-sbt ";scalafmt::test ;test:scalafmt::test ;mimaReportBinaryIssues ;coverage ;clean ;test ;coverageReport ;coverageOff"
+sbt ";test:scalafmt::test ;mimaReportBinaryIssues ;coverage ;clean ;test ;coverageReport ;coverageOff"
 exitCode=$?
 
 echo "Uploading codecov"

--- a/build.sbt
+++ b/build.sbt
@@ -501,5 +501,3 @@ def initCommands(additionalImports: String*) =
   ) ++ additionalImports).mkString("import ", ", ", "")
 
 addCommandAlias("validate", ";test ;scalafmt::test; test:scalafmt::test ;makeSite ;mimaReportBinaryIssues")
-// Why doesn't this work from project/*.scala?
-scalafmtOnCompile in Sbt := false

--- a/build.sbt
+++ b/build.sbt
@@ -500,4 +500,4 @@ def initCommands(additionalImports: String*) =
     "cats.implicits._"
   ) ++ additionalImports).mkString("import ", ", ", "")
 
-addCommandAlias("validate", ";test ;scalafmt::test; test:scalafmt::test ;makeSite ;mimaReportBinaryIssues")
+addCommandAlias("validate", ";test ;scalafmt::test; makeSite ;mimaReportBinaryIssues")

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -46,7 +46,17 @@ object Http4sPlugin extends AutoPlugin {
 
     addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary),
 
-    scalafmtVersion := "1.2.0"
+    scalafmtVersion := "1.2.0",
+    scalafmt in Test := {
+      (scalafmt in Compile).value
+      (scalafmt in Test).value
+      ()
+    },
+    test in (Test, scalafmt) := {
+      (test in (Compile, scalafmt)).value
+      (test in (Test, scalafmt)).value
+      ()
+    }
   )
 
   def extractApiVersion(version: String) = {

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -46,8 +46,7 @@ object Http4sPlugin extends AutoPlugin {
 
     addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary),
 
-    scalafmtVersion := "1.2.0",
-    scalafmtOnCompile := sys.env.get("TRAVIS").isEmpty
+    scalafmtVersion := "1.2.0"
   )
 
   def extractApiVersion(version: String) = {

--- a/website/src/hugo/content/contributing.md
+++ b/website/src/hugo/content/contributing.md
@@ -60,10 +60,11 @@ This runs:
 
 ### Formatting
 
-[Scalafmt] is run on compile.  The Travis CI build verifies that all
-code is formatted correctly and will fail if a diff is found.  If you
-compile your code before submitting a pull request, formatting should
-just work.
+The Travis CI build verifies that code is formatted correctly
+according to the [Scalafmt] config and will fail if a diff is found.
+
+You can run `validate` to test the formatting before opening a PR.  If
+your PR fails due to formatting, run `;scalafmt ;test:scalafmt`.
 
 [Scalafmt]: http://scalameta.org/scalafmt/
 

--- a/website/src/hugo/content/contributing.md
+++ b/website/src/hugo/content/contributing.md
@@ -64,7 +64,7 @@ The Travis CI build verifies that code is formatted correctly
 according to the [Scalafmt] config and will fail if a diff is found.
 
 You can run `validate` to test the formatting before opening a PR.  If
-your PR fails due to formatting, run `;scalafmt ;test:scalafmt`.
+your PR fails due to formatting, run `;test:scalafmt`.
 
 [Scalafmt]: http://scalameta.org/scalafmt/
 


### PR DESCRIPTION
This makes me sad, but it's taking my laptop 25 seconds to figure out there's nothing new to compile, on every compile.

I welcome better suggestions, because this is going to trip up new contributors constantly.