### PR TITLE
authmiddleware to consume the entire request

### DIFF
--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
@@ -84,7 +84,6 @@ class AuthMiddlewareSpec extends Http4sSpec {
       val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] =
         Kleisli.pure(userId)
 
-
       val authedService: AuthedService[User, IO] =
         AuthedService {
           case POST -> Root as _ => Ok()
@@ -101,7 +100,6 @@ class AuthMiddlewareSpec extends Http4sSpec {
     "return 401 for a matched, but unauthenticated route" in {
       val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] =
         Kleisli.lift(OptionT.none)
-
 
       val authedService: AuthedService[User, IO] =
         AuthedService {
@@ -122,7 +120,6 @@ class AuthMiddlewareSpec extends Http4sSpec {
       val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] =
         Kleisli.pure(userId)
 
-
       val authedService1: AuthedService[User, IO] =
         AuthedService {
           case POST -> Root as _ => Ok()
@@ -132,7 +129,6 @@ class AuthMiddlewareSpec extends Http4sSpec {
         AuthedService {
           case GET -> Root as _ => Ok()
         }
-
 
       val middleware = AuthMiddleware(authUser)
 
@@ -145,7 +141,6 @@ class AuthMiddlewareSpec extends Http4sSpec {
     "consume the entire request for an unauthenticated route for service composition" in {
       val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] =
         Kleisli.lift(OptionT.none)
-
 
       val authedService: AuthedService[User, IO] =
         AuthedService {
@@ -160,10 +155,11 @@ class AuthMiddlewareSpec extends Http4sSpec {
 
       val service = middleware(authedService)
 
-      (service <+> regularService).orNotFound(Request[IO](method = Method.POST)) must returnStatus(Unauthorized)
-      (service <+> regularService).orNotFound(Request[IO](method = Method.GET)) must returnStatus(Unauthorized)
+      (service <+> regularService).orNotFound(Request[IO](method = Method.POST)) must returnStatus(
+        Unauthorized)
+      (service <+> regularService).orNotFound(Request[IO](method = Method.GET)) must returnStatus(
+        Unauthorized)
     }
-
 
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
@@ -5,6 +5,7 @@ import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.server.AuthMiddleware
+import cats.syntax.semigroupk._
 
 class AuthMiddlewareSpec extends Http4sSpec {
 
@@ -76,6 +77,94 @@ class AuthMiddlewareSpec extends Http4sSpec {
       service.orNotFound(Request[IO](method = Method.POST)) must returnStatus(Ok)
       service.orNotFound(Request[IO](method = Method.GET)) must returnStatus(NotFound)
     }
+
+    "return 404 for an unmatched but authenticated route" in {
+      val userId: User = 42
+
+      val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] =
+        Kleisli.pure(userId)
+
+
+      val authedService: AuthedService[User, IO] =
+        AuthedService {
+          case POST -> Root as _ => Ok()
+        }
+
+      val middleware = AuthMiddleware(authUser)
+
+      val service = middleware(authedService)
+
+      service.orNotFound(Request[IO](method = Method.POST)) must returnStatus(Ok)
+      service.orNotFound(Request[IO](method = Method.GET)) must returnStatus(NotFound)
+    }
+
+    "return 401 for a matched, but unauthenticated route" in {
+      val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] =
+        Kleisli.lift(OptionT.none)
+
+
+      val authedService: AuthedService[User, IO] =
+        AuthedService {
+          case POST -> Root as _ => Ok()
+        }
+
+      val middleware = AuthMiddleware(authUser)
+
+      val service = middleware(authedService)
+
+      service.orNotFound(Request[IO](method = Method.POST)) must returnStatus(Unauthorized)
+      service.orNotFound(Request[IO](method = Method.GET)) must returnStatus(Unauthorized)
+    }
+
+    "compose authedServices and not fall through" in {
+      val userId: User = 42
+
+      val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] =
+        Kleisli.pure(userId)
+
+
+      val authedService1: AuthedService[User, IO] =
+        AuthedService {
+          case POST -> Root as _ => Ok()
+        }
+
+      val authedService2: AuthedService[User, IO] =
+        AuthedService {
+          case GET -> Root as _ => Ok()
+        }
+
+
+      val middleware = AuthMiddleware(authUser)
+
+      val service = middleware(authedService1 <+> authedService2)
+
+      service.orNotFound(Request[IO](method = Method.GET)) must returnStatus(Ok)
+      service.orNotFound(Request[IO](method = Method.POST)) must returnStatus(Ok)
+    }
+
+    "consume the entire request for an unauthenticated route for service composition" in {
+      val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] =
+        Kleisli.lift(OptionT.none)
+
+
+      val authedService: AuthedService[User, IO] =
+        AuthedService {
+          case POST -> Root as _ => Ok()
+        }
+
+      val regularService: HttpService[IO] = HttpService[IO] {
+        case GET -> Root => Ok()
+      }
+
+      val middleware = AuthMiddleware(authUser)
+
+      val service = middleware(authedService)
+
+      (service <+> regularService).orNotFound(Request[IO](method = Method.POST)) must returnStatus(Unauthorized)
+      (service <+> regularService).orNotFound(Request[IO](method = Method.GET)) must returnStatus(Unauthorized)
+    }
+
+
   }
 
 }


### PR DESCRIPTION
This pr aims to address this issue
```scala
import cats._
import cats.data._
import org.http4s._
import org.http4s.dsl.io._
import cats.effect.IO
import cats.implicits._
import org.http4s.implicits._
import org.http4s.server.AuthMiddleware

case class User(id: Int)

val authedService: AuthedService[User, IO] = AuthedService[User, IO] {
  case GET -> Root / "asd" as user =>
    Ok()
}

val middleware: AuthMiddleware[IO, User] =
  AuthMiddleware[IO, User](Kleisli(_ => OptionT.none))

val service1 = middleware(authedService)

val service2: HttpService[IO] = HttpService[IO] {
  case GET -> Root =>
    Ok()
}


(middleware(authedService) <+> service2).orNotFound(Request[IO]()).unsafeRunSync()
```
For security reasons, going through an `AuthMiddleware` should consume an entire request: i.e, it should never fall through to the other service. This _should_ return 404, but it currently returns ok.

This pr adjusts that behavior in the following manner:
* If the user is authenticated, but the route is unmatched, the request will fall through to not found
* if the user is not authenticated, it will be  `Unauthorized`
* service composition with `<+>` for authmiddleware'd service will never reach any service composed 
to the right of the authed service