### PR TITLE
update authentication docs to point to tsec-http4s

### DIFF
--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -4,6 +4,8 @@ weight: 120
 title: Authentication
 ---
 
+## Built in
+
 A [service] is a `Kleisli[F, Request, Response]`, the composable version of
 `Request[F] => F[Response[F]]`. A service with authentication also requires some kind of `User`
 object which identifies which user did the request. To store the `User` object
@@ -132,6 +134,12 @@ val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ request 
 })
 ```
 
+### Using tsec-http4s for Authentication and Authorization
+The [TSec] project provides an authentication and authorization module
+ for the http4s project 0.18-M4+. Docs specific to http4s are located [here].
+
 [service]: ../service
 [SPA]: https://en.wikipedia.org/wiki/Single-page_application
 [ADT]: http://typelevel.org/blog/2014/11/10/why_is_adt_pattern_matching_allowed.html
+[TSec]: https://jmcardon.github.io/tsec/
+[here]: https://jmcardon.github.io/tsec/docs/http4s-auth.html

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -136,10 +136,9 @@ val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ request 
 
 ### Using tsec-http4s for Authentication and Authorization
 The [TSec] project provides an authentication and authorization module
- for the http4s project 0.18-M4+. Docs specific to http4s are located [here].
+ for the http4s project 0.18-M4+. Docs specific to http4s are located [Here](https://jmcardon.github.io/tsec/docs/http4s-auth.html).
 
 [service]: ../service
 [SPA]: https://en.wikipedia.org/wiki/Single-page_application
 [ADT]: http://typelevel.org/blog/2014/11/10/why_is_adt_pattern_matching_allowed.html
 [TSec]: https://jmcardon.github.io/tsec/
-[here]: https://jmcardon.github.io/tsec/docs/http4s-auth.html

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -6,13 +6,13 @@ title: Authentication
 
 ## Built in
 
-A [service] is a `Kleisli[F, Request, Response]`, the composable version of
-`Request[F] => F[Response[F]]`. A service with authentication also requires some kind of `User`
-object which identifies which user did the request. To store the `User` object
-along with the `Request`, there's `AuthedRequest[F, User]`, which is equivalent to
+A [service] is a `Kleisli[OptionT[F, ?], Request[F], Response[F]]`, the composable version of
+`Request[F] => OptionT[F, Response[F]]`. A service with authentication also requires some kind of `User`
+object which identifies which user did the request. To reference the `User` object
+along with the `Request[F]`, there's `AuthedRequest[F, User]`, which is equivalent to
 `(User, Request[F])`. So the service has the signature `AuthedRequest[F, User] =>
-F[Response[F]]`, or `AuthedService[User, F]`. So we'll need a `Request[F] => User`
-function, or more likely, a `Request[F] => F[User]`, because the `User` will
+OptionT[F, Response[F]]`, or `AuthedService[User, F]`. So we'll need a `Request[F] => Option[User]`
+function, or more likely, a `Request[F] => OptionT[F, User]`, because the `User` can
 come from a database. We can convert that into an `AuthMiddleware` and apply it.
 Or in code, using `cats.effect.IO` as the effect type:
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -5,7 +5,8 @@ weight: 1
 ---
 
 **Note**: To run examples, please make sure that the flag `-Ypartial-unification`  
-is enabled in your compiler options (i.e `scalacOptions += "-Ypartial-unification"` in sbt.)
+is enabled in your compiler options (i.e `scalacOptions += "-Ypartial-unification"` in sbt).
+This is enabled by default in the giter8 template.
 
 
 Getting started with http4s is easy.  Let's materialize an http4s

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -4,6 +4,10 @@ menu: main
 weight: 1
 ---
 
+**Note**: To run examples, please make sure that the flag `-Ypartial-unification`  
+is enabled in your compiler options (i.e `scalacOptions += "-Ypartial-unification"` in sbt.)
+
+
 Getting started with http4s is easy.  Let's materialize an http4s
 skeleton project from its [giter8 template]:
 


### PR DESCRIPTION
I wasn't sure whether tsec-auth should be at the top, or at the bottom, so I put it at the bottom by default.

If you guys feel tsec-http4s is good, we can move it accordingly so it's easier to see.