### PR TITLE
Fix AutoSlash in Router

### DIFF
--- a/server/src/main/scala/org/http4s/server/Router.scala
+++ b/server/src/main/scala/org/http4s/server/Router.scala
@@ -18,7 +18,7 @@ object Router {
 
   /**
     * Defines an [[HttpRoutes]] based on list of mappings and
-    * a default Service to be used when none in the list match incomming requests.
+    * a default Service to be used when none in the list match incoming requests.
     *
     * The mappings are processed in descending order (longest first) of prefix length.
     */

--- a/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
@@ -5,6 +5,7 @@ package middleware
 import cats._
 import cats.data.Kleisli
 import cats.implicits._
+import org.http4s.server.middleware.URITranslation.translateRoot
 
 /** Removes a trailing slash from [[Request]] path
   *
@@ -21,8 +22,11 @@ object AutoSlash {
         val pi = req.pathInfo
         if (pi.isEmpty || pi.charAt(pi.length - 1) != '/')
           F.empty
-        else
-          http(req.withPathInfo(pi.substring(0, pi.length - 1)))
+        else {
+          // Translate the service, in case it comes from a Router with a prefix
+          val translated = translateRoot(req.scriptName)(http)
+          translated(req.withPathInfo(pi.substring(0, pi.length - 1)))
+        }
       }
     }
 }


### PR DESCRIPTION
Fixes #1378 (again)

The problem is that just doing `withPathInfo`, the "translated-away" prefix of the prefixed route is added again.

This PR fixes that by calling `translateRoot` on the service with a prefix of `req.scriptName`.

I'm not sure this is a good way of solving the problem, but it was the one I could see.