### PR TITLE
fix auth response handling

### DIFF
--- a/core/src/main/scala/org/http4s/AuthedService.scala
+++ b/core/src/main/scala/org/http4s/AuthedService.scala
@@ -20,8 +20,10 @@ object AuthedService {
     */
   def apply[T, F[_]](pf: PartialFunction[AuthedRequest[F, T], F[Response[F]]])(
       implicit F: Applicative[F]): AuthedService[T, F] =
-    Kleisli(req => pf.andThen(OptionT.liftF(_))
-      .applyOrElse(req, Function.const(OptionT.pure(Response[F](Status.Unauthorized)))))
+    Kleisli(
+      req =>
+        pf.andThen(OptionT.liftF(_))
+          .applyOrElse(req, Function.const(OptionT.pure(Response[F](Status.Unauthorized)))))
 
   /**
     * The empty service (all requests fallthrough).

--- a/core/src/main/scala/org/http4s/AuthedService.scala
+++ b/core/src/main/scala/org/http4s/AuthedService.scala
@@ -20,7 +20,8 @@ object AuthedService {
     */
   def apply[T, F[_]](pf: PartialFunction[AuthedRequest[F, T], F[Response[F]]])(
       implicit F: Applicative[F]): AuthedService[T, F] =
-    Kleisli(req => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none)))
+    Kleisli(req => pf.andThen(OptionT.liftF(_))
+      .applyOrElse(req, Function.const(OptionT.pure(Response[F](Status.Unauthorized)))))
 
   /**
     * The empty service (all requests fallthrough).

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
@@ -74,7 +74,7 @@ class AuthMiddlewareSpec extends Http4sSpec {
       val service = middleWare(authedService)
 
       service.orNotFound(Request[IO](method = Method.POST)) must returnStatus(Ok)
-      service.orNotFound(Request[IO](method = Method.GET)) must returnStatus(NotFound)
+      service.orNotFound(Request[IO](method = Method.GET)) must returnStatus(Unauthorized)
     }
   }
 


### PR DESCRIPTION
On gitter, @aeons mentioned how `AuthedService` should consume anything it doesn't handle into a `401` unauthorized, to potentially avoid information leaks.

I actually agree with this statement. Currently, for a non-match, it will simply return `notFound`.

This PR addresses this example:

```scala
import cats.Applicative
import cats.data.{Kleisli, OptionT}
import org.http4s._
import org.http4s.dsl.io._
import cats.effect.IO
import org.http4s.implicits._
import org.http4s.server.AuthMiddleware

case class User(id: Int)

val authedService: AuthedService[User, IO] = AuthedService[User, IO] {
  case GET -> Root / "asd" as user =>
    Ok()
}

val middleware: AuthMiddleware[IO, User] =
  AuthMiddleware[IO, User](Kleisli(_ => OptionT.pure(User(123))))

//Following this pr, the following would return `Unauthorized`. Currently, this returns 404.
val service = middleware(authedService).orNotFound(Request[IO]()).unsafeRunSync()
```
