### PR TITLE
Change AuthMiddleware default apply to use OptionT

### DIFF
--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -24,7 +24,7 @@ import org.http4s.server._
 
 case class User(id: Long, name: String)
 
-val authUser: Service[IO, Request[IO], User] = Kleisli(_ => IO(???))
+val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] = Kleisli(_ => OptionT.liftF(IO(???)))
 val middleware: AuthMiddleware[IO, User] = AuthMiddleware(authUser)
 val authedService: AuthedService[IO, User] =
   AuthedService {

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -49,7 +49,8 @@ package object server {
   type SSLBits = SSLConfig
 
   object AuthMiddleware {
-    def apply[F[_]: Monad, T](authUser: Kleisli[OptionT[F, ?], Request[F], T]): AuthMiddleware[F, T] =
+    def apply[F[_]: Monad, T](
+        authUser: Kleisli[OptionT[F, ?], Request[F], T]): AuthMiddleware[F, T] =
       service => {
         service.compose(Kleisli((req: Request[F]) => authUser(req).map(AuthedRequest(_, req))))
       }

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -49,14 +49,14 @@ package object server {
   type SSLBits = SSLConfig
 
   object AuthMiddleware {
-    def apply[F[_]: Monad, T](authUser: Kleisli[F, Request[F], T]): AuthMiddleware[F, T] =
+    def apply[F[_]: Monad, T](authUser: Kleisli[OptionT[F, ?], Request[F], T]): AuthMiddleware[F, T] =
       service => {
-        service.compose(AuthedRequest(authUser.run).mapF(OptionT.liftF(_)))
+        service.compose(Kleisli((req: Request[F]) => authUser(req).map(AuthedRequest(_, req))))
       }
 
     def apply[F[_], Err, T](
         authUser: Kleisli[F, Request[F], Either[Err, T]],
-        onFailure: Kleisli[OptionT[F, ?], AuthedRequest[F, Err], Response[F]]
+        onFailure: AuthedService[F, Err]
     )(implicit F: Monad[F], C: Choice[Kleisli[OptionT[F, ?], ?, ?]]): AuthMiddleware[F, T] = {
       service: AuthedService[F, T] =>
         C.choice(onFailure, service)


### PR DESCRIPTION
This is a small QOL change. In particular, extracting a `T` from a `Request[F]` probably has more explicit errors like the `apply` signature, but the default case where an `Option` is enough to signify no such T was extracted (where you can just discard the error), is common enough for stuff like extracting a token from a header or decoding a body.

edit: A few commas to make it readable.