### PR TITLE
Make retry use the correct duration units

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -63,7 +63,7 @@ object Retry {
           }
         }
         .getOrElse(0L)
-      val sleepDuration = Math.max(headerDuration, duration.length).seconds
+      val sleepDuration = headerDuration.seconds.max(duration)
       scheduler.sleep_[F](sleepDuration).compile.drain *> prepareLoop(
         req.withEmptyBody,
         attempts + 1)


### PR DESCRIPTION
Used to convert everything to seconds wrong (as in, `5.millis` => `5.seconds`), now just does the entire `max` computation inside `Duration`.