### PR TITLE
ContentCoding without Registry

### DIFF
--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -26,7 +26,6 @@ import org.http4s.QValue.QValueParser
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
 import org.http4s.parser.Http4sParser
 import org.http4s.util._
-
 import scala.util.hashing.MurmurHash3
 
 class ContentCoding private (val coding: String, override val qValue: QValue = QValue.One)
@@ -63,7 +62,7 @@ class ContentCoding private (val coding: String, override val qValue: QValue = Q
   override def toString = s"ContentCoding(${coding.toLowerCase}, $qValue)"
 
   override def compare(other: ContentCoding): Int =
-    ContentCoding.order.compare(this, other)
+    ContentCoding.http4sOrderForContentCoding.compare(this, other)
 
   override def render(writer: Writer): writer.type =
     ContentCoding.http4sInstancesForContentCoding.render(writer, this)
@@ -90,11 +89,11 @@ object ContentCoding {
   val `x-compress` = compress
   val `x-gzip` = gzip
 
-  def standard: Map[String, ContentCoding] =
+  val standard: Map[String, ContentCoding] =
     List(`*`, compress, deflate, exi, gzip, identity, `pack200-gzip`).map(c => c.coding -> c).toMap
 
   /**
-    * Parse a Transfer Coding
+    * Parse a Content Coding
     */
   def parse(s: String): ParseResult[ContentCoding] =
     new Http4sParser[ContentCoding](s, "Invalid Content Coding") with ContentCodingParser {
@@ -129,6 +128,7 @@ object ContentCoding {
 
     }
 
-  implicit val order: Order[ContentCoding] = Order.by(c => (c.coding.toLowerCase, c.qValue))
+  implicit val http4sOrderForContentCoding: Order[ContentCoding] =
+    Order.by(c => (c.coding.toLowerCase, c.qValue))
 
 }

--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -18,54 +18,111 @@
  */
 package org.http4s
 
-import org.http4s.syntax.string._
+import cats.{Order, Show}
+import cats.syntax.eq._
+import cats.instances.tuple._
+import cats.instances.string._
+import org.http4s.internal.parboiled2.{Parser => PbParser, _}
+import org.http4s.parser.Http4sParser
 import org.http4s.util._
+import org.http4s.QValue.QValueParser
+import scala.util.hashing.MurmurHash3
 
-final case class ContentCoding(coding: CaseInsensitiveString, qValue: QValue = QValue.One)
+class ContentCoding(val coding: String, override val qValue: QValue = QValue.One)
     extends HasQValue
+    with Ordered[ContentCoding]
     with Renderable {
-  def withQValue(q: QValue): ContentCoding = copy(coding, q)
+  def withQValue(q: QValue): ContentCoding = ContentCoding(coding, q)
 
   @deprecated("Use `Accept-Encoding`.isSatisfiedBy(encoding)", "0.16.1")
   def satisfies(encoding: ContentCoding): Boolean = encoding.satisfiedBy(this)
 
   @deprecated("Use `Accept-Encoding`.isSatisfiedBy(encoding)", "0.16.1")
   def satisfiedBy(encoding: ContentCoding): Boolean =
-    (this.coding.toString == "*" || this.coding == encoding.coding) &&
+    (this === ContentCoding.`*` || this.coding.equalsIgnoreCase(encoding.coding)) &&
       qValue.isAcceptable && encoding.qValue.isAcceptable
 
   def matches(encoding: ContentCoding): Boolean =
-    (this.coding.toString == "*" || this.coding == encoding.coding)
+    (this === ContentCoding.`*` || this.coding.equalsIgnoreCase(encoding.coding))
 
-  override def render(writer: Writer): writer.type = writer << coding << qValue
+  override def equals(o: Any) = o match {
+    case that: ContentCoding => this.coding.equalsIgnoreCase(that.coding) && this.qValue === that.qValue
+    case _ => false
+  }
 
-  // We want the normal case class generated methods except copy
-  private def copy(coding: CaseInsensitiveString, q: QValue) =
-    ContentCoding(coding, q)
+  private[this] var hash = 0
+  override def hashCode(): Int = {
+    if (hash == 0) {
+      hash = MurmurHash3.mixLast(coding.toLowerCase.##, qValue.##)
+    }
+    hash
+  }
+
+  override def toString = s"ContentCoding(${coding.toLowerCase}, $qValue)"
+
+  override def compare(other: ContentCoding): Int =
+    ContentCoding.order.compare(this, other)
+
+  override def render(writer: Writer): writer.type = writer << coding.toLowerCase << qValue
 }
 
-object ContentCoding extends Registry {
-  type Key = CaseInsensitiveString
-  type Value = ContentCoding
+object ContentCoding {
+  def apply(coding: String): ContentCoding = new ContentCoding(coding)
+  def apply(coding: String, qValue: QValue): ContentCoding = new ContentCoding(coding, qValue)
 
-  implicit def fromKey(k: CaseInsensitiveString): ContentCoding = ContentCoding(k)
-
-  implicit def fromValue(v: ContentCoding): CaseInsensitiveString = v.coding
-
-  val `*` : ContentCoding = registerKey("*".ci)
+  val `*` : ContentCoding = ContentCoding("*")
 
   // http://www.iana.org/assignments/http-parameters/http-parameters.xml#http-parameters-1
-  val compress = registerKey("compress".ci)
-  val deflate = registerKey("deflate".ci)
-  val exi = registerKey("exi".ci)
-  val gzip = registerKey("gzip".ci)
-  val identity = registerKey("identity".ci)
-  val `pack200-gzip` = registerKey("pack200-gzip".ci)
+  val compress = ContentCoding("compress")
+  val deflate = ContentCoding("deflate")
+  val exi = ContentCoding("exi")
+  val gzip = ContentCoding("gzip")
+  val identity = ContentCoding("identity")
+  val `pack200-gzip` = ContentCoding("pack200-gzip")
 
   // Legacy encodings defined by RFC2616 3.5.
-  val `x-compress` = register("x-compress".ci, compress)
-  val `x-gzip` = register("x-gzip".ci, gzip)
+  val `x-compress` = compress
+  val `x-gzip` = gzip
 
-  def registered: Iterable[ContentCoding] =
-    registry.snapshot.values
+  def standard: Map[String, ContentCoding] =
+    List(`*`, compress, deflate, exi, gzip, identity, `pack200-gzip`).map(c => c.coding -> c).toMap
+
+  /**
+    * Parse a Transfer Coding
+    */
+  def parse(s: String): ParseResult[ContentCoding] =
+    new Http4sParser[ContentCoding](s, "Invalid Content Coding") with ContentCodingParser {
+      def main = EncodingRangeDecl
+    }.parse
+
+  private[http4s] trait ContentCodingParser extends QValueParser { self: PbParser =>
+
+    def EncodingRangeDecl: Rule1[ContentCoding] = rule {
+      (EncodingRangeDef ~ QualityValue) ~> { (coding: ContentCoding, q: QValue) =>
+        if (q == org.http4s.QValue.One) coding
+        else coding.withQValue(q)
+      }
+    }
+
+    def EncodingRangeDef: Rule1[ContentCoding] = rule {
+      "*" ~ push(ContentCoding.`*`) | Token ~> { s: String =>
+        ContentCoding.standard.getOrElse(s, ContentCoding(s))
+      }
+    }
+  }
+
+  implicit val http4sInstancesForContentCoding: Show[ContentCoding] with HttpCodec[ContentCoding] =
+    new Show[ContentCoding] with HttpCodec[ContentCoding] {
+      override def show(s: ContentCoding): String = s.toString
+
+      override def parse(s: String): ParseResult[ContentCoding] =
+        ContentCoding.parse(s)
+
+      override def render(writer: Writer, coding: ContentCoding): writer.type =
+        writer << coding.coding.toLowerCase << coding.qValue
+
+    }
+
+  implicit val order: Order[ContentCoding] = Order.by(c => (c.coding.toLowerCase, c.qValue))
+
 }

--- a/core/src/main/scala/org/http4s/headers/Accept-Encoding.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Encoding.scala
@@ -2,8 +2,8 @@ package org.http4s
 package headers
 
 import cats.data.NonEmptyList
+import cats.syntax.eq._
 import org.http4s.parser.HttpHeaderParser
-import org.http4s.syntax.string._
 
 object `Accept-Encoding` extends HeaderKey.Internal[`Accept-Encoding`] with HeaderKey.Recurring {
   override def parse(s: String): ParseResult[`Accept-Encoding`] =
@@ -21,10 +21,10 @@ final case class `Accept-Encoding`(values: NonEmptyList[ContentCoding])
 
   def qValue(coding: ContentCoding): QValue = {
     def specific = values.toList.collectFirst {
-      case cc: ContentCoding if cc.coding != "*".ci && cc.matches(coding) => cc.qValue
+      case cc: ContentCoding if cc =!= ContentCoding.`*` && cc.matches(coding) => cc.qValue
     }
     def splatted = values.toList.collectFirst {
-      case cc: ContentCoding if cc.coding == "*".ci => cc.qValue
+      case cc: ContentCoding if cc === ContentCoding.`*` => cc.qValue
     }
     specific.orElse(splatted).getOrElse(QValue.Zero)
   }

--- a/core/src/main/scala/org/http4s/parser/AcceptEncodingHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/AcceptEncodingHeader.scala
@@ -19,10 +19,8 @@ package org.http4s
 package parser
 
 import org.http4s.internal.parboiled2._
-import org.http4s.ContentCoding._
-import org.http4s.QValue.QValueParser
+import org.http4s.ContentCoding.ContentCodingParser
 import org.http4s.headers.`Accept-Encoding`
-import org.http4s.util.CaseInsensitiveString
 
 private[parser] trait AcceptEncodingHeader {
   def ACCEPT_ENCODING(value: String): ParseResult[`Accept-Encoding`] =
@@ -30,7 +28,7 @@ private[parser] trait AcceptEncodingHeader {
 
   private class AcceptEncodingParser(input: ParserInput)
       extends Http4sHeaderParser[`Accept-Encoding`](input)
-      with QValueParser {
+      with ContentCodingParser {
 
     def entry: Rule1[`Accept-Encoding`] = rule {
       oneOrMore(EncodingRangeDecl).separatedBy(ListSep) ~ EOL ~> { xs: Seq[ContentCoding] =>
@@ -38,18 +36,5 @@ private[parser] trait AcceptEncodingHeader {
       }
     }
 
-    def EncodingRangeDecl: Rule1[ContentCoding] = rule {
-      (EncodingRangeDef ~ QualityValue) ~> { (coding: ContentCoding, q: QValue) =>
-        if (q == org.http4s.QValue.One) coding
-        else coding.withQValue(q)
-      }
-    }
-
-    def EncodingRangeDef: Rule1[ContentCoding] = rule {
-      "*" ~ push(`*`) | Token ~> { s: String =>
-        val cis = CaseInsensitiveString(s)
-        org.http4s.ContentCoding.getOrElseCreate(cis)
-      }
-    }
   }
 }

--- a/core/src/main/scala/org/http4s/parser/AcceptEncodingHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/AcceptEncodingHeader.scala
@@ -18,9 +18,9 @@
 package org.http4s
 package parser
 
-import org.http4s.internal.parboiled2._
 import org.http4s.ContentCoding.ContentCodingParser
 import org.http4s.headers.`Accept-Encoding`
+import org.http4s.internal.parboiled2._
 
 private[parser] trait AcceptEncodingHeader {
   def ACCEPT_ENCODING(value: String): ParseResult[`Accept-Encoding`] =

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -68,7 +68,7 @@ private[parser] trait SimpleHeaders {
     new Http4sHeaderParser[`Content-Encoding`](value) {
       def entry = rule {
         Token ~ EOL ~> { s: String =>
-          `Content-Encoding`(ContentCoding.standard.getOrElse(s, ContentCoding(s)))
+          `Content-Encoding`(ContentCoding.standard.getOrElse(s, ContentCoding.unsafeFromString(s)))
         }
       }
     }.parse

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -68,7 +68,7 @@ private[parser] trait SimpleHeaders {
     new Http4sHeaderParser[`Content-Encoding`](value) {
       def entry = rule {
         Token ~ EOL ~> { s: String =>
-          `Content-Encoding`(ContentCoding.getOrElseCreate(s.ci))
+          `Content-Encoding`(ContentCoding.standard.getOrElse(s, ContentCoding(s)))
         }
       }
     }.parse

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -65,10 +65,11 @@ private[parser] trait SimpleHeaders {
     }.parse
 
   def CONTENT_ENCODING(value: String): ParseResult[`Content-Encoding`] =
-    new Http4sHeaderParser[`Content-Encoding`](value) {
+    new Http4sHeaderParser[`Content-Encoding`](value)
+    with org.http4s.ContentCoding.ContentCodingParser {
       def entry = rule {
-        Token ~ EOL ~> { s: String =>
-          `Content-Encoding`(ContentCoding.standard.getOrElse(s, ContentCoding.unsafeFromString(s)))
+        EncodingRangeDecl ~ EOL ~> { c: ContentCoding =>
+          `Content-Encoding`(c)
         }
       }
     }.parse

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -204,8 +204,9 @@ trait ArbitraryInstances {
         }
       } yield `Accept-Charset`(charsetRangesWithQ.head, charsetRangesWithQ.tail: _*)
     }
+
   def genContentCodingNoQuality: Gen[ContentCoding] =
-    oneOf(ContentCoding.registered.toSeq)
+    oneOf(ContentCoding.standard.values.toSeq)
 
   implicit val arbitraryContentCoding: Arbitrary[ContentCoding] =
     Arbitrary {
@@ -214,6 +215,9 @@ trait ArbitraryInstances {
         q <- arbitrary[QValue]
       } yield cc.withQValue(q)
     }
+
+  implicit val cogenContentCoding: Cogen[ContentCoding] =
+    Cogen[String].contramap(_.coding.toLowerCase(Locale.ROOT))
 
   implicit val arbitraryAcceptEncoding: Arbitrary[`Accept-Encoding`] =
     Arbitrary {

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -232,6 +232,13 @@ trait ArbitraryInstances {
       } yield `Accept-Encoding`(contentCodingsWithQ.head, contentCodingsWithQ.tail: _*)
     }
 
+  implicit val arbitraryContentEncoding: Arbitrary[`Content-Encoding`] =
+    Arbitrary {
+      for {
+        contentCoding <- genContentCodingNoQuality
+      } yield `Content-Encoding`(contentCoding)
+    }
+
   def genLanguageTagNoQuality: Gen[LanguageTag] =
     frequency(
       3 -> (for {

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -206,7 +206,10 @@ trait ArbitraryInstances {
     }
 
   def genContentCodingNoQuality: Gen[ContentCoding] =
-    oneOf(ContentCoding.standard.values.toSeq)
+    Gen.frequency(
+      (10, oneOf(ContentCoding.standard.values.toSeq)),
+      (2, Gen.alphaStr.filter(_.nonEmpty).map(ContentCoding.unsafeFromString))
+    )
 
   implicit val arbitraryContentCoding: Arbitrary[ContentCoding] =
     Arbitrary {

--- a/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
@@ -1,0 +1,57 @@
+package org.http4s
+
+import cats.kernel.laws.discipline.OrderTests
+import cats.implicits._
+import org.http4s.testing.HttpCodecTests
+import org.http4s.util.Renderer
+
+class ContentCodingSpec extends Http4sSpec {
+  "equals" should {
+    "be consistent with equalsIgnoreCase of the codings and quality" in prop {
+      (a: ContentCoding, b: ContentCoding) =>
+        (a == b) must_== a.coding.equalsIgnoreCase(b.coding) && a.qValue == b.qValue
+    }
+  }
+
+  "compare" should {
+    "be consistent with coding.compareToIgnoreCase for same quality" in {
+      prop { (a: ContentCoding, b: ContentCoding) =>
+        (a.qValue == b.qValue) ==> (a.coding.compareToIgnoreCase(b.coding) must_== a.compare(b))
+      }
+    }
+    "be consistent with qValue.compareTo for same coding" in {
+      prop { (a: ContentCoding, b: ContentCoding) =>
+        (a.coding.toLowerCase == b.coding.toLowerCase) must_==(a.qValue.compareTo(b.qValue) == a.compare(b))
+      }
+    }
+  }
+
+  "hashCode" should {
+    "be consistent with equality" in
+      prop { (a: ContentCoding, b: ContentCoding) =>
+        a == b must_== (a.## == b.##)
+      }
+  }
+
+  "matches" should {
+    "ContentCoding.* always matches" in
+      prop { (a: ContentCoding) =>
+        ContentCoding.`*`.matches(a) must beTrue
+      }
+    "always matches itself" in
+      prop { (a: ContentCoding) =>
+        a.matches(a) must beTrue
+      }
+  }
+
+  "render" should {
+    "return coding and quality" in
+      prop { s: ContentCoding =>
+        Renderer.renderString(s) must_== s"${s.coding}${Renderer.renderString(s.qValue)}"
+      }
+  }
+
+
+  checkAll("Order[ContentCoding]", OrderTests[ContentCoding].order)
+  checkAll("HttpCodec[ContentCoding]", HttpCodecTests[ContentCoding].httpCodec)
+}

--- a/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
@@ -53,9 +53,7 @@ class ContentCodingSpec extends Http4sSpec {
       ContentCoding.parse("mycoding") must_== ContentCoding.fromString("mycoding")
     }
     "parse with quality" in {
-      ContentCoding.parse("gzip;q=0.8") must_== QValue
-        .fromDouble(0.8)
-        .map(qv => ContentCoding.gzip.withQValue(qv))
+      ContentCoding.parse("gzip;q=0.8") must_== Right(ContentCoding.gzip.withQValue(q(0.8)))
     }
     "fail on empty" in {
       ContentCoding.parse("") must beLeft

--- a/tests/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeadersSpec.scala
@@ -57,11 +57,12 @@ class HeadersSpec extends Http4sSpec {
     }
 
     "Work with Raw headers (++)" in {
-      val h1 = `Accept-Encoding`(ContentCoding("foo")).toRaw
-      val h2 = `Accept-Encoding`(ContentCoding("bar")).toRaw
+      val foo = ContentCoding.unsafeFromString("foo")
+      val bar = ContentCoding.unsafeFromString("bar")
+      val h1 = `Accept-Encoding`(foo).toRaw
+      val h2 = `Accept-Encoding`(bar).toRaw
       val hs = Headers(clength.toRaw) ++ Headers(h1) ++ Headers(h2)
-      hs.get(`Accept-Encoding`) must beSome(
-        `Accept-Encoding`(ContentCoding("foo"), ContentCoding("bar")))
+      hs.get(`Accept-Encoding`) must beSome(`Accept-Encoding`(foo, bar))
       hs.exists(_ == clength) must_== true
     }
 

--- a/tests/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeadersSpec.scala
@@ -57,11 +57,11 @@ class HeadersSpec extends Http4sSpec {
     }
 
     "Work with Raw headers (++)" in {
-      val h1 = `Accept-Encoding`(ContentCoding("foo".ci)).toRaw
-      val h2 = `Accept-Encoding`(ContentCoding("bar".ci)).toRaw
+      val h1 = `Accept-Encoding`(ContentCoding("foo")).toRaw
+      val h2 = `Accept-Encoding`(ContentCoding("bar")).toRaw
       val hs = Headers(clength.toRaw) ++ Headers(h1) ++ Headers(h2)
       hs.get(`Accept-Encoding`) must beSome(
-        `Accept-Encoding`(ContentCoding("foo".ci), ContentCoding("bar".ci)))
+        `Accept-Encoding`(ContentCoding("foo"), ContentCoding("bar")))
       hs.exists(_ == clength) must_== true
     }
 

--- a/tests/src/test/scala/org/http4s/headers/ContentEncodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ContentEncodingSpec.scala
@@ -1,0 +1,6 @@
+package org.http4s
+package headers
+
+class ContentEncodingSpec extends HeaderLaws {
+  checkAll("Content-Encoding", headerLaws(`Content-Encoding`))
+}

--- a/tests/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
@@ -19,7 +19,7 @@ class AcceptEncodingSpec extends Specification with HeaderParserHelper[`Accept-E
   "Accept-Encoding parser" should {
 
     "parse all encodings" in {
-      foreach(ContentCoding.snapshot) {
+      foreach(ContentCoding.standard) {
         case (_, coding) =>
           parse(coding.renderString).values.head should be_==(coding)
       }


### PR DESCRIPTION
This started as a removal of `Registry` from `ContentCoding` but grew into a bigger refactoring using the current coding standards:

* Removal of `Registry` usage
* Removed usage of `CaseInsensitiveString`
* Implementation of `HttpCodec[ContentCoding]`
* Tightening constructions. Empty strings codings are not allowed
* More testing
