### PR TITLE
Don't decrypt unless on http4s/http4s

### DIFF
--- a/scripts/helpers
+++ b/scripts/helpers
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function decrypt_deploy_key() {
-    if [[ $TRAVIS_PULL_REQUEST = "false" ]]; then
+    if [[ $TRAVIS_PULL_REQUEST = "false" && $TRAVIS_REPO_SLUG = "http4s/http4s" ]]; then
         echo "Decrypting deploy key"
         eval "$(ssh-agent -s)"
         openssl aes-256-cbc -K $encrypted_8735ae5b3321_key -iv $encrypted_8735ae5b3321_iv -in project/travis-deploy-key.enc -d | ssh-add -
@@ -11,7 +11,7 @@ function decrypt_deploy_key() {
 }
 
 function decrypt_pgp_secrets() {
-    if [[ $TRAVIS_PULL_REQUEST = "false" ]]; then
+    if [[ $TRAVIS_PULL_REQUEST = "false" && $TRAVIS_REPO_SLUG = "http4s/http4s" ]]; then
         echo "Decrypting PGP secrets"
         openssl aes-256-cbc -K $encrypted_8735ae5b3321_key -iv $encrypted_8735ae5b3321_iv -in project/.gnupg/secret.tar.enc -out project/.gnupg/secret.tar -d
         tar xv -C project/.gnupg -f project/.gnupg/secret.tar


### PR DESCRIPTION
Fixes #1446, though I'm now drawing a blank which builds have `$TRAVIS_PULL_REQUEST = false` and _aren't_ on that repo slug.