### PR TITLE
Upgrade to rig-5.0.39

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.typesafe.sbt"   %  "sbt-twirl"             % "1.3.7")
 addSbtPlugin("io.gatling"         %  "gatling-sbt"           % "2.2.2")
 addSbtPlugin("io.get-coursier"    %  "sbt-coursier"          % "1.0.0-RC11")
 addSbtPlugin("io.spray"           %  "sbt-revolver"          % "0.9.0")
-addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "5.0.38")
+addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "5.0.39")
 addSbtPlugin("pl.project13.scala" %  "sbt-jmh"               % "0.2.27")
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"


### PR DESCRIPTION
This fixes the `None.get` issue we're seeing when publishing snapshots (i.e., publishing without opening a dedicated Sonatype repo).