### PR TITLE
Add to Json docs to explain how to generate EntityDecoder instances for all A that has Decoder instances.

### DIFF
--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -193,7 +193,7 @@ Ok("""{"name":"Alice"}""").flatMap(_.as[User]).unsafeRunSync
 POST(uri("/hello"), """{"name":"Bob"}""").flatMap(_.as[User]).unsafeRunSync
 ```
 
-If we are always decoding from JSON to a typed model, we can use 
+If we are always decoding from JSON to a typed model, we can use
 the following one-liner:
 
 ```tut:book
@@ -202,7 +202,7 @@ implicit def decoders[F[_]: Sync, A: Decoder]: EntityDecoder[F, A] = jsonOf[F, A
 
 This creates an `EntityDecoder[A]` for every `A` that has a `Decoder` instance.
 
-However, be cautious when using this. Having this implicit 
+However, be cautious when using this. Having this implicit
 in scope does mean that we would always try to decode HTTP entities
 from JSON (even if it is XML or plain text, for instance).
 
@@ -213,7 +213,7 @@ from JSON (even if it is XML or plain text, for instance).
 Our hello world service will parse a `User` from a request and offer a
 proper greeting.
 
-```tut:silent
+```tut:silent:reset
 import cats.effect._
 
 import io.circe._
@@ -249,6 +249,8 @@ val blazeServer = builder.unsafeRunSync
 Now let's make a client for the service above:
 
 ```tut:silent
+import org.http4s.client._
+import org.http4s.client.dsl.io._
 import org.http4s.client.blaze._
 import cats.effect.IO
 import io.circe.generic.auto._

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -193,6 +193,17 @@ Ok("""{"name":"Alice"}""").flatMap(_.as[User]).unsafeRunSync
 POST(uri("/hello"), """{"name":"Bob"}""").flatMap(_.as[User]).unsafeRunSync
 ```
 
+If we are always decoding from JSON to a typed model, we can use 
+the following one-liner:
+
+```tut:book
+implicit def decoders[F[_]: Sync, A: Decoder]: EntityDecoder[F, A] = jsonOf[F, A]
+```
+
+However, be cautious when using this. Having this implicit 
+in scope does mean that we would always try to decode HTTP entities
+from JSON (even if it is XML or plain text, for instance).
+
 ## Putting it all together
 
 ### A Hello world service

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -200,6 +200,8 @@ the following one-liner:
 implicit def decoders[F[_]: Sync, A: Decoder]: EntityDecoder[F, A] = jsonOf[F, A]
 ```
 
+This creates an `EntityDecoder[A]` for every `A` that has a `Decoder` instance.
+
 However, be cautious when using this. Having this implicit 
 in scope does mean that we would always try to decode HTTP entities
 from JSON (even if it is XML or plain text, for instance).


### PR DESCRIPTION
I think a lot of Http4s users would be using it for largely Json services. I understand why this is not the default behaviour, but I think this would be good to sit in the docs for those of us who write 100% Json services.