### PR TITLE
Start building for JDK9 to detect problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,29 @@
 language: scala
 dist: trusty
-jdk: oraclejdk8
-scala:
-- 2.12.3
-- 2.11.11
-- 2.10.6
+matrix:
+  include:
+  - jdk: oraclejdk8
+    scala: 2.12.3
+    env: SCALAZ_VERSION=7.2.15
+  - jdk: oraclejdk8
+    scala: 2.12.3
+    env: SCALAZ_VERSION=7.1.13
+  - jdk: oraclejdk8
+    scala: 2.12.3
+    env: SCALAZ_VERSION=7.2.15
+  - jdk: oraclejdk8
+    scala: 2.12.3
+    env: SCALAZ_VERSION=7.1.13
+  - jdk: oraclejdk8
+    scala: 2.12.3
+    env: SCALAZ_VERSION=7.2.15
+  - jdk: oraclejdk8
+    scala: 2.12.3
+    env: SCALAZ_VERSION=7.1.13
+  - jdk: oraclejdk9
+    scala: 2.12.3
+    env: SCALAZ_VERSION=7.2.15
 env:
-  matrix:
-  - SCALAZ_VERSION=7.2.15
-  - SCALAZ_VERSION=7.1.13
   global:
   - HUGO_VERSION=0.26
   - LOGBACK_ROOT_LEVEL=WARN

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -45,6 +45,7 @@ object Http4sPlugin extends AutoPlugin {
       sys.env.get("TRAVIS") == Some("true") &&
         sys.env.get("TRAVIS_PULL_REQUEST") == Some("false") &&
         sys.env.get("TRAVIS_REPO_SLUG") == Some("http4s/http4s") &&
+        sys.env.get("TRAVIS_JDK_VERSION") == Some("oraclejdk8") &&
         (sys.env.get("TRAVIS_BRANCH") match {
            case Some("master") => true
            case Some(branch) if branch.startsWith("release-") => true


### PR DESCRIPTION
We're not requiring Java 9 anytime soon, but with increased modularization of the JDK, we should be sure we're not depending on more modules than necessary.  This adds a non-publishing build to the matrix that acts as a canary.