### PR TITLE
Add clean as initial step to sbt ci

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -501,4 +501,4 @@ def initCommands(additionalImports: String*) =
 
 // Everything is driven through release steps and the http4s* variables
 // This won't actually release unless on Travis.
-addCommandAlias("ci", ";release with-defaults")
+addCommandAlias("ci", ";clean ;release with-defaults")


### PR DESCRIPTION
Prevents false negatives locally by cleaning before the operation is run.