### PR TITLE
CSRF Middleware backport 0.17.x

### DIFF
--- a/core/src/main/scala/org/http4s/util/package.scala
+++ b/core/src/main/scala/org/http4s/util/package.scala
@@ -12,34 +12,61 @@ package object util {
   def decode[F[_]](charset: Charset): Pipe[F, Byte, String] = {
     val decoder = charset.nioCharset.newDecoder
     val maxCharsPerByte = math.ceil(decoder.maxCharsPerByte().toDouble).toInt
-    val avgBytesPerChar = math.ceil(1.0 / decoder.averageCharsPerByte().toDouble).toInt
+    val avgBytesPerChar =
+      math.ceil(1.0 / decoder.averageCharsPerByte().toDouble).toInt
     val charBufferSize = 128
 
     _.repeatPull[String] {
-      _.awaitN(charBufferSize * avgBytesPerChar, allowFewer = true).optional.flatMap {
-        case None =>
-          val charBuffer = CharBuffer.allocate(1)
-          decoder.decode(ByteBuffer.allocate(0), charBuffer, true)
-          decoder.flush(charBuffer)
-          val outputString = charBuffer.flip().toString
-          if (outputString.isEmpty) Pull.done
-          else Pull.output1(outputString) as Handle.empty
-        case Some((chunks, handle)) =>
-          val chunk = chunks.flatMap(_.toList)
-          val byteVector = ByteVector(chunk.toArray)
-          val byteBuffer = byteVector.toByteBuffer
-          val charBuffer = CharBuffer.allocate(byteVector.size.toInt * maxCharsPerByte)
-          decoder.decode(byteBuffer, charBuffer, false)
-          val nextByteVector = ByteVector.view(byteBuffer.slice)
-          val nextHandle = handle.push(Chunk.bytes(nextByteVector.toArray))
-          Pull.output1(charBuffer.flip().toString) as nextHandle
-      }
+      _.awaitN(charBufferSize * avgBytesPerChar, allowFewer = true).optional
+        .flatMap {
+          case None =>
+            val charBuffer = CharBuffer.allocate(1)
+            decoder.decode(ByteBuffer.allocate(0), charBuffer, true)
+            decoder.flush(charBuffer)
+            val outputString = charBuffer.flip().toString
+            if (outputString.isEmpty) Pull.done
+            else Pull.output1(outputString) as Handle.empty
+          case Some((chunks, handle)) =>
+            val chunk = chunks.flatMap(_.toList)
+            val byteVector = ByteVector(chunk.toArray)
+            val byteBuffer = byteVector.toByteBuffer
+            val charBuffer =
+              CharBuffer.allocate(byteVector.size.toInt * maxCharsPerByte)
+            decoder.decode(byteBuffer, charBuffer, false)
+            val nextByteVector = ByteVector.view(byteBuffer.slice)
+            val nextHandle = handle.push(Chunk.bytes(nextByteVector.toArray))
+            Pull.output1(charBuffer.flip().toString) as nextHandle
+        }
     }
+  }
+
+  /** Hex encoding digits. Adapted from apache commons Hex.encodeHex **/
+  private val Digits: Array[Char] = Array('0', '1', '2', '3', '4', '5', '6',
+    '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
+
+  /** Encode a string to a Hexadecimal string representation
+    * Adapted from apache commons Hex.encodeHex
+    */
+  def encodeHex(data: Array[Byte]): Array[Char] = {
+    val l = data.length
+    val out = new Array[Char](l << 1)
+    // two characters form the hex value.
+    var i = 0
+    var j = 0
+    while (i < l) {
+      out(j) = Digits((0xF0 & data(i)) >>> 4)
+      j += 1
+      out(j) = Digits(0x0F & data(i))
+      j += 1
+      i += 1
+    }
+    out
   }
 
   /** Constructs an assertion error with a reference back to our issue tracker. Use only with head hung low. */
   def bug(message: String): AssertionError =
-    new AssertionError(s"This is a bug. Please report to https://github.com/http4s/http4s/issues: ${message}")
+    new AssertionError(
+      s"This is a bug. Please report to https://github.com/http4s/http4s/issues: ${message}")
 
   private[http4s] def tryCatchNonFatal[A](f: => A): Attempt[A] =
     try Right(f)

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -15,7 +15,7 @@ import org.http4s._
 import fs2.Task
 import fs2.interop.cats._
 
-final class CSRFMiddleware private[middleware] (
+final class CSRF private[middleware] (
     val headerName: String = "X-Csrf-Token",
     val cookieName: String = "csrf-token",
     key: SecretKey,
@@ -28,7 +28,7 @@ final class CSRFMiddleware private[middleware] (
   private[middleware] def signToken(token: String): Task[String] = {
     val joined = token + "-" + clock.millis()
     Task.delay {
-      val mac = Mac.getInstance(CSRFMiddleware.SigningAlgo)
+      val mac = Mac.getInstance(CSRF.SigningAlgo)
       mac.init(key)
       val out = mac.doFinal(joined.getBytes(StandardCharsets.UTF_8))
       joined + "-" + Base64.getEncoder.encodeToString(out)
@@ -37,7 +37,7 @@ final class CSRFMiddleware private[middleware] (
 
   /** Generate a new token **/
   private[middleware] def generateToken: Task[String] =
-    signToken(CSRFMiddleware.genTokenString)
+    signToken(CSRF.genTokenString)
 
   /** Decode our CSRF token and extract the original token string to sign
     */
@@ -45,7 +45,7 @@ final class CSRFMiddleware private[middleware] (
     token.split("-") match {
       case Array(raw, nonce, signed) =>
         OptionT[Task, String](Task.delay {
-          val mac = Mac.getInstance(CSRFMiddleware.SigningAlgo)
+          val mac = Mac.getInstance(CSRF.SigningAlgo)
           mac.init(key)
           val out =
             mac.doFinal((raw + "-" + nonce).getBytes(StandardCharsets.UTF_8))
@@ -72,12 +72,12 @@ final class CSRFMiddleware private[middleware] (
     service =>
       Kleisli[Task, Request, MaybeResponse] { r =>
         (for {
-          c1 <- CSRFMiddleware.cookieFromHeaders(r, cookieName)
+          c1 <- CSRF.cookieFromHeaders(r, cookieName)
           c2 <- OptionT(
             Task.now(r.headers.get(CaseInsensitiveString(headerName))))
           raw1 <- extractRaw(c1.content)
           raw2 <- extractRaw(c2.value)
-          response <- if (CSRFMiddleware.isEqual(raw1, raw2)) {
+          response <- if (CSRF.isEqual(raw1, raw2)) {
             OptionT[Task, MaybeResponse](service(r).map(Some(_)))
           } else {
             OptionT.none[Task, MaybeResponse]
@@ -103,26 +103,26 @@ final class CSRFMiddleware private[middleware] (
 
 }
 
-object CSRFMiddleware {
+object CSRF {
 
   /** Default method for constructing CSRF middleware **/
   def apply(headerName: String = "X-Csrf-Token",
             cookieName: String = "csrf-token",
             key: SecretKey,
-            clock: Clock = Clock.systemUTC()): CSRFMiddleware =
-    new CSRFMiddleware(headerName, cookieName, key, clock)
+            clock: Clock = Clock.systemUTC()): CSRF =
+    new CSRF(headerName, cookieName, key, clock)
 
   /** Sugar for instantiating a middleware by generating a key **/
   def withGeneratedKey(headerName: String = "X-Csrf-Token",
                        cookieName: String = "csrf-token",
-                       clock: Clock = Clock.systemUTC()): Task[CSRFMiddleware] =
+                       clock: Clock = Clock.systemUTC()): Task[CSRF] =
     generateSigningKey().map(apply(headerName, cookieName, _, clock))
 
   /** Sugar for pre-loading a key **/
   def withKeyBytes(keyBytes: Array[Byte],
                    headerName: String = "X-Csrf-Token",
                    cookieName: String = "csrf-token",
-                   clock: Clock = Clock.systemUTC()): Task[CSRFMiddleware] =
+                   clock: Clock = Clock.systemUTC()): Task[CSRF] =
     buildSigningKey(keyBytes).map(apply(headerName, cookieName, _, clock))
 
   /** An instance of SecureRandom to generate

--- a/server/src/main/scala/org/http4s/server/middleware/CSRFMiddleware.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRFMiddleware.scala
@@ -1,0 +1,178 @@
+package org.http4s.server.middleware
+
+import java.nio.charset.StandardCharsets
+import java.security.{MessageDigest, SecureRandom}
+import java.time.Clock
+import java.util.Base64
+import javax.crypto.spec.SecretKeySpec
+import javax.crypto.{KeyGenerator, Mac, SecretKey}
+
+import cats.data.{Kleisli, OptionT}
+import org.http4s.headers.{Cookie => HCookie}
+import org.http4s.server.Middleware
+import org.http4s.util.{CaseInsensitiveString, encodeHex}
+import org.http4s._
+import fs2.Task
+import fs2.interop.cats._
+
+final class CSRFMiddleware private[middleware] (
+    val headerName: String = "X-Csrf-Token",
+    val cookieName: String = "csrf-token",
+    key: SecretKey,
+    clock: Clock = Clock.systemUTC()) {
+
+  /** Sign our token using the current time in milliseconds as a nonce
+    * Signing and generating a token is potentially a unsafe operation
+    * if constructed with a bad key.
+    */
+  private[middleware] def signToken(token: String): Task[String] = {
+    val joined = token + "-" + clock.millis()
+    Task.delay {
+      val mac = Mac.getInstance(CSRFMiddleware.SigningAlgo)
+      mac.init(key)
+      val out = mac.doFinal(joined.getBytes(StandardCharsets.UTF_8))
+      joined + "-" + Base64.getEncoder.encodeToString(out)
+    }
+  }
+
+  /** Generate a new token **/
+  private[middleware] def generateToken: Task[String] =
+    signToken(CSRFMiddleware.genTokenString)
+
+  /** Decode our CSRF token and extract the original token string to sign
+    */
+  private[middleware] def extractRaw(token: String): OptionT[Task, String] =
+    token.split("-") match {
+      case Array(raw, nonce, signed) =>
+        OptionT[Task, String](Task.delay {
+          val mac = Mac.getInstance(CSRFMiddleware.SigningAlgo)
+          mac.init(key)
+          val out =
+            mac.doFinal((raw + "-" + nonce).getBytes(StandardCharsets.UTF_8))
+          if (MessageDigest.isEqual(out, Base64.getDecoder.decode(signed))) {
+            Some(raw)
+          } else {
+            None
+          }
+        })
+      case _ =>
+        OptionT.none[Task, String]
+    }
+
+  /** Constructs a middleware that will check for the csrf token
+    * presence on both the proper cookie, and header values.
+    *
+    * If it is a valid token, it will then embed a new one,
+    * to effectively randomize the complete token while
+    * avoiding the generation of a new secure random Id, to guard
+    * against [BREACH](http://breachattack.com/)
+    *
+    */
+  def validate: Middleware[Request, MaybeResponse, Request, MaybeResponse] = {
+    service =>
+      Kleisli[Task, Request, MaybeResponse] { r =>
+        (for {
+          c1 <- CSRFMiddleware.cookieFromHeaders(r, cookieName)
+          c2 <- OptionT(
+            Task.now(r.headers.get(CaseInsensitiveString(headerName))))
+          raw1 <- extractRaw(c1.content)
+          raw2 <- extractRaw(c2.value)
+          response <- if (CSRFMiddleware.isEqual(raw1, raw2)) {
+            OptionT[Task, MaybeResponse](service(r).map(Some(_)))
+          } else {
+            OptionT.none[Task, MaybeResponse]
+          }
+          newToken <- OptionT[Task, String](signToken(raw1).map(Some(_)))
+        } yield
+          response.cata(_.addCookie(Cookie(cookieName, newToken)),
+                        Response(Status.NotFound)))
+          .getOrElse(Response(Status.Unauthorized))
+      }
+  }
+
+  /** Embed a token into a response **/
+  def embedNew(res: MaybeResponse): Task[MaybeResponse] =
+    generateToken.map(
+      content =>
+        res.cata(_.addCookie(Cookie(cookieName, content)),
+                 Response(Status.NotFound)))
+
+  /** Middleware to embed a csrf token into routes that do not have one. **/
+  def withNewToken: Middleware[Request, MaybeResponse, Request, MaybeResponse] =
+    _.andThen(Kleisli(embedNew))
+
+}
+
+object CSRFMiddleware {
+
+  /** Default method for constructing CSRF middleware **/
+  def apply(headerName: String = "X-Csrf-Token",
+            cookieName: String = "csrf-token",
+            key: SecretKey,
+            clock: Clock = Clock.systemUTC()): CSRFMiddleware =
+    new CSRFMiddleware(headerName, cookieName, key, clock)
+
+  /** Sugar for instantiating a middleware by generating a key **/
+  def withGeneratedKey(headerName: String = "X-Csrf-Token",
+                       cookieName: String = "csrf-token",
+                       clock: Clock = Clock.systemUTC()): Task[CSRFMiddleware] =
+    generateSigningKey().map(apply(headerName, cookieName, _, clock))
+
+  /** Sugar for pre-loading a key **/
+  def withKeyBytes(keyBytes: Array[Byte],
+                   headerName: String = "X-Csrf-Token",
+                   cookieName: String = "csrf-token",
+                   clock: Clock = Clock.systemUTC()): Task[CSRFMiddleware] =
+    buildSigningKey(keyBytes).map(apply(headerName, cookieName, _, clock))
+
+  /** An instance of SecureRandom to generate
+    * tokens, properly seeded:
+    * https://tersesystems.com/blog/2015/12/17/the-right-way-to-use-securerandom/
+    */
+  private val CachedRandom = {
+    val r = new SecureRandom()
+    r.nextBytes(new Array[Byte](20))
+    r
+  }
+
+  val SigningAlgo = "HmacSHA1"
+  val SHA1ByteLen = 20
+  val CSRFTokenLength = 32
+
+  private[middleware] def cookieFromHeaders(
+      request: Request,
+      headerName: String): OptionT[Task, Cookie] =
+    OptionT(
+      Task.now(HCookie
+          .from(request.headers)
+          .flatMap(_.values.find(_.name == headerName))))
+
+  /** A Constant-time string equality **/
+  def isEqual(s1: String, s2: String): Boolean =
+    MessageDigest.isEqual(s1.getBytes(StandardCharsets.UTF_8),
+                          s2.getBytes(StandardCharsets.UTF_8))
+
+  /** Generate an unsigned CSRF token from a `SecureRandom` **/
+  private[middleware] def genTokenString: String = {
+    val bytes = new Array[Byte](CSRFTokenLength)
+    CachedRandom.nextBytes(bytes)
+    new String(encodeHex(bytes))
+  }
+
+  /** Generate a signing Key for the CSRF token **/
+  def generateSigningKey(): Task[SecretKey] =
+    Task.delay(KeyGenerator.getInstance(SigningAlgo).generateKey())
+
+  /** Build a new HMACSHA1 Key for our CSRF Middleware
+    * from key bytes. This operation is unsafe, in that
+    * any amount less than 20 bytes will throw an exception when loaded
+    * into `Mac`, and any value above will be truncated (not good for entropy).
+    *
+    * Use for loading a key from a config file, after having generated
+    * one safely
+    *
+    */
+  def buildSigningKey(array: Array[Byte]): Task[SecretKey] =
+    Task.delay(new SecretKeySpec(array.slice(0, SHA1ByteLen), SigningAlgo))
+
+}

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -17,14 +17,14 @@ class CSRFSpec extends Http4sSpec {
 
   val dummyRequest = Request()
 
-  CSRFMiddleware.withGeneratedKey().map { csrf =>
-    "CSRFMiddleware" should {
+  CSRF.withGeneratedKey().map { csrf =>
+    "CSRF" should {
 
       "not validate different tokens" in {
         val equalCheck = for {
           t1 <- csrf.generateToken
           t2 <- csrf.generateToken
-        } yield CSRFMiddleware.isEqual(t1, t2)
+        } yield CSRF.isEqual(t1, t2)
 
         equalCheck.unsafeValue() must beSome(false)
       }

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -1,0 +1,120 @@
+package org.http4s.server.middleware
+
+import org.http4s._
+import org.http4s.dsl._
+import org.http4s.headers.{`Set-Cookie` => HCookie}
+import fs2.Task
+import org.http4s.implicits._
+import cats.implicits._
+
+class CSRFSpec extends Http4sSpec {
+
+  val dummyService: HttpService = HttpService {
+    case GET -> Root =>
+      Thread.sleep(1) //Fix so clock doesn't compute the same nonce, to emulate a real service
+      Ok()
+  }
+
+  val dummyRequest = Request()
+
+  CSRFMiddleware.withGeneratedKey().map { csrf =>
+    "CSRFMiddleware" should {
+
+      "not validate different tokens" in {
+        val equalCheck = for {
+          t1 <- csrf.generateToken
+          t2 <- csrf.generateToken
+        } yield CSRFMiddleware.isEqual(t1, t2)
+
+        equalCheck.unsafeValue() must beSome(false)
+      }
+      "validate for the correct csrf token" in {
+        val response = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService).orNotFound(
+            dummyRequest
+              .addCookie(Cookie(csrf.cookieName, token))
+              .putHeaders(Header(csrf.headerName, token))
+          )
+        } yield res).unsafeValue()
+
+        response.map(_.status) must beSome(Status.Ok)
+      }
+
+      "not validate for token missing in cookie" in {
+        val response = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService).orNotFound(
+            dummyRequest
+              .putHeaders(Header(csrf.headerName, token))
+          )
+        } yield res).unsafeValue()
+
+        response.map(_.status) must beSome(Status.Unauthorized)
+      }
+
+      "not validate for token missing in header" in {
+        val response = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService).orNotFound(
+            dummyRequest
+              .addCookie(Cookie(csrf.cookieName, token))
+          )
+        } yield res).unsafeValue()
+
+        response.map(_.status) must beSome(Status.Unauthorized)
+      }
+
+      "not validate if token is missing in both" in {
+        val response = csrf.validate(dummyService).orNotFound(dummyRequest).unsafeValue()
+
+        response.map(_.status) must beSome(Status.Unauthorized)
+      }
+
+      "not validate for different tokens" in {
+        val response = (for {
+          token1 <- csrf.generateToken
+          token2 <- csrf.generateToken
+          res <- csrf.validate(dummyService).orNotFound(
+            dummyRequest
+              .addCookie(Cookie(csrf.cookieName, token1))
+              .putHeaders(Header(csrf.headerName, token2))
+          )
+        } yield res).unsafeValue()
+
+        response.map(_.status) must beSome(Status.Unauthorized)
+      }
+
+      "not return the same token to mitigate BREACH" in {
+        val (response, originalToken) = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService).apply(
+            dummyRequest
+              .addCookie(Cookie(csrf.cookieName, token))
+              .putHeaders(Header(csrf.headerName, token))
+          )
+          c <- Task.now(
+            HCookie
+              .from(res.orNotFound.headers)
+              .map(_.cookie)
+              .find(_.name == csrf.cookieName))
+        } yield (c, token)).unsafeValue().get
+        response.isDefined must_== true
+        response.map(_.content) must_!= Some(originalToken)
+      }
+
+      "not return a token for a failed CSRF check" in {
+        val response = (for {
+          token <- csrf.generateToken
+          res <- csrf.validate(dummyService).orNotFound(dummyRequest)
+        } yield res).unsafeValue().get
+
+        response.status must_== Status.Unauthorized
+        !HCookie
+          .from(response.headers)
+          .map(_.cookie).exists(_.name == csrf.cookieName) must_== true
+      }
+    }
+  }.unsafeValue()
+
+}

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -36,9 +36,9 @@ class CSRFSpec extends Http4sSpec {
               .addCookie(Cookie(csrf.cookieName, token))
               .putHeaders(Header(csrf.headerName, token))
           )
-        } yield res).unsafeValue()
+        } yield res).unsafeValue().get
 
-        response.map(_.status) must beSome(Status.Ok)
+        response.status must_== Status.Ok
       }
 
       "not validate for token missing in cookie" in {
@@ -48,9 +48,9 @@ class CSRFSpec extends Http4sSpec {
             dummyRequest
               .putHeaders(Header(csrf.headerName, token))
           )
-        } yield res).unsafeValue()
+        } yield res).unsafeValue().get
 
