### PR TITLE
copy server logging middleware to client module

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -1,0 +1,78 @@
+package org.http4s
+package client
+package middleware
+
+import cats.effect._
+import fs2._
+import org.http4s.util.CaseInsensitiveString
+import org.log4s.{Logger ⇒ SLogger}
+
+/**
+  * Simple Middleware for Logging All Requests and Responses
+  */
+object Logger {
+  def apply[F[_]: Effect](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
+  )(client: Client[F]): Client[F] =
+    Client.fromHttpService(
+      ResponseLogger(logHeaders, logBody, redactHeadersWhen)(
+        RequestLogger(logHeaders, logBody, redactHeadersWhen)(
+          client.toHttpService
+        )
+      )
+    )
+
+  def logMessage[F[_], A <: Message[F]](message: A)(
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
+      logger: SLogger)(implicit F: Effect[F]): F[Unit] = {
+
+    val charset = message.charset
+    val isBinary = message.contentType.exists(_.mediaType.binary)
+    val isJson = message.contentType.exists(mT =>
+      mT.mediaType == MediaType.`application/json` || mT.mediaType == MediaType.`application/hal+json`)
+
+    val isText = !isBinary || isJson
+
+    def prelude = message match {
+      case Request(method, uri, httpVersion, _, _, _) =>
+        s"$httpVersion $method $uri"
+
+      case Response(status, httpVersion, _, _, _) =>
+        s"$httpVersion $status"
+    }
+
+    val headers =
+      if (logHeaders)
+        message.headers.redactSensitive(redactHeadersWhen).toList.mkString("Headers(", ", ", ")")
+      else ""
+
+    val bodyStream = if (logBody && isText) {
+      message.bodyAsText(charset.getOrElse(Charset.`UTF-8`))
+    } else if (logBody) {
+      message.body
+        .fold(new StringBuilder)((sb, b) => sb.append(java.lang.Integer.toHexString(b & 0xff)))
+        .map(_.toString)
+    } else {
+      Stream.empty.covary[F]
+    }
+
+    val bodyText = if (logBody) {
+      bodyStream.fold("")(_ + _).map(text => s"""body="$text"""")
+    } else {
+      Stream("").covary[F]
+    }
+
+    if (!logBody && !logHeaders) F.unit
+    else {
+      bodyText
+        .map(body => s"$prelude $headers $body")
+        .map(text => logger.info(text))
+        .compile
+        .drain
+    }
+  }
+}

--- a/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -1,0 +1,53 @@
+package org.http4s
+package client
+package middleware
+
+import cats.data.{Kleisli, OptionT}
+import cats.effect._
+import cats.implicits._
+import fs2._
+import org.http4s.util.CaseInsensitiveString
+import org.log4s._
+import scala.concurrent.ExecutionContext
+
+/**
+  * Simple Middleware for Logging Requests As They Are Processed
+  */
+object RequestLogger {
+  private[this] val logger = getLogger
+
+  def apply[F[_]: Effect](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
+  )(service: HttpService[F])(
+      implicit ec: ExecutionContext = ExecutionContext.global): HttpService[F] =
+    Kleisli { req =>
+      if (!logBody)
+        OptionT(
+          Logger.logMessage[F, Request[F]](req)(logHeaders, logBody)(logger) *> service(req).value)
+      else
+        OptionT
+          .liftF(async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]))
+          .flatMap { vec =>
+            val newBody = Stream
+              .eval(vec.get)
+              .flatMap(v => Stream.emits(v).covary[F])
+              .flatMap(c => Stream.segment(c).covary[F])
+
+            val changedRequest = req.withBodyStream(
+              req.body
+              // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+                .observe(_.segments.flatMap(s => Stream.eval_(vec.modify(_ :+ s))))
+                .onFinalize(
+                  Logger.logMessage[F, Request[F]](req.withBodyStream(newBody))(
+                    logHeaders,
+                    logBody,
+                    redactHeadersWhen)(logger)
+                )
+            )
+
+            service(changedRequest)
+          }
+    }
+}

