### PR TITLE
Remove redundant slash check in BlazeBuilder (0.18.x)

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -128,11 +128,7 @@ class BlazeBuilder[F[_]](
     val prefixedService =
       if (prefix.isEmpty || prefix == "/") service
       else {
-        val newCaret = prefix match {
-          case "/" => 0
-          case x if x.startsWith("/") => x.length
-          case x => x.length + 1
-        }
+        val newCaret = (if (prefix.startsWith("/")) 0 else 1) + prefix.length
 
         service.local { req: Request[F] =>
           req.withAttribute(Request.Keys.PathInfoCaret(newCaret))


### PR DESCRIPTION
Targeting 0.18.x as discussed in #1856 