### PR TITLE
Fix deadlock in client logging middleware

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/PooledClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/PooledClientSpec.scala
@@ -78,7 +78,7 @@ class PooledClientSpec extends Http4sSpec {
     "raise error NoConnectionAllowedException if no connections are permitted for key" in {
       val u = uri("https://httpbin.org/get")
       val resp = failClient.expect[String](u).attempt.unsafeRunTimed(timeout)
-      resp must beSome(
+      resp must_== Some(
         Left(NoConnectionAllowedException(RequestKey(u.scheme.get, u.authority.get))))
     }
 

--- a/client/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -16,11 +16,9 @@ object Logger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
   )(client: Client[F]): Client[F] =
-    Client.fromHttpService(
-      ResponseLogger(logHeaders, logBody, redactHeadersWhen)(
-        RequestLogger(logHeaders, logBody, redactHeadersWhen)(
-          client.toHttpService
-        )
+    ResponseLogger.apply0(logHeaders, logBody, redactHeadersWhen)(
+      RequestLogger.apply0(logHeaders, logBody, redactHeadersWhen)(
+        client
       )
     )
 

--- a/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -16,6 +16,7 @@ import scala.concurrent.ExecutionContext
 object RequestLogger {
   private[this] val logger = getLogger
 
+  @deprecated("Deadlocks. Use apply0 until we can break compatibility.", "0.18.11")
   def apply[F[_]: Effect](
       logHeaders: Boolean,
       logBody: Boolean,
@@ -50,4 +51,36 @@ object RequestLogger {
             service(changedRequest)
           }
     }
+
+  def apply0[F[_]: Effect](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
+  )(client: Client[F])(implicit ec: ExecutionContext = ExecutionContext.global): Client[F] =
+    client.copy(open = Kleisli { req =>
+      if (!logBody)
+        Logger.logMessage[F, Request[F]](req)(logHeaders, logBody)(logger) *> client.open(req)
+      else
+        async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).flatMap {
+          vec =>
+            val newBody = Stream
+              .eval(vec.get)
+              .flatMap(v => Stream.emits(v).covary[F])
+              .flatMap(c => Stream.segment(c).covary[F])
+
+            val changedRequest = req.withBodyStream(
+              req.body
+              // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+                .observe(_.segments.flatMap(s => Stream.eval_(vec.modify(_ :+ s))))
+                .onFinalize(
+                  Logger.logMessage[F, Request[F]](req.withBodyStream(newBody))(
+                    logHeaders,
+                    logBody,
+                    redactHeadersWhen)(logger)
+                )
+            )
+
+            client.open(changedRequest)
+        }
+    })
 }

--- a/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -16,6 +16,7 @@ import scala.concurrent.ExecutionContext
 object ResponseLogger {
   private[this] val logger = getLogger
 
+  @deprecated("Deadlocks. Use apply0 until we can break compatibility.", "0.18.11")
   def apply[F[_]](
       logHeaders: Boolean,
       logBody: Boolean,
@@ -50,4 +51,41 @@ object ResponseLogger {
           }
       }
     }
+
+  def apply0[F[_]](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
+  )(client: Client[F])(
+      implicit F: Effect[F],
+      ec: ExecutionContext = ExecutionContext.global): Client[F] =
+    client.copy(open = Kleisli { req =>
+      client.open(req).flatMap {
+        case dr @ DisposableResponse(response, _) =>
+          if (!logBody)
+            Logger.logMessage[F, Response[F]](response)(logHeaders, logBody, redactHeadersWhen)(
+              logger) *> F.delay(dr)
+          else
+            async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map {
+              vec =>
+                val newBody = Stream
+                  .eval(vec.get)
+                  .flatMap(v => Stream.emits(v).covary[F])
+                  .flatMap(c => Stream.segment(c).covary[F])
+
+                dr.copy(
+                  response = response.copy(
+                    body = response.body
+                    // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+                      .observe(_.segments.flatMap(s => Stream.eval_(vec.modify(_ :+ s))))
+                      .onFinalize {
+                        Logger.logMessage[F, Response[F]](response.withBodyStream(newBody))(
+                          logHeaders,
+                          logBody,
+                          redactHeadersWhen)(logger)
+                      }
+                  ))
+            }
+      }
+    })
 }

--- a/client/src/test/scala/org/http4s/client/middleware/LoggerSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/LoggerSpec.scala
@@ -26,34 +26,33 @@ class LoggerSpec extends Http4sSpec {
   val expectedBody: String = Source.fromInputStream(testResource).mkString
 
   "ResponseLogger" should {
-    val responseLoggerService = ResponseLogger(true, true)(testService)
+    val responseLoggerClient =
+      ResponseLogger.apply0(true, true)(Client.fromHttpService(testService))
 
     "not affect a Get" in {
       val req = Request[IO](uri = uri("/request"))
-      responseLoggerService.orNotFound(req) must returnStatus(Status.Ok)
+      responseLoggerClient.status(req).unsafeRunSync() must_== Status.Ok
     }
 
     "not affect a Post" in {
       val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
-      val res = responseLoggerService.orNotFound(req)
-      res must returnStatus(Status.Ok)
-      res must returnBody(expectedBody)
+      val res = responseLoggerClient.expect[String](req)
+      res.unsafeRunSync() must_== expectedBody
     }
   }
 
   "RequestLogger" should {
-    val requestLoggerService = RequestLogger(true, true)(testService)
+    val requestLoggerClient = RequestLogger.apply0(true, true)(Client.fromHttpService(testService))
 
     "not affect a Get" in {
       val req = Request[IO](uri = uri("/request"))
-      requestLoggerService.orNotFound(req) must returnStatus(Status.Ok)
+      requestLoggerClient.status(req).unsafeRunSync() must_== Status.Ok
     }
 
     "not affect a Post" in {
       val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
-      val res = requestLoggerService.orNotFound(req)
-      res must returnStatus(Status.Ok)
-      res must returnBody(expectedBody)
+      val res = requestLoggerClient.expect[String](req)
+      res.unsafeRunSync() must_== expectedBody
     }
   }
 


### PR DESCRIPTION
Going to and from HttpService in the client logging middleware means dispose isn't called. :face_with_head_bandage: 

Unit testing this is tricky: the problem is in the client project, and we'd normally test that with `Client.fromHttpService`, but that has a trivial `dispose` method.  We need to test this somewhere we have a real client.  I manually tested this with the reproduction in #1833.

When merged to master, apply0 will replace apply.

Fixes #1833.

/cc @rhyskeepence