### PR TITLE
We only need to tag the primary build

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -146,7 +146,7 @@ object Http4sPlugin extends AutoPlugin {
         checkSnapshotDependencies.when(release),
         inquireVersions.when(release),
         setReleaseVersion.when(release),
-        tagRelease.when(release),
+        tagRelease.when(primary && release),
         runTestWithCoverage,
         releaseStepCommand("mimaReportBinaryIssues"),
         releaseStepCommand("docs/makeSite").when(primary),


### PR DESCRIPTION
Tagging all releases, even when we don't push, is why I had to temporarily delete a tag when cleaning out the other mess.  We _do_ need to tag before we build the site to generate the site matrix properly, but that also only runs on the primary build.