### PR TITLE
Add BlockingHttp4sServlet

### DIFF
--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -15,7 +15,7 @@ import org.eclipse.jetty.util.component.LifeCycle
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
-import org.http4s.servlet.{Http4sServlet, ServletContainer, ServletIo}
+import org.http4s.servlet.{AsyncHttp4sServlet, ServletContainer, ServletIo}
 import org.log4s.getLogger
 import scala.concurrent.ExecutionContext
 import scala.collection.immutable
@@ -107,7 +107,7 @@ sealed class JettyBuilder[F[_]: Effect] private (
 
   override def mountService(service: HttpRoutes[F], prefix: String): Self =
     copy(mounts = mounts :+ Mount[F] { (context, index, builder) =>
-      val servlet = new Http4sServlet(
+      val servlet = new AsyncHttp4sServlet(
         service = service,
         asyncTimeout = builder.asyncTimeout,
         servletIo = builder.servletIo,

--- a/jetty/src/test/scala/org/http4s/server/jetty/Issue454.scala
+++ b/jetty/src/test/scala/org/http4s/server/jetty/Issue454.scala
@@ -7,7 +7,7 @@ import cats.effect.IO
 import org.eclipse.jetty.server.{HttpConfiguration, HttpConnectionFactory, Server, ServerConnector}
 import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.http4s.dsl.io._
-import org.http4s.servlet.Http4sServlet
+import org.http4s.servlet.AsyncHttp4sServlet
 
 object Issue454 {
   // If the bug is not triggered right away, try increasing or
@@ -41,7 +41,7 @@ object Issue454 {
     server.start()
   }
 
-  val servlet = new Http4sServlet[IO](
+  val servlet = new AsyncHttp4sServlet[IO](
     service = HttpRoutes.of[IO] {
       case GET -> Root => Ok(insanelyHugeData)
     },

--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -1,0 +1,142 @@
+package org.http4s
+package servlet
+
+import cats.data.OptionT
+import cats.effect._
+import cats.implicits.{catsSyntaxEither => _, _}
+import fs2.async
+import javax.servlet._
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+import org.http4s.server._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.Duration
+
+class AsyncHttp4sServlet[F[_]](
+    service: HttpRoutes[F],
+    asyncTimeout: Duration = Duration.Inf,
+    implicit private[this] val executionContext: ExecutionContext = ExecutionContext.global,
+    private[this] var servletIo: ServletIo[F],
+    serviceErrorHandler: ServiceErrorHandler[F])(implicit F: Effect[F])
+    extends Http4sServlet[F](service, servletIo) {
+  private val asyncTimeoutMillis = if (asyncTimeout.isFinite()) asyncTimeout.toMillis else -1 // -1 == Inf
+
+  private[this] val optionTSync = Sync[OptionT[F, ?]]
+
+  override def init(config: ServletConfig): Unit = {
+    super.init(config)
+
+    verifyServletIo(servletApiVersion)
+    logServletIo()
+  }
+
+  // TODO This is a dodgy check.  It will have already triggered class loading of javax.servlet.WriteListener.
+  // Remove when we can break binary compatibility.
+  private def verifyServletIo(servletApiVersion: ServletApiVersion): Unit = servletIo match {
+    case NonBlockingServletIo(chunkSize) if servletApiVersion < ServletApiVersion(3, 1) =>
+      logger.warn(
+        "Non-blocking servlet I/O requires Servlet API >= 3.1. Falling back to blocking I/O.")
+      servletIo = BlockingServletIo[F](chunkSize)
+    case _ => // cool
+  }
+
+  private def logServletIo(): Unit =
+    logger.info(servletIo match {
+      case BlockingServletIo(chunkSize) => s"Using blocking servlet I/O with chunk size $chunkSize"
+      case NonBlockingServletIo(chunkSize) =>
+        s"Using non-blocking servlet I/O with chunk size $chunkSize"
+    })
+
+  override def service(
+      servletRequest: HttpServletRequest,
+      servletResponse: HttpServletResponse): Unit =
+    try {
+      val ctx = servletRequest.startAsync()
+      ctx.setTimeout(asyncTimeoutMillis)
+      // Must be done on the container thread for Tomcat's sake when using async I/O.
+      val bodyWriter = servletIo.initWriter(servletResponse)
+      async.unsafeRunAsync(
+        toRequest(servletRequest).fold(
+          onParseFailure(_, servletResponse, bodyWriter),
+          handleRequest(ctx, _, bodyWriter)
+        )) {
+        case Right(()) =>
+          IO(ctx.complete())
+        case Left(t) =>
+          IO(errorHandler(servletRequest, servletResponse)(t))
+      }
+    } catch errorHandler(servletRequest, servletResponse)
+
+  private def handleRequest(
+      ctx: AsyncContext,
+      request: Request[F],
+      bodyWriter: BodyWriter[F]): F[Unit] = {
+    ctx.addListener(new AsyncTimeoutHandler(request, bodyWriter))
+    // Note: We're catching silly user errors in the lift => flatten.
+    val response = Async.shift(executionContext) *>
+      optionTSync
+        .suspend(serviceFn(request))
+        .getOrElse(Response.notFound)
+        .recoverWith(serviceErrorHandler(request))
+
+    val servletResponse = ctx.getResponse.asInstanceOf[HttpServletResponse]
+    renderResponse(response, servletResponse, bodyWriter)
+  }
+
+  private def errorHandler(
+      servletRequest: ServletRequest,
+      servletResponse: HttpServletResponse): PartialFunction[Throwable, Unit] = {
+    case t: Throwable if servletResponse.isCommitted =>
+      logger.error(t)("Error processing request after response was committed")
+
+    case t: Throwable =>
+      logger.error(t)("Error processing request")
+      val response = F.pure(Response[F](Status.InternalServerError))
+      // We don't know what I/O mode we're in here, and we're not rendering a body
+      // anyway, so we use a NullBodyWriter.
+      async
+        .unsafeRunAsync(renderResponse(response, servletResponse, NullBodyWriter)) { _ =>
+          IO {
+            if (servletRequest.isAsyncStarted)
+              servletRequest.getAsyncContext.complete()
+          }
+        }
+  }
+
+  private class AsyncTimeoutHandler(request: Request[F], bodyWriter: BodyWriter[F])
+      extends AbstractAsyncListener {
+    override def onTimeout(event: AsyncEvent): Unit = {
+      val ctx = event.getAsyncContext
+      val servletResponse = ctx.getResponse.asInstanceOf[HttpServletResponse]
+      async.unsafeRunAsync {
+        if (!servletResponse.isCommitted) {
+          val response =
+            F.pure(
+              Response[F](Status.InternalServerError)
+                .withEntity("Service timed out."))
+          renderResponse(response, servletResponse, bodyWriter)
+        } else {
+          logger.warn(
+            s"Async context timed out, but response was already committed: ${request.method} ${request.uri.path}")
+          F.unit
+        }
+      } {
+        case Right(()) => IO(ctx.complete())
+        case Left(t) => IO(logger.error(t)("Error timing out async context")) *> IO(ctx.complete())
+      }
+    }
+  }
+}
+
+object AsyncHttp4sServlet {
+  def apply[F[_]: Effect](
+      service: HttpRoutes[F],
+      asyncTimeout: Duration = Duration.Inf,
+      executionContext: ExecutionContext = ExecutionContext.global): AsyncHttp4sServlet[F] =
+    new AsyncHttp4sServlet[F](
+      service,
+      asyncTimeout,
+      executionContext,
+      BlockingServletIo[F](DefaultChunkSize),
+      DefaultServiceErrorHandler
+    )
+}

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -49,8 +49,8 @@ class BlockingHttp4sServlet[F[_]](
       )
 
       F.runAsync(render) {
-          case Right(_) => Sync[IO].unit
-          case Left(t) => Sync[IO].delay(errorHandler(servletResponse)(t))
+          case Right(_) => IO.unit
+          case Left(t) => IO(errorHandler(servletResponse)(t))
         }
         .unsafeRunSync()
     } catch errorHandler(servletResponse)

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -1,42 +1,17 @@
 package org.http4s
 package servlet
 
-import java.net.InetSocketAddress
-import javax.servlet._
-import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse, HttpSession}
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import cats.effect._
 import cats.implicits.{catsSyntaxEither => _, _}
-import org.http4s.headers.`Transfer-Encoding`
 import org.http4s.server._
-import org.log4s.getLogger
-
-import scala.collection.JavaConverters._
 
 class BlockingHttp4sServlet[F[_]](
     service: HttpRoutes[F],
     servletIo: BlockingServletIo[F],
     serviceErrorHandler: ServiceErrorHandler[F])(implicit F: Effect[F])
-    extends HttpServlet {
-  private[this] val logger = getLogger
-
-  private[this] var serverSoftware: ServerSoftware = _
-
-  // micro-optimization: unwrap the service and call its .run directly
-  private[this] val serviceFn = service.run
-
-  object ServletRequestKeys {
-    val HttpSession: AttributeKey[Option[HttpSession]] = AttributeKey[Option[HttpSession]]
-  }
-
-  override def init(config: ServletConfig): Unit = {
-    val servletContext = config.getServletContext
-    val servletApiVersion = ServletApiVersion(servletContext)
-    logger.info(s"Detected Servlet API version $servletApiVersion")
-
-    serverSoftware = ServerSoftware(servletContext.getServerInfo)
-  }
-
+    extends Http4sServlet[F](service, servletIo) {
   override def service(
       servletRequest: HttpServletRequest,
       servletResponse: HttpServletResponse): Unit =
@@ -55,17 +30,6 @@ class BlockingHttp4sServlet[F[_]](
         .unsafeRunSync()
     } catch errorHandler(servletResponse)
 
-  private def onParseFailure(
-      parseFailure: ParseFailure,
-      servletResponse: HttpServletResponse,
-      bodyWriter: BodyWriter[F]): F[Unit] = {
-    val response =
-      F.pure(
-        Response[F](Status.BadRequest)
-          .withEntity(parseFailure.sanitized))
-    renderResponse(response, servletResponse, bodyWriter)
-  }
-
   private def handleRequest(
       request: Request[F],
       servletResponse: HttpServletResponse,
@@ -78,28 +42,6 @@ class BlockingHttp4sServlet[F[_]](
     renderResponse(response, servletResponse, bodyWriter)
   }
 
-  private def renderResponse(
-      response: F[Response[F]],
-      servletResponse: HttpServletResponse,
-      bodyWriter: BodyWriter[F]): F[Unit] =
-    response.flatMap { resp =>
-      // Note: the servlet API gives us no undeprecated method to both set
-      // a body and a status reason.  We sacrifice the status reason.
-      F.delay {
-          servletResponse.setStatus(resp.status.code)
-          for (header <- resp.headers if header.isNot(`Transfer-Encoding`))
-            servletResponse.addHeader(header.name.toString, header.value)
-        }
-        .attempt
-        .flatMap {
-          case Right(()) => bodyWriter(resp)
-          case Left(t) =>
-            resp.body.drain.compile.drain.handleError {
-              case t2 => logger.error(t2)("Error draining body")
-            } *> F.raiseError(t)
-        }
-    }
-
   private def errorHandler(servletResponse: HttpServletResponse): PartialFunction[Throwable, Unit] = {
     case t: Throwable if servletResponse.isCommitted =>
       logger.error(t)("Error processing request after response was committed")
@@ -111,44 +53,6 @@ class BlockingHttp4sServlet[F[_]](
       // anyway, so we use a NullBodyWriter.
       val render = renderResponse(response, servletResponse, NullBodyWriter)
       F.runAsync(render)(_ => IO.unit).unsafeRunSync()
-  }
-
-  private def toRequest(req: HttpServletRequest): ParseResult[Request[F]] =
-    for {
-      method <- Method.fromString(req.getMethod)
-      uri <- Uri.requestTarget(
-        Option(req.getQueryString)
-          .map { q =>
-            s"${req.getRequestURI}?$q"
-          }
-          .getOrElse(req.getRequestURI))
-      version <- HttpVersion.fromString(req.getProtocol)
-    } yield
-      Request(
-        method = method,
-        uri = uri,
-        httpVersion = version,
-        headers = toHeaders(req),
-        body = servletIo.reader(req),
-        attributes = AttributeMap(
-          Request.Keys.PathInfoCaret(req.getContextPath.length + req.getServletPath.length),
-          Request.Keys.ConnectionInfo(
-            Request.Connection(
-              InetSocketAddress.createUnresolved(req.getRemoteAddr, req.getRemotePort),
-              InetSocketAddress.createUnresolved(req.getLocalAddr, req.getLocalPort),
-              req.isSecure
-            )),
-          Request.Keys.ServerSoftware(serverSoftware),
-          ServletRequestKeys.HttpSession(Option(req.getSession(false)))
-        )
-      )
-
-  private def toHeaders(req: HttpServletRequest): Headers = {
-    val headers = for {
-      name <- req.getHeaderNames.asScala
-      value <- req.getHeaders(name).asScala
-    } yield Header(name, value)
-    Headers(headers.toSeq: _*)
   }
 }
 

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -1,0 +1,162 @@
+package org.http4s
+package servlet
+
+import java.net.InetSocketAddress
+import javax.servlet._
+import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse, HttpSession}
+
+import cats.effect._
+import cats.implicits.{catsSyntaxEither => _, _}
+import org.http4s.headers.`Transfer-Encoding`
+import org.http4s.server._
+import org.log4s.getLogger
+
+import scala.collection.JavaConverters._
+
+class BlockingHttp4sServlet[F[_]](
+    service: HttpRoutes[F],
+    servletIo: BlockingServletIo[F],
+    serviceErrorHandler: ServiceErrorHandler[F])(implicit F: Effect[F])
+    extends HttpServlet {
+  private[this] val logger = getLogger
+
+  private[this] var serverSoftware: ServerSoftware = _
+
+  // micro-optimization: unwrap the service and call its .run directly
+  private[this] val serviceFn = service.run
+
+  object ServletRequestKeys {
+    val HttpSession: AttributeKey[Option[HttpSession]] = AttributeKey[Option[HttpSession]]
+  }
+
+  override def init(config: ServletConfig): Unit = {
+    val servletContext = config.getServletContext
+    val servletApiVersion = ServletApiVersion(servletContext)
+    logger.info(s"Detected Servlet API version $servletApiVersion")
+
+    serverSoftware = ServerSoftware(servletContext.getServerInfo)
+  }
+
+  override def service(
+      servletRequest: HttpServletRequest,
+      servletResponse: HttpServletResponse): Unit =
+    try {
+      val bodyWriter = servletIo.initWriter(servletResponse)
+
+      val render = toRequest(servletRequest).fold(
+        onParseFailure(_, servletResponse, bodyWriter),
+        handleRequest(_, servletResponse, bodyWriter)
+      )
+
+      F.runAsync(render) {
+          case Right(_) => Sync[IO].unit
+          case Left(t) => Sync[IO].delay(errorHandler(servletResponse)(t))
+        }
+        .unsafeRunSync()
+    } catch errorHandler(servletResponse)
+
+  private def onParseFailure(
+      parseFailure: ParseFailure,
+      servletResponse: HttpServletResponse,
+      bodyWriter: BodyWriter[F]): F[Unit] = {
+    val response =
+      F.pure(
+        Response[F](Status.BadRequest)
+          .withEntity(parseFailure.sanitized))
+    renderResponse(response, servletResponse, bodyWriter)
+  }
+
+  private def handleRequest(
+      request: Request[F],
+      servletResponse: HttpServletResponse,
+      bodyWriter: BodyWriter[F]): F[Unit] = {
+    // Note: We're catching silly user errors in the lift => flatten.
+    val response = serviceFn(request)
+      .getOrElse(Response.notFound)
+      .recoverWith(serviceErrorHandler(request))
+
+    renderResponse(response, servletResponse, bodyWriter)
+  }
+
+  private def renderResponse(
+      response: F[Response[F]],
+      servletResponse: HttpServletResponse,
+      bodyWriter: BodyWriter[F]): F[Unit] =
+    response.flatMap { resp =>
+      // Note: the servlet API gives us no undeprecated method to both set
+      // a body and a status reason.  We sacrifice the status reason.
+      F.delay {
+          servletResponse.setStatus(resp.status.code)
+          for (header <- resp.headers if header.isNot(`Transfer-Encoding`))
+            servletResponse.addHeader(header.name.toString, header.value)
+        }
+        .attempt
+        .flatMap {
+          case Right(()) => bodyWriter(resp)
+          case Left(t) =>
+            resp.body.drain.compile.drain.handleError {
+              case t2 => logger.error(t2)("Error draining body")
+            } *> F.raiseError(t)
+        }
+    }
+
+  private def errorHandler(servletResponse: HttpServletResponse): PartialFunction[Throwable, Unit] = {
+    case t: Throwable if servletResponse.isCommitted =>
+      logger.error(t)("Error processing request after response was committed")
+
+    case t: Throwable =>
+      logger.error(t)("Error processing request")
+      val response = F.pure(Response[F](Status.InternalServerError))
+      // We don't know what I/O mode we're in here, and we're not rendering a body
+      // anyway, so we use a NullBodyWriter.
+      val render = renderResponse(response, servletResponse, NullBodyWriter)
+      F.runAsync(render)(_ => IO.unit).unsafeRunSync()
+  }
+
+  private def toRequest(req: HttpServletRequest): ParseResult[Request[F]] =
+    for {
+      method <- Method.fromString(req.getMethod)
+      uri <- Uri.requestTarget(
+        Option(req.getQueryString)
+          .map { q =>
+            s"${req.getRequestURI}?$q"
+          }
+          .getOrElse(req.getRequestURI))
+      version <- HttpVersion.fromString(req.getProtocol)
+    } yield
+      Request(
+        method = method,
+        uri = uri,
+        httpVersion = version,
+        headers = toHeaders(req),
+        body = servletIo.reader(req),
+        attributes = AttributeMap(
+          Request.Keys.PathInfoCaret(req.getContextPath.length + req.getServletPath.length),
+          Request.Keys.ConnectionInfo(
+            Request.Connection(
+              InetSocketAddress.createUnresolved(req.getRemoteAddr, req.getRemotePort),
+              InetSocketAddress.createUnresolved(req.getLocalAddr, req.getLocalPort),
+              req.isSecure
+            )),
+          Request.Keys.ServerSoftware(serverSoftware),
+          ServletRequestKeys.HttpSession(Option(req.getSession(false)))
+        )
+      )
+
+  private def toHeaders(req: HttpServletRequest): Headers = {
+    val headers = for {
+      name <- req.getHeaderNames.asScala
+      value <- req.getHeaders(name).asScala
+    } yield Header(name, value)
+    Headers(headers.toSeq: _*)
+  }
+}
+
+object BlockingHttp4sServlet {
+  def apply[F[_]: Effect](service: HttpRoutes[F]): BlockingHttp4sServlet[F] =
+    new BlockingHttp4sServlet[F](
+      service,
+      BlockingServletIo(DefaultChunkSize),
+      DefaultServiceErrorHandler
+    )
+}

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -1,36 +1,28 @@
-package org.http4s
-package servlet
+package org.http4s.servlet
 
-import cats.data.OptionT
-import cats.effect._
-import cats.implicits.{catsSyntaxEither => _, _}
-import fs2.async
 import java.net.InetSocketAddress
-import javax.servlet._
+import javax.servlet.ServletConfig
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse, HttpSession}
+
+import cats.effect.Effect
+import cats.implicits._
+import org.http4s._
 import org.http4s.headers.`Transfer-Encoding`
-import org.http4s.server._
+import org.http4s.server.ServerSoftware
 import org.log4s.getLogger
+
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.Duration
 
-class Http4sServlet[F[_]](
-    service: HttpRoutes[F],
-    asyncTimeout: Duration = Duration.Inf,
-    implicit private[this] val executionContext: ExecutionContext = ExecutionContext.global,
-    private[this] var servletIo: ServletIo[F],
-    serviceErrorHandler: ServiceErrorHandler[F])(implicit F: Effect[F])
+abstract class Http4sServlet[F[_]](service: HttpRoutes[F], servletIo: ServletIo[F])(
+    implicit F: Effect[F])
     extends HttpServlet {
-  private[this] val logger = getLogger
-
-  private val asyncTimeoutMillis = if (asyncTimeout.isFinite()) asyncTimeout.toMillis else -1 // -1 == Inf
-
-  private[this] var serverSoftware: ServerSoftware = _
+  protected val logger = getLogger
 
   // micro-optimization: unwrap the service and call its .run directly
-  private[this] val serviceFn = service.run
-  private[this] val optionTSync = Sync[OptionT[F, ?]]
+  protected val serviceFn = service.run
+
+  protected var servletApiVersion: ServletApiVersion = _
+  private[this] var serverSoftware: ServerSoftware = _
 
   object ServletRequestKeys {
     val HttpSession: AttributeKey[Option[HttpSession]] = AttributeKey[Option[HttpSession]]
@@ -38,52 +30,12 @@ class Http4sServlet[F[_]](
 
   override def init(config: ServletConfig): Unit = {
     val servletContext = config.getServletContext
-    val servletApiVersion = ServletApiVersion(servletContext)
+    servletApiVersion = ServletApiVersion(servletContext)
     logger.info(s"Detected Servlet API version $servletApiVersion")
-
-    verifyServletIo(servletApiVersion)
-    logServletIo()
     serverSoftware = ServerSoftware(servletContext.getServerInfo)
   }
 
-  // TODO This is a dodgy check.  It will have already triggered class loading of javax.servlet.WriteListener.
-  // Remove when we can break binary compatibility.
-  private def verifyServletIo(servletApiVersion: ServletApiVersion): Unit = servletIo match {
-    case NonBlockingServletIo(chunkSize) if servletApiVersion < ServletApiVersion(3, 1) =>
-      logger.warn(
-        "Non-blocking servlet I/O requires Servlet API >= 3.1. Falling back to blocking I/O.")
-      servletIo = BlockingServletIo[F](chunkSize)
-    case _ => // cool
-  }
-
-  private def logServletIo(): Unit =
-    logger.info(servletIo match {
-      case BlockingServletIo(chunkSize) => s"Using blocking servlet I/O with chunk size $chunkSize"
-      case NonBlockingServletIo(chunkSize) =>
-        s"Using non-blocking servlet I/O with chunk size $chunkSize"
-    })
-
-  override def service(
-      servletRequest: HttpServletRequest,
-      servletResponse: HttpServletResponse): Unit =
-    try {
-      val ctx = servletRequest.startAsync()
-      ctx.setTimeout(asyncTimeoutMillis)
-      // Must be done on the container thread for Tomcat's sake when using async I/O.
-      val bodyWriter = servletIo.initWriter(servletResponse)
-      async.unsafeRunAsync(
-        toRequest(servletRequest).fold(
-          onParseFailure(_, servletResponse, bodyWriter),
-          handleRequest(ctx, _, bodyWriter)
-        )) {
-        case Right(()) =>
-          IO(ctx.complete())
-        case Left(t) =>
-          IO(errorHandler(servletRequest, servletResponse)(t))
-      }
-    } catch errorHandler(servletRequest, servletResponse)
-
-  private def onParseFailure(
+  protected def onParseFailure(
       parseFailure: ParseFailure,
       servletResponse: HttpServletResponse,
       bodyWriter: BodyWriter[F]): F[Unit] = {
@@ -94,47 +46,7 @@ class Http4sServlet[F[_]](
     renderResponse(response, servletResponse, bodyWriter)
   }
 
-  private def handleRequest(
-      ctx: AsyncContext,
-      request: Request[F],
-      bodyWriter: BodyWriter[F]): F[Unit] = {
-    ctx.addListener(new AsyncTimeoutHandler(request, bodyWriter))
-    // Note: We're catching silly user errors in the lift => flatten.
-    val response = Async.shift(executionContext) *>
-      optionTSync
-        .suspend(serviceFn(request))
-        .getOrElse(Response.notFound)
-        .recoverWith(serviceErrorHandler(request))
-
-    val servletResponse = ctx.getResponse.asInstanceOf[HttpServletResponse]
-    renderResponse(response, servletResponse, bodyWriter)
-  }
-
-  private class AsyncTimeoutHandler(request: Request[F], bodyWriter: BodyWriter[F])
-      extends AbstractAsyncListener {
-    override def onTimeout(event: AsyncEvent): Unit = {
-      val ctx = event.getAsyncContext
-      val servletResponse = ctx.getResponse.asInstanceOf[HttpServletResponse]
-      async.unsafeRunAsync {
-        if (!servletResponse.isCommitted) {
-          val response =
-            F.pure(
-              Response[F](Status.InternalServerError)
-                .withEntity("Service timed out."))
-          renderResponse(response, servletResponse, bodyWriter)
-        } else {
-          logger.warn(
-            s"Async context timed out, but response was already committed: ${request.method} ${request.uri.path}")
-          F.unit
-        }
-      } {
-        case Right(()) => IO(ctx.complete())
-        case Left(t) => IO(logger.error(t)("Error timing out async context")) *> IO(ctx.complete())
-      }
-    }
-  }
-
-  private def renderResponse(
+  protected def renderResponse(
       response: F[Response[F]],
       servletResponse: HttpServletResponse,
       bodyWriter: BodyWriter[F]): F[Unit] =
@@ -156,27 +68,7 @@ class Http4sServlet[F[_]](
         }
     }
 
-  private def errorHandler(
-      servletRequest: ServletRequest,
-      servletResponse: HttpServletResponse): PartialFunction[Throwable, Unit] = {
-    case t: Throwable if servletResponse.isCommitted =>
-      logger.error(t)("Error processing request after response was committed")
-
-    case t: Throwable =>
-      logger.error(t)("Error processing request")
-      val response = F.pure(Response[F](Status.InternalServerError))
-      // We don't know what I/O mode we're in here, and we're not rendering a body
-      // anyway, so we use a NullBodyWriter.
-      async
-        .unsafeRunAsync(renderResponse(response, servletResponse, NullBodyWriter)) { _ =>
-          IO {
-            if (servletRequest.isAsyncStarted)
-              servletRequest.getAsyncContext.complete()
-          }
-        }
-  }
-
-  private def toRequest(req: HttpServletRequest): ParseResult[Request[F]] =
+  protected def toRequest(req: HttpServletRequest): ParseResult[Request[F]] =
     for {
       method <- Method.fromString(req.getMethod)
       uri <- Uri.requestTarget(
@@ -206,25 +98,11 @@ class Http4sServlet[F[_]](
         )
       )
 
-  private def toHeaders(req: HttpServletRequest): Headers = {
+  protected def toHeaders(req: HttpServletRequest): Headers = {
     val headers = for {
       name <- req.getHeaderNames.asScala
       value <- req.getHeaders(name).asScala
     } yield Header(name, value)
     Headers(headers.toSeq: _*)
   }
-}
-
-object Http4sServlet {
-  def apply[F[_]: Effect](
-      service: HttpRoutes[F],
-      asyncTimeout: Duration = Duration.Inf,
-      executionContext: ExecutionContext = ExecutionContext.global): Http4sServlet[F] =
-    new Http4sServlet[F](
-      service,
-      asyncTimeout,
-      executionContext,
-      BlockingServletIo[F](DefaultChunkSize),
-      DefaultServiceErrorHandler
-    )
 }

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -17,7 +17,7 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
   /** Wraps an [[HttpRoutes]] and mounts it as a servlet */
   def mountService[F[_]: Effect](name: String, service: HttpRoutes[F], mapping: String = "/*")(
       implicit ec: ExecutionContext = ExecutionContext.global): ServletRegistration.Dynamic = {
-    val servlet = new Http4sServlet(
+    val servlet = new AsyncHttp4sServlet(
       service = service,
       asyncTimeout = AsyncTimeoutSupport.DefaultAsyncTimeout,
       executionContext = ec,

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -12,7 +12,7 @@ import org.apache.catalina.startup.Tomcat
 import org.apache.catalina.util.ServerInfo
 import org.apache.tomcat.util.descriptor.web.{FilterDef, FilterMap}
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
-import org.http4s.servlet.{Http4sServlet, ServletContainer, ServletIo}
+import org.http4s.servlet.{AsyncHttp4sServlet, ServletContainer, ServletIo}
 import org.log4s.getLogger
 import scala.collection.JavaConverters._
 import scala.collection.immutable
@@ -113,7 +113,7 @@ sealed class TomcatBuilder[F[_]: Effect] private (
 
   override def mountService(service: HttpRoutes[F], prefix: String): Self =
     copy(mounts = mounts :+ Mount[F] { (ctx, index, builder) =>
-      val servlet = new Http4sServlet(
+      val servlet = new AsyncHttp4sServlet(
         service = service,
         asyncTimeout = builder.asyncTimeout,
         servletIo = builder.servletIo,


### PR DESCRIPTION
The current `Http4sServlet` [uses](https://github.com/http4s/http4s/blob/release-0.18.x/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala#L70) the async `Servlet` feature in its implementation. Unfortunately this is [not supported](https://issuetracker.google.com/issues/65104189) in the Google App Engine (GAE) standard environment so that a blocking implementation is necessary.

Consider this PR as an initial draft. I started off by copying the `Http4sServlet` and ripping it apart. So there is currently quite a lot of code duplication which should be improved.

Please note that I have never worked with `Servlet` nor with `cats.Effect` before, so unfortunately some of the changes here were a bit of guesswork for me.