### PR TITLE
Make TransferCoding immutable

### DIFF
--- a/core/src/main/scala/org/http4s/TransferCoding.scala
+++ b/core/src/main/scala/org/http4s/TransferCoding.scala
@@ -20,21 +20,23 @@ package org.http4s
 
 import org.http4s.syntax.string._
 import org.http4s.util._
+import cats.Eq
 
 final case class TransferCoding private (coding: CaseInsensitiveString) extends Renderable {
   override def render(writer: Writer): writer.type = writer.append(coding.toString)
 }
 
-object TransferCoding extends Registry {
-  type Key = CaseInsensitiveString
-  type Value = TransferCoding
+object TransferCoding {
+  implicit class CI2TransferCoding(val ci: CaseInsensitiveString) extends AnyVal {
+    def toTransferCoding: TransferCoding = TransferCoding(ci)
+  }
 
-  implicit def fromKey(k: CaseInsensitiveString): TransferCoding = new TransferCoding(k)
+  implicit val eq: Eq[TransferCoding] = Eq.fromUniversalEquals
 
   // http://www.iana.org/assignments/http-parameters/http-parameters.xml#http-parameters-2
-  val chunked = registerKey("chunked".ci)
-  val compress = registerKey("compress".ci)
-  val deflate = registerKey("deflate".ci)
-  val gzip = registerKey("gzip".ci)
-  val identity = registerKey("identity".ci)
+  val chunked = TransferCoding("chunked".ci)
+  val compress = TransferCoding("compress".ci)
+  val deflate = TransferCoding("deflate".ci)
+  val gzip = TransferCoding("gzip".ci)
+  val identity = TransferCoding("identity".ci)
 }

--- a/core/src/main/scala/org/http4s/TransferCoding.scala
+++ b/core/src/main/scala/org/http4s/TransferCoding.scala
@@ -40,7 +40,7 @@ object TransferCoding {
   /**
     * Parse a list of Transfer Coding entries
     */
-  def parse(s: String): ParseResult[NonEmptyList[TransferCoding]] =
+  def parseList(s: String): ParseResult[NonEmptyList[TransferCoding]] =
     new Http4sParser[NonEmptyList[TransferCoding]](s, "Invalid Transfer Coding")
     with Rfc2616BasicRules {
       private def codingRule = rule {

--- a/core/src/main/scala/org/http4s/headers/Transfer-Encoding.scala
+++ b/core/src/main/scala/org/http4s/headers/Transfer-Encoding.scala
@@ -2,6 +2,7 @@ package org.http4s
 package headers
 
 import cats.data.NonEmptyList
+import cats.syntax.eq._
 import org.http4s.parser.HttpHeaderParser
 
 object `Transfer-Encoding`
@@ -14,6 +15,6 @@ object `Transfer-Encoding`
 final case class `Transfer-Encoding`(values: NonEmptyList[TransferCoding])
     extends Header.RecurringRenderable {
   override def key: `Transfer-Encoding`.type = `Transfer-Encoding`
-  def hasChunked: Boolean = values.exists(_.renderString.equalsIgnoreCase("chunked"))
+  def hasChunked: Boolean = values.exists(_ === TransferCoding.chunked)
   type Value = TransferCoding
 }

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -21,6 +21,7 @@ package parser
 import cats.data.NonEmptyList
 import java.net.InetAddress
 import java.nio.charset.StandardCharsets
+import org.http4s.TransferCoding._
 import org.http4s.headers._
 import org.http4s.headers.ETag.EntityTag
 import org.http4s.internal.parboiled2.Rule1
@@ -172,11 +173,11 @@ private[parser] trait SimpleHeaders {
     new Http4sHeaderParser[`Transfer-Encoding`](value) {
       def entry = rule {
         oneOrMore(Token).separatedBy(ListSep) ~> { vals: Seq[String] =>
-          if (vals.tail.isEmpty) `Transfer-Encoding`(TransferCoding.fromKey(vals.head.ci))
+          if (vals.tail.isEmpty) `Transfer-Encoding`(vals.head.ci.toTransferCoding)
           else
             `Transfer-Encoding`(
-              TransferCoding.fromKey(vals.head.ci),
-              vals.tail.map(s => TransferCoding.fromKey(s.ci)): _*)
+              vals.head.ci.toTransferCoding,
+              vals.tail.map(s => s.ci.toTransferCoding): _*)
         }
       }
     }.parse

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -169,7 +169,7 @@ private[parser] trait SimpleHeaders {
     }.parse
 
   def TRANSFER_ENCODING(value: String): ParseResult[`Transfer-Encoding`] =
-    TransferCoding.parse(value).map(`Transfer-Encoding`.apply)
+    TransferCoding.parseList(value).map(`Transfer-Encoding`.apply)
 
   def USER_AGENT(value: String): ParseResult[`User-Agent`] =
     new Http4sHeaderParser[`User-Agent`](value) {

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -21,7 +21,6 @@ package parser
 import cats.data.NonEmptyList
 import java.net.InetAddress
 import java.nio.charset.StandardCharsets
-import org.http4s.TransferCoding._
 import org.http4s.headers._
 import org.http4s.headers.ETag.EntityTag
 import org.http4s.internal.parboiled2.Rule1
@@ -170,17 +169,7 @@ private[parser] trait SimpleHeaders {
     }.parse
 
   def TRANSFER_ENCODING(value: String): ParseResult[`Transfer-Encoding`] =
-    new Http4sHeaderParser[`Transfer-Encoding`](value) {
-      def entry = rule {
-        oneOrMore(Token).separatedBy(ListSep) ~> { vals: Seq[String] =>
-          if (vals.tail.isEmpty) `Transfer-Encoding`(vals.head.ci.toTransferCoding)
-          else
-            `Transfer-Encoding`(
-              vals.head.ci.toTransferCoding,
-              vals.tail.map(s => s.ci.toTransferCoding): _*)
-        }
-      }
-    }.parse
+    TransferCoding.parse(value).map(`Transfer-Encoding`.apply)
 
   def USER_AGENT(value: String): ParseResult[`User-Agent`] =
     new Http4sHeaderParser[`User-Agent`](value) {

--- a/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -5,7 +5,9 @@ package middleware
 import cats.Functor
 import cats.data.{NonEmptyList, OptionT}
 import cats.effect.Effect
-import cats.implicits._
+import cats.syntax.eq._
+import cats.syntax.functor._
+import cats.syntax.flatMap._
 import fs2._
 import fs2.interop.scodec.ByteVectorChunk
 import org.http4s.EntityEncoder.chunkEncoder
@@ -33,7 +35,7 @@ object ChunkAggregator {
         // leaving the remaining values unchanged
         case e: `Transfer-Encoding` =>
           NonEmptyList
-            .fromList(e.values.filterNot(_ == TransferCoding.chunked))
+            .fromList(e.values.filterNot(_ === TransferCoding.chunked))
             .map(`Transfer-Encoding`.apply)
             .toList
         case header =>

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -529,6 +529,13 @@ trait ArbitraryInstances {
   implicit val cogenScheme: Cogen[Scheme] =
     Cogen[String].contramap(_.value.toLowerCase(Locale.ROOT))
 
+  implicit val arbitraryTransferCoding: Arbitrary[TransferCoding] = Arbitrary {
+    Gen.oneOf(TransferCoding.chunked, TransferCoding.compress, TransferCoding.deflate, TransferCoding.gzip, TransferCoding.identity)
+  }
+
+  implicit val cogenTransferCoding: Cogen[TransferCoding] =
+    Cogen[String].contramap(_.coding.toLowerCase(Locale.ROOT))
+
   /** https://tools.ietf.org/html/rfc3986 */
   implicit val arbitraryUri: Arbitrary[Uri] = Arbitrary {
     val genSegmentNzNc =

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -530,7 +530,12 @@ trait ArbitraryInstances {
     Cogen[String].contramap(_.value.toLowerCase(Locale.ROOT))
 
   implicit val arbitraryTransferCoding: Arbitrary[TransferCoding] = Arbitrary {
-    Gen.oneOf(TransferCoding.chunked, TransferCoding.compress, TransferCoding.deflate, TransferCoding.gzip, TransferCoding.identity)
+    Gen.oneOf(
+      TransferCoding.chunked,
+      TransferCoding.compress,
+      TransferCoding.deflate,
+      TransferCoding.gzip,
+      TransferCoding.identity)
   }
 
   implicit val cogenTransferCoding: Cogen[TransferCoding] =

--- a/tests/src/test/scala/org/http4s/TransferCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/TransferCodingSpec.scala
@@ -1,0 +1,20 @@
+package org.http4s
+
+import cats.data.NonEmptyList
+import cats.kernel.laws.OrderLaws
+
+class TransferCodingSpec extends Http4sSpec {
+
+  "parse" should {
+    "parse single items" in {
+      prop { (a: TransferCoding) =>
+        TransferCoding.parseList(a.coding) must_== ParseResult.success(NonEmptyList.one(a))
+      }
+    }
+    "parse multiple items" in {
+      TransferCoding.parseList("gzip, chunked") must_== ParseResult.success(NonEmptyList.of(TransferCoding.gzip, TransferCoding.chunked))
+    }
+  }
+
+  checkAll("order", OrderLaws[TransferCoding].order)
+}

--- a/tests/src/test/scala/org/http4s/TransferCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/TransferCodingSpec.scala
@@ -2,8 +2,16 @@ package org.http4s
 
 import cats.data.NonEmptyList
 import cats.kernel.laws.OrderLaws
+import org.http4s.testing.HttpCodecTests
 
 class TransferCodingSpec extends Http4sSpec {
+  "compareTo" should {
+    "be consistent with coding.compareToIgnoreCase" in {
+      prop { (a: TransferCoding, b: TransferCoding) =>
+        a.coding.compareToIgnoreCase(b.coding) must_== a.compareTo(b)
+      }
+    }
+  }
 
   "parse" should {
     "parse single items" in {
@@ -12,9 +20,11 @@ class TransferCodingSpec extends Http4sSpec {
       }
     }
     "parse multiple items" in {
-      TransferCoding.parseList("gzip, chunked") must_== ParseResult.success(NonEmptyList.of(TransferCoding.gzip, TransferCoding.chunked))
+      TransferCoding.parseList("gzip, chunked") must_== ParseResult.success(
+        NonEmptyList.of(TransferCoding.gzip, TransferCoding.chunked))
     }
   }
 
   checkAll("order", OrderLaws[TransferCoding].order)
+  checkAll("httpCodec", HttpCodecTests[TransferCoding].httpCodec)
 }


### PR DESCRIPTION
I'm trying to remove the use of `Registry` as it creates troubles on `scala.js` and it is not very sound anyway.

In this PR I'm removing `Registry` from `TransferCoding`. Any reason why this was mutable? Should end users be able to add their own `TransferCoding` definitions?

I'm also making the conversion from `CaseInsensitiveString` explicit and added the `Eq` instance