### PR TITLE
TransferCoding is not a case class

### DIFF
--- a/core/src/main/scala/org/http4s/TransferCoding.scala
+++ b/core/src/main/scala/org/http4s/TransferCoding.scala
@@ -20,14 +20,27 @@ package org.http4s
 
 import cats.{Order, Show}
 import cats.data.NonEmptyList
-import org.http4s.util.{Renderable, Writer}
+import org.http4s.util._
 import org.http4s.parser.{Http4sParser, Rfc2616BasicRules}
 import org.http4s.internal.parboiled2.{Parser => PbParser}
 
-sealed abstract case class TransferCoding private (coding: String)
-    extends Comparable[TransferCoding]
-    with Renderable {
-  override def compareTo(other: TransferCoding): Int =
+class TransferCoding private (val coding: String) extends Ordered[TransferCoding] with Renderable {
+  override def equals(o: Any) = o match {
+    case that: TransferCoding => this.coding.equalsIgnoreCase(that.coding)
+    case _ => false
+  }
+
+  private[this] var hash = 0
+  override def hashCode(): Int = {
+    if (hash == 0) {
+      hash = hashLower(coding)
+    }
+    hash
+  }
+
+  override def toString = s"TransferCoding($coding)"
+
+  override def compare(other: TransferCoding): Int =
     coding.compareToIgnoreCase(other.coding)
 
   override def render(writer: Writer): writer.type = writer.append(coding.toString)

--- a/tests/src/test/scala/org/http4s/SchemeSpec.scala
+++ b/tests/src/test/scala/org/http4s/SchemeSpec.scala
@@ -16,10 +16,10 @@ class SchemeSpec extends Http4sSpec {
     }
   }
 
-  "compareTo" should {
+  "compare" should {
     "be consistent with value.compareToIgnoreCase" in {
       prop { (a: Scheme, b: Scheme) =>
-        a.value.compareToIgnoreCase(b.value) must_== a.compareTo(b)
+        a.value.compareToIgnoreCase(b.value) must_== a.compare(b)
       }
     }
   }
@@ -58,6 +58,6 @@ class SchemeSpec extends Http4sSpec {
     }
   }
 
-  checkAll("order", OrderTests[Scheme].order)
-  checkAll("httpCodec", HttpCodecTests[Scheme].httpCodec)
+  checkAll("Order[Scheme]", OrderTests[Scheme].order)
+  checkAll("HttpCodec[Scheme]", HttpCodecTests[Scheme].httpCodec)
 }

--- a/tests/src/test/scala/org/http4s/TransferCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/TransferCodingSpec.scala
@@ -4,14 +4,29 @@ import cats.data.NonEmptyList
 import cats.implicits._
 import cats.kernel.laws.discipline.OrderTests
 import org.http4s.testing.HttpCodecTests
+import org.http4s.util.Renderer
 
 class TransferCodingSpec extends Http4sSpec {
-  "compareTo" should {
+  "equals" should {
+    "be consistent with equalsIgnoreCase of the codings" in prop {
+      (a: TransferCoding, b: TransferCoding) =>
+        (a == b) must_== a.coding.equalsIgnoreCase(b.coding)
+    }
+  }
+
+  "compare" should {
     "be consistent with coding.compareToIgnoreCase" in {
       prop { (a: TransferCoding, b: TransferCoding) =>
-        a.coding.compareToIgnoreCase(b.coding) must_== a.compareTo(b)
+        a.coding.compareToIgnoreCase(b.coding) must_== a.compare(b)
       }
     }
+  }
+
+  "hashCode" should {
+    "be consistent with equality" in
+      prop { (a: TransferCoding, b: TransferCoding) =>
+        (a == b) ==> (a.## must_== b.##)
+      }
   }
 
   "parse" should {
@@ -26,6 +41,12 @@ class TransferCodingSpec extends Http4sSpec {
     }
   }
 
-  checkAll("order", OrderTests[TransferCoding].order)
-  checkAll("httpCodec", HttpCodecTests[TransferCoding].httpCodec)
+  "render" should {
+    "return coding" in prop { s: TransferCoding =>
+      Renderer.renderString(s) must_== s.coding
+    }
+  }
+
+  checkAll("Order[TransferCoding]", OrderTests[TransferCoding].order)
+  checkAll("HttpCodec[TransferCoding]", HttpCodecTests[TransferCoding].httpCodec)
 }


### PR DESCRIPTION
Its equality semantics are not consistent with the equality of its components.  Better to just make this a wrapper class, like `Scheme`.
