### PR TITLE
Don't build tags from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: scala
 dist: trusty
+branches:
+  only:
+    - master
+    - /^release-/
 jdk: oraclejdk8
 scala:
 - 2.12.3


### PR DESCRIPTION
When Travis pushes a tag, it's kicking off a build that complains that the tag already exists.  Since pushing non-snapshot versions to the release branches is our release process, we shouldn't build tags.