### PR TITLE
Deprecate Monoid[MaybeResponse]

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -348,7 +348,7 @@ object MaybeResponse {
         a orElse b
     }
 
-  @deprecated("""We derive `Monoid[Kleisli[Task, Request, MaybeResponse]]` from `Monoid[Task[MaybeResponse]]`, which needs to have the "orElse"-like semantics of `taskInstance`.  The presence of this monoid makes it easy to locate a monoid that evaluates both effects, which is not what we want when chaining `HttpService`s.  Use `taskInstance` instead.""", "0.16.3")
+  @deprecated("""We derive `Monoid[Kleisli[Task, Request, MaybeResponse]]` from `Monoid[Task[MaybeResponse]]`, which needs to have the "orElse"-like semantics of `taskInstance`.  The presence of this monoid makes it easy to locate a monoid that evaluates both effects, which means that when chaining `HttpService`s, both services run even if the first service does not return `Pass`.  To ensure that a correct monoid is resolved for this use case, use `taskInstance` instead.  If you really need a `Monoid[MaybeResponse]` and understand how it can hurt you, use `monoidInstance`.""", "0.16.3")
   implicit val instance: Monoid[MaybeResponse] =
     monoidInstance
 

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -337,13 +337,20 @@ sealed trait MaybeResponse {
 }
 
 object MaybeResponse {
-  implicit val instance: Monoid[MaybeResponse] =
+  /** Intentionally not implicit. Do not use unless you've read and understood the
+    * deprecation warning on [[instance]].
+    */
+  val monoidInstance: Monoid[MaybeResponse] =
     new Monoid[MaybeResponse] {
       def zero =
         Pass
       def append(a: MaybeResponse, b: => MaybeResponse) =
         a orElse b
     }
+
+  @deprecated("""We derive `Monoid[Kleisli[Task, Request, MaybeResponse]]` from `Monoid[Task[MaybeResponse]]`, which needs to have the "orElse"-like semantics of `taskInstance`.  The presence of this monoid makes it easy to locate a monoid that evaluates both effects, which is not what we want when chaining `HttpService`s.  Use `taskInstance` instead.""", "0.16.3")
+  implicit val instance: Monoid[MaybeResponse] =
+    monoidInstance
 
   implicit val taskInstance: Monoid[Task[MaybeResponse]] =
     new Monoid[Task[MaybeResponse]] {

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -348,7 +348,18 @@ object MaybeResponse {
         a orElse b
     }
 
-  @deprecated("""We derive `Monoid[Kleisli[Task, Request, MaybeResponse]]` from `Monoid[Task[MaybeResponse]]`, which needs to have the "orElse"-like semantics of `taskInstance`.  The presence of this monoid makes it easy to locate a monoid that evaluates both effects, which means that when chaining `HttpService`s, both services run even if the first service does not return `Pass`.  To ensure that a correct monoid is resolved for this use case, use `taskInstance` instead.  If you really need a `Monoid[MaybeResponse]` and understand how it can hurt you, use `monoidInstance`.""", "0.16.3")
+  @deprecated(
+    """We derive `Monoid[Kleisli[Task, Request, MaybeResponse]]`
+      |from `Monoid[Task[MaybeResponse]]`, which needs to have the
+      |"orElse"-like semantics of `taskInstance`. The presence of
+      |this monoid makes it easy to locate a monoid that evaluates
+      |both effects, which means that when chaining `HttpService`s,
+      |both services run even if the first service does not return
+      |`Pass`. To ensure that a correct monoid is resolved for this
+      |use case, use `taskInstance` instead. If you really need a
+      |`Monoid[MaybeResponse]` and understand how it can hurt you,
+      |use `monoidInstance`.""".stripMargin,
+    "0.16.3")
   implicit val instance: Monoid[MaybeResponse] =
     monoidInstance
 

--- a/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -49,7 +49,7 @@ object WebjarService {
     * @param config The configuration for this service
     * @return The HttpService
     */
-  def apply(config: Config): HttpService = Service {
+  def apply(config: Config): HttpService = HttpService.lift {
     // Intercepts the routes that match webjar asset names
     case request if request.method == Method.GET =>
       Option(request.pathInfo)
@@ -57,7 +57,9 @@ object WebjarService {
           .flatMap(toWebjarAsset)
           .filter(config.filter)
           .map(serveWebjarAsset(config, request))
-          .getOrElse(Pass.now)
+        .getOrElse(Pass.now)
+    case _ =>
+      Pass.now
   }
 
   /**


### PR DESCRIPTION
The presence of this monoid risks implicit resolution that breaks service chaining by evaluating both effects.  This retains binary compatibility but warns people who fall into this trap.

The long-term solution is #1424.