### PR TITLE
Set up /stable and /latest rewrites

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -496,7 +496,7 @@ lazy val commonSettings = Seq(
     "*.html" | "*.png" | "*.jpg" | "*.gif" | "*.ico" | "*.svg" |
       "*.js" | "*.swf" | "*.json" | "*.md" |
       "*.css" | "*.woff" | "*.woff2" | "*.ttf" |
-      "CNAME" | "_config.yml"
+      "CNAME" | "_config.yml" | "_redirects"
   )
 )
 

--- a/website/src/hugo/static/_redirects
+++ b/website/src/hugo/static/_redirects
@@ -1,0 +1,2 @@
+/stable/*   /v0.18/:splat   200
+/latest/*   /v0.19/:splat   200


### PR DESCRIPTION
After this, we can set up a banner to render on EOL versions of the site, and always direct to the current versions without having to go back and republish those.