### PR TITLE
Altered Logger, RequestLogger and ResponseLogger to be more parametric using Kleisli

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -22,7 +22,7 @@ object RequestLogger {
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: String => Unit = logger.info(_)
   )(@deprecatedName('service) http: Kleisli[F, Request[F], Response[F]])(
-      implicit ec: ExecutionContext = ExecutionContext.global,
+      implicit ec: ExecutionContext,
       F: Sync[F]): Kleisli[F, Request[F], Response[F]] =
     Kleisli { req =>
       if (!logBody) {

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -5,11 +5,9 @@ package middleware
 import cats.data.Kleisli
 import cats.effect._
 import cats.implicits._
-import cats.~>
 import fs2._
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger
-
 import scala.concurrent.ExecutionContext
 
 /**
@@ -18,44 +16,44 @@ import scala.concurrent.ExecutionContext
 object ResponseLogger {
   private[this] val logger = getLogger
 
-  def apply[F[_]: Sync, G[_]: Effect, A](f: G ~> F, logAction: String => Unit = logger.info(_))(
-                            logHeaders: Boolean,
-                            logBody: Boolean,
-                            redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
-                            @deprecatedName('service) http: Kleisli[F, A, Response[G]])(
-                            implicit ec: ExecutionContext = ExecutionContext.global): Kleisli[F, A, Response[G]] = {
-
-    Kleisli { req =>
+  def apply[F[_]: Effect, A](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: String => Unit = logger.info(_))(
+      @deprecatedName('service) http: Kleisli[F, A, Response[F]])(
+      implicit ec: ExecutionContext = ExecutionContext.global,
+      F: Sync[F]): Kleisli[F, A, Response[F]] =
+    Kleisli[F, A, Response[F]] { req =>
       http(req)
         .flatMap { response =>
           if (!logBody)
-            f(Logger.logMessage[G, Response[G]](response)(logHeaders, logBody, redactHeadersWhen)(
-              logAction) *> Effect[G].delay(response))
+            Logger.logMessage[F, Response[F]](response)(logHeaders, logBody, redactHeadersWhen)(
+              logAction) *> F.delay(response)
           else
-            f(async.refOf[G, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map {
+            async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map {
               vec =>
                 val newBody = Stream
                   .eval(vec.get)
-                  .flatMap(v => Stream.emits(v).covary[G])
-                  .flatMap(c => Stream.segment(c).covary[G])
+                  .flatMap(v => Stream.emits(v).covary[F])
+                  .flatMap(c => Stream.segment(c).covary[F])
 
                 response.copy(
                   body = response.body
-                    // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+                  // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
                     .observe(_.segments.flatMap(s => Stream.eval_(vec.modify(_ :+ s))))
                     .onFinalize {
-                      Logger.logMessage[G, Response[G]](response.withBodyStream(newBody))(
+                      Logger.logMessage[F, Response[F]](response.withBodyStream(newBody))(
                         logHeaders,
                         logBody,
                         redactHeadersWhen)(logAction)
                     }
                 )
-            })
+            }
         }
         .handleErrorWith(t =>
-          f(Effect[G].delay(logger.info(s"service raised an error: ${t.getClass}")) *> Effect[G]
-            .raiseError[Response[G]](t)))
+          F.delay(logger.info(s"service raised an error: ${t.getClass}")) *> F
+            .raiseError[Response[F]](t))
     }
-  }
 
 }

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -2,12 +2,14 @@ package org.http4s
 package server
 package middleware
 
-import cats.data.{Kleisli, OptionT}
+import cats.data.Kleisli
 import cats.effect._
 import cats.implicits._
+import cats.~>
 import fs2._
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger
+
 import scala.concurrent.ExecutionContext
 
 /**
@@ -16,42 +18,44 @@ import scala.concurrent.ExecutionContext
 object ResponseLogger {
   private[this] val logger = getLogger
 
-  def apply[F[_]](
-      logHeaders: Boolean,
-      logBody: Boolean,
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains
-  )(@deprecatedName('service) routes: HttpRoutes[F])(
-      implicit F: Effect[F],
-      ec: ExecutionContext = ExecutionContext.global): HttpRoutes[F] =
+  def apply[F[_]: Sync, G[_]: Effect, A](f: G ~> F, logAction: String => Unit = logger.info(_))(
+                            logHeaders: Boolean,
+                            logBody: Boolean,
+                            redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
+                            @deprecatedName('service) http: Kleisli[F, A, Response[G]])(
+                            implicit ec: ExecutionContext = ExecutionContext.global): Kleisli[F, A, Response[G]] = {
+
     Kleisli { req =>
-      routes(req)
-        .semiflatMap { response =>
+      http(req)
+        .flatMap { response =>
           if (!logBody)
-            Logger.logMessage[F, Response[F]](response)(logHeaders, logBody, redactHeadersWhen)(
-              logger.info(_)) *> F.delay(response)
+            f(Logger.logMessage[G, Response[G]](response)(logHeaders, logBody, redactHeadersWhen)(
+              logAction) *> Effect[G].delay(response))
           else
-            async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map {
+            f(async.refOf[G, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).map {
               vec =>
                 val newBody = Stream
                   .eval(vec.get)
-                  .flatMap(v => Stream.emits(v).covary[F])
-                  .flatMap(c => Stream.segment(c).covary[F])
+                  .flatMap(v => Stream.emits(v).covary[G])
+                  .flatMap(c => Stream.segment(c).covary[G])
 
                 response.copy(
                   body = response.body
-                  // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+                    // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
                     .observe(_.segments.flatMap(s => Stream.eval_(vec.modify(_ :+ s))))
                     .onFinalize {
-                      Logger.logMessage[F, Response[F]](response.withBodyStream(newBody))(
+                      Logger.logMessage[G, Response[G]](response.withBodyStream(newBody))(
                         logHeaders,
                         logBody,
-                        redactHeadersWhen)(logger.info(_))
+                        redactHeadersWhen)(logAction)
                     }
                 )
-            }
+            })
         }
         .handleErrorWith(t =>
-          OptionT.liftF(F.delay(logger.info(s"service raised an error: ${t.getClass}")) *> F
-            .raiseError[Response[F]](t)))
+          f(Effect[G].delay(logger.info(s"service raised an error: ${t.getClass}")) *> Effect[G]
+            .raiseError[Response[G]](t)))
     }
+  }
+
 }

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -22,7 +22,7 @@ object ResponseLogger {
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: String => Unit = logger.info(_))(
       @deprecatedName('service) http: Kleisli[F, A, Response[F]])(
-      implicit ec: ExecutionContext = ExecutionContext.global,
+      implicit ec: ExecutionContext,
       F: Sync[F]): Kleisli[F, A, Response[F]] =
     Kleisli[F, A, Response[F]] { req =>
       http(req)

--- a/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
@@ -2,9 +2,11 @@ package org.http4s
 package server
 package middleware
 
+import cats.data.OptionT
 import cats.effect._
 import fs2.io.readInputStream
 import org.http4s.dsl.io._
+
 import scala.io.Source
 
 /**
@@ -26,7 +28,7 @@ class LoggerSpec extends Http4sSpec {
   val expectedBody: String = Source.fromInputStream(testResource).mkString
 
   "ResponseLogger" should {
-    val app = ResponseLogger(true, true)(testRoutes).orNotFound
+    val app = ResponseLogger(OptionT.liftK[IO])(true, true)(testRoutes).orNotFound
 
     "not affect a Get" in {
       val req = Request[IO](uri = uri("/request"))
@@ -42,7 +44,7 @@ class LoggerSpec extends Http4sSpec {
   }
 
   "RequestLogger" should {
-    val app = RequestLogger(true, true)(testRoutes).orNotFound
+    val app = RequestLogger(OptionT.liftK[IO])(true, true)(testRoutes).orNotFound
 
     "not affect a Get" in {
       val req = Request[IO](uri = uri("/request"))
@@ -58,7 +60,7 @@ class LoggerSpec extends Http4sSpec {
   }
 
   "Logger" should {
-    val app = Logger(true, true)(testRoutes).orNotFound
+    val app = Logger(OptionT.liftK[IO])(true, true)(testRoutes).orNotFound
 
     "not affect a Get" in {
       val req = Request[IO](uri = uri("/request"))

--- a/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
@@ -17,8 +17,8 @@ class LoggerSpec extends Http4sSpec {
       Ok("request response")
     case req @ POST -> Root / "post" =>
       Ok(req.body)
-    case r =>
-      IO.pure(Response[IO](Ok).withEntity(r.body))
+    case _ =>
+      Ok()
   }
 
   def testResource = getClass.getResourceAsStream("/testresource.txt")


### PR DESCRIPTION
Couple of concerns:

1. Lost the handling of a none in F inside RequestLogger. Would this need to be handled in the passed in natural transformation?

2. Existing spec only appears to assert that there is no impact on the requests, not that the logging occurs. Also doesn't exercise the !logBody paths.

Thanks in advance for review and feedback.