### PR TITLE
Specialize byte chunks to use array-backed chunks.

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
@@ -30,7 +30,7 @@ private[http4s] class CachingChunkWriter[F[_]](
 
   private def addChunk(b: Chunk[Byte]): Chunk[Byte] = {
     if (bodyBuffer == null) bodyBuffer = b
-    else bodyBuffer = (bodyBuffer ++ b).toChunk
+    else bodyBuffer = Chunk.bytes(bodyBuffer.toBytes.values ++ b.toBytes.values)
     bodyBuffer
   }
 

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingStaticWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingStaticWriter.scala
@@ -29,7 +29,7 @@ private[http4s] class CachingStaticWriter[F[_]](
 
   private def addChunk(b: Chunk[Byte]): Chunk[Byte] = {
     if (bodyBuffer == null) bodyBuffer = b
-    else bodyBuffer = (bodyBuffer ++ b).toChunk
+    else bodyBuffer = Chunk.bytes(bodyBuffer.toBytes.values ++ b.toBytes.values)
     bodyBuffer
   }
 

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
@@ -39,7 +39,7 @@ private[http4s] class IdentityWriter[F[_]](size: Long, out: TailStage[ByteBuffer
 
       logger.warn(msg)
 
-      val reducedChunk = chunk.take(size - bodyBytesWritten).toChunk
+      val reducedChunk = Chunk.bytes(chunk.take(size - bodyBytesWritten).toArray)
       writeBodyChunk(reducedChunk, flush = true) *> Future.failed(new IllegalArgumentException(msg))
     } else {
       val b = chunk.toByteBuffer

--- a/core/src/main/scala/org/http4s/util/Renderable.scala
+++ b/core/src/main/scala/org/http4s/util/Renderable.scala
@@ -197,7 +197,7 @@ final case class ChunkWriter(
 ) extends Writer {
 
   override def append(s: String): this.type = {
-    toChunk = (toChunk ++ Chunk.bytes(s.getBytes(charset))).toChunk
+    toChunk = Chunk.bytes(toChunk.toBytes.values ++ s.getBytes(charset))
     this
   }
 

--- a/core/src/main/scala/org/http4s/util/chunk.scala
+++ b/core/src/main/scala/org/http4s/util/chunk.scala
@@ -10,7 +10,7 @@ trait ChunkInstances extends ChunkInstances0 {
   implicit val ByteChunkMonoid: Monoid[Chunk[Byte]] =
     new Monoid[Chunk[Byte]] {
       def combine(chunk1: Chunk[Byte], chunk2: Chunk[Byte]): Chunk[Byte] =
-        (chunk1 ++ chunk2).toChunk
+        Chunk.bytes(chunk1.toBytes.values ++ chunk2.toBytes.values)
 
       val empty: Chunk[Byte] =
         Chunk.empty

--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -101,7 +101,7 @@ object GZip {
     (Segment[Byte, Unit], Stream[Pure, Byte])]) => Pull[Pure, Byte, Option[Stream[Pure, Byte]]] = {
     case None => Pull.pure(None)
     case Some((segment, stream)) =>
-      val chunkArray = segment.toChunk.toArray
+      val chunkArray = segment.toArray
       gen.crc.update(chunkArray)
       gen.inputLength = gen.inputLength + chunkArray.length
       Pull.output(segment) *> stream.pull


### PR DESCRIPTION
This gets rid of a lot of `toChunk` calls, which are actually `Chunk.vector(toVector)` in fs2, for Array-backed Chunks for byte chunk instances.