### PR TITLE
CSRF middleware backport - 0.16.x

### DIFF
--- a/core/src/main/scala/org/http4s/util/NonEmptyList.scala
+++ b/core/src/main/scala/org/http4s/util/NonEmptyList.scala
@@ -170,6 +170,13 @@ final class NonEmptyList[+A] private[util] (val head: A, val tail: List[A]) {
 
   def length: Int =
     1 + tail.length
+
+  def find(p: A => Boolean): Option[A] =
+    if (p(head)) {
+      Some(head)
+    } else {
+      tail.find(p)
+    }
 }
 
 object NonEmptyList extends NonEmptyListInstances with NonEmptyListFunctions {

--- a/core/src/main/scala/org/http4s/util/package.scala
+++ b/core/src/main/scala/org/http4s/util/package.scala
@@ -56,6 +56,31 @@ package object util {
     breakBigChunks() pipe go() onComplete flush()
   }
 
+  /** Hex encoding digits. Adapted from apache commons Hex.encodeHex **/
+  private val Digits: Array[Char] = Array('0', '1', '2', '3', '4', '5', '6',
+    '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
+
+  /** Encode a string to a Hexadecimal string representation
+    * Adapted from apache commons Hex.encodeHex
+    */
+  def encodeHex(data: Array[Byte]): Array[Char] = {
+    val l = data.length
+    val out = new Array[Char](l << 1)
+    // two characters form the hex value.
+    var i = 0
+    var j = 0
+    while (i < l) {
+      out(j) = Digits((0xF0 & data(i)) >>> 4)
+      j += 1
+      out(j) = Digits(0x0F & data(i))
+      j += 1
+      i += 1
+    }
+    out
+  }
+
+
+
   /** Constructs an assertion error with a reference back to our issue tracker. Use only with head hung low. */
   def bug(message: String): AssertionError =
     new AssertionError(s"This is a bug. Please report to https://github.com/http4s/http4s/issues: ${message}")

--- a/server/src/main/scala/org/http4s/server/middleware/CSRFMiddleware.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRFMiddleware.scala
@@ -3,56 +3,57 @@ package org.http4s.server.middleware
 import java.nio.charset.StandardCharsets
 import java.security.{MessageDigest, SecureRandom}
 import java.time.Clock
-import javax.crypto.{KeyGenerator, Mac, SecretKey}
-import javax.crypto.spec.SecretKeySpec
 import java.util.Base64
+import javax.crypto.spec.SecretKeySpec
+import javax.crypto.{KeyGenerator, Mac, SecretKey}
 
-import org.http4s.{MaybeResponse, Request, Response, Status, Cookie}
-import org.http4s.server.Middleware
 import org.http4s.headers.{Cookie => HCookie}
-import org.http4s.util.{CaseInsensitiveString, NonEmptyList}
+import org.http4s.server.Middleware
+import org.http4s.util.{CaseInsensitiveString, encodeHex}
+import org.http4s._
 
-import scalaz.{Kleisli, OptionT}
 import scalaz.concurrent.Task
 import scalaz.syntax.std.boolean._
+import scalaz.{Kleisli, OptionT}
 
-case class CSRFMiddleware(config: CSRFConfiguration,
-  clock: Clock = Clock.systemUTC()) {
+final class CSRFMiddleware private[middleware] (
+    val headerName: String = "X-Csrf-Token",
+    val cookieName: String = "csrf-token",
+    key: SecretKey,
+    clock: Clock = Clock.systemUTC()) {
 
   /** Sign our token using the current time in milliseconds as a nonce
     * Signing and generating a token is potentially a unsafe operation
     * if constructed with a bad key.
     */
-  protected[middleware] def signToken(token: String): Task[String] = {
+  private[middleware] def signToken(token: String): Task[String] = {
     val joined = token + "-" + clock.millis()
-    for {
-      instance <- Task.delay(Mac.getInstance(CSRFMiddleware.SigningAlgo))
-      _ <- Task.delay(instance.init(config.key))
-      out <- Task.delay(instance.doFinal(joined.getBytes("UTF-8")))
-    } yield joined + "-" + Base64.getEncoder.encodeToString(out)
+    Task.delay {
+      val mac = Mac.getInstance(CSRFMiddleware.SigningAlgo)
+      mac.init(key)
+      val out = mac.doFinal(joined.getBytes(StandardCharsets.UTF_8))
+      joined + "-" + Base64.getEncoder.encodeToString(out)
+    }
   }
 
   /** Generate a new token **/
-  protected[middleware] def generateToken: Task[String] =
+  private[middleware] def generateToken: Task[String] =
     signToken(CSRFMiddleware.genTokenString)
 
   /** Decode our CSRF token and extract the original token string to sign
     */
-  protected[middleware] def extractRaw(token: String): OptionT[Task, String] =
+  private[middleware] def extractRaw(token: String): OptionT[Task, String] =
     token.split("-") match {
       case Array(raw, nonce, signed) =>
-        val res = for {
-          instance <- Task.delay(Mac.getInstance(CSRFMiddleware.SigningAlgo))
-          _ <- Task.delay(instance.init(config.key))
-          out <- Task.delay(
-            instance.doFinal(
-              (raw + "-" + nonce).getBytes(StandardCharsets.UTF_8)))
-          r <- Task.point(
-            MessageDigest
-              .isEqual(out, Base64.getDecoder.decode(signed))
-              .option(raw))
-        } yield r
-        OptionT(res)
+        OptionT[Task, String](Task.delay {
+          val mac = Mac.getInstance(CSRFMiddleware.SigningAlgo)
+          mac.init(key)
+          val out =
+            mac.doFinal((raw + "-" + nonce).getBytes(StandardCharsets.UTF_8))
+          MessageDigest
+            .isEqual(out, Base64.getDecoder.decode(signed))
+            .option(raw)
+        })
       case _ =>
         OptionT.none
     }
@@ -70,9 +71,9 @@ case class CSRFMiddleware(config: CSRFConfiguration,
     service =>
       Kleisli[Task, Request, MaybeResponse] { r =>
         (for {
-          c1 <- CSRFMiddleware.cookieFromHeaders(r, config.cookieName)
+          c1 <- CSRFMiddleware.cookieFromHeaders(r, cookieName)
           c2 <- OptionT(
-            Task.point(r.headers.get(CaseInsensitiveString(config.headerName))))
+            Task.point(r.headers.get(CaseInsensitiveString(headerName))))
           raw1 <- extractRaw(c1.content)
           raw2 <- extractRaw(c2.value)
           response <- if (CSRFMiddleware.isEqual(raw1, raw2)) {
@@ -82,9 +83,8 @@ case class CSRFMiddleware(config: CSRFConfiguration,
           }
           newToken <- OptionT[Task, String](signToken(raw1).map(Some(_)))
         } yield
-          response.cata(
-            _.addCookie(Cookie(config.cookieName, newToken)),
-            Response(Status.NotFound)))
+          response.cata(_.addCookie(Cookie(cookieName, newToken)),
+                        Response(Status.NotFound)))
           .getOrElse(Response(Status.Unauthorized))
       }
   }
@@ -93,8 +93,8 @@ case class CSRFMiddleware(config: CSRFConfiguration,
   def embedNew(res: MaybeResponse): Task[Response] =
     generateToken.map(
       content =>
-        res.cata(_.addCookie(Cookie(config.cookieName, content)),
-          Response(Status.NotFound)))
+        res.cata(_.addCookie(Cookie(cookieName, content)),
+                 Response(Status.NotFound)))
 
   /** Middleware to embed a csrf token into routes that do not have one. **/
   def withNewToken: Middleware[Request, MaybeResponse, Request, MaybeResponse] =
@@ -104,11 +104,31 @@ case class CSRFMiddleware(config: CSRFConfiguration,
 
 object CSRFMiddleware {
 
+  /** Default method for constructing CSRF middleware **/
+  def apply(headerName: String = "X-Csrf-Token",
+            cookieName: String = "csrf-token",
+            key: SecretKey,
+            clock: Clock = Clock.systemUTC()): CSRFMiddleware =
+    new CSRFMiddleware(headerName, cookieName, key, clock)
+
+  /** Sugar for instantiating a middleware by generating a key **/
+  def withGeneratedKey(headerName: String = "X-Csrf-Token",
+                       cookieName: String = "csrf-token",
+                       clock: Clock = Clock.systemUTC()): Task[CSRFMiddleware] =
+    generateSigningKey().map(apply(headerName, cookieName, _, clock))
+
+  /** Sugar for pre-loading a key **/
+  def withKeyBytes(keyBytes: Array[Byte],
+                   headerName: String = "X-Csrf-Token",
+                   cookieName: String = "csrf-token",
+                   clock: Clock = Clock.systemUTC()): Task[CSRFMiddleware] =
+    buildSigningKey(keyBytes).map(apply(headerName, cookieName, _, clock))
+
   /** An instance of SecureRandom to generate
     * tokens, properly seeded:
     * https://tersesystems.com/blog/2015/12/17/the-right-way-to-use-securerandom/
     */
-  private lazy val CachedRandom = {
+  private val CachedRandom = {
     val r = new SecureRandom()
     r.nextBytes(new Array[Byte](20))
     r
@@ -118,58 +138,30 @@ object CSRFMiddleware {
   val SHA1ByteLen = 20
   val CSRFTokenLength = 32
 
-  /** Hex encoding digits. Adapted from apache commons Hex.encodeHex **/
-  private val Digits: Array[Char] = Array('0', '1', '2', '3', '4', '5', '6',
-    '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
-
-  protected def find[A](nel: NonEmptyList[A], p: A => Boolean): Option[A] =
-    if (p(nel.head)) {
-      Some(nel.head)
-    } else {
-      nel.tail.find(p)
-    }
-
-  protected def cookieFromHeaders(request: Request,
-    headerName: String): OptionT[Task, Cookie] =
+  private[middleware] def cookieFromHeaders(
+      request: Request,
+      headerName: String): OptionT[Task, Cookie] =
     OptionT(
-      Task.point(HCookie
-        .from(request.headers)
-        .flatMap(v => CSRFMiddleware.find[Cookie](v.values, _.name == headerName))))
+      Task.point(
+        HCookie
+          .from(request.headers)
+          .flatMap(_.values.find(_.name == headerName))))
 
   /** A Constant-time string equality **/
   def isEqual(s1: String, s2: String): Boolean =
     MessageDigest.isEqual(s1.getBytes(StandardCharsets.UTF_8),
-      s2.getBytes(StandardCharsets.UTF_8))
-
-  /** Encode a string to a Hexadecimal string representation
-    * Adapted from apache commons Hex.encodeHex
-    */
-  protected def encodeHex(data: Array[Byte]): Array[Char] = {
-    val l = data.length
-    val out = new Array[Char](l << 1)
-    // two characters form the hex value.
-    var i = 0
-    var j = 0
-    while (i < l) {
-      out(j) = Digits((0xF0 & data(i)) >>> 4)
-      j += 1
-      out(j) = Digits(0x0F & data(i))
-      j += 1
-      i += 1
-    }
-    out
-  }
+                          s2.getBytes(StandardCharsets.UTF_8))
 
   /** Generate an unsigned CSRF token from a `SecureRandom` **/
-  protected def genTokenString: String = {
+  private[middleware] def genTokenString: String = {
     val bytes = new Array[Byte](CSRFTokenLength)
     CachedRandom.nextBytes(bytes)
     new String(encodeHex(bytes))
   }
 
   /** Generate a signing Key for the CSRF token **/
-  def generateSigningKey(): SecretKey =
-    KeyGenerator.getInstance(SigningAlgo).generateKey()
+  def generateSigningKey(): Task[SecretKey] =
+    Task.delay(KeyGenerator.getInstance(SigningAlgo).generateKey())
 
   /** Build a new HMACSHA1 Key for our CSRF Middleware
     * from key bytes. This operation is unsafe, in that
@@ -183,14 +175,4 @@ object CSRFMiddleware {
   def buildSigningKey(array: Array[Byte]): Task[SecretKey] =
     Task.delay(new SecretKeySpec(array.slice(0, SHA1ByteLen), SigningAlgo))
 
-  def unsafeBuildSigningKey(array: Array[Byte]): SecretKey =
-    new SecretKeySpec(array, SigningAlgo)
-
 }
-
-/** A basic CSRF configuration class **/
-case class CSRFConfiguration(
-  headerName: String = "X-Csrf-Token",
-  cookieName: String = "csrf-token",
-  key: SecretKey
-)

--- a/server/src/main/scala/org/http4s/server/middleware/CSRFMiddleware.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRFMiddleware.scala
@@ -73,7 +73,7 @@ final class CSRFMiddleware private[middleware] (
         (for {
           c1 <- CSRFMiddleware.cookieFromHeaders(r, cookieName)
           c2 <- OptionT(
-            Task.point(r.headers.get(CaseInsensitiveString(headerName))))
+            Task.now(r.headers.get(CaseInsensitiveString(headerName))))
           raw1 <- extractRaw(c1.content)
           raw2 <- extractRaw(c2.value)
           response <- if (CSRFMiddleware.isEqual(raw1, raw2)) {
@@ -142,7 +142,7 @@ object CSRFMiddleware {
       request: Request,
       headerName: String): OptionT[Task, Cookie] =
     OptionT(
-      Task.point(
+      Task.now(
         HCookie
           .from(request.headers)
           .flatMap(_.values.find(_.name == headerName))))

--- a/server/src/main/scala/org/http4s/server/middleware/CSRFMiddleware.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRFMiddleware.scala
@@ -1,0 +1,196 @@
+package org.http4s.server.middleware
+
+import java.nio.charset.StandardCharsets
+import java.security.{MessageDigest, SecureRandom}
+import java.time.Clock
+import javax.crypto.{KeyGenerator, Mac, SecretKey}
+import javax.crypto.spec.SecretKeySpec
+import java.util.Base64
+
+import org.http4s.{MaybeResponse, Request, Response, Status, Cookie}
+import org.http4s.server.Middleware
+import org.http4s.headers.{Cookie => HCookie}
+import org.http4s.util.{CaseInsensitiveString, NonEmptyList}
+
+import scalaz.{Kleisli, OptionT}
+import scalaz.concurrent.Task
+import scalaz.syntax.std.boolean._
+
+case class CSRFMiddleware(config: CSRFConfiguration,
+  clock: Clock = Clock.systemUTC()) {
+
+  /** Sign our token using the current time in milliseconds as a nonce
+    * Signing and generating a token is potentially a unsafe operation
+    * if constructed with a bad key.
+    */
+  protected[middleware] def signToken(token: String): Task[String] = {
+    val joined = token + "-" + clock.millis()
+    for {
+      instance <- Task.delay(Mac.getInstance(CSRFMiddleware.SigningAlgo))
+      _ <- Task.delay(instance.init(config.key))
+      out <- Task.delay(instance.doFinal(joined.getBytes("UTF-8")))
+    } yield joined + "-" + Base64.getEncoder.encodeToString(out)
+  }
+
+  /** Generate a new token **/
+  protected[middleware] def generateToken: Task[String] =
+    signToken(CSRFMiddleware.genTokenString)
+
+  /** Decode our CSRF token and extract the original token string to sign
+    */
+  protected[middleware] def extractRaw(token: String): OptionT[Task, String] =
+    token.split("-") match {
+      case Array(raw, nonce, signed) =>
+        val res = for {
+          instance <- Task.delay(Mac.getInstance(CSRFMiddleware.SigningAlgo))
+          _ <- Task.delay(instance.init(config.key))
+          out <- Task.delay(
+            instance.doFinal(
+              (raw + "-" + nonce).getBytes(StandardCharsets.UTF_8)))
+          r <- Task.point(
+            MessageDigest
+              .isEqual(out, Base64.getDecoder.decode(signed))
+              .option(raw))
+        } yield r
+        OptionT(res)
+      case _ =>
+        OptionT.none
+    }
+
+  /** Constructs a middleware that will check for the csrf token
+    * presence on both the proper cookie, and header values.
+    *
+    * If it is a valid token, it will then embed a new one,
+    * to effectively randomize the complete token while
+    * avoiding the generation of a new secure random Id, to guard
+    * against [BREACH](http://breachattack.com/)
+    *
+    */
+  def validate: Middleware[Request, MaybeResponse, Request, MaybeResponse] = {
+    service =>
+      Kleisli[Task, Request, MaybeResponse] { r =>
+        (for {
+          c1 <- CSRFMiddleware.cookieFromHeaders(r, config.cookieName)
+          c2 <- OptionT(
+            Task.point(r.headers.get(CaseInsensitiveString(config.headerName))))
+          raw1 <- extractRaw(c1.content)
+          raw2 <- extractRaw(c2.value)
+          response <- if (CSRFMiddleware.isEqual(raw1, raw2)) {
+            OptionT[Task, MaybeResponse](service(r).map(Some(_)))
+          } else {
+            OptionT.none[Task, MaybeResponse]
+          }
+          newToken <- OptionT[Task, String](signToken(raw1).map(Some(_)))
+        } yield
+          response.cata(
+            _.addCookie(Cookie(config.cookieName, newToken)),
+            Response(Status.NotFound)))
+          .getOrElse(Response(Status.Unauthorized))
+      }
+  }
+
+  /** Embed a token into a response **/
+  def embedNew(res: MaybeResponse): Task[Response] =
+    generateToken.map(
+      content =>
+        res.cata(_.addCookie(Cookie(config.cookieName, content)),
+          Response(Status.NotFound)))
+
+  /** Middleware to embed a csrf token into routes that do not have one. **/
+  def withNewToken: Middleware[Request, MaybeResponse, Request, MaybeResponse] =
+    _.andThen(Kleisli(embedNew))
+
+}
+
+object CSRFMiddleware {
+
+  /** An instance of SecureRandom to generate
+    * tokens, properly seeded:
+    * https://tersesystems.com/blog/2015/12/17/the-right-way-to-use-securerandom/
+    */
+  private lazy val CachedRandom = {
+    val r = new SecureRandom()
+    r.nextBytes(new Array[Byte](20))
+    r
+  }
+
+  val SigningAlgo = "HmacSHA1"
+  val SHA1ByteLen = 20
+  val CSRFTokenLength = 32
+
+  /** Hex encoding digits. Adapted from apache commons Hex.encodeHex **/
+  private val Digits: Array[Char] = Array('0', '1', '2', '3', '4', '5', '6',
+    '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
+
+  protected def find[A](nel: NonEmptyList[A], p: A => Boolean): Option[A] =
+    if (p(nel.head)) {
+      Some(nel.head)
+    } else {
+      nel.tail.find(p)
+    }
+
+  protected def cookieFromHeaders(request: Request,
+    headerName: String): OptionT[Task, Cookie] =
+    OptionT(
+      Task.point(HCookie
+        .from(request.headers)
+        .flatMap(v => CSRFMiddleware.find[Cookie](v.values, _.name == headerName))))
+
+  /** A Constant-time string equality **/
+  def isEqual(s1: String, s2: String): Boolean =
+    MessageDigest.isEqual(s1.getBytes(StandardCharsets.UTF_8),
+      s2.getBytes(StandardCharsets.UTF_8))
+
+  /** Encode a string to a Hexadecimal string representation
+    * Adapted from apache commons Hex.encodeHex
+    */
+  protected def encodeHex(data: Array[Byte]): Array[Char] = {
+    val l = data.length
+    val out = new Array[Char](l << 1)
+    // two characters form the hex value.
+    var i = 0
+    var j = 0
+    while (i < l) {
+      out(j) = Digits((0xF0 & data(i)) >>> 4)
+      j += 1
+      out(j) = Digits(0x0F & data(i))
+      j += 1
+      i += 1
+    }
+    out
+  }
+
+  /** Generate an unsigned CSRF token from a `SecureRandom` **/
+  protected def genTokenString: String = {
+    val bytes = new Array[Byte](CSRFTokenLength)
+    CachedRandom.nextBytes(bytes)
+    new String(encodeHex(bytes))
+  }
+
+  /** Generate a signing Key for the CSRF token **/
+  def generateSigningKey(): SecretKey =
+    KeyGenerator.getInstance(SigningAlgo).generateKey()
+
+  /** Build a new HMACSHA1 Key for our CSRF Middleware
+    * from key bytes. This operation is unsafe, in that
+    * any amount less than 20 bytes will throw an exception when loaded
+    * into `Mac`, and any value above will be truncated (not good for entropy).
+    *
+    * Use for loading a key from a config file, after having generated
+    * one safely
+    *
+    */
+  def buildSigningKey(array: Array[Byte]): Task[SecretKey] =
+    Task.delay(new SecretKeySpec(array.slice(0, SHA1ByteLen), SigningAlgo))
+
+  def unsafeBuildSigningKey(array: Array[Byte]): SecretKey =
+    new SecretKeySpec(array, SigningAlgo)
+
+}
+
+/** A basic CSRF configuration class **/
+case class CSRFConfiguration(
+  headerName: String = "X-Csrf-Token",
+  cookieName: String = "csrf-token",
+  key: SecretKey
+)

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -17,108 +17,104 @@ class CSRFSpec extends Http4sSpec {
 
   val dummyRequest = Request()
 
-  "CSRFMiddleware" should {
+  CSRFMiddleware.withGeneratedKey().map { csrf =>
+    "CSRFMiddleware" should {
 
-    val newKey = CSRFMiddleware.generateSigningKey()
-    val config = CSRFConfiguration(key = newKey)
-    val csrf = CSRFMiddleware(config)
+      "not validate different tokens" in {
+        val equalCheck = for {
+          t1 <- csrf.generateToken
+          t2 <- csrf.generateToken
+        } yield CSRFMiddleware.isEqual(t1, t2)
 
-    "not validate different tokens" in {
-      val equalCheck = for {
-        t1 <- csrf.generateToken
-        t2 <- csrf.generateToken
-      } yield CSRFMiddleware.isEqual(t1, t2)
+        equalCheck.unsafePerformSync must_== false
+      }
+      "validate for the correct csrf token" in {
+        val response = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService)(
+            dummyRequest
+              .addCookie(Cookie(csrf.cookieName, token))
+              .putHeaders(Header(csrf.headerName, token))
+          )
+        } yield res).unsafePerformSync.orNotFound
 
-      equalCheck.unsafePerformSync must_== false
+        response.status must_== Status.Ok
+      }
+
+      "not validate for token missing in cookie" in {
+        val response = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService)(
+            dummyRequest
+              .putHeaders(Header(csrf.headerName, token))
+          )
+        } yield res).unsafePerformSync.orNotFound
+
+        response.status must_== Status.Unauthorized
+      }
+
+      "not validate for token missing in header" in {
+        val response = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService)(
+            dummyRequest
+              .addCookie(Cookie(csrf.cookieName, token))
+          )
+        } yield res).unsafePerformSync.orNotFound
+
+        response.status must_== Status.Unauthorized
+      }
+
+      "not validate if token is missing in both" in {
+        val response = csrf.validate(dummyService)(dummyRequest).unsafePerformSync
+
+        response.orNotFound.status must_== Status.Unauthorized
+      }
+
+      "not validate for different tokens" in {
+        val response = (for {
+          token1 <- csrf.generateToken
+          token2 <- csrf.generateToken
+          res <- csrf.validate(dummyService)(
+            dummyRequest
+              .addCookie(Cookie(csrf.cookieName, token1))
+              .putHeaders(Header(csrf.headerName, token2))
+          )
+        } yield res).unsafePerformSync.orNotFound
+
+        response.status must_== Status.Unauthorized
+      }
+
+      "not return the same token to mitigate BREACH" in {
+        val (response, originalToken) = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService)(
+            dummyRequest
+              .addCookie(Cookie(csrf.cookieName, token))
+              .putHeaders(Header(csrf.headerName, token))
+          )
+          c <- Task.point(
+            HCookie
+              .from(res.orNotFound.headers)
+              .map(_.cookie)
+              .find(_.name == csrf.cookieName))
+        } yield (c, token)).unsafePerformSync
+        response.isDefined must_== true
+        response.map(_.content) must_!= Some(originalToken)
+      }
+
+      "not return a token for a failed CSRF check" in {
+        val response = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService)(dummyRequest)
+        } yield res.orNotFound).unsafePerformSync
+
+        response.status must_== Status.Unauthorized
+        !HCookie
+          .from(response.headers)
+          .map(_.cookie).exists(_.name == csrf.cookieName) must_== true
+      }
     }
-    "validate for the correct csrf token" in {
-      val response = (for {
-        token <- csrf.generateToken
-        res <- csrf.validate(dummyService)(
-          dummyRequest
-            .addCookie(Cookie(config.cookieName, token))
-            .putHeaders(Header(config.headerName, token))
-        )
-      } yield res).unsafePerformSync.orNotFound
-
-      response.status must_== Status.Ok
-    }
-
-    "not validate for token missing in cookie" in {
-      val response = (for {
-        token <- csrf.generateToken
-        res <- csrf.validate(dummyService)(
-          dummyRequest
-            .putHeaders(Header(config.headerName, token))
-        )
-      } yield res).unsafePerformSync.orNotFound
-
-      response.status must_== Status.Unauthorized
-    }
-
-    "not validate for token missing in header" in {
-      val response = (for {
-        token <- csrf.generateToken
-        res <- csrf.validate(dummyService)(
-          dummyRequest
-            .addCookie(Cookie(config.cookieName, token))
-        )
-      } yield res).unsafePerformSync.orNotFound
-
-      response.status must_== Status.Unauthorized
-    }
-
-    "not validate if token is missing in both" in {
-      val response = csrf.validate(dummyService)(dummyRequest).unsafePerformSync
-
-      response.orNotFound.status must_== Status.Unauthorized
-    }
-
-    "not validate for different tokens" in {
-      val response = (for {
-        token1 <- csrf.generateToken
-        token2 <- csrf.generateToken
-        res <- csrf.validate(dummyService)(
-          dummyRequest
-            .addCookie(Cookie(config.cookieName, token1))
-            .putHeaders(Header(config.headerName, token2))
-        )
-      } yield res).unsafePerformSync.orNotFound
-
-      response.status must_== Status.Unauthorized
-    }
-
-    "not return the same token to mitigate BREACH" in {
-      val (response, originalToken) = (for {
-        token <- csrf.generateToken
-        res <- csrf.validate(dummyService)(
-          dummyRequest
-            .addCookie(Cookie(config.cookieName, token))
-            .putHeaders(Header(config.headerName, token))
-        )
-        c <- Task.point(
-          HCookie
-            .from(res.orNotFound.headers)
-            .map(_.cookie)
-            .find(_.name == config.cookieName))
-      } yield (c, token)).unsafePerformSync
-      response.isDefined must_== true
-      response.map(_.content) must_!= Some(originalToken)
-    }
-
-    "not return a token for a failed CSRF check" in {
-      val response = (for {
-        token <- csrf.generateToken
-        res <- csrf.validate(dummyService)(dummyRequest)
-      } yield res.orNotFound).unsafePerformSync
-
-      response.status must_== Status.Unauthorized
-      HCookie
-        .from(response.headers)
-        .map(_.cookie)
-        .find(_.name == config.cookieName)
-        .isEmpty must_== true
-    }
-  }
+  }.unsafePerformSync
 
 }

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -93,7 +93,7 @@ class CSRFSpec extends Http4sSpec {
               .addCookie(Cookie(csrf.cookieName, token))
               .putHeaders(Header(csrf.headerName, token))
           )
