### PR TITLE
Monad[F] constraint on Router.apply

### DIFF
--- a/server/src/main/scala/org/http4s/server/Router.scala
+++ b/server/src/main/scala/org/http4s/server/Router.scala
@@ -1,9 +1,9 @@
 package org.http4s
 package server
 
+import cats.Monad
 import cats.data.Kleisli
-import cats.effect._
-import cats.implicits._
+import cats.syntax.semigroupk._
 
 object Router {
 
@@ -13,7 +13,7 @@ object Router {
     * Defines an HttpService based on list of mappings.
     * @see define
     */
-  def apply[F[_]: Sync](mappings: (String, HttpService[F])*): HttpService[F] =
+  def apply[F[_]: Monad](mappings: (String, HttpService[F])*): HttpService[F] =
     define(mappings: _*)(HttpService.empty[F])
 
   /**
@@ -22,7 +22,7 @@ object Router {
     *
     * The mappings are processed in descending order (longest first) of prefix length.
     */
-  def define[F[_]: Sync](mappings: (String, HttpService[F])*)(
+  def define[F[_]: Monad](mappings: (String, HttpService[F])*)(
       default: HttpService[F]): HttpService[F] =
     mappings.sortBy(_._1.length).foldLeft(default) {
       case (acc, (prefix, service)) =>

--- a/server/src/test/scala/org/http4s/server/RouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSpec.scala
@@ -1,6 +1,7 @@
 package org.http4s
 package server
 
+import cats.Monad
 import cats.effect._
 import org.http4s.dsl.io._
 
@@ -72,6 +73,13 @@ class RouterSpec extends Http4sSpec {
     "Return the fallthrough response if no route is found" in {
       val router = Router[IO]("/foo" -> notFound)
       router(Request[IO](uri = uri("/bar"))).value must returnValue(None)
+    }
+
+    "Only require a Monad instance for a given F[_]" in {
+      def router[F[_]: Monad]: HttpService[F] = Router(
+        "/" -> HttpService.empty[F]
+      )
+      router[IO] must haveClass[HttpService[IO]]
     }
   }
 }


### PR DESCRIPTION
Making Router.apply take just a `Monad[F]` instead of an unnecessary `Sync[F]`. 

***Note that `Monad` is the minimal requirement***. Internal function `translate` requires only a `Functor` but it seems the `Kleisli` instance for `SemigroupK` requires a `Monad` and `<+>` is being used to combine `HttpService`s.

Discussed it a bit on on Gitter with @jmcardon.