### PR TITLE
Prevent zero padding at servlet input chunk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,8 @@ lazy val servlet = libraryProject("servlet")
     libraryDependencies ++= Seq(
       javaxServletApi % "provided",
       jettyServer % "test",
-      jettyServlet % "test"
+      jettyServlet % "test",
+      mockito % "test"
     )
   )
   .dependsOn(server % "compile;test->test")

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -308,4 +308,5 @@ object Http4sPlugin extends AutoPlugin {
   lazy val tomcatCatalina                   = "org.apache.tomcat"      %  "tomcat-catalina"           % "9.0.7"
   lazy val tomcatCoyote                     = "org.apache.tomcat"      %  "tomcat-coyote"             % tomcatCatalina.revision
   lazy val twirlApi                         = "com.typesafe.play"      %% "twirl-api"                 % "1.3.15"
+  lazy val mockito                          = "org.mockito"            %  "mockito-core"              % "2.18.3"
 }

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -89,7 +89,7 @@ final case class NonBlockingServletIo[F[_]: Async](chunkSize: Int) extends Servl
         } else if (len == 0) {
           logger.warn("Encountered a read of length 0")
           cb(rightSome(Chunk.empty))
-        } else cb(rightSome(Chunk.bytes(buf)))
+        } else cb(rightSome(Chunk.bytes(buf, 0, len)))
       }
 
       if (in.isFinished) Stream.empty

--- a/servlet/src/test/scala/org/http4s/servlet/ServletIoSpec.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/ServletIoSpec.scala
@@ -1,0 +1,62 @@
+package org.http4s.servlet
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets.UTF_8
+import javax.servlet._
+import javax.servlet.http._
+
+import cats.effect.IO
+import org.http4s.Http4sSpec
+import org.mockito.Mockito._
+
+class ServletIoSpec extends Http4sSpec {
+
+  "NonBlockingServletIo" should {
+
+    "decode request body which is smaller than chunk size correctly" in {
+      val request = mock(classOf[HttpServletRequest])
+      when(request.getInputStream).thenReturn(new TestServletInputStream("test".getBytes(UTF_8)))
+
+      val io = NonBlockingServletIo[IO](10)
+      val body = io.reader(request)
+      val bytes = body.compile.toList.unsafeRunSync()
+
+      new String(bytes.toArray, UTF_8) must_== ("test")
+    }
+
+    "decode request body which is bigger than chunk size correctly" in {
+      val request = mock(classOf[HttpServletRequest])
+      when(request.getInputStream)
+        .thenReturn(new TestServletInputStream("testtesttest".getBytes(UTF_8)))
+
+      val io = NonBlockingServletIo[IO](10)
+      val body = io.reader(request)
+      val bytes = body.compile.toList.unsafeRunSync()
+
+      new String(bytes.toArray, UTF_8) must_== ("testtesttest")
+    }
+  }
+
+  class TestServletInputStream(body: Array[Byte]) extends ServletInputStream {
+
+    private var readListener: ReadListener = null
+    private val in = new ByteArrayInputStream(body)
+
+    override def isReady: Boolean = true
+
+    override def isFinished: Boolean = in.available() == 0
+
+    override def setReadListener(readListener: ReadListener): Unit = {
+      this.readListener = readListener
+      readListener.onDataAvailable()
+    }
+
+    override def read(): Int = {
+      val result = in.read()
+      if (in.available() == 0) {
+        readListener.onAllDataRead()
+      }
+      result
+    }
+  }
+}


### PR DESCRIPTION
Zero padded chunk causes following exception for JSON request:
```
org.http4s.MalformedMessageBodyFailure: Malformed message body: Invalid JSON
	at org.http4s.circe.CirceInstances.$anonfun$jsonDecoderByteBufferImpl$1(CirceInstances.scala:30)
	at cats.data.EitherT.$anonfun$flatMap$1(EitherT.scala:87)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:128)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:310)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:292)
	at cats.effect.internals.Callback$AsyncIdempotentCallback$$anon$3.run(Callback.scala:142)
	at cats.effect.internals.TrampolineEC.cats$effect$internals$TrampolineEC$$localRunLoop(TrampolineEC.scala:62)
	at cats.effect.internals.TrampolineEC.$anonfun$execute$1(TrampolineEC.scala:54)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:81)
	at cats.effect.internals.TrampolineEC.execute(TrampolineEC.scala:54)
	at cats.effect.internals.Callback$AsyncIdempotentCallback.apply(Callback.scala:139)
	at cats.effect.internals.Callback$AsyncIdempotentCallback.apply(Callback.scala:130)
	at org.http4s.servlet.NonBlockingServletIo.org$http4s$servlet$NonBlockingServletIo$$read$1(ServletIo.scala:92)
	at org.http4s.servlet.NonBlockingServletIo$$anon$1.onDataAvailable(ServletIo.scala:109)
	at org.eclipse.jetty.server.HttpInput.run(HttpInput.java:871)
	at org.eclipse.jetty.server.handler.ContextHandler.handle(ContextHandler.java:1339)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:398)
	at org.eclipse.jetty.server.HttpChannel.run(HttpChannel.java:264)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:673)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:591)
	at java.lang.Thread.run(Thread.java:748)
Caused by: jawn.ParseException: expected whitespace or eof got  (line 1, column 212)
	at jawn.Parser.die(Parser.scala:107)
	at jawn.SyncParser.parse(SyncParser.scala:30)
	at jawn.SupportParser.$anonfun$parseFromByteBuffer$1(SupportParser.scala:27)
	at jawn.SupportParser.parseFromByteBuffer(SupportParser.scala:27)
	at jawn.SupportParser.parseFromByteBuffer$(SupportParser.scala:26)
	at io.circe.jawn.CirceSupportParser$.parseFromByteBuffer(CirceSupportParser.scala:7)
	at io.circe.jawn.JawnParser.parseByteBuffer(JawnParser.scala:22)
	at org.http4s.circe.CirceInstances.$anonfun$jsonDecoderByteBufferImpl$1(CirceInstances.scala:25)
	... 21 common frames omitted
```