### PR TITLE
fix parsing of uneven stream bodies

### DIFF
--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -568,7 +568,7 @@ object MultipartParser {
       c: Chunk[Byte]
   ): (Int, Stream[F, Byte], Stream[F, Byte], Int) = {
     val ixx = i - currState
-    if (middleChunked || state == 0) {
+    if (middleChunked) {
       val (lchunk, rchunk) = c.splitAt(ixx)
       (
         currState,

--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -222,7 +222,6 @@ object MultipartParser {
     *
     */
   private def splitCompleteMatch[F[_]: Sync](
-      state: Int,
       middleChunked: Boolean,
       sti: Int,
       i: Int,
@@ -236,12 +235,6 @@ object MultipartParser {
         //Emit the partial match as well
         acc ++ carry ++ Stream.chunk(c.take(i - sti)),
         Stream.chunk(c.drop(i))) //Emit after the match
-    } else if (state == 0) {
-      (
-        sti,
-        //Ignore the partial match (carry)
-        acc ++ Stream.chunk(c.take(i - sti)),
-        Stream.chunk(c.drop(i)))
     } else {
       (
         sti,
@@ -265,7 +258,6 @@ object MultipartParser {
     *
     */
   def splitPartialMatch[F[_]: Sync](
-      state: Int,
       middleChunked: Boolean,
       currState: Int,
       i: Int,
@@ -274,7 +266,7 @@ object MultipartParser {
       c: Chunk[Byte]
   ): (Int, Stream[F, Byte], Stream[F, Byte]) = {
     val ixx = i - currState
-    if (middleChunked || state == 0) {
+    if (middleChunked) {
       val (lchunk, rchunk) = c.splitAt(ixx)
       (currState, acc ++ carry ++ Stream.chunk(lchunk), Stream.chunk(rchunk))
     } else {
@@ -305,25 +297,28 @@ object MultipartParser {
     var i = 0
     var currState = state
     val len = values.length
-    var middleChunked = false
     while (currState < len && i < c.size) {
       if (c(i) == values(currState)) {
         currState += 1
       } else if (c(i) == values(0)) {
-        middleChunked = true
         currState = 1
       } else {
         currState = 0
       }
       i += 1
     }
+    //It will only be zero if
+    //the chunk matches from the very beginning,
+    //since currstate can never be greater than
+    //(i + state).
+    val middleChunked = i + state - currState > 0
 
     if (currState == 0) {
       (0, acc ++ carry ++ Stream.chunk(c), Stream.empty)
     } else if (currState == len) {
-      splitCompleteMatch(state, middleChunked, currState, i, acc, carry, c)
+      splitCompleteMatch(middleChunked, currState, i, acc, carry, c)
     } else {
-      splitPartialMatch(state, middleChunked, currState, i, acc, carry, c)
+      splitPartialMatch(middleChunked, currState, i, acc, carry, c)
     }
   }
 
@@ -540,13 +535,6 @@ object MultipartParser {
         //Emit after the match
         Stream.chunk(c.drop(i)),
         state + i - sti)
-    } else if (state == 0) {
-      (
-        sti,
-        //Ignore the partial match (carry)
-        acc ++ Stream.chunk(c.take(i - sti)),
-        Stream.chunk(c.drop(i)),
-        i - sti)
     } else {
       (
         sti,
@@ -602,18 +590,22 @@ object MultipartParser {
     var i = 0
     var currState = state
     val len = values.length
-    var middleChunked = false
     while (currState < len && i < c.size) {
       if (c(i) == values(currState)) {
         currState += 1
       } else if (c(i) == values(0)) {
-        middleChunked = true
         currState = 1
       } else {
         currState = 0
       }
       i += 1
     }
+
+    //It will only be zero if
+    //the chunk matches from the very beginning,
+    //since currstate can never be greater than
+    //(i + state).
+    val middleChunked = i + state - currState > 0
 
     if (currState == 0) {
       (0, acc ++ carry ++ Stream.chunk(c), Stream.empty, i)

--- a/tests/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
@@ -18,6 +18,20 @@ object MultipartParserSpec extends Specification {
     case c => c.toString
   }
 
+  def jumble(str: String): Stream[IO, Byte] = {
+    val rand = new scala.util.Random()
+
+    def jumbleAccum(s: String, acc: Stream[IO, Byte]): Stream[IO, Byte] =
+      if (s.length <= 1) {
+        acc ++ Stream.chunk(Chunk.bytes(s.getBytes()))
+      } else {
+        val (l, r) = s.splitAt(rand.nextInt(s.length - 1) + 1)
+        jumbleAccum(r, acc ++ Stream.chunk(Chunk.bytes(l.getBytes)))
+      }
+
+    jumbleAccum(str, Stream.empty)
+  }
+
   def unspool(str: String, limit: Int = Int.MaxValue): Stream[IO, Byte] =
     if (str.isEmpty) {
       Stream.empty
@@ -705,6 +719,41 @@ object MultipartParserSpec extends Specification {
         .fold("")(_ ++ _)
 
       bodies.attempt.unsafeRunSync() must beRight("bar")
+    }
+
+    Fragments.foreach(List.range(0, 100)) { count =>
+      s"parse randomized chunk length properly iteration #$count" in {
+
+        val unprocessedInput =
+          """
+            |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+            |Content-Disposition: form-data; name="upload"; filename="integration.txt"
+            |Content-Type: application/octet-stream
+            |Content-Transfer-Encoding: binary
+            |
+            |this is a test
+            |here's another test
+            |catch me if you can!
+            |
+            |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+            |Content-Disposition: form-data; name="foo"
+            |
+            |bar
+            |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI--""".stripMargin.replaceAllLiterally("\n", "\r\n")
+
+        val unprocessed = jumble(unprocessedInput)
+
+        val results = unprocessed.through(MultipartParser.parseStreamed(boundary))
+        val multipartMaterialized = results.compile.last.map(_.get).unsafeRunSync()
+        val bodies = multipartMaterialized
+          .parts(1)
+          .body
+          .through(asciiDecode)
+          .compile
+          .fold("")(_ ++ _)
+
+        bodies.attempt.unsafeRunSync() must beRight("bar")
+      }
     }
 
     "produce the correct headers from a two part input" in {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.18.6-SNAPSHOT"
+version in ThisBuild := "0.18.6"

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -8,6 +8,9 @@ Maintenance branches are merged before each new release. This change log is
 ordered chronologically, so each release contains all changes described below
 it.
 
+# v0.18.6 (2018-04-03)
+* Fix parsing of multipart bodies across chunk boundaries. [#1764](https://github.com/http4s/http4s/pull/1764)
+
 # v0.18.5 (2018-03-28)
 * Add `&` extractor to http4s-dsl. [#1758](https://github.com/http4s/http4s/pull/1758)
 * Deprecate `EntityEncoder[F, Future[A]]`.  The `EntityEncoder` is strict in its argument, which causes any side effect of the `Future` to execute immediately.  Wrap your `future` in `IO.fromFuture(IO(future))` instead. [#1759](https://github.com/http4s/http4s/pull/1759)


### PR DESCRIPTION
Closes #1755 .

Fixes a bug happening on uneven chunks + chunks that ended on a partial match with the boundary, but the boundary was contained in the middle of the chunk.