### PR TITLE
Move ServerSoftware to top-level package

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -7,7 +7,6 @@ import fs2.text._
 import java.io.File
 import java.net.{InetAddress, InetSocketAddress}
 import org.http4s.headers._
-import org.http4s.server.ServerSoftware
 import org.log4s.getLogger
 
 /**

--- a/core/src/main/scala/org/http4s/ServerSoftware.scala
+++ b/core/src/main/scala/org/http4s/ServerSoftware.scala
@@ -1,4 +1,4 @@
-package org.http4s.server
+package org.http4s
 
 final case class ServerSoftware(
     product: String,

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -8,7 +8,6 @@ import cats.effect.Effect
 import cats.implicits.{catsSyntaxEither => _, _}
 import org.http4s._
 import org.http4s.headers.`Transfer-Encoding`
-import org.http4s.server.ServerSoftware
 import org.log4s.getLogger
 
 import scala.collection.JavaConverters._

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -33,7 +33,7 @@ it.
 * Add `BlockingHttp4sServlet` for use in Google App Engine and Servlet 2.5 containers.  Rename `Http4sServlet` to `AsyncHttp4sServlet`. [#1830](https://github.com/http4s/http4s/pull/1830)
 * Generalize `Logger` middleware to log with `String => Unit` instead of `logger.info(_)` [#1839](https://github.com/http4s/http4s/pull/1839)
 * Rename `RequestLogger.apply0` and `ResponseLogger.apply0` to `RequestLogger.apply` and `ResponseLogger.apply`.  [#1837](https://github.com/http4s/http4s/pull/1837)
-* Move `org.http4s.server.ServerSoftware` to `org.http4s.ServerSoftware` [#1883](https://github.com/http4s/http4s/pull/1883)
+* Move `org.http4s.server.ServerSoftware` to `org.http4s.ServerSoftware` [#1884](https://github.com/http4s/http4s/pull/1884)
 * Dependency upgrades:
   * async-http-client-2.4.7
   * blaze-0.14.0-M3

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -33,6 +33,7 @@ it.
 * Add `BlockingHttp4sServlet` for use in Google App Engine and Servlet 2.5 containers.  Rename `Http4sServlet` to `AsyncHttp4sServlet`. [#1830](https://github.com/http4s/http4s/pull/1830)
 * Generalize `Logger` middleware to log with `String => Unit` instead of `logger.info(_)` [#1839](https://github.com/http4s/http4s/pull/1839)
 * Rename `RequestLogger.apply0` and `ResponseLogger.apply0` to `RequestLogger.apply` and `ResponseLogger.apply`.  [#1837](https://github.com/http4s/http4s/pull/1837)
+* Move `org.http4s.server.ServerSoftware` to `org.http4s.ServerSoftware` [#1883](https://github.com/http4s/http4s/pull/1883)
 * Dependency upgrades:
   * async-http-client-2.4.7
   * blaze-0.14.0-M3


### PR DESCRIPTION
http4s-core shouldn't have anything in the `org.http4s.server` package.