### PR TITLE
Don't use filter in Arbitrary[`Content-Length`]

### DIFF
--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -350,7 +350,7 @@ trait ArbitraryInstances {
   implicit val arbitraryContentLength: Arbitrary[`Content-Length`] =
     Arbitrary {
       for {
-        long <- arbitrary[Long] if long > 0L
+        long <- Gen.chooseNum(0L, Long.MaxValue)
       } yield `Content-Length`.unsafeFromLong(long)
     }
 


### PR DESCRIPTION
Simpler version of fix in #1677.  Prevents the generator from giving up due to a long run of discarded values, which results in a `None` sample.