### PR TITLE
`BlazeBuilder` now properly shuts down its `ExecutorService`

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServer.scala
@@ -192,6 +192,7 @@ class BlazeBuilder(
       override def shutdown: Task[Unit] = Task.delay {
         serverChannel.close()
         factory.closeGroup()
+        serviceExecutor.shutdown()
       }
 
       override def onShutdown(f: => Unit): this.type = {


### PR DESCRIPTION
This means shutdown behavior of `http4s` will be as expected when using non-deamon threads