-        response.map(_.status) must beSome(Status.Unauthorized)
+        response.status must_== Status.Unauthorized
       }
 
       "not validate for token missing in header" in {
@@ -60,15 +60,15 @@ class CSRFSpec extends Http4sSpec {
             dummyRequest
               .addCookie(Cookie(csrf.cookieName, token))
           )
-        } yield res).unsafeValue()
+        } yield res).unsafeValue().get
 
-        response.map(_.status) must beSome(Status.Unauthorized)
+        response.status must_== Status.Unauthorized
       }
 
       "not validate if token is missing in both" in {
-        val response = csrf.validate(dummyService).orNotFound(dummyRequest).unsafeValue()
+        val response = csrf.validate(dummyService).orNotFound(dummyRequest).unsafeValue().get
 
-        response.map(_.status) must beSome(Status.Unauthorized)
+        response.status must_== Status.Unauthorized
       }
 
       "not validate for different tokens" in {
@@ -80,9 +80,9 @@ class CSRFSpec extends Http4sSpec {
               .addCookie(Cookie(csrf.cookieName, token1))
               .putHeaders(Header(csrf.headerName, token2))
           )
-        } yield res).unsafeValue()
+        } yield res).unsafeValue().get
 
-        response.map(_.status) must beSome(Status.Unauthorized)
+        response.status must_== Status.Unauthorized
       }
 
       "not return the same token to mitigate BREACH" in {


### PR DESCRIPTION
Same as #1533, but for 0.17.x

The tests kinda look ugly because old fs2 task returns `Option`.

Practically copy paste from the other branch, except with different imports.