### PR TITLE
Removed fixed log level from Logger

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -5,7 +5,6 @@ package middleware
 import cats.effect._
 import fs2._
 import org.http4s.util.CaseInsensitiveString
-import org.log4s.{Logger ⇒ SLogger}
 
 /**
   * Simple Middleware for Logging All Requests and Responses
@@ -28,7 +27,7 @@ object Logger {
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
-      logger: SLogger)(implicit F: Effect[F]): F[Unit] = {
+        log: String => Unit)(implicit F: Effect[F]): F[Unit] = {
 
     val charset = message.charset
     val isBinary = message.contentType.exists(_.mediaType.binary)
@@ -70,7 +69,7 @@ object Logger {
     else {
       bodyText
         .map(body => s"$prelude $headers $body")
-        .map(text => logger.info(text))
+        .map(text => log(text))
         .compile
         .drain
     }

--- a/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -23,7 +23,7 @@ object RequestLogger {
   )(app: HttpApp[F])(implicit ec: ExecutionContext = ExecutionContext.global): HttpApp[F] =
     Kleisli { req =>
       if (!logBody)
-        Logger.logMessage[F, Request[F]](req)(logHeaders, logBody)(logger) *> app(req)
+        Logger.logMessage[F, Request[F]](req)(logHeaders, logBody)(logger.info(_)) *> app(req)
       else
         async
           .refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]])
@@ -41,7 +41,7 @@ object RequestLogger {
                   Logger.logMessage[F, Request[F]](req.withBodyStream(newBody))(
                     logHeaders,
                     logBody,
-                    redactHeadersWhen)(logger)
+                    redactHeadersWhen)(logger.info(_))
                 )
             )
 

--- a/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -27,7 +27,7 @@ object ResponseLogger {
       app(req).flatMap { response =>
         if (!logBody)
           Logger.logMessage[F, Response[F]](response)(logHeaders, logBody, redactHeadersWhen)(
-            logger) *> F.delay(response)
+            logger.info(_)) *> F.delay(response)
         else
           async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map {
             vec =>
@@ -44,7 +44,7 @@ object ResponseLogger {
                     Logger.logMessage[F, Response[F]](response.withBodyStream(newBody))(
                       logHeaders,
                       logBody,
-                      redactHeadersWhen)(logger)
+                      redactHeadersWhen)(logger.info(_))
                   }
               )
           }

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -5,7 +5,6 @@ package middleware
 import cats.effect._
 import fs2._
 import org.http4s.util.CaseInsensitiveString
-import org.log4s.{Logger => SLogger}
 
 /**
   * Simple Middleware for Logging All Requests and Responses
@@ -26,7 +25,7 @@ object Logger {
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
-      logger: SLogger)(implicit F: Effect[F]): F[Unit] = {
+        log: String => Unit)(implicit F: Effect[F]): F[Unit] = {
 
     val charset = message.charset
     val isBinary = message.contentType.exists(_.mediaType.binary)
@@ -68,7 +67,7 @@ object Logger {
     else {
       bodyText
         .map(body => s"$prelude $headers $body")
-        .map(text => logger.info(text))
+        .map(text => log(text))
         .compile
         .drain
     }

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -25,7 +25,7 @@ object RequestLogger {
     Kleisli { req =>
       if (!logBody)
         OptionT(
-          Logger.logMessage[F, Request[F]](req)(logHeaders, logBody)(logger) *> routes(req).value)
+          Logger.logMessage[F, Request[F]](req)(logHeaders, logBody)(logger.info(_)) *> routes(req).value)
       else
         OptionT
           .liftF(async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]))
@@ -43,7 +43,7 @@ object RequestLogger {
                   Logger.logMessage[F, Request[F]](req.withBodyStream(newBody))(
                     logHeaders,
                     logBody,
-                    redactHeadersWhen)(logger)
+                    redactHeadersWhen)(logger.info(_))
                 )
             )
 

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -27,7 +27,7 @@ object ResponseLogger {
       routes(req).semiflatMap { response =>
         if (!logBody)
           Logger.logMessage[F, Response[F]](response)(logHeaders, logBody, redactHeadersWhen)(
-            logger) *> F.delay(response)
+            logger.info(_)) *> F.delay(response)
         else
           async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map {
             vec =>
@@ -44,7 +44,7 @@ object ResponseLogger {
                     Logger.logMessage[F, Response[F]](response.withBodyStream(newBody))(
                       logHeaders,
                       logBody,
-                      redactHeadersWhen)(logger)
+                      redactHeadersWhen)(logger.info(_))
                   }
               )
           }


### PR DESCRIPTION
A small PR to remove `log4s` dependency from `Logger` and the fixed log level (`info`).

before:
```
Logger.logMessage[F, Message[F]](msg)(logHeaders, logBody)(org.log4s.Logger)
```

now:
```
Logger.logMessage[F, Message[F]](msg)(logHeaders, logBody)(message => log.info(message) // or .warn, .error, etc.)
```