### PR TITLE
Break up Cookie into Request and Response

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -363,7 +363,7 @@ final case class Response[F[_]](
   /** Returns a list of cookies from the [[org.http4s.headers.Set-Cookie]]
     * headers. Includes expired cookies, such as those that represent cookie
     * deletion. */
-  def cookies: List[Cookie] =
+  def cookies: List[ResponseCookie] =
     `Set-Cookie`.from(headers).map(_.cookie)
 }
 

--- a/core/src/main/scala/org/http4s/MessageOps.scala
+++ b/core/src/main/scala/org/http4s/MessageOps.scala
@@ -124,8 +124,7 @@ trait RequestOps[F[_]] extends Any with MessageOps[F] {
     putHeaders(org.http4s.headers.Cookie(NonEmptyList.of(cookie)))
 
   /** Add a Cookie header with the provided values */
-  final def addCookie(name: String, content: String)(
-      implicit F: Functor[F]): Self =
+  final def addCookie(name: String, content: String)(implicit F: Functor[F]): Self =
     addCookie(RequestCookie(name, content))
 }
 

--- a/core/src/main/scala/org/http4s/MessageOps.scala
+++ b/core/src/main/scala/org/http4s/MessageOps.scala
@@ -120,13 +120,13 @@ trait RequestOps[F[_]] extends Any with MessageOps[F] {
       implicit F: Monad[F]): F[Response[F]]
 
   /** Add a Cookie header for the provided [[Cookie]] */
-  final def addCookie(cookie: Cookie)(implicit F: Functor[F]): Self =
+  final def addCookie(cookie: RequestCookie)(implicit F: Functor[F]): Self =
     putHeaders(org.http4s.headers.Cookie(NonEmptyList.of(cookie)))
 
   /** Add a Cookie header with the provided values */
