### PR TITLE
Updating EntityBody[F] alias, to have the correct parameters

### DIFF
--- a/docs/src/main/tut/entity.md
+++ b/docs/src/main/tut/entity.md
@@ -12,8 +12,9 @@ streaming), but before the body has been fully received. The same applies to the
 http client usage, where you can start a connection before the body is fully
 materialized. You don't have to load the full body into memory to submit the
 request either. Taking a look at `Request[F]` and `Response[F]`, both have a body of
-type `EntityBody[F]`, which is simply an alias to `Stream[F, ByteVector]`. To
-understand `Stream`, take a look at the [streams-tutorial].
+type `EntityBody[F]`, which is simply an alias to `Stream[F, Byte]`. To
+understand `Stream`, take a look at the [streams-tutorial] or a youtube video on an
+[introduction-to-functional-streams].
 
 The `EntityDecoder` and `EntityEncoder` help with the streaming nature of the
 data in a http body, and they also have additional logic to deal with media
@@ -96,7 +97,8 @@ If you're working with [twirl] templates, there's a bridge for that too:
 
 - scala-twirl: `"org.http4s" %% "http4s-twirl" % Http4sVersion`
 
-[streams-tutorial]: https://gist.github.com/djspiewak/d93a9c4983f63721c41c
+[introduction-to-functional-streams]: https://www.youtube.com/watch?v=cahvyadYfX8&feature=youtu.be
+[streams-tutorial]: https://github.com/functional-streams-for-scala/fs2
 [EntityEncoder]: ../api/org/http4s/EntityEncoder$
 [EntityDecoder]: ../api/org/http4s/EntityDecoder$
 [MediaType]: ../api/org/http4s/MediaType$

--- a/docs/src/main/tut/entity.md
+++ b/docs/src/main/tut/entity.md
@@ -13,7 +13,7 @@ http client usage, where you can start a connection before the body is fully
 materialized. You don't have to load the full body into memory to submit the
 request either. Taking a look at `Request[F]` and `Response[F]`, both have a body of
 type `EntityBody[F]`, which is simply an alias to `Stream[F, Byte]`. To
-understand `Stream`, take a look at the [streams-tutorial] or a youtube video [introduction-to-functional-streams].
+understand `Stream`, take a look at the [introduction-to-functional-streams].
 
 The `EntityDecoder` and `EntityEncoder` help with the streaming nature of the
 data in a http body, and they also have additional logic to deal with media
@@ -96,8 +96,7 @@ If you're working with [twirl] templates, there's a bridge for that too:
 
 - scala-twirl: `"org.http4s" %% "http4s-twirl" % Http4sVersion`
 
-[introduction-to-functional-streams]: https://www.youtube.com/watch?v=cahvyadYfX8&feature=youtu.be
-[streams-tutorial]: https://github.com/functional-streams-for-scala/fs2
+[introduction-to-functional-streams]: https://github.com/functional-streams-for-scala/fs2
 [EntityEncoder]: ../api/org/http4s/EntityEncoder$
 [EntityDecoder]: ../api/org/http4s/EntityDecoder$
 [MediaType]: ../api/org/http4s/MediaType$

--- a/docs/src/main/tut/entity.md
+++ b/docs/src/main/tut/entity.md
@@ -13,8 +13,7 @@ http client usage, where you can start a connection before the body is fully
 materialized. You don't have to load the full body into memory to submit the
 request either. Taking a look at `Request[F]` and `Response[F]`, both have a body of
 type `EntityBody[F]`, which is simply an alias to `Stream[F, Byte]`. To
-understand `Stream`, take a look at the [streams-tutorial] or a youtube video on an
-[introduction-to-functional-streams].
+understand `Stream`, take a look at the [streams-tutorial] or a youtube video [introduction-to-functional-streams].
 
 The `EntityDecoder` and `EntityEncoder` help with the streaming nature of the
 data in a http body, and they also have additional logic to deal with media

--- a/docs/src/main/tut/entity.md
+++ b/docs/src/main/tut/entity.md
@@ -96,7 +96,7 @@ If you're working with [twirl] templates, there's a bridge for that too:
 
 - scala-twirl: `"org.http4s" %% "http4s-twirl" % Http4sVersion`
 
-[introduction-to-functional-streams]: https://github.com/functional-streams-for-scala/fs2
+[introduction-to-functional-streams]: https://youtu.be/cahvyadYfX8
 [EntityEncoder]: ../api/org/http4s/EntityEncoder$
 [EntityDecoder]: ../api/org/http4s/EntityDecoder$
 [MediaType]: ../api/org/http4s/MediaType$


### PR DESCRIPTION
Updated `EntityBody` to have the correct alias of ``Stream[F, Byte]` instead of `Stream[F, ByteVector]`

Updated links to the functional streams library and a youtube video on the topic.

closes https://github.com/http4s/http4s/issues/1505