### PR TITLE
Add UUID path extractor

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -22,6 +22,7 @@ trait Http4sDsl[F[_]] extends Http4s with Methods with Statuses with Responses[F
 
   val IntVar: impl.IntVar.type = impl.IntVar
   val LongVar: impl.LongVar.type = impl.LongVar
+  val UUIDVar: impl.UUIDVar.type = impl.UUIDVar
 
   type QueryParamDecoderMatcher[T] = impl.QueryParamDecoderMatcher[T]
   type QueryParamMatcher[T] = impl.QueryParamMatcher[T]

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -162,11 +162,10 @@ object /: {
     }
 }
 
-// Base class for Integer and Long path variable extractors.
-protected class NumericPathVar[A <: AnyVal](cast: String => A) {
+protected class PathVar[A](cast: String => Try[A]) {
   def unapply(str: String): Option[A] =
     if (!str.isEmpty)
-      Try(cast(str)).toOption
+      cast(str).toOption
     else
       None
 }
@@ -178,7 +177,7 @@ protected class NumericPathVar[A <: AnyVal](cast: String => A) {
   *      case Root / "user" / IntVar(userId) => ...
   * }}}
   */
-object IntVar extends NumericPathVar(_.toInt)
+object IntVar extends PathVar(str => Try(str.toInt))
 
 /**
   * Long extractor of a path variable:
@@ -187,7 +186,16 @@ object IntVar extends NumericPathVar(_.toInt)
   *      case Root / "user" / LongVar(userId) => ...
   * }}}
   */
-object LongVar extends NumericPathVar(_.toLong)
+object LongVar extends PathVar(str => Try(str.toLong))
+
+/**
+  * UUID extractor of a path variable:
+  * {{{
+  *   Path("/user/13251d88-7a73-4fcf-b935-54dfae9f023e") match {
+  *      case Root / "user" / UUIDVar(userId) => ...
+  * }}}
+  */
+object UUIDVar extends PathVar(str => Try(java.util.UUID.fromString(str)))
 
 /**
   * Multiple param extractor:

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -184,7 +184,8 @@ class PathSpec extends Http4sSpec {
       "valid" >> {
         "a UUID" in {
           (Path("/user/13251d88-7a73-4fcf-b935-54dfae9f023e") match {
-            case Root / "user"/ UUIDVar(userId) => userId.toString == "13251d88-7a73-4fcf-b935-54dfae9f023e"
+            case Root / "user" / UUIDVar(userId) =>
+              userId.toString == "13251d88-7a73-4fcf-b935-54dfae9f023e"
             case _ => false
           }) must beTrue
         }
@@ -192,19 +193,19 @@ class PathSpec extends Http4sSpec {
       "invalid" >> {
         "a number" in {
           (Path("/user/123") match {
-            case Root / "user"/ UUIDVar(userId @ _) => true
+            case Root / "user" / UUIDVar(userId @ _) => true
             case _ => false
           }) must beFalse
         }
         "a word" in {
           (Path("/user/invalid") match {
-            case Root / "user"/ UUIDVar(userId @ _) => true
+            case Root / "user" / UUIDVar(userId @ _) => true
             case _ => false
           }) must beFalse
         }
         "a bad UUID" in {
           (Path("/user/13251d88-7a73-4fcf-b935") match {
-            case Root / "user"/ UUIDVar(userId @ _) => true
+            case Root / "user" / UUIDVar(userId @ _) => true
             case _ => false
           }) must beFalse
         }

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -179,5 +179,36 @@ class PathSpec extends Http4sSpec {
         }
       }
     }
+
+    "UUID extractor" >> {
+      "valid" >> {
+        "a UUID" in {
+          (Path("/user/13251d88-7a73-4fcf-b935-54dfae9f023e") match {
+            case Root / "user"/ UUIDVar(userId) => userId.toString == "13251d88-7a73-4fcf-b935-54dfae9f023e"
+            case _ => false
+          }) must beTrue
+        }
+      }
+      "invalid" >> {
+        "a number" in {
+          (Path("/user/123") match {
+            case Root / "user"/ UUIDVar(userId @ _) => true
+            case _ => false
+          }) must beFalse
+        }
+        "a word" in {
+          (Path("/user/invalid") match {
+            case Root / "user"/ UUIDVar(userId @ _) => true
+            case _ => false
+          }) must beFalse
+        }
+        "a bad UUID" in {
+          (Path("/user/13251d88-7a73-4fcf-b935") match {
+            case Root / "user"/ UUIDVar(userId @ _) => true
+            case _ => false
+          }) must beFalse
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Add UUIDVar, a path extractor for java.util.UUID

I also considered adding a ValidatedUUIDVar to extract a Validated[Throwable, UUID] from paths but then realized that there is already a simple way to return BadRequest for invalid UUIDs:

```
HttpService[IO] match {
  case GET -> Root / "user" / UUIDVar(userId) => ...
  case GET -> Root / "user" / str => BadRequest(s"Invalid identifier '$str'")
}
```

The [original PR](https://github.com/http4s/http4s/pull/1945) targeted 0.18.x but broke binary compatibility, this new one targets master to avoid that complication.