### PR TITLE
Make client DSL more similar to server DSL

### DIFF
--- a/client/src/main/scala/org/http4s/client/Http4sClientDsl.scala
+++ b/client/src/main/scala/org/http4s/client/Http4sClientDsl.scala
@@ -1,0 +1,35 @@
+package org.http4s
+package client
+
+import cats._
+import org.http4s.Method.{NoBody, PermitsBody}
+import org.http4s.client.impl.{EmptyRequestGenerator, EntityRequestGenerator}
+
+trait Http4sClientDsl[F[_]] {
+  import Http4sClientDsl._
+
+  implicit def http4sWithBodySyntax(method: Method with PermitsBody): WithBodyOps[F] =
+    new WithBodyOps[F](method)
+
+  implicit def http4sNoBodyOps(method: Method with NoBody): NoBodyOps[F] =
+    new NoBodyOps[F](method)
+
+  implicit def http4sHeadersDecoder[T](
+    implicit F: Applicative[F],
+    decoder: EntityDecoder[F, T]): EntityDecoder[F, (Headers, T)] = {
+    val s = decoder.consumes.toList
+    EntityDecoder.decodeBy(s.head, s.tail: _*)(resp =>
+      decoder.decode(resp, strict = true).map(t => (resp.headers, t)))
+  }
+}
+
+object Http4sClientDsl {
+
+  /** Syntax classes to generate a request directly from a [[Method]] */
+  implicit class WithBodyOps[F[_]](val method: Method with PermitsBody)
+      extends AnyVal
+      with EntityRequestGenerator[F]
+  implicit class NoBodyOps[F[_]](val method: Method with NoBody)
+      extends AnyVal
+      with EmptyRequestGenerator[F]
+}

--- a/client/src/main/scala/org/http4s/client/Http4sClientDsl.scala
+++ b/client/src/main/scala/org/http4s/client/Http4sClientDsl.scala
@@ -1,5 +1,6 @@
 package org.http4s
 package client
+package dsl
 
 import cats._
 import org.http4s.Method.{NoBody, PermitsBody}
