### PR TITLE
Unit tests for Transfer-Encoding

### DIFF
--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -388,6 +388,13 @@ trait ArbitraryInstances {
         headers.`Strict-Transport-Security`.unsafeFromDuration(age, includeSubDomains, preload)
     }
 
+  implicit val arbitraryTransferEncoding: Arbitrary[`Transfer-Encoding`] =
+    Arbitrary {
+      for {
+        codings <- arbitrary[NonEmptyList[TransferCoding]]
+      } yield `Transfer-Encoding`(codings)
+    }
+
   implicit val arbitraryRawHeader: Arbitrary[Header.Raw] =
     Arbitrary {
       for {

--- a/tests/src/test/scala/org/http4s/headers/TransferEncodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/TransferEncodingSpec.scala
@@ -1,0 +1,37 @@
+package org.http4s
+package headers
+
+import cats.data.NonEmptyList
+import org.scalacheck.Prop.forAll
+
+class TransferEncodingSpec extends HeaderLaws {
+  checkAll("TransferEncoding", headerLaws(`Transfer-Encoding`))
+
+  "render" should {
+    "include all the encodings" in {
+      `Transfer-Encoding`(TransferCoding.chunked).renderString must_== "Transfer-Encoding: chunked"
+      `Transfer-Encoding`(TransferCoding.chunked, TransferCoding.gzip).renderString must_== "Transfer-Encoding: chunked, gzip"
+    }
+  }
+
+  "parse" should {
+    "accept single codings" in {
+      `Transfer-Encoding`.parse("chunked").map(_.values) must beRight(
+        NonEmptyList.one(TransferCoding.chunked))
+    }
+    "accept multiple codings" in {
+      `Transfer-Encoding`.parse("chunked, gzip").map(_.values) must beRight(
+        NonEmptyList.of(TransferCoding.chunked, TransferCoding.gzip))
+      `Transfer-Encoding`.parse("chunked,gzip").map(_.values) must beRight(
+        NonEmptyList.of(TransferCoding.chunked, TransferCoding.gzip))
+    }
+  }
+
+  "hasChunked" should {
+    "detect chunked" in {
+      forAll { t: `Transfer-Encoding` =>
+        t.hasChunked must_== (t.values.contains(TransferCoding.chunked))
+      }
+    }
+  }
+}


### PR DESCRIPTION
For completeness and as a corollary of #1499 here are unit tests for `Transfer-Encoding`