### PR TITLE
Change Streaming to a more idiomatic response

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -116,17 +116,14 @@ final case class Client[F[_]](
       }
       .mapF(OptionT.liftF(_))
 
-  def streaming[A](req: Request[F])(f: Response[F] => Stream[F, A]): Stream[F, A] =
+  def streaming[A](req: Request[F]): Stream[F, Response[F]] =
     Stream
       .eval(open(req))
       .flatMap {
         case DisposableResponse(response, dispose) =>
-          f(response)
+          Stream(response)
             .onFinalize(dispose)
       }
-
-  def streaming[A](req: F[Request[F]])(f: Response[F] => Stream[F, A]): Stream[F, A] =
-    Stream.eval(req).flatMap(streaming(_)(f))
 
   /**
     * Submits a request and decodes the response on success.  On failure, the

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -12,7 +12,10 @@ import org.http4s.Status.Successful
 import org.http4s.headers.{Accept, MediaRangeAndQValue}
 import scala.util.control.NoStackTrace
 import org.log4s.getLogger
-
+/**
+  * A [[Client]] submits [[Request]]s to a server and processes the [[Response]].
+  *
+  */
 trait Client[F[_]]{
   import Client._
 
@@ -99,212 +102,34 @@ trait Client[F[_]]{
         F.raiseError(UnexpectedStatus(failedResponse.status))
     }
   }
-
+  
+  /**
+    * Submits a request and decodes the response on success.  On failure, the
+    * status code is returned.  The underlying HTTP connection is closed at the
+    * completion of the decoding.
+    */
   def getUriAs[A](uri: Uri)(implicit d: EntityDecoder[F, A], F: Sync[F]): F[A] =
     fetchAs(Request[F](Method.GET, uri))
+
+  /**
+    * Submits a request and decodes the response on success.  On failure, the
+    * status code is returned.  The underlying HTTP connection is closed at the
+    * completion of the decoding.
+    */
   def getStringAs[A](s: String)(implicit d: EntityDecoder[F, A], F: Sync[F]): F[A] = 
     Uri.fromString(s).fold(F.raiseError, uri => getUriAs(uri))
-  
+
+  /** Submits a request and returns the response status */
   def status(req: Request[F])(implicit F: Sync[F]): F[Status] = 
     fetch(req)(resp => F.pure(resp.status))
+  
+  /** 
+    * Submits a request and returns true if and only if the response status is
+    * successful 
+    */
   def successful(req: Request[F])(implicit F: Sync[F]): F[Boolean] =
     status(req).map(_.isSuccess)
 }
-
-/**
-  * A [[Client]] submits [[Request]]s to a server and processes the [[Response]].
-  *
-  * @param open a service to asynchronously return a [[DisposableResponse]] from
-  *             a [[Request]].  This is a low-level operation intended for client
-  *             implementations and middleware.
-  *
-  * @param shutdown an effect to shut down this Shutdown this client, closing any
-  *                 open connections and freeing resources
-  */
-
-// final case class Client[F[_]](
-//     open: Kleisli[F, Request[F], DisposableResponse[F]],
-//     shutdown: F[Unit])(implicit F: MonadError[F, Throwable]) {
-
-  /** Submits a request, and provides a callback to process the response.
-    *
-    * @param req The request to submit
-    * @param f   A callback for the response to req.  The underlying HTTP connection
-    *            is disposed when the returned task completes.  Attempts to read the
-    *            response body afterward will result in an error.
-    * @return The result of applying f to the response to req
-    */
-//   def fetch[A](req: Request[F])(f: Response[F] => F[A]): F[A] =
-//     open.run(req).flatMap(_.apply(f))
-
-//   /** Submits a request, and provides a callback to process the response.
-//     *
-//     * @param req An effect of the request to submit
-//     * @param f A callback for the response to req.  The underlying HTTP connection
-//     *          is disposed when the returned task completes.  Attempts to read the
-//     *          response body afterward will result in an error.
-//     * @return The result of applying f to the response to req
-//     */
-//   def fetch[A](req: F[Request[F]])(f: Response[F] => F[A]): F[A] =
-//     req.flatMap(fetch(_)(f))
-
-  /**
-    * Returns this client as a [[Kleisli]].  All connections created by this
-    * service are disposed on completion of callback task f.
-    *
-    * This method effectively reverses the arguments to `fetch`, and is
-    * preferred when an HTTP client is composed into a larger Kleisli function,
-    * or when a common response callback is used by many call sites.
-    */
-//   def toKleisli[A](f: Response[F] => F[A]): Kleisli[F, Request[F], A] =
-//     open.flatMapF(_.apply(f))
-
-//   @deprecated("Use toKleisli", "0.18")
-//   def toService[A](f: Response[F] => F[A]): Service[F, Request[F], A] =
-//     toKleisli(f)
-
-  /**
-    * Returns this client as an [[HttpService]].  It is the responsibility of
-    * callers of this service to run the response body to dispose of the
-    * underlying HTTP connection.
-    *
-    * This is intended for use in proxy servers.  `fetch`, `fetchAs`,
-    * [[toKleisli]], and [[streaming]] are safer alternatives, as their
-    * signatures guarantee disposal of the HTTP connection.
-    */
-//   def toHttpService: HttpService[F] =
-//     open
-//       .map {
-//         case DisposableResponse(response, dispose) =>
-//           response.copy(body = response.body.onFinalize(dispose))
-//       }
-//       .mapF(OptionT.liftF(_))
-
-//   def streaming[A](req: Request[F]): Stream[F, Response[F]] =
-//     Stream
-//       .eval(open(req))
-//       .flatMap {
-//         case DisposableResponse(response, dispose) =>
-//           Stream(response)
-//             .onFinalize(dispose)
-//       }
-
-//   /**
-//     * Submits a request and decodes the response on success.  On failure, the
-//     * status code is returned.  The underlying HTTP connection is closed at the
-//     * completion of the decoding.
-//     */
-  // def expect[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[A] = {
-  //   val r = if (d.consumes.nonEmpty) {
-  //     val m = d.consumes.toList
-  //     req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
-  //   } else req
-  //   fetch(r) {
-  //     case Successful(resp) =>
-  //       d.decode(resp, strict = false).fold(throw _, identity)
-  //     case failedResponse =>
-  //       F.raiseError(UnexpectedStatus(failedResponse.status))
-  //   }
-  // }
-
-//   def expect[A](req: F[Request[F]])(implicit d: EntityDecoder[F, A]): F[A] =
-//     req.flatMap(expect(_)(d))
-
-//   /**
-//     * Submits a GET request to the specified URI and decodes the response on
-//     * success.  On failure, the status code is returned.  The underlying HTTP
-//     * connection is closed at the completion of the decoding.
-//     */
-//   def expect[A](uri: Uri)(implicit d: EntityDecoder[F, A]): F[A] =
-//     expect(Request[F](Method.GET, uri))(d)
-
-//   /**
-//     * Submits a GET request to the URI specified by the String and decodes the
-//     * response on success.  On failure, the status code is returned.  The
-//     * underlying HTTP connection is closed at the completion of the decoding.
-//     */
-//   def expect[A](s: String)(implicit d: EntityDecoder[F, A]): F[A] =
-//     Uri.fromString(s).fold(F.raiseError, uri => expect[A](uri))
-
-
-
-//   /**
-//     * Submits a request and decodes the response, regardless of the status code.
-//     * The underlying HTTP connection is closed at the completion of the
-//     * decoding.
-//     */
-//   def fetchAs[A](req: F[Request[F]])(implicit d: EntityDecoder[F, A]): F[A] =
-//     req.flatMap(fetchAs(_)(d))
-
-//   /** Submits a request and returns the response status */
-//   def status(req: Request[F]): F[Status] =
-//     fetch(req)(resp => F.pure(resp.status))
-
-//   /** Submits a request and returns the response status */
-//   def status(req: F[Request[F]]): F[Status] =
-//     req.flatMap(status)
-
-//   /** Submits a request and returns true if and only if the response status is
-//     * successful */
-//   def successful(req: Request[F]): F[Boolean] =
-//     status(req).map(_.isSuccess)
-
-//   /** Submits a request and returns true if and only if the response status is
-//     * successful */
-//   def successful(req: F[Request[F]]): F[Boolean] =
-//     req.flatMap(successful)
-
-//   @deprecated("Use expect", "0.14")
-//   def prepAs[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[A] =
-//     fetchAs(req)(d)
-
-//   /** Submits a GET request, and provides a callback to process the response.
-//     *
-//     * @param uri The URI to GET
-//     * @param f A callback for the response to a GET on uri.  The underlying HTTP connection
-//     *          is disposed when the returned task completes.  Attempts to read the
-//     *          response body afterward will result in an error.
-//     * @return The result of applying f to the response to req
-//     */
-//   def get[A](uri: Uri)(f: Response[F] => F[A]): F[A] =
-//     fetch(Request[F](Method.GET, uri))(f)
-
-//   /**
-//     * Submits a request and decodes the response on success.  On failure, the
-//     * status code is returned.  The underlying HTTP connection is closed at the
-//     * completion of the decoding.
-//     */
-//   def get[A](s: String)(f: Response[F] => F[A]): F[A] =
-//     Uri.fromString(s).fold(F.raiseError, uri => get(uri)(f))
-
-//   /**
-//     * Submits a GET request and decodes the response.  The underlying HTTP
-//     * connection is closed at the completion of the decoding.
-//     */
-//   @deprecated("Use expect", "0.14")
-//   def getAs[A](uri: Uri)(implicit d: EntityDecoder[F, A]): F[A] =
-//     fetchAs(Request[F](Method.GET, uri))(d)
-
-//   @deprecated("Use expect", "0.14")
-//   def getAs[A](s: String)(implicit d: EntityDecoder[F, A]): F[A] =
-//     Uri.fromString(s).fold(F.raiseError, uri => expect[A](uri))
-
-//   @deprecated("Use expect", "0.14")
-//   def prepAs[T](req: F[Request[F]])(implicit d: EntityDecoder[F, T]): F[T] =
-//     fetchAs(req)
-
-//   /** Shuts this client down, and blocks until complete. */
-//   def shutdownNow()(implicit F: Effect[F]): Unit = {
-//     val wait = new SyncVar[Unit]
-//     F.runAsync(shutdown) { _ =>
-//         wait.put(())
-//         IO.unit
-//       }
-//       .unsafeRunSync()
-//     wait.get
-//   }
-// }
-
 
 object Client {
 

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -208,7 +208,8 @@ class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThro
 
     "streaming returns a stream" in {
       client
-        .streaming(req)(_.body.through(fs2.text.utf8Decode))
+        .streaming(req)
+        .flatMap(_.body.through(fs2.text.utf8Decode))
         .compile
         .toVector
         .unsafeRunSync() must_== Vector("hello")
@@ -216,18 +217,19 @@ class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThro
 
     "streaming returns a stream from a request task" in {
       client
-        .streaming(req)(_.body.through(fs2.text.utf8Decode))
+        .streaming(req)
+        .flatMap(_.body.through(fs2.text.utf8Decode))
         .compile
         .toVector
         .unsafeRunSync() must_== Vector("hello")
     }
 
     "streaming disposes of the response on success" in {
-      assertDisposes(_.streaming(req)(_.body).compile.drain)
+      assertDisposes(_.streaming(req).flatMap(_.body).compile.drain)
     }
 
     "streaming disposes of the response on failure" in {
-      assertDisposes(_.streaming(req)(_ => Stream.raiseError(SadTrombone)).compile.drain)
+      assertDisposes(_.streaming(req).flatMap(_ => Stream.raiseError(SadTrombone)).compile.drain)
     }
 
     "toService disposes of the response on success" in {

--- a/docs/src/main/tut/streaming.md
+++ b/docs/src/main/tut/streaming.md
@@ -48,7 +48,7 @@ function, which takes a `Request[F]` and a `Response[F] => Stream[F, A]` and ret
 to consume a stream is just:
 
 ```scala
-client.streaming(req)(resp => resp.body)
+client.streaming(req).flatMap(resp => resp.body)
 ```
 
 That gives you a `Stream[F, Byte]`, but you probably want something other than a `Byte`.
@@ -115,7 +115,7 @@ abstract class TWStreamApp[F[_]: Effect] extends StreamApp[F] {
     for {
       client <- Http1Client.stream[F]()
       sr  <- Stream.eval(sign(consumerKey, consumerSecret, accessToken, accessSecret)(req))
-      res <- client.streaming(sr)(resp => resp.body.chunks.parseJsonStream)
+      res <- client.streaming(sr).flatMap(resp => resp.body.chunks.parseJsonStream)
     } yield res
 
   /* Stream the sample statuses.

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/client/StreamClient.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/client/StreamClient.scala
@@ -21,7 +21,7 @@ class HttpClient[F[_]](implicit F: Effect[F], S: StreamUtils[F]) extends StreamA
       .flatMap { client =>
         val request = Request[F](uri = Uri.uri("http://localhost:8080/v1/dirs?depth=3"))
         for {
-          response <- client.streaming(request)(_.body.chunks.through(fs2.text.utf8DecodeC))
+          response <- client.streaming(request).flatMap(_.body.chunks.through(fs2.text.utf8DecodeC))
           _ <- S.putStr(response)
         } yield ()
       }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
@@ -30,7 +30,7 @@ class GitHubService[F[_]: Sync](client: Client[F]) extends Http4sClientDsl[F] {
       .withQueryParam("scopes", "public_repo")
       .withQueryParam("state", "test_api")
 
-    client.streaming[Byte](Request[F](uri = uri))(_.body)
+    client.streaming[Byte](Request[F](uri = uri)).flatMap(_.body)
   }
 
   def accessToken(code: String, state: String): F[String] = {


### PR DESCRIPTION
Since responses will be automatically disposed with this signature, this allows a more direct experience to a Response which can be worked with, rather than modified inside this function only.