### PR TITLE
Docs: improve client doc

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -56,7 +56,7 @@ final case class DisposableResponse[F[_]](response: Response[F], dispose: F[Unit
   *             a [[Request]].  This is a low-level operation intended for client
   *             implementations and middleware.
   *
-  * @param shutdown an effect to shut down this Shutdown this client, closing any
+  * @param shutdown an effect to shut down this client, closing any
   *                 open connections and freeing resources
   */
 final case class Client[F[_]](

--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -46,14 +46,15 @@ val server = builder.unsafeRunSync
 A good default choice is the `Http1Client`.  The `Http1Client` maintains a connection pool and
 speaks HTTP 1.x.
 
-Note: In production code you would want to use `Http1Client.stream[F[_]: Effect]: Stream[F, Http1Client]`
-to safely acquire and release resources. In the documentation we are forced to use `.unsafeRunSync` to 
+Note: In production code you would want to use `Http1Client.stream[F[_]: Effect]: Stream[F, Client[F]]`
+to safely acquire and release resources. In the documentation we are forced to use `.unsafeRunSync` to
 create the client.
 
 ```tut:book
 import org.http4s.client.blaze._
+import org.http4s.client._
 
-val httpClient = Http1Client[IO]().unsafeRunSync
+val httpClient: Client[IO] = Http1Client[IO]().unsafeRunSync
 ```
 
 ### Describing a call


### PR DESCRIPTION
The documentation says that when using `.stream` you'll receive
a `Stream[F, Http1Client]`, this is false. The method returns a
`Client[F]`.

I've also added the type on the `val` below just to make it obvious
what you have at this point. To me, it was not when I first reached
into the doc.