### PR TITLE
Upgrade to scala-2.12.6, drop macro-compat

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
     TEST_SUITE: test
   matrix:
     - SCALA_VERSION: 2.11.12
-    - SCALA_VERSION: 2.12.4
+    - SCALA_VERSION: 2.12.6
 
 install:
   - ps: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ env:
 matrix:
   include:
   - jdk: oraclejdk8
-    scala: 2.12.4
+    scala: 2.12.6
   - jdk: oraclejdk8
     scala: 2.11.12
   - jdk: oraclejdk9
-    scala: 2.12.4
+    scala: 2.12.6
 notifications:
   webhooks:
     urls:

--- a/build.sbt
+++ b/build.sbt
@@ -28,13 +28,11 @@ lazy val core = libraryProject("core")
       fs2Scodec,
       http4sWebsocket,
       log4s,
-      macroCompat,
       parboiled,
       scalaReflect(scalaOrganization.value, scalaVersion.value) % "provided",
       scodecBits,
       scalaCompiler(scalaOrganization.value, scalaVersion.value) % "provided"
     ),
-    macroParadiseSetting
   )
 
 lazy val testing = libraryProject("testing")
@@ -45,7 +43,6 @@ lazy val testing = libraryProject("testing")
       scalacheck,
       specs2Core
     ),
-    macroParadiseSetting
   )
   .dependsOn(core)
 
@@ -265,7 +262,6 @@ lazy val docs = http4sProject("docs")
       circeLiteral,
       cryptobits
     ),
-    macroParadiseSetting,
     description := "Documentation for http4s",
     autoAPIMappings := true,
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject --
@@ -377,7 +373,6 @@ lazy val examplesBlaze = exampleProject("examples-blaze")
     description := "Examples of http4s server and clients on blaze",
     fork := true,
     libraryDependencies ++= Seq(alpnBoot, metricsJson),
-    macroParadiseSetting,
     javaOptions in run ++= (managedClasspath in Runtime).map { attList =>
       for {
         file <- attList.map(_.data)

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -1,7 +1,6 @@
 package org.http4s
 
 import cats._
-import macrocompat.bundle
 import org.http4s.internal.parboiled2.{Parser => PbParser}
 import org.http4s.util.Writer
 import org.http4s.parser.{AdditionalRules, Http4sParser}
@@ -96,7 +95,6 @@ object QValue extends QValueInstances with QValueFunctions {
   /** Exists to support compile-time verified literals. Do not call directly. */
   def ☠(thousandths: Int): QValue = new QValue(thousandths)
 
-  @bundle
   class Macros(val c: Context) {
     import c.universe._
 

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -3,7 +3,6 @@ package org.http4s
 import cats._
 import cats.implicits.{catsSyntaxEither => _, _}
 import java.nio.charset.StandardCharsets
-import macrocompat.bundle
 import org.http4s.Uri._
 import org.http4s.internal.parboiled2.{Parser => PbParser}
 import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit}
@@ -119,7 +118,6 @@ final case class Uri(
 }
 
 object Uri extends UriFunctions {
-  @bundle
   class Macros(val c: Context) {
     import c.universe._
 

--- a/docs/src/main/tut/methods.md
+++ b/docs/src/main/tut/methods.md
@@ -9,13 +9,13 @@ Http4s has a list of all the [methods] you're familiar with, and a few more.
 
 ```tut:book
 import cats.effect._
-import io.circe.generic._
+import io.circe.generic.auto._
 import io.circe.syntax._
 import org.http4s._, org.http4s.dsl.io._
 import org.http4s.circe._
 
-@JsonCodec case class TweetWithId(id: Int, message: String)
-@JsonCodec case class Tweet(message: String)
+case class TweetWithId(id: Int, message: String)
+case class Tweet(message: String)
 
 def getTweet(tweetId: Int): IO[Option[TweetWithId]] = ???
 def addTweet(tweet: Tweet): IO[TweetWithId] = ???

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -10,7 +10,7 @@ and calling it with http4s' client.
 Create a new directory, with the following build.sbt in the root:
 
 ```scala
-scalaVersion := "2.12.4" // Also supports 2.11.x
+scalaVersion := "2.12.6" // Also supports 2.11.x
 
 val http4sVersion = "{{< version "http4s.doc" >}}"
 

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -61,7 +61,7 @@ object Http4sPlugin extends AutoPlugin {
   ) ++ signingSettings
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    scalaVersion := (sys.env.get("TRAVIS_SCALA_VERSION") orElse sys.env.get("SCALA_VERSION") getOrElse "2.12.4"),
+    scalaVersion := (sys.env.get("TRAVIS_SCALA_VERSION") orElse sys.env.get("SCALA_VERSION") getOrElse "2.12.6"),
 
     // Rig will take care of this on production builds.  We haven't fully
     // implemented that machinery yet, so we're going to live without this

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -227,9 +227,6 @@ object Http4sPlugin extends AutoPlugin {
     }
   }
 
-  val macroParadiseSetting =
-    libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
-
   def latestPerMinorVersion(file: File): Map[(Int, Int), Version] =
     JGit(file).tags.collect {
       case ref if ref.getName.startsWith("refs/tags/v") =>
@@ -285,7 +282,6 @@ object Http4sPlugin extends AutoPlugin {
   lazy val jspApi                           = "javax.servlet.jsp"      %  "javax.servlet.jsp-api"     % "2.3.1" // YourKit hack
   lazy val log4s                            = "org.log4s"              %% "log4s"                     % "1.6.1"
   lazy val logbackClassic                   = "ch.qos.logback"         %  "logback-classic"           % "1.2.3"
-  lazy val macroCompat                      = "org.typelevel"          %% "macro-compat"              % "1.1.1"
   lazy val metricsCore                      = "io.dropwizard.metrics"  %  "metrics-core"              % "4.0.2"
   lazy val metricsJson                      = "io.dropwizard.metrics"  %  "metrics-json"              % metricsCore.revision
   lazy val prometheusClient                 = "io.prometheus"          %  "simpleclient_common"       % "0.3.0"

--- a/testing/src/test/scala/org/http4s/illTyped.scala
+++ b/testing/src/test/scala/org/http4s/illTyped.scala
@@ -31,7 +31,6 @@ object illTyped {
   def apply(code: String, expected: String): Unit = macro IllTypedMacros.applyImpl
 }
 
-@macrocompat.bundle
 class IllTypedMacros(val c: whitebox.Context) {
   import c.universe._
 

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -9,7 +9,7 @@ ordered chronologically, so each release contains all changes described below
 it.
 
 # v0.18.10-SNAPSHOT
-* Eliminate dependnecy on Macro Paradise and macro-compat [#1816](https://github.com/http4s/http4s/pull/1816)
+* Eliminate dependency on Macro Paradise and macro-compat [#1816](https://github.com/http4s/http4s/pull/1816)
 * Dependency upgrades:
   * cats-effect-0.10.1
   * fs2-0.10.4

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -9,6 +9,7 @@ ordered chronologically, so each release contains all changes described below
 it.
 
 # v0.18.10-SNAPSHOT
+* Eliminate dependnecy on Macro Paradise and macro-compat [#1816](https://github.com/http4s/http4s/pull/1816)
 * Dependency upgrades:
   * cats-effect-0.10.1
   * fs2-0.10.4


### PR DESCRIPTION
Macro Paradise is not yet available for 2.12.6 and won't be for 2.13.  It appears we only needed it to bridge the macro gap to Scala 2.10, which is no longer an issue.

Fixes #1803.