### PR TITLE
Fix RequestLoggerRedaction #1950. Supercedes PR #1951.

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -59,7 +59,9 @@ object RequestLogger {
   )(client: Client[F])(implicit ec: ExecutionContext = ExecutionContext.global): Client[F] =
     client.copy(open = Kleisli { req =>
       if (!logBody)
-        Logger.logMessage[F, Request[F]](req)(logHeaders, logBody)(logger) *> client.open(req)
+        Logger.logMessage[F, Request[F]](req)(logHeaders, logBody, redactHeadersWhen)(
+          logger
+        ) *> client.open(req)
       else
         async.refOf[F, Vector[Segment[Byte, Unit]]](Vector.empty[Segment[Byte, Unit]]).flatMap {
           vec =>


### PR DESCRIPTION
Added redactHeadersWhen arg to Logger.logMessage

In the !logBody branch of RequestLogger this argument was accidentally
not passed, causing the default value to be used, potentially logging
sensitive headers.