### PR TITLE
Replace link in documentation; Task->cats-effect

### DIFF
--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -40,10 +40,10 @@ An `HttpRoutes[F]` is a simple alias for
 `Kleisli[OptionT[F, ?[, Request, Response]`.  If that's meaningful to you,
 great.  If not, don't panic: `Kleisli` is just a convenient wrapper
 around a `Request => F[Response]`, and `F` is an effectful
-operation.  We'll teach you what you need to know as we go, or you
-can, uh, fork a task to read these introductions first:
+operation.  We'll teach you what you need to know as we go, or if you
+prefer you can read these introductions first:
 
-* [Scalaz Task: The Missing Documentation]
+* [cats-effect: The IO Monad for Scala]
 * [Cats Kleisli Datatype]
 
 ### Defining your service
@@ -178,5 +178,5 @@ object Main extends StreamApp[IO] {
 [blaze]: https://github.com/http4s/blaze
 [tut]: https://github.com/tpolecat/tut
 [Cats Kleisli Datatype]: https://typelevel.org/cats/datatypes/kleisli.html
-[Scalaz Task: The Missing Documentation]: http://timperrett.com/2014/07/20/scalaz-task-the-missing-documentation/
+[cats-effect: The IO Monad for Scala]: https://typelevel.org/cats-effect/
 [http4s-dsl]: ../dsl


### PR DESCRIPTION
I changed the link and removed the pun about "task" (since there is no mention of `Task` anymore).
