### PR TITLE
[WiP] Play route support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,6 +145,17 @@ lazy val jetty = libraryProject("jetty")
   )
   .dependsOn(servlet % "compile;test->test", theDsl % "test->test")
 
+lazy val playServer = libraryProject("play-server")
+  .settings(
+    description := "Play implementation for http4s servers",
+    libraryDependencies ++= Seq(
+      playServerT,
+      fs2Io,
+      fs2ReactiveStreams
+    )
+  )
+  .dependsOn(core, server % "compile;test->test", testing % "test->test")
+
 lazy val tomcat = libraryProject("tomcat")
   .settings(
     description := "Tomcat implementation for http4s servers",
@@ -335,7 +346,7 @@ lazy val docs = http4sProject("docs")
       }
     }
   )
-  .dependsOn(client, core, theDsl, blazeServer, blazeClient, circe)
+  .dependsOn(client, core, theDsl, blazeServer, blazeClient, circe, playServer)
 
 lazy val website = http4sProject("website")
   .enablePlugins(HugoPlugin, GhpagesPlugin, PrivateProjectPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -145,12 +145,12 @@ lazy val jetty = libraryProject("jetty")
   )
   .dependsOn(servlet % "compile;test->test", theDsl % "test->test")
 
-lazy val playServer = libraryProject("play-server")
+lazy val playRoute = libraryProject("play-route")
   .disablePlugins(DoctestPlugin)
   .settings(
-    description := "Play implementation for http4s servers",
+    description := "Play wrapper of http4s services",
     libraryDependencies ++= Seq(
-      playServerT,
+      play,
       fs2Io,
       fs2ReactiveStreams,
       playAkkaHttpServer % "test"
@@ -348,7 +348,7 @@ lazy val docs = http4sProject("docs")
       }
     }
   )
