### PR TITLE
Fix Displayed Scala Version in Service Doc

### DIFF
--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -10,7 +10,7 @@ and calling it with http4s' client.
 Create a new directory, with the following build.sbt in the root:
 
 ```scala
-scalaVersion := "2.11.8" // Also supports 2.10.x and 2.12.x
+scalaVersion := "2.12.4" // Also supports 2.11.x
 
 val http4sVersion = "{{< version "http4s.doc" >}}"
 


### PR DESCRIPTION
We were even lying about 2.10 support.