### PR TITLE
Tighten up logging of errors thrown by services

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -2,7 +2,8 @@ package org.http4s
 package server
 package blaze
 
-import cats.effect.{Effect, IO}
+import cats.data.OptionT
+import cats.effect.{Effect, IO, Sync}
 import cats.implicits._
 import fs2._
 import java.nio.ByteBuffer
@@ -60,6 +61,7 @@ private[blaze] class Http1ServerStage[F[_]](
 
   // micro-optimization: unwrap the service and call its .run directly
   private[this] val serviceFn = service.run
+  private[this] val optionTSync = Sync[OptionT[F, ?]]
 
   // both `parser` and `isClosed` are protected by synchronization on `parser`
   private[this] val parser = new Http1ServerParser[F](logger, maxRequestLineLen, maxHeadersLen)
@@ -140,19 +142,21 @@ private[blaze] class Http1ServerStage[F[_]](
     parser.collectMessage(body, requestAttrs) match {
       case Right(req) =>
         executionContext.execute(new Runnable {
-          def run(): Unit =
-            F.runAsync {
-                try serviceFn(req)
-                  .getOrElse(Response.notFound)
-                  .handleErrorWith(serviceErrorHandler(req))
-                catch serviceErrorHandler(req)
-              } {
-                case Right(resp) =>
-                  IO(renderResponse(req, resp, cleanup))
+          def run(): Unit = {
+            val action = optionTSync
+              .suspend(serviceFn(req))
+              .getOrElse(Response.notFound)
+              .recoverWith(serviceErrorHandler(req))
+              .flatMap(resp => F.delay(renderResponse(req, resp, cleanup)))
+
+            F.runAsync(action) {
+                case Right(()) => IO.unit
                 case Left(t) =>
-                  IO(internalServerError(s"Error running route: $req", t, req, cleanup))
+                  IO(logger.error(t)(s"Error running request: $req")).attempt *> IO(
+                    closeConnection())
               }
               .unsafeRunSync()
+          }
         })
       case Left((e, protocol)) =>
         badMessage(e.details, new BadRequest(e.sanitized), Request[F]().withHttpVersion(protocol))

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -7,7 +7,6 @@ import cats.implicits._
 import org.http4s.headers.{Connection, `Content-Length`}
 import org.http4s.syntax.string._
 import org.log4s.getLogger
-import scala.util.control.NonFatal
 
 package object server {
 
@@ -101,7 +100,7 @@ package object server {
         s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
           .getOrElse("<unknown>")}""")
       mf.toHttpResponse(req.httpVersion)
-    case NonFatal(t) =>
+    case t if !t.isInstanceOf[VirtualMachineError] =>
       serviceErrorLogger.error(t)(
         s"""Error servicing request: ${req.method} ${req.pathInfo} from ${req.remoteAddr.getOrElse(
           "<unknown>")}""")


### PR DESCRIPTION
- Use recoverWith on serviceErrorHandler, as it's partial.  It is not designed to catch fatal errors.
- Treat only VirtualMachineError as "non-fatal", which is consistent with cats-effect and fs2
- Lessen the work we do in runAsyncCallback, to reduce risk of errors being ignored
- typelevel/cats-effect#182 should log the rest

Fixes #1783 for blaze-http1, blaze-http2, and servlets.

