### PR TITLE
Upgrade dependencies and plugins

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -265,7 +265,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.11.v20170118"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.0.37"
-  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.12.9"
+  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.12.10"
   lazy val catsEffectLaws                   = "org.typelevel"          %% "cats-effect-laws"          % "0.5"
   lazy val catsKernelLaws                   = "org.typelevel"          %% "cats-kernel-laws"          % catsLaws.revision
   lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % "1.0.0-RC1"
@@ -308,5 +308,5 @@ object Http4sPlugin extends AutoPlugin {
   lazy val specs2Scalacheck                 = "org.specs2"             %% "specs2-scalacheck"         % specs2Core.revision
   lazy val tomcatCatalina                   = "org.apache.tomcat"      %  "tomcat-catalina"           % "8.5.23"
   lazy val tomcatCoyote                     = "org.apache.tomcat"      %  "tomcat-coyote"             % tomcatCatalina.revision
-  lazy val twirlApi                         = "com.typesafe.play"      %% "twirl-api"                 % "1.3.12"
+  lazy val twirlApi                         = "com.typesafe.play"      %% "twirl-api"                 % "1.3.13"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,16 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.earldouglas"    %  "xsbt-web-plugin"       % "4.0.0")
+addSbtPlugin("com.earldouglas"    %  "xsbt-web-plugin"       % "4.0.1")
 addSbtPlugin("com.lucidchart"     %  "sbt-scalafmt-coursier" % "1.14")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("com.typesafe"       %  "sbt-mima-plugin"       % "0.1.14")
-addSbtPlugin("com.typesafe.sbt"   %  "sbt-native-packager"   % "1.2.2")
-addSbtPlugin("com.typesafe.sbt"   %  "sbt-twirl"             % "1.3.12")
+addSbtPlugin("com.typesafe"       %  "sbt-mima-plugin"       % "0.1.18")
+addSbtPlugin("com.typesafe.sbt"   %  "sbt-native-packager"   % "1.3.2")
+addSbtPlugin("com.typesafe.sbt"   %  "sbt-twirl"             % "1.3.13")
 addSbtPlugin("io.gatling"         %  "gatling-sbt"           % "2.2.2")
-addSbtPlugin("io.get-coursier"    %  "sbt-coursier"          % "1.0.0-RC11")
-addSbtPlugin("io.spray"           %  "sbt-revolver"          % "0.9.0")
+addSbtPlugin("io.get-coursier"    %  "sbt-coursier"          % "1.0.0-RC13")
+addSbtPlugin("io.spray"           %  "sbt-revolver"          % "0.9.1")
 addSbtPlugin("io.verizon.build"   %  "sbt-rig"               % "5.0.39")
+addSbtPlugin("org.tpolecat"       %  "tut-plugin"            % "0.6.1")
 addSbtPlugin("pl.project13.scala" %  "sbt-jmh"               % "0.2.27")
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"


### PR DESCRIPTION
Notable:
- blaze upgrade should resolve log4s warning reported by @coltfred and @tpolecat 
- coursier upgrade is Java 9 compatible, which may unblock #1462.