### PR TITLE
Call Async Callback to Correctly Initiate Shutdown

### DIFF
--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -54,7 +54,9 @@ trait ServerBuilder[F[_]] {
     * that runs for the rest of the JVM's life.
     */
   final def serve(implicit F: Async[F]): Stream[F, ExitCode] =
-    Stream.bracket(start)((_: Server[F]) => Stream.eval_(F.async[Unit](cb => cb(Right(())))), _.shutdown)
+    Stream.bracket(start)(
+      (_: Server[F]) => Stream.eval_(F.async[Unit](cb => cb(Right(())))),
+      _.shutdown)
 
   /** Set the banner to display when the server starts up */
   def withBanner(banner: immutable.Seq[String]): Self

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -54,7 +54,7 @@ trait ServerBuilder[F[_]] {
     * that runs for the rest of the JVM's life.
     */
   final def serve(implicit F: Async[F]): Stream[F, ExitCode] =
-    Stream.bracket(start)((_: Server[F]) => Stream.eval_(F.async[Unit](_ => ())), _.shutdown)
+    Stream.bracket(start)((_: Server[F]) => Stream.eval_(F.async[Unit](cb => cb(Right(())))), _.shutdown)
 
   /** Set the banner to display when the server starts up */
   def withBanner(banner: immutable.Seq[String]): Self


### PR DESCRIPTION
Fixes Concurrently Leakage

I don't know why we were even using async here originally but by not calling the provided callback we broke lots of stuff. Lesson for the day, don't do that.