### PR TITLE
Add a stream constructor for async-http-client

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -38,7 +38,6 @@ object AsyncHttpClient {
     * Create an HTTP client based on the AsyncHttpClient library
     *
     * @param config configuration for the client
-    * @param bufferSize body chunks to buffer when reading the body; defaults to 8
     * @param ec The ExecutionContext to run responses on
     */
   def apply[F[_]](config: AsyncHttpClientConfig = defaultConfig)(
@@ -55,6 +54,19 @@ object AsyncHttpClient {
       F.delay(client.close())
     )
   }
+
+  /**
+    * Create a bracketed HTTP client based on the AsyncHttpClient library.
+    *
+    * @param config configuration for the client
+    * @param ec The ExecutionContext to run responses on
+    * @return a singleton stream of the client.  The client will be
+    * shutdown when the stream terminates.
+    */
+  def stream[F[_]](config: AsyncHttpClientConfig = defaultConfig)(
+      implicit F: Effect[F],
+      ec: ExecutionContext): Stream[F, Client[F]] =
+    Stream.bracket(F.delay(apply(config)))(c => Stream.emit(c), _.shutdown)
 
   private def asyncHandler[F[_]](
       cb: Callback[DisposableResponse[F]])(implicit F: Effect[F], ec: ExecutionContext) =


### PR DESCRIPTION
Added this while investigating #1774.

The `apply` method should return an effect.  It's inconsistent with `Http1Client`, and that one is better.  But we can't fix that here.