### PR TITLE
Release v0.17.3

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.17.3-SNAPSHOT"
+version in ThisBuild := "0.17.3"

--- a/website/src/hugo/content/CHANGELOG.md
+++ b/website/src/hugo/content/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.17.3
+# v0.17.3 (2017-10-02)
 * Shift execution of HttpService to the `ExecutionContext` provided by the
   `BlazeBuilder` when using HTTP/2. Previously, it only shifted the response
   task and body stream.


### PR DESCRIPTION
Merging this should trigger a release of v0.17.3 with sonatype release, tag, and version on this branch bumped to v0.17.4-SNAPSHOT.