### PR TITLE
Disable publishSigned in private projects

### DIFF
--- a/project/PrivateProject.scala
+++ b/project/PrivateProject.scala
@@ -1,5 +1,6 @@
 package org.http4s.build
 
+import com.typesafe.sbt.pgp.PgpKeys.{publishLocalSigned, publishSigned}
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 import sbt._
@@ -15,6 +16,8 @@ object PrivateProjectPlugin extends AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_]] =
     DisablePublishingPlugin.projectSettings ++ Seq(
       coverageExcludedPackages := ".*",
-      mimaPreviousArtifacts := Set.empty
+      mimaPreviousArtifacts := Set.empty,
+      publishLocalSigned := {},
+      publishSigned := {}
     )
 }


### PR DESCRIPTION
Our examples projects shouldn't be publishing.  I think it's biting us now because we started [signing our snapshots](https://travis-ci.org/http4s/http4s/jobs/283139624#L4514).

If this fixes it, I'll add the fix in rig and remove it from our private project plugin.