-          c <- Task.point(
+          c <- Task.now(
             HCookie
               .from(res.orNotFound.headers)
               .map(_.cookie)

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -1,0 +1,124 @@
+package org.http4s.server.middleware
+
+import org.http4s._
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+import scalaz.stream.Process._
+import org.http4s.Uri.uri
+import org.http4s.dsl._
+import org.http4s.headers.{`Set-Cookie` => HCookie}
+
+class CSRFSpec extends Http4sSpec {
+
+  val dummyService: HttpService = HttpService {
+    case GET -> Root =>
+      Ok()
+  }
+
+  val dummyRequest = Request()
+
+  "CSRFMiddleware" should {
+
+    val newKey = CSRFMiddleware.generateSigningKey()
+    val config = CSRFConfiguration(key = newKey)
+    val csrf = CSRFMiddleware(config)
+
+    "not validate different tokens" in {
+      val equalCheck = for {
+        t1 <- csrf.generateToken
+        t2 <- csrf.generateToken
+      } yield CSRFMiddleware.isEqual(t1, t2)
+
+      equalCheck.unsafePerformSync must_== false
+    }
+    "validate for the correct csrf token" in {
+      val response = (for {
+        token <- csrf.generateToken
+        res <- csrf.validate(dummyService)(
+          dummyRequest
+            .addCookie(Cookie(config.cookieName, token))
+            .putHeaders(Header(config.headerName, token))
+        )
+      } yield res).unsafePerformSync.orNotFound
+
+      response.status must_== Status.Ok
+    }
+
+    "not validate for token missing in cookie" in {
+      val response = (for {
+        token <- csrf.generateToken
+        res <- csrf.validate(dummyService)(
+          dummyRequest
+            .putHeaders(Header(config.headerName, token))
+        )
+      } yield res).unsafePerformSync.orNotFound
+
+      response.status must_== Status.Unauthorized
+    }
+
+    "not validate for token missing in header" in {
+      val response = (for {
+        token <- csrf.generateToken
+        res <- csrf.validate(dummyService)(
+          dummyRequest
+            .addCookie(Cookie(config.cookieName, token))
+        )
+      } yield res).unsafePerformSync.orNotFound
+
+      response.status must_== Status.Unauthorized
+    }
+
+    "not validate if token is missing in both" in {
+      val response = csrf.validate(dummyService)(dummyRequest).unsafePerformSync
+
+      response.orNotFound.status must_== Status.Unauthorized
+    }
+
+    "not validate for different tokens" in {
+      val response = (for {
+        token1 <- csrf.generateToken
+        token2 <- csrf.generateToken
+        res <- csrf.validate(dummyService)(
+          dummyRequest
+            .addCookie(Cookie(config.cookieName, token1))
+            .putHeaders(Header(config.headerName, token2))
+        )
+      } yield res).unsafePerformSync.orNotFound
+
+      response.status must_== Status.Unauthorized
+    }
+
+    "not return the same token to mitigate BREACH" in {
+      val (response, originalToken) = (for {
+        token <- csrf.generateToken
+        res <- csrf.validate(dummyService)(
+          dummyRequest
+            .addCookie(Cookie(config.cookieName, token))
+            .putHeaders(Header(config.headerName, token))
+        )
+        c <- Task.point(
+          HCookie
+            .from(res.orNotFound.headers)
+            .map(_.cookie)
+            .find(_.name == config.cookieName))
+      } yield (c, token)).unsafePerformSync
+      response.isDefined must_== true
+      response.map(_.content) must_!= Some(originalToken)
+    }
+
+    "not return a token for a failed CSRF check" in {
+      val response = (for {
+        token <- csrf.generateToken
+        res <- csrf.validate(dummyService)(dummyRequest)
+      } yield res.orNotFound).unsafePerformSync
+
+      response.status must_== Status.Unauthorized
+      HCookie
+        .from(response.headers)
+        .map(_.cookie)
+        .find(_.name == config.cookieName)
+        .isEmpty must_== true
+    }
+  }
+
+}

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -13,6 +13,7 @@ class CSRFSpec extends Http4sSpec {
 
   val dummyService: HttpService = HttpService {
     case GET -> Root =>
+      Thread.sleep(1) //Fix so clock doesn't compute the same nonce, to emulate a real service
       Ok()
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -7,6 +7,7 @@ import scalaz.stream.Process._
 import org.http4s.Uri.uri
 import org.http4s.dsl._
 import org.http4s.headers.{`Set-Cookie` => HCookie}
+import org.http4s.internal.compatibility._
 
 class CSRFSpec extends Http4sSpec {
 

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -32,12 +32,12 @@ class CSRFSpec extends Http4sSpec {
       "validate for the correct csrf token" in {
         val response = (for {
           token <- csrf.generateToken
-          res <- csrf.validate(dummyService)(
+          res <- csrf.validate(dummyService).orNotFound(
             dummyRequest
               .addCookie(Cookie(csrf.cookieName, token))
               .putHeaders(Header(csrf.headerName, token))
           )
-        } yield res).unsafePerformSync.orNotFound
+        } yield res).unsafePerformSync
 
         response.status must_== Status.Ok
       }
@@ -45,11 +45,11 @@ class CSRFSpec extends Http4sSpec {
       "not validate for token missing in cookie" in {
         val response = (for {
           token <- csrf.generateToken
-          res <- csrf.validate(dummyService)(
+          res <- csrf.validate(dummyService).orNotFound(
             dummyRequest
               .putHeaders(Header(csrf.headerName, token))
           )
-        } yield res).unsafePerformSync.orNotFound
+        } yield res).unsafePerformSync
 
         response.status must_== Status.Unauthorized
       }
@@ -57,31 +57,31 @@ class CSRFSpec extends Http4sSpec {
       "not validate for token missing in header" in {
         val response = (for {
           token <- csrf.generateToken
-          res <- csrf.validate(dummyService)(
+          res <- csrf.validate(dummyService).orNotFound(
             dummyRequest
               .addCookie(Cookie(csrf.cookieName, token))
           )
-        } yield res).unsafePerformSync.orNotFound
+        } yield res).unsafePerformSync
 
         response.status must_== Status.Unauthorized
       }
 
       "not validate if token is missing in both" in {
-        val response = csrf.validate(dummyService)(dummyRequest).unsafePerformSync
+        val response = csrf.validate(dummyService).orNotFound(dummyRequest).unsafePerformSync
 
-        response.orNotFound.status must_== Status.Unauthorized
+        response.status must_== Status.Unauthorized
       }
 
       "not validate for different tokens" in {
         val response = (for {
           token1 <- csrf.generateToken
           token2 <- csrf.generateToken
-          res <- csrf.validate(dummyService)(
+          res <- csrf.validate(dummyService).orNotFound(
             dummyRequest
               .addCookie(Cookie(csrf.cookieName, token1))
               .putHeaders(Header(csrf.headerName, token2))
           )
-        } yield res).unsafePerformSync.orNotFound
+        } yield res).unsafePerformSync
 
         response.status must_== Status.Unauthorized
       }
@@ -89,7 +89,7 @@ class CSRFSpec extends Http4sSpec {
       "not return the same token to mitigate BREACH" in {
         val (response, originalToken) = (for {
           token <- csrf.generateToken
-          res <- csrf.validate(dummyService)(
+          res <- csrf.validate(dummyService).apply(
             dummyRequest
               .addCookie(Cookie(csrf.cookieName, token))
               .putHeaders(Header(csrf.headerName, token))
@@ -107,8 +107,8 @@ class CSRFSpec extends Http4sSpec {
       "not return a token for a failed CSRF check" in {
         val response = (for {
           token <- csrf.generateToken
-          res <- csrf.validate(dummyService)(dummyRequest)
-        } yield res.orNotFound).unsafePerformSync
+          res <- csrf.validate(dummyService).orNotFound(dummyRequest)
+        } yield res).unsafePerformSync
 
         response.status must_== Status.Unauthorized
         !HCookie

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -19,14 +19,14 @@ class CSRFSpec extends Http4sSpec {
 
   val dummyRequest = Request()
 
-  CSRFMiddleware.withGeneratedKey().map { csrf =>
-    "CSRFMiddleware" should {
+  CSRF.withGeneratedKey().map { csrf =>
+    "CSRF" should {
 
       "not validate different tokens" in {
         val equalCheck = for {
           t1 <- csrf.generateToken
           t2 <- csrf.generateToken
-        } yield CSRFMiddleware.isEqual(t1, t2)
+        } yield CSRF.isEqual(t1, t2)
 
         equalCheck.unsafePerformSync must_== false
       }


### PR DESCRIPTION
Here's a tentative implementation of the backport from `TSec`.

I had to port apache commons `Hex.encodeHex` to avoid bringing in another dependency to be able to get a 
performant Hex encoder, and handwrote `find` on NonEmptyList only because I'm not too familiar with `scalaz`. I figured there maybe a find function already I just can't find it.

It's syntactically Equivalent to the version I currently am PRing fixes onto `tsec` for, and adapted similarly from the `play framework` implementation. The gist of the vulnerability mitigation is to use the middleware to set the token cookie, and send such a token along with a custom header value. Given that an attacker forging a request cannot access the values of a cookie due to same-origin policy, this will guard against CSRF.

To defend against `BREACH`, we effectively randomize the token on each request,  but to avoid recomputing both the signature _and_ the tokenId, we can reuse the raw value from the incoming request.

After some review and seeing what you guys think (if anyone can improve some of the code in there, awesome, I don't use scalaz much), I can port this onto 0.17.x as well.