### PR TITLE
Set Tomcat docBase to null

### DIFF
--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -122,7 +122,11 @@ sealed class TomcatBuilder private (
   override def start: Task[Server] = Task.delay {
     val tomcat = new Tomcat
 
-    val context = tomcat.addContext("", getClass.getResource("/").getPath)
+    val docBase = getClass.getResource("/") match {
+      case null => null 
+      case resource => resource.getPath
+    }
+    val context = tomcat.addContext("", docBase)
 
     val conn = tomcat.getConnector()
 


### PR DESCRIPTION
`getClass.getResource("/")` may return null.  When it does, we throw an NPE.

The `docBase` property isn't hugely useful to most users anyway.  It's used to set the context root from which calls like `servletContext.getResource` work.  http4s services don't have a concept of a servlet root, so this is only useful when mixing in legacy servlets.  Serving static files still works even when this property is `null`.

In 0.18, we can make this configurable.  On 0.16 and 0.17, we'll just make the most conservative change.

Fixes #1453