### PR TITLE
Change BasicCredentials extractor to return (username, password)

### DIFF
--- a/core/src/main/scala/org/http4s/Credentials.scala
+++ b/core/src/main/scala/org/http4s/Credentials.scala
@@ -81,10 +81,12 @@ object BasicCredentials {
     }
   }
 
-  def unapply(creds: Credentials): Option[BasicCredentials] =
+  def unapply(creds: Credentials): Option[(String, String)] =
     creds match {
-      case Credentials.Token(AuthScheme.Basic, token) =>
-        Some(BasicCredentials(token))
+      case Credentials.Token(AuthScheme.Basic, token) => {
+        val basicCredentials = BasicCredentials(token)
+        Some(basicCredentials.username, basicCredentials.password)
+      }
       case _ =>
         None
     }

--- a/core/src/main/scala/org/http4s/Credentials.scala
+++ b/core/src/main/scala/org/http4s/Credentials.scala
@@ -85,7 +85,7 @@ object BasicCredentials {
     creds match {
       case Credentials.Token(AuthScheme.Basic, token) => {
         val basicCredentials = BasicCredentials(token)
-        Some(basicCredentials.username, basicCredentials.password)
+        Some((basicCredentials.username, basicCredentials.password))
       }
       case _ =>
         None

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
@@ -47,8 +47,8 @@ object BasicAuth {
   private def validatePassword[F[_], A](validate: BasicAuthenticator[F, A], req: Request[F])(
       implicit F: Applicative[F]): F[Option[A]] =
     req.headers.get(Authorization) match {
-      case Some(Authorization(BasicCredentials(creds))) =>
-        validate(creds)
+      case Some(Authorization(BasicCredentials(username, password))) =>
+        validate(BasicCredentials(username, password))
       case _ =>
         F.pure(None)
     }


### PR DESCRIPTION
Changes the BasicCredentials extractor to give (username, password).

This is motivated by having a `Credentials` object and needing the authentication information. Currently, the pattern match looks like
```scala
authInfo match {
  case BasicCredentials(BasicCredentials(username, password)) => ...
  ...
}
```

After this change, it now looks like
```scala
authInfo match {
  case BasicCredentials(username, password) => ...
  ...
}
```