### PR TITLE
Retain Logging Concept With Less Bulk

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -29,23 +29,24 @@ object ResponseLogger {
           Logger.logMessage[F, Response[F]](response)(logHeaders, logBody, redactHeadersWhen)(
             logger) *> F.delay(response)
         else
-          async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map { vec =>
-            val newBody = Stream
-              .eval(vec.get)
-              .flatMap(v => Stream.emits(v).covary[F])
-              .flatMap(c => Stream.segment(c).covary[F])
+          async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map {
+            vec =>
+              val newBody = Stream
+                .eval(vec.get)
+                .flatMap(v => Stream.emits(v).covary[F])
+                .flatMap(c => Stream.segment(c).covary[F])
 
-            response.copy(
-              body = response.body
+              response.copy(
+                body = response.body
                 // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
-                .observe(_.segments.flatMap(s => Stream.eval_(vec.modify(_ :+ s))))
-                .onFinalize {
-                  Logger.logMessage[F, Response[F]](response.withBodyStream(newBody))(
-                    logHeaders,
-                    logBody,
-                    redactHeadersWhen)(logger)
-                }
-            )
+                  .observe(_.segments.flatMap(s => Stream.eval_(vec.modify(_ :+ s))))
+                  .onFinalize {
+                    Logger.logMessage[F, Response[F]](response.withBodyStream(newBody))(
+                      logHeaders,
+                      logBody,
+                      redactHeadersWhen)(logger)
+                  }
+              )
           }
       }
     }


### PR DESCRIPTION
Should preserve semantics and chunkiness rather than pulling a single element at a time from the queue. This is more of a patch for optimizations than a fix of any kind.