### PR TITLE
Remove java.xml.bind dependency.

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -6,8 +6,8 @@ import cats._
 import fs2._
 import fs2.Stream._
 import fs2.compress._
+import java.nio.{ByteBuffer, ByteOrder}
 import java.util.zip.{CRC32, Deflater}
-import javax.xml.bind.DatatypeConverter
 import org.http4s.headers._
 import org.log4s.getLogger
 
@@ -110,6 +110,10 @@ object GZip {
 
   private def trailerFinish(gen: TrailerGen): Chunk[Byte] =
     Chunk.bytes(
-      DatatypeConverter.parseHexBinary("%08x".format(gen.crc.getValue)).reverse ++
-        DatatypeConverter.parseHexBinary("%08x".format(gen.inputLength % GZIP_LENGTH_MOD)).reverse)
+      ByteBuffer
+        .allocate(Integer.BYTES * 2)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt(gen.crc.getValue.toInt)
+        .putInt((gen.inputLength % GZIP_LENGTH_MOD).toInt)
+        .array())
 }


### PR DESCRIPTION
java.xml.bind is under a separate module in Java 9 and needs to be
included with a command line switch. Implement GZip trailer calculation
without javax.xml.bind.DatatypeConverter for better Java 9
compatibility.