### PR TITLE
Remove duplication of QValue parsers

### DIFF
--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -15,7 +15,7 @@ import scala.reflect.macros.whitebox.Context
   * @param thousandths between 0 (for q=0) and 1000 (for q=1)
   * @see [[http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.9 RFC 2616, Section 3.9]]
   */
-final class QValue private[QValue] (val thousandths: Int) extends AnyVal with Ordered[QValue] {
+final class QValue private (val thousandths: Int) extends AnyVal with Ordered[QValue] {
   def toDouble: Double = 0.001 * thousandths
 
   def isAcceptable: Boolean = thousandths > 0

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -2,7 +2,9 @@ package org.http4s
 
 import cats._
 import macrocompat.bundle
-import org.http4s.util.{Renderable, Writer}
+import org.http4s.internal.parboiled2.{Parser => PbParser}
+import org.http4s.util.Writer
+import org.http4s.parser.{AdditionalRules, Http4sParser}
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox.Context
 
@@ -13,10 +15,7 @@ import scala.reflect.macros.whitebox.Context
   * @param thousandths between 0 (for q=0) and 1000 (for q=1)
   * @see [[http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.9 RFC 2616, Section 3.9]]
   */
-final class QValue private[QValue] (val thousandths: Int)
-    extends AnyVal
-    with Ordered[QValue]
-    with Renderable {
+final class QValue private[QValue] (val thousandths: Int) extends AnyVal with Ordered[QValue] {
   def toDouble: Double = 0.001 * thousandths
 
   def isAcceptable: Boolean = thousandths > 0
@@ -81,6 +80,17 @@ object QValue extends QValueInstances with QValueFunctions {
       case _: NumberFormatException => ParseResult.fail("Invalid q-value", s"${s} is not a number")
     }
 
+  def parse(s: String): ParseResult[QValue] =
+    new Http4sParser[QValue](s, "Invalid q-value") with QValueParser {
+      def main = QualityValue
+    }.parse
+
+  private[http4s] trait QValueParser extends AdditionalRules { self: PbParser =>
+    def QualityValue = rule { // QValue is already taken
+      ";" ~ OptWS ~ "q" ~ "=" ~ QValue | push(org.http4s.QValue.One)
+    }
+  }
+
   /** Exists to support compile-time verified literals. Do not call directly. */
   def ☠(thousandths: Int): QValue = new QValue(thousandths)
 
@@ -106,6 +116,10 @@ object QValue extends QValueInstances with QValueFunctions {
 trait QValueInstances {
   implicit val qValueOrder = Order.fromOrdering[QValue]
   implicit val qValueShow = Show.fromToString[QValue]
+  implicit val qValueHttpCodec = new HttpCodec[QValue] {
+    def parse(s: String): ParseResult[QValue] = QValue.parse(s)
+    def render(writer: Writer, q: QValue): writer.type = q.render(writer)
+  }
 }
 
 trait QValueFunctions {

--- a/core/src/main/scala/org/http4s/parser/AcceptLanguageHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/AcceptLanguageHeader.scala
@@ -19,6 +19,7 @@ package org.http4s
 package parser
 
 import org.http4s.internal.parboiled2._
+import org.http4s.QValue.QValueParser
 
 private[parser] trait AcceptLanguageHeader {
 
@@ -27,7 +28,8 @@ private[parser] trait AcceptLanguageHeader {
 
   private class AcceptLanguageParser(value: String)
       extends Http4sHeaderParser[headers.`Accept-Language`](value)
-      with MediaParser {
+      with MediaParser
+      with QValueParser {
     def entry: Rule1[headers.`Accept-Language`] = rule {
       oneOrMore(languageTag).separatedBy(ListSep) ~> { tags: Seq[LanguageTag] =>
         headers.`Accept-Language`(tags.head, tags.tail: _*)
@@ -35,14 +37,10 @@ private[parser] trait AcceptLanguageHeader {
     }
 
     def languageTag: Rule1[LanguageTag] = rule {
-      capture(oneOrMore(Alpha)) ~ zeroOrMore("-" ~ Token) ~ TagQuality ~> {
+      capture(oneOrMore(Alpha)) ~ zeroOrMore("-" ~ Token) ~ QualityValue ~> {
         (main: String, sub: Seq[String], q: QValue) =>
           LanguageTag(main, q, sub)
       }
-    }
-
-    def TagQuality: Rule1[QValue] = rule {
-      (";" ~ OptWS ~ "q" ~ "=" ~ QValue) | push(org.http4s.QValue.One)
     }
 
   }

--- a/tests/src/test/scala/org/http4s/QValueSpec.scala
+++ b/tests/src/test/scala/org/http4s/QValueSpec.scala
@@ -7,8 +7,8 @@ import org.http4s.testing.HttpCodecTests
 class QValueSpec extends Http4sSpec {
   import QValue._
 
-  checkAll("QValue", OrderTests[QValue].order)
-  checkAll("HttpCodec", HttpCodecTests[QValue].httpCodec)
+  checkAll("Order[QValue]", OrderTests[QValue].order)
+  checkAll("HttpCodec[QValue]", HttpCodecTests[QValue].httpCodec)
 
   "sort by descending q-value" in {
     prop { (x: QValue, y: QValue) =>

--- a/tests/src/test/scala/org/http4s/QValueSpec.scala
+++ b/tests/src/test/scala/org/http4s/QValueSpec.scala
@@ -2,11 +2,13 @@ package org.http4s
 
 import cats.implicits._
 import cats.kernel.laws.discipline.OrderTests
+import org.http4s.testing.HttpCodecTests
 
 class QValueSpec extends Http4sSpec {
   import QValue._
 
   checkAll("QValue", OrderTests[QValue].order)
+  checkAll("HttpCodec", HttpCodecTests[QValue].httpCodec)
 
   "sort by descending q-value" in {
     prop { (x: QValue, y: QValue) =>


### PR DESCRIPTION
I noted several instances of parsers for `QValue`. This PR removes that duplication and adds a `QValueParser`

It also adds an instance of `HttpCodec[QValue]`

Let me know what you think. It may make the header's parsers a bit less readable