### PR TITLE
Sanitize more than two dots as well

### DIFF
--- a/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -80,7 +80,7 @@ object FileService {
 
   // Attempts to sanitize the file location and retrieve the file. Returns None if the file doesn't exist.
   private def getFile(unsafePath: String): Option[File] = {
-    val f = new File(sanitize(unsafePath))
+    val f = new File(PathNormalizer.removeDotSegments(unsafePath))
     if (f.exists()) Some(f)
     else None
   }

--- a/server/src/main/scala/org/http4s/server/staticcontent/PathNormalizer.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/PathNormalizer.scala
@@ -1,0 +1,91 @@
+package org.http4s.server.staticcontent
+
+import java.lang.StringBuilder
+
+// Adapted from https://github.com/Norconex/commons-lang/blob/c83fdeac7a60ac99c8602e0b47056ad77b08f570/norconex-commons-lang/src/main/java/com/norconex/commons/lang/url/URLNormalizer.java#L429
+object PathNormalizer {
+
+  private def startsWith(b: StringBuilder, str: String): Boolean =
+    b.indexOf(str) == 0
+  private def equalStrings(b: StringBuilder, str: String): Boolean =
+    b.length == str.length && startsWith(b, str)
+  private def deleteStart(b: StringBuilder, str: String): StringBuilder =
+    b.delete(0, str.length)
+  private def replaceStart(b: StringBuilder, target: String, replacement: String): StringBuilder = {
+    deleteStart(b, target)
+    b.insert(0, replacement)
+  }
+  private def removeLastSegment(b: StringBuilder): Unit =
+    b.lastIndexOf("/") match {
+      case -1 => b.setLength(0)
+      case n  => b.setLength(n)
+    }
+
+  def removeDotSegments(path: String): String = {
+    // (Bulleted comments are from RFC3986, section-5.2.4)
+
+    // 1.  The input buffer is initialized with the now-appended path
+    //     components and the output buffer is initialized to the empty
+    //     string.
+    val in  = new StringBuilder(path)
+    val out = new StringBuilder
+
+    // 2.  While the input buffer is not empty, loop as follows:
+    while (in.length > 0) {
+
+      // A.  If the input buffer begins with a prefix of "../" or "./",
+      //     then remove that prefix from the input buffer; otherwise,
+      if (startsWith(in, "../"))
+        deleteStart(in, "../")
+      else if (startsWith(in, "./"))
+        deleteStart(in, "./")
+
+      // B.  if the input buffer begins with a prefix of "/./" or "/.",
+      //     where "." is a complete path segment, then replace that
+      //     prefix with "/" in the input buffer; otherwise,
+      else if (startsWith(in, "/./"))
+        replaceStart(in, "/./", "/")
+      else if (equalStrings(in, "/."))
+        replaceStart(in, "/.", "/")
+
+      // C.  if the input buffer begins with a prefix of "/../" or "/..",
+      //     where ".." is a complete path segment, then replace that
+      //     prefix with "/" in the input buffer and remove the last
+      //     segment and its preceding "/" (if any) from the output
+      //     buffer; otherwise,
+      else if (startsWith(in, "/../")) {
+        replaceStart(in, "/../", "/")
+        removeLastSegment(out)
+      } else if (equalStrings(in, "/..")) {
+        replaceStart(in, "/..", "/")
+        removeLastSegment(out)
+      }
+
+      // D.  if the input buffer consists only of "." or "..", then remove
+      //      that from the input buffer; otherwise,
+      else if (equalStrings(in, ".."))
+        deleteStart(in, "..")
+      else if (equalStrings(in, "."))
+        deleteStart(in, ".")
+
+      // E.  move the first path segment in the input buffer to the end of
+      //     the output buffer, including the initial "/" character (if
+      //     any) and any subsequent characters up to, but not including,
+      //     the next "/" character or the end of the input buffer.
+      else
+        in.indexOf("/", 1) match {
+          case nextSlashIndex if nextSlashIndex > -1 =>
+            out.append(in.substring(0, nextSlashIndex))
+            in.delete(0, nextSlashIndex)
+          case _ =>
+            out.append(in)
+            in.setLength(0)
+        }
+    }
+
+    // 3.  Finally, the output buffer is returned as the result of
+    //     remove_dot_segments.
+    out.toString
+  }
+
+}

--- a/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
@@ -33,7 +33,7 @@ object ResourceService {
     if (!uriPath.startsWith(config.pathPrefix))
       Pass.now
     else
-      StaticFile.fromResource(sanitize(config.basePath + '/' + getSubPath(uriPath, config.pathPrefix)), Some(req))
+      StaticFile.fromResource(PathNormalizer.removeDotSegments(config.basePath + '/' + getSubPath(uriPath, config.pathPrefix)), Some(req))
         .fold(Pass.now)(config.cacheStrategy.cache(uriPath, _))
   }
 }

--- a/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -53,7 +53,7 @@ object WebjarService {
     // Intercepts the routes that match webjar asset names
     case request if request.method == Method.GET =>
       Option(request.pathInfo)
-          .map(sanitize)
+          .map(PathNormalizer.removeDotSegments)
           .flatMap(toWebjarAsset)
           .filter(config.filter)
           .map(serveWebjarAsset(config, request))

--- a/server/src/main/scala/org/http4s/server/staticcontent/package.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/package.scala
@@ -20,8 +20,6 @@ package object staticcontent {
   /** Make a new [[org.http4s.HttpService]] that serves static files from webjars */
   def webjarService(config: WebjarService.Config): HttpService = WebjarService(config)
 
-  private[staticcontent] val sanitize = "\\.\\.".r.replaceAllIn(_: String, ".")
-
   private[staticcontent] val AcceptRangeHeader = `Accept-Ranges`(RangeUnit.Bytes)
 
   // Will strip the pathPrefix from the first part of the Uri, returning the remainder without a leading '/'

--- a/server/src/test/scala/org/http4s/server/staticcontent/PathNormalizerSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/PathNormalizerSpec.scala
@@ -1,0 +1,18 @@
+package org.http4s.server.staticcontent
+
+import org.specs2.mutable.Specification
+
+class PathNormalizerSpec extends Specification {
+
+  "PathNormalizer.removeDotSegments" should {
+    "remove dot segments correctly" in {
+      val path1 = "/a/b/c/./../../g"
+
+      PathNormalizer.removeDotSegments(path1) must_=== "/a/g"
+
+      val path2 = "mid/content=5/../6"
+      PathNormalizer.removeDotSegments(path2) must_=== "mid/6"
+    }
+  }
+
+}


### PR DESCRIPTION
`org.http4s.server.staticcontent.sanitize` is supposed to protect against getting arbitrary files in static services by replacing `..` with `.`

However, if you pass it `...` it will replace it with `..`

This PR replaces an arbitrary number of periods with a single.