### PR TITLE
Boopickle encoders

### DIFF
--- a/boopickle/src/main/scala/org/http4s/booPickle/BooPickleInstances.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/BooPickleInstances.scala
@@ -1,0 +1,53 @@
+package org.http4s
+package booPickle
+
+import boopickle.Default._
+import boopickle.Pickler
+import cats.Applicative
+import cats.effect.Sync
+import fs2.Chunk
+import java.nio.ByteBuffer
+import org.http4s._
+import org.http4s.EntityEncoder.chunkEncoder
+import org.http4s.headers.`Content-Type`
+import scala.util.{Failure, Success}
+
+/**
+  * Generic factories for http4s encoders/decoders for boopickle
+  * Note that the media type is set for application/octet-stream
+  */
+trait BooPickleInstances {
+
+  private def booDecoderByteBuffer[F[_]: Sync, A](msg: Message[F])(
+      implicit pickler: Pickler[A]): DecodeResult[F, A] =
+    EntityDecoder.collectBinary(msg).flatMap { segment =>
+      val bb = ByteBuffer.wrap(segment.force.toArray)
+      if (bb.hasRemaining) {
+        Unpickle[A](pickler).tryFromBytes(bb) match {
+          case Success(bb) =>
+            DecodeResult.success[F, A](bb)
+          case Failure(pf) =>
+            DecodeResult.failure[F, A](MalformedMessageBodyFailure("Invalid binary body", Some(pf)))
+        }
+      } else {
+        DecodeResult.failure[F, A](MalformedMessageBodyFailure("Invalid binary: empty body", None))
+      }
+    }
+
+  /**
+    * Create an `EntityDecoder` for `A` given a `Pickler[A]`
+    */
+  def booOf[F[_]: Sync, A: Pickler]: EntityDecoder[F, A] =
+    EntityDecoder.decodeBy(MediaType.`application/octet-stream`)(booDecoderByteBuffer[F, A])
+
+  /**
+    * Create an `EntityEncoder` for `A` given a `Pickler[A]`
+    */
+  def booEncoderOf[F[_]: Applicative, A: Pickler]: EntityEncoder[F, A] =
+    chunkEncoder[F]
+      .contramap[A] { v =>
+        Chunk.ByteBuffer(Pickle.intoBytes(v))
+      }
+      .withContentType(`Content-Type`(MediaType.`application/octet-stream`))
+
+}

--- a/boopickle/src/main/scala/org/http4s/booPickle/package.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/package.scala
@@ -1,0 +1,3 @@
+package org.http4s
+
+package object booPickle extends BooPickleInstances

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
@@ -68,5 +68,5 @@ class BoopickleSpec extends Http4sSpec with BooPickleInstances {
     }
   }
 
-  checkAll("EntityCodec[IO, Json]", EntityCodecTests[IO, Fruit].entityCodec)
+  checkAll("EntityCodec[IO, Fruit]", EntityCodecTests[IO, Fruit].entityCodec)
 }

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
@@ -1,0 +1,72 @@
+package org.http4s
+package booPickle
+
+import boopickle.Default._
+import cats.effect.IO
+import cats.Eq
+import cats.effect.laws.util.TestContext
+import org.http4s.headers.`Content-Type`
+import org.http4s.testing.EntityCodecTests
+import org.http4s.MediaType
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+
+class BoopickleSpec extends Http4sSpec with BooPickleInstances {
+  trait Fruit {
+    val weight: Double
+    def color: String
+  }
+
+  case class Banana(weight: Double) extends Fruit {
+    def color = "yellow"
+  }
+
+  case class Kiwi(weight: Double) extends Fruit {
+    def color = "brown"
+  }
+
+  case class Carambola(weight: Double) extends Fruit {
+    def color = "yellow"
+  }
+
+  implicit val fruitPickler: Pickler[Fruit] =
+    compositePickler[Fruit].addConcreteType[Banana].addConcreteType[Kiwi].addConcreteType[Carambola]
+
+  implicit val encoder = booEncoderOf[IO, Fruit]
+  implicit val decoder = booOf[IO, Fruit]
+
+  implicit val fruitArbitrary: Arbitrary[Fruit] = Arbitrary {
+    for {
+      w <- Gen.posNum[Double]
+      f <- Gen.oneOf(Banana(w), Kiwi(w), Carambola(w))
+    } yield f
+  }
+
+  implicit val fruitEq: Eq[Fruit] = Eq.fromUniversalEquals
+
+  implicit val testContext = TestContext()
+
+  "boopickle encoder" should {
+    "have octet-stream content type" in {
+      encoder.headers.get(`Content-Type`) must_== Some(
+        `Content-Type`(MediaType.`application/octet-stream`))
+    }
+  }
+
+  "booEncoderOf" should {
+    "have octect-stream content type" in {
+      booEncoderOf[IO, Fruit].headers.get(`Content-Type`) must_== Some(
+        `Content-Type`(MediaType.`application/octet-stream`))
+    }
+  }
+
+  "booOf" should {
+    "decode a class from a boopickle decoder" in {
+      val result = booOf[IO, Fruit]
+        .decode(Request[IO]().withBody(Banana(10.0): Fruit).unsafeRunSync, strict = true)
+      result.value.unsafeRunSync must_== Right(Banana(10.0))
+    }
+  }
+
+  checkAll("EntityCodec[IO, Json]", EntityCodecTests[IO, Fruit].entityCodec)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -176,6 +176,15 @@ lazy val argonaut = libraryProject("argonaut")
   )
   .dependsOn(core, testing % "test->test", jawn % "compile;test->test")
 
+lazy val boopickle = libraryProject("boopickle")
+  .settings(
+    description := "Provides Boopickle codecs for http4s",
+    libraryDependencies ++= Seq(
+      Http4sPlugin.boopickle
+    )
+  )
+  .dependsOn(core, testing % "test->test", jawn % "compile;test->test")
+
 lazy val circe = libraryProject("circe")
   .settings(
     description := "Provides Circe codecs for http4s",

--- a/build.sbt
+++ b/build.sbt
@@ -181,9 +181,10 @@ lazy val boopickle = libraryProject("boopickle")
     description := "Provides Boopickle codecs for http4s",
     libraryDependencies ++= Seq(
       Http4sPlugin.boopickle
-    )
+    ),
+    mimaPreviousArtifacts := Set.empty
   )
-  .dependsOn(core, testing % "test->test", jawn % "compile;test->test")
+  .dependsOn(core, testing % "test->test")
 
 lazy val circe = libraryProject("circe")
   .settings(

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -253,6 +253,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.1"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.0.39"
   lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.12.13"
+  lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.0"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.1.0"
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "0.10.1"
   lazy val catsEffectLaws                   = "org.typelevel"          %% "cats-effect-laws"          % catsEffect.revision


### PR DESCRIPTION
We use [boopickle](https://boopickle.suzaku.io/) on our application with the encoders in this PR. I thought this could be generally useful in http4s though I'm not sure how widely used `boopickle` is.

This is also an opportunity, to receive any criticism you may have to my implementation. In particular I'm not sure if there is enough testing

I couldn't find an aggregate on `build.sbt` to include this into the overall build. Is it needed?