### PR TITLE
Smarter version of Chunk.toByteBuffer syntax

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/BytesBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/BytesBench.scala
@@ -1,0 +1,56 @@
+package org.http4s.bench
+
+import fs2._
+import fs2.interop.scodec.ByteVectorChunk
+import org.http4s.util.chunk._
+import org.openjdk.jmh.annotations._
+import scodec.bits.ByteVector
+
+@Fork(2)
+@Threads(1)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+class BytesBench {
+  val bs = new Array[Byte](1024)
+  scala.util.Random.nextBytes(bs)
+
+  @Benchmark def byteVectorChunkToByteBuffer() = {
+    val s = Segment.chunk(ByteVectorChunk(ByteVector.view(bs))) ++
+      Segment.chunk(ByteVectorChunk(ByteVector.view(bs))) ++
+      Segment.chunk(ByteVectorChunk(ByteVector.view(bs))) ++
+      Segment.chunk(ByteVectorChunk(ByteVector.view(bs))) ++
+      Segment.chunk(ByteVectorChunk(ByteVector.view(bs)))
+    s.force.foreachChunk { c =>
+      c.toByteBuffer; ()
+    }
+  }
+
+  @Benchmark def bytesToByteBuffer() = {
+    val s = Segment.chunk(Chunk.bytes(bs.array)) ++
+      Segment.chunk(Chunk.bytes(bs.array)) ++
+      Segment.chunk(Chunk.bytes(bs.array)) ++
+      Segment.chunk(Chunk.bytes(bs.array)) ++
+      Segment.chunk(Chunk.bytes(bs.array))
+    s.force.foreachChunk { c =>
+      c.toByteBuffer; ()
+    }
+  }
+
+  @Benchmark def byteVectorChunkToArray() = {
+    val s = Segment.chunk(ByteVectorChunk(ByteVector.view(bs))) ++
+      Segment.chunk(ByteVectorChunk(ByteVector.view(bs))) ++
+      Segment.chunk(ByteVectorChunk(ByteVector.view(bs))) ++
+      Segment.chunk(ByteVectorChunk(ByteVector.view(bs))) ++
+      Segment.chunk(ByteVectorChunk(ByteVector.view(bs)))
+    s.force.toArray
+  }
+
+  @Benchmark def bytesToArray() = {
+    val s = Segment.chunk(Chunk.bytes(bs.array)) ++
+      Segment.chunk(Chunk.bytes(bs.array)) ++
+      Segment.chunk(Chunk.bytes(bs.array)) ++
+      Segment.chunk(Chunk.bytes(bs.array)) ++
+      Segment.chunk(Chunk.bytes(bs.array))
+    s.force.toArray
+  }
+}

--- a/core/src/main/scala/org/http4s/util/chunk.scala
+++ b/core/src/main/scala/org/http4s/util/chunk.scala
@@ -2,6 +2,7 @@ package org.http4s.util
 
 import cats._
 import fs2._
+import fs2.interop.scodec.ByteVectorChunk
 import java.nio.ByteBuffer
 
 trait ChunkInstances {
@@ -18,10 +19,16 @@ trait ChunkInstances {
 }
 
 class ByteChunkOps(val self: Chunk[Byte]) extends AnyVal {
-  def toByteBuffer: ByteBuffer = {
-    val byteChunk = self.toBytes //Avoids copying
-    ByteBuffer.wrap(byteChunk.values, byteChunk.offset, byteChunk.length).asReadOnlyBuffer
-  }
+  def toByteBuffer: ByteBuffer =
+    self match {
+      case bvc: ByteVectorChunk =>
+        bvc.toByteVector.toByteBuffer
+      case bs: Chunk.Bytes =>
+        bs.toByteBuffer
+      case _ =>
+        val byteChunk = self.toBytes //Avoids copying
+        ByteBuffer.wrap(byteChunk.values, byteChunk.offset, byteChunk.length).asReadOnlyBuffer
+    }
 }
 
 trait ByteChunkSyntax {


### PR DESCRIPTION
We have `ByteVectorChunk` in part so we can wrap `ByteBuffer`s, and then we forfeit that advantage when converting them back to a `ByteBuffer` at rendering time.