### PR TITLE
Qualify reference to identity in uriLiteral macro

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -130,7 +130,7 @@ object Uri extends UriFunctions {
             .fromString(s)
             .fold(
               e => c.abort(c.enclosingPosition, e.details),
-              qValue => q"_root_.org.http4s.Uri.fromString($s).fold(throw _, identity)"
+              qValue => q"_root_.org.http4s.Uri.fromString($s).fold(throw _, _root_.scala.Predef.identity)"
             )
         case _ =>
           c.abort(


### PR DESCRIPTION
Custom predefs mean qualifying `identity` is a better choice here. Might also be okay to use `x => x` but I don't know much about macros.