### PR TITLE
adds server-logging functionality to BlazeBuilder

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
@@ -4,9 +4,12 @@ package blaze
 
 import cats.effect.Effect
 import java.nio.ByteBuffer
+
 import javax.net.ssl.SSLEngine
 import org.http4s.blaze.http.http20._
 import org.http4s.blaze.pipeline.{LeafBuilder, TailStage}
+import org.http4s.server.logging.ServerLogging
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
 
@@ -19,7 +22,8 @@ private[blaze] object ProtocolSelector {
       maxHeadersLen: Int,
       requestAttributes: AttributeMap,
       executionContext: ExecutionContext,
-      serviceErrorHandler: ServiceErrorHandler[F]): ALPNSelector = {
+      serviceErrorHandler: ServiceErrorHandler[F],
+      serverLogging: ServerLogging[F]): ALPNSelector = {
 
     def http2Stage(): TailStage[ByteBuffer] = {
 
@@ -31,7 +35,8 @@ private[blaze] object ProtocolSelector {
             executionContext,
             requestAttributes,
             service,
-            serviceErrorHandler))
+            serviceErrorHandler,
+            serverLogging))
       }
 
       Http2Stage(
@@ -52,7 +57,8 @@ private[blaze] object ProtocolSelector {
         enableWebSockets = false,
         maxRequestLineLen,
         maxHeadersLen,
-        serviceErrorHandler
+        serviceErrorHandler,
+        serverLogging
       )
 
     def preference(protos: Seq[String]): String =

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -5,13 +5,16 @@ import cats.effect._
 import cats.implicits._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+
 import org.http4s.{headers => H, _}
 import org.http4s.blaze._
 import org.http4s.blaze.pipeline.{Command => Cmd}
 import org.http4s.blazecore.{ResponseParser, SeqTestHead}
 import org.http4s.dsl.io._
 import org.http4s.headers.{Date, `Content-Length`, `Transfer-Encoding`}
+import org.http4s.server.logging.ServerLogging
 import org.specs2.specification.core.Fragment
+
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
@@ -45,7 +48,8 @@ class Http1ServerStageSpec extends Http4sSpec {
       enableWebSockets = true,
       maxReqLine,
       maxHeaders,
-      DefaultServiceErrorHandler)
+      DefaultServiceErrorHandler,
+      ServerLogging.disabled)
 
     pipeline.LeafBuilder(httpStage).base(head)
     head.sendInboundCommand(Cmd.Connected)

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -7,10 +7,13 @@ import fs2.StreamApp.ExitCode
 import fs2._
 import java.net.{InetAddress, InetSocketAddress}
 import java.util.concurrent.ExecutorService
+
 import javax.net.ssl.SSLContext
 import fs2.async.immutable.Signal
 import fs2.async.Ref
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
+import org.http4s.server.logging.ServerLogging
+
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -137,6 +140,10 @@ object SSLKeyStoreSupport {
 
 trait SSLContextSupport[F[_]] { this: ServerBuilder[F] =>
   def withSSLContext(sslContext: SSLContext, clientAuth: Boolean = false): Self
+}
+
+trait ServerLoggingSupport[F[_]] { this: ServerBuilder[F] =>
+  def withRequestResponseLogging(serverLogging: ServerLogging[F]): Self
 }
 
 /*

--- a/server/src/main/scala/org/http4s/server/logging/ServerLogging.scala
+++ b/server/src/main/scala/org/http4s/server/logging/ServerLogging.scala
@@ -1,0 +1,46 @@
+package org.http4s
+package server
+package logging
+
+import java.time.format.DateTimeFormatter
+import java.time.{Clock, OffsetDateTime}
+
+import org.http4s.headers.Authorization
+
+abstract class ServerLogging[F[_]] {
+  def enabled: Boolean
+  def logRequestResponse(request: Request[F], response: Response[F]): Unit
+}
+
+object ServerLogging {
+  def apply[F[_]](log: (Request[F], Response[F]) => Unit): ServerLogging[F] =
+    new ServerLogging[F] {
+      override final val enabled = true
+      override def logRequestResponse(request: Request[F], response: Response[F]): Unit =
+        log(request, response)
+    }
+
+  def disabled[F[_]]: ServerLogging[F] = new ServerLogging[F] {
+    override final val enabled: Boolean = false
+    override def logRequestResponse(request: Request[F], response: Response[F]): Unit = ()
+  }
+
+  def commonLogFormat[F[_]](clock: Clock = Clock.systemDefaultZone()): ServerLogging[F] = {
+    val formatter = DateTimeFormatter.ofPattern("dd/MMM/yyyy:hh:mm:ss Z")
+
+    apply[F] { (req, res) =>
+      val remotehost = req.remoteAddr.getOrElse("-")
+      val rfc931 = "-"
+      val authuser = Authorization.from(req.headers).map(_.credentials) match {
+        case Some(BasicCredentials(credentials)) => credentials.username
+        case _ => "-"
+      }
+      val date = formatter.format(OffsetDateTime.now(clock))
+      val request = s"${req.method} ${req.uri} ${req.httpVersion}"
+      val status = res.status.code
+      val bytes = res.contentLength.map(_.toString).getOrElse("-")
+
+      println(s"""$remotehost $rfc931 $authuser [$date] "$request" $status $bytes""")
+    }
+  }
+}

--- a/server/src/main/scala/org/http4s/server/logging/ServerLogging.scala
+++ b/server/src/main/scala/org/http4s/server/logging/ServerLogging.scala
@@ -8,20 +8,17 @@ import java.time.{Clock, OffsetDateTime}
 import org.http4s.headers.Authorization
 
 abstract class ServerLogging[F[_]] {
-  def enabled: Boolean
   def logRequestResponse(request: Request[F], response: Response[F]): Unit
 }
 
 object ServerLogging {
   def apply[F[_]](log: (Request[F], Response[F]) => Unit): ServerLogging[F] =
     new ServerLogging[F] {
-      override final val enabled = true
       override def logRequestResponse(request: Request[F], response: Response[F]): Unit =
         log(request, response)
     }
 
   def disabled[F[_]]: ServerLogging[F] = new ServerLogging[F] {
-    override final val enabled: Boolean = false
     override def logRequestResponse(request: Request[F], response: Response[F]): Unit = ()
   }
 


### PR DESCRIPTION
This PR adds basic support for the Common Log Format as discussed @ #1708

A few things are still missing or unclear:
* A request that fails and gets handled by `ServiceErrorHandler[F]` seems to yield a `Response[F]` without a Content-Length header. Blaze handles this "elsewhere", like in https://github.com/http4s/http4s/blob/d973c013ca0913ed3250d4c8eefbf8e2e7647ece/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala#L70. At this point the response is disregarded so the logger will output an unhelpful "-" instead of the actual byte-count
* `Request[F]` has a value `.remoteUser` which is is always None. Not sure what this is for.

The initial implementation focuses more on performance than elegance as a logger at this level means a performance hit for every request. It may need to be even more low-level.

Packages, naming and formatting will probably need some clean-up. I will address this as I go.