### PR TITLE
Remove internal syntax for NonEmptyList and use cat's instead

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -8,7 +8,6 @@ import java.io.File
 import java.net.{InetAddress, InetSocketAddress}
 import org.http4s.headers._
 import org.http4s.server.ServerSoftware
-import org.http4s.syntax.nonEmptyList._
 import org.log4s.getLogger
 
 /**
@@ -96,7 +95,7 @@ sealed trait Message[F[_]] extends MessageOps[F] { self =>
   def charset: Option[Charset] = contentType.flatMap(_.charset)
 
   def isChunked: Boolean =
-    headers.get(`Transfer-Encoding`).exists(_.values.contains(TransferCoding.chunked))
+    headers.get(`Transfer-Encoding`).exists(_.values.contains_(TransferCoding.chunked))
 
   /**
     * The trailer headers, as specified in Section 3.6.1 of RFC 2616.  The resulting

--- a/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
@@ -2,8 +2,9 @@ package org.http4s
 package headers
 
 import cats.data.NonEmptyList
+import cats.syntax.foldable._
 import org.http4s.parser.HttpHeaderParser
-import org.http4s.syntax.nonEmptyList._
+import CharsetRange.Atom
 
 object `Accept-Charset` extends HeaderKey.Internal[`Accept-Charset`] with HeaderKey.Recurring {
   override def parse(s: String): ParseResult[`Accept-Charset`] =
@@ -16,10 +17,11 @@ final case class `Accept-Charset`(values: NonEmptyList[CharsetRange])
   type Value = CharsetRange
 
   def qValue(charset: Charset): QValue = {
-    def specific = values.collectFirst {
-      case cs: CharsetRange.Atom if cs.matches(charset) => cs.qValue
-    }
-    def splatted = values.collectFirst { case cs: CharsetRange.`*` => cs.qValue }
+    def specific =
+      values.collectFirst { case cs: Atom if cs.matches(charset) => cs.qValue }
+    def splatted =
+      values.collectFirst { case cs: CharsetRange.`*` => cs.qValue }
+
     specific.orElse(splatted).getOrElse(QValue.Zero)
   }
 

--- a/core/src/main/scala/org/http4s/headers/Connection.scala
+++ b/core/src/main/scala/org/http4s/headers/Connection.scala
@@ -2,6 +2,7 @@ package org.http4s
 package headers
 
 import cats.data.NonEmptyList
+import cats.syntax.foldable._
 import org.http4s.parser.HttpHeaderParser
 import org.http4s.syntax.all._
 import org.http4s.util.{CaseInsensitiveString, Writer}
@@ -16,8 +17,8 @@ object Connection extends HeaderKey.Internal[Connection] with HeaderKey.Recurrin
 final case class Connection(values: NonEmptyList[CaseInsensitiveString]) extends Header.Recurring {
   override def key: Connection.type = Connection
   type Value = CaseInsensitiveString
-  def hasClose: Boolean = values.contains("close".ci)
-  def hasKeepAlive: Boolean = values.contains("keep-alive".ci)
+  def hasClose: Boolean = values.contains_("close".ci)
+  def hasKeepAlive: Boolean = values.contains_("keep-alive".ci)
   override def renderValue(writer: Writer): writer.type =
     writer.addStringNel(values.map(_.toString), ", ")
 }

--- a/core/src/main/scala/org/http4s/headers/ETag.scala
+++ b/core/src/main/scala/org/http4s/headers/ETag.scala
@@ -3,6 +3,7 @@ package headers
 
 import org.http4s.parser.HttpHeaderParser
 import org.http4s.util.Writer
+import cats.Show
 
 object ETag extends HeaderKey.Internal[ETag] with HeaderKey.Singleton {
   final case class EntityTag(tag: String, weak: Boolean = false) {
@@ -11,10 +12,14 @@ object ETag extends HeaderKey.Internal[ETag] with HeaderKey.Singleton {
       else "\"" + tag + '"'
   }
 
+  implicit val http4sShowForEntityTag: Show[EntityTag] =
+    Show.fromToString
+
   def apply(tag: String, weak: Boolean = false): ETag = ETag(EntityTag(tag, weak))
 
   override def parse(s: String): ParseResult[ETag] =
     HttpHeaderParser.ETAG(s)
+
 }
 
 final case class ETag(tag: ETag.EntityTag) extends Header.Parsed {

--- a/core/src/main/scala/org/http4s/headers/If-None-Match.scala
+++ b/core/src/main/scala/org/http4s/headers/If-None-Match.scala
@@ -2,8 +2,8 @@ package org.http4s
 package headers
 
 import cats.data.NonEmptyList
+import cats.syntax.foldable._
 import org.http4s.parser.HttpHeaderParser
-import org.http4s.syntax.nonEmptyList._
 import org.http4s.util.Writer
 
 object `If-None-Match` extends HeaderKey.Internal[`If-None-Match`] with HeaderKey.Singleton {
@@ -22,7 +22,7 @@ final case class `If-None-Match`(tags: Option[NonEmptyList[ETag.EntityTag]]) ext
   override def key: `If-None-Match`.type = `If-None-Match`
   override def value: String = tags match {
     case None => "*"
-    case Some(tags) => tags.mkString(",")
+    case Some(tags) => tags.mkString_("", ",", "")
   }
   override def renderValue(writer: Writer): writer.type = writer.append(value)
 }

--- a/core/src/main/scala/org/http4s/syntax/NonEmptyListSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/NonEmptyListSyntax.scala
@@ -3,23 +3,26 @@ package org.http4s.syntax
 import cats.data.NonEmptyList
 
 trait NonEmptyListSyntax {
+  @deprecated("Use cats.foldable._", "0.18.5")
   implicit def http4sNonEmptyListSyntax[A](l: NonEmptyList[A]): NonEmptyListOps[A] =
     new NonEmptyListOps[A](l)
 }
 
 final class NonEmptyListOps[A](val self: NonEmptyList[A]) extends AnyVal {
+  @deprecated("Use cats.foldable._", "0.18.5")
   def contains(a: A): Boolean =
     if (a == self.head) true
     else self.tail.contains(a)
 
+  @deprecated("Use cats.foldable._", "0.18.5")
   def collectFirst[B](pf: PartialFunction[A, B]): Option[B] =
     pf.lift(self.head).orElse(self.tail.collectFirst(pf))
 
+  @deprecated("Use cats.foldable._", "0.18.5")
   def mkString(s: String): String =
-    // TODO Could squeeze a few more cycles out of this
     self.toList.mkString(s)
 
+  @deprecated("Use cats.foldable._", "0.18.5")
   def mkString(begin: String, s: String, end: String): String =
-    // TODO Could squeeze a few more cycles out of this
     self.toList.mkString(begin, s, end)
 }

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -9,6 +9,7 @@ package object syntax {
   object effectResponse extends EffectResponseSyntax
   object kleisli extends KleisliSyntax
   object literals extends LiteralsSyntax
+  @deprecated("Use cats.foldable._", "0.18.5")
   object nonEmptyList extends NonEmptyListSyntax
   object string extends StringSyntax
 }

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -137,7 +137,6 @@ Extra headers can be added using `putHeaders`, for example to specify cache poli
 import org.http4s.headers.`Cache-Control`
 import org.http4s.CacheDirective.`no-cache`
 import cats.data.NonEmptyList
-import org.http4s.util.nonEmptyList
 ```
 
 ```tut

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpServiceSpec.scala
@@ -3,6 +3,8 @@ package dsl
 
 import cats.data.Validated._
 import cats.effect.IO
+import cats.instances.string._
+import cats.syntax.foldable._
 import org.http4s.dsl.io._
 
 object PathInHttpServiceSpec extends Http4sSpec {
@@ -51,12 +53,12 @@ object PathInHttpServiceSpec extends Http4sSpec {
       Ok(s"counter: $c")
     case GET -> Root / "valid" :? ValidatingCounter(c) =>
       c.fold(
-        errors => BadRequest(errors.map(_.sanitized).mkString(",")),
+        errors => BadRequest(errors.map(_.sanitized).mkString_("", ",", "")),
         vc => Ok(s"counter: $vc")
       )
     case GET -> Root / "optvalid" :? OptValidatingCounter(c) =>
       c match {
-        case Some(Invalid(errors)) => BadRequest(errors.map(_.sanitized).mkString(","))
+        case Some(Invalid(errors)) => BadRequest(errors.map(_.sanitized).mkString_("", ",", ""))
         case Some(Valid(cv)) => Ok(s"counter: $cv")
         case None => Ok("no counter")
       }

--- a/tests/src/test/scala/org/http4s/headers/TransferEncodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/TransferEncodingSpec.scala
@@ -2,6 +2,7 @@ package org.http4s
 package headers
 
 import cats.data.NonEmptyList
+import cats.syntax.foldable._
 import org.scalacheck.Prop.forAll
 
 class TransferEncodingSpec extends HeaderLaws {
@@ -30,7 +31,7 @@ class TransferEncodingSpec extends HeaderLaws {
   "hasChunked" should {
     "detect chunked" in {
       forAll { t: `Transfer-Encoding` =>
-        t.hasChunked must_== (t.values.contains(TransferCoding.chunked))
+        t.hasChunked must_== (t.values.contains_(TransferCoding.chunked))
       }
     }
   }


### PR DESCRIPTION
Completely removes the internal custom syntax for `NonEmptyList` using cats' instead. Note this removes some deprecated instances and may break existing code.

Is there a better alternative for `collectFirst` in cats?

Fixes #1510 