### PR TITLE
More polymorphic middlewares

### DIFF
--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/Module.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/Module.scala
@@ -24,9 +24,9 @@ class Module[F[_]](client: Client[F])(implicit F: Effect[F], S: Scheduler) {
   private val gitHubService = new GitHubService[F](client)
 
   def middleware: HttpMiddleware[F] = { (service: HttpService[F]) =>
-    GZip(service)(F)
+    GZip(service)
   }.compose { service =>
-    AutoSlash(service)(F)
+    AutoSlash(service)
   }
 
   val fileHttpEndpoint: HttpService[F] =

--- a/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
@@ -3,7 +3,8 @@ package server
 package middleware
 
 import cats._
-import cats.data.{Kleisli, OptionT}
+import cats.data.Kleisli
+import cats.implicits._
 
 /** Removes a trailing slash from [[Request]] path
   *
@@ -12,14 +13,13 @@ import cats.data.{Kleisli, OptionT}
   * uri = "/foo/" to match the route.
   */
 object AutoSlash {
-  def apply[F[_]: Monad](service: HttpService[F]): HttpService[F] =
-    Kleisli { req =>
-      service(req).orElse {
-        val pi = req.pathInfo
-        if (pi.isEmpty || pi.charAt(pi.length - 1) != '/')
-          OptionT.none
-        else
-          service.apply(req.withPathInfo(pi.substring(0, pi.length - 1)))
-      }
+  def apply[F[_], G[_]: Functor, B](service: Kleisli[F, Request[G], B])(
+      implicit M: MonoidK[F]): Kleisli[F, Request[G], B] =
+    service <+> Kleisli { req =>
+      val pi = req.pathInfo
+      if (pi.isEmpty || pi.charAt(pi.length - 1) != '/')
+        M.empty
+      else
+        service.apply(req.withPathInfo(pi.substring(0, pi.length - 1)))
     }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -14,7 +14,8 @@ import cats.implicits._
   * requiring more optimization should implement their own HEAD handler.
   */
 object DefaultHead {
-  def apply[F[_]: Monad](service: HttpService[F]): HttpService[F] =
+  def apply[F[_]: Monad: SemigroupK, G[_], H[_]](
+      service: Kleisli[F, Request[G], Response[H]]): Kleisli[F, Request[G], Response[H]] =
     Kleisli { req =>
       req.method match {
         case Method.HEAD =>
@@ -24,7 +25,8 @@ object DefaultHead {
       }
     }
 
-  private def headAsTruncatedGet[F[_]: Functor](service: HttpService[F]): HttpService[F] =
+  private def headAsTruncatedGet[F[_]: Functor, G[_], H[_]](
+      service: Kleisli[F, Request[G], Response[H]]): Kleisli[F, Request[G], Response[H]] =
     Kleisli { req =>
       val getReq = req.withMethod(Method.GET)
       service(getReq).map(response => response.copy(body = response.body.drain))

--- a/server/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -2,6 +2,7 @@ package org.http4s
 package server
 package middleware
 
+import cats.data.Kleisli
 import fs2._
 import scala.util.control.NoStackTrace
 
@@ -11,8 +12,8 @@ object EntityLimiter {
 
   val DefaultMaxEntitySize: Long = 2L * 1024L * 1024L // 2 MB default
 
-  def apply[F[_]](service: HttpService[F], limit: Long = DefaultMaxEntitySize): HttpService[F] =
-    service.local { req: Request[F] =>
+  def apply[F[_], G[_], B](service: Kleisli[F, Request[G], B], limit: Long = DefaultMaxEntitySize): Kleisli[F, Request[G], B] =
+    service.local { req: Request[G] =>
       req.withBodyStream(req.body.through(takeLimited(limit)))
     }
 

--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -17,11 +17,12 @@ object GZip {
 
   // TODO: It could be possible to look for F.pure type bodies, and change the Content-Length header after
   // TODO      zipping and buffering all the input. Just a thought.
-  def apply[F[_]: Functor](
-      service: HttpService[F],
+  def apply[F[_]: Functor, G[_], H[_]: Functor](
+      service: Kleisli[F, Request[G], Response[H]],
       bufferSize: Int = 32 * 1024,
       level: Int = Deflater.DEFAULT_COMPRESSION,
-      isZippable: Response[F] => Boolean = defaultIsZippable[F](_: Response[F])): HttpService[F] =
+      isZippable: Response[H] => Boolean = defaultIsZippable[F](_: Response[F]))
+    : Kleisli[F, Request[G], Response[H]] =
     Kleisli { req =>
       req.headers.get(`Accept-Encoding`) match {
         case Some(acceptEncoding) if satisfiedByGzip(acceptEncoding) =>

--- a/server/src/main/scala/org/http4s/server/middleware/HSTS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HSTS.scala
@@ -17,20 +17,20 @@ object HSTS {
     includeSubDomains = true,
     preload = false)
 
-  def apply[F[_]: Functor](service: HttpService[F]): HttpService[F] =
+  def apply[F[_]: Functor, G[_]: Functor, A](service: Kleisli[F, A, Response[G]]): Kleisli[F, A, Response[G]] =
     apply(service, defaultHSTSPolicy)
 
-  def apply[F[_]: Functor](
-      service: HttpService[F],
-      header: `Strict-Transport-Security`): HttpService[F] = Kleisli { req =>
+  def apply[F[_]: Functor, G[_]: Functor, A](
+      service: Kleisli[F, A, Response[G]],
+      header: `Strict-Transport-Security`): Kleisli[F, A, Response[G]] = Kleisli { req =>
     service.map(_.putHeaders(header)).apply(req)
   }
 
-  def unsafeFromDuration[F[_]: Functor](
-      service: HttpService[F],
+  def unsafeFromDuration[F[_]: Functor, G[_]: Functor, A](
+      service: Kleisli[F, A, Response[G]],
       maxAge: FiniteDuration = 365.days,
       includeSubDomains: Boolean = true,
-      preload: Boolean = false): HttpService[F] = {
+      preload: Boolean = false): Kleisli[F, A, Response[G]] = {
     val header = `Strict-Transport-Security`.unsafeFromDuration(maxAge, includeSubDomains, preload)
 
     apply(service, header)

--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
@@ -7,7 +7,7 @@ import fs2.Stream._
 import org.http4s.dsl.io._
 
 class DefaultHeadSpec extends Http4sSpec {
-  val service = DefaultHead[IO](HttpService[IO] {
+  val service = DefaultHead(HttpService[IO] {
     case GET -> Root / "hello" =>
       Ok("hello")
 
@@ -41,7 +41,7 @@ class DefaultHeadSpec extends Http4sSpec {
 
     "allow GET body to clean up on fallthrough" in {
       var cleanedUp = false
-      val service = DefaultHead[IO](HttpService[IO] {
+      val service = DefaultHead(HttpService[IO] {
         case GET -> _ =>
           val body: EntityBody[IO] = eval_(IO({ cleanedUp = true }))
           Ok(body)


### PR DESCRIPTION
Some of our middleware is overconstrained.  Many of the transformations are valid regardless of the effect type.  Others depend only on `MonoidK` rather than a specific monad transformer.  These types permit more reasoning about what happens in the middleware and are applicable to more intermediate shapes in the course of building up a service.