### PR TITLE
EntityEncoder as a typeclass with a pure operation

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -30,10 +30,9 @@ trait ArgonautInstances {
   implicit def jsonEncoder[F[_]: Applicative]: EntityEncoder[F, Json] =
     jsonEncoderWithPrettyParams[F](defaultPrettyParams)
 
-  def jsonEncoderWithPrettyParams[F[_]](prettyParams: PrettyParams)(
-      implicit A: Applicative[F]): EntityEncoder[F, Json] =
+  def jsonEncoderWithPrettyParams[F[_]](prettyParams: PrettyParams): EntityEncoder[F, Json] =
     EntityEncoder
-      .stringEncoder(A, Charset.`UTF-8`)
+      .stringEncoder(Charset.`UTF-8`)
       .contramap[Json](prettyParams.pretty)
       .withContentType(`Content-Type`(MediaType.`application/json`, Charset.`UTF-8`))
 

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -3,6 +3,7 @@ package argonaut.test // Get out of argonaut package so we can import custom ins
 
 import _root_.argonaut._
 import cats.effect.IO
+import cats.syntax.applicative._
 import java.nio.charset.StandardCharsets
 import org.http4s.Status.Ok
 import org.http4s.argonaut._
@@ -74,10 +75,10 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
       // TODO Urgh.  We need to make testing these smoother.
       // https://github.com/http4s/http4s/issues/157
       def getBody(body: EntityBody[IO]): Array[Byte] = body.compile.toVector.unsafeRunSync.toArray
-      val req = Request[IO]().withBody(jNumberOrNull(157)).unsafeRunSync
+      val req = Request[IO]().withBody(jNumberOrNull(157))
       val body = req
         .decode { json: Json =>
-          Response(Ok).withBody(json.number.flatMap(_.toLong).getOrElse(0L).toString)
+          Response[IO](Ok).withBody(json.number.flatMap(_.toLong).getOrElse(0L).toString).pure[IO]
         }
         .unsafeRunSync
         .body
@@ -87,9 +88,8 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
 
   "jsonOf" should {
     "decode JSON from an Argonaut decoder" in {
-      val result = jsonOf[IO, Foo].decode(
-        Request[IO]().withBody(jObjectFields("bar" -> jNumberOrNull(42))).unsafeRunSync,
-        strict = true)
+      val result = jsonOf[IO, Foo]
+        .decode(Request[IO]().withBody(jObjectFields("bar" -> jNumberOrNull(42))), strict = true)
       result.value.unsafeRunSync must beRight(Foo(42))
     }
 
@@ -100,7 +100,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
       s"handle JSON with umlauts: $wort" >> {
         val json = Json("wort" -> jString(wort))
         val result =
-          jsonOf[IO, Umlaut].decode(Request[IO]().withBody(json).unsafeRunSync, strict = true)
+          jsonOf[IO, Umlaut].decode(Request[IO]().withBody(json), strict = true)
         result.value.unsafeRunSync must_== Right(Umlaut(wort))
       }
     }
@@ -117,12 +117,12 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
   "Message[F].decodeJson[A]" should {
     "decode json from a message" in {
       val req = Request[IO]().withBody(foo.asJson)
-      req.flatMap(_.decodeJson[Foo]) must returnValue(foo)
+      req.decodeJson[Foo] must returnValue(foo)
     }
 
     "fail on invalid json" in {
       val req = Request[IO]().withBody(List(13, 14).asJson)
-      req.flatMap(_.decodeJson[Foo]).attempt.unsafeRunSync must beLeft
+      req.decodeJson[Foo].attempt.unsafeRunSync must beLeft
     }
   }
 }

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -75,10 +75,10 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
       // TODO Urgh.  We need to make testing these smoother.
       // https://github.com/http4s/http4s/issues/157
       def getBody(body: EntityBody[IO]): Array[Byte] = body.compile.toVector.unsafeRunSync.toArray
-      val req = Request[IO]().withBody(jNumberOrNull(157))
+      val req = Request[IO]().withEntity(jNumberOrNull(157))
       val body = req
         .decode { json: Json =>
-          Response[IO](Ok).withBody(json.number.flatMap(_.toLong).getOrElse(0L).toString).pure[IO]
+          Response[IO](Ok).withEntity(json.number.flatMap(_.toLong).getOrElse(0L).toString).pure[IO]
         }
         .unsafeRunSync
         .body
@@ -89,7 +89,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
   "jsonOf" should {
     "decode JSON from an Argonaut decoder" in {
       val result = jsonOf[IO, Foo]
-        .decode(Request[IO]().withBody(jObjectFields("bar" -> jNumberOrNull(42))), strict = true)
+        .decode(Request[IO]().withEntity(jObjectFields("bar" -> jNumberOrNull(42))), strict = true)
       result.value.unsafeRunSync must beRight(Foo(42))
     }
 
@@ -100,7 +100,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
       s"handle JSON with umlauts: $wort" >> {
         val json = Json("wort" -> jString(wort))
         val result =
-          jsonOf[IO, Umlaut].decode(Request[IO]().withBody(json), strict = true)
+          jsonOf[IO, Umlaut].decode(Request[IO]().withEntity(json), strict = true)
         result.value.unsafeRunSync must_== Right(Umlaut(wort))
       }
     }
@@ -116,12 +116,12 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
 
   "Message[F].decodeJson[A]" should {
     "decode json from a message" in {
-      val req = Request[IO]().withBody(foo.asJson)
+      val req = Request[IO]().withEntity(foo.asJson)
       req.decodeJson[Foo] must returnValue(foo)
     }
 
     "fail on invalid json" in {
-      val req = Request[IO]().withBody(List(13, 14).asJson)
+      val req = Request[IO]().withEntity(List(13, 14).asJson)
       req.decodeJson[Foo].attempt.unsafeRunSync must beLeft
     }
   }

--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -46,7 +46,7 @@ object CirceJsonBench {
       val arraySize = (approxContentLength.toDouble /
         jsonStr.getBytes("UTF-8").length.toDouble).round.toInt
       val json = Json.arr((1 to arraySize).map(_ => obj): _*)
-      req = Request[IO]().withBody(json)
+      req = Request[IO]().withEntity(json)
       println(
         s"Array size: $arraySize; Approx. Content-Length: $approxContentLength; Content-Length: ${req.contentLength}")
     }

--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -46,7 +46,7 @@ object CirceJsonBench {
       val arraySize = (approxContentLength.toDouble /
         jsonStr.getBytes("UTF-8").length.toDouble).round.toInt
       val json = Json.arr((1 to arraySize).map(_ => obj): _*)
-      req = Request[IO]().withBody(json).unsafeRunSync
+      req = Request[IO]().withBody(json)
       println(
         s"Array size: $arraySize; Approx. Content-Length: $approxContentLength; Content-Length: ${req.contentLength}")
     }

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -153,7 +153,7 @@ class Http1ServerStageSpec extends Http4sSpec {
           val headers = Headers(H.`Transfer-Encoding`(TransferCoding.identity))
           IO.pure(
             Response[IO](headers = headers)
-              .withBody("hello world"))
+              .withEntity("hello world"))
       }
 
       // The first request will get split into two chunks, leaving the last byte off
@@ -176,7 +176,7 @@ class Http1ServerStageSpec extends Http4sSpec {
           IO.pure(
             Response[IO](status = Status.NotModified)
               .putHeaders(`Transfer-Encoding`(TransferCoding.chunked))
-              .withBody("Foo!"))
+              .withEntity("Foo!"))
       }
 
       val req = "GET /foo HTTP/1.1\r\n\r\n"
