### PR TITLE
Add a couple of examples to the Client doc page

### DIFF
--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -112,6 +112,56 @@ val greetingsStringEffect = greetingList.map(_.mkString("\n"))
 greetingsStringEffect.unsafeRunSync
 ```
 
+## Examples
+
+### Send a GET request, treating the response as a string
+
+You can send a GET by calling the `expect` method on the client, passing either
+a String or a `Uri`:
+
+```tut:book
+httpClient.expect[String]("https://google.com/")
+
+httpClient.expect[String](Uri.uri("https://google.com/"))
+```
+
+If you need to do something more complicated like setting request headers, you
+can build up a request object and pass that to `expect`:
+
+```tut:book
+import org.http4s.client.dsl.io._
+import org.http4s.headers._
+import org.http4s.MediaType._
+
+val request = GET(
+  Uri.uri("https://my-lovely-api.com/"),
+  Authorization(Credentials.Token(AuthScheme.Bearer, "open sesame")),
+  Accept(`application/json`)
+)
+
+httpClient.expect[String](request)
+```
+
+### Post a form, decoding the JSON response to a case class
+
+```tut:book
+case class AuthResponse(access_token: String)
+
+// See the JSON page for details on how to define this
+implicit val authResponseEntityDecoder: EntityDecoder[IO, AuthResponse] = null
+
+val postRequest = POST(
+  Uri.uri("https://my-lovely-api.com/oauth2/token"),
+  UrlForm(
+    "grant_type" -> "client_credentials",
+    "client_id" -> "my-awesome-client",
+    "client_secret" -> "s3cr3t"
+  )
+)
+
+httpClient.expect[AuthResponse](postRequest)
+```
+
 ## Cleaning up
 
 Our client consumes system resources. Let's clean up after ourselves by shutting

--- a/website/src/hugo/content/contributing.md
+++ b/website/src/hugo/content/contributing.md
@@ -218,9 +218,9 @@ code is added.
 
 ## Submit a pull request
 
-Before you open a pull request, you should make sure that `sbt
-validate` runs successfully. Travis CI will run this as well, but it
-may save you some time to be alerted to style or tut problems earlier.
+Before you open a pull request, you should make sure that `sbt ci` runs
+successfully. Travis CI will run this as well, but it may save you some
+time to be alerted to style or tut problems earlier.
 
 If your pull request addresses an existing issue, please tag that
 issue number in the body of your pull request or commit message. For


### PR DESCRIPTION
I've tried to take a leaf from the [OkHttp docs](http://square.github.io/okhttp/): few words of explanation, just a few lines of code showing how to get something useful done with the client.