### PR TITLE
Make the blaze-client tick wheel executor lazy

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
@@ -17,7 +17,7 @@ private[blaze] object bits {
   val DefaultMaxTotalConnections = 10
   val DefaultMaxWaitQueueLimit = 256
 
-  val ClientTickWheel = new TickWheelExecutor()
+  lazy val ClientTickWheel = new TickWheelExecutor()
 
   /** Caution: trusts all certificates and disables endpoint identification */
   lazy val TrustingSslContext: SSLContext = {


### PR DESCRIPTION
Having a resource allocated in an object is something we want to address in #1821.  Meanwhile, @lbialy made this monkey patch for his Graal work, and I don't see any downside for regular use.