### PR TITLE
Relax some typeclass constraints

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -4,15 +4,15 @@ package argonaut
 import _root_.argonaut.{DecodeResult => ArgDecodeResult, _}
 import _root_.argonaut.Argonaut._
 import cats.Applicative
-import cats.effect.Effect
+import cats.effect.Sync
 import org.http4s.argonaut.Parser.facade
 import org.http4s.headers.`Content-Type`
 
 trait ArgonautInstances {
-  implicit def jsonDecoder[F[_]: Effect]: EntityDecoder[F, Json] =
+  implicit def jsonDecoder[F[_]: Sync]: EntityDecoder[F, Json] =
     jawn.jawnDecoder
 
-  def jsonOf[F[_]: Effect, A](implicit decoder: DecodeJson[A]): EntityDecoder[F, A] =
+  def jsonOf[F[_]: Sync, A](implicit decoder: DecodeJson[A]): EntityDecoder[F, A] =
     jsonDecoder[F].flatMapR { json =>
       decoder
         .decodeJson(json)
@@ -55,7 +55,7 @@ trait ArgonautInstances {
               .fold(err => ArgDecodeResult.fail(err.toString, c.history), ArgDecodeResult.ok))
   )
 
-  implicit class MessageSyntax[F[_]: Effect](self: Message[F]) {
+  implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
     def decodeJson[A](implicit decoder: DecodeJson[A]): F[A] =
       self.as(implicitly, jsonOf[F, A])
   }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -243,7 +243,8 @@ object Http1Stage {
 
   private val CachedEmptyBufferThunk = {
     val b = Future.successful(emptyBuffer)
-    () => b
+    () =>
+      b
   }
 
   private val CachedEmptyBody = EmptyBody -> CachedEmptyBufferThunk

--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -243,8 +243,7 @@ object Http1Stage {
 
   private val CachedEmptyBufferThunk = {
     val b = Future.successful(emptyBuffer)
-    () =>
-      b
+    () => b
   }
 
   private val CachedEmptyBody = EmptyBody -> CachedEmptyBufferThunk

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -14,13 +14,13 @@ import org.http4s.headers.`Content-Type`
 import scodec.bits.ByteVector
 
 trait CirceInstances {
-  def jsonDecoderIncremental[F[_]: Effect]: EntityDecoder[F, Json] =
+  def jsonDecoderIncremental[F[_]: Sync]: EntityDecoder[F, Json] =
     jawn.jawnDecoder[F, Json]
 
-  def jsonDecoderByteBuffer[F[_]: Effect]: EntityDecoder[F, Json] =
+  def jsonDecoderByteBuffer[F[_]: Sync]: EntityDecoder[F, Json] =
     EntityDecoder.decodeBy(MediaType.`application/json`)(jsonDecoderByteBufferImpl[F])
 
-  private def jsonDecoderByteBufferImpl[F[_]: Effect](msg: Message[F]): DecodeResult[F, Json] =
+  private def jsonDecoderByteBufferImpl[F[_]: Sync](msg: Message[F]): DecodeResult[F, Json] =
     EntityDecoder.collectBinary(msg).flatMap { segment =>
       val bb = ByteBuffer.wrap(segment.force.toArray)
       if (bb.hasRemaining) {
@@ -36,9 +36,9 @@ trait CirceInstances {
       }
     }
 
-  implicit def jsonDecoder[F[_]: Effect]: EntityDecoder[F, Json]
+  implicit def jsonDecoder[F[_]: Sync]: EntityDecoder[F, Json]
 
-  def jsonDecoderAdaptive[F[_]: Effect](cutoff: Long): EntityDecoder[F, Json] =
+  def jsonDecoderAdaptive[F[_]: Sync](cutoff: Long): EntityDecoder[F, Json] =
     EntityDecoder.decodeBy(MediaType.`application/json`) { msg =>
       msg.contentLength match {
         case Some(contentLength) if contentLength < cutoff =>
@@ -47,7 +47,7 @@ trait CirceInstances {
       }
     }
 
-  def jsonOf[F[_]: Effect, A](implicit decoder: Decoder[A]): EntityDecoder[F, A] =
+  def jsonOf[F[_]: Sync, A](implicit decoder: Decoder[A]): EntityDecoder[F, A] =
     jsonDecoder[F].flatMapR { json =>
       decoder
         .decodeJson(json)
@@ -89,7 +89,7 @@ trait CirceInstances {
       Uri.fromString(str).leftMap(_ => "Uri")
     }
 
-  implicit class MessageSyntax[F[_]: Effect](self: Message[F]) {
+  implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
     def decodeJson[A](implicit decoder: Decoder[A]): F[A] =
       self.as(implicitly, jsonOf[F, A])
   }
@@ -99,10 +99,10 @@ object CirceInstances {
   def withPrinter(p: Printer): CirceInstances =
     new CirceInstances {
       val defaultPrinter: Printer = p
-      def jsonDecoder[F[_]: Effect]: EntityDecoder[F, Json] = defaultJsonDecoder
+      def jsonDecoder[F[_]: Sync]: EntityDecoder[F, Json] = defaultJsonDecoder
     }
 
   // default cutoff value is based on benchmarks results
-  def defaultJsonDecoder[F[_]: Effect]: EntityDecoder[F, Json] =
+  def defaultJsonDecoder[F[_]: Sync]: EntityDecoder[F, Json] =
     jsonDecoderAdaptive(cutoff = 100000)
 }

--- a/circe/src/main/scala/org/http4s/circe/package.scala
+++ b/circe/src/main/scala/org/http4s/circe/package.scala
@@ -1,12 +1,12 @@
 package org.http4s
 
-import cats.effect.Effect
+import cats.effect.Sync
 import io.circe.{Json, Printer}
 
 package object circe extends CirceInstances {
   override val defaultPrinter: Printer =
     Printer.noSpaces
 
-  override def jsonDecoder[F[_]: Effect]: EntityDecoder[F, Json] =
+  override def jsonDecoder[F[_]: Sync]: EntityDecoder[F, Json] =
     CirceInstances.defaultJsonDecoder
 }

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -1,7 +1,7 @@
 package org.http4s
 
 import cats._
-import cats.effect.Effect
+import cats.effect.Sync
 import cats.implicits._
 import fs2._
 import fs2.io._
@@ -175,11 +175,11 @@ object EntityDecoder extends EntityDecoderInstances {
   }
 
   /** Helper method which simply gathers the body into a single ByteVector */
-  def collectBinary[F[_]: Effect](msg: Message[F]): DecodeResult[F, Segment[Byte, Unit]] =
+  def collectBinary[F[_]: Sync](msg: Message[F]): DecodeResult[F, Segment[Byte, Unit]] =
     DecodeResult.success(msg.body.segments.runFoldMonoid)
 
   /** Decodes a message to a String */
-  def decodeString[F[_]: Effect](msg: Message[F])(
+  def decodeString[F[_]: Sync](msg: Message[F])(
       implicit defaultCharset: Charset = DefaultCharset): F[String] =
     msg.bodyAsText.runFoldMonoid
 }
@@ -191,49 +191,49 @@ trait EntityDecoderInstances {
   /////////////////// Instances //////////////////////////////////////////////
 
   /** Provides a mechanism to fail decoding */
-  def error[F[_], T](t: Throwable)(implicit F: Effect[F]): EntityDecoder[F, T] =
+  def error[F[_], T](t: Throwable)(implicit F: Sync[F]): EntityDecoder[F, T] =
     new EntityDecoder[F, T] {
       override def decode(msg: Message[F], strict: Boolean): DecodeResult[F, T] =
         DecodeResult(msg.body.run *> F.raiseError(t))
       override def consumes: Set[MediaRange] = Set.empty
     }
 
-  implicit def binary[F[_]: Effect]: EntityDecoder[F, Segment[Byte, Unit]] =
+  implicit def binary[F[_]: Sync]: EntityDecoder[F, Segment[Byte, Unit]] =
     EntityDecoder.decodeBy(MediaRange.`*/*`)(collectBinary[F])
 
-  implicit def binaryChunk[F[_]: Effect]: EntityDecoder[F, Chunk[Byte]] =
+  implicit def binaryChunk[F[_]: Sync]: EntityDecoder[F, Chunk[Byte]] =
     binary[F].map(_.force.toChunk)
 
-  implicit def byteArrayDecoder[F[_]: Effect]: EntityDecoder[F, Array[Byte]] =
+  implicit def byteArrayDecoder[F[_]: Sync]: EntityDecoder[F, Array[Byte]] =
     binary.map(_.force.toArray)
 
-  implicit def text[F[_]: Effect](
+  implicit def text[F[_]: Sync](
       implicit defaultCharset: Charset = DefaultCharset): EntityDecoder[F, String] =
     EntityDecoder.decodeBy(MediaRange.`text/*`)(msg =>
       collectBinary(msg).map(bs =>
         new String(bs.force.toArray, msg.charset.getOrElse(defaultCharset).nioCharset)))
 
-  implicit def charArrayDecoder[F[_]: Effect]: EntityDecoder[F, Array[Char]] =
+  implicit def charArrayDecoder[F[_]: Sync]: EntityDecoder[F, Array[Char]] =
     text.map(_.toArray)
 
   // File operations // TODO: rewrite these using NIO non blocking FileChannels, and do these make sense as a 'decoder'?
-  def binFile[F[_]](file: File)(implicit F: Effect[F]): EntityDecoder[F, File] =
+  def binFile[F[_]](file: File)(implicit F: Sync[F]): EntityDecoder[F, File] =
     EntityDecoder.decodeBy(MediaRange.`*/*`) { msg =>
       val sink = writeOutputStream[F](F.delay(new FileOutputStream(file)))
       DecodeResult.success(msg.body.to(sink).run).map(_ => file)
     }
 
-  def textFile[F[_]](file: File)(implicit F: Effect[F]): EntityDecoder[F, File] =
+  def textFile[F[_]](file: File)(implicit F: Sync[F]): EntityDecoder[F, File] =
     EntityDecoder.decodeBy(MediaRange.`text/*`) { msg =>
       val sink = writeOutputStream[F](F.delay(new PrintStream(new FileOutputStream(file))))
       DecodeResult.success(msg.body.to(sink).run).map(_ => file)
     }
 
-  implicit def multipart[F[_]: Effect]: EntityDecoder[F, Multipart[F]] =
+  implicit def multipart[F[_]: Sync]: EntityDecoder[F, Multipart[F]] =
     MultipartDecoder.decoder
 
   /** An entity decoder that ignores the content and returns unit. */
-  implicit def void[F[_]: Effect]: EntityDecoder[F, Unit] =
+  implicit def void[F[_]: Sync]: EntityDecoder[F, Unit] =
     EntityDecoder.decodeBy(MediaRange.`*/*`) { msg =>
       DecodeResult.success(msg.body.drain.run)
     }

--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -1,7 +1,7 @@
 package org.http4s
 
 import cats._
-import cats.effect.Effect
+import cats.effect.Sync
 import cats.implicits.{catsSyntaxEither => _, _}
 import org.http4s.headers._
 import org.http4s.parser._
@@ -93,7 +93,7 @@ object UrlForm {
       .withContentType(`Content-Type`(MediaType.`application/x-www-form-urlencoded`, charset))
 
   implicit def entityDecoder[F[_]](
-      implicit F: Effect[F],
+      implicit F: Sync[F],
       defaultCharset: Charset = DefaultCharset): EntityDecoder[F, UrlForm] =
     EntityDecoder.decodeBy(MediaType.`application/x-www-form-urlencoded`) { m =>
       DecodeResult(

--- a/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -9,7 +9,7 @@ import scodec.bits.ByteVector
 
 private[http4s] object MultipartDecoder {
 
-  def decoder[F[_]: Effect]: EntityDecoder[F, Multipart[F]] =
+  def decoder[F[_]: Sync]: EntityDecoder[F, Multipart[F]] =
     EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
       msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
         case Some(boundary) =>

--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -22,7 +22,7 @@ object MultipartParser {
 
   final case class Out[+A](a: A, tail: Option[ByteVector] = None)
 
-  def parse[F[_]: Effect](boundary: Boundary): Pipe[F, Byte, Either[Headers, ByteVector]] = s => {
+  def parse[F[_]: Sync](boundary: Boundary): Pipe[F, Byte, Either[Headers, ByteVector]] = s => {
     val bufferedMultipartT = s.runLog.map(vec => ByteVector(vec))
     val parts = bufferedMultipartT.flatMap(parseToParts(_)(boundary))
     val listT = parts.map(splitParts(_)(boundary)(List.empty[Either[Headers, ByteVector]]))

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -13,8 +13,7 @@ trait JawnInstances {
     EntityDecoder.decodeBy(MediaType.`application/json`)(jawnDecoderImpl[F, J])
 
   // some decoders may reuse it and avoid extra content negotiation
-  private[http4s] def jawnDecoderImpl[F[_]: Sync, J: Facade](
-      msg: Message[F]): DecodeResult[F, J] =
+  private[http4s] def jawnDecoderImpl[F[_]: Sync, J: Facade](msg: Message[F]): DecodeResult[F, J] =
     DecodeResult {
       msg.body.chunks
         .parseJson(AsyncParser.SingleValue)

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -9,11 +9,11 @@ import fs2.Stream
 import jawnfs2._
 
 trait JawnInstances {
-  def jawnDecoder[F[_]: Effect, J: Facade]: EntityDecoder[F, J] =
+  def jawnDecoder[F[_]: Sync, J: Facade]: EntityDecoder[F, J] =
     EntityDecoder.decodeBy(MediaType.`application/json`)(jawnDecoderImpl[F, J])
 
   // some decoders may reuse it and avoid extra content negotiation
-  private[http4s] def jawnDecoderImpl[F[_]: Effect, J: Facade](
+  private[http4s] def jawnDecoderImpl[F[_]: Sync, J: Facade](
       msg: Message[F]): DecodeResult[F, J] =
     DecodeResult {
       msg.body.chunks

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -14,10 +14,10 @@ object CustomParser extends Parser(useBigDecimalForDouble = true, useBigIntForLo
 trait Json4sInstances[J] {
   import CustomParser.facade
 
-  implicit def jsonDecoder[F[_]: Effect]: EntityDecoder[F, JValue] =
+  implicit def jsonDecoder[F[_]: Sync]: EntityDecoder[F, JValue] =
     jawn.jawnDecoder
 
-  def jsonOf[F[_]: Effect, A](implicit reader: Reader[A]): EntityDecoder[F, A] =
+  def jsonOf[F[_]: Sync, A](implicit reader: Reader[A]): EntityDecoder[F, A] =
     jsonDecoder.flatMapR { json =>
       try DecodeResult.success(reader.read(json))
       catch {
@@ -32,7 +32,7 @@ trait Json4sInstances[J] {
     * Editorial: This is heavily dependent on reflection. This is more idiomatic json4s, but less
     * idiomatic http4s, than [[jsonOf]].
     */
-  def jsonExtract[F[_]: Effect, A](
+  def jsonExtract[F[_]: Sync, A](
       implicit formats: Formats,
       manifest: Manifest[A]): EntityDecoder[F, A] =
     jsonDecoder.flatMapR { json =>
@@ -77,7 +77,7 @@ trait Json4sInstances[J] {
         JString(uri.toString)
     }
 
-  implicit class MessageSyntax[F[_]: Effect](self: Message[F]) {
+  implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
     def decodeJson[A](implicit decoder: Reader[A]): F[A] =
       self.as(implicitly, jsonOf[F, A])
   }

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -26,7 +26,7 @@ trait ElemInstances {
     *
     * @return an XML element
     */
-  implicit def xml[F[_]](implicit F: Effect[F]): EntityDecoder[F, Elem] = {
+  implicit def xml[F[_]](implicit F: Sync[F]): EntityDecoder[F, Elem] = {
     import EntityDecoder._
     decodeBy(MediaType.`text/xml`, MediaType.`text/html`, MediaType.`application/xml`) { msg =>
       collectBinary(msg).flatMap[DecodeFailure, Elem] { arr =>

--- a/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
@@ -7,7 +7,7 @@ import javax.servlet.{DispatcherType, Filter}
 import javax.servlet.http.HttpServlet
 import org.http4s.server.{AsyncTimeoutSupport, ServerBuilder}
 
-abstract class ServletContainer[F[_]: Effect] extends ServerBuilder[F] with AsyncTimeoutSupport[F] {
+abstract class ServletContainer[F[_]: Async] extends ServerBuilder[F] with AsyncTimeoutSupport[F] {
   type Self <: ServletContainer[F]
 
   /**
@@ -47,7 +47,7 @@ abstract class ServletContainer[F[_]: Effect] extends ServerBuilder[F] with Asyn
 }
 
 object ServletContainer {
-  def DefaultServletIo[F[_]: Effect]: ServletIo[F] = NonBlockingServletIo[F](DefaultChunkSize)
+  def DefaultServletIo[F[_]: Async]: ServletIo[F] = NonBlockingServletIo[F](DefaultChunkSize)
 
   /**
     * Trims an optional trailing slash and then appends "/\u002b'.  Translates an argument to

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -15,8 +15,8 @@ import scala.annotation.tailrec
 /**
   * Determines the mode of I/O used for reading request bodies and writing response bodies.
   */
-sealed abstract class ServletIo[F[_]: Effect] {
-  protected[servlet] val F = Effect[F]
+sealed abstract class ServletIo[F[_]: Async] {
+  protected[servlet] val F = Async[F]
 
   protected[servlet] def reader(servletRequest: HttpServletRequest): EntityBody[F]
 
@@ -30,7 +30,7 @@ sealed abstract class ServletIo[F[_]: Effect] {
   * This is more CPU efficient per request than [[NonBlockingServletIo]], but is likely to
   * require a larger request thread pool for the same load.
   */
-final case class BlockingServletIo[F[_]: Effect](chunkSize: Int) extends ServletIo[F] {
+final case class BlockingServletIo[F[_]: Async](chunkSize: Int) extends ServletIo[F] {
   override protected[servlet] def reader(servletRequest: HttpServletRequest): EntityBody[F] =
     io.readInputStream[F](F.pure(servletRequest.getInputStream), chunkSize)
 
@@ -56,7 +56,7 @@ final case class BlockingServletIo[F[_]: Effect](chunkSize: Int) extends Servlet
   * under high load up through  at least Tomcat 8.0.15.  These appear to be harmless, but are
   * operationally annoying.
   */
-final case class NonBlockingServletIo[F[_]: Effect](chunkSize: Int) extends ServletIo[F] {
+final case class NonBlockingServletIo[F[_]: Async](chunkSize: Int) extends ServletIo[F] {
   private[this] val logger = getLogger
 
   private[this] def rightSome[A](a: A) = Right(Some(a))


### PR DESCRIPTION
Now that the different run methods on Streams just require a Sync instance, many typeclass constraints can be relaxed.