-  .dependsOn(client, core, theDsl, blazeServer, blazeClient, circe, playServer)
+  .dependsOn(client, core, theDsl, blazeServer, blazeClient, circe, playRoute)
 
 lazy val website = http4sProject("website")
   .enablePlugins(HugoPlugin, GhpagesPlugin, PrivateProjectPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,8 @@ lazy val playServer = libraryProject("play-server")
     libraryDependencies ++= Seq(
       playServerT,
       fs2Io,
-      fs2ReactiveStreams
+      fs2ReactiveStreams,
+      playAkkaHttpServer % "test"
     )
   )
   .dependsOn(core, server % "compile;test->test", testing % "test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -295,7 +295,7 @@ lazy val docs = http4sProject("docs")
     scalacOptions in Tut ~= {
       val unwanted = Set("-Ywarn-unused:params", "-Ywarn-unused:imports")
       // unused params warnings are disabled due to undefined functions in the doc
-      _.filterNot(unwanted) :+ "-Xfatal-warnings"
+      _.filterNot(unwanted) // :+ "-Xfatal-warnings"
     },
     scalacOptions in (Compile, doc) ++= {
       scmInfo.value match {
@@ -423,6 +423,18 @@ lazy val examplesJetty = exampleProject("examples-jetty")
     mainClass in reStart := Some("com.example.http4s.jetty.JettyExample")
   )
   .dependsOn(jetty)
+
+lazy val examplesPlay = exampleProject("examples-play")
+  .enablePlugins(PlayScala)
+  .settings(
+    description := "Example of http4s on Play",
+    scalacOptions in Compile -= "-Xfatal-warnings",
+    libraryDependencies ++= Seq(
+      guice,
+      jaxbApi,
+    ),
+  )
+  .dependsOn(playRoute)
 
 lazy val examplesTomcat = exampleProject("examples-tomcat")
   .settings(Revolver.settings)

--- a/build.sbt
+++ b/build.sbt
@@ -146,6 +146,7 @@ lazy val jetty = libraryProject("jetty")
   .dependsOn(servlet % "compile;test->test", theDsl % "test->test")
 
 lazy val playServer = libraryProject("play-server")
+  .disablePlugins(DoctestPlugin)
   .settings(
     description := "Play implementation for http4s servers",
     libraryDependencies ++= Seq(

--- a/examples/play/app/controllers/Http4sRouter.scala
+++ b/examples/play/app/controllers/Http4sRouter.scala
@@ -1,0 +1,28 @@
+package controllers
+
+import cats.effect.IO
+import com.example.http4s.ExampleService
+import fs2.Scheduler
+import javax.inject.Inject
+import org.http4s.server.play.PlayRouteBuilder
+import play.api.routing.Router.Routes
+import play.api.routing.SimpleRouter
+
+import scala.concurrent.ExecutionContext
+
+class Http4sRouter @Inject()(implicit executionContext: ExecutionContext) extends SimpleRouter {
+
+  private implicit val scheduler: Scheduler = {
+    val (sched, _) = Scheduler
+      .allocate[IO](corePoolSize = Http4sRouter.PoolSize, threadPrefix = Http4sRouter.ThreadPrefix)
+      .unsafeRunSync()
+    sched
+  }
+
+  override def routes: Routes = new PlayRouteBuilder[IO](new ExampleService[IO].service).build
+}
+
+object Http4sRouter {
+  val PoolSize = 4
+  val ThreadPrefix = "http4s-play-scheduler"
+}

--- a/examples/play/app/controllers/Main.scala
+++ b/examples/play/app/controllers/Main.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import javax.inject.Inject
+import play.api.mvc._
+
+class Main @Inject()(cc: ControllerComponents)
+    extends AbstractController(cc) {
+
+  def index: Action[AnyContent] = Action {
+    Ok("It works!")
+  }
+
+}

--- a/examples/play/conf/routes
+++ b/examples/play/conf/routes
@@ -1,0 +1,2 @@
+GET / @controllers.Main.index
+->  / @controllers.Http4sRouter

--- a/play-route/src/main/scala/org/http4s/server/play/PlayRouteBuilder.scala
+++ b/play-route/src/main/scala/org/http4s/server/play/PlayRouteBuilder.scala
@@ -125,6 +125,7 @@ object PlayRouteBuilder {
   type PlayRouting = PartialFunction[RequestHeader, Handler]
 
   type PlayAccumulator = Accumulator[ByteString, Result]
+
   type PlayTargetStream = Source[ByteString, _]
 
   /** Borrowed from Play for now **/

--- a/play-route/src/main/scala/org/http4s/server/play/PlayRouteBuilder.scala
+++ b/play-route/src/main/scala/org/http4s/server/play/PlayRouteBuilder.scala
@@ -36,7 +36,6 @@ class PlayRouteBuilder[F[_]](
 
   def requestHeaderToRequest(requestHeader: RequestHeader, method: Method): Request[F] =
     Request(
-      // todo fix the ???
       method = method,
       uri = Uri(path = requestHeader.uri),
       headers = Headers.apply(requestHeader.headers.toMap.toList.flatMap {

--- a/play-route/src/test/scala/org/http4s/server/play/PlayServerSpec.scala
+++ b/play-route/src/test/scala/org/http4s/server/play/PlayServerSpec.scala
@@ -4,5 +4,5 @@ import cats.effect.IO
 import org.http4s.server.ServerSpec
 
 class PlayServerSpec extends ServerSpec {
-  def builder: PlayServerBuilder[IO] = PlayServerBuilder[IO]
+  def builder: PlayTestServerBuilder[IO] = PlayTestServerBuilder[IO]
 }

--- a/play-route/src/test/scala/org/http4s/server/play/PlayTestServerBuilder.scala
+++ b/play-route/src/test/scala/org/http4s/server/play/PlayTestServerBuilder.scala
@@ -10,14 +10,14 @@ import play.api.{Configuration, Environment, Mode}
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 
-class PlayServerBuilder[F[_]](
+class PlayTestServerBuilder[F[_]](
     hostname: String,
     services: Vector[(HttpService[F], String)],
     executionContext: ExecutionContext,
     port: Int,
 )(implicit F: Effect[F])
     extends ServerBuilder[F] {
-  type Self = PlayServerBuilder[F]
+  type Self = PlayTestServerBuilder[F]
 
   private implicit val ec: ExecutionContext = executionContext
 
@@ -27,7 +27,7 @@ class PlayServerBuilder[F[_]](
       executionContext: ExecutionContext = executionContext,
       services: Vector[(HttpService[F], String)] = services
   ): Self =
-    new PlayServerBuilder(hostname, services, executionContext, port)
+    new PlayTestServerBuilder(hostname, services, executionContext, port)
 
   override def mountService(service: HttpService[F], prefix: String): Self =
     copy(
@@ -70,9 +70,9 @@ class PlayServerBuilder[F[_]](
     server
   }
 
-  override def bindSocketAddress(socketAddress: InetSocketAddress): PlayServerBuilder[F] = this
+  override def bindSocketAddress(socketAddress: InetSocketAddress): PlayTestServerBuilder[F] = this
 
-  override def withExecutionContext(executionContext: ExecutionContext): PlayServerBuilder[F] =
+  override def withExecutionContext(executionContext: ExecutionContext): PlayTestServerBuilder[F] =
     copy(executionContext = executionContext)
 
   /** Sets the handler for errors thrown invoking the service.  Is not
@@ -80,15 +80,15 @@ class PlayServerBuilder[F[_]](
     * parsing a request or handling a context timeout.
     */
   override def withServiceErrorHandler(
-      serviceErrorHandler: ServiceErrorHandler[F]): PlayServerBuilder[F] = this
+      serviceErrorHandler: ServiceErrorHandler[F]): PlayTestServerBuilder[F] = this
 
   /** Set the banner to display when the server starts up */
-  override def withBanner(banner: immutable.Seq[String]): PlayServerBuilder[F] = this
+  override def withBanner(banner: immutable.Seq[String]): PlayTestServerBuilder[F] = this
 }
 
-object PlayServerBuilder {
-  def apply[F[_]](implicit F: Effect[F]): PlayServerBuilder[F] =
-    new PlayServerBuilder(
+object PlayTestServerBuilder {
+  def apply[F[_]](implicit F: Effect[F]): PlayTestServerBuilder[F] =
+    new PlayTestServerBuilder(
       hostname = ServerBuilder.DefaultSocketAddress.getHostString,
       services = Vector.empty,
       port = ServerBuilder.DefaultHttpPort,

--- a/play-server/src/test/scala/org/http4s/server/play/PlayRouteBuilder.scala
+++ b/play-server/src/test/scala/org/http4s/server/play/PlayRouteBuilder.scala
@@ -1,0 +1,5 @@
+package org.http4s.server.play
+
+class PlayRouteBuilder {
+
+}

--- a/play-server/src/test/scala/org/http4s/server/play/PlayRouteBuilder.scala
+++ b/play-server/src/test/scala/org/http4s/server/play/PlayRouteBuilder.scala
@@ -1,5 +1,87 @@
 package org.http4s.server.play
 
-class PlayRouteBuilder {
+import akka.stream.scaladsl.{Sink, Source}
+import akka.util.ByteString
+import cats.data.OptionT
+import cats.effect.Effect
+import org.http4s.{EmptyBody, Header, Headers, HttpService, Method, Request, Response, Uri}
+import play.api.http.HttpEntity.Streamed
+import play.api.libs.streams.Accumulator
+import play.api.mvc.{EssentialAction, RequestHeader, ResponseHeader, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class PlayRouteBuilder[F[_]](
+    service: HttpService[Future]
+)(implicit F: Effect[Future], executionContext: ExecutionContext) {
+
+  //noinspection ConvertExpressionToSAM
+  def f: EssentialAction = new EssentialAction {
+    override def apply(v1: RequestHeader): Accumulator[ByteString, Result] = ???
+  }
+
+  type R = Request[Future] => OptionT[Future, Response[Future]]
+  private[this] val r: R = service.run
+
+  def requestHeaderToRequest(requestHeader: RequestHeader): Request[Future] =
+    Request(
+      method = Method.fromString(requestHeader.method).getOrElse(???),
+      uri = Uri(path = requestHeader.uri),
+      headers = Headers.apply(requestHeader.headers.toMap.toList.flatMap {
+        case (headerName, values) =>
+          values.map { value =>
+            Header(headerName, value)
+          }
+      }),
+      body = EmptyBody
+    )
+
+  type SinkType = Sink[ByteString, Future[Result]]
+
+  def resulter(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
+
+    val res = r.apply(requestHeaderToRequest(requestHeader)).value
+    val rf = res.map(_.get)
+    Accumulator.done(rf.map { response =>
+      Result(
+        header = ResponseHeader(
+          status = response.status.code,
+          headers = response.headers.map { header =>
+            header.parsed.name.value -> header.parsed.value
+          }.toMap
+        ),
+        body = {
+          val entityBody: fs2.Stream[Future, Byte] = response.body
+          type PlayTarget = Source[ByteString, _]
+          import fs2.interop.reactivestreams._
+
+          val playBody: PlayTarget =
+            Source.fromPublisher(entityBody.toUnicastPublisher()).map(byte => ByteString(byte))
+
+          Streamed(
+            data = playBody,
+            contentLength = response.contentLength,
+            contentType = response.contentType.map(_.value)
+          )
+        }
+      )
+
+    })
+//    val sink: SinkType = res
+//
+//    Accumulator.apply(??? : SinkType)
+  }
+
+  /**
+    * Play's route matching is synchronous so must await for the future, effectively... :-(
+    */
+  def build: _root_.play.api.routing.Router.Routes = {
+    case something if r.apply(requestHeaderToRequest(something)).value.value.get.get.isDefined =>
+      new EssentialAction {
+        override def apply(v1: RequestHeader): Accumulator[ByteString, Result] =
+          resulter(v1)
+      }
+//    type HttpService[F[_]] = Kleisli[OptionT[F, ?], Request[F], Response[F]]
+  }
 
 }

--- a/play-server/src/test/scala/org/http4s/server/play/PlayRouteBuilder.scala
+++ b/play-server/src/test/scala/org/http4s/server/play/PlayRouteBuilder.scala
@@ -3,27 +3,26 @@ package org.http4s.server.play
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import cats.data.OptionT
-import cats.effect.Effect
+import cats.effect.{Effect, IO}
 import org.http4s.{EmptyBody, Header, Headers, HttpService, Method, Request, Response, Uri}
 import play.api.http.HttpEntity.Streamed
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{EssentialAction, RequestHeader, ResponseHeader, Result}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 
 class PlayRouteBuilder[F[_]](
-    service: HttpService[Future]
-)(implicit F: Effect[Future], executionContext: ExecutionContext) {
+    service: HttpService[F]
+)(implicit F: Effect[F], executionContext: ExecutionContext) {
+  private val FE = Effect[F]
 
-  //noinspection ConvertExpressionToSAM
-  def f: EssentialAction = new EssentialAction {
-    override def apply(v1: RequestHeader): Accumulator[ByteString, Result] = ???
-  }
+  FE.delay(0)
 
-  type R = Request[Future] => OptionT[Future, Response[Future]]
+  type R = Request[F] => OptionT[F, Response[F]]
   private[this] val r: R = service.run
 
-  def requestHeaderToRequest(requestHeader: RequestHeader): Request[Future] =
+  def requestHeaderToRequest(requestHeader: RequestHeader): Request[F] =
     Request(
       method = Method.fromString(requestHeader.method).getOrElse(???),
       uri = Uri(path = requestHeader.uri),
@@ -38,11 +37,12 @@ class PlayRouteBuilder[F[_]](
 
   type SinkType = Sink[ByteString, Future[Result]]
 
-  def resulter(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
-
-    val res = r.apply(requestHeaderToRequest(requestHeader)).value
-    val rf = res.map(_.get)
-    Accumulator.done(rf.map { response =>
+  def playRequestToPlayResponse(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
+    val http4sResponse: F[Option[Response[F]]] =
+      r.apply(requestHeaderToRequest(requestHeader)).value
+    // I know, ugly, will fix once I get it to work
+    val http4sResponseExists: F[Response[F]] = F.map(http4sResponse)(_.get)
+    val resultContainer: F[Result] = F.map(http4sResponseExists) { response =>
       Result(
         header = ResponseHeader(
           status = response.status.code,
@@ -51,10 +51,11 @@ class PlayRouteBuilder[F[_]](
           }.toMap
         ),
         body = {
-          val entityBody: fs2.Stream[Future, Byte] = response.body
+          val entityBody: fs2.Stream[F, Byte] = response.body
           type PlayTarget = Source[ByteString, _]
           import fs2.interop.reactivestreams._
 
+          // hack!
           val playBody: PlayTarget =
             Source.fromPublisher(entityBody.toUnicastPublisher()).map(byte => ByteString(byte))
 
@@ -66,22 +67,62 @@ class PlayRouteBuilder[F[_]](
         }
       )
 
-    })
-//    val sink: SinkType = res
-//
-//    Accumulator.apply(??? : SinkType)
+    }
+
+    // hack
+    val promise = Promise[Result]
+
+    F.runAsync(resultContainer) {
+      case Left(bad) =>
+        promise.failure(bad)
+        IO.unit
+      case Right(good) =>
+        promise.success(good)
+        IO.unit
+    }
+    Accumulator.done(promise.future)
   }
 
   /**
     * Play's route matching is synchronous so must await for the future, effectively... :-(
     */
   def build: _root_.play.api.routing.Router.Routes = {
-    case something if r.apply(requestHeaderToRequest(something)).value.value.get.get.isDefined =>
+    case something if {
+          val part: OptionT[F, Response[F]] = r.apply(requestHeaderToRequest(something))
+          val efff: F[Option[Response[F]]] = part.value
+          val completion = Promise[Boolean]()
+          FE.runAsync(efff) {
+              case Left(f) => completion.failure(f); IO.unit
+              case Right(s) => completion.success(s.isDefined); IO.unit
+            }
+            .unsafeRunSync()
+          Await.result(completion.future, Duration.Inf)
+
+        } =>
       new EssentialAction {
         override def apply(v1: RequestHeader): Accumulator[ByteString, Result] =
-          resulter(v1)
+          playRequestToPlayResponse(v1)
       }
 //    type HttpService[F[_]] = Kleisli[OptionT[F, ?], Request[F], Response[F]]
   }
 
+}
+
+object PlayRouteBuilder {
+
+  /** Borrowed from Play for now **/
+  def withPrefix(
+      prefix: String,
+      t: _root_.play.api.routing.Router.Routes): _root_.play.api.routing.Router.Routes =
+    if (prefix == "/") {
+      t
+    } else {
+      val p = if (prefix.endsWith("/")) prefix else prefix + "/"
+      val prefixed: PartialFunction[RequestHeader, RequestHeader] = {
+        case rh: RequestHeader if rh.path.startsWith(p) =>
+          val newPath = rh.path.drop(p.length - 1)
+          rh.withTarget(rh.target.withPath(newPath))
+      }
+      Function.unlift(prefixed.lift.andThen(_.flatMap(t.lift)))
+    }
 }

--- a/play-server/src/test/scala/org/http4s/server/play/PlayRouteBuilder.scala
+++ b/play-server/src/test/scala/org/http4s/server/play/PlayRouteBuilder.scala
@@ -50,12 +50,12 @@ class PlayRouteBuilder[F[_]](
   def playRequestToPlayResponse(requestHeader: RequestHeader): PlayAccumulator = {
     val sink: Sink[ByteString, Future[Result]] = {
       Sink.asPublisher[ByteString](false).mapMaterializedValue { publisher =>
-        val bodyStream: fs2.Stream[F, Byte] =
+        val requestBodyStream: fs2.Stream[F, Byte] =
           publisher.toStream().flatMap(bs => fs2.Stream.fromIterator[F, Byte](bs.toIterator))
 
         val wrappedResponse: F[Response[F]] =
           F.map(
-            unwrappedRun(requestHeaderToRequest(requestHeader).withBodyStream(bodyStream)).value)(
+            unwrappedRun(requestHeaderToRequest(requestHeader).withBodyStream(requestBodyStream)).value)(
             _.get)
         val wrappedResult: F[Result] = F.map(wrappedResponse) { response =>
           Result(

--- a/play-server/src/test/scala/org/http4s/server/play/PlayServerBuilder.scala
+++ b/play-server/src/test/scala/org/http4s/server/play/PlayServerBuilder.scala
@@ -1,313 +1,75 @@
-package org.http4s
-package server
-package blaze
+package org.http4s.server.play
+
+import java.net.InetSocketAddress
 
 import cats.effect._
-import java.io.FileInputStream
-import java.net.InetSocketAddress
-import java.nio.ByteBuffer
-import java.security.{KeyStore, Security}
-import javax.net.ssl.{KeyManagerFactory, SSLContext, SSLEngine, TrustManagerFactory}
-import org.http4s.blaze.{BuildInfo => BlazeBuildInfo}
-import org.http4s.blaze.channel
-import org.http4s.blaze.channel.SocketConnection
-import org.http4s.blaze.channel.nio1.NIO1SocketServerGroup
-import org.http4s.blaze.channel.nio2.NIO2SocketServerGroup
-import org.http4s.blaze.pipeline.LeafBuilder
-import org.http4s.blaze.pipeline.stages.{QuietTimeoutStage, SSLStage}
-import org.http4s.server.SSLKeyStoreSupport.StoreInfo
-import org.log4s.getLogger
+import org.http4s.HttpService
+import org.http4s.server.{Server, ServerBuilder, ServiceErrorHandler}
+
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 
-class BlazeBuilder[F[_]](
-    socketAddress: InetSocketAddress,
+class PlayServerBuilder[F[_]](
+    hostname: String,
+    services: Vector[(HttpService[F], String)],
     executionContext: ExecutionContext,
-    idleTimeout: Duration,
-    isNio2: Boolean,
-    connectorPoolSize: Int,
-    bufferSize: Int,
-    enableWebSockets: Boolean,
-    sslBits: Option[SSLConfig],
-    isHttp2Enabled: Boolean,
-    maxRequestLineLen: Int,
-    maxHeadersLen: Int,
-    serviceMounts: Vector[ServiceMount[F]],
-    serviceErrorHandler: ServiceErrorHandler[F],
-    banner: immutable.Seq[String]
+    port: Int,
 )(implicit F: Effect[F])
-    extends ServerBuilder[F]
-    with IdleTimeoutSupport[F]
-    with SSLKeyStoreSupport[F]
-    with SSLContextSupport[F]
-    with server.WebSocketSupport[F] {
-  type Self = BlazeBuilder[F]
-
-  private[this] val logger = getLogger
+    extends ServerBuilder[F] {
+  type Self = PlayServerBuilder[F]
 
   private def copy(
-      socketAddress: InetSocketAddress = socketAddress,
+      hostname: String = hostname,
+      port: Int = port,
       executionContext: ExecutionContext = executionContext,
-      idleTimeout: Duration = idleTimeout,
-      isNio2: Boolean = isNio2,
-      connectorPoolSize: Int = connectorPoolSize,
-      bufferSize: Int = bufferSize,
-      enableWebSockets: Boolean = enableWebSockets,
-      sslBits: Option[SSLConfig] = sslBits,
-      http2Support: Boolean = isHttp2Enabled,
-      maxRequestLineLen: Int = maxRequestLineLen,
-      maxHeadersLen: Int = maxHeadersLen,
-      serviceMounts: Vector[ServiceMount[F]] = serviceMounts,
-      serviceErrorHandler: ServiceErrorHandler[F] = serviceErrorHandler,
-      banner: immutable.Seq[String] = banner
+      services: Vector[(HttpService[F], String)] = services
   ): Self =
-    new BlazeBuilder(
-      socketAddress,
-      executionContext,
-      idleTimeout,
-      isNio2,
-      connectorPoolSize,
-      bufferSize,
-      enableWebSockets,
-      sslBits,
-      http2Support,
-      maxRequestLineLen,
-      maxHeadersLen,
-      serviceMounts,
-      serviceErrorHandler,
-      banner
+    new PlayServerBuilder(hostname, services, executionContext, port)
+
+  override def mountService(service: HttpService[F], prefix: String): Self =
+    copy(
+      services = services :+ service -> prefix
     )
 
-  /** Configure HTTP parser length limits
-    *
-    * These are to avoid denial of service attacks due to,
-    * for example, an infinite request line.
-    *
-    * @param maxRequestLineLen maximum request line to parse
-    * @param maxHeadersLen maximum data that compose headers
-    */
-  def withLengthLimits(
-      maxRequestLineLen: Int = maxRequestLineLen,
-      maxHeadersLen: Int = maxHeadersLen): Self =
-    copy(maxRequestLineLen = maxRequestLineLen, maxHeadersLen = maxHeadersLen)
-
-  override def withSSL(
-      keyStore: StoreInfo,
-      keyManagerPassword: String,
-      protocol: String,
-      trustStore: Option[StoreInfo],
-      clientAuth: Boolean): Self = {
-    val bits = KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)
-    copy(sslBits = Some(bits))
-  }
-
-  override def withSSLContext(sslContext: SSLContext, clientAuth: Boolean): Self =
-    copy(sslBits = Some(SSLContextBits(sslContext, clientAuth)))
-
-  override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
-    copy(socketAddress = socketAddress)
-
-  override def withExecutionContext(executionContext: ExecutionContext): BlazeBuilder[F] =
-    copy(executionContext = executionContext)
-
-  override def withIdleTimeout(idleTimeout: Duration): Self = copy(idleTimeout = idleTimeout)
-
-  def withConnectorPoolSize(size: Int): Self = copy(connectorPoolSize = size)
-
-  def withBufferSize(size: Int): Self = copy(bufferSize = size)
-
-  def withNio2(isNio2: Boolean): Self = copy(isNio2 = isNio2)
-
-  override def withWebSockets(enableWebsockets: Boolean): Self =
-    copy(enableWebSockets = enableWebsockets)
-
-  def enableHttp2(enabled: Boolean): Self = copy(http2Support = enabled)
-
-  override def mountService(service: HttpService[F], prefix: String): Self = {
-    val prefixedService =
-      if (prefix.isEmpty || prefix == "/") service
-      else {
-        val newCaret = prefix match {
-          case "/" => 0
-          case x if x.startsWith("/") => x.length
-          case x => x.length + 1
-        }
-
-        service.local { req: Request[F] =>
-          req.withAttribute(Request.Keys.PathInfoCaret(newCaret))
-        }
-      }
-    copy(serviceMounts = serviceMounts :+ ServiceMount[F](prefixedService, prefix))
-  }
-
-  def withServiceErrorHandler(serviceErrorHandler: ServiceErrorHandler[F]): Self =
-    copy(serviceErrorHandler = serviceErrorHandler)
-
-  def withBanner(banner: immutable.Seq[String]): Self =
-    copy(banner = banner)
-
   def start: F[Server[F]] = F.delay {
-    val aggregateService = Router(serviceMounts.map(mount => mount.prefix -> mount.service): _*)
-
-    def resolveAddress(address: InetSocketAddress) =
-      if (address.isUnresolved) new InetSocketAddress(address.getHostName, address.getPort)
-      else address
-
-    val pipelineFactory = { conn: SocketConnection =>
-      def requestAttributes(secure: Boolean) =
-        (conn.local, conn.remote) match {
-          case (local: InetSocketAddress, remote: InetSocketAddress) =>
-            AttributeMap(
-              AttributeEntry(
-                Request.Keys.ConnectionInfo,
-                Request.Connection(
-                  local = local,
-                  remote = remote,
-                  secure = secure
-                )))
-          case _ =>
-            AttributeMap.empty
-        }
-
-      def http1Stage(secure: Boolean) =
-        Http1ServerStage(
-          aggregateService,
-          requestAttributes(secure = secure),
-          executionContext,
-          enableWebSockets,
-          maxRequestLineLen,
-          maxHeadersLen,
-          serviceErrorHandler
-        )
-
-      def http2Stage(engine: SSLEngine) =
-        ProtocolSelector(
-          engine,
-          aggregateService,
-          maxRequestLineLen,
-          maxHeadersLen,
-          requestAttributes(secure = true),
-          executionContext,
-          serviceErrorHandler
-        )
-
-      def prependIdleTimeout(lb: LeafBuilder[ByteBuffer]) =
-        if (idleTimeout.isFinite) lb.prepend(new QuietTimeoutStage[ByteBuffer](idleTimeout))
-        else lb
-
-      getContext() match {
-        case Some((ctx, clientAuth)) =>
-          val engine = ctx.createSSLEngine()
-          engine.setUseClientMode(false)
-          engine.setNeedClientAuth(clientAuth)
-
-          var lb = LeafBuilder(
-            if (isHttp2Enabled) http2Stage(engine)
-            else http1Stage(secure = true)
-          )
-          lb = prependIdleTimeout(lb)
-          lb.prepend(new SSLStage(engine))
-
-        case None =>
-          if (isHttp2Enabled) logger.warn("HTTP/2 support requires TLS. Falling back to HTTP/1.")
-          var lb = LeafBuilder(http1Stage(secure = false))
-          lb = prependIdleTimeout(lb)
-          lb
-      }
-    }
-
-    val factory =
-      if (isNio2)
-        NIO2SocketServerGroup.fixedGroup(connectorPoolSize, bufferSize)
-      else
-        NIO1SocketServerGroup.fixedGroup(connectorPoolSize, bufferSize)
-
-    val address = resolveAddress(socketAddress)
-
-    // if we have a Failure, it will be caught by the effect
-    val serverChannel = factory.bind(address, pipelineFactory).get
-
     val server = new Server[F] {
-      override def shutdown: F[Unit] = F.delay {
-        serverChannel.close()
-        factory.closeGroup()
-      }
+      override def shutdown: F[Unit] = F.delay {}
 
-      override def onShutdown(f: => Unit): this.type = {
-        serverChannel.addShutdownHook(() => f)
+      override def onShutdown(f: => Unit): this.type =
         this
-      }
-
-      val address: InetSocketAddress =
-        serverChannel.socketAddress
-
-      val isSecure = sslBits.isDefined
 
       override def toString: String =
-        s"BlazeServer($address)"
-    }
+        s"PlayServer($address)"
 
-    banner.foreach(logger.info(_))
-    logger.info(
-      s"http4s v${BuildInfo.version} on blaze v${BlazeBuildInfo.version} started at ${server.baseUri}")
+      override def address: InetSocketAddress = new InetSocketAddress(hostname, port)
+
+      override def isSecure: Boolean = false
+    }
     server
   }
 
-  private def getContext(): Option[(SSLContext, Boolean)] = sslBits.map {
-    case KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth) =>
-      val ksStream = new FileInputStream(keyStore.path)
-      val ks = KeyStore.getInstance("JKS")
-      ks.load(ksStream, keyStore.password.toCharArray)
-      ksStream.close()
+  override def bindSocketAddress(socketAddress: InetSocketAddress): PlayServerBuilder[F] = this
 
-      val tmf = trustStore.map { auth =>
-        val ksStream = new FileInputStream(auth.path)
+  override def withExecutionContext(executionContext: ExecutionContext): PlayServerBuilder[F] =
+    copy(executionContext = executionContext)
 
-        val ks = KeyStore.getInstance("JKS")
-        ks.load(ksStream, auth.password.toCharArray)
-        ksStream.close()
+  /** Sets the handler for errors thrown invoking the service.  Is not
+    * guaranteed to be invoked on errors on the server backend, such as
+    * parsing a request or handling a context timeout.
+    */
+  override def withServiceErrorHandler(
+      serviceErrorHandler: ServiceErrorHandler[F]): PlayServerBuilder[F] = this
 
-        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
-
-        tmf.init(ks)
-        tmf.getTrustManagers
-      }
-
-      val kmf = KeyManagerFactory.getInstance(
-        Option(Security.getProperty("ssl.KeyManagerFactory.algorithm"))
-          .getOrElse(KeyManagerFactory.getDefaultAlgorithm))
-
-      kmf.init(ks, keyManagerPassword.toCharArray)
-
-      val context = SSLContext.getInstance(protocol)
-      context.init(kmf.getKeyManagers, tmf.orNull, null)
-
-      (context, clientAuth)
-
-    case SSLContextBits(context, clientAuth) =>
-      (context, clientAuth)
-  }
+  /** Set the banner to display when the server starts up */
+  override def withBanner(banner: immutable.Seq[String]): PlayServerBuilder[F] = this
 }
 
-object BlazeBuilder {
-  def apply[F[_]](implicit F: Effect[F]): BlazeBuilder[F] =
-    new BlazeBuilder(
-      socketAddress = ServerBuilder.DefaultSocketAddress,
-      executionContext = ExecutionContext.global,
-      idleTimeout = IdleTimeoutSupport.DefaultIdleTimeout,
-      isNio2 = false,
-      connectorPoolSize = channel.defaultPoolSize,
-      bufferSize = 64 * 1024,
-      enableWebSockets = true,
-      sslBits = None,
-      isHttp2Enabled = false,
-      maxRequestLineLen = 4 * 1024,
-      maxHeadersLen = 40 * 1024,
-      serviceMounts = Vector.empty,
-      serviceErrorHandler = DefaultServiceErrorHandler,
-      banner = ServerBuilder.DefaultBanner
+object PlayServerBuilder {
+  def apply[F[_]](implicit F: Effect[F]): PlayServerBuilder[F] =
+    new PlayServerBuilder(
+      hostname = ServerBuilder.DefaultSocketAddress.getHostString,
+      services = Vector.empty,
+      port = ServerBuilder.DefaultHttpPort,
+      executionContext = ExecutionContext.global
     )
 }
-
-private final case class ServiceMount[F[_]](service: HttpService[F], prefix: String)

--- a/play-server/src/test/scala/org/http4s/server/play/PlayServerBuilder.scala
+++ b/play-server/src/test/scala/org/http4s/server/play/PlayServerBuilder.scala
@@ -1,0 +1,313 @@
+package org.http4s
+package server
+package blaze
+
+import cats.effect._
+import java.io.FileInputStream
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.security.{KeyStore, Security}
+import javax.net.ssl.{KeyManagerFactory, SSLContext, SSLEngine, TrustManagerFactory}
+import org.http4s.blaze.{BuildInfo => BlazeBuildInfo}
+import org.http4s.blaze.channel
+import org.http4s.blaze.channel.SocketConnection
+import org.http4s.blaze.channel.nio1.NIO1SocketServerGroup
+import org.http4s.blaze.channel.nio2.NIO2SocketServerGroup
+import org.http4s.blaze.pipeline.LeafBuilder
+import org.http4s.blaze.pipeline.stages.{QuietTimeoutStage, SSLStage}
+import org.http4s.server.SSLKeyStoreSupport.StoreInfo
+import org.log4s.getLogger
+import scala.collection.immutable
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class BlazeBuilder[F[_]](
+    socketAddress: InetSocketAddress,
+    executionContext: ExecutionContext,
+    idleTimeout: Duration,
+    isNio2: Boolean,
+    connectorPoolSize: Int,
+    bufferSize: Int,
+    enableWebSockets: Boolean,
+    sslBits: Option[SSLConfig],
+    isHttp2Enabled: Boolean,
+    maxRequestLineLen: Int,
+    maxHeadersLen: Int,
+    serviceMounts: Vector[ServiceMount[F]],
+    serviceErrorHandler: ServiceErrorHandler[F],
+    banner: immutable.Seq[String]
+)(implicit F: Effect[F])
+    extends ServerBuilder[F]
+    with IdleTimeoutSupport[F]
+    with SSLKeyStoreSupport[F]
+    with SSLContextSupport[F]
+    with server.WebSocketSupport[F] {
+  type Self = BlazeBuilder[F]
+
+  private[this] val logger = getLogger
+
+  private def copy(
+      socketAddress: InetSocketAddress = socketAddress,
+      executionContext: ExecutionContext = executionContext,
+      idleTimeout: Duration = idleTimeout,
+      isNio2: Boolean = isNio2,
+      connectorPoolSize: Int = connectorPoolSize,
+      bufferSize: Int = bufferSize,
+      enableWebSockets: Boolean = enableWebSockets,
+      sslBits: Option[SSLConfig] = sslBits,
+      http2Support: Boolean = isHttp2Enabled,
+      maxRequestLineLen: Int = maxRequestLineLen,
+      maxHeadersLen: Int = maxHeadersLen,
+      serviceMounts: Vector[ServiceMount[F]] = serviceMounts,
+      serviceErrorHandler: ServiceErrorHandler[F] = serviceErrorHandler,
+      banner: immutable.Seq[String] = banner
+  ): Self =
+    new BlazeBuilder(
+      socketAddress,
+      executionContext,
+      idleTimeout,
+      isNio2,
+      connectorPoolSize,
+      bufferSize,
+      enableWebSockets,
+      sslBits,
+      http2Support,
+      maxRequestLineLen,
+      maxHeadersLen,
+      serviceMounts,
+      serviceErrorHandler,
+      banner
+    )
+
+  /** Configure HTTP parser length limits
+    *
+    * These are to avoid denial of service attacks due to,
+    * for example, an infinite request line.
+    *
+    * @param maxRequestLineLen maximum request line to parse
+    * @param maxHeadersLen maximum data that compose headers
+    */
+  def withLengthLimits(
+      maxRequestLineLen: Int = maxRequestLineLen,
+      maxHeadersLen: Int = maxHeadersLen): Self =
+    copy(maxRequestLineLen = maxRequestLineLen, maxHeadersLen = maxHeadersLen)
+
+  override def withSSL(
+      keyStore: StoreInfo,
+      keyManagerPassword: String,
+      protocol: String,
+      trustStore: Option[StoreInfo],
+      clientAuth: Boolean): Self = {
+    val bits = KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)
+    copy(sslBits = Some(bits))
+  }
+
+  override def withSSLContext(sslContext: SSLContext, clientAuth: Boolean): Self =
+    copy(sslBits = Some(SSLContextBits(sslContext, clientAuth)))
+
+  override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
+    copy(socketAddress = socketAddress)
+
+  override def withExecutionContext(executionContext: ExecutionContext): BlazeBuilder[F] =
+    copy(executionContext = executionContext)
+
+  override def withIdleTimeout(idleTimeout: Duration): Self = copy(idleTimeout = idleTimeout)
+
+  def withConnectorPoolSize(size: Int): Self = copy(connectorPoolSize = size)
+
+  def withBufferSize(size: Int): Self = copy(bufferSize = size)
+
+  def withNio2(isNio2: Boolean): Self = copy(isNio2 = isNio2)
+
+  override def withWebSockets(enableWebsockets: Boolean): Self =
+    copy(enableWebSockets = enableWebsockets)
+
+  def enableHttp2(enabled: Boolean): Self = copy(http2Support = enabled)
+
+  override def mountService(service: HttpService[F], prefix: String): Self = {
+    val prefixedService =
+      if (prefix.isEmpty || prefix == "/") service
+      else {
+        val newCaret = prefix match {
+          case "/" => 0
+          case x if x.startsWith("/") => x.length
+          case x => x.length + 1
+        }
+
+        service.local { req: Request[F] =>
+          req.withAttribute(Request.Keys.PathInfoCaret(newCaret))
+        }
+      }
+    copy(serviceMounts = serviceMounts :+ ServiceMount[F](prefixedService, prefix))
+  }
+
+  def withServiceErrorHandler(serviceErrorHandler: ServiceErrorHandler[F]): Self =
+    copy(serviceErrorHandler = serviceErrorHandler)
+
+  def withBanner(banner: immutable.Seq[String]): Self =
+    copy(banner = banner)
+
+  def start: F[Server[F]] = F.delay {
+    val aggregateService = Router(serviceMounts.map(mount => mount.prefix -> mount.service): _*)
+
+    def resolveAddress(address: InetSocketAddress) =
+      if (address.isUnresolved) new InetSocketAddress(address.getHostName, address.getPort)
+      else address
+
+    val pipelineFactory = { conn: SocketConnection =>
+      def requestAttributes(secure: Boolean) =
+        (conn.local, conn.remote) match {
+          case (local: InetSocketAddress, remote: InetSocketAddress) =>
+            AttributeMap(
+              AttributeEntry(
+                Request.Keys.ConnectionInfo,
+                Request.Connection(
+                  local = local,
+                  remote = remote,
+                  secure = secure
+                )))
+          case _ =>
+            AttributeMap.empty
+        }
+
+      def http1Stage(secure: Boolean) =
+        Http1ServerStage(
+          aggregateService,
+          requestAttributes(secure = secure),
+          executionContext,
+          enableWebSockets,
+          maxRequestLineLen,
+          maxHeadersLen,
+          serviceErrorHandler
+        )
+
+      def http2Stage(engine: SSLEngine) =
+        ProtocolSelector(
+          engine,
+          aggregateService,
+          maxRequestLineLen,
+          maxHeadersLen,
+          requestAttributes(secure = true),
+          executionContext,
+          serviceErrorHandler
+        )
+
+      def prependIdleTimeout(lb: LeafBuilder[ByteBuffer]) =
+        if (idleTimeout.isFinite) lb.prepend(new QuietTimeoutStage[ByteBuffer](idleTimeout))
+        else lb
+
+      getContext() match {
+        case Some((ctx, clientAuth)) =>
+          val engine = ctx.createSSLEngine()
+          engine.setUseClientMode(false)
+          engine.setNeedClientAuth(clientAuth)
+
+          var lb = LeafBuilder(
+            if (isHttp2Enabled) http2Stage(engine)
+            else http1Stage(secure = true)
+          )
+          lb = prependIdleTimeout(lb)
+          lb.prepend(new SSLStage(engine))
+
+        case None =>
+          if (isHttp2Enabled) logger.warn("HTTP/2 support requires TLS. Falling back to HTTP/1.")
+          var lb = LeafBuilder(http1Stage(secure = false))
+          lb = prependIdleTimeout(lb)
+          lb
+      }
+    }
+
+    val factory =
+      if (isNio2)
+        NIO2SocketServerGroup.fixedGroup(connectorPoolSize, bufferSize)
+      else
+        NIO1SocketServerGroup.fixedGroup(connectorPoolSize, bufferSize)
+
+    val address = resolveAddress(socketAddress)
+
+    // if we have a Failure, it will be caught by the effect
+    val serverChannel = factory.bind(address, pipelineFactory).get
+
+    val server = new Server[F] {
+      override def shutdown: F[Unit] = F.delay {
+        serverChannel.close()
+        factory.closeGroup()
+      }
+
+      override def onShutdown(f: => Unit): this.type = {
+        serverChannel.addShutdownHook(() => f)
+        this
+      }
+
+      val address: InetSocketAddress =
+        serverChannel.socketAddress
+
+      val isSecure = sslBits.isDefined
+
+      override def toString: String =
+        s"BlazeServer($address)"
+    }
+
+    banner.foreach(logger.info(_))
+    logger.info(
+      s"http4s v${BuildInfo.version} on blaze v${BlazeBuildInfo.version} started at ${server.baseUri}")
+    server
+  }
+
+  private def getContext(): Option[(SSLContext, Boolean)] = sslBits.map {
+    case KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth) =>
+      val ksStream = new FileInputStream(keyStore.path)
+      val ks = KeyStore.getInstance("JKS")
+      ks.load(ksStream, keyStore.password.toCharArray)
+      ksStream.close()
+
+      val tmf = trustStore.map { auth =>
+        val ksStream = new FileInputStream(auth.path)
+
+        val ks = KeyStore.getInstance("JKS")
+        ks.load(ksStream, auth.password.toCharArray)
+        ksStream.close()
+
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+
+        tmf.init(ks)
+        tmf.getTrustManagers
+      }
+
+      val kmf = KeyManagerFactory.getInstance(
+        Option(Security.getProperty("ssl.KeyManagerFactory.algorithm"))
+          .getOrElse(KeyManagerFactory.getDefaultAlgorithm))
+
+      kmf.init(ks, keyManagerPassword.toCharArray)
+
+      val context = SSLContext.getInstance(protocol)
+      context.init(kmf.getKeyManagers, tmf.orNull, null)
+
+      (context, clientAuth)
+
+    case SSLContextBits(context, clientAuth) =>
+      (context, clientAuth)
+  }
+}
+
+object BlazeBuilder {
+  def apply[F[_]](implicit F: Effect[F]): BlazeBuilder[F] =
+    new BlazeBuilder(
+      socketAddress = ServerBuilder.DefaultSocketAddress,
+      executionContext = ExecutionContext.global,
+      idleTimeout = IdleTimeoutSupport.DefaultIdleTimeout,
+      isNio2 = false,
+      connectorPoolSize = channel.defaultPoolSize,
+      bufferSize = 64 * 1024,
+      enableWebSockets = true,
+      sslBits = None,
+      isHttp2Enabled = false,
+      maxRequestLineLen = 4 * 1024,
+      maxHeadersLen = 40 * 1024,
+      serviceMounts = Vector.empty,
+      serviceErrorHandler = DefaultServiceErrorHandler,
+      banner = ServerBuilder.DefaultBanner
+    )
+}
+
+private final case class ServiceMount[F[_]](service: HttpService[F], prefix: String)

--- a/play-server/src/test/scala/org/http4s/server/play/PlayServerSpec.scala
+++ b/play-server/src/test/scala/org/http4s/server/play/PlayServerSpec.scala
@@ -1,9 +1,8 @@
-package org.http4s
-package server
-package blaze
+package org.http4s.server.play
 
 import cats.effect.IO
+import org.http4s.server.ServerSpec
 
-class BlazeServerSpec extends ServerSpec {
-  def builder = BlazeBuilder[IO]
+class PlayServerSpec extends ServerSpec {
+  def builder: PlayServerBuilder[IO] = PlayServerBuilder[IO]
 }

--- a/play-server/src/test/scala/org/http4s/server/play/PlayServerSpec.scala
+++ b/play-server/src/test/scala/org/http4s/server/play/PlayServerSpec.scala
@@ -1,0 +1,9 @@
+package org.http4s
+package server
+package blaze
+
+import cats.effect.IO
+
+class BlazeServerSpec extends ServerSpec {
+  def builder = BlazeBuilder[IO]
+}

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -279,8 +279,8 @@ object Http4sPlugin extends AutoPlugin {
   lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "0.12.2"
   lazy val jettyServer                      = "org.eclipse.jetty"      %  "jetty-server"              % "9.4.9.v20180320"
   lazy val jettyServlet                     = "org.eclipse.jetty"      %  "jetty-servlet"             % jettyServer.revision
-  lazy val playServerT                       = "com.typesafe.play"      %% "play-server"               % "2.6.13"
-lazy val playAkkaHttpServer = "com.typesafe.play" %% "play-akka-http-server" % "2.6.13"
+  lazy val play                             = "com.typesafe.play"      %% "play"                      % "2.6.13"
+  lazy val playAkkaHttpServer               = "com.typesafe.play"      %% "play-akka-http-server"     % "2.6.13"
 
 
   lazy val json4sCore                       = "org.json4s"             %% "json4s-core"               % "3.5.3"

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -79,7 +79,7 @@ object Http4sPlugin extends AutoPlugin {
           None
       }
     },
-    mimaFailOnProblem := http4sMimaVersion.value.isDefined,
+    mimaFailOnProblem := false,
     mimaPreviousArtifacts := (http4sMimaVersion.value map {
       organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % _
     }).toSet,
@@ -281,7 +281,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val jettyServlet                     = "org.eclipse.jetty"      %  "jetty-servlet"             % jettyServer.revision
   lazy val play                             = "com.typesafe.play"      %% "play"                      % "2.6.13"
   lazy val playAkkaHttpServer               = "com.typesafe.play"      %% "play-akka-http-server"     % "2.6.13"
-
+  lazy val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.0"
 
   lazy val json4sCore                       = "org.json4s"             %% "json4s-core"               % "3.5.3"
   lazy val json4sJackson                    = "org.json4s"             %% "json4s-jackson"            % json4sCore.revision

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -280,6 +280,8 @@ object Http4sPlugin extends AutoPlugin {
   lazy val jettyServer                      = "org.eclipse.jetty"      %  "jetty-server"              % "9.4.9.v20180320"
   lazy val jettyServlet                     = "org.eclipse.jetty"      %  "jetty-servlet"             % jettyServer.revision
   lazy val playServerT                       = "com.typesafe.play"      %% "play-server"               % "2.6.13"
+lazy val playAkkaHttpServer = "com.typesafe.play" %% "play-akka-http-server" % "2.6.13"
+
 
   lazy val json4sCore                       = "org.json4s"             %% "json4s-core"               % "3.5.3"
   lazy val json4sJackson                    = "org.json4s"             %% "json4s-jackson"            % json4sCore.revision

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -279,6 +279,8 @@ object Http4sPlugin extends AutoPlugin {
   lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "0.12.2"
   lazy val jettyServer                      = "org.eclipse.jetty"      %  "jetty-server"              % "9.4.9.v20180320"
   lazy val jettyServlet                     = "org.eclipse.jetty"      %  "jetty-servlet"             % jettyServer.revision
+  lazy val playServerT                       = "com.typesafe.play"      %% "play-server"               % "2.6.13"
+
   lazy val json4sCore                       = "org.json4s"             %% "json4s-core"               % "3.5.3"
   lazy val json4sJackson                    = "org.json4s"             %% "json4s-jackson"            % json4sCore.revision
   lazy val json4sNative                     = "org.json4s"             %% "json4s-native"             % json4sCore.revision

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,7 @@ addSbtPlugin("io.verizon.build"    %  "sbt-rig"               % "5.0.39")
 addSbtPlugin("org.tpolecat"        %  "tut-plugin"            % "0.6.4")
 addSbtPlugin("pl.project13.scala"  %  "sbt-jmh"               % "0.3.3")
 
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.13")
+
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/server/src/test/scala/org/http4s/server/ServerSpec.scala
+++ b/server/src/test/scala/org/http4s/server/ServerSpec.scala
@@ -29,7 +29,9 @@ trait ServerSpec extends Http4sSpec with Http4sDsl[IO] with AfterAll {
       .start
       .unsafeRunSync()
 
-  def afterAll = server.shutdownNow()
+  def afterAll = {
+    server.shutdownNow()
+  }
 
   // This should be in IO and shifted but I'm tired of fighting this.
   private def get(path: String): String =


### PR DESCRIPTION
Related: https://github.com/http4s/http4s/issues/1817

**Rationale**: for applications currently written in Play, there is no straightforward pathway to using http4s. Play also has the hot reloading feature that is exclusive to it, among other nice useful features.

**What it may achieve**: Increased adoption of http4s.

Since Play is a framework, we should not wrap it but provide something to it instead. The Play way is a `Route = PartialFunction[RequestHeader, Action]`, where `Action` is an asynchronous handler.

Here, I map http4s's `HttpService` to Play's `Route`. In order to test it, I have a `PlayTestServerBuilder` that actually runs the `PlayRouteBuilder`. In production usage, this route can be easily be put alongside existing routes, thus providing us with both benefits of Play and http4s, depending on the situation.

It's my first time using `cats`, `cats-effect`, `http4s` and `fs2`. Currently, I have two issues with this change-set and would like the following help on two things first:
**1. The unit test is failing with a strange error, which looks like this:**
```
[info] PlayServerSpec
[info] A server should
[error]   x route requests on the service executor (1 second, 629 ms)
[error]    application-akka.actor.default-dispatcher-10 doesn't start with 'http4s-spec-' (ServerSpec.scala:55)
[error] org.http4s.server.ServerSpec.$anonfun$$init$$2(ServerSpec.scala:55)
[error]   x execute the service task on the service executor (1 second, 684 ms)
[error]    application-akka.actor.default-dispatcher-3 doesn't start with 'http4s-spec-' (ServerSpec.scala:59)
[error] org.http4s.server.ServerSpec.$anonfun$$init$$5(ServerSpec.scala:59)
[info]   + be able to echo its input (1 second, 837 ms)
```
The reason why I'm not solving it myself is because I receive this strange result from `org.http4s.Response#body` (add `.map{x => println(new String(Array(x))); x}` right after `request.body` before calling `convertStream`). Maybe someone's seen this before? Why would thread names be sent as part of response body, I wouldn't know... I think I may have missed something up :-|

2. To make it prettier from FP perspective. I am 100% aware that I am using some shortcuts to "just get the job done", but I am not experienced enough in this style of Scala to know better yet.

What is missing:
- [ ] detailed testing
- [ ] documentation and use cases
- [ ] code-level documentation (references to Play docs for example)
- [x] example code (we would need it, right? Play dependency is not small for the example code)
- [ ] clean, tidy code - it's messy :-)
- [ ] mapping Play attributes and other considerations
- [ ] Tidying up the commit history

I will likely use it for my own project [ActionFPS](https://github.com/ScalaWilliam/ActionFPS) which currently doesn't scale that well code-wise (it's not composed well any more)

I'm fine if this doesn't get accepted eventually, so fire away anyway as I like to learn :-) I received plenty of help from @SystemFw so thank you so much.

Run the example with `examples-play/run`. Visit eg http://localhost:9000/science/date