### PR TITLE
Remove Unecessary Parboiled Exclusion

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -12,6 +12,3 @@ rewrite.rules = [
   AsciiSortImports
   PreferCurlyFors
 ]
-
-// We track parboiled2 against upstream
-project.excludeFilters = [ parboiled2 ]


### PR DESCRIPTION
We Have moved parboiled to its own project so this exclusion is no longer necessary.