### PR TITLE
Fix deprecated call in testing.md

### DIFF
--- a/docs/src/main/tut/testing.md
+++ b/docs/src/main/tut/testing.md
@@ -18,7 +18,8 @@ import cats.implicits._
 import io.circe._
 import io.circe.syntax._
 import io.circe.generic.semiauto._
-import cats.effect._, org.http4s._, org.http4s.dsl.io._
+import cats.effect._
+import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.io._
 
@@ -33,9 +34,9 @@ def service[F[_]](repo: UserRepo[F])(
       implicit F: Effect[F]
 ): HttpService[F] = HttpService[F] {
   case GET -> Root / "user" / id =>
-    repo.find(id).flatMap {
-      case Some(user) => Response(status = Status.Ok).withBody(user.asJson)
-      case None       => F.pure(Response(status = Status.NotFound))
+    repo.find(id).map {
+      case Some(user) => Response(status = Status.Ok).withEntity(user.asJson)
+      case None       => Response(status = Status.NotFound)
     }
 }
 ```


### PR DESCRIPTION
I broke this when I merged #1718 to master without running tut.  My fault.  This is what ails #1749.

Observation: it's hard to use the DSL for a polymorphic service inside a tut.