### PR TITLE
Fix #1542 Random error on ContentCoding equality

### DIFF
--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -22,6 +22,7 @@ import cats.{Order, Show}
 import cats.syntax.eq._
 import cats.instances.tuple._
 import cats.instances.string._
+import cats.instances.int._
 import org.http4s.QValue.QValueParser
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
 import org.http4s.parser.Http4sParser
@@ -129,6 +130,6 @@ object ContentCoding {
     }
 
   implicit val http4sOrderForContentCoding: Order[ContentCoding] =
-    Order.by(c => (c.coding.toLowerCase, c.qValue))
+    Order.by(c => (c.coding.toLowerCase, c.qValue.thousandths))
 
 }

--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -22,7 +22,6 @@ import cats.{Order, Show}
 import cats.syntax.eq._
 import cats.instances.tuple._
 import cats.instances.string._
-import cats.instances.int._
 import org.http4s.QValue.QValueParser
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
 import org.http4s.parser.Http4sParser
@@ -130,6 +129,6 @@ object ContentCoding {
     }
 
   implicit val http4sOrderForContentCoding: Order[ContentCoding] =
-    Order.by(c => (c.coding.toLowerCase, c.qValue.thousandths))
+    Order.by(c => (c.coding.toLowerCase, c.qValue))
 
 }

--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -103,14 +103,14 @@ object ContentCoding {
   private[http4s] trait ContentCodingParser extends QValueParser { self: PbParser =>
 
     def EncodingRangeDecl: Rule1[ContentCoding] = rule {
-      (EncodingRangeDef ~ QualityValue) ~> { (coding: ContentCoding, q: QValue) =>
+      (ContentCodingToken ~ QualityValue) ~> { (coding: ContentCoding, q: QValue) =>
         if (q === org.http4s.QValue.One) coding
         else coding.withQValue(q)
       }
     }
 
-    def EncodingRangeDef: Rule1[ContentCoding] = rule {
-      "*" ~ push(ContentCoding.`*`) | Token ~> { s: String =>
+    private def ContentCodingToken: Rule1[ContentCoding] = rule {
+      Token ~> { s: String =>
         ContentCoding.standard.getOrElse(s, new ContentCoding(s))
       }
     }

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -208,7 +208,7 @@ trait ArbitraryInstances {
   def genContentCodingNoQuality: Gen[ContentCoding] =
     Gen.frequency(
       (10, oneOf(ContentCoding.standard.values.toSeq)),
-      (2, genToken.filter(!_.startsWith("*")).map(ContentCoding.unsafeFromString))
+      (2, genToken.map(ContentCoding.unsafeFromString))
     )
 
   implicit val arbitraryContentCoding: Arbitrary[ContentCoding] =

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -208,7 +208,7 @@ trait ArbitraryInstances {
   def genContentCodingNoQuality: Gen[ContentCoding] =
     Gen.frequency(
       (10, oneOf(ContentCoding.standard.values.toSeq)),
-      (2, Gen.alphaStr.filter(_.nonEmpty).map(ContentCoding.unsafeFromString))
+      (2, genToken.filter(!_.startsWith("*")).map(ContentCoding.unsafeFromString))
     )
 
   implicit val arbitraryContentCoding: Arbitrary[ContentCoding] =
@@ -220,7 +220,7 @@ trait ArbitraryInstances {
     }
 
   implicit val cogenContentCoding: Cogen[ContentCoding] =
-    Cogen[String].contramap(_.coding.toLowerCase(Locale.ROOT))
+    Cogen[String].contramap(_.coding)
 
   implicit val arbitraryAcceptEncoding: Arbitrary[`Accept-Encoding`] =
     Arbitrary {

--- a/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
@@ -4,6 +4,7 @@ import cats.implicits._
 import cats.kernel.laws.discipline.OrderTests
 import org.http4s.testing.HttpCodecTests
 import org.http4s.util.Renderer
+import scala.math.signum
 
 class ContentCodingSpec extends Http4sSpec {
   "equals" should {
@@ -17,7 +18,7 @@ class ContentCodingSpec extends Http4sSpec {
     "be consistent with coding.compareToIgnoreCase for same quality" in {
       prop { (a: ContentCoding, b: ContentCoding) =>
         ((a.coding, a.qValue), (b.coding, b.qValue)) match {
-          case ((ac, aq), (bc, bq)) if ac == bc => aq.compareTo(bq) must_== a.compare(b)
+          case ((ac, aq), (bc, bq)) if ac == bc => signum(aq.compareTo(bq)) must_== signum(a.compare(b))
           case ((ac, _), (bc, _)) if ac.compareToIgnoreCase(bc) > 0 => a.compare(b) must be_>(0)
           case _ => a.compare(b) must be_<(0)
         }

--- a/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
@@ -18,7 +18,8 @@ class ContentCodingSpec extends Http4sSpec {
     "be consistent with coding.compareToIgnoreCase for same quality" in {
       prop { (a: ContentCoding, b: ContentCoding) =>
         ((a.coding, a.qValue), (b.coding, b.qValue)) match {
-          case ((ac, aq), (bc, bq)) if ac == bc => signum(aq.compareTo(bq)) must_== signum(a.compare(b))
+          case ((ac, aq), (bc, bq)) if ac == bc =>
+            signum(aq.compareTo(bq)) must_== signum(a.compare(b))
           case ((ac, _), (bc, _)) if ac.compareToIgnoreCase(bc) > 0 => a.compare(b) must be_>(0)
           case _ => a.compare(b) must be_<(0)
         }

--- a/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
@@ -59,8 +59,18 @@ class ContentCodingSpec extends Http4sSpec {
       ContentCoding.parse("") must beLeft
       ContentCoding.parse(";q=0.8") must beLeft
     }
+    "fail on non token" in {
+      ContentCoding.parse("\\\\") must beLeft
+    }
     "parse *" in {
       ContentCoding.parse("*") must_== ParseResult.success(ContentCoding.`*`)
+    }
+    "parse tokens starting with *" in {
+      // Strange content coding but valid
+      ContentCoding.parse("*fahon") must_== ParseResult.success(
+        ContentCoding.unsafeFromString("*fahon"))
+      ContentCoding.parse("*fahon;q=0.1") must_== ParseResult.success(
+        ContentCoding.unsafeFromString("*fahon").withQValue(q(0.1)))
     }
   }
 


### PR DESCRIPTION
I haven't been able to reproduce this locally but I suspect this is happening because `QValue` is an `AnyVal`. I have changed compare to use the `thousandths` element for comparisons