@@ -15,8 +16,8 @@ trait Http4sClientDsl[F[_]] {
     new NoBodyOps[F](method)
 
   implicit def http4sHeadersDecoder[T](
-    implicit F: Applicative[F],
-    decoder: EntityDecoder[F, T]): EntityDecoder[F, (Headers, T)] = {
+      implicit F: Applicative[F],
+      decoder: EntityDecoder[F, T]): EntityDecoder[F, (Headers, T)] = {
     val s = decoder.consumes.toList
     EntityDecoder.decodeBy(s.head, s.tail: _*)(resp =>
       decoder.decode(resp, strict = true).map(t => (resp.headers, t)))

--- a/client/src/main/scala/org/http4s/client/dsl/io.scala
+++ b/client/src/main/scala/org/http4s/client/dsl/io.scala
@@ -1,5 +1,6 @@
 package org.http4s
 package client
+package dsl
 
 import cats.effect.IO
 

--- a/client/src/main/scala/org/http4s/client/io.scala
+++ b/client/src/main/scala/org/http4s/client/io.scala
@@ -1,0 +1,26 @@
+package org.http4s
+package client
+
+import cats.effect.IO
+
+/** Provides extension methods for using a http4s [[org.http4s.client.Client]]
+  * {{{
+  *   import cats.effect.IO
+  *   import org.http4s._
+  *   import org.http4s.client._
+  *   import org.http4s.client.io._
+  *   import org.http4s.Http4s._
+  *   import org.http4s.Status._
+  *   import org.http4s.Method._
+  *   import org.http4s.EntityDecoder
+  *
+  *   def client: Client[IO] = ???
+  *
+  *   val r: IO[String] = client(GET(uri("https://www.foo.bar/"))).as[String]
+  *   val r2: DecodeResult[String] = client(GET(uri("https://www.foo.bar/"))).attemptAs[String] // implicitly resolve the decoder
+  *   val req1 = r.unsafeRunSync
+  *   val req2 = r.unsafeRunSync // Each invocation fetches a new Result based on the behavior of the Client
+  *
+  * }}}
+  */
+object io extends Http4sClientDsl[IO]

--- a/client/src/main/scala/org/http4s/client/package.scala
+++ b/client/src/main/scala/org/http4s/client/package.scala
@@ -1,30 +1,6 @@
 package org.http4s
 
-import cats._
-import cats.effect.IO
-import org.http4s.Method.{NoBody, PermitsBody}
-import org.http4s.client.impl.{EmptyRequestGenerator, EntityRequestGenerator}
-
-/** Provides extension methods for using a http4s [[org.http4s.client.Client]]
-  * {{{
-  *   import cats.effect.IO
-  *   import org.http4s._
-  *   import org.http4s.client._
-  *   import org.http4s.Http4s._
-  *   import org.http4s.Status._
-  *   import org.http4s.Method._
-  *   import org.http4s.EntityDecoder
-  *
-  *   def client: Client[IO] = ???
-  *
-  *   val r: IO[String] = client(GET(uri("https://www.foo.bar/"))).as[String]
-  *   val r2: DecodeResult[String] = client(GET(uri("https://www.foo.bar/"))).attemptAs[String] // implicitly resolve the decoder
-  *   val req1 = r.unsafeRunSync
-  *   val req2 = r.unsafeRunSync // Each invocation fetches a new Result based on the behavior of the Client
-  *
-  * }}}
-  */
-package object client extends Http4sClientDsl[IO] with ClientTypes
+package object client extends ClientTypes
 
 trait ClientTypes {
   import org.http4s.client._
@@ -32,33 +8,4 @@ trait ClientTypes {
   type ConnectionBuilder[F[_], A <: Connection[F]] = RequestKey => F[A]
 
   type Middleware[F[_]] = Client[F] => Client[F]
-}
-
-trait Http4sClientDsl[F[_]] {
-  import Http4sClientDsl._
-
-  implicit def http4sWithBodySyntax(method: Method with PermitsBody): WithBodyOps[F] =
-    new WithBodyOps[F](method)
-
-  implicit def http4sNoBodyOps(method: Method with NoBody): NoBodyOps[F] =
-    new NoBodyOps[F](method)
-
-  implicit def http4sHeadersDecoder[T](
-      implicit F: Applicative[F],
-      decoder: EntityDecoder[F, T]): EntityDecoder[F, (Headers, T)] = {
-    val s = decoder.consumes.toList
-    EntityDecoder.decodeBy(s.head, s.tail: _*)(resp =>
-      decoder.decode(resp, strict = true).map(t => (resp.headers, t)))
-  }
-}
-
-object Http4sClientDsl {
-
-  /** Syntax classes to generate a request directly from a [[Method]] */
-  implicit class WithBodyOps[F[_]](val method: Method with PermitsBody)
-      extends AnyVal
-      with EntityRequestGenerator[F]
-  implicit class NoBodyOps[F[_]](val method: Method with NoBody)
-      extends AnyVal
-      with EmptyRequestGenerator[F]
 }

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -1,21 +1,18 @@
 package org.http4s
 package client
 
-import java.net.InetSocketAddress
-
 import cats.effect._
 import cats.implicits._
 import fs2._
+import java.net.InetSocketAddress
 import javax.servlet.ServletOutputStream
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
-
 import org.http4s.client.testroutes.GetRoutes
 import org.http4s.dsl.io._
 import org.specs2.specification.core.Fragments
-
 import scala.concurrent.duration._
 
-abstract class ClientRouteTestBattery(name: String, client: Client[IO]) extends Http4sSpec {
+abstract class ClientRouteTestBattery(name: String, client: Client[IO]) extends Http4sSpec with Http4sClientDsl[IO] {
   val timeout = 20.seconds
   val jettyServ = new JettyScaffold(1)
   var address: InetSocketAddress = null

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -8,11 +8,14 @@ import java.net.InetSocketAddress
 import javax.servlet.ServletOutputStream
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import org.http4s.client.testroutes.GetRoutes
+import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.dsl.io._
 import org.specs2.specification.core.Fragments
 import scala.concurrent.duration._
 
-abstract class ClientRouteTestBattery(name: String, client: Client[IO]) extends Http4sSpec with Http4sClientDsl[IO] {
+abstract class ClientRouteTestBattery(name: String, client: Client[IO])
+    extends Http4sSpec
+    with Http4sClientDsl[IO] {
   val timeout = 20.seconds
   val jettyServ = new JettyScaffold(1)
   var address: InetSocketAddress = null

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -9,7 +9,7 @@ import org.http4s.Status.{BadRequest, Created, InternalServerError, Ok}
 import org.http4s.headers.Accept
 import org.specs2.matcher.MustThrownMatchers
 
-class ClientSyntaxSpec extends Http4sSpec with MustThrownMatchers {
+class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with  MustThrownMatchers {
 
   val route = HttpService[IO] {
     case r if r.method == GET && r.pathInfo == "/" =>

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -6,10 +6,11 @@ import fs2._
 import fs2.Stream._
 import org.http4s.Method._
 import org.http4s.Status.{BadRequest, Created, InternalServerError, Ok}
+import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers.Accept
 import org.specs2.matcher.MustThrownMatchers
 
-class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with  MustThrownMatchers {
+class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThrownMatchers {
 
   val route = HttpService[IO] {
     case r if r.method == GET && r.pathInfo == "/" =>

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -6,6 +6,7 @@ import cats.effect._
 import cats.implicits._
 import fs2._
 import java.util.concurrent.atomic._
+import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.specs2.mutable.Tables

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -10,7 +10,7 @@ import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.specs2.mutable.Tables
 
-class FollowRedirectSpec extends Http4sSpec with Tables {
+class FollowRedirectSpec extends Http4sSpec with Http4sClientDsl[IO] with Tables {
 
   private val loopCounter = new AtomicInteger(0)
 

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -339,7 +339,7 @@ in which `IntVar` does it.
 ```tut:book
 import java.time.LocalDate
 import scala.util.Try
-import org.http4s.client._
+import org.http4s.client.dsl.io._
 
 object LocalDateVar {
   def unapply(str: String): Option[LocalDate] = {

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -98,6 +98,7 @@ useful on client requests:
 
 ```tut:book
 import org.http4s.client._
+import org.http4s.client.dsl.io._
 
 POST(uri("/hello"), json"""{"name": "Alice"}""").unsafeRunSync
 ```

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
@@ -3,13 +3,13 @@ package com.example.http4s.blaze
 import cats.effect.IO
 import org.http4s._
 import org.http4s.Uri._
-import org.http4s.client._
+import org.http4s.client.Http4sClientDsl
 import org.http4s.client.blaze.{defaultClient => client}
-import org.http4s.dsl.io._
 import org.http4s.headers._
+import org.http4s.implicits._
 import org.http4s.multipart._
 
-object ClientMultipartPostExample {
+object ClientMultipartPostExample extends Http4sClientDsl[IO] {
 
   val bottle = getClass().getResource("/beerbottle.png")
 

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
@@ -3,8 +3,8 @@ package com.example.http4s.blaze
 import cats.effect.IO
 import org.http4s._
 import org.http4s.Uri._
-import org.http4s.client.Http4sClientDsl
 import org.http4s.client.blaze.{defaultClient => client}
+import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers._
 import org.http4s.implicits._
 import org.http4s.multipart._

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
@@ -3,10 +3,11 @@ package com.example.http4s.blaze
 import cats.effect._
 import org.http4s._
 import org.http4s.client._
+import org.http4s.client.Http4sClientDsl
 import org.http4s.client.blaze.{defaultClient => client}
 import org.http4s.dsl.io._
 
-object ClientPostExample extends App {
+object ClientPostExample extends App with Http4sClientDsl[IO] {
   val req = POST(uri("https://duckduckgo.com/"), UrlForm("q" -> "http4s"))
   val responseBody = client[IO].expect[String](req)
   println(responseBody.unsafeRunSync())

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
@@ -2,9 +2,8 @@ package com.example.http4s.blaze
 
 import cats.effect._
 import org.http4s._
-import org.http4s.client._
-import org.http4s.client.Http4sClientDsl
 import org.http4s.client.blaze.{defaultClient => client}
+import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.dsl.io._
 
 object ClientPostExample extends App with Http4sClientDsl[IO] {


### PR DESCRIPTION
* `Http4sClientDsl[F]` is like `Http4sClientDsl[F]`
* Create `io` object that extends `Http4sClientDsl[IO]`, like http4s-dsl has
* Don't extend `Http4sClientDsl[IO]` from client package, like http4s-dsl doesn't.

This is still not quite harmonious: http4s-dsl imports the status codes, whereas client doesn't.
