### PR TITLE
Fix the versions table on the site

### DIFF
--- a/scripts/helpers
+++ b/scripts/helpers
@@ -41,6 +41,9 @@ EOM
         git remote set-url origin git@github.com:${TRAVIS_REPO_SLUG}.git
         git config branch.${TRAVIS_BRANCH}.merge
         git config branch.${TRAVIS_BRANCH}.remote
+
+        # Need this so we can build the versions table
+        git fetch --tags
     fi
     return 0
 }


### PR DESCRIPTION
Travis clones to a depth of 50, which doesn't include all the tags.  We need them all.  This is why the versions table seems to work on a local site preview, but isn't populating past a certain point on the live site.