### PR TITLE
Scheme type

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/SchemeBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/SchemeBench.scala
@@ -1,0 +1,22 @@
+package org.http4s
+package bench
+
+import org.openjdk.jmh.annotations._
+
+@Fork(2)
+@Threads(1)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+class SchemeBench {
+  @Benchmark
+  def parseHttp =
+    Scheme.parse("http")
+
+  @Benchmark
+  def parseHttps =
+    Scheme.parse("https")
+
+  @Benchmark
+  def parseMailto =
+    Scheme.parse("mailto")
+}

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val testing = libraryProject("testing")
   .settings(
     description := "Instances and laws for testing http4s code",
     libraryDependencies ++= Seq(
+      catsLaws,
       scalacheck,
       specs2Core
     ),

--- a/client/src/main/scala/org/http4s/client/RequestKey.scala
+++ b/client/src/main/scala/org/http4s/client/RequestKey.scala
@@ -1,8 +1,8 @@
 package org.http4s
 package client
 
-import org.http4s.Uri.{Authority, Scheme}
-import org.http4s.syntax.string._
+import org.http4s.Scheme
+import org.http4s.Uri.Authority
 
 /** Represents a key for requests that can conceivably share a [[Connection]]. */
 final case class RequestKey(scheme: Scheme, authority: Authority)
@@ -10,6 +10,6 @@ final case class RequestKey(scheme: Scheme, authority: Authority)
 object RequestKey {
   def fromRequest[F[_]](request: Request[F]): RequestKey = {
     val uri = request.uri
-    RequestKey(uri.scheme.getOrElse("http".ci), uri.authority.getOrElse(Authority()))
+    RequestKey(uri.scheme.getOrElse(Scheme.http), uri.authority.getOrElse(Authority()))
   }
 }

--- a/core/src/main/scala/org/http4s/HttpCodec.scala
+++ b/core/src/main/scala/org/http4s/HttpCodec.scala
@@ -1,0 +1,17 @@
+package org.http4s
+
+import org.http4s.util.Renderer
+
+trait HttpCodec[A] extends Renderer[A] {
+  def parse(s: String): ParseResult[A]
+
+  /** Warning: partial method. Intended for tests and macros that have
+    * assured that `s` can be parsed to a valid `A`.
+    */
+  final def parseOrThrow(s: String): A =
+    parse(s).valueOr(throw _)
+}
+
+object HttpCodec {
+  def apply[A](implicit A: HttpCodec[A]): HttpCodec[A] = A
+}

--- a/core/src/main/scala/org/http4s/Scheme.scala
+++ b/core/src/main/scala/org/http4s/Scheme.scala
@@ -1,0 +1,64 @@
+package org.http4s
+
+import cats.{Order, Show}
+import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit}
+import org.http4s.internal.parboiled2.{Parser => PbParser}
+import org.http4s.parser.Http4sParser
+import org.http4s.util.{Writer, hashLower}
+
+/** Each [[org.http4s.Uri]] begins with a scheme name that refers to a
+  * specification for assigning identifiers within that scheme.
+  *
+  * @see https://www.ietf.org/rfc/rfc3986.txt, Section 3.1
+  */
+final class Scheme private (val value: String) extends Comparable[Scheme] {
+  override def equals(o: Any) = o match {
+    case that: Scheme => this.value.equalsIgnoreCase(that.value)
+    case _ => false
+  }
+
+  private[this] var hash = 0
+  override def hashCode(): Int = {
+    if (hash == 0) {
+      hash = hashLower(value)
+    }
+    hash
+  }
+
+  override def toString = s"Scheme($value)"
+
+  override def compareTo(other: Scheme): Int =
+    value.compareToIgnoreCase(other.value)
+}
+
+object Scheme {
+  val http: Scheme = new Scheme("http")
+  val https: Scheme = new Scheme("https")
+
+  def parse(s: String): ParseResult[Scheme] =
+    new Http4sParser[Scheme](s, "Invalid scheme") with Parser {
+      def main = scheme
+    }.parse
+
+  private[http4s] trait Parser { self: PbParser =>
+    def scheme = rule {
+      "https" ~ push(https) |
+        "http" ~ push(http) |
+        capture(Alpha ~ zeroOrMore(Alpha | Digit | "+" | "-" | ".")) ~> (new Scheme(_))
+    }
+  }
+
+  implicit val http4sInstancesForScheme: Show[Scheme] with HttpCodec[Scheme] with Order[Scheme] =
+    new Show[Scheme] with HttpCodec[Scheme] with Order[Scheme] {
+      def show(s: Scheme): String = s.toString
+
+      def parse(s: String): ParseResult[Scheme] =
+        Scheme.parse(s)
+
+      def render(writer: Writer, scheme: Scheme): writer.type =
+        writer << scheme.value
+
+      def compare(x: Scheme, y: Scheme) =
+        x.compareTo(y)
+    }
+}

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -7,7 +7,7 @@ import org.http4s.Uri._
 import org.http4s.internal.parboiled2.Parser
 import org.http4s.parser._
 import org.http4s.syntax.string._
-import org.http4s.util.{CaseInsensitiveString, Renderable, UrlCodingUtils, Writer}
+import org.http4s.util._
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox.Context
 
@@ -20,7 +20,7 @@ import scala.reflect.macros.whitebox.Context
   */
 // TODO fix Location header, add unit tests
 final case class Uri(
-    scheme: Option[CaseInsensitiveString] = None,
+    scheme: Option[Scheme] = None,
     authority: Option[Authority] = None,
     path: Path = "",
     query: Query = Query.empty,
@@ -157,8 +157,6 @@ object Uri extends UriFunctions {
     new RequestUriParser(s, StandardCharsets.UTF_8).RequestUri
       .run()(Parser.DeliveryScheme.Either)
       .leftMap(e => ParseFailure("Invalid request target", e.format(s)))
-
-  type Scheme = CaseInsensitiveString
 
   type UserInfo = String
 

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -3,6 +3,7 @@ package org.http4s
 import java.net.URLEncoder
 import org.http4s.Uri.{apply => _, unapply => _, Fragment => _, Path => _, _}
 import org.http4s.UriTemplate._
+import org.http4s.util.StringWriter
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Success, Try}
@@ -220,7 +221,8 @@ object UriTemplate {
     case _ => ""
   }
 
-  protected def renderScheme(s: Scheme): String = s + ":"
+  protected def renderScheme(s: Scheme): String =
+    (new StringWriter << s << ":").result
 
   protected def renderSchemeAndAuthority(t: UriTemplate): String = t match {
     case UriTemplate(None, None, _, _, _) => ""

--- a/core/src/main/scala/org/http4s/internal/Macros.scala
+++ b/core/src/main/scala/org/http4s/internal/Macros.scala
@@ -1,0 +1,21 @@
+package org.http4s
+package internal
+
+import scala.reflect.macros.whitebox.Context
+
+private[http4s] object Macros {
+  private def literalString(c: Context): String = {
+    import c.universe._
+    val Apply(_, List(Apply(_, List(Literal(Constant(s: String)))))) = c.prefix.tree
+    s
+  }
+
+  def scheme(c: Context)(): c.Expr[Scheme] = {
+    import c.universe._
+    val s = literalString(c)
+    Scheme.parse(s) match {
+      case Right(_) => c.Expr(q"""org.http4s.HttpCodec[org.http4s.Scheme].parseOrThrow($s)""")
+      case Left(e) => throw e
+    }
+  }
+}

--- a/core/src/main/scala/org/http4s/parser/Http4sParser.scala
+++ b/core/src/main/scala/org/http4s/parser/Http4sParser.scala
@@ -1,0 +1,15 @@
+package org.http4s
+package parser
+
+import cats.implicits._
+import org.http4s.internal.parboiled2._
+
+/** Helper class that produces a `ParseResult` from the `main` target. */
+private[http4s] abstract class Http4sParser[A](s: String, failureSummary: String) extends Parser {
+  def input = s
+  def main: Rule1[A]
+  private[this] def target = rule { main ~ EOI }
+  def parse =
+    __run(target)(Parser.DeliveryScheme.Either)
+      .leftMap(e => ParseFailure(failureSummary, e.format(s)))
+}

--- a/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
@@ -8,3 +8,4 @@ trait AllSyntax
     with EffectRequestSyntax
     with KleisliSyntax
     with StringSyntax
+    with LiteralsSyntax

--- a/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
@@ -1,0 +1,12 @@
+package org.http4s
+package syntax
+
+import org.http4s.internal.Macros
+
+trait LiteralsSyntax {
+  implicit def http4sLiteralsSyntax(sc: StringContext) = new LiteralsOps(sc)
+}
+
+class LiteralsOps(val sc: StringContext) extends AnyVal {
+  def scheme(): Scheme = macro Macros.scheme
+}

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -8,5 +8,6 @@ package object syntax {
   @deprecated("Use map or flatMap on the request instead", "0.18.0-M2")
   object effectResponse extends EffectResponseSyntax
   object kleisli extends KleisliSyntax
+  object literals extends LiteralsSyntax
   object string extends StringSyntax
 }

--- a/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
+++ b/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
@@ -18,19 +18,7 @@ sealed class CaseInsensitiveString private (val value: String)
   private[this] var hash = 0
   override def hashCode(): Int = {
     if (hash == 0) {
-      var h = 0
-      var i = 0
-      val len = value.length
-      while (i < len) {
-        // Strings are equal igoring case if either their uppercase or lowercase
-        // forms are equal. Equality of one does not imply the other, so we need
-        // to go in both directions. A character is not guaranteed to make this
-        // round trip, but it doesn't matter as long as all equal characters
-        // hash the same.
-        h = h * 31 + Character.toLowerCase(Character.toUpperCase(value.charAt(i)))
-        i += 1
-      }
-      hash = h
+      hash = hashLower(value)
     }
     hash
   }

--- a/core/src/main/scala/org/http4s/util/package.scala
+++ b/core/src/main/scala/org/http4s/util/package.scala
@@ -54,4 +54,23 @@ package object util {
     "Moved to org.http4s.execution.trampoline, is now merely a ExecutionContextExecutor.",
     "0.18.0-M2")
   val TrampolineExecutionContext: ExecutionContextExecutor = execution.trampoline
+
+  /* This is nearly identical to the hashCode of java.lang.String, but converting
+   * to lower case on the fly to avoid copying `value`'s character storage.
+   */
+  def hashLower(s: String): Int = {
+    var h = 0
+    var i = 0
+    val len = s.length
+    while (i < len) {
+      // Strings are equal igoring case if either their uppercase or lowercase
+      // forms are equal. Equality of one does not imply the other, so we need
+      // to go in both directions. A character is not guaranteed to make this
+      // round trip, but it doesn't matter as long as all equal characters
+      // hash the same.
+      h = h * 31 + Character.toLowerCase(Character.toUpperCase(s.charAt(i)))
+      i += 1
+    }
+    h
+  }
 }

--- a/docs/src/main/tut/uri.md
+++ b/docs/src/main/tut/uri.md
@@ -36,11 +36,10 @@ assert(docs == docs2)
 
 ```tut:book
 import org.http4s.UriTemplate._
-import org.http4s.syntax.string._
 
 val template = UriTemplate(
   authority = Some(Uri.Authority(host = Uri.RegName("http4s.org"))),
-  scheme = Some("http".ci),
+  scheme = Some(Scheme.http),
   path = List(PathElm("docs"), PathElm("0.15"))
 )
 

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
@@ -6,7 +6,6 @@ import org.http4s.Uri._
 import org.http4s.client.blaze.{defaultClient => client}
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers._
-import org.http4s.implicits._
 import org.http4s.multipart._
 
 object ClientMultipartPostExample extends Http4sClientDsl[IO] {
@@ -16,7 +15,7 @@ object ClientMultipartPostExample extends Http4sClientDsl[IO] {
   def go: String = {
     // n.b. This service does not appear to gracefully handle chunked requests.
     val url = Uri(
-      scheme = Some("http".ci),
+      scheme = Some(Scheme.http),
       authority = Some(Authority(host = RegName("www.posttestserver.com"))),
       path = "/post.php?dir=http4s")
 

--- a/examples/src/main/scala/com/example/http4s/ssl/SslExampleWithRedirect.scala
+++ b/examples/src/main/scala/com/example/http4s/ssl/SslExampleWithRedirect.scala
@@ -5,7 +5,7 @@ import cats.effect.Effect
 import cats.syntax.option._
 import fs2._
 import java.nio.file.Paths
-import org.http4s.HttpService
+import org.http4s.{HttpService, Scheme}
 import org.http4s.Uri.{Authority, RegName}
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.{Host, Location}
@@ -30,7 +30,7 @@ abstract class SslExampleWithRedirect[F[_]: Effect] extends StreamApp[F] with Ht
       request.headers.get(Host) match {
         case Some(Host(host, _)) =>
           val baseUri = request.uri.copy(
-            scheme = "https".ci.some,
+            scheme = Scheme.https.some,
             authority = Some(
               Authority(
                 request.uri.authority.flatMap(_.userInfo),

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -8,6 +8,7 @@ import java.nio.charset.{Charset => NioCharset}
 import java.time._
 import java.util.Locale
 import org.http4s.headers._
+import org.http4s.syntax.literals._
 import org.http4s.syntax.string._
 import org.http4s.util.CaseInsensitiveString
 import org.scalacheck.{Arbitrary, Cogen, Gen}
@@ -501,6 +502,29 @@ trait ArbitraryInstances {
     oneOf(alphaChar, numChar, const('-'), const('.'), const('_'), const('~'))
   val genSubDelims: Gen[Char] = oneOf(Seq('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='))
 
+  implicit val arbitraryScheme: Arbitrary[Scheme] = Arbitrary {
+    frequency(
+      5 -> Scheme.http,
+      5 -> Scheme.https,
+      1 -> scheme"HTTP",
+      1 -> scheme"HTTPS",
+      3 -> (for {
+        head <- alphaChar
+        tail <- listOf(
+          frequency(
+            36 -> alphaNumChar,
+            1 -> const('+'),
+            1 -> const('-'),
+            1 -> const('.')
+          )
+        )
+      } yield HttpCodec[Scheme].parseOrThrow(tail.mkString(head.toString, "", "")))
+    )
+  }
+
+  implicit val cogenScheme: Cogen[Scheme] =
+    Cogen[String].contramap(_.value.toLowerCase(Locale.ROOT))
+
   /** https://tools.ietf.org/html/rfc3986 */
   implicit val arbitraryUri: Arbitrary[Uri] = Arbitrary {
     val genSegmentNzNc =
@@ -513,7 +537,7 @@ trait ArbitraryInstances {
     val genPathRootless = genSegmentNz |+| genPathAbEmpty
     val genPathNoScheme = genSegmentNzNc |+| genPathAbEmpty
     val genPathAbsolute = const("/") |+| opt(genPathRootless)
-    val genScheme = oneOf("http", "https").map(CaseInsensitiveString.apply)
+    val genScheme = oneOf(Scheme.http, Scheme.https)
     val genPath =
       oneOf(genPathAbEmpty, genPathAbsolute, genPathNoScheme, genPathRootless, genPathEmpty)
     val genFragment: Gen[Uri.Fragment] =

--- a/testing/src/main/scala/org/http4s/testing/HttpCodecTests.scala
+++ b/testing/src/main/scala/org/http4s/testing/HttpCodecTests.scala
@@ -1,0 +1,45 @@
+package org.http4s
+package testing
+
+import cats.Eq
+import cats.implicits._
+import cats.laws._
+import cats.laws.discipline._
+import org.http4s.util.Renderer
+import org.scalacheck.{Arbitrary, Prop, Shrink}
+import org.typelevel.discipline.Laws
+
+trait HttpCodecLaws[A] {
+  implicit def C: HttpCodec[A]
+
+  def httpCodecRoundTrip(a: A): IsEq[ParseResult[A]] =
+    C.parse(Renderer.renderString(a)) <-> Right(a)
+}
+
+object HttpCodecLaws {
+  def apply[A](implicit httpCodecA: HttpCodec[A]): HttpCodecLaws[A] = new HttpCodecLaws[A] {
+    val C = httpCodecA
+  }
+}
+
+trait HttpCodecTests[A] extends Laws {
+  def laws: HttpCodecLaws[A]
+
+  def httpCodec(
+      implicit
+      arbitraryA: Arbitrary[A],
+      shrinkA: Shrink[A],
+      eqA: Eq[A]): RuleSet = new DefaultRuleSet(
+    name = "HTTP codec",
+    parent = None,
+    "roundTrip" -> Prop.forAll { (a: A) =>
+      laws.httpCodecRoundTrip(a)
+    }
+  )
+}
+
+object HttpCodecTests {
+  def apply[A: HttpCodec]: HttpCodecTests[A] = new HttpCodecTests[A] {
+    val laws: HttpCodecLaws[A] = HttpCodecLaws[A]
+  }
+}

--- a/tests/src/test/scala/org/http4s/SchemeSpec.scala
+++ b/tests/src/test/scala/org/http4s/SchemeSpec.scala
@@ -1,0 +1,61 @@
+package org.http4s
+
+import cats.kernel.laws.OrderLaws
+import org.http4s.internal.parboiled2.CharPredicate
+import org.http4s.testing.HttpCodecTests
+import org.http4s.util.Renderer
+
+class SchemeSpec extends Http4sSpec {
+  "equals" should {
+    "be consistent with equalsIgnoreCase of the values" in {
+      prop { (a: Scheme, b: Scheme) =>
+        (a == b) must_== a.value.equalsIgnoreCase(b.value)
+      }
+    }
+  }
+
+  "compareTo" should {
+    "be consistent with value.compareToIgnoreCase" in {
+      prop { (a: Scheme, b: Scheme) =>
+        a.value.compareToIgnoreCase(b.value) must_== a.compareTo(b)
+      }
+    }
+  }
+
+  "hashCode" should {
+    "be consistent with equality" in {
+      prop { (a: Scheme, b: Scheme) =>
+        (a == b) ==> (a.## must_== b.##)
+      }
+    }
+  }
+
+  "render" should {
+    "return value" in prop { s: Scheme =>
+      Renderer.renderString(s) must_== s.value
+    }
+  }
+
+  "fromString" should {
+    "reject all invalid schemes" in { s: String =>
+      (s.isEmpty ||
+      !CharPredicate.Alpha(s.charAt(0)) ||
+      !s.forall(CharPredicate.Alpha ++ CharPredicate(".-+"))) ==>
+        (Scheme.parse(s) must beLeft)
+    }
+  }
+
+  "literal syntax" should {
+    "accept valid literals" in {
+      scheme"https" must_== Scheme.https
+    }
+
+    "reject invalid literals" in {
+      illTyped("""scheme"нет"""")
+      true
+    }
+  }
+
+  checkAll("order", OrderLaws[Scheme].order)
+  checkAll("httpCodec", HttpCodecTests[Scheme].httpCodec)
+}

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -33,7 +33,7 @@ class UriSpec extends Http4sSpec with MustThrownMatchers {
 
       "parse scheme correctly" in {
         val uri = getUri("http://localhost/")
-        uri.scheme must_=== Some("http".ci)
+        uri.scheme must_=== Some(Scheme.http)
       }
 
       "parse the authority correctly" in {
@@ -127,15 +127,16 @@ http://example.org/a file
 
   "Uri copy" should {
     "support updating the schema" in {
-      uri("http://example.com/").copy(scheme = "https".ci.some) must_== uri("https://example.com/")
+      uri("http://example.com/").copy(scheme = Scheme.https.some) must_== uri(
+        "https://example.com/")
       // Must add the authority to set the scheme and host
       uri("/route/").copy(
-        scheme = "https".ci.some,
+        scheme = Scheme.https.some,
         authority = Some(Authority(None, RegName("example.com")))) must_== uri(
         "https://example.com/route/")
       // You can add a port too
       uri("/route/").copy(
-        scheme = "https".ci.some,
+        scheme = Scheme.https.some,
         authority = Some(Authority(None, RegName("example.com"), Some(8443)))) must_== uri(
         "https://example.com:8443/route/")
     }
@@ -156,7 +157,7 @@ http://example.org/a file
 
       foreach(variants) { s =>
         Uri(
-          Some("http".ci),
+          Some(Scheme.http),
           Some(Authority(host = IPv6(s.ci))),
           "/foo",
           Query.fromPairs("bar" -> "baz")).toString must_==
@@ -166,39 +167,39 @@ http://example.org/a file
 
     "render URL with parameters" in {
       Uri(
-        Some("http".ci),
+        Some(Scheme.http),
         Some(Authority(host = RegName("www.foo.com".ci))),
         "/foo",
         Query.fromPairs("bar" -> "baz")).toString must_== ("http://www.foo.com/foo?bar=baz")
     }
 
     "render URL with port" in {
-      Uri(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci), port = Some(80)))).toString must_== ("http://www.foo.com:80")
+      Uri(Some(Scheme.http), Some(Authority(host = RegName("www.foo.com".ci), port = Some(80)))).toString must_== ("http://www.foo.com:80")
     }
 
     "render URL without port" in {
-      Uri(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci)))).toString must_== ("http://www.foo.com")
+      Uri(Some(Scheme.http), Some(Authority(host = RegName("www.foo.com".ci)))).toString must_== ("http://www.foo.com")
     }
 
     "render IPv4 URL with parameters" in {
       Uri(
-        Some("http".ci),
+        Some(Scheme.http),
         Some(Authority(host = IPv4("192.168.1.1".ci), port = Some(80))),
         "/c",
         Query.fromPairs("GB" -> "object", "Class" -> "one")).toString must_== ("http://192.168.1.1:80/c?GB=object&Class=one")
     }
 
     "render IPv4 URL with port" in {
-      Uri(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci), port = Some(8080)))).toString must_== ("http://192.168.1.1:8080")
+      Uri(Some(Scheme.http), Some(Authority(host = IPv4("192.168.1.1".ci), port = Some(8080)))).toString must_== ("http://192.168.1.1:8080")
     }
 
     "render IPv4 URL without port" in {
-      Uri(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci)))).toString must_== ("http://192.168.1.1")
+      Uri(Some(Scheme.http), Some(Authority(host = IPv4("192.168.1.1".ci)))).toString must_== ("http://192.168.1.1")
     }
 
     "render IPv6 URL with parameters" in {
       Uri(
-        Some("http".ci),
+        Some(Scheme.http),
         Some(Authority(host = IPv6("2001:db8::7".ci))),
         "/c",
         Query.fromPairs("GB" -> "object", "Class" -> "one")).toString must_== ("http://[2001:db8::7]/c?GB=object&Class=one")
@@ -206,7 +207,7 @@ http://example.org/a file
 
     "render IPv6 URL with port" in {
       Uri(
-        Some("http".ci),
+        Some(Scheme.http),
         Some(Authority(
           host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci),
           port = Some(8080)))).toString must_== ("http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080")
@@ -214,7 +215,7 @@ http://example.org/a file
 
     "render IPv6 URL without port" in {
       Uri(
-        Some("http".ci),
+        Some(Scheme.http),
         Some(Authority(host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)))).toString must_== ("http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]")
     }
 
@@ -223,12 +224,12 @@ http://example.org/a file
     }
 
     "render email address" in {
-      Uri(Some("mailto".ci), path = "John.Doe@example.com").toString must_== ("mailto:John.Doe@example.com")
+      Uri(Some(scheme"mailto"), path = "John.Doe@example.com").toString must_== ("mailto:John.Doe@example.com")
     }
 
     "render an URL with username and password" in {
       Uri(
-        Some("http".ci),
+        Some(Scheme.http),
         Some(Authority(Some("username:password"), RegName("some.example.com"), None)),
         "/",
         Query.empty,
@@ -237,7 +238,7 @@ http://example.org/a file
 
     "render an URL with username and password, path and params" in {
       Uri(
-        Some("http".ci),
+        Some(Scheme.http),
         Some(Authority(Some("username:password"), RegName("some.example.com"), None)),
         "/some/path",
         Query.fromString("param1=5&param-without-value"),

--- a/tests/src/test/scala/org/http4s/UriTemplateSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriTemplateSpec.scala
@@ -189,7 +189,7 @@ object UriTemplateSpec extends Http4sSpec {
       UriTemplate(query = Nil, fragment = fragment).toString must equalTo("/#")
     }
     "render http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/foo?bar=baz" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
@@ -198,7 +198,7 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo("http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/foo?bar=baz")
     }
     "render http://www.foo.com/foo?bar=baz" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = RegName("www.foo.com")
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
@@ -207,7 +207,7 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo("http://www.foo.com/foo?bar=baz")
     }
     "render http://www.foo.com:80" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = RegName("www.foo.com".ci)
       val authority = Some(Authority(host = host, port = Some(80)))
       val path = Nil
@@ -216,15 +216,15 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo("http://www.foo.com:80")
     }
     "render http://www.foo.com" in {
-      UriTemplate(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci)))).toString must
+      UriTemplate(Some(Scheme.http), Some(Authority(host = RegName("www.foo.com".ci)))).toString must
         equalTo("http://www.foo.com")
     }
     "render http://192.168.1.1" in {
-      UriTemplate(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci)))).toString must
+      UriTemplate(Some(Scheme.http), Some(Authority(host = IPv4("192.168.1.1".ci)))).toString must
         equalTo("http://192.168.1.1")
     }
     "render http://192.168.1.1:8080" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(host = host, port = Some(8080)))
       val query = List(ParamElm("", Nil))
@@ -232,7 +232,7 @@ object UriTemplateSpec extends Http4sSpec {
       UriTemplate(scheme, authority, Nil, Nil).toString must equalTo("http://192.168.1.1:8080")
     }
     "render http://192.168.1.1:80/c?GB=object&Class=one" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(host = host, port = Some(80)))
       val path = List(PathElm("c"))
@@ -241,21 +241,21 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo("http://192.168.1.1:80/c?GB=object&Class=one")
     }
     "render http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)
       val authority = Some(Authority(host = host, port = Some(8080)))
       UriTemplate(scheme, authority).toString must
         equalTo("http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080")
     }
     "render http://[2001:db8::7]" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("2001:db8::7".ci)
       val authority = Some(Authority(host = host))
       UriTemplate(scheme, authority).toString must
         equalTo("http://[2001:db8::7]")
     }
     "render http://[2001:db8::7]/c?GB=object&Class=one" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("2001:db8::7".ci)
       val authority = Some(Authority(host = host))
       val path = List(PathElm("c"))
@@ -265,17 +265,17 @@ object UriTemplateSpec extends Http4sSpec {
     }
     "render http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]" in {
       UriTemplate(
-        Some("http".ci),
+        Some(Scheme.http),
         Some(Authority(host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)))).toString must
         equalTo("http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]")
     }
     "render email address (not supported at the moment)" in {
-      UriTemplate(Some("mailto".ci), path = List(PathElm("John.Doe@example.com"))).toString must
+      UriTemplate(Some(scheme"mailto"), path = List(PathElm("John.Doe@example.com"))).toString must
         equalTo("mailto:/John.Doe@example.com")
       // but should equalTo("mailto:John.Doe@example.com")
     }
     "render http://username:password@some.example.com" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
       UriTemplate(scheme, authority).toString must
@@ -284,7 +284,7 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo("http://username:password@some.example.com")
     }
     "render http://username:password@some.example.com/some/path?param1=5&param-without-value" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
       val path = List(PathElm("some"), PathElm("path"))
@@ -415,7 +415,7 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo(Uri(fragment = Some("")))
     }
     "convert http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/{rel}/search{?term}{#section} to UriTemplate" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
       val authority = Some(Authority(host = host))
       val path = List(VarExp("rel"), PathElm("search"))
@@ -425,7 +425,7 @@ object UriTemplateSpec extends Http4sSpec {
       tpl.toUriIfPossible.isFailure
     }
     "convert http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]:8080/{rel}/search{?term}{#section} to UriTemplate" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
       val authority = Some(Authority(host = host, port = Some(8080)))
       val path = List(VarExp("rel"), PathElm("search"))
@@ -435,7 +435,7 @@ object UriTemplateSpec extends Http4sSpec {
       tpl.toUriIfPossible.isFailure
     }
     "convert http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/foo?bar=baz Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
@@ -444,7 +444,7 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo(Uri(scheme, authority, "/foo", Query.fromString("bar=baz")))
     }
     "convert http://www.foo.com/foo?bar=baz to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = RegName("www.foo.com")
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
@@ -453,7 +453,7 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo(Uri(scheme, authority, "/foo", Query.fromString("bar=baz")))
     }
     "convert http://www.foo.com:80 to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = RegName("www.foo.com".ci)
       val authority = Some(Authority(host = host, port = Some(80)))
       val path = Nil
@@ -461,21 +461,21 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo(Uri(scheme, authority, ""))
     }
     "convert http://www.foo.com to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = RegName("www.foo.com".ci)
       val authority = Some(Authority(host = host))
-      UriTemplate(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci)))).toUriIfPossible.get must
+      UriTemplate(Some(Scheme.http), Some(Authority(host = RegName("www.foo.com".ci)))).toUriIfPossible.get must
         equalTo(Uri(scheme, authority))
     }
     "convert http://192.168.1.1 to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(None, host, None))
       UriTemplate(scheme, authority).toUriIfPossible.get must
         equalTo(Uri(scheme, authority))
     }
     "convert http://192.168.1.1:8080 to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(host = host, port = Some(8080)))
       val query = List(ParamElm("", Nil))
@@ -485,7 +485,7 @@ object UriTemplateSpec extends Http4sSpec {
         Uri(scheme, authority, "", Query.empty))
     }
     "convert http://192.168.1.1:80/c?GB=object&Class=one to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv4("192.168.1.1".ci)
       val authority = Some(Authority(host = host, port = Some(80)))
       val path = List(PathElm("c"))
@@ -494,7 +494,7 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo(Uri(scheme, authority, "/c", Query.fromString("GB=object&Class=one")))
     }
     "convert http://[2001:db8::7]/c?GB=object&Class=one to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("2001:db8::7".ci)
       val authority = Some(Authority(host = host))
       val path = List(PathElm("c"))
@@ -503,28 +503,28 @@ object UriTemplateSpec extends Http4sSpec {
         equalTo(Uri(scheme, authority, "/c", Query.fromString("GB=object&Class=one")))
     }
     "convert http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344] to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)
       val authority = Some(Authority(None, host, None))
       UriTemplate(scheme, authority).toUriIfPossible.get must
         equalTo(Uri(scheme, authority))
     }
     "convert http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080 to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)
       val authority = Some(Authority(None, host, Some(8080)))
       UriTemplate(scheme, authority).toUriIfPossible.get must
         equalTo(Uri(scheme, authority))
     }
     "convert https://username:password@some.example.com to Uri" in {
-      val scheme = Some("https".ci)
+      val scheme = Some(Scheme.https)
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
       UriTemplate(scheme, authority, Nil, Nil, Nil).toUriIfPossible.get must
         equalTo(Uri(scheme, authority))
     }
     "convert http://username:password@some.example.com/some/path?param1=5&param-without-value to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
       val path = List(PathElm("some"), PathElm("path"))
@@ -534,7 +534,7 @@ object UriTemplateSpec extends Http4sSpec {
           Uri(scheme, authority, "/some/path", Query.fromString("param1=5&param-without-value")))
     }
     "convert http://username:password@some.example.com/some/path?param1=5&param-without-value#sec-1.2 to Uri" in {
-      val scheme = Some("http".ci)
+      val scheme = Some(Scheme.http)
       val host = RegName("some.example.com")
       val authority = Some(Authority(Some("username:password"), host, None))
       val path = List(PathElm("some"), PathElm("path"))

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -9,7 +9,6 @@ import java.io.File
 import org.http4s.MediaType._
 import org.http4s.headers._
 import org.http4s.Uri._
-import org.http4s.util._
 import org.http4s.EntityEncoder._
 import org.specs2.Specification
 import scodec.bits.ByteVector
@@ -28,7 +27,7 @@ class MultipartSpec extends Specification {
      """
 
   val url = Uri(
-    scheme = Some(CaseInsensitiveString("https")),
+    scheme = Some(Scheme.https),
     authority = Some(Authority(host = RegName("example.com"))),
     path = "/path/to/some/where")
 

--- a/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -57,13 +57,13 @@ class UriParserSpec extends Http4sSpec {
       val portExamples: Seq[(String, Uri)] = Seq(
         (
           "http://foo.com",
-          Uri(Some("http".ci), Some(Authority(host = RegName("foo.com".ci), port = None)))),
+          Uri(Some(Scheme.http), Some(Authority(host = RegName("foo.com".ci), port = None)))),
         (
           "http://foo.com:",
-          Uri(Some("http".ci), Some(Authority(host = RegName("foo.com".ci), port = None)))),
+          Uri(Some(Scheme.http), Some(Authority(host = RegName("foo.com".ci), port = None)))),
         (
           "http://foo.com:80",
-          Uri(Some("http".ci), Some(Authority(host = RegName("foo.com".ci), port = Some(80)))))
+          Uri(Some(Scheme.http), Some(Authority(host = RegName("foo.com".ci), port = Some(80)))))
       )
 
       check(portExamples)
@@ -73,32 +73,32 @@ class UriParserSpec extends Http4sSpec {
       val absoluteUris: Seq[(String, Uri)] = Seq(
         (
           "http://www.foo.com",
-          Uri(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci))))),
+          Uri(Some(Scheme.http), Some(Authority(host = RegName("www.foo.com".ci))))),
         (
           "http://www.foo.com/foo?bar=baz",
           Uri(
-            Some("http".ci),
+            Some(Scheme.http),
             Some(Authority(host = RegName("www.foo.com".ci))),
             "/foo",
             Query.fromPairs("bar" -> "baz"))),
         (
           "http://192.168.1.1",
-          Uri(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci))))),
+          Uri(Some(Scheme.http), Some(Authority(host = IPv4("192.168.1.1".ci))))),
         (
           "http://192.168.1.1:80/c?GB=object&Class=one",
           Uri(
-            Some("http".ci),
+            Some(Scheme.http),
             Some(Authority(host = IPv4("192.168.1.1".ci), port = Some(80))),
             "/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         (
           "http://[2001:db8::7]/c?GB=object&Class=one",
           Uri(
-            Some("http".ci),
+            Some(Scheme.http),
             Some(Authority(host = IPv6("2001:db8::7".ci))),
             "/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
-        ("mailto:John.Doe@example.com", Uri(Some("mailto".ci), path = "John.Doe@example.com"))
+        ("mailto:John.Doe@example.com", Uri(Some(scheme"mailto"), path = "John.Doe@example.com"))
       )
 
       check(absoluteUris)
@@ -120,7 +120,7 @@ class UriParserSpec extends Http4sSpec {
       val u = Uri.requestTarget("http://foo.bar/foo#Examples")
       u must beRight(
         Uri(
-          Some("http".ci),
+          Some(Scheme.http),
           Some(Authority(host = RegName("foo.bar".ci))),
           "/foo",
           Query.empty,
@@ -131,7 +131,7 @@ class UriParserSpec extends Http4sSpec {
       val u = Uri.requestTarget("http://foo.bar/foo?bar=baz#Example-Fragment")
       u must beRight(
         Uri(
-          Some("http".ci),
+          Some(Scheme.http),
           Some(Authority(host = RegName("foo.bar".ci))),
           "/foo",
           Query.fromPairs("bar" -> "baz"),
@@ -214,32 +214,32 @@ class UriParserSpec extends Http4sSpec {
       val absoluteUris: Seq[(String, Uri)] = Seq(
         (
           "http://www.foo.com",
-          Uri(Some("http".ci), Some(Authority(host = RegName("www.foo.com".ci))))),
+          Uri(Some(Scheme.http), Some(Authority(host = RegName("www.foo.com".ci))))),
         (
           "http://www.foo.com/foo?bar=baz",
           Uri(
-            Some("http".ci),
+            Some(Scheme.http),
             Some(Authority(host = RegName("www.foo.com".ci))),
             "/foo",
             Query.fromPairs("bar" -> "baz"))),
         (
           "http://192.168.1.1",
-          Uri(Some("http".ci), Some(Authority(host = IPv4("192.168.1.1".ci))))),
+          Uri(Some(Scheme.http), Some(Authority(host = IPv4("192.168.1.1".ci))))),
         (
           "http://192.168.1.1:80/c?GB=object&Class=one",
           Uri(
-            Some("http".ci),
+            Some(Scheme.http),
             Some(Authority(host = IPv4("192.168.1.1".ci), port = Some(80))),
             "/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         (
           "http://[2001:db8::7]/c?GB=object&Class=one",
           Uri(
-            Some("http".ci),
+            Some(Scheme.http),
             Some(Authority(host = IPv6("2001:db8::7".ci))),
             "/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
-        ("mailto:John.Doe@example.com", Uri(Some("mailto".ci), path = "John.Doe@example.com"))
+        ("mailto:John.Doe@example.com", Uri(Some(scheme"mailto"), path = "John.Doe@example.com"))
       )
 
       check(absoluteUris)


### PR DESCRIPTION
Less exciting as a type as much as a template for shoring up the HTTP model.

* `HttpCodec` is anything that can be parsed and rendered as a round trip, with a law to enforce it.
* `unsafeFromString` that is polluting everything gets moved to the `HttpCodec` type class.
* Move literal support to `StringContext` instead of methods on the companion.
* Macros get centralized in their own object.
* Gets rid of skull-and-crossbones constructors for macros.
* `toString` is for debugging, not serialization.
* Begins to phase out `CaseInsensitiveString`.