@@ -241,7 +241,7 @@ class Http1ServerStageSpec extends Http4sSpec {
       val service = HttpService[IO] {
         case req =>
           req.as[String].map { s =>
-            Response().withBody("Result: " + s)
+            Response().withEntity("Result: " + s)
           }
       }
 
@@ -264,7 +264,7 @@ class Http1ServerStageSpec extends Http4sSpec {
     "Maintain the connection if the body is ignored but was already read to completion by the Http1Stage" in {
 
       val service = HttpService[IO] {
-        case _ => IO.pure(Response().withBody("foo"))
+        case _ => IO.pure(Response().withEntity("foo"))
       }
 
       // The first request will get split into two chunks, leaving the last byte off
@@ -284,7 +284,7 @@ class Http1ServerStageSpec extends Http4sSpec {
     "Drop the connection if the body is ignored and was not read to completion by the Http1Stage" in {
 
       val service = HttpService[IO] {
-        case _ => IO.pure(Response().withBody("foo"))
+        case _ => IO.pure(Response().withEntity("foo"))
       }
 
       // The first request will get split into two chunks, leaving the last byte off
@@ -306,7 +306,7 @@ class Http1ServerStageSpec extends Http4sSpec {
     "Handle routes that runs the request body for non-chunked" in {
 
       val service = HttpService[IO] {
-        case req => req.body.compile.drain *> IO.pure(Response().withBody("foo"))
+        case req => req.body.compile.drain *> IO.pure(Response().withEntity("foo"))
       }
 
       // The first request will get split into two chunks, leaving the last byte off

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -151,8 +151,9 @@ class Http1ServerStageSpec extends Http4sSpec {
       val service = HttpService[IO] {
         case _ =>
           val headers = Headers(H.`Transfer-Encoding`(TransferCoding.identity))
-          Response[IO](headers = headers)
-            .withBody("hello world")
+          IO.pure(
+            Response[IO](headers = headers)
+              .withBody("hello world"))
       }
 
       // The first request will get split into two chunks, leaving the last byte off
@@ -172,9 +173,10 @@ class Http1ServerStageSpec extends Http4sSpec {
     "Do not send an entity or entity-headers for a status that doesn't permit it" in {
       val service: HttpService[IO] = HttpService[IO] {
         case _ =>
-          Response[IO](status = Status.NotModified)
-            .putHeaders(`Transfer-Encoding`(TransferCoding.chunked))
-            .withBody("Foo!")
+          IO.pure(
+            Response[IO](status = Status.NotModified)
+              .putHeaders(`Transfer-Encoding`(TransferCoding.chunked))
+              .withBody("Foo!"))
       }
 
       val req = "GET /foo HTTP/1.1\r\n\r\n"
@@ -238,7 +240,7 @@ class Http1ServerStageSpec extends Http4sSpec {
     "Handle routes that consumes the full request body for non-chunked" in {
       val service = HttpService[IO] {
         case req =>
-          req.as[String].flatMap { s =>
+          req.as[String].map { s =>
             Response().withBody("Result: " + s)
           }
       }
@@ -262,7 +264,7 @@ class Http1ServerStageSpec extends Http4sSpec {
     "Maintain the connection if the body is ignored but was already read to completion by the Http1Stage" in {
 
       val service = HttpService[IO] {
-        case _ => Response().withBody("foo")
+        case _ => IO.pure(Response().withBody("foo"))
       }
 
       // The first request will get split into two chunks, leaving the last byte off
@@ -282,7 +284,7 @@ class Http1ServerStageSpec extends Http4sSpec {
     "Drop the connection if the body is ignored and was not read to completion by the Http1Stage" in {
 
       val service = HttpService[IO] {
-        case _ => Response().withBody("foo")
+        case _ => IO.pure(Response().withBody("foo"))
       }
 
       // The first request will get split into two chunks, leaving the last byte off
@@ -304,7 +306,7 @@ class Http1ServerStageSpec extends Http4sSpec {
     "Handle routes that runs the request body for non-chunked" in {
 
       val service = HttpService[IO] {
-        case req => req.body.compile.drain *> Response().withBody("foo")
+        case req => req.body.compile.drain *> IO.pure(Response().withBody("foo"))
       }
 
       // The first request will get split into two chunks, leaving the last byte off

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -3,6 +3,7 @@ package circe.test // Get out of circe package so we can import custom instances
 
 import cats.effect.IO
 import cats.effect.laws.util.TestContext
+import cats.syntax.applicative._
 import io.circe._
 import io.circe.syntax._
 import io.circe.testing.instances._
@@ -40,7 +41,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
     val json = Json.obj("test" -> Json.fromString("CirceSupport"))
 
     "have json content type" in {
-      jsonEncoder.headers.get(`Content-Type`) must_== Some(
+      jsonEncoder[IO].headers.get(`Content-Type`) must_== Some(
         `Content-Type`(MediaType.`application/json`))
     }
 
@@ -94,10 +95,10 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
       // TODO Urgh.  We need to make testing these smoother.
       // https://github.com/http4s/http4s/issues/157
       def getBody(body: EntityBody[IO]): Array[Byte] = body.compile.toVector.unsafeRunSync.toArray
-      val req = Request[IO]().withBody(Json.fromDoubleOrNull(157)).unsafeRunSync
+      val req = Request[IO]().withBody(Json.fromDoubleOrNull(157))
       val body = req
         .decode { json: Json =>
-          Response(Ok).withBody(json.asNumber.flatMap(_.toLong).getOrElse(0L).toString)
+          Response[IO](Ok).withBody(json.asNumber.flatMap(_.toLong).getOrElse(0L).toString).pure[IO]
         }
         .unsafeRunSync
         .body
@@ -107,9 +108,8 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
 
   "jsonOf" should {
     "decode JSON from a Circe decoder" in {
-      val result = jsonOf[IO, Foo].decode(
-        Request[IO]().withBody(Json.obj("bar" -> Json.fromDoubleOrNull(42))).unsafeRunSync,
-        strict = true)
+      val result = jsonOf[IO, Foo]
+        .decode(Request[IO]().withBody(Json.obj("bar" -> Json.fromDoubleOrNull(42))), strict = true)
       result.value.unsafeRunSync must_== Right(Foo(42))
     }
 
@@ -120,7 +120,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
       s"handle JSON with umlauts: $wort" >> {
         val json = Json.obj("wort" -> Json.fromString(wort))
         val result =
-          jsonOf[IO, Umlaut].decode(Request[IO]().withBody(json).unsafeRunSync, strict = true)
+          jsonOf[IO, Umlaut].decode(Request[IO]().withBody(json), strict = true)
         result.value.unsafeRunSync must_== Right(Umlaut(wort))
       }
     }
@@ -128,16 +128,15 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
 
   "accumulatingJsonOf" should {
     "decode JSON from a Circe decoder" in {
-      val result = accumulatingJsonOf[IO, Foo].decode(
-        Request[IO]().withBody(Json.obj("bar" -> Json.fromDoubleOrNull(42))).unsafeRunSync,
-        strict = true)
+      val result = accumulatingJsonOf[IO, Foo]
+        .decode(Request[IO]().withBody(Json.obj("bar" -> Json.fromDoubleOrNull(42))), strict = true)
       result.value.unsafeRunSync must_== Right(Foo(42))
     }
 
     "return an InvalidMessageBodyFailure with a list of failures on invalid JSON messages" in {
       val json = Json.obj("a" -> Json.fromString("sup"), "b" -> Json.fromInt(42))
       val result = accumulatingJsonOf[IO, Bar]
-        .decode(Request[IO]().withBody(json).unsafeRunSync, strict = true)
+        .decode(Request[IO]().withBody(json), strict = true)
       result.value.unsafeRunSync must beLike {
         case Left(InvalidMessageBodyFailure(_, Some(DecodingFailures(NonEmptyList(_, _))))) => ok
       }
@@ -155,12 +154,12 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
   "Message[F].decodeJson[A]" should {
     "decode json from a message" in {
       val req = Request[IO]().withBody(foo.asJson)
-      req.flatMap(_.decodeJson[Foo]) must returnValue(foo)
+      req.decodeJson[Foo] must returnValue(foo)
     }
 
     "fail on invalid json" in {
       val req = Request[IO]().withBody(List(13, 14).asJson)
-      req.flatMap(_.decodeJson[Foo]).attempt.unsafeRunSync must beLeft
+      req.decodeJson[Foo].attempt.unsafeRunSync must beLeft
     }
   }
 

--- a/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
+++ b/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
@@ -1,7 +1,6 @@
 package org.http4s.client.impl
 
 import cats._
-import cats.implicits._
 import org.http4s._
 import org.http4s.headers.`Content-Length`
 
@@ -23,14 +22,12 @@ trait EntityRequestGenerator[F[_]] extends Any with EmptyRequestGenerator[F] {
       implicit F: Monad[F],
       w: EntityEncoder[F, A]): F[Request[F]] = {
     val h = w.headers ++ headers
-    w.toEntity(body).flatMap {
-      case Entity(proc, len) =>
-        val headers = len
-          .map { l =>
-            `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
-          }
-          .getOrElse(h)
-        F.pure(Request(method = method, uri = uri, headers = headers, body = proc))
-    }
+    val entity = w.toEntity(body)
+    val newHeaders = entity.length
+      .map { l =>
+        `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
+      }
+      .getOrElse(h)
+    F.pure(Request(method = method, uri = uri, headers = newHeaders, body = entity.body))
   }
 }

--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -111,12 +111,12 @@ package object oauth1 {
       case Some(t)
           if (req.method == Method.POST || req.method == Method.PUT) &&
             t.mediaType == MediaType.`application/x-www-form-urlencoded` =>
-        req.as[UrlForm].flatMap { urlform =>
+        req.as[UrlForm].map { urlform =>
           val bodyparams = urlform.values.toSeq
             .flatMap { case (k, vs) => if (vs.isEmpty) Seq(k -> "") else vs.map((k, _)) }
 
           implicit val charset = req.charset.getOrElse(Charset.`UTF-8`)
-          req.withBody(urlform).map(_ -> (qparams ++ bodyparams))
+          req.withBody(urlform) -> (qparams ++ bodyparams)
         }
 
       case _ => F.pure(req -> qparams)

--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -116,7 +116,7 @@ package object oauth1 {
             .flatMap { case (k, vs) => if (vs.isEmpty) Seq(k -> "") else vs.map((k, _)) }
 
           implicit val charset = req.charset.getOrElse(Charset.`UTF-8`)
-          req.withBody(urlform) -> (qparams ++ bodyparams)
+          req.withEntity(urlform) -> (qparams ++ bodyparams)
         }
 
       case _ => F.pure(req -> qparams)

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -2,13 +2,14 @@ package org.http4s
 package client
 
 import cats.effect._
+import cats.implicits._
 import java.io.IOException
 import org.http4s.Method._
 import org.http4s.Status.Ok
 
 class ClientSpec extends Http4sSpec {
   val service = HttpService[IO] {
-    case r => Response[IO](Ok).withBody(r.body)
+    case r => Response[IO](Ok).withBody(r.body).pure[IO]
   }
   val client: Client[IO] = Client.fromHttpService(service)
 
@@ -20,6 +21,7 @@ class ClientSpec extends Http4sSpec {
     "fail to read body after dispose" in {
       Request[IO](POST)
         .withBody("foo")
+        .pure[IO]
         .flatMap { req =>
           // This is bad.  Don't do this.
           client.fetch(req)(IO.pure).flatMap(_.as[String])

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -9,18 +9,18 @@ import org.http4s.Status.Ok
 
 class ClientSpec extends Http4sSpec {
   val service = HttpService[IO] {
-    case r => Response[IO](Ok).withBody(r.body).pure[IO]
+    case r => Response[IO](Ok).withEntity(r.body).pure[IO]
   }
   val client: Client[IO] = Client.fromHttpService(service)
 
   "mock client" should {
     "read body before dispose" in {
-      client.expect[String](Request[IO](POST).withBody("foo")).unsafeRunSync() must_== "foo"
+      client.expect[String](Request[IO](POST).withEntity("foo")).unsafeRunSync() must_== "foo"
     }
 
     "fail to read body after dispose" in {
       Request[IO](POST)
-        .withBody("foo")
+        .withEntity("foo")
         .pure[IO]
         .flatMap { req =>
           // This is bad.  Don't do this.
@@ -35,7 +35,7 @@ class ClientSpec extends Http4sSpec {
     "fail to read body after client shutdown" in {
       val client: Client[IO] = Client.fromHttpService(service)
       client.shutdownNow()
-      client.expect[String](Request[IO](POST).withBody("foo")).attempt.unsafeRunSync() must beLeft
+      client.expect[String](Request[IO](POST).withEntity("foo")).attempt.unsafeRunSync() must beLeft
         .like {
           case e: IOException => e.getMessage == "client was shut down"
         }

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -15,15 +15,15 @@ class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThro
 
   val route = HttpService[IO] {
     case r if r.method == GET && r.pathInfo == "/" =>
-      Response[IO](Ok).withBody("hello").pure[IO]
+      Response[IO](Ok).withEntity("hello").pure[IO]
     case r if r.method == PUT && r.pathInfo == "/put" =>
-      Response[IO](Created).withBody(r.body).pure[IO]
+      Response[IO](Created).withEntity(r.body).pure[IO]
     case r if r.method == GET && r.pathInfo == "/echoheaders" =>
       r.headers.get(Accept).fold(IO.pure(Response[IO](BadRequest))) { m =>
-        Response[IO](Ok).withBody(m.toString).pure[IO]
+        Response[IO](Ok).withEntity(m.toString).pure[IO]
       }
     case r if r.pathInfo == "/status/500" =>
-      Response[IO](InternalServerError).withBody("Oops").pure[IO]
+      Response[IO](InternalServerError).withEntity("Oops").pure[IO]
     case r => sys.error("Path not found: " + r.pathInfo)
   }
 

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -1,6 +1,7 @@
 package org.http4s
 package client
 
+import cats.syntax.applicative._
 import cats.effect._
 import fs2._
 import fs2.Stream._
@@ -14,15 +15,15 @@ class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThro
 
   val route = HttpService[IO] {
     case r if r.method == GET && r.pathInfo == "/" =>
-      Response[IO](Ok).withBody("hello")
+      Response[IO](Ok).withBody("hello").pure[IO]
     case r if r.method == PUT && r.pathInfo == "/put" =>
-      Response[IO](Created).withBody(r.body)
+      Response[IO](Created).withBody(r.body).pure[IO]
     case r if r.method == GET && r.pathInfo == "/echoheaders" =>
       r.headers.get(Accept).fold(IO.pure(Response[IO](BadRequest))) { m =>
-        Response[IO](Ok).withBody(m.toString)
+        Response[IO](Ok).withBody(m.toString).pure[IO]
       }
     case r if r.pathInfo == "/status/500" =>
-      Response(InternalServerError).withBody("Oops")
+      Response[IO](InternalServerError).withBody("Oops").pure[IO]
     case r => sys.error("Path not found: " + r.pathInfo)
   }
 

--- a/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
@@ -14,7 +14,7 @@ class ClientXmlSpec extends Http4sSpec {
   val xml = s"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>$body"""
   val service = HttpService[IO] {
     case _ =>
-      Response[IO](Ok).withBody(xml).pure[IO]
+      Response[IO](Ok).withEntity(xml).pure[IO]
   }
   val client = Client.fromHttpService(service)
 

--- a/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
@@ -14,7 +14,7 @@ class ClientXmlSpec extends Http4sSpec {
   val xml = s"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>$body"""
   val service = HttpService[IO] {
     case _ =>
-      Response(Ok).withBody(xml)
+      Response[IO](Ok).withBody(xml).pure[IO]
   }
   val client = Client.fromHttpService(service)
 

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -134,7 +134,7 @@ class FollowRedirectSpec extends Http4sSpec with Http4sClientDsl[IO] with Tables
       val statefulService = HttpService[IO] {
         case GET -> Root / "loop" =>
           val body = loopCounter.incrementAndGet.toString
-          MovedPermanently(Location(uri("/loop"))).flatMap(_.withBody(body))
+          MovedPermanently(Location(uri("/loop"))).map(_.withBody(body))
       }
       val client = FollowRedirect(3)(Client.fromHttpService(statefulService))
       client.fetch(Request[IO](uri = uri("http://localhost/loop"))) {

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -120,7 +120,7 @@ class FollowRedirectSpec extends Http4sSpec with Http4sClientDsl[IO] with Tables
 
     "Strip payload headers when switching to GET" in {
       // We could test others, and other scenarios, but this was a pain.
-      val req = Request[IO](PUT, uri("http://localhost/303")).withBody("foo")
+      val req = Request[IO](PUT, uri("http://localhost/303")).withEntity("foo")
       client
         .fetch(req) {
           case Ok(resp) =>
@@ -134,7 +134,7 @@ class FollowRedirectSpec extends Http4sSpec with Http4sClientDsl[IO] with Tables
       val statefulService = HttpService[IO] {
         case GET -> Root / "loop" =>
           val body = loopCounter.incrementAndGet.toString
-          MovedPermanently(Location(uri("/loop"))).map(_.withBody(body))
+          MovedPermanently(Location(uri("/loop"))).map(_.withEntity(body))
       }
       val client = FollowRedirect(3)(Client.fromHttpService(statefulService))
       client.fetch(Request[IO](uri = uri("http://localhost/loop"))) {

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -33,7 +33,7 @@ class RetrySpec extends Http4sSpec with Tables {
       }
     }
     val retryClient = Retry[IO](policy)(client)
-    val req = Request[IO](method, uri("http://localhost/") / status.code.toString).withBody(body)
+    val req = Request[IO](method, uri("http://localhost/") / status.code.toString).withEntity(body)
     retryClient
       .fetch(req) { _ =>
         IO.unit

--- a/client/src/test/scala/org/http4s/client/oauth1/OAuthTest.scala
+++ b/client/src/test/scala/org/http4s/client/oauth1/OAuthTest.scala
@@ -67,12 +67,12 @@ class OAuthTest extends Specification {
   "RFC 5849 example" should {
 
     implicit def urlFormEncoder: EntityEncoder[IO, UrlForm] =
-      UrlForm.entityEncoder(implicitly, Charset.`US-ASCII`)
+      UrlForm.entityEncoder(Charset.`US-ASCII`)
 
     val Right(uri) = Uri.fromString("http://example.com/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b")
     val Right(body) = UrlForm.decodeString(Charset.`US-ASCII`)("c2&a3=2+q")
 
-    val req = Request[IO](method = Method.POST, uri = uri).withBody(body).unsafeRunSync()
+    val req = Request[IO](method = Method.POST, uri = uri).withBody(body)
 
     "Collect proper params, pg 22" in {
       oauth1.getUserParams(req).unsafeRunSync()._2.sorted must_== Seq(

--- a/client/src/test/scala/org/http4s/client/oauth1/OAuthTest.scala
+++ b/client/src/test/scala/org/http4s/client/oauth1/OAuthTest.scala
@@ -72,7 +72,7 @@ class OAuthTest extends Specification {
     val Right(uri) = Uri.fromString("http://example.com/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b")
     val Right(body) = UrlForm.decodeString(Charset.`US-ASCII`)("c2&a3=2+q")
 
-    val req = Request[IO](method = Method.POST, uri = uri).withBody(body)
+    val req = Request[IO](method = Method.POST, uri = uri).withEntity(body)
 
     "Collect proper params, pg 22" in {
       oauth1.getUserParams(req).unsafeRunSync()._2.sorted must_== Seq(

--- a/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -15,11 +15,12 @@ object GetRoutes {
 
   def getPaths(implicit ec: ExecutionContext): Map[String, Response[IO]] =
     Map(
-      SimplePath -> Response[IO](Ok).withBody("simple path"),
-      ChunkedPath -> Response[IO](Ok).withBody(
-        Stream.emits("chunk".toSeq.map(_.toString)).covary[IO]),
+      SimplePath -> Response[IO](Ok).withBody("simple path").pure[IO],
+      ChunkedPath -> Response[IO](Ok)
+        .withBody(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
+        .pure[IO],
       DelayedPath ->
         Http4sSpec.TestScheduler.sleep_[IO](1.second).compile.drain *>
-          Response[IO](Ok).withBody("delayed path")
+          Response[IO](Ok).withBody("delayed path").pure[IO]
     ).mapValues(_.unsafeRunSync())
 }

--- a/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -15,12 +15,12 @@ object GetRoutes {
 
   def getPaths(implicit ec: ExecutionContext): Map[String, Response[IO]] =
     Map(
-      SimplePath -> Response[IO](Ok).withBody("simple path").pure[IO],
+      SimplePath -> Response[IO](Ok).withEntity("simple path").pure[IO],
       ChunkedPath -> Response[IO](Ok)
-        .withBody(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
+        .withEntity(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
         .pure[IO],
       DelayedPath ->
         Http4sSpec.TestScheduler.sleep_[IO](1.second).compile.drain *>
-          Response[IO](Ok).withBody("delayed path").pure[IO]
+          Response[IO](Ok).withEntity("delayed path").pure[IO]
     ).mapValues(_.unsafeRunSync())
 }

--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -148,19 +148,9 @@ trait EntityEncoderInstances extends EntityEncoderInstances0 {
     encodeBy(`Transfer-Encoding`(TransferCoding.chunked)) { body =>
       Entity(body, None)
     }
-//
-//  implicit def effectEncoder[F[_], A](
-//      implicit F: FlatMap[F],
-//      W: EntityEncoder[F, A]): EntityEncoder[F, F[A]] =
-//    new EntityEncoder[F, F[A]] {
-//      override def toEntity(a: F[A]): Entity[F] = a.map(W.toEntity)
-//      override def headers: Headers = W.headers
-//    }
 
 //  // TODO parameterize chunk size
 //  // TODO if Header moves to Entity, can add a Content-Disposition with the filename
-//  implicit def fileEncoder[F[_]](implicit F: Sync[F]): EntityEncoder[F, File] =
-//    inputStreamEncoder[F, FileInputStream].contramap(file => F.delay(new FileInputStream(file)))
   implicit def fileEncoder[F[_]](implicit F: Sync[F]): EntityEncoder[F, File] =
     filePathEncoder[F].contramap(_.toPath)
 

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -48,7 +48,7 @@ sealed trait Message[F[_]] extends MessageOps[F] { self =>
   override def withAttribute[A](key: AttributeKey[A], value: A)(implicit F: Functor[F]): Self =
     change(attributes = attributes.put(key, value))
 
-  @deprecated("User withEntity and `pure`", "0.19")
+  @deprecated("Use withEntity", "0.19")
   def withBody[T](b: T)(implicit F: Applicative[F], w: EntityEncoder[F, T]): F[Self] =
     F.pure(withEntity(b))
 

--- a/core/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/src/main/scala/org/http4s/MessageFailure.scala
@@ -43,7 +43,7 @@ final case class ParseFailure(sanitized: String, details: String)
   def toHttpResponse[F[_]](httpVersion: HttpVersion)(implicit F: Monad[F]): F[Response[F]] =
     F.pure(
       Response[F](Status.BadRequest, httpVersion)
-        .withBody(sanitized)(EntityEncoder.stringEncoder[F]))
+        .withEntity(sanitized)(EntityEncoder.stringEncoder[F]))
 }
 
 object ParseFailure {
@@ -83,7 +83,7 @@ final case class MalformedMessageBodyFailure(details: String, cause: Option[Thro
   def toHttpResponse[F[_]](httpVersion: HttpVersion)(implicit F: Monad[F]): F[Response[F]] =
     F.pure(
       Response[F](Status.BadRequest, httpVersion)
-        .withBody(s"The request body was malformed.")(EntityEncoder.stringEncoder[F]))
+        .withEntity(s"The request body was malformed.")(EntityEncoder.stringEncoder[F]))
 }
 
 /** Indicates a semantic error decoding the body of an HTTP [[Message]]. */
@@ -96,7 +96,7 @@ final case class InvalidMessageBodyFailure(details: String, cause: Option[Throwa
       implicit F: Monad[F]): F[Response[F]] =
     F.pure(
       Response[F](Status.UnprocessableEntity, httpVersion)
-        .withBody(s"The request body was invalid.")(EntityEncoder.stringEncoder[F]))
+        .withEntity(s"The request body was invalid.")(EntityEncoder.stringEncoder[F]))
 }
 
 /** Indicates that a [[Message]] came with no supported [[MediaType]]. */
@@ -112,7 +112,7 @@ sealed abstract class UnsupportedMediaTypeFailure extends DecodeFailure with NoS
   def toHttpResponse[F[_]](httpVersion: HttpVersion)(implicit F: Monad[F]): F[Response[F]] =
     F.pure(
       Response[F](Status.UnsupportedMediaType, httpVersion)
-        .withBody(responseMsg)(EntityEncoder.stringEncoder[F]))
+        .withEntity(responseMsg)(EntityEncoder.stringEncoder[F]))
 }
 
 /** Indicates that a [[Message]] attempting to be decoded has no [[MediaType]] and no

--- a/core/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/src/main/scala/org/http4s/MessageFailure.scala
@@ -41,8 +41,8 @@ final case class ParseFailure(sanitized: String, details: String)
   def cause: Option[Throwable] = None
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion)(implicit F: Monad[F]): F[Response[F]] =
-    Response[F](Status.BadRequest, httpVersion)
-      .withBody(sanitized)(F, EntityEncoder.stringEncoder[F])
+    F.pure(Response[F](Status.BadRequest, httpVersion)
+      .withBody(sanitized)(EntityEncoder.stringEncoder[F]))
 }
 
 object ParseFailure {
@@ -80,8 +80,8 @@ final case class MalformedMessageBodyFailure(details: String, cause: Option[Thro
     s"Malformed message body: $details"
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion)(implicit F: Monad[F]): F[Response[F]] =
-    Response[F](Status.BadRequest, httpVersion)
-      .withBody(s"The request body was malformed.")(F, EntityEncoder.stringEncoder[F])
+    F.pure(Response[F](Status.BadRequest, httpVersion)
+      .withBody(s"The request body was malformed.")(EntityEncoder.stringEncoder[F]))
 }
 
 /** Indicates a semantic error decoding the body of an HTTP [[Message]]. */
@@ -92,8 +92,8 @@ final case class InvalidMessageBodyFailure(details: String, cause: Option[Throwa
 
   override def toHttpResponse[F[_]](httpVersion: HttpVersion)(
       implicit F: Monad[F]): F[Response[F]] =
-    Response[F](Status.UnprocessableEntity, httpVersion)
-      .withBody(s"The request body was invalid.")(F, EntityEncoder.stringEncoder[F])
+    F.pure(Response[F](Status.UnprocessableEntity, httpVersion)
+      .withBody(s"The request body was invalid.")(EntityEncoder.stringEncoder[F]))
 }
 
 /** Indicates that a [[Message]] came with no supported [[MediaType]]. */
@@ -107,8 +107,8 @@ sealed abstract class UnsupportedMediaTypeFailure extends DecodeFailure with NoS
   protected def responseMsg: String = s"$sanitizedResponsePrefix. $expectedMsg"
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion)(implicit F: Monad[F]): F[Response[F]] =
-    Response[F](Status.UnsupportedMediaType, httpVersion)
-      .withBody(responseMsg)(F, EntityEncoder.stringEncoder[F])
+    F.pure(Response[F](Status.UnsupportedMediaType, httpVersion)
+      .withBody(responseMsg)(EntityEncoder.stringEncoder[F]))
 }
 
 /** Indicates that a [[Message]] attempting to be decoded has no [[MediaType]] and no

--- a/core/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/src/main/scala/org/http4s/MessageFailure.scala
@@ -41,8 +41,9 @@ final case class ParseFailure(sanitized: String, details: String)
   def cause: Option[Throwable] = None
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion)(implicit F: Monad[F]): F[Response[F]] =
-    F.pure(Response[F](Status.BadRequest, httpVersion)
-      .withBody(sanitized)(EntityEncoder.stringEncoder[F]))
+    F.pure(
+      Response[F](Status.BadRequest, httpVersion)
+        .withBody(sanitized)(EntityEncoder.stringEncoder[F]))
 }
 
 object ParseFailure {
@@ -80,8 +81,9 @@ final case class MalformedMessageBodyFailure(details: String, cause: Option[Thro
     s"Malformed message body: $details"
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion)(implicit F: Monad[F]): F[Response[F]] =
-    F.pure(Response[F](Status.BadRequest, httpVersion)
-      .withBody(s"The request body was malformed.")(EntityEncoder.stringEncoder[F]))
+    F.pure(
+      Response[F](Status.BadRequest, httpVersion)
+        .withBody(s"The request body was malformed.")(EntityEncoder.stringEncoder[F]))
 }
 
 /** Indicates a semantic error decoding the body of an HTTP [[Message]]. */
@@ -92,8 +94,9 @@ final case class InvalidMessageBodyFailure(details: String, cause: Option[Throwa
 
   override def toHttpResponse[F[_]](httpVersion: HttpVersion)(
       implicit F: Monad[F]): F[Response[F]] =
-    F.pure(Response[F](Status.UnprocessableEntity, httpVersion)
-      .withBody(s"The request body was invalid.")(EntityEncoder.stringEncoder[F]))
+    F.pure(
+      Response[F](Status.UnprocessableEntity, httpVersion)
+        .withBody(s"The request body was invalid.")(EntityEncoder.stringEncoder[F]))
 }
 
 /** Indicates that a [[Message]] came with no supported [[MediaType]]. */
@@ -107,8 +110,9 @@ sealed abstract class UnsupportedMediaTypeFailure extends DecodeFailure with NoS
   protected def responseMsg: String = s"$sanitizedResponsePrefix. $expectedMsg"
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion)(implicit F: Monad[F]): F[Response[F]] =
-    F.pure(Response[F](Status.UnsupportedMediaType, httpVersion)
-      .withBody(responseMsg)(EntityEncoder.stringEncoder[F]))
+    F.pure(
+      Response[F](Status.UnsupportedMediaType, httpVersion)
+        .withBody(responseMsg)(EntityEncoder.stringEncoder[F]))
 }
 
 /** Indicates that a [[Message]] attempting to be decoded has no [[MediaType]] and no

--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -85,8 +85,7 @@ object UrlForm {
     apply(values: _*)
 
   implicit def entityEncoder[F[_]](
-      implicit F: Applicative[F],
-      charset: Charset = DefaultCharset): EntityEncoder[F, UrlForm] =
+      implicit charset: Charset = DefaultCharset): EntityEncoder[F, UrlForm] =
     EntityEncoder
       .stringEncoder[F]
       .contramap[UrlForm](encodeString(charset))

--- a/core/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
@@ -10,8 +10,9 @@ private[http4s] class MultipartEncoder[F[_]: Sync] extends EntityEncoder[F, Mult
   //TODO: Refactor encoders to create headers dependent on value.
   def headers: Headers = Headers.empty
 
-  def toEntity(mp: Multipart[F]): F[Entity[F]] =
-    Sync[F].delay(Entity(renderParts(mp.boundary)(mp.parts), None))
+  //Note: Is this actually effecting?
+  def toEntity(mp: Multipart[F]): Entity[F] =
+    Entity(renderParts(mp.boundary)(mp.parts), None)
 
   val dash: String = "--"
 

--- a/core/src/main/scala/org/http4s/syntax/EffectMessageSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/EffectMessageSyntax.scala
@@ -13,8 +13,8 @@ trait EffectMessageSyntax[F[_], M <: Message[F]] extends Any with MessageOps[F] 
   def transformHeaders(f: Headers => Headers)(implicit F: Functor[F]): Self =
     self.map(_.transformHeaders(f))
 
-  def withBody[T](b: T)(implicit F: Monad[F], w: EntityEncoder[F, T]): Self =
-    self.flatMap(_.withBody(b).widen[M#Self])
+  def withBody[T](b: T)(implicit F: Functor[F], w: EntityEncoder[F, T]): Self =
+    self.map(_.withBody(b))
 
   override def withAttribute[A](key: AttributeKey[A], value: A)(implicit F: Functor[F]): Self =
     self.map(_.withAttribute(key, value))

--- a/core/src/main/scala/org/http4s/syntax/EffectMessageSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/EffectMessageSyntax.scala
@@ -13,8 +13,12 @@ trait EffectMessageSyntax[F[_], M <: Message[F]] extends Any with MessageOps[F] 
   def transformHeaders(f: Headers => Headers)(implicit F: Functor[F]): Self =
     self.map(_.transformHeaders(f))
 
-  def withBody[T](b: T)(implicit F: Functor[F], w: EntityEncoder[F, T]): Self =
-    self.map(_.withBody(b))
+  @deprecated("Use withEntity", "0.19")
+  def withBody[T](b: T)(implicit F: Applicative[F], w: EntityEncoder[F, T]): Self =
+    self.map(_.withEntity(b))
+
+  def withEntity[T](b: T)(implicit F: Functor[F], w: EntityEncoder[F, T]): Self =
+    self.map(_.withEntity(b))
 
   override def withAttribute[A](key: AttributeKey[A], value: A)(implicit F: Functor[F]): Self =
     self.map(_.withAttribute(key, value))

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -78,7 +78,7 @@ be seen as `Ok(getTweet(tweetId))(tweetEncoder)`.
 
 We've defined `tweetsEncoder` as being implicit so that we don't need to explicitly
 reference it when serving the response, which can be seen as
-`Ok(getPopularTweets())`.
+`getPopularTweets().flatMap(Ok(_))`.
 
 ```tut:book
 case class Tweet(id: Int, message: String)
@@ -91,7 +91,7 @@ def getPopularTweets(): IO[Seq[Tweet]] = ???
 
 val tweetService = HttpService[IO] {
   case GET -> Root / "tweets" / "popular" =>
-    Ok(getPopularTweets())
+    getPopularTweets().flatMap(Ok(_))
   case GET -> Root / "tweets" / IntVar(tweetId) =>
     getTweet(tweetId).flatMap(Ok(_))
 }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -38,6 +38,9 @@ trait EntityResponseGenerator[F[_]] extends Any with ResponseGenerator {
   def apply(headers: Header*)(implicit F: Applicative[F]): F[Response[F]] =
     F.pure(Response(status, headers = Headers(`Content-Length`.zero +: headers: _*)))
 
+  def apply[A](body: F[A])(implicit F: Monad[F], w: EntityEncoder[F, A]): F[Response[F]] =
+    F.flatMap(body)(apply[A](_))
+
   def apply[A](body: A, headers: Header*)(
       implicit F: Monad[F],
       w: EntityEncoder[F, A]): F[Response[F]] = {

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -3,7 +3,6 @@ package dsl
 package impl
 
 import cats._
-import cats.implicits._
 import org.http4s.headers._
 
 trait ResponseGenerator extends Any {
@@ -43,15 +42,13 @@ trait EntityResponseGenerator[F[_]] extends Any with ResponseGenerator {
       implicit F: Monad[F],
       w: EntityEncoder[F, A]): F[Response[F]] = {
     val h = w.headers ++ headers
-    w.toEntity(body).flatMap {
-      case Entity(proc, len) =>
-        val headers = len
-          .map { l =>
-            `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
-          }
-          .getOrElse(h)
-        F.pure(Response(status = status, headers = headers, body = proc))
-    }
+    val entity = w.toEntity(body)
+    val newHeaders = entity.length
+      .map { l =>
+        `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
+      }
+      .getOrElse(h)
+    F.pure(Response(status = status, headers = newHeaders, body = entity.body))
   }
 }
 
@@ -87,15 +84,13 @@ trait WwwAuthenticateResponseGenerator[F[_]] extends Any with ResponseGenerator 
       implicit F: Monad[F],
       w: EntityEncoder[F, A]): F[Response[F]] = {
     val h = w.headers ++ Headers(authenticate +: headers.toList)
-    w.toEntity(body).flatMap {
-      case Entity(proc, len) =>
-        val headers = len
-          .map { l =>
-            `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
-          }
-          .getOrElse(h)
-        F.pure(Response(status = status, headers = headers, body = proc))
-    }
+    val entity = w.toEntity(body)
+    val newHeaders = entity.length
+      .map { l =>
+        `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
+      }
+      .getOrElse(h)
+    F.pure(Response(status = status, headers = newHeaders, body = entity.body))
   }
 }
 
@@ -124,14 +119,12 @@ trait ProxyAuthenticateResponseGenerator[F[_]] extends Any with ResponseGenerato
       implicit F: Monad[F],
       w: EntityEncoder[F, A]): F[Response[F]] = {
     val h = w.headers ++ Headers(authenticate +: headers.toList)
-    w.toEntity(body).flatMap {
-      case Entity(proc, len) =>
-        val headers = len
-          .map { l =>
-            `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
-          }
-          .getOrElse(h)
-        F.pure(Response(status = status, headers = headers, body = proc))
-    }
+    val entity = w.toEntity(body)
+    val newHeaders = entity.length
+      .map { l =>
+        `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
+      }
+      .getOrElse(h)
+    F.pure(Response(status = status, headers = newHeaders, body = entity.body))
   }
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/auth/GitHubHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/auth/GitHubHttpEndpoint.scala
@@ -20,8 +20,10 @@ class GitHubHttpEndpoint[F[_]](gitHubService: GitHubService[F])(implicit F: Sync
 
     // OAuth2 Callback URI
     case GET -> Root / ApiVersion / "login" / "github" :? CodeQuery(code) :? StateQuery(state) =>
-      Ok(gitHubService.accessToken(code, state).flatMap(gitHubService.userData))
-        .map(_.putHeaders(Header("Content-Type", "application/json")))
+      for {
+        o <- Ok()
+        code <- gitHubService.accessToken(code, state).flatMap(gitHubService.userData)
+      } yield o.withBody(code).putHeaders(Header("Content-Type", "application/json"))
   }
 
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/auth/GitHubHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/auth/GitHubHttpEndpoint.scala
@@ -23,7 +23,7 @@ class GitHubHttpEndpoint[F[_]](gitHubService: GitHubService[F])(implicit F: Sync
       for {
         o <- Ok()
         code <- gitHubService.accessToken(code, state).flatMap(gitHubService.userData)
-      } yield o.withBody(code).putHeaders(Header("Content-Type", "application/json"))
+      } yield o.withEntity(code).putHeaders(Header("Content-Type", "application/json"))
   }
 
 }

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -45,10 +45,6 @@ class ExampleService[F[_]](implicit F: Effect[F]) extends Http4sDsl[F] {
         // EntityEncoder allows for easy conversion of types to a response body
         Ok("pong")
 
-      case GET -> Root / "future" =>
-        // EntityEncoder allows rendering asynchronous results as well
-        Ok(Future("Hello from the future!"))
-
       case GET -> Root / "streaming" =>
         // It's also easy to stream responses to clients
         Ok(dataStream(100))

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
@@ -7,19 +7,19 @@ trait JawnDecodeSupportSpec[J] extends Http4sSpec with JawnInstances {
   def testJsonDecoder(decoder: EntityDecoder[IO, J]) =
     "json decoder" should {
       "return right when the entity is valid" in {
-        val resp = Response[IO](Status.Ok).withBody("""{"valid": true}""").unsafeRunSync
+        val resp = Response[IO](Status.Ok).withBody("""{"valid": true}""")
         decoder.decode(resp, strict = false).value.unsafeRunSync must beRight
       }
 
       "return a ParseFailure when the entity is invalid" in {
-        val resp = Response[IO](Status.Ok).withBody("""garbage""").unsafeRunSync
+        val resp = Response[IO](Status.Ok).withBody("""garbage""")
         decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like {
           case MalformedMessageBodyFailure("Invalid JSON", _) => ok
         }
       }
 
       "return a ParseFailure when the entity is empty" in {
-        val resp = Response[IO](Status.Ok).withBody("").unsafeRunSync
+        val resp = Response[IO](Status.Ok).withBody("")
         decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like {
           case MalformedMessageBodyFailure("Invalid JSON: empty body", _) => ok
         }

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
@@ -7,19 +7,19 @@ trait JawnDecodeSupportSpec[J] extends Http4sSpec with JawnInstances {
   def testJsonDecoder(decoder: EntityDecoder[IO, J]) =
     "json decoder" should {
       "return right when the entity is valid" in {
-        val resp = Response[IO](Status.Ok).withBody("""{"valid": true}""")
+        val resp = Response[IO](Status.Ok).withEntity("""{"valid": true}""")
         decoder.decode(resp, strict = false).value.unsafeRunSync must beRight
       }
 
       "return a ParseFailure when the entity is invalid" in {
-        val resp = Response[IO](Status.Ok).withBody("""garbage""")
+        val resp = Response[IO](Status.Ok).withEntity("""garbage""")
         decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like {
           case MalformedMessageBodyFailure("Invalid JSON", _) => ok
         }
       }
 
       "return a ParseFailure when the entity is empty" in {
-        val resp = Response[IO](Status.Ok).withBody("")
+        val resp = Response[IO](Status.Ok).withEntity("")
         decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like {
           case MalformedMessageBodyFailure("Invalid JSON: empty body", _) => ok
         }

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -46,9 +46,9 @@ trait Json4sInstances[J] {
 
   protected def jsonMethods: JsonMethods[J]
 
-  implicit def jsonEncoder[F[_], A <: JValue](implicit F: Applicative[F]): EntityEncoder[F, A] =
+  implicit def jsonEncoder[F[_], A <: JValue]: EntityEncoder[F, A] =
     EntityEncoder
-      .stringEncoder(F, Charset.`UTF-8`)
+      .stringEncoder(Charset.`UTF-8`)
       .contramap[A] { json =>
         // TODO naive implementation materializes to a String.
         // Look into replacing after https://github.com/non/jawn/issues/6#issuecomment-65018736

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -42,13 +42,13 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
   "jsonOf" should {
     "decode JSON from an json4s reader" in {
       val result =
-        jsonOf[IO, Int].decode(Request[IO]().withBody("42"), strict = false)
+        jsonOf[IO, Int].decode(Request[IO]().withEntity("42"), strict = false)
       result.value.unsafeRunSync must beRight(42)
     }
 
     "handle reader failures" in {
       val result =
-        jsonOf[IO, Int].decode(Request[IO]().withBody(""""oops""""), strict = false)
+        jsonOf[IO, Int].decode(Request[IO]().withEntity(""""oops""""), strict = false)
       result.value.unsafeRunSync must beLeft.like {
         case InvalidMessageBodyFailure("Could not map JSON", _) => ok
       }
@@ -60,13 +60,13 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
 
     "extract JSON from formats" in {
       val result = jsonExtract[IO, Foo]
-        .decode(Request[IO]().withBody(JObject("bar" -> JInt(42))), strict = false)
+        .decode(Request[IO]().withEntity(JObject("bar" -> JInt(42))), strict = false)
       result.value.unsafeRunSync must beRight(Foo(42))
     }
 
     "handle extract failures" in {
       val result = jsonExtract[IO, Foo]
-        .decode(Request[IO]().withBody(""""oops""""), strict = false)
+        .decode(Request[IO]().withEntity(""""oops""""), strict = false)
       result.value.unsafeRunSync must beLeft.like {
         case InvalidMessageBodyFailure("Could not extract JSON", _) => ok
       }
@@ -85,14 +85,14 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
   "Message[F].decodeJson[A]" should {
     "decode json from a message" in {
       val req = Request[IO]()
-        .withBody("42")
+        .withEntity("42")
         .withContentType(`Content-Type`(MediaType.`application/json`))
       req.decodeJson[Option[Int]] must returnValue(Some(42))
     }
 
     "fail on invalid json" in {
       val req = Request[IO]()
-        .withBody("not a number")
+        .withEntity("not a number")
         .withContentType(`Content-Type`(MediaType.`application/json`))
       req.decodeJson[Int].attempt.unsafeRunSync must beLeft
     }

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -42,13 +42,13 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
   "jsonOf" should {
     "decode JSON from an json4s reader" in {
       val result =
-        jsonOf[IO, Int].decode(Request[IO]().withBody("42").unsafeRunSync, strict = false)
+        jsonOf[IO, Int].decode(Request[IO]().withBody("42"), strict = false)
       result.value.unsafeRunSync must beRight(42)
     }
 
     "handle reader failures" in {
       val result =
-        jsonOf[IO, Int].decode(Request[IO]().withBody(""""oops"""").unsafeRunSync, strict = false)
+        jsonOf[IO, Int].decode(Request[IO]().withBody(""""oops""""), strict = false)
       result.value.unsafeRunSync must beLeft.like {
         case InvalidMessageBodyFailure("Could not map JSON", _) => ok
       }
@@ -60,13 +60,13 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
 
     "extract JSON from formats" in {
       val result = jsonExtract[IO, Foo]
-        .decode(Request[IO]().withBody(JObject("bar" -> JInt(42))).unsafeRunSync, strict = false)
+        .decode(Request[IO]().withBody(JObject("bar" -> JInt(42))), strict = false)
       result.value.unsafeRunSync must beRight(Foo(42))
     }
 
     "handle extract failures" in {
       val result = jsonExtract[IO, Foo]
-        .decode(Request[IO]().withBody(""""oops"""").unsafeRunSync, strict = false)
+        .decode(Request[IO]().withBody(""""oops""""), strict = false)
       result.value.unsafeRunSync must beLeft.like {
         case InvalidMessageBodyFailure("Could not extract JSON", _) => ok
       }
@@ -86,15 +86,15 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
     "decode json from a message" in {
       val req = Request[IO]()
         .withBody("42")
-        .map(_.withContentType(`Content-Type`(MediaType.`application/json`)))
-      req.flatMap(_.decodeJson[Option[Int]]) must returnValue(Some(42))
+        .withContentType(`Content-Type`(MediaType.`application/json`))
+      req.decodeJson[Option[Int]] must returnValue(Some(42))
     }
 
     "fail on invalid json" in {
       val req = Request[IO]()
         .withBody("not a number")
-        .map(_.withContentType(`Content-Type`(MediaType.`application/json`)))
-      req.flatMap(_.decodeJson[Int]).attempt.unsafeRunSync must beLeft
+        .withContentType(`Content-Type`(MediaType.`application/json`))
+      req.decodeJson[Int].attempt.unsafeRunSync must beLeft
     }
   }
 }

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -17,7 +17,7 @@ class ScalaXmlSpec extends Http4sSpec {
   "xml" should {
     val server: Request[IO] => IO[Response[IO]] = { req =>
       req.decode { elem: Elem =>
-        Response[IO](Ok).withBody(elem.label)
+        IO.pure(Response[IO](Ok).withBody(elem.label))
       }
     }
 

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -17,7 +17,7 @@ class ScalaXmlSpec extends Http4sSpec {
   "xml" should {
     val server: Request[IO] => IO[Response[IO]] = { req =>
       req.decode { elem: Elem =>
-        IO.pure(Response[IO](Ok).withBody(elem.label))
+        IO.pure(Response[IO](Ok).withEntity(elem.label))
       }
     }
 

--- a/server-metrics/src/main/scala/org/http4s/server/metrics/package.scala
+++ b/server-metrics/src/main/scala/org/http4s/server/metrics/package.scala
@@ -26,7 +26,7 @@ package object metrics {
       registry: MetricRegistry,
       mapper: ObjectMapper = defaultMapper): F[Response[F]] = {
     implicit val encoder = metricRegistryEncoder[F](mapper)
-    Response[F](Status.Ok).withBody(registry)
+    Monad[F].pure(Response[F](Status.Ok).withBody(registry))
   }
 
   /** Returns an OK response with a JSON dump of a MetricRegistry */

--- a/server-metrics/src/main/scala/org/http4s/server/metrics/package.scala
+++ b/server-metrics/src/main/scala/org/http4s/server/metrics/package.scala
@@ -26,7 +26,7 @@ package object metrics {
       registry: MetricRegistry,
       mapper: ObjectMapper = defaultMapper): F[Response[F]] = {
     implicit val encoder = metricRegistryEncoder[F](mapper)
-    Monad[F].pure(Response[F](Status.Ok).withBody(registry))
+    Monad[F].pure(Response[F](Status.Ok).withEntity(registry))
   }
 
   /** Returns an OK response with a JSON dump of a MetricRegistry */

--- a/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -7,7 +7,6 @@ import cats.data.{NonEmptyList, OptionT}
 import cats.effect.Effect
 import cats.syntax.eq._
 import cats.syntax.functor._
-import cats.syntax.flatMap._
 import fs2._
 import fs2.interop.scodec.ByteVectorChunk
 import org.http4s.EntityEncoder.chunkEncoder
@@ -17,19 +16,19 @@ import scodec.bits.ByteVector
 object ChunkAggregator {
   def apply[F[_]](service: HttpService[F])(implicit F: Effect[F]): HttpService[F] =
     service.flatMapF { response =>
-      OptionT.liftF(response.body.compile.fold(ByteVector.empty.bufferBy(4096))(_ :+ _).flatMap {
+      OptionT.liftF(response.body.compile.fold(ByteVector.empty.bufferBy(4096))(_ :+ _).map {
         fullBody =>
           if (fullBody.nonEmpty)
-            response
-              .withBody(ByteVectorChunk(fullBody): Chunk[Byte])
-              .map(removeChunkedTransferEncoding)
+            removeChunkedTransferEncoding(
+              response
+                .withBody(ByteVectorChunk(fullBody): Chunk[Byte]))
           else
-            F.pure(response)
+            response
       })
     }
 
-  private def removeChunkedTransferEncoding[F[_]: Functor]: Response[F] => Response[F] =
-    _.transformHeaders { headers =>
+  private def removeChunkedTransferEncoding[F[_]: Functor](res: Response[F]): Response[F] =
+    res.transformHeaders { headers =>
       headers.flatMap {
         // Remove the `TransferCoding.chunked` value from the `Transfer-Encoding` header,
         // leaving the remaining values unchanged

--- a/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -21,7 +21,7 @@ object ChunkAggregator {
           if (fullBody.nonEmpty)
             removeChunkedTransferEncoding(
               response
-                .withBody(ByteVectorChunk(fullBody): Chunk[Byte]))
+                .withEntity(ByteVectorChunk(fullBody): Chunk[Byte]))
           else
             response
       })

--- a/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -41,7 +41,7 @@ object Jsonp {
           }
         case Some(invalidCallback) =>
           logger.warn(s"Jsonp requested with invalid callback function name $invalidCallback")
-          OptionT.liftF(Response[F](Status.BadRequest).withBody(s"Not a valid callback name."))
+          OptionT.pure(Response[F](Status.BadRequest).withBody(s"Not a valid callback name."))
         case None =>
           service(req)
       }

--- a/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -41,7 +41,7 @@ object Jsonp {
           }
         case Some(invalidCallback) =>
           logger.warn(s"Jsonp requested with invalid callback function name $invalidCallback")
-          OptionT.pure(Response[F](Status.BadRequest).withBody(s"Not a valid callback name."))
+          OptionT.pure(Response[F](Status.BadRequest).withEntity(s"Not a valid callback name."))
         case None =>
           service(req)
       }

--- a/server/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -81,5 +81,5 @@ object Timeout {
       scheduler: Scheduler): HttpService[F] =
     apply(
       timeout,
-      Response[F](Status.InternalServerError).withBody("The service timed out.").pure[F])(service)
+      Response[F](Status.InternalServerError).withEntity("The service timed out.").pure[F])(service)
 }

--- a/server/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -79,6 +79,7 @@ object Timeout {
   def apply[F[_]: Effect](timeout: Duration)(service: HttpService[F])(
       implicit executionContext: ExecutionContext,
       scheduler: Scheduler): HttpService[F] =
-    apply(timeout, Response[F](Status.InternalServerError).withBody("The service timed out.").pure[F])(
-      service)
+    apply(
+      timeout,
+      Response[F](Status.InternalServerError).withBody("The service timed out.").pure[F])(service)
 }

--- a/server/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -79,6 +79,6 @@ object Timeout {
   def apply[F[_]: Effect](timeout: Duration)(service: HttpService[F])(
       implicit executionContext: ExecutionContext,
       scheduler: Scheduler): HttpService[F] =
-    apply(timeout, Response[F](Status.InternalServerError).withBody("The service timed out."))(
+    apply(timeout, Response[F](Status.InternalServerError).withBody("The service timed out.").pure[F])(
       service)
 }

--- a/server/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -64,7 +64,7 @@ object VirtualHost {
     Kleisli { req =>
       req.headers
         .get(Host)
-        .fold(OptionT.pure[F](Response[F](BadRequest).withBody("Host header required."))) { h =>
+        .fold(OptionT.pure[F](Response[F](BadRequest).withEntity("Host header required."))) { h =>
           // Fill in the host port if possible
           val host: Host = h.port match {
             case Some(_) => h
@@ -73,7 +73,8 @@ object VirtualHost {
           }
           (first +: rest).toVector
             .collectFirst { case HostService(s, p) if p(host) => s(req) }
-            .getOrElse(OptionT.pure[F](Response[F](NotFound).withBody(s"Host '$host' not found.")))
+            .getOrElse(
+              OptionT.pure[F](Response[F](NotFound).withEntity(s"Host '$host' not found.")))
         }
     }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -64,7 +64,7 @@ object VirtualHost {
     Kleisli { req =>
       req.headers
         .get(Host)
-        .fold(OptionT.liftF(Response[F](BadRequest).withBody("Host header required."))) { h =>
+        .fold(OptionT.pure[F](Response[F](BadRequest).withBody("Host header required."))) { h =>
           // Fill in the host port if possible
           val host: Host = h.port match {
             case Some(_) => h
@@ -73,7 +73,7 @@ object VirtualHost {
           }
           (first +: rest).toVector
             .collectFirst { case HostService(s, p) if p(host) => s(req) }
-            .getOrElse(OptionT.liftF(Response[F](NotFound).withBody(s"Host '$host' not found.")))
+            .getOrElse(OptionT.pure[F](Response[F](NotFound).withBody(s"Host '$host' not found.")))
         }
     }
 }

--- a/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -49,9 +49,9 @@ object WebSocketBuilder {
         receive: Sink[F, WebSocketFrame],
         headers: Headers = Headers.empty,
         onNonWebSocketRequest: F[Response[F]] =
-          Response[F](Status.NotImplemented).withBody("This is a WebSocket route."),
+          Response[F](Status.NotImplemented).withBody("This is a WebSocket route.").pure[F],
         onHandshakeFailure: F[Response[F]] =
-          Response[F](Status.BadRequest).withBody("WebSocket handshake failed.")): F[Response[F]] =
+          Response[F](Status.BadRequest).withBody("WebSocket handshake failed.").pure[F]): F[Response[F]] =
       WebSocketBuilder(send, receive, headers, onNonWebSocketRequest, onHandshakeFailure).onNonWebSocketRequest
         .map(
           _.withAttribute(

--- a/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -49,9 +49,9 @@ object WebSocketBuilder {
         receive: Sink[F, WebSocketFrame],
         headers: Headers = Headers.empty,
         onNonWebSocketRequest: F[Response[F]] =
-          Response[F](Status.NotImplemented).withBody("This is a WebSocket route.").pure[F],
+          Response[F](Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F],
         onHandshakeFailure: F[Response[F]] = Response[F](Status.BadRequest)
-          .withBody("WebSocket handshake failed.")
+          .withEntity("WebSocket handshake failed.")
           .pure[F]): F[Response[F]] =
       WebSocketBuilder(send, receive, headers, onNonWebSocketRequest, onHandshakeFailure).onNonWebSocketRequest
         .map(

--- a/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -50,8 +50,9 @@ object WebSocketBuilder {
         headers: Headers = Headers.empty,
         onNonWebSocketRequest: F[Response[F]] =
           Response[F](Status.NotImplemented).withBody("This is a WebSocket route.").pure[F],
-        onHandshakeFailure: F[Response[F]] =
-          Response[F](Status.BadRequest).withBody("WebSocket handshake failed.").pure[F]): F[Response[F]] =
+        onHandshakeFailure: F[Response[F]] = Response[F](Status.BadRequest)
+          .withBody("WebSocket handshake failed.")
+          .pure[F]): F[Response[F]] =
       WebSocketBuilder(send, receive, headers, onNonWebSocketRequest, onHandshakeFailure).onNonWebSocketRequest
         .map(
           _.withAttribute(

--- a/server/src/main/scala/org/http4s/server/websocket/package.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/package.scala
@@ -2,6 +2,7 @@ package org.http4s
 package server
 
 import cats._
+import cats.implicits._
 import fs2._
 import org.http4s.websocket.WebSocketContext
 import org.http4s.websocket.WebsocketBits.WebSocketFrame
@@ -48,11 +49,11 @@ package object websocket {
       receive,
       Headers.empty,
       status,
-      Response[F](Status.BadRequest).withBody("WebSocket handshake failed."))
+      Response[F](Status.BadRequest).withBody("WebSocket handshake failed.").pure[F])
 
   @deprecated("Use WebSocketBuilder", "0.18.0-M7")
   def WS[F[_]](send: Stream[F, WebSocketFrame], receive: Sink[F, WebSocketFrame])(
       implicit F: Monad[F],
       W: EntityEncoder[F, String]): F[Response[F]] =
-    WS(send, receive, Response[F](Status.NotImplemented).withBody("This is a WebSocket route."))
+    WS(send, receive, Response[F](Status.NotImplemented).withBody("This is a WebSocket route.").pure[F])
 }

--- a/server/src/main/scala/org/http4s/server/websocket/package.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/package.scala
@@ -49,7 +49,7 @@ package object websocket {
       receive,
       Headers.empty,
       status,
-      Response[F](Status.BadRequest).withBody("WebSocket handshake failed.").pure[F])
+      Response[F](Status.BadRequest).withEntity("WebSocket handshake failed.").pure[F])
 
   @deprecated("Use WebSocketBuilder", "0.18.0-M7")
   def WS[F[_]](send: Stream[F, WebSocketFrame], receive: Sink[F, WebSocketFrame])(
@@ -58,5 +58,5 @@ package object websocket {
     WS(
       send,
       receive,
-      Response[F](Status.NotImplemented).withBody("This is a WebSocket route.").pure[F])
+      Response[F](Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F])
 }

--- a/server/src/main/scala/org/http4s/server/websocket/package.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/package.scala
@@ -55,5 +55,8 @@ package object websocket {
   def WS[F[_]](send: Stream[F, WebSocketFrame], receive: Sink[F, WebSocketFrame])(
       implicit F: Monad[F],
       W: EntityEncoder[F, String]): F[Response[F]] =
-    WS(send, receive, Response[F](Status.NotImplemented).withBody("This is a WebSocket route.").pure[F])
+    WS(
+      send,
+      receive,
+      Response[F](Status.NotImplemented).withBody("This is a WebSocket route.").pure[F])
 }

--- a/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
@@ -8,21 +8,21 @@ class HttpServiceSpec extends Http4sSpec {
 
   val srvc1 = HttpService[IO] {
     case req if req.pathInfo == "/match" =>
-      Response[IO](Status.Ok).withBody("match").pure[IO]
+      Response[IO](Status.Ok).withEntity("match").pure[IO]
 
     case req if req.pathInfo == "/conflict" =>
-      Response[IO](Status.Ok).withBody("srvc1conflict").pure[IO]
+      Response[IO](Status.Ok).withEntity("srvc1conflict").pure[IO]
 
     case req if req.pathInfo == "/notfound" =>
-      Response[IO](Status.NotFound).withBody("notfound").pure[IO]
+      Response[IO](Status.NotFound).withEntity("notfound").pure[IO]
   }
 
   val srvc2 = HttpService[IO] {
     case req if req.pathInfo == "/srvc2" =>
-      Response[IO](Status.Ok).withBody("srvc2").pure[IO]
+      Response[IO](Status.Ok).withEntity("srvc2").pure[IO]
 
     case req if req.pathInfo == "/conflict" =>
-      Response[IO](Status.Ok).withBody("srvc2conflict").pure[IO]
+      Response[IO](Status.Ok).withEntity("srvc2conflict").pure[IO]
   }
 
   val aggregate1 = srvc1 <+> srvc2

--- a/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/HttpServiceSpec.scala
@@ -8,21 +8,21 @@ class HttpServiceSpec extends Http4sSpec {
 
   val srvc1 = HttpService[IO] {
     case req if req.pathInfo == "/match" =>
-      Response[IO](Status.Ok).withBody("match")
+      Response[IO](Status.Ok).withBody("match").pure[IO]
 
     case req if req.pathInfo == "/conflict" =>
-      Response[IO](Status.Ok).withBody("srvc1conflict")
+      Response[IO](Status.Ok).withBody("srvc1conflict").pure[IO]
 
     case req if req.pathInfo == "/notfound" =>
-      Response[IO](Status.NotFound).withBody("notfound")
+      Response[IO](Status.NotFound).withBody("notfound").pure[IO]
   }
 
   val srvc2 = HttpService[IO] {
     case req if req.pathInfo == "/srvc2" =>
-      Response[IO](Status.Ok).withBody("srvc2")
+      Response[IO](Status.Ok).withBody("srvc2").pure[IO]
 
     case req if req.pathInfo == "/conflict" =>
-      Response[IO](Status.Ok).withBody("srvc2conflict")
+      Response[IO](Status.Ok).withBody("srvc2conflict").pure[IO]
   }
 
   val aggregate1 = srvc1 <+> srvc2

--- a/server/src/test/scala/org/http4s/server/MockRoute.scala
+++ b/server/src/test/scala/org/http4s/server/MockRoute.scala
@@ -10,7 +10,7 @@ object MockRoute extends Http4s {
 
   def route(): HttpService[IO] = HttpService {
     case req if req.uri.path === "/ping" =>
-      Response[IO](Ok).withBody("pong").pure[IO]
+      Response[IO](Ok).withEntity("pong").pure[IO]
 
     case req if req.method === Method.POST && req.uri.path === "/echo" =>
       IO.pure(Response[IO](body = req.body))
@@ -26,6 +26,6 @@ object MockRoute extends Http4s {
 
     /** For testing the PushSupport middleware */
     case req if req.uri.path === "/push" =>
-      Response[IO](Ok).withBody("Hello").pure[IO].push("/ping")(req)
+      Response[IO](Ok).withEntity("Hello").pure[IO].push("/ping")(req)
   }
 }

--- a/server/src/test/scala/org/http4s/server/MockRoute.scala
+++ b/server/src/test/scala/org/http4s/server/MockRoute.scala
@@ -10,7 +10,7 @@ object MockRoute extends Http4s {
 
   def route(): HttpService[IO] = HttpService {
     case req if req.uri.path === "/ping" =>
-      Response[IO](Ok).withBody("pong")
+      Response[IO](Ok).withBody("pong").pure[IO]
 
     case req if req.method === Method.POST && req.uri.path === "/echo" =>
       IO.pure(Response[IO](body = req.body))
@@ -26,6 +26,6 @@ object MockRoute extends Http4s {
 
     /** For testing the PushSupport middleware */
     case req if req.uri.path === "/push" =>
-      Response[IO](Ok).withBody("Hello").push("/ping")(req)
+      Response[IO](Ok).withBody("Hello").pure[IO].push("/ping")(req)
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
@@ -10,8 +10,8 @@ import org.http4s.headers._
 class CORSSpec extends Http4sSpec {
 
   val service = HttpService[IO] {
-    case req if req.pathInfo == "/foo" => Response(Ok).withBody("foo")
-    case req if req.pathInfo == "/bar" => Response(Unauthorized).withBody("bar")
+    case req if req.pathInfo == "/foo" => Response[IO](Ok).withBody("foo").pure[IO]
+    case req if req.pathInfo == "/bar" => Response[IO](Unauthorized).withBody("bar").pure[IO]
   }
 
   val cors1 = CORS(service)

--- a/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
@@ -10,8 +10,8 @@ import org.http4s.headers._
 class CORSSpec extends Http4sSpec {
 
   val service = HttpService[IO] {
-    case req if req.pathInfo == "/foo" => Response[IO](Ok).withBody("foo").pure[IO]
-    case req if req.pathInfo == "/bar" => Response[IO](Unauthorized).withBody("bar").pure[IO]
+    case req if req.pathInfo == "/foo" => Response[IO](Ok).withEntity("foo").pure[IO]
+    case req if req.pathInfo == "/bar" => Response[IO](Unauthorized).withEntity("bar").pure[IO]
   }
 
   val cors1 = CORS(service)

--- a/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
@@ -14,7 +14,7 @@ import org.http4s.Status._
 class EntityLimiterSpec extends Http4sSpec {
 
   val s = HttpService[IO] {
-    case r if r.uri.path == "/echo" => r.decode[String](Response[IO](Ok).withBody(_).pure[IO])
+    case r if r.uri.path == "/echo" => r.decode[String](Response[IO](Ok).withEntity(_).pure[IO])
   }
 
   val b = chunk(Chunk.bytes("hello".getBytes(StandardCharsets.UTF_8)))
@@ -38,7 +38,8 @@ class EntityLimiterSpec extends Http4sSpec {
 
     "Chain correctly with other HttpServices" in {
       val s2 = HttpService[IO] {
-        case r if r.uri.path == "/echo2" => r.decode[String](Response[IO](Ok).withBody(_).pure[IO])
+        case r if r.uri.path == "/echo2" =>
+          r.decode[String](Response[IO](Ok).withEntity(_).pure[IO])
       }
 
       val st = EntityLimiter(s, 3) <+> s2

--- a/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
@@ -14,7 +14,7 @@ import org.http4s.Status._
 class EntityLimiterSpec extends Http4sSpec {
 
   val s = HttpService[IO] {
-    case r if r.uri.path == "/echo" => r.decode[String](Response[IO](Ok).withBody)
+    case r if r.uri.path == "/echo" => r.decode[String](Response[IO](Ok).withBody(_).pure[IO])
   }
 
   val b = chunk(Chunk.bytes("hello".getBytes(StandardCharsets.UTF_8)))
@@ -38,7 +38,7 @@ class EntityLimiterSpec extends Http4sSpec {
 
     "Chain correctly with other HttpServices" in {
       val s2 = HttpService[IO] {
-        case r if r.uri.path == "/echo2" => r.decode[String](Response[IO](Ok).withBody)
+        case r if r.uri.path == "/echo2" => r.decode[String](Response[IO](Ok).withBody(_).pure[IO])
       }
 
       val st = EntityLimiter(s, 3) <+> s2

--- a/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSpec.scala
@@ -21,19 +21,21 @@ class UrlFormLifterSpec extends Http4sSpec {
 
   "UrlFormLifter" should {
     "Add application/x-www-form-urlencoded bodies to the query params" in {
-      val req = Request[IO](method = POST).withBody(urlForm).pure[IO]
+      val req = Request[IO](method = POST).withEntity(urlForm).pure[IO]
       req.flatMap(service.orNotFound.run) must returnStatus(Ok)
     }
 
     "Add application/x-www-form-urlencoded bodies after query params" in {
       val req =
-        Request[IO](method = Method.POST, uri = Uri.uri("/foo?foo=biz")).withBody(urlForm).pure[IO]
+        Request[IO](method = Method.POST, uri = Uri.uri("/foo?foo=biz"))
+          .withEntity(urlForm)
+          .pure[IO]
       req.flatMap(service.orNotFound.run) must returnStatus(Ok)
       req.flatMap(service.orNotFound.run) must returnBody("biz,bar")
     }
 
     "Ignore Requests that don't have application/x-www-form-urlencoded bodies" in {
-      val req = Request[IO](method = Method.POST).withBody("foo").pure[IO]
+      val req = Request[IO](method = Method.POST).withEntity("foo").pure[IO]
       req.flatMap(service.orNotFound.run) must returnStatus(BadRequest)
     }
   }

--- a/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSpec.scala
@@ -3,6 +3,7 @@ package server
 package middleware
 
 import cats.effect._
+import cats.syntax.applicative._
 import org.http4s.dsl.io._
 
 class UrlFormLifterSpec extends Http4sSpec {
@@ -20,18 +21,19 @@ class UrlFormLifterSpec extends Http4sSpec {
 
   "UrlFormLifter" should {
     "Add application/x-www-form-urlencoded bodies to the query params" in {
-      val req = Request[IO](method = POST).withBody(urlForm)
+      val req = Request[IO](method = POST).withBody(urlForm).pure[IO]
       req.flatMap(service.orNotFound.run) must returnStatus(Ok)
     }
 
     "Add application/x-www-form-urlencoded bodies after query params" in {
-      val req = Request[IO](method = Method.POST, uri = Uri.uri("/foo?foo=biz")).withBody(urlForm)
+      val req =
+        Request[IO](method = Method.POST, uri = Uri.uri("/foo?foo=biz")).withBody(urlForm).pure[IO]
       req.flatMap(service.orNotFound.run) must returnStatus(Ok)
       req.flatMap(service.orNotFound.run) must returnBody("biz,bar")
     }
 
     "Ignore Requests that don't have application/x-www-form-urlencoded bodies" in {
-      val req = Request[IO](method = Method.POST).withBody("foo")
+      val req = Request[IO](method = Method.POST).withBody("foo").pure[IO]
       req.flatMap(service.orNotFound.run) must returnStatus(BadRequest)
     }
   }

--- a/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
@@ -11,15 +11,15 @@ import org.http4s.Status.{BadRequest, NotFound, Ok}
 class VirtualHostSpec extends Http4sSpec {
 
   val default = HttpService[IO] {
-    case _ => Response[IO](Ok).withBody("default").pure[IO]
+    case _ => Response[IO](Ok).withEntity("default").pure[IO]
   }
 
   val servicea = HttpService[IO] {
-    case _ => Response[IO](Ok).withBody("servicea").pure[IO]
+    case _ => Response[IO](Ok).withEntity("servicea").pure[IO]
   }
 
   val serviceb = HttpService[IO] {
-    case _ => Response[IO](Ok).withBody("serviceb").pure[IO]
+    case _ => Response[IO](Ok).withEntity("serviceb").pure[IO]
   }
 
   "VirtualHost" >> {

--- a/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
@@ -3,6 +3,7 @@ package server
 package middleware
 
 import cats.effect._
+import cats.syntax.applicative._
 import org.http4s.Method._
 import org.http4s.headers.Host
 import org.http4s.Status.{BadRequest, NotFound, Ok}
@@ -10,15 +11,15 @@ import org.http4s.Status.{BadRequest, NotFound, Ok}
 class VirtualHostSpec extends Http4sSpec {
 
   val default = HttpService[IO] {
-    case _ => Response(Ok).withBody("default")
+    case _ => Response[IO](Ok).withBody("default").pure[IO]
   }
 
   val servicea = HttpService[IO] {
-    case _ => Response(Ok).withBody("servicea")
+    case _ => Response[IO](Ok).withBody("servicea").pure[IO]
   }
 
   val serviceb = HttpService[IO] {
-    case _ => Response(Ok).withBody("serviceb")
+    case _ => Response[IO](Ok).withBody("serviceb").pure[IO]
   }
 
   "VirtualHost" >> {

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -88,7 +88,7 @@ class Http4sServlet[F[_]](
     val response =
       F.pure(
         Response[F](Status.BadRequest)
-          .withBody(parseFailure.sanitized))
+          .withEntity(parseFailure.sanitized))
     renderResponse(response, servletResponse, bodyWriter)
   }
 
@@ -117,7 +117,7 @@ class Http4sServlet[F[_]](
           val response =
             F.pure(
               Response[F](Status.InternalServerError)
-                .withBody("Service timed out."))
+                .withEntity("Service timed out."))
           renderResponse(response, servletResponse, bodyWriter)
         } else {
           logger.warn(

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -86,8 +86,8 @@ class Http4sServlet[F[_]](
       servletResponse: HttpServletResponse,
       bodyWriter: BodyWriter[F]): F[Unit] = {
     val response =
-      Response[F](Status.BadRequest)
-        .withBody(parseFailure.sanitized)
+      F.pure(Response[F](Status.BadRequest)
+        .withBody(parseFailure.sanitized))
     renderResponse(response, servletResponse, bodyWriter)
   }
 
@@ -114,8 +114,8 @@ class Http4sServlet[F[_]](
       async.unsafeRunAsync {
         if (!servletResponse.isCommitted) {
           val response =
-            Response[F](Status.InternalServerError)
-              .withBody("Service timed out.")
+            F.pure(Response[F](Status.InternalServerError)
+              .withBody("Service timed out."))
           renderResponse(response, servletResponse, bodyWriter)
         } else {
           logger.warn(

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -86,8 +86,9 @@ class Http4sServlet[F[_]](
       servletResponse: HttpServletResponse,
       bodyWriter: BodyWriter[F]): F[Unit] = {
     val response =
-      F.pure(Response[F](Status.BadRequest)
-        .withBody(parseFailure.sanitized))
+      F.pure(
+        Response[F](Status.BadRequest)
+          .withBody(parseFailure.sanitized))
     renderResponse(response, servletResponse, bodyWriter)
   }
 
@@ -114,8 +115,9 @@ class Http4sServlet[F[_]](
       async.unsafeRunAsync {
         if (!servletResponse.isCommitted) {
           val response =
-            F.pure(Response[F](Status.InternalServerError)
-              .withBody("Service timed out."))
+            F.pure(
+              Response[F](Status.InternalServerError)
+                .withBody("Service timed out."))
           renderResponse(response, servletResponse, bodyWriter)
         } else {
           logger.warn(

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -706,17 +706,16 @@ trait ArbitraryInstances {
       for {
         body <- genEntityBody
         length <- Gen.oneOf(Some(size.toLong), None)
-      } yield Entity(body, length)
+      } yield Entity(body.covary[F], length)
     })
 
   implicit def cogenEntity[F[_]](implicit F: Effect[F], ec: TestContext): Cogen[Entity[F]] =
     Cogen[(EntityBody[F], Option[Long])].contramap(entity => (entity.body, entity.length))
 
   implicit def arbitraryEntityEncoder[F[_], A](
-      implicit CA: Cogen[A],
-      AF: Arbitrary[F[Entity[F]]]): Arbitrary[EntityEncoder[F, A]] =
+      implicit CA: Cogen[A]): Arbitrary[EntityEncoder[F, A]] =
     Arbitrary(for {
-      f <- arbitrary[A => F[Entity[F]]]
+      f <- arbitrary[A => Entity[F]]
       hs <- arbitrary[Headers]
     } yield EntityEncoder.encodeBy(hs)(f))
 }

--- a/testing/src/main/scala/org/http4s/testing/EntityCodecTests.scala
+++ b/testing/src/main/scala/org/http4s/testing/EntityCodecTests.scala
@@ -17,7 +17,7 @@ trait EntityCodecLaws[F[_], A] extends EntityEncoderLaws[F, A] with ToIOSyntax {
 
   def entityCodecRoundTrip(a: A): IsEq[IO[Either[DecodeFailure, A]]] =
     (for {
-      entity <- encoder.toEntity(a)
+      entity <- effect.delay(encoder.toEntity(a))
       message = Request(body = entity.body, headers = encoder.headers)
       a0 <- decoder.decode(message, strict = true).value
     } yield a0).toIO <-> IO.pure(Right(a))

--- a/testing/src/main/scala/org/http4s/testing/EntityEncoderTests.scala
+++ b/testing/src/main/scala/org/http4s/testing/EntityEncoderTests.scala
@@ -14,7 +14,7 @@ trait EntityEncoderLaws[F[_], A] extends ToIOSyntax {
 
   def accurateContentLengthIfDefined(a: A) =
     (for {
-      entity <- encoder.toEntity(a)
+      entity <- effect.pure(encoder.toEntity(a))
       body <- entity.body.compile.toVector
       bodyLength = body.size.toLong
       contentLength = entity.length

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -68,8 +68,9 @@ trait Http4sSpec
 
   def writeToString[A](a: A)(implicit W: EntityEncoder[IO, A]): String =
     Stream
-      .eval(W.toEntity(a))
-      .flatMap { case Entity(body, _) => body }
+      .emit(W.toEntity(a))
+      .covary[IO]
+      .flatMap(_.body)
       .through(utf8Decode)
       .foldMonoid
       .compile
@@ -79,8 +80,9 @@ trait Http4sSpec
 
   def writeToByteVector[A](a: A)(implicit W: EntityEncoder[IO, A]): Chunk[Byte] =
     Stream
-      .eval(W.toEntity(a))
-      .flatMap { case Entity(body, _) => body }
+      .emit(W.toEntity(a))
+      .covary[IO]
+      .flatMap(_.body)
       .bufferAll
       .chunks
       .compile

--- a/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -22,7 +22,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
     chunk(Chunk.bytes(body.getBytes(StandardCharsets.UTF_8)))
 
   "EntityDecoder".can {
-    val req = Response[IO](Ok).withBody("foo").pure[IO]
+    val req = Response[IO](Ok).withEntity("foo").pure[IO]
     "flatMapR with success" in {
       DecodeResult.success(req).flatMap { r =>
         EntityDecoder
@@ -278,7 +278,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
   }
 
   "apply" should {
-    val request = Request[IO]().withBody("whatever")
+    val request = Request[IO]().withEntity("whatever")
 
     "invoke the function with  the right on a success" in {
       val happyDecoder: EntityDecoder[IO, String] =
@@ -307,7 +307,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
 
     val server: Request[IO] => IO[Response[IO]] = { req =>
       req
-        .decode[UrlForm](form => Response[IO](Ok).withBody(form).pure[IO])
+        .decode[UrlForm](form => Response[IO](Ok).withEntity(form).pure[IO])
         .attempt
         .map((e: Either[Throwable, Response[IO]]) => e.right.getOrElse(Response(Status.BadRequest)))
     }
@@ -320,7 +320,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
           "Name" -> Seq("Jonathan Doe")
         ))
       val resp: IO[Response[IO]] = Request[IO]()
-        .withBody(urlForm)(UrlForm.entityEncoder(Charset.`UTF-8`))
+        .withEntity(urlForm)(UrlForm.entityEncoder(Charset.`UTF-8`))
         .pure[IO]
         .flatMap(server)
       resp must returnValue(haveStatus(Ok))
@@ -360,7 +360,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
       try {
         val response = mockServe(Request()) { req =>
           req.decodeWith(textFile(tmpFile), strict = false) { _ =>
-            Response[IO](Ok).withBody("Hello").pure[IO]
+            Response[IO](Ok).withEntity("Hello").pure[IO]
           }
         }.unsafeRunSync
 
@@ -379,7 +379,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
         val response = mockServe(Request()) {
           case req =>
             req.decodeWith(binFile(tmpFile), strict = false) { _ =>
-              Response[IO](Ok).withBody("Hello").pure[IO]
+              Response[IO](Ok).withEntity("Hello").pure[IO]
             }
         }.unsafeRunSync
 
@@ -419,14 +419,14 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
     val str = "Oekraïene"
     "Use an charset defined by the Content-Type header" in {
       val resp = Response[IO](Ok)
-        .withBody(str.getBytes(Charset.`UTF-8`.nioCharset))
+        .withEntity(str.getBytes(Charset.`UTF-8`.nioCharset))
         .withContentType(`Content-Type`(MediaType.`text/plain`, Some(Charset.`UTF-8`)))
       EntityDecoder.decodeString(resp)(implicitly, Charset.`US-ASCII`) must returnValue(str)
     }
 
     "Use the default if the Content-Type header does not define one" in {
       val resp = Response[IO](Ok)
-        .withBody(str.getBytes(Charset.`UTF-8`.nioCharset))
+        .withEntity(str.getBytes(Charset.`UTF-8`.nioCharset))
         .withContentType(`Content-Type`(MediaType.`text/plain`, None))
       EntityDecoder.decodeString(resp)(implicitly, Charset.`UTF-8`) must returnValue(str)
     }

--- a/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -2,8 +2,6 @@ package org.http4s
 
 import cats.Eq
 import cats.effect.IO
-import cats.effect.laws.discipline.arbitrary.catsEffectLawsArbitraryForIO
-import cats.effect.laws.util.TestContext
 import cats.implicits._
 import cats.laws.discipline.ContravariantTests
 import cats.laws.discipline.eq._
@@ -13,20 +11,10 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeoutException
 import org.http4s.headers._
 import org.scalacheck.Arbitrary
-import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class EntityEncoderSpec extends Http4sSpec {
   "EntityEncoder" should {
-    "render futures" in {
-      val hello = "Hello"
-      writeToString(Future(hello)) must_== hello
-    }
-
-    "render IOs" in {
-      val hello = "Hello"
-      writeToString(IO.pure(hello)) must_== hello
-    }
 
     "render streams" in {
       val helloWorld: Stream[IO, String] = Stream("hello", "world")
@@ -42,8 +30,7 @@ class EntityEncoderSpec extends Http4sSpec {
     "render streams with chunked transfer encoding without wiping out other encodings" in {
       trait Foo
       implicit val FooEncoder: EntityEncoder[IO, Foo] =
-        EntityEncoder.encodeBy[IO, Foo](`Transfer-Encoding`(TransferCoding.gzip))(_ =>
-          IO.pure(Entity.empty))
+        EntityEncoder.encodeBy[IO, Foo](`Transfer-Encoding`(TransferCoding.gzip))(_ => Entity.empty)
       implicitly[EntityEncoder[IO, Stream[IO, Foo]]].headers.get(`Transfer-Encoding`) must beLike {
         case Some(coding) =>
           coding must_== `Transfer-Encoding`(TransferCoding.gzip, TransferCoding.chunked)
@@ -54,7 +41,7 @@ class EntityEncoderSpec extends Http4sSpec {
       trait Foo
       implicit val FooEncoder =
         EntityEncoder.encodeBy[IO, Foo](`Transfer-Encoding`(TransferCoding.chunked))(_ =>
-          IO.pure(Entity.empty))
+          Entity.empty)
       EntityEncoder[IO, Stream[IO, Foo]].headers.get(`Transfer-Encoding`) must beLike {
         case Some(coding) => coding must_== `Transfer-Encoding`(TransferCoding.chunked)
       }
@@ -125,8 +112,6 @@ class EntityEncoderSpec extends Http4sSpec {
   }
 
   {
-    implicit val ec: TestContext = TestContext()
-
     implicit val throwableEq: Eq[Throwable] =
       Eq.fromUniversalEquals
 
@@ -142,7 +127,7 @@ class EntityEncoderSpec extends Http4sSpec {
 
     implicit def entityEncoderEq[A: Arbitrary]: Eq[EntityEncoder[IO, A]] =
       Eq.by[EntityEncoder[IO, A], (Headers, A => IO[Entity[IO]])](enc =>
-        (enc.headers, enc.toEntity))
+        (enc.headers, a => IO.pure(enc.toEntity(a))))
 
     checkAll(
       "Contravariant[EntityEncoder[F, ?]]",

--- a/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -104,12 +104,12 @@ class ServerSentEventSpec extends Http4sSpec {
     val eventStream: Stream[IO, ServerSentEvent] =
       Stream.range(0, 5).map(i => ServerSentEvent(data = i.toString))
     "set Content-Type to text/event-stream" in {
-      Response[IO]().withBody(eventStream).contentType must beSome(
+      Response[IO]().withEntity(eventStream).contentType must beSome(
         `Content-Type`(MediaType.`text/event-stream`))
     }
 
     "decode to original event stream" in {
-      val resp = Response[IO]().withBody(eventStream)
+      val resp = Response[IO]().withEntity(eventStream)
       resp.body
         .through(ServerSentEvent.decoder)
         .compile

--- a/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -104,12 +104,12 @@ class ServerSentEventSpec extends Http4sSpec {
     val eventStream: Stream[IO, ServerSentEvent] =
       Stream.range(0, 5).map(i => ServerSentEvent(data = i.toString))
     "set Content-Type to text/event-stream" in {
-      Response[IO]().withBody(eventStream).unsafeRunSync.contentType must beSome(
+      Response[IO]().withBody(eventStream).contentType must beSome(
         `Content-Type`(MediaType.`text/event-stream`))
     }
 
     "decode to original event stream" in {
-      val resp = Response[IO]().withBody(eventStream).unsafeRunSync
+      val resp = Response[IO]().withBody(eventStream)
       resp.body
         .through(ServerSentEvent.decoder)
         .compile

--- a/tests/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.syntax.applicative._
 import cats.data._
 import cats.effect.IO
 
@@ -20,8 +20,10 @@ class UrlFormSpec extends Http4sSpec {
 
     "entityDecoder . entityEncoder == right" in prop { (urlForm: UrlForm) =>
       DecodeResult
-        .success(Request[IO]()
-          .withBody(urlForm)(Monad[IO], UrlForm.entityEncoder(Applicative[IO], charset)))
+        .success(
+          Request[IO]()
+            .withBody(urlForm)(UrlForm.entityEncoder(charset))
+            .pure[IO])
         .flatMap { req =>
           UrlForm.entityDecoder[IO].decode(req, strict = false)
         } must returnRight(urlForm)

--- a/tests/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -22,7 +22,7 @@ class UrlFormSpec extends Http4sSpec {
       DecodeResult
         .success(
           Request[IO]()
-            .withBody(urlForm)(UrlForm.entityEncoder(charset))
+            .withEntity(urlForm)(UrlForm.entityEncoder(charset))
             .pure[IO])
         .flatMap { req =>
           UrlForm.entityDecoder[IO].decode(req, strict = false)

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -57,7 +57,7 @@ class MultipartSpec extends Specification {
     val field2 = Part.formData[IO]("field2", "Text_Field_2")
     val multipart = Multipart(Vector(field1, field2))
     val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
-    val body = entity.unsafeRunSync().body
+    val body = entity.body
     val request = Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
     val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
     val result = decoded.value.unsafeRunSync()
@@ -74,7 +74,7 @@ class MultipartSpec extends Specification {
     val multipart = Multipart[IO](Vector(field1))
 
     val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
-    val body = entity.unsafeRunSync().body
+    val body = entity.body
     val request = Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
     val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
     val result = decoded.value.unsafeRunSync()
@@ -96,7 +96,7 @@ class MultipartSpec extends Specification {
     val multipart = Multipart[IO](Vector(field1, field2))
 
     val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
-    val body = entity.unsafeRunSync().body
+    val body = entity.body
     val request = Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
 
     val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)

--- a/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
+++ b/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
@@ -26,8 +26,8 @@ trait TwirlInstances {
       implicit charset: Charset = DefaultCharset): EntityEncoder[F, Txt] =
     contentEncoder(`text/plain`)
 
-  private def contentEncoder[F[_], C <: Content](
-      mediaType: MediaType)(implicit charset: Charset): EntityEncoder[F, C] =
+  private def contentEncoder[F[_], C <: Content](mediaType: MediaType)(
+      implicit charset: Charset): EntityEncoder[F, C] =
     EntityEncoder
       .stringEncoder[F]
       .contramap[C](content => content.body)

--- a/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
+++ b/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
@@ -1,13 +1,12 @@
 package org.http4s
 package twirl
 
-import cats._
 import org.http4s.headers.`Content-Type`
 import org.http4s.MediaType._
 import play.twirl.api._
 
 trait TwirlInstances {
-  implicit def htmlContentEncoder[F[_]: Applicative](
+  implicit def htmlContentEncoder[F[_]](
       implicit charset: Charset = DefaultCharset): EntityEncoder[F, Html] =
     contentEncoder(`text/html`)
 
@@ -15,20 +14,20 @@ trait TwirlInstances {
     * Note: Twirl uses a media type of `text/javascript`.  This is obsolete, so we instead return
     * [[org.http4s.MediaType.application/javascript]].
     */
-  implicit def jsContentEncoder[F[_]: Applicative](
+  implicit def jsContentEncoder[F[_]](
       implicit charset: Charset = DefaultCharset): EntityEncoder[F, JavaScript] =
     contentEncoder(`application/javascript`)
 
-  implicit def xmlContentEncoder[F[_]: Applicative](
+  implicit def xmlContentEncoder[F[_]](
       implicit charset: Charset = DefaultCharset): EntityEncoder[F, Xml] =
     contentEncoder(`application/xml`)
 
-  implicit def txtContentEncoder[F[_]: Applicative](
+  implicit def txtContentEncoder[F[_]](
       implicit charset: Charset = DefaultCharset): EntityEncoder[F, Txt] =
     contentEncoder(`text/plain`)
 
   private def contentEncoder[F[_], C <: Content](
-      mediaType: MediaType)(implicit F: Applicative[F], charset: Charset): EntityEncoder[F, C] =
+      mediaType: MediaType)(implicit charset: Charset): EntityEncoder[F, C] =
     EntityEncoder
       .stringEncoder[F]
       .contramap[C](content => content.body)

--- a/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
+++ b/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
@@ -26,7 +26,7 @@ class TwirlSpec extends Http4sSpec {
     }
 
     "render the body" in prop { implicit cs: Charset =>
-      val resp = Response[IO](Ok).withBody(html.test())
+      val resp = Response[IO](Ok).withEntity(html.test())
       text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("<h1>test html</h1>")
     }
   }
@@ -40,7 +40,7 @@ class TwirlSpec extends Http4sSpec {
     }
 
     "render the body" in prop { implicit cs: Charset =>
-      val resp = Response[IO](Ok).withBody(js.test())
+      val resp = Response[IO](Ok).withEntity(js.test())
       text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(""""test js"""")
     }
   }
@@ -52,7 +52,7 @@ class TwirlSpec extends Http4sSpec {
     }
 
     "render the body" in prop { implicit cs: Charset =>
-      val resp = Response[IO](Ok).withBody(txt.test())
+      val resp = Response[IO](Ok).withEntity(txt.test())
       text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("""test text""")
     }
   }
@@ -65,7 +65,7 @@ class TwirlSpec extends Http4sSpec {
     }
 
     "render the body" in prop { implicit cs: Charset =>
-      val resp = Response[IO](Ok).withBody(_root_.xml.test())
+      val resp = Response[IO](Ok).withEntity(_root_.xml.test())
       text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
         "<test>test xml</test>")
     }

--- a/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
+++ b/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
@@ -27,8 +27,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withBody(html.test())
-      text[IO].decode(resp.unsafeRunSync, strict = false).value.unsafeRunSync must beRight(
-        "<h1>test html</h1>")
+      text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("<h1>test html</h1>")
     }
   }
 
@@ -42,8 +41,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withBody(js.test())
-      text[IO].decode(resp.unsafeRunSync, strict = false).value.unsafeRunSync must beRight(
-        """"test js"""")
+      text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(""""test js"""")
     }
   }
 
@@ -55,8 +53,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withBody(txt.test())
-      text[IO].decode(resp.unsafeRunSync, strict = false).value.unsafeRunSync must beRight(
-        """test text""")
+      text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("""test text""")
     }
   }
 
@@ -69,7 +66,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withBody(_root_.xml.test())
-      text[IO].decode(resp.unsafeRunSync, strict = false).value.unsafeRunSync must beRight(
+      text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
         "<test>test xml</test>")
     }
   }


### PR DESCRIPTION
This PR tackles eneity encoders as pure operations.

`toEntity` becomes `Entity[F]` instead of `F[Entity[F]]` 

We could also tentatively consider `EntityEncoder[A]` with `toEntity[F[_]: Sync]: Entity[F]` given that you need at least `Sync` to run a stream. This universal quantification on the bound would also work, and it would remove the necessity of requiring more than one `F[_]` for an entitydecoder.