--- a/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -1,0 +1,53 @@
+package org.http4s
+package client
+package middleware
+
+import cats.data.Kleisli
+import cats.effect._
+import cats.implicits._
+import fs2._
+import org.http4s.util.CaseInsensitiveString
+import org.log4s.getLogger
+import scala.concurrent.ExecutionContext
+
+/**
+  * Simple middleware for logging responses as they are processed
+  */
+object ResponseLogger {
+  private[this] val logger = getLogger
+
+  def apply[F[_]](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
+  )(service: HttpService[F])(
+      implicit F: Effect[F],
+      ec: ExecutionContext = ExecutionContext.global): HttpService[F] =
+    Kleisli { req =>
+      service(req).semiflatMap { response =>
+        if (!logBody)
+          Logger.logMessage[F, Response[F]](response)(logHeaders, logBody, redactHeadersWhen)(
+            logger) *> F.delay(response)
+        else
+          async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map {
+            vec =>
+              val newBody = Stream
+                .eval(vec.get)
+                .flatMap(v => Stream.emits(v).covary[F])
+                .flatMap(c => Stream.segment(c).covary[F])
+
+              response.copy(
+                body = response.body
+                // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+                  .observe(_.segments.flatMap(s => Stream.eval_(vec.modify(_ :+ s))))
+                  .onFinalize {
+                    Logger.logMessage[F, Response[F]](response.withBodyStream(newBody))(
+                      logHeaders,
+                      logBody,
+                      redactHeadersWhen)(logger)
+                  }
+              )
+          }
+      }
+    }
+}

--- a/client/src/test/resources/testresource.txt
+++ b/client/src/test/resources/testresource.txt
@@ -1,0 +1,1 @@
+This is a test resource.

--- a/client/src/test/scala/org/http4s/client/middleware/LoggerSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/LoggerSpec.scala
@@ -1,0 +1,76 @@
+package org.http4s
+package client
+package middleware
+
+import cats.effect._
+import fs2.io.readInputStream
+import org.http4s.dsl.io._
+import scala.io.Source
+
+/**
+  * Common Tests for Logger, RequestLogger, and ResponseLogger
+  */
+class LoggerSpec extends Http4sSpec {
+
+  val testService = HttpService[IO] {
+    case GET -> Root / "request" =>
+      Ok("request response")
+    case req @ POST -> Root / "post" =>
+      Ok(req.body)
+  }
+
+  def testResource = getClass.getResourceAsStream("/testresource.txt")
+
+  def body: EntityBody[IO] = readInputStream[IO](IO.pure(testResource), 4096)
+
+  val expectedBody: String = Source.fromInputStream(testResource).mkString
+
+  "ResponseLogger" should {
+    val responseLoggerService = ResponseLogger(true, true)(testService)
+
+    "not affect a Get" in {
+      val req = Request[IO](uri = uri("/request"))
+      responseLoggerService.orNotFound(req) must returnStatus(Status.Ok)
+    }
+
+    "not affect a Post" in {
+      val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
+      val res = responseLoggerService.orNotFound(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(expectedBody)
+    }
+  }
+
+  "RequestLogger" should {
+    val requestLoggerService = RequestLogger(true, true)(testService)
+
+    "not affect a Get" in {
+      val req = Request[IO](uri = uri("/request"))
+      requestLoggerService.orNotFound(req) must returnStatus(Status.Ok)
+    }
+
+    "not affect a Post" in {
+      val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
+      val res = requestLoggerService.orNotFound(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(expectedBody)
+    }
+  }
+
+  "Logger" should {
+    val loggerService =
+      Logger(true, true)(Client.fromHttpService(testService)).toHttpService.orNotFound
+
+    "not affect a Get" in {
+      val req = Request[IO](uri = uri("/request"))
+      loggerService(req) must returnStatus(Status.Ok)
+    }
+
+    "not affect a Post" in {
+      val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
+      val res = loggerService(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(expectedBody)
+    }
+  }
+}


### PR DESCRIPTION
The copied files are mostly unchanged, except for updating the package name, running `scalafmt`, and changing the interface of `Logger.apply` to work better with `Client[F]`.

(Hopefully this is set up against the right base branch to be merged and released as part of the 0.18 series.)