### PR TITLE
Remove reference to `.as()` function call from docs

### DIFF
--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -189,11 +189,6 @@ Ok("""{"name":"Alice"}""").flatMap(_.as[User]).unsafeRunSync
 POST(uri("/hello"), """{"name":"Bob"}""").flatMap(_.as[User]).unsafeRunSync
 ```
 
-Note the argument to `as` is in parentheses instead of square
-brackets, as it's a function call instead of a type.  We are
-_implicitly_ summoning a `Decoder[A]`, but _explicitly_ declaring that
-`A` is encoded as JSON.
-
 ## Putting it all together
 
 ### A Hello world service


### PR DESCRIPTION
It seems the syntax with `.as(..)` and the function call is not used anymore so it could be dropped from the docs or replaced with something else if there is explanation necessary?