### PR TITLE
Change StreamApp to take Stream[F, ExitCode]

### DIFF
--- a/core/src/main/scala/org/http4s/util/StreamApp.scala
+++ b/core/src/main/scala/org/http4s/util/StreamApp.scala
@@ -84,8 +84,8 @@ object StreamApp {
   sealed abstract case class ExitCode(code: Int)
 
   object ExitCode {
-    def fromInt(code: Int): ExitCode = new ExitCode(code) {}
-    val success: ExitCode = fromInt(0)
-    val error: ExitCode = fromInt(-1)
+    def apply(code: Int): ExitCode = new ExitCode(code) {}
+    val success: ExitCode = apply(0)
+    val error: ExitCode = apply(1)
   }
 }

--- a/core/src/main/scala/org/http4s/util/StreamApp.scala
+++ b/core/src/main/scala/org/http4s/util/StreamApp.scala
@@ -77,15 +77,15 @@ abstract class StreamApp[F[_]](implicit F: Effect[F]) {
   }
 
   def main(args: Array[String]): Unit =
-    sys.exit(doMain(args.toList).unsafeRunSync.code)
+    sys.exit(doMain(args.toList).unsafeRunSync.code.toInt)
 }
 
 object StreamApp {
-  sealed abstract case class ExitCode(code: Int)
+  final case class ExitCode(code: Byte)
 
   object ExitCode {
-    def apply(code: Int): ExitCode = new ExitCode(code) {}
-    val success: ExitCode = apply(0)
-    val error: ExitCode = apply(1)
+    def fromInt(code: Int): ExitCode = ExitCode(code.toByte)
+    val success: ExitCode = ExitCode(0)
+    val error: ExitCode = ExitCode(1)
   }
 }

--- a/core/src/main/scala/org/http4s/util/StreamApp.scala
+++ b/core/src/main/scala/org/http4s/util/StreamApp.scala
@@ -4,14 +4,17 @@ import cats.effect._
 import cats.effect.implicits._
 import cats.implicits._
 import fs2._
+import fs2.async.Ref
 import fs2.async.mutable.Signal
+import org.http4s.util.StreamApp.ExitCode
 import org.log4s.getLogger
 import scala.concurrent.ExecutionContext
 
 abstract class StreamApp[F[_]](implicit F: Effect[F]) {
   private[this] val logger = getLogger
 
-  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, Nothing]
+  /** An application stream that should never emit or emit a single ExitCode */
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, ExitCode]
 
   /** Adds a shutdown hook that interrupts the stream and waits for it to finish */
   private def addShutdownHook(
@@ -19,41 +22,70 @@ abstract class StreamApp[F[_]](implicit F: Effect[F]) {
       halted: Signal[IO, Boolean]): F[Unit] =
     F.delay {
       sys.addShutdownHook {
-        val hook = requestShutdown.set(true).runAsync(_ => IO.unit) >> halted.discrete
-          .takeWhile(_ == false)
-          .run
+        val hook = requestShutdown.set(true).runAsync(_ => IO.unit) >>
+          halted.discrete
+            .takeWhile(_ == false)
+            .run
         hook.unsafeRunSync()
       }
       ()
     }
 
   /** Exposed for testing, so we can check exit values before the dramatic sys.exit */
-  private[util] def doMain(args: List[String]): IO[Int] = {
+  private[util] def doMain(args: List[String]): IO[ExitCode] = {
     implicit val ec: ExecutionContext = execution.direct
-    async.ref[IO, Int].flatMap { exitCode =>
-      async.signalOf[IO, Boolean](false).flatMap { halted =>
-        async
-          .signalOf[F, Boolean](false)
-          .flatMap { requestShutdown =>
-            addShutdownHook(requestShutdown, halted) >>
-              stream(args, requestShutdown.set(true))
-                .interruptWhen(requestShutdown)
-                .run
-          }
-          .runAsync {
-            case Left(t) =>
-              IO(logger.error(t)("Error running stream")) >>
-                halted.set(true) >>
-                exitCode.setSyncPure(-1)
-            case Right(_) =>
-              halted.set(true) >>
-                exitCode.setSyncPure(0)
-          } >>
-          exitCode.get
-      }
-    }
+    for {
+      exitCodeRef <- async.ref[IO, ExitCode]
+      halted <- async.signalOf[IO, Boolean](false)
+      exitCode <- runStream(args, exitCodeRef, halted)
+    } yield exitCode
+  }
+
+  /**
+    * Runs the application stream to an ExitCode.
+    *
+    * @param args The command line arguments
+    * @param exitCodeRef A ref that will be set to the exit code from the stream
+    * @param halted A signal that is set when the application stream is done
+    * @param ec Implicit EC to run the application stream
+    * @return An IO that will produce an ExitCode
+    */
+  private[util] def runStream(
+      args: List[String],
+      exitCodeRef: Ref[IO, ExitCode],
+      halted: Signal[IO, Boolean]
+  )(implicit ec: ExecutionContext): IO[ExitCode] = {
+    val runStreamLast: F[Option[ExitCode]] =
+      for {
+        requestShutdown <- async.signalOf[F, Boolean](false)
+        _ <- addShutdownHook(requestShutdown, halted)
+        exitCode <- stream(args, requestShutdown.set(true))
+          .interruptWhen(requestShutdown)
+          .take(1)
+          .runLast
+      } yield exitCode
+    runStreamLast.runAsync {
+      case Left(t) =>
+        IO(logger.error(t)("Error running stream")) >>
+          halted.set(true) >>
+          exitCodeRef.setSyncPure(ExitCode.error)
+      case Right(exitCode) =>
+        halted.set(true) >>
+          exitCodeRef.setSyncPure(exitCode.getOrElse(ExitCode.success))
+    } >>
+      exitCodeRef.get
   }
 
   def main(args: Array[String]): Unit =
-    sys.exit(doMain(args.toList).unsafeRunSync)
+    sys.exit(doMain(args.toList).unsafeRunSync.code)
+}
+
+object StreamApp {
+  sealed abstract case class ExitCode(code: Int)
+
+  object ExitCode {
+    def fromInt(code: Int): ExitCode = new ExitCode(code) {}
+    val success: ExitCode = fromInt(0)
+    val error: ExitCode = fromInt(-1)
+  }
 }

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -160,9 +160,10 @@ process and gracefully shut down your server when a SIGTERM is received.
 import fs2.Stream
 import org.http4s.server.blaze._
 import org.http4s.util.StreamApp
+import org.http4s.util.StreamApp.ExitCode
 
 object Main extends StreamApp[IO] {
-  override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, Nothing] =
+  override def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] =
     BlazeBuilder[IO]
       .bindHttp(8080, "localhost")
       .mountService(helloWorldService, "/")

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -5,12 +5,13 @@ import com.example.http4s.ExampleService
 import fs2.Scheduler
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.util.StreamApp
+import org.http4s.util.StreamApp.ExitCode
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object BlazeExample extends BlazeExampleApp[IO]
 
 class BlazeExampleApp[F[_]: Effect] extends StreamApp[F] {
-  def stream(args: List[String], requestShutdown: F[Unit]) =
+  def stream(args: List[String], requestShutdown: F[Unit]): fs2.Stream[F, ExitCode] =
     Scheduler(corePoolSize = 2).flatMap { implicit scheduler =>
       BlazeBuilder[F]
         .bindHttp(8080)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -8,6 +8,7 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.server.websocket._
 import org.http4s.util.StreamApp
+import org.http4s.util.StreamApp.ExitCode
 import org.http4s.websocket.WebsocketBits._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -45,13 +46,14 @@ class BlazeWebSocketExampleApp[F[_]](implicit F: Effect[F]) extends StreamApp[F]
       }
   }
 
-  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, Nothing] =
-    Scheduler[F](corePoolSize = 2).flatMap { scheduler =>
-      BlazeBuilder[F]
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, ExitCode] =
+    for {
+      scheduler <- Scheduler[F](corePoolSize = 2)
+      exitCode <- BlazeBuilder[F]
         .bindHttp(8080)
         .withWebSockets(true)
         .mountService(route(scheduler), "/http4s")
         .serve
-    }
+    } yield exitCode
 
 }

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
@@ -9,6 +9,7 @@ import org.http4s.server.HttpMiddleware
 import org.http4s.server.jetty.JettyBuilder
 import org.http4s.server.metrics._
 import org.http4s.util.StreamApp
+import org.http4s.util.StreamApp.ExitCode
 
 object JettyExample extends JettyExampleApp[IO]
 
@@ -16,7 +17,7 @@ class JettyExampleApp[F[_]: Effect] extends StreamApp[F] with Http4sDsl[F] {
   val metricsRegistry: MetricRegistry = new MetricRegistry
   val metrics: HttpMiddleware[F] = Metrics[F](metricsRegistry)
 
-  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, Nothing] =
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, ExitCode] =
     Scheduler(corePoolSize = 2).flatMap { implicit scheduler =>
       JettyBuilder[F]
         .bindHttp(8080)

--- a/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
+++ b/examples/src/main/scala/com/example/http4s/ssl/SslExample.scala
@@ -8,6 +8,7 @@ import org.http4s.server.{SSLKeyStoreSupport, ServerBuilder}
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import org.http4s.server.middleware.HSTS
 import org.http4s.util.StreamApp
+import org.http4s.util.StreamApp.ExitCode
 
 abstract class SslExample[F[_]: Effect] extends StreamApp[F] {
   // TODO: Reference server.jks from something other than one child down.
@@ -15,7 +16,7 @@ abstract class SslExample[F[_]: Effect] extends StreamApp[F] {
 
   def builder: ServerBuilder[F] with SSLKeyStoreSupport[F]
 
-  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, Nothing] =
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, ExitCode] =
     Scheduler(corePoolSize = 2).flatMap { implicit scheduler =>
       builder
         .withSSL(StoreInfo(keypath, "password"), keyManagerPassword = "secure")

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
@@ -15,7 +15,7 @@ class TomcatExampleApp[F[_]: Effect] extends StreamApp[F] {
   val metricsRegistry: MetricRegistry = new MetricRegistry
   val metrics: HttpMiddleware[F] = Metrics[F](metricsRegistry)
 
-  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, Nothing] =
+  def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, StreamApp.ExitCode] =
     Scheduler(corePoolSize = 2).flatMap { implicit scheduler =>
       TomcatBuilder[F]
         .bindHttp(8080)

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -7,6 +7,7 @@ import java.net.{InetAddress, InetSocketAddress}
 import java.util.concurrent.ExecutorService
 import javax.net.ssl.SSLContext
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
+import org.http4s.util.StreamApp.ExitCode
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -51,7 +52,7 @@ trait ServerBuilder[F[_]] {
     * Runs the server as a process that never emits.  Useful for a server
     * that runs for the rest of the JVM's life.
     */
-  final def serve(implicit F: Async[F]): Stream[F, Nothing] =
+  final def serve(implicit F: Async[F]): Stream[F, ExitCode] =
     Stream.bracket(start)((_: Server[F]) => Stream.eval_(F.async[Unit](_ => ())), _.shutdown)
 }
 


### PR DESCRIPTION
This is an extension on #1444 and @hejfelix s ideas.

It introduces an `ExitCode` type that wraps an int, with values for success (0) and a generic error (-1).

Naming and location of the type can certainly be discussed.

This works around the dead code warning/error when using the `.serve` stream in a for-comprehension, allowing code like the following to compile with strict scalac flags:

```scala
import cats.effect._
import fs2._
import org.http4s.server.blaze.BlazeBuilder
import org.http4s.util.StreamApp
import org.http4s.util.StreamApp.ExitCode

object TestApp extends Test[IO]

class Test[F[_]: Effect] extends StreamApp[F] {

  case class SomeClient(success: Boolean)

  val mkClient: Stream[F, SomeClient] = Stream.emit(SomeClient(true))

  def mkServer(client: SomeClient): Stream[F, ExitCode] = {
    // do something with client
    val _ = client
    BlazeBuilder[F].bindAny().serve
  }

  override def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, ExitCode] =
    for {
      client <- mkClient
      exitCode <- mkServer(client)
    } yield exitCode
}
```