### PR TITLE
Move ByteChunkSyntax to the org.http4s.syntax package

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/BytesBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/BytesBench.scala
@@ -2,7 +2,7 @@ package org.http4s.bench
 
 import fs2._
 import fs2.interop.scodec.ByteVectorChunk
-import org.http4s.util.chunk._
+import org.http4s.syntax.byteChunk._
 import org.openjdk.jmh.annotations._
 import scodec.bits.ByteVector
 

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
@@ -8,7 +8,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.ISO_8859_1
 import org.http4s.blaze.pipeline.TailStage
 import org.http4s.util.StringWriter
-import org.http4s.util.chunk._
+import org.http4s.syntax.byteChunk._
 import scala.concurrent._
 
 private[http4s] class CachingChunkWriter[F[_]](

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.ISO_8859_1
 import org.http4s.blaze.pipeline.TailStage
 import org.http4s.util.StringWriter
-import org.http4s.util.chunk._
+import org.http4s.syntax.byteChunk._
 import scala.concurrent._
 
 private[util] object ChunkWriter {

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/Http2Writer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/Http2Writer.scala
@@ -7,7 +7,7 @@ import fs2._
 import org.http4s.blaze.http.Headers
 import org.http4s.blaze.http.http20.NodeMsg._
 import org.http4s.blaze.pipeline.TailStage
-import org.http4s.util.chunk._
+import org.http4s.syntax.byteChunk._
 import scala.concurrent._
 
 private[http4s] class Http2Writer[F[_]](

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
@@ -8,7 +8,7 @@ import fs2._
 import java.nio.ByteBuffer
 import org.http4s.blaze.pipeline.TailStage
 import org.http4s.util.StringWriter
-import org.http4s.util.chunk._
+import org.http4s.syntax.byteChunk._
 import org.log4s.getLogger
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
@@ -4,6 +4,7 @@ package syntax
 trait AllSyntax
     extends AnyRef
     with AsyncSyntax
+    with ByteChunkSyntax
     with EffectResponseSyntax
     with EffectRequestSyntax
     with KleisliSyntax

--- a/core/src/main/scala/org/http4s/syntax/ByteChunkSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/ByteChunkSyntax.scala
@@ -1,0 +1,23 @@
+package org.http4s.syntax
+
+import fs2.Chunk
+import fs2.interop.scodec.ByteVectorChunk
+import java.nio.ByteBuffer
+
+trait ByteChunkSyntax {
+  implicit def http4sByteChunkSyntax(self: Chunk[Byte]): ByteChunkOps =
+    new ByteChunkOps(self)
+}
+
+final class ByteChunkOps(val self: Chunk[Byte]) extends AnyVal {
+  def toByteBuffer: ByteBuffer =
+    self match {
+      case bvc: ByteVectorChunk =>
+        bvc.toByteVector.toByteBuffer
+      case bs: Chunk.Bytes =>
+        bs.toByteBuffer
+      case _ =>
+        val byteChunk = self.toBytes //Avoids copying
+        ByteBuffer.wrap(byteChunk.values, byteChunk.offset, byteChunk.length).asReadOnlyBuffer
+    }
+}

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -3,6 +3,7 @@ package org.http4s
 package object syntax {
   object all extends AllSyntax
   object async extends AsyncSyntax
+  object byteChunk extends ByteChunkSyntax
   @deprecated("Use map or flatMap on the request instead", "0.18.0-M2")
   object effectRequest extends EffectRequestSyntax
   @deprecated("Use map or flatMap on the request instead", "0.18.0-M2")

--- a/core/src/main/scala/org/http4s/util/chunk.scala
+++ b/core/src/main/scala/org/http4s/util/chunk.scala
@@ -1,25 +1,6 @@
 package org.http4s.util
 
-import fs2._
-import fs2.interop.scodec.ByteVectorChunk
-import java.nio.ByteBuffer
+import org.http4s.syntax.ByteChunkSyntax
 
-class ByteChunkOps(val self: Chunk[Byte]) extends AnyVal {
-  def toByteBuffer: ByteBuffer =
-    self match {
-      case bvc: ByteVectorChunk =>
-        bvc.toByteVector.toByteBuffer
-      case bs: Chunk.Bytes =>
-        bs.toByteBuffer
-      case _ =>
-        val byteChunk = self.toBytes //Avoids copying
-        ByteBuffer.wrap(byteChunk.values, byteChunk.offset, byteChunk.length).asReadOnlyBuffer
-    }
-}
-
-trait ByteChunkSyntax {
-  implicit def toByteChunkOps(self: Chunk[Byte]): ByteChunkOps =
-    new ByteChunkOps(self)
-}
-
+@deprecated("Moved to org.http4s.syntax.byteChunk", "0.18.0-M7")
 object chunk extends AnyRef with ByteChunkSyntax


### PR DESCRIPTION
To be consistent with other syntax enrichments