### PR TITLE
Remove prometheus-server-metrics MiMa exemption

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,6 @@ lazy val prometheusServerMetrics = libraryProject("prometheus-server-metrics")
       prometheusClient,
       prometheusHotspot
     ),
-    mimaPreviousArtifacts := Set.empty
   )
   .dependsOn(server % "compile;test->test", theDsl)
 


### PR DESCRIPTION
It was necessary when it was added mid-cycle, but now it's ready to play by the rules.