### PR TITLE
Fix URI scheme for http4s.org and typelevel.org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 Please see the [Code of Conduct] at http4s.org.
 
-[Code of Conduct]: http://http4s.org/code-of-conduct/
+[Code of Conduct]: https://http4s.org/code-of-conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,4 @@ http4s is licensed under the [Apache License 2.0]. Opening a pull
 request signifies your consent to license your contributions under the
 Apache License 2.0.
 
-[contributors' guide]: http://http4s.org/contributing/
+[contributors' guide]: https://http4s.org/contributing/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Http4s [![Build Status](https://travis-ci.org/http4s/http4s.svg?branch=master)](https://travis-ci.org/http4s/http4s) [![Build status](https://ci.appveyor.com/api/projects/status/aprulmaagd5u1705?svg=true)](https://ci.appveyor.com/project/ChristopherDavenport/http4s-m0hqu) [![Gitter chat](https://badges.gitter.im/http4s/http4s.png)](https://gitter.im/http4s/http4s) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.http4s/http4s-core_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.http4s/http4s-core_2.12) [![Typelevel library](https://img.shields.io/badge/typelevel-library-green.svg)](http://typelevel.org/projects/#http4s)
+# Http4s [![Build Status](https://travis-ci.org/http4s/http4s.svg?branch=master)](https://travis-ci.org/http4s/http4s) [![Build status](https://ci.appveyor.com/api/projects/status/aprulmaagd5u1705?svg=true)](https://ci.appveyor.com/project/ChristopherDavenport/http4s-m0hqu) [![Gitter chat](https://badges.gitter.im/http4s/http4s.png)](https://gitter.im/http4s/http4s) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.http4s/http4s-core_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.http4s/http4s-core_2.12) [![Typelevel library](https://img.shields.io/badge/typelevel-library-green.svg)](https://typelevel.org/projects/#http4s)
 
 Http4s is a minimal, idiomatic Scala interface for HTTP services.  Http4s is
 Scala's answer to Ruby's Rack, Python's WSGI, Haskell's WAI, and Java's
@@ -11,7 +11,7 @@ val service = HttpService {
   }
 ```
 
-Learn more at [http4s.org](http://http4s.org/).
+Learn more at [http4s.org](https://http4s.org/).
 
 If you run into any difficulties please enable partial unification in your `build.sbt`
 
@@ -21,16 +21,16 @@ scalacOptions ++= Seq("-Ypartial-unification")
 
 ## Code of Conduct
 
-http4s is proud to be a [Typelevel](http://typelevel.org/) incubator
+http4s is proud to be a [Typelevel](https://typelevel.org/) incubator
 project.  We are dedicated to providing a harassment-free community
 for everyone, and ask that the community adhere to the
-[code of conduct](http://typelevel.org/conduct.html).
+[code of conduct](https://typelevel.org/conduct.html).
 
 ## License
 
 This software is licensed under the Apache 2 license, quoted below.
 
-> Copyright 2013-2017 http4s [[http://http4s.org](http://http4s.org/)]
+> Copyright 2013-2017 http4s [[https://http4s.org](https://http4s.org/)]
 
 > Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/build.sbt
+++ b/build.sbt
@@ -303,7 +303,7 @@ lazy val docs = http4sProject("docs")
     makeSite := makeSite.dependsOn(tutQuick, http4sBuildData).value,
     baseURL in Hugo := {
       val docsPrefix = extractDocsPrefix(version.value)
-      if (isTravisBuild.value) new URI(s"http://http4s.org${docsPrefix}")
+      if (isTravisBuild.value) new URI(s"https://http4s.org${docsPrefix}")
       else new URI(s"http://127.0.0.1:${previewFixedPort.value.getOrElse(4000)}${docsPrefix}")
     },
     siteMappings := {
@@ -331,7 +331,7 @@ lazy val website = http4sProject("website")
   .settings(
     description := "Common area of http4s.org",
     baseURL in Hugo := {
-      if (isTravisBuild.value) new URI(s"http://http4s.org")
+      if (isTravisBuild.value) new URI(s"https://http4s.org")
       else new URI(s"http://127.0.0.1:${previewFixedPort.value.getOrElse(4000)}")
     },
     makeSite := makeSite.dependsOn(http4sBuildData).value,

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -140,5 +140,5 @@ The [TSec] project provides an authentication and authorization module
 
 [service]: ../service
 [SPA]: https://en.wikipedia.org/wiki/Single-page_application
-[ADT]: http://typelevel.org/blog/2014/11/10/why_is_adt_pattern_matching_allowed.html
+[ADT]: https://typelevel.org/blog/2014/11/10/why_is_adt_pattern_matching_allowed.html
 [TSec]: https://jmcardon.github.io/tsec/

--- a/docs/src/main/tut/middleware.md
+++ b/docs/src/main/tut/middleware.md
@@ -158,4 +158,4 @@ And a few others.
 [Service Timeout]: ../api/org/http4s/server/middleware/Timeout$
 [Jsonp]: ../api/org/http4s/server/middleware/Jsonp$
 [Virtual Host]: ../api/org/http4s/server/middleware/VirtualHost$
-[`Kleisli`]: http://typelevel.org/cats/datatypes/kleisli.html
+[`Kleisli`]: https://typelevel.org/cats/datatypes/kleisli.html

--- a/project/CentralRequirements.scala
+++ b/project/CentralRequirements.scala
@@ -32,7 +32,7 @@ object CentralRequirementsPlugin extends AutoPlugin {
       Developer("shengc"               , "Sheng Chen"            , ""                                 , url("https://github.com/shengc"))
     ),
     licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
-    homepage := Some(url("http://http4s.org/")),
+    homepage := Some(url("https://http4s.org/")),
     scmInfo := Some(ScmInfo(url("https://github.com/http4s/http4s"), "git@github.com:http4s/http4s.git")),
     startYear := Some(2013)
   )

--- a/website/src/hugo/config.toml
+++ b/website/src/hugo/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://http4s.org"
+baseurl = "https://http4s.org"
 dataDir = "../../target/hugo-data"
 languageCode = "en-us"
 title = "http4s"

--- a/website/src/hugo/data/principles.toml
+++ b/website/src/hugo/data/principles.toml
@@ -24,5 +24,5 @@ the foundation for processing and emitting large payloads in
 constant space and implementing websockets.
 
 [fs2]: https://github.com/functional-streams-for-scala/fs2
-[cats]: http://typelevel.org/cats
+[cats]: https://typelevel.org/cats
 """

--- a/website/src/hugo/themes/http4s.org/layouts/_default/single.html
+++ b/website/src/hugo/themes/http4s.org/layouts/_default/single.html
@@ -14,13 +14,13 @@
       <div class="collapse navbar-collapse" id="navbarsExampleDefault">
         <ul class="navbar-nav mr-auto">
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="http://http4s.org/#" id="docs-menu-item" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link dropdown-toggle" href="https://http4s.org/#" id="docs-menu-item" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Documentation
           </a>
           {{ partial "nav-docs.html" . }}
         </li>
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="http://http4s.org/#" id="projects-menu-item" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link dropdown-toggle" href="https://http4s.org/#" id="projects-menu-item" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Projects
           </a>
           <div class="dropdown-menu" aria-labelledby="projects-menu-item"> 

--- a/website/src/hugo/themes/http4s.org/layouts/partials/nav.html
+++ b/website/src/hugo/themes/http4s.org/layouts/partials/nav.html
@@ -14,7 +14,7 @@
     <div id="navbar" class="collapse navbar-collapse">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="http://http4s.org/#" id="projects-menu-item" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link dropdown-toggle" href="https://http4s.org/#" id="projects-menu-item" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Projects
           </a>
           <div class="dropdown-menu" aria-labelledby="projects-menu-item"> 


### PR DESCRIPTION
http4s.org and typelevel.org are now both served over https.  Canonicalize the links appropriately.