-  final def addCookie(name: String, content: String, expires: Option[HttpDate] = None)(
+  final def addCookie(name: String, content: String)(
       implicit F: Functor[F]): Self =
-    addCookie(Cookie(name, content, expires))
+    addCookie(RequestCookie(name, content))
 }
 
 trait ResponseOps[F[_]] extends Any with MessageOps[F] {
@@ -139,19 +139,19 @@ trait ResponseOps[F[_]] extends Any with MessageOps[F] {
   def withStatus(status: Status)(implicit F: Functor[F]): Self
 
   /** Add a Set-Cookie header for the provided [[Cookie]] */
-  final def addCookie(cookie: Cookie)(implicit F: Functor[F]): Self =
+  final def addCookie(cookie: ResponseCookie)(implicit F: Functor[F]): Self =
     putHeaders(`Set-Cookie`(cookie))
 
   /** Add a Set-Cookie header with the provided values */
   final def addCookie(name: String, content: String, expires: Option[HttpDate] = None)(
       implicit F: Functor[F]): Self =
-    addCookie(Cookie(name, content, expires))
+    addCookie(ResponseCookie(name, content, expires))
 
   /** Add a [[org.http4s.headers.Set-Cookie]] which will remove the specified cookie from the client */
-  final def removeCookie(cookie: Cookie)(implicit F: Functor[F]): Self =
+  final def removeCookie(cookie: ResponseCookie)(implicit F: Functor[F]): Self =
     putHeaders(cookie.clearCookie)
 
   /** Add a [[org.http4s.headers.Set-Cookie]] which will remove the specified cookie from the client */
   final def removeCookie(name: String)(implicit F: Functor[F]): Self =
-    putHeaders(Cookie(name, "").clearCookie)
+    putHeaders(ResponseCookie(name, "").clearCookie)
 }

--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -42,7 +42,8 @@ object RequestCookieJar {
       def result(): RequestCookieJar = new RequestCookieJar(Vector(coll.toSeq: _*))
     }
 
-  implicit def canBuildFrom: CanBuildFrom[TraversableOnce[RequestCookie], RequestCookie, RequestCookieJar] =
+  implicit def canBuildFrom
+    : CanBuildFrom[TraversableOnce[RequestCookie], RequestCookie, RequestCookieJar] =
     new CanBuildFrom[TraversableOnce[RequestCookie], RequestCookie, RequestCookieJar] {
       def apply(
           from: TraversableOnce[RequestCookie]
@@ -63,9 +64,11 @@ class RequestCookieJar(private val headers: Seq[RequestCookie])
   def get(key: String): Option[RequestCookie] = headers.find(_.name == key)
   def apply(key: String): RequestCookie = get(key).getOrElse(default(key))
   def contains(key: String): Boolean = headers.exists(_.name == key)
-  def getOrElse(key: String, default: => String): RequestCookie = get(key).getOrElse(RequestCookie(key, default))
+  def getOrElse(key: String, default: => String): RequestCookie =
+    get(key).getOrElse(RequestCookie(key, default))
   override def seq: RequestCookieJar = this
-  def default(key: String): RequestCookie = throw new NoSuchElementException("Can't find RequestCookie " + key)
+  def default(key: String): RequestCookie =
+    throw new NoSuchElementException("Can't find RequestCookie " + key)
 
   def keySet: Set[String] = headers.map(_.name).toSet
 
@@ -135,7 +138,7 @@ final case class RequestCookie(name: String, content: String) extends Renderable
   override lazy val renderString: String = super.renderString
 
   override def render(writer: Writer): writer.type = {
-    writer.append (name).append ('=').append (content)
+    writer.append(name).append('=').append(content)
     writer
   }
 }

--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -25,14 +25,14 @@ import scala.collection.generic.CanBuildFrom
 object RequestCookieJar {
   def empty: RequestCookieJar = new RequestCookieJar(Nil)
 
-  def apply(cookies: Cookie*): RequestCookieJar = (newBuilder ++= cookies).result()
+  def apply(cookies: RequestCookie*): RequestCookieJar = (newBuilder ++= cookies).result()
 
   /** The default builder for RequestCookieJar objects.
     */
-  def newBuilder: mutable.Builder[Cookie, RequestCookieJar] =
-    new mutable.Builder[Cookie, RequestCookieJar] {
-      private[this] val coll = mutable.ListBuffer[Cookie]()
-      def +=(elem: Cookie): this.type = {
+  def newBuilder: mutable.Builder[RequestCookie, RequestCookieJar] =
+    new mutable.Builder[RequestCookie, RequestCookieJar] {
+      private[this] val coll = mutable.ListBuffer[RequestCookie]()
+      def +=(elem: RequestCookie): this.type = {
         coll += elem
         this
       }
@@ -42,30 +42,30 @@ object RequestCookieJar {
       def result(): RequestCookieJar = new RequestCookieJar(Vector(coll.toSeq: _*))
     }
 
-  implicit def canBuildFrom: CanBuildFrom[TraversableOnce[Cookie], Cookie, RequestCookieJar] =
-    new CanBuildFrom[TraversableOnce[Cookie], Cookie, RequestCookieJar] {
+  implicit def canBuildFrom: CanBuildFrom[TraversableOnce[RequestCookie], RequestCookie, RequestCookieJar] =
+    new CanBuildFrom[TraversableOnce[RequestCookie], RequestCookie, RequestCookieJar] {
       def apply(
-          from: TraversableOnce[Cookie]
-      ): mutable.Builder[Cookie, RequestCookieJar] = newBuilder
+          from: TraversableOnce[RequestCookie]
+      ): mutable.Builder[RequestCookie, RequestCookieJar] = newBuilder
 
-      def apply(): mutable.Builder[Cookie, RequestCookieJar] = newBuilder
+      def apply(): mutable.Builder[RequestCookie, RequestCookieJar] = newBuilder
     }
 
 }
-class RequestCookieJar(private val headers: Seq[Cookie])
-    extends Iterable[Cookie]
-    with IterableLike[Cookie, RequestCookieJar] {
-  override protected[this] def newBuilder: mutable.Builder[Cookie, RequestCookieJar] =
+class RequestCookieJar(private val headers: Seq[RequestCookie])
+    extends Iterable[RequestCookie]
+    with IterableLike[RequestCookie, RequestCookieJar] {
+  override protected[this] def newBuilder: mutable.Builder[RequestCookie, RequestCookieJar] =
     RequestCookieJar.newBuilder
-  def iterator: Iterator[Cookie] = headers.iterator
+  def iterator: Iterator[RequestCookie] = headers.iterator
   def empty: RequestCookieJar = RequestCookieJar.empty
 
-  def get(key: String): Option[Cookie] = headers.find(_.name == key)
-  def apply(key: String): Cookie = get(key).getOrElse(default(key))
+  def get(key: String): Option[RequestCookie] = headers.find(_.name == key)
+  def apply(key: String): RequestCookie = get(key).getOrElse(default(key))
   def contains(key: String): Boolean = headers.exists(_.name == key)
-  def getOrElse(key: String, default: => String): Cookie = get(key).getOrElse(Cookie(key, default))
+  def getOrElse(key: String, default: => String): RequestCookie = get(key).getOrElse(RequestCookie(key, default))
   override def seq: RequestCookieJar = this
-  def default(key: String): Cookie = throw new NoSuchElementException("Can't find cookie " + key)
+  def default(key: String): RequestCookie = throw new NoSuchElementException("Can't find RequestCookie " + key)
 
   def keySet: Set[String] = headers.map(_.name).toSet
 
@@ -85,7 +85,7 @@ class RequestCookieJar(private val headers: Seq[Cookie])
     *
     *  @return the values of this map as an iterable.
     */
-  def cookies: Iterable[Cookie] = headers
+  def cookies: Iterable[RequestCookie] = headers
 
   /** Creates an iterator for all keys.
     *
@@ -109,8 +109,8 @@ class RequestCookieJar(private val headers: Seq[Cookie])
     new RequestCookieJar(headers.filter(c => p(c.name)))
 
   /* Overridden for efficiency. */
-  override def toSeq: Seq[Cookie] = headers
-  override def toBuffer[C >: Cookie]: mutable.Buffer[C] = {
+  override def toSeq: Seq[RequestCookie] = headers
+  override def toBuffer[C >: RequestCookie]: mutable.Buffer[C] = {
     val result = new mutable.ArrayBuffer[C](size)
     copyToBuffer(result)
     result
@@ -130,7 +130,17 @@ class RequestCookieJar(private val headers: Seq[Cookie])
 }
 
 // see http://tools.ietf.org/html/rfc6265
-final case class Cookie(
+final case class RequestCookie(name: String, content: String) extends Renderable {
+
+  override lazy val renderString: String = super.renderString
+
+  override def render(writer: Writer): writer.type = {
+    writer.append (name).append ('=').append (content)
+    writer
+  }
+}
+
+final case class ResponseCookie(
     name: String,
     content: String,
     expires: Option[HttpDate] = None,

--- a/core/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/src/main/scala/org/http4s/headers/Cookie.scala
@@ -10,8 +10,7 @@ object Cookie extends HeaderKey.Internal[Cookie] with HeaderKey.Recurring {
     HttpHeaderParser.COOKIE(s)
 }
 
-final case class Cookie(values: NonEmptyList[RequestCookie])
-    extends Header.RecurringRenderable {
+final case class Cookie(values: NonEmptyList[RequestCookie]) extends Header.RecurringRenderable {
   override def key: Cookie.type = Cookie
   type Value = RequestCookie
   override def renderValue(writer: Writer): writer.type = {

--- a/core/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/src/main/scala/org/http4s/headers/Cookie.scala
@@ -10,10 +10,10 @@ object Cookie extends HeaderKey.Internal[Cookie] with HeaderKey.Recurring {
     HttpHeaderParser.COOKIE(s)
 }
 
-final case class Cookie(values: NonEmptyList[org.http4s.Cookie])
+final case class Cookie(values: NonEmptyList[RequestCookie])
     extends Header.RecurringRenderable {
   override def key: Cookie.type = Cookie
-  type Value = org.http4s.Cookie
+  type Value = RequestCookie
   override def renderValue(writer: Writer): writer.type = {
     values.head.render(writer)
     values.tail.foreach(writer << "; " << _)

--- a/core/src/main/scala/org/http4s/headers/Set-Cookie.scala
+++ b/core/src/main/scala/org/http4s/headers/Set-Cookie.scala
@@ -3,6 +3,7 @@ package headers
 
 import cats.data.NonEmptyList
 import org.http4s.parser.HttpHeaderParser
+import org.http4s.ResponseCookie
 import org.http4s.util.Writer
 
 object `Set-Cookie` extends HeaderKey.Internal[`Set-Cookie`] {
@@ -21,7 +22,7 @@ object `Set-Cookie` extends HeaderKey.Internal[`Set-Cookie`] {
     HttpHeaderParser.SET_COOKIE(s)
 }
 
-final case class `Set-Cookie`(cookie: org.http4s.Cookie) extends Header.Parsed {
+final case class `Set-Cookie`(cookie: ResponseCookie) extends Header.Parsed {
   override def key: `Set-Cookie`.type = `Set-Cookie`
   override def renderValue(writer: Writer): writer.type = cookie.render(writer)
 }

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -33,14 +33,16 @@ private[parser] trait CookieHeader {
   // scalastyle:off public.methods.have.type
   private class SetCookieParser(input: ParserInput) extends BaseCookieParser[`Set-Cookie`](input) {
     def entry: Rule1[`Set-Cookie`] = rule {
-      CookiePair(ResponseCookie(_, _)) ~ zeroOrMore(";" ~ OptWS ~ CookieAttrs) ~ EOI ~> (`Set-Cookie`(_))
+      CookiePair(ResponseCookie(_, _)) ~ zeroOrMore(";" ~ OptWS ~ CookieAttrs) ~ EOI ~> (`Set-Cookie`(
+        _))
     }
   }
 
   private class CookieParser(input: ParserInput) extends BaseCookieParser[headers.Cookie](input) {
     def entry: Rule1[headers.Cookie] = rule {
-      oneOrMore(CookiePair(RequestCookie)).separatedBy(";" ~ OptWS) ~ EOI ~> { xs: Seq[RequestCookie] =>
-        headers.Cookie(xs.head, xs.tail: _*)
+      oneOrMore(CookiePair(RequestCookie)).separatedBy(";" ~ OptWS) ~ EOI ~> {
+        xs: Seq[RequestCookie] =>
+          headers.Cookie(xs.head, xs.tail: _*)
       }
     }
   }

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -126,7 +126,7 @@ val logIn: Kleisli[IO, Request[IO], Response[IO]] = Kleisli({ request =>
       Forbidden(error)
     case Right(user) => {
       val message = crypto.signToken(user.id.toString, clock.millis.toString)
-      Ok("Logged in!").map(_.addCookie(Cookie("authcookie", message)))
+      Ok("Logged in!").map(_.addCookie(ResponseCookie("authcookie", message)))
     }
   })
 })

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -158,13 +158,13 @@ http4s has special support for Cookie headers using the `Cookie` type to add
 and invalidate cookies. Adding a cookie will generate the correct `Set-Cookie` header:
 
 ```tut
-Ok("Ok response.").map(_.addCookie(Cookie("foo", "bar"))).unsafeRunSync.headers
+Ok("Ok response.").map(_.addCookie(ResponseCookie("foo", "bar"))).unsafeRunSync.headers
 ```
 
 `Cookie` can be further customized to set, e.g., expiration, the secure flag, httpOnly, flag, etc
 
 ```tut
-Ok("Ok response.").map(_.addCookie(Cookie("foo", "bar", expires = Some(HttpDate.now), httpOnly = true, secure = true))).unsafeRunSync.headers
+Ok("Ok response.").map(_.addCookie(ResponseCookie("foo", "bar", expires = Some(HttpDate.now), httpOnly = true, secure = true))).unsafeRunSync.headers
 ```
 
 To request a cookie to be removed on the client, you need to set the cookie value

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -51,7 +51,7 @@ class CSRFSpec extends Http4sSpec {
     "fail a request with an invalid cookie, despite it being a safe method" in {
       val response =
         csrf
-          .validate()(dummyService)(passThroughRequest.addCookie(Cookie(csrf.cookieName, "MOOSE")))
+          .validate()(dummyService)(passThroughRequest.addCookie(RequestCookie(csrf.cookieName, "MOOSE")))
           .getOrElse(orElse)
           .unsafeRunSync()
 
@@ -70,7 +70,7 @@ class CSRFSpec extends Http4sSpec {
           newCookie <- IO.pure(
             response.cookies
               .find(_.name == csrf.cookieName)
-              .getOrElse(Cookie("invalid", "Invalid2")))
+              .getOrElse(ResponseCookie("invalid", "Invalid2")))
           raw2 <- csrf.extractRaw(newCookie.content).getOrElse("Invalid1")
         } yield (oldToken, raw1, response, newCookie, raw2)).unsafeRunSync()
 

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -51,7 +51,8 @@ class CSRFSpec extends Http4sSpec {
     "fail a request with an invalid cookie, despite it being a safe method" in {
       val response =
         csrf
-          .validate()(dummyService)(passThroughRequest.addCookie(RequestCookie(csrf.cookieName, "MOOSE")))
+          .validate()(dummyService)(
+            passThroughRequest.addCookie(RequestCookie(csrf.cookieName, "MOOSE")))
           .getOrElse(orElse)
           .unsafeRunSync()
 

--- a/tests/src/test/scala/org/http4s/CookieSpec.scala
+++ b/tests/src/test/scala/org/http4s/CookieSpec.scala
@@ -6,7 +6,7 @@ final class CookieSpec extends Http4sSpec {
   "RequestCookieJar" should {
 
     "Not duplicate elements when adding the empty set" in {
-      val jar = new RequestCookieJar(List(new Cookie("foo", "bar")))
+      val jar = new RequestCookieJar(List(RequestCookie("foo", "bar")))
       (jar ++ Set()).## must_== jar.##
     }
 

--- a/tests/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeadersSpec.scala
@@ -27,15 +27,15 @@ class HeadersSpec extends Http4sSpec {
 
     "also find headers created raw" in {
       val headers = Headers(
-        org.http4s.headers.`Cookie`(org.http4s.Cookie("foo", "bar")),
-        Header("Cookie", org.http4s.Cookie("baz", "quux").toString)
+        org.http4s.headers.`Cookie`(RequestCookie("foo", "bar")),
+        Header("Cookie", RequestCookie("baz", "quux").toString)
       )
       headers.get(org.http4s.headers.Cookie).map(_.values.length) must beSome(2)
     }
 
     "Find the headers with DefaultHeaderKey keys" in {
       val headers = Headers(
-        `Set-Cookie`(org.http4s.Cookie("foo", "bar")),
+        `Set-Cookie`(ResponseCookie("foo", "bar")),
         Header("Accept-Patch", ""),
         Header("Access-Control-Allow-Credentials", "")
       )
@@ -49,8 +49,8 @@ class HeadersSpec extends Http4sSpec {
     }
 
     "Allow multiple Set-Cookie headers" in {
-      val h1 = `Set-Cookie`(org.http4s.Cookie("foo1", "bar1")).toRaw
-      val h2 = `Set-Cookie`(org.http4s.Cookie("foo2", "bar2")).toRaw
+      val h1 = `Set-Cookie`(ResponseCookie("foo1", "bar1")).toRaw
+      val h2 = `Set-Cookie`(ResponseCookie("foo2", "bar2")).toRaw
       val hs = Headers(clength) ++ Headers(h1) ++ Headers(h2)
       hs.count(_.parsed match { case `Set-Cookie`(_) => true; case _ => false }) must_== 2
       hs.exists(_ == clength) must_== true

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -60,7 +60,7 @@ class MessageSpec extends Http4sSpec {
     "support cookies" should {
       "contain a Cookie header when an explicit cookie is added" in {
         Request(Method.GET)
-          .addCookie(Cookie("token", "value"))
+          .addCookie(RequestCookie("token", "value"))
           .headers
           .get("Cookie".ci)
           .map(_.value) must beSome("token=value")
@@ -132,7 +132,7 @@ class MessageSpec extends Http4sSpec {
   "Response" >> {
     "toString" should {
       "redact a `Set-Cookie` header" in {
-        val resp = Response().putHeaders(headers.`Set-Cookie`(Cookie("token", "value")))
+        val resp = Response().putHeaders(headers.`Set-Cookie`(ResponseCookie("token", "value")))
         resp.toString must_== ("Response(status=200, headers=Headers(Set-Cookie: <REDACTED>))")
       }
     }

--- a/tests/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/tests/src/test/scala/org/http4s/ResponderSpec.scala
@@ -82,11 +82,15 @@ class ResponderSpec extends Specification {
     }
 
     "Set cookie from Cookie" in {
-      resp.addCookie(ResponseCookie("foo", "bar")).cookies must_== List(ResponseCookie("foo", "bar"))
+      resp.addCookie(ResponseCookie("foo", "bar")).cookies must_== List(
+        ResponseCookie("foo", "bar"))
     }
 
     "Set multiple cookies" in {
-      resp.addCookie(ResponseCookie("foo", "bar")).addCookie(ResponseCookie("baz", "quux")).cookies must_== List(
+      resp
+        .addCookie(ResponseCookie("foo", "bar"))
+        .addCookie(ResponseCookie("baz", "quux"))
+        .cookies must_== List(
         ResponseCookie("foo", "bar"),
         ResponseCookie("baz", "quux")
       )

--- a/tests/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/tests/src/test/scala/org/http4s/ResponderSpec.scala
@@ -78,23 +78,24 @@ class ResponderSpec extends Specification {
     }
 
     "Set cookie from tuple" in {
-      resp.addCookie("foo", "bar").cookies must_== List(org.http4s.Cookie("foo", "bar"))
+      resp.addCookie("foo", "bar").cookies must_== List(ResponseCookie("foo", "bar"))
     }
 
     "Set cookie from Cookie" in {
-      resp.addCookie(Cookie("foo", "bar")).cookies must_== List(org.http4s.Cookie("foo", "bar"))
+      resp.addCookie(ResponseCookie("foo", "bar")).cookies must_== List(ResponseCookie("foo", "bar"))
     }
 
     "Set multiple cookies" in {
-      resp.addCookie(Cookie("foo", "bar")).addCookie(Cookie("baz", "quux")).cookies must_== List(
-        org.http4s.Cookie("foo", "bar"),
-        org.http4s.Cookie("baz", "quux"))
+      resp.addCookie(ResponseCookie("foo", "bar")).addCookie(ResponseCookie("baz", "quux")).cookies must_== List(
+        ResponseCookie("foo", "bar"),
+        ResponseCookie("baz", "quux")
+      )
     }
 
     "Remove cookie" in {
-      val cookie = Cookie("foo", "bar")
+      val cookie = ResponseCookie("foo", "bar")
       resp.removeCookie(cookie).cookies must_== List(
-        org.http4s.Cookie("foo", "", expires = Option(HttpDate.Epoch), maxAge = Some(0L))
+        ResponseCookie("foo", "", expires = Option(HttpDate.Epoch), maxAge = Some(0L))
       )
     }
   }

--- a/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
@@ -8,18 +8,6 @@ class SetCookieHeaderSpec extends Specification with HeaderParserHelper[`Set-Coo
   def hparse(value: String): ParseResult[`Set-Cookie`] = HttpHeaderParser.SET_COOKIE(value)
 
   "Set-Cookie parser" should {
-
-//    case class Cookie(
-//                       name: String,
-//                       content: String,
-//                       expires: Option[DateTime] = None,
-//                       maxAge: Option[Long] = None,
-//                       domain: Option[String] = None,
-//                       path: Option[String] = None,
-//                       secure: Boolean = false,
-//                       httpOnly: Boolean = false,
-//                       extension: Option[String] = None
-
     val cookiestr = "myname=\"foo\"; Domain=value; Max-Age=1; Path=value; Secure;HttpOnly"
 
     "parse a set cookie" in {
@@ -40,7 +28,7 @@ class CookieHeaderSpec extends Specification with HeaderParserHelper[headers.Coo
   def hparse(value: String): ParseResult[headers.Cookie] = HttpHeaderParser.COOKIE(value)
 
   val cookiestr = "key1=value1; key2=\"value2\""
-  val cookies = Seq(Cookie("key1", "value1"), Cookie("key2", "value2"))
+  val cookies = Seq(RequestCookie("key1", "value1"), RequestCookie("key2", "value2"))
 
   "Cookie parser" should {
     "parse a cookie" in {


### PR DESCRIPTION
This PR adds a `RequestCookie` and `ResponseCookie` per the discussion in https://gitter.im/http4s/http4s?at=5a90d82b0202dc012e79241a.

I opened this PR due to the following motivation:

> The only reason I ask is that, at work, I, having not used Cookie's in a real app, wrongly wrote code that checked on an HTTP Request's Cookie's cookie.isSecure && cookie.isHttpOnly. If an HTTP Request's Cookie only contained name=value pairs, then that would eliminate that type of error

per https://gitter.im/http4s/http4s?at=5a90d82b0202dc012e79241a.

It uses the `abstract class` approach that @jmcardon mentioned in https://gitter.im/http4s/http4s?at=5a90d8cd0202dc012e79266d.