### PR TITLE
Add StaticHeaders middleware

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/StaticHeaders.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/StaticHeaders.scala
@@ -1,0 +1,17 @@
+package org.http4s.server.middleware
+
+import cats.Functor
+import cats.data.{Kleisli, NonEmptyList}
+import org.http4s.{CacheDirective, Header, Headers, HttpService}
+import org.http4s.headers.`Cache-Control`
+
+object StaticHeaders {
+
+  def apply[F[_]: Functor](headers: Headers)(service: HttpService[F]): HttpService[F] = 
+    Kleisli { req =>
+      service(req).map(resp => resp.copy(headers = headers ++ resp.headers))
+    }
+
+  private val noCacheHeader: Header = `Cache-Control`(NonEmptyList.of(CacheDirective.`no-cache`()))
+  def `no-cache`[F[_]: Functor](service: HttpService[F]): HttpService[F] = StaticHeaders[F](Headers(noCacheHeader))(service)
+}

--- a/server/src/main/scala/org/http4s/server/middleware/StaticHeaders.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/StaticHeaders.scala
@@ -5,6 +5,9 @@ import cats.data.{Kleisli, NonEmptyList}
 import org.http4s.{CacheDirective, Header, Headers, HttpService}
 import org.http4s.headers.`Cache-Control`
 
+/**
+  * Simple Middleware for adding a static set of headers to responses returned by the service.
+  */
 object StaticHeaders {
 
   def apply[F[_]: Functor](headers: Headers)(service: HttpService[F]): HttpService[F] = 

--- a/server/src/main/scala/org/http4s/server/middleware/StaticHeaders.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/StaticHeaders.scala
@@ -10,11 +10,12 @@ import org.http4s.headers.`Cache-Control`
   */
 object StaticHeaders {
 
-  def apply[F[_]: Functor](headers: Headers)(service: HttpService[F]): HttpService[F] = 
+  def apply[F[_]: Functor](headers: Headers)(service: HttpService[F]): HttpService[F] =
     Kleisli { req =>
       service(req).map(resp => resp.copy(headers = headers ++ resp.headers))
     }
 
   private val noCacheHeader: Header = `Cache-Control`(NonEmptyList.of(CacheDirective.`no-cache`()))
-  def `no-cache`[F[_]: Functor](service: HttpService[F]): HttpService[F] = StaticHeaders[F](Headers(noCacheHeader))(service)
+  def `no-cache`[F[_]: Functor](service: HttpService[F]): HttpService[F] =
+    StaticHeaders[F](Headers(noCacheHeader))(service)
 }

--- a/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSpec.scala
@@ -1,0 +1,27 @@
+package org.http4s.server.middleware
+
+import cats.effect._
+import org.http4s._
+import org.http4s.dsl.io._
+
+
+class StaticHeadersSpec extends Http4sSpec {
+
+  val testService = HttpService[IO] {
+    case GET -> Root / "request" =>
+      Ok("request response")
+    case req @ POST -> Root / "post" =>
+      Ok(req.body)
+  }
+
+  "NoCache middleware" should {
+    "add a no-cache header to a response" in {
+      val req = Request[IO](uri = uri("/request"))
+      val resp = StaticHeaders.`no-cache`(testService).orNotFound(req) 
+      
+      val check = resp.map(_.headers.toList.map(_.toString).contains("Cache-Control: no-cache")).unsafeRunSync 
+      check must_=== true
+    }
+  }
+
+}

--- a/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSpec.scala
@@ -4,7 +4,6 @@ import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._
 
-
 class StaticHeadersSpec extends Http4sSpec {
 
   val testService = HttpService[IO] {
@@ -17,9 +16,10 @@ class StaticHeadersSpec extends Http4sSpec {
   "NoCache middleware" should {
     "add a no-cache header to a response" in {
       val req = Request[IO](uri = uri("/request"))
-      val resp = StaticHeaders.`no-cache`(testService).orNotFound(req) 
-      
-      val check = resp.map(_.headers.toList.map(_.toString).contains("Cache-Control: no-cache")).unsafeRunSync 
+      val resp = StaticHeaders.`no-cache`(testService).orNotFound(req)
+
+      val check =
+        resp.map(_.headers.toList.map(_.toString).contains("Cache-Control: no-cache")).unsafeRunSync
       check must_=== true
     }
   }


### PR DESCRIPTION
Adds Static Headers to a request. Puts in place a `no-cache` middleware based on this design.