### PR TITLE
Add an OkHttp client (with HTTP/2) (to 0.18)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,16 @@ lazy val asyncHttpClient = libraryProject("async-http-client")
   )
   .dependsOn(core, testing % "test->test", client % "compile;test->test")
 
+lazy val okHttpClient = libraryProject("okhttp-client")
+  .settings(
+    description := "okhttp implementation for http4s clients",
+    libraryDependencies ++= Seq(
+      Http4sPlugin.okhttp
+    )
+  )
+  .dependsOn(core, testing % "test->test", client % "compile;test->test")
+
+
 lazy val servlet = libraryProject("servlet")
   .settings(
     description := "Portable servlet implementation for http4s servers",

--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,8 @@ lazy val okHttpClient = libraryProject("okhttp-client")
     description := "okhttp implementation for http4s clients",
     libraryDependencies ++= Seq(
       Http4sPlugin.okhttp
-    )
+    ),
+    mimaPreviousArtifacts := Set.empty // remove me once merged
   )
   .dependsOn(core, testing % "test->test", client % "compile;test->test")
 

--- a/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttp.scala
+++ b/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttp.scala
@@ -63,10 +63,13 @@ object OkHttp {
     )
   }
 
-  def stream[F[_]](config: F[OkHttpClient.Builder] = null)(
+  def stream[F[_]]()(implicit F: Effect[F], ec: ExecutionContext): Stream[F, Client[F]] =
+    stream(defaultConfig[F]())
+
+  def stream[F[_]](config: F[OkHttpClient.Builder])(
       implicit F: Effect[F],
       ec: ExecutionContext): Stream[F, Client[F]] =
-    Stream.bracket(apply(Option(config).getOrElse(defaultconfig[F]())))(c => Stream.emit(c), _.shutdown)
+    Stream.bracket(apply(config))(c => Stream.emit(c), _.shutdown)
 
   private def handler[F[_]](cb: Either[Throwable, DisposableResponse[F]] => Unit)(
       implicit F: Effect[F],

--- a/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttp.scala
+++ b/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttp.scala
@@ -1,0 +1,134 @@
+package org.http4s.client.okhttp
+
+import java.io.IOException
+
+import cats.data._
+import cats.effect._
+import cats.effect.implicits._
+import okhttp3.{
+  Call,
+  Callback,
+  OkHttpClient,
+  Protocol,
+  RequestBody,
+  Headers => OKHeaders,
+  MediaType => OKMediaType,
+  Request => OKRequest,
+  Response => OKResponse
+}
+import okio.BufferedSink
+import org.http4s.{Header, Headers, HttpVersion, Method, Request, Response, Status}
+import org.http4s.client.{Client, DisposableResponse}
+import fs2.Stream._
+import fs2._
+import fs2.io._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+object OkHttp {
+
+  val defaultconfig = new OkHttpClient.Builder()
+    .protocols(
+      List(
+        Protocol.HTTP_2,
+        Protocol.HTTP_1_1
+      ).asJava)
+
+  def apply[F[_]](config: OkHttpClient.Builder = defaultconfig)(
+      implicit F: Effect[F],
+      ec: ExecutionContext): Client[F] = {
+    val client = config.build()
+    Client(
+      Kleisli { req =>
+        F.async[DisposableResponse[F]] { cb =>
+          client.newCall(toOkHttpRequest(req)).enqueue(handler(cb))
+          ()
+        }
+      },
+      F.delay({
+        client.dispatcher.executorService().shutdown()
+        client.connectionPool().evictAll()
+        if (client.cache() != null) {
+          client.cache().close()
+        }
+      })
+    )
+  }
+
+  def stream[F[_]](config: OkHttpClient.Builder = defaultconfig)(
+      implicit F: Effect[F],
+      ec: ExecutionContext): Stream[F, Client[F]] =
+    Stream.bracket(F.delay(apply(config)))(c => Stream.emit(c), _.shutdown)
+
+  private def handler[F[_]](cb: Either[Throwable, DisposableResponse[F]] => Unit)(
+      implicit F: Effect[F],
+      ec: ExecutionContext): Callback =
+    new Callback {
+      override def onFailure(call: Call, e: IOException): Unit =
+        ec.execute(() => cb(Left(e)))
+
+      override def onResponse(call: Call, response: OKResponse): Unit = {
+        val protocol = response.protocol() match {
+          case Protocol.HTTP_2 => HttpVersion.`HTTP/2.0`
+          case Protocol.HTTP_1_1 => HttpVersion.`HTTP/1.1`
+          case Protocol.HTTP_1_0 => HttpVersion.`HTTP/1.0`
+          case _ => HttpVersion.`HTTP/1.1`
+        }
+        val bodyStream = response.body.byteStream()
+        val dr = new DisposableResponse[F](
+          Response[F](headers = getHeaders(response), httpVersion = protocol)
+            .withStatus(
+              Status
+                .fromInt(response.code())
+                .getOrElse(Status.apply(response.code())))
+            .withBodyStream(readInputStream(F.pure(bodyStream), chunkSize = 1024, closeAfterUse = true)),
+          F.delay({ bodyStream.close(); () })
+        )
+        ec.execute(() => cb(Right(dr)))
+      }
+    }
+
+  private def getHeaders(response: OKResponse): Headers =
+    Headers(response.headers().names().asScala.toList.flatMap { v =>
+      response.headers().values(v).asScala.map(Header(v, _))
+    })
+
+  private def toOkHttpRequest[F[_]](req: Request[F])(implicit F: Effect[F]): OKRequest = {
+    val body = req match {
+      case _ if req.isChunked || req.contentLength.isDefined =>
+        new RequestBody {
+          override def contentType(): OKMediaType =
+            req.contentType.map(c => OKMediaType.parse(c.toString())).orNull
+
+          override def writeTo(sink: BufferedSink): Unit =
+            req.body.chunks
+              .map(_.toArray)
+              .to(Sink { b: Array[Byte] =>
+                F.delay {
+                  sink.write(b); ()
+                }
+              })
+              .compile
+              .drain
+              .runAsync(_ => IO.unit)
+              .unsafeRunSync()
+        }
+        // if it's a GET or HEAD, okhttp wants us to pass null
+      case _ if req.method == Method.GET || req.method == Method.HEAD => null
+        // for anything else we can pass a body which produces no output
+      case _ =>
+        new RequestBody {
+          override def contentType(): OKMediaType = null
+          override def writeTo(sink: BufferedSink): Unit = ()
+        }
+    }
+
+    new OKRequest.Builder()
+      .headers(OKHeaders.of(req.headers.toList.map(h => (h.name.value, h.value)).toMap.asJava))
+      .method(req.method.toString(), body)
+      .url(req.uri.toString())
+      .build()
+  }
+
+}

--- a/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttp.scala
+++ b/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttp.scala
@@ -37,10 +37,14 @@ object OkHttp {
         ).asJava)
   }
 
+  /** Create an okhttp client with the default config */
+  def apply[F[_]]()(implicit F: Effect[F], ec: ExecutionContext): F[Client[F]] =
+    apply(defaultconfig[F]())
 
-  def apply[F[_]](config: F[OkHttpClient.Builder] = null)(
+  /** Create an okhttp client with a supplied config */
+  def apply[F[_]](config: F[OkHttpClient.Builder])(
       implicit F: Effect[F],
-      ec: ExecutionContext): F[Client[F]] = F.map(Option(config).getOrElse(defaultconfig[F]())) { c =>
+      ec: ExecutionContext): F[Client[F]] = F.map(config) { c =>
     val client = c.build()
     Client(
       Kleisli { req =>

--- a/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttp.scala
+++ b/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttp.scala
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext
 
 object OkHttp {
 
-  val defaultconfig = new OkHttpClient.Builder()
+  val defaultconfig: OkHttpClient.Builder = new OkHttpClient.Builder()
     .protocols(
       List(
         Protocol.HTTP_2,
@@ -37,7 +37,7 @@ object OkHttp {
 
   def apply[F[_]](config: OkHttpClient.Builder = defaultconfig)(
       implicit F: Effect[F],
-      ec: ExecutionContext): Client[F] = {
+      ec: ExecutionContext): F[Client[F]] = F.delay {
     val client = config.build()
     Client(
       Kleisli { req =>
@@ -59,7 +59,7 @@ object OkHttp {
   def stream[F[_]](config: OkHttpClient.Builder = defaultconfig)(
       implicit F: Effect[F],
       ec: ExecutionContext): Stream[F, Client[F]] =
-    Stream.bracket(F.delay(apply(config)))(c => Stream.emit(c), _.shutdown)
+    Stream.bracket(apply(config))(c => Stream.emit(c), _.shutdown)
 
   private def handler[F[_]](cb: Either[Throwable, DisposableResponse[F]] => Unit)(
       implicit F: Effect[F],

--- a/okhttp-client/src/test/scala/org/http4s/client/okhttp/OkHttpClientSpec.scala
+++ b/okhttp-client/src/test/scala/org/http4s/client/okhttp/OkHttpClientSpec.scala
@@ -7,5 +7,5 @@ import cats.effect.{Effect, IO}
 class OkHttpClientSpec
     extends ClientRouteTestBattery(
       "OkHttp",
-      OkHttp()(Effect[IO], Http4sSpec.TestExecutionContext)
+      OkHttp()(Effect[IO], Http4sSpec.TestExecutionContext).unsafeRunSync()
     )

--- a/okhttp-client/src/test/scala/org/http4s/client/okhttp/OkHttpClientSpec.scala
+++ b/okhttp-client/src/test/scala/org/http4s/client/okhttp/OkHttpClientSpec.scala
@@ -1,0 +1,11 @@
+package org.http4s
+package client
+package okhttp
+
+import cats.effect.{Effect, IO}
+
+class OkHttpClientSpec
+    extends ClientRouteTestBattery(
+      "OkHttp",
+      OkHttp()(Effect[IO], Http4sSpec.TestExecutionContext)
+    )

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -296,6 +296,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val logbackClassic                   = "ch.qos.logback"         %  "logback-classic"           % "1.2.3"
   lazy val metricsCore                      = "io.dropwizard.metrics"  %  "metrics-core"              % "4.0.2"
   lazy val metricsJson                      = "io.dropwizard.metrics"  %  "metrics-json"              % metricsCore.revision
+  lazy val okhttp                           = "com.squareup.okhttp3"   %  "okhttp"                    % "3.10.0"
   lazy val prometheusClient                 = "io.prometheus"          %  "simpleclient_common"       % "0.4.0"
   lazy val prometheusHotspot                = "io.prometheus"          %  "simpleclient_hotspot"      % prometheusClient.revision
   lazy val parboiled                        = "org.http4s"             %% "parboiled"                 % "1.0.0"


### PR DESCRIPTION
This adds an OkHttp implementation for Client.

This is heavily based on the one for async-http-client.

The motivation for this is to have a Client backend which is capable of HTTP/2.

This PR continues https://github.com/http4s/http4s/pull/1851 and is against `release-0.18.x` in stead of master