### PR TITLE
extract filename for multipart

### DIFF
--- a/core/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/src/main/scala/org/http4s/multipart/Part.scala
@@ -11,7 +11,8 @@ import org.http4s.headers.`Content-Disposition`
 
 final case class Part[F[_]](headers: Headers, body: Stream[F, Byte]) {
   def name: Option[String] = headers.get(`Content-Disposition`).flatMap(_.parameters.get("name"))
-  def filename: Option[String] = headers.get(`Content-Disposition`).flatMap(_.parameters.get("filename"))
+  def filename: Option[String] =
+    headers.get(`Content-Disposition`).flatMap(_.parameters.get("filename"))
 }
 
 object Part {

--- a/core/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/src/main/scala/org/http4s/multipart/Part.scala
@@ -11,6 +11,7 @@ import org.http4s.headers.`Content-Disposition`
 
 final case class Part[F[_]](headers: Headers, body: Stream[F, Byte]) {
   def name: Option[String] = headers.get(`Content-Disposition`).flatMap(_.parameters.get("name"))
+  def filename: Option[String] = headers.get(`Content-Disposition`).flatMap(_.parameters.get("filename"))
 }
 
 object Part {

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -23,7 +23,8 @@ class MultipartSpec extends Specification {
         encoded and decoded with    binary data    $encodeAndDecodeMultipartWithBinaryFormData
         decode  and encode  with    content types  $decodeMultipartRequestWithContentTypes
         decode  and encode  without content types  $decodeMultipartRequestWithoutContentTypes
-        extract name properly if it is present     $extractNameIfPresent
+        extract name     properly if it is present $extractNameIfPresent
+        extract filename property if it is present $extractFilenameIfPresent
      """
 
   val url = Uri(
@@ -173,5 +174,13 @@ I am a big moose
       Headers(`Content-Disposition`("form-data", Map("name" -> "Rich Homie Quan"))),
       Stream.empty.covary[IO])
     part.name must beEqualTo(Some("Rich Homie Quan"))
+  }
+
+  def extractFilenameIfPresent = {
+    val part = Part(
+      Headers(`Content-Disposition`("form-data", Map("name" -> "file", "filename" -> "file.txt"))),
+      Stream.empty.covary[IO]
+    )
+    part.filename must beEqualTo(Some("file.txt"))
   }
 }


### PR DESCRIPTION
The filename is something that is often needed when handling a multi part encoded request, having a method to extract this from a part is helpful.