### PR TITLE
EntityCodecLaws

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val testing = libraryProject("testing")
   .settings(
     description := "Instances and laws for testing http4s code",
     libraryDependencies ++= Seq(
+      catsEffectLaws,
       scalacheck,
       specs2Core
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,10 @@ lazy val argonaut = libraryProject("argonaut")
 lazy val circe = libraryProject("circe")
   .settings(
     description := "Provides Circe codecs for http4s",
-    libraryDependencies += circeJawn
+    libraryDependencies ++= Seq(
+      circeJawn,
+      circeTesting % "test"
+    )
   )
   .dependsOn(core, testing % "test->test", jawn % "compile;test->test")
 

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -2,17 +2,22 @@ package org.http4s
 package circe.test // Get out of circe package so we can import custom instances
 
 import cats.effect.IO
+import cats.effect.laws.util.TestContext
 import io.circe._
 import io.circe.syntax._
+import io.circe.testing.instances._
 import java.nio.charset.StandardCharsets
 import org.http4s.Status.Ok
 import org.http4s.circe._
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSpec
+import org.http4s.testing.EntityCodecTests
 import org.specs2.specification.core.Fragment
 
 // Originally based on ArgonautSpec
 class CirceSpec extends JawnDecodeSupportSpec[Json] {
+  implicit val testContext = TestContext()
+
   testJsonDecoder(jsonDecoder)
 
   sealed case class Foo(bar: Int)
@@ -133,4 +138,6 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
       req.flatMap(_.decodeJson[Foo]).attempt.unsafeRunSync must beLeft
     }
   }
+
+  checkAll("EntityCodec[IO, Json]", EntityCodecTests[IO, Json].entityCodec)
 }

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -156,11 +156,17 @@ trait EntityDecoderInstances {
   implicit def binary[F[_]: Sync]: EntityDecoder[F, Chunk[Byte]] =
     EntityDecoder.decodeBy(MediaRange.`*/*`)(collectBinary[F])
 
+  implicit def byteArrayDecoder[F[_]: Sync]: EntityDecoder[F, Array[Byte]] =
+    binary.map(_.toArray)
+
   implicit def text[F[_]: Sync](
       implicit defaultCharset: Charset = DefaultCharset): EntityDecoder[F, String] =
     EntityDecoder.decodeBy(MediaRange.`text/*`)(msg =>
       collectBinary(msg).map(bs =>
         new String(bs.toArray, msg.charset.getOrElse(defaultCharset).nioCharset)))
+
+  implicit def charArrayDecoder[F[_]: Sync]: EntityDecoder[F, Array[Char]] =
+    text.map(_.toArray)
 
   // File operations // TODO: rewrite these using NIO non blocking FileChannels, and do these make sense as a 'decoder'?
   def binFile[F[_]: MonadError[?[_], Throwable]](file: File)(

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -266,6 +266,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.0.37"
   lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.12.9"
+  lazy val catsEffectLaws                   = "org.typelevel"          %% "cats-effect-laws"          % "0.4"
   lazy val catsKernelLaws                   = "org.typelevel"          %% "cats-kernel-laws"          % catsLaws.revision
   lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % "1.0.0-MF"
   lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % circeJawn.revision

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -273,6 +273,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val circeJawn                        = "io.circe"               %% "circe-jawn"                % "0.9.0-M1"
   lazy val circeLiteral                     = "io.circe"               %% "circe-literal"             % circeJawn.revision
   lazy val circeParser                      = "io.circe"               %% "circe-parser"              % circeJawn.revision
+  lazy val circeTesting                     = "io.circe"               %% "circe-testing"             % circeJawn.revision
   lazy val cryptobits                       = "org.reactormonk"        %% "cryptobits"                % "1.1"
   lazy val discipline                       = "org.typelevel"          %% "discipline"                % "0.8"
   lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "0.10.0-M6"

--- a/testing/src/main/scala/org/http4s/testing/EntityCodecTests.scala
+++ b/testing/src/main/scala/org/http4s/testing/EntityCodecTests.scala
@@ -1,0 +1,72 @@
+package org.http4s
+package testing
+
+import cats.Eq
+import cats.implicits._
+import cats.effect._
+import cats.effect.laws.util.TestContext
+import cats.effect.laws.util.TestInstances._
+import cats.laws._
+import cats.laws.discipline._
+import org.scalacheck.{Arbitrary, Prop, Shrink}
+import org.typelevel.discipline.Laws
+
+trait EntityCodecLaws[F[_], A] {
+  implicit def effect: Effect[F]
+  implicit def encoder: EntityEncoder[F, A]
+  implicit def decoder: EntityDecoder[F, A]
+
+  def entityCodecRoundTrip(a: A): IsEq[IO[Either[DecodeFailure, A]]] = {
+    var result: Option[Either[DecodeFailure, A]] = None
+    val read = IO(result.get)
+    effect.runAsync(for {
+      entity <- encoder.toEntity(a)
+      message = Request(body = entity.body, headers = encoder.headers)
+      a0 <- decoder.decode(message, strict = true).value
+    } yield a0) {
+      case Left(e) => IO.raiseError(e)
+      case Right(a) => IO { result = Some(a) }
+    } >> read <-> IO.pure(Right(a))
+  }
+}
+
+object EntityCodecLaws {
+  def apply[F[_], A](
+      implicit effectF: Effect[F],
+      entityEncoderFA: EntityEncoder[F, A],
+      entityDecoderFA: EntityDecoder[F, A]): EntityCodecLaws[F, A] = new EntityCodecLaws[F, A] {
+    val effect = effectF
+    val encoder = entityEncoderFA
+    val decoder = entityDecoderFA
+  }
+}
+
+trait EntityCodecTests[F[_], A] extends Laws {
+  def laws: EntityCodecLaws[F, A]
+
+  implicit def eqDecodeFailure: Eq[DecodeFailure] =
+    Eq.fromUniversalEquals[DecodeFailure]
+
+  def entityCodec(
+      implicit
+      arbitraryA: Arbitrary[A],
+      shrinkA: Shrink[A],
+      eqA: Eq[A],
+      testContext: TestContext): RuleSet = new DefaultRuleSet(
+    name = "Entity codec",
+    parent = None,
+    "roundTrip" -> Prop.forAll { (a: A) =>
+      laws.entityCodecRoundTrip(a)
+    }
+  )
+}
+
+object EntityCodecTests {
+  def apply[F[_], A](
+      implicit effect: Effect[F],
+      entityEncoder: EntityEncoder[F, A],
+      entityDecoder: EntityDecoder[F, A],
+  ): EntityCodecTests[F, A] = new EntityCodecTests[F, A] {
+    val laws: EntityCodecLaws[F, A] = EntityCodecLaws[F, A]
+  }
+}

--- a/testing/src/main/scala/org/http4s/testing/EntityCodecTests.scala
+++ b/testing/src/main/scala/org/http4s/testing/EntityCodecTests.scala
@@ -58,7 +58,7 @@ object EntityCodecTests {
   def apply[F[_], A](
       implicit effectF: Effect[F],
       entityEncoderFA: EntityEncoder[F, A],
-      entityDecoderFA: EntityDecoder[F, A],
+      entityDecoderFA: EntityDecoder[F, A]
   ): EntityCodecTests[F, A] = new EntityCodecTests[F, A] {
     val laws: EntityCodecLaws[F, A] = EntityCodecLaws[F, A]
   }

--- a/testing/src/main/scala/org/http4s/testing/EntityEncoderTests.scala
+++ b/testing/src/main/scala/org/http4s/testing/EntityEncoderTests.scala
@@ -30,7 +30,7 @@ trait EntityEncoderLaws[F[_], A] extends ToIOSyntax {
 object EntityEncoderLaws {
   def apply[F[_], A](
       implicit effectF: Effect[F],
-      entityEncoderFA: EntityEncoder[F, A],
+      entityEncoderFA: EntityEncoder[F, A]
   ): EntityEncoderLaws[F, A] = new EntityEncoderLaws[F, A] {
     val effect = effectF
     val encoder = entityEncoderFA
@@ -51,7 +51,7 @@ trait EntityEncoderTests[F[_], A] extends Laws {
       ioBooleanToProp(laws.accurateContentLengthIfDefined(a))
     },
     "noContentLengthInStaticHeaders" -> laws.noContentLengthInStaticHeaders,
-    "noTransferEncodingInStaticHeaders" -> laws.noTransferEncodingInStaticHeaders,
+    "noTransferEncodingInStaticHeaders" -> laws.noTransferEncodingInStaticHeaders
   )
 }
 

--- a/testing/src/main/scala/org/http4s/testing/EntityEncoderTests.scala
+++ b/testing/src/main/scala/org/http4s/testing/EntityEncoderTests.scala
@@ -1,0 +1,65 @@
+package org.http4s
+package testing
+
+import cats.implicits._
+import cats.effect._
+import cats.effect.laws.util.TestContext
+import org.http4s.headers.{`Content-Length`, `Transfer-Encoding`}
+import org.scalacheck.{Arbitrary, Prop, Shrink}
+import org.typelevel.discipline.Laws
+
+trait EntityEncoderLaws[F[_], A] extends ToIOSyntax {
+  implicit def effect: Effect[F]
+  implicit def encoder: EntityEncoder[F, A]
+
+  def accurateContentLengthIfDefined(a: A) =
+    (for {
+      entity <- encoder.toEntity(a)
+      body <- entity.body.runLog
+      bodyLength = body.size.toLong
+      contentLength = entity.length
+    } yield contentLength.fold(true)(_ === bodyLength)).toIO
+
+  def noContentLengthInStaticHeaders =
+    encoder.headers.get(`Content-Length`).isEmpty
+
+  def noTransferEncodingInStaticHeaders =
+    encoder.headers.get(`Transfer-Encoding`).isEmpty
+}
+
+object EntityEncoderLaws {
+  def apply[F[_], A](
+      implicit effectF: Effect[F],
+      entityEncoderFA: EntityEncoder[F, A],
+  ): EntityEncoderLaws[F, A] = new EntityEncoderLaws[F, A] {
+    val effect = effectF
+    val encoder = entityEncoderFA
+  }
+}
+
+trait EntityEncoderTests[F[_], A] extends Laws {
+  def laws: EntityEncoderLaws[F, A]
+
+  def entityEncoder(
+      implicit
+      arbitraryA: Arbitrary[A],
+      shrinkA: Shrink[A],
+      testContext: TestContext): RuleSet = new DefaultRuleSet(
+    name = "EntityEncoder",
+    parent = None,
+    "accurateContentLength" -> Prop.forAll { (a: A) =>
+      ioBooleanToProp(laws.accurateContentLengthIfDefined(a))
+    },
+    "noContentLengthInStaticHeaders" -> laws.noContentLengthInStaticHeaders,
+    "noTransferEncodingInStaticHeaders" -> laws.noTransferEncodingInStaticHeaders,
+  )
+}
+
+object EntityEncoderTests {
+  def apply[F[_], A](
+      implicit effectF: Effect[F],
+      entityEncoderFA: EntityEncoder[F, A]
+  ): EntityEncoderTests[F, A] = new EntityEncoderTests[F, A] {
+    val laws: EntityEncoderLaws[F, A] = EntityEncoderLaws.apply[F, A]
+  }
+}

--- a/testing/src/main/scala/org/http4s/testing/ToIOSyntax.scala
+++ b/testing/src/main/scala/org/http4s/testing/ToIOSyntax.scala
@@ -1,0 +1,20 @@
+package org.http4s.testing
+
+import cats.effect.{Effect, IO}
+import cats.implicits._
+
+trait ToIOSyntax {
+  implicit def http4sToIoSyntax[F[_]: Effect, A](fa: F[A]) =
+    new ToIOOps(fa)
+}
+
+class ToIOOps[F[_], A](val fa: F[A])(implicit val F: Effect[F]) {
+  def toIO: IO[A] = {
+    var result: Option[A] = None
+    val read: IO[A] = IO(result.get)
+    F.runAsync(fa) {
+      case Left(e) => IO.raiseError(e)
+      case Right(a) => IO(result = Some(a))
+    } >> read
+  }
+}

--- a/testing/src/main/scala/org/http4s/testing/package.scala
+++ b/testing/src/main/scala/org/http4s/testing/package.scala
@@ -1,0 +1,17 @@
+package org.http4s
+
+import cats.effect.IO
+import cats.effect.laws.util.TestContext
+import org.scalacheck.Prop
+import scala.util.Success
+
+package object testing {
+  def ioBooleanToProp(iob: IO[Boolean])(implicit ec: TestContext): Prop = {
+    val f = iob.unsafeToFuture()
+    ec.tick()
+    f.value match {
+      case Some(Success(true)) => true
+      case _ => false
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/EntityCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityCodecSpec.scala
@@ -1,0 +1,25 @@
+package org.http4s
+
+import cats.Eq
+import cats.effect.IO
+import cats.effect.laws.util.TestContext
+import cats.implicits._
+import fs2.Chunk
+import org.http4s.testing.EntityCodecTests
+
+class EntityCodecSpec extends Http4sSpec {
+  implicit val testContext = TestContext()
+
+  implicit def eqArray[A](implicit AA: Eq[Vector[A]]): Eq[Array[A]] =
+    AA.on(_.toVector)
+  implicit def eqChunk[A](implicit AA: Eq[Vector[A]]): Eq[Chunk[A]] =
+    AA.on(_.toVector)
+
+  checkAll("EntityCodec[IO, String]", EntityCodecTests[IO, String].entityCodec)
+  checkAll("EntityCodec[IO, Array[Char]]", EntityCodecTests[IO, Array[Char]].entityCodec)
+
+  checkAll("EntityCodec[IO, Chunk[Byte]]", EntityCodecTests[IO, Chunk[Byte]].entityCodec)
+  checkAll("EntityCodec[IO, Array[Byte]]", EntityCodecTests[IO, Array[Byte]].entityCodec)
+
+  checkAll("EntityCodec[IO, Unit]", EntityCodecTests[IO, Unit].entityCodec)
+}


### PR DESCRIPTION
If we have an `EntityEncoder[A]` and an `EntityDecoder[A]`, they ought to make a round trip.