### PR TITLE
Prometheus client metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,13 @@ lazy val prometheusServerMetrics = libraryProject("prometheus-server-metrics")
   )
   .dependsOn(server % "compile;test->test", theDsl)
 
+lazy val prometheusClientMetrics = libraryProject("prometheus-client-metrics")
+  .settings(
+    description := "Support for Prometheus Metrics on the client",
+    libraryDependencies += prometheusClient
+  )
+  .dependsOn(client % "compile;test->test")
+
 lazy val client = libraryProject("client")
   .settings(
     description := "Base library for building http4s clients",

--- a/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/DestinationAttribute.scala
+++ b/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/DestinationAttribute.scala
@@ -1,0 +1,23 @@
+package org.http4s.client.prometheus
+
+import cats.data.Kleisli
+import cats.effect.Sync
+import org.http4s._
+import org.http4s.client.Client
+
+object DestinationAttribute {
+
+  /** The value of this key in the request's attributes is used as the value for the destination metric label. */
+  val Destination = AttributeKey[String]
+
+  val EmptyDestination = ""
+
+  /** The returned function can be used when creating the PrometheusClientMetrics middleware, to extract destination from request attributes. */
+  def getDestination[F[_]](default: String = EmptyDestination): Request[F] => String =
+    _.attributes.get(Destination).getOrElse(default)
+
+  /** Client middleware that sets the destination attribute of every request to the specified value. */
+  def setRequestDestination[F[_]: Sync](client: Client[F], destination: String): Client[F] =
+    client.copy(open = Kleisli(r => client.open(r.withAttribute(Destination, destination))))
+
+}

--- a/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
+++ b/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
@@ -18,14 +18,8 @@ object PrometheusClientMetrics {
       case _ => "5xx"
     }
 
-  /** The value of this key in the request's attributes is used as the value for the destination metric label. */
-  val Destination = AttributeKey[String]
-  val EmptyDestination = ""
-  private def reportDestination(attributes: AttributeMap, destination: String): String =
-    attributes.get(Destination).getOrElse(destination)
-
-  private case class ClientMetrics(
-      destination: String,
+  private case class ClientMetrics[F[_]](
+      destination: Request[F] => String,
       responseDuration: Histogram,
       activeRequests: Gauge,
       responseCounter: Counter,
@@ -33,7 +27,7 @@ object PrometheusClientMetrics {
   )
 
   private def metricsClient[F[_]: Sync](
-      metrics: ClientMetrics,
+      metrics: ClientMetrics[F],
       client: Client[F]
   )(
       request: Request[F]
@@ -42,7 +36,7 @@ object PrometheusClientMetrics {
       start <- Sync[F].delay(System.nanoTime())
       _ <- Sync[F].delay(
         metrics.activeRequests
-          .labels(reportDestination(request.attributes, metrics.destination))
+          .labels(metrics.destination(request))
           .inc())
       responseAttempt <- client.open(request).attempt
       end <- Sync[F].delay(System.nanoTime())
@@ -54,14 +48,14 @@ object PrometheusClientMetrics {
       )
     } yield result
 
-  private def onClientError[F[_]: Sync](request: Request[F], metrics: ClientMetrics): F[Unit] =
+  private def onClientError[F[_]: Sync](request: Request[F], metrics: ClientMetrics[F]): F[Unit] =
     Sync[F].delay {
       //not updating responseDuration or responseCounter, since we did not receive a response
       metrics.activeRequests
-        .labels(reportDestination(request.attributes, metrics.destination))
+        .labels(metrics.destination(request))
         .dec()
       metrics.clientErrorsCounter
-        .labels(reportDestination(request.attributes, metrics.destination))
+        .labels(metrics.destination(request))
         .inc()
     }
 
@@ -70,31 +64,31 @@ object PrometheusClientMetrics {
       response: Response[F],
       start: Long,
       end: Long,
-      metrics: ClientMetrics): F[Unit] =
+      metrics: ClientMetrics[F]): F[Unit] =
     Sync[F].delay {
       metrics.responseDuration
         .labels(
-          reportDestination(request.attributes, metrics.destination),
+          metrics.destination(request),
           reportStatus(response.status))
         .observe(SimpleTimer.elapsedSecondsFromNanos(start, end))
       metrics.responseCounter
         .labels(
-          reportDestination(request.attributes, metrics.destination),
+          metrics.destination(request),
           reportStatus(response.status))
         .inc()
       metrics.activeRequests
-        .labels(reportDestination(request.attributes, metrics.destination))
+        .labels(metrics.destination(request))
         .dec()
     }
 
   def apply[F[_]: Sync](
       c: CollectorRegistry,
       prefix: String = "org_http4s_client",
-      destination: String = EmptyDestination
+      destination: Request[F] => String = {_: Request[F] => ""}
   ): Kleisli[F, Client[F], Client[F]] =
     Kleisli { client =>
       Sync[F].delay {
-        val clientMetrics = ClientMetrics(
+        val clientMetrics = ClientMetrics[F](
           destination = destination,
           responseDuration = Histogram
             .build()
@@ -124,8 +118,21 @@ object PrometheusClientMetrics {
         client.copy(open = Kleisli(metricsClient[F](clientMetrics, client)(_)))
       }
     }
+}
+
+object DestinationAttribute {
+
+  /** The value of this key in the request's attributes is used as the value for the destination metric label. */
+  val Destination = AttributeKey[String]
+
+  val EmptyDestination = ""
+
+  /** The returned function can be used when creating the PrometheusClientMetrics middleware, to extract destination from request attributes. */
+  def getDestination[F[_]](default: String = EmptyDestination): Request[F] => String =
+    _.attributes.get(Destination).getOrElse(default)
 
   /** Client middleware that sets the destination attribute of every request to the specified value. */
   def setRequestDestination[F[_]: Sync](client: Client[F], destination: String): Client[F] =
     client.copy(open = Kleisli(r => client.open(r.withAttribute(Destination, destination))))
+
 }

--- a/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
+++ b/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
@@ -67,14 +67,10 @@ object PrometheusClientMetrics {
       metrics: ClientMetrics[F]): F[Unit] =
     Sync[F].delay {
       metrics.responseDuration
-        .labels(
-          metrics.destination(request),
-          reportStatus(response.status))
+        .labels(metrics.destination(request), reportStatus(response.status))
         .observe(SimpleTimer.elapsedSecondsFromNanos(start, end))
       metrics.responseCounter
-        .labels(
-          metrics.destination(request),
-          reportStatus(response.status))
+        .labels(metrics.destination(request), reportStatus(response.status))
         .inc()
       metrics.activeRequests
         .labels(metrics.destination(request))
@@ -84,7 +80,9 @@ object PrometheusClientMetrics {
   def apply[F[_]: Sync](
       c: CollectorRegistry,
       prefix: String = "org_http4s_client",
-      destination: Request[F] => String = {_: Request[F] => ""}
+      destination: Request[F] => String = { _: Request[F] =>
+        ""
+      }
   ): Kleisli[F, Client[F], Client[F]] =
     Kleisli { client =>
       Sync[F].delay {

--- a/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
+++ b/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
@@ -117,20 +117,3 @@ object PrometheusClientMetrics {
       }
     }
 }
-
-object DestinationAttribute {
-
-  /** The value of this key in the request's attributes is used as the value for the destination metric label. */
-  val Destination = AttributeKey[String]
-
-  val EmptyDestination = ""
-
-  /** The returned function can be used when creating the PrometheusClientMetrics middleware, to extract destination from request attributes. */
-  def getDestination[F[_]](default: String = EmptyDestination): Request[F] => String =
-    _.attributes.get(Destination).getOrElse(default)
-
-  /** Client middleware that sets the destination attribute of every request to the specified value. */
-  def setRequestDestination[F[_]: Sync](client: Client[F], destination: String): Client[F] =
-    client.copy(open = Kleisli(r => client.open(r.withAttribute(Destination, destination))))
-
-}

--- a/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
+++ b/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
@@ -1,0 +1,121 @@
+package org.http4s.client.prometheus
+
+import io.prometheus.client._
+import cats.implicits._
+import cats.data.Kleisli
+import cats.effect.Sync
+import org.http4s._
+import org.http4s.client.{Client, DisposableResponse}
+
+object PrometheusClientMetrics {
+
+  private def reportStatus(status: Status): String =
+    status.code match {
+      case hundreds if hundreds < 200 => "1xx"
+      case twohundreds if twohundreds < 300 => "2xx"
+      case threehundreds if threehundreds < 400 => "3xx"
+      case fourhundreds if fourhundreds < 500 => "4xx"
+      case _ => "5xx"
+    }
+
+  /** The value of this key in the request's attributes is used as the value for the destination metric label. */
+  val Destination = AttributeKey[String]
+  val EmptyDestination = ""
+  private def reportDestination(attributes: AttributeMap, destination: String): String =
+    attributes.get(Destination).getOrElse(destination)
+
+  private case class ClientMetrics(
+      destination: String,
+      responseDuration: Histogram,
+      activeRequests: Gauge,
+      responseCounter: Counter
+  )
+
+  private def metricsClient[F[_]: Sync](
+      metrics: ClientMetrics,
+      client: Client[F]
+  )(
+      request: Request[F]
+  ): F[DisposableResponse[F]] =
+    for {
+      start <- Sync[F].delay(System.nanoTime())
+      _ <- Sync[F].delay(
+        metrics.activeRequests
+          .labels(reportDestination(request.attributes, metrics.destination))
+          .inc())
+      responseAttempt <- client.open(request).attempt
+      end <- Sync[F].delay(System.nanoTime())
+      result <- responseAttempt.fold(
+        e =>
+          onClientError(request, e, start, end, metrics) *>
+            Sync[F].raiseError[DisposableResponse[F]](e),
+        r => onResponse(request, r.response, start, end, metrics) *> r.pure[F]
+      )
+    } yield result
+
+  private def onClientError[F[_]: Sync](
+      request: Request[F],
+      e: Throwable,
+      start: Long,
+      end: Long,
+      metrics: ClientMetrics): F[Unit] =
+    ??? //TODO when would this happen? how should we update metrics?
+
+  private def onResponse[F[_]: Sync](
+      request: Request[F],
+      response: Response[F],
+      start: Long,
+      end: Long,
+      metrics: ClientMetrics): F[Unit] =
+    Sync[F].delay {
+      metrics.responseDuration
+        .labels(
+          reportDestination(request.attributes, metrics.destination),
+          reportStatus(response.status))
+        .observe(SimpleTimer.elapsedSecondsFromNanos(start, end))
+      metrics.responseCounter
+        .labels(
+          reportDestination(request.attributes, metrics.destination),
+          reportStatus(response.status))
+        .inc()
+      metrics.activeRequests
+        .labels(reportDestination(request.attributes, metrics.destination))
+        .dec()
+    }
+
+  def apply[F[_]: Sync](
+      c: CollectorRegistry,
+      prefix: String = "org_http4s_client",
+      destination: String = EmptyDestination
+  ): Kleisli[F, Client[F], Client[F]] =
+    Kleisli { client =>
+      Sync[F].delay {
+        val clientMetrics = ClientMetrics(
+          destination = destination,
+          responseDuration = Histogram
+            .build()
+            .name(prefix + "_" + "response_duration_seconds")
+            .help("Response Duration in seconds.")
+            .labelNames("destination", "code")
+            .register(c),
+          activeRequests = Gauge
+            .build()
+            .name(prefix + "_" + "active_request_count")
+            .help("Total Active Requests.")
+            .labelNames("destination")
+            .register(c),
+          responseCounter = Counter
+            .build()
+            .name(prefix + "_" + "response_total")
+            .help("Total Responses.")
+            .labelNames("destination", "code")
+            .register(c)
+        )
+        client.copy(open = Kleisli(metricsClient[F](clientMetrics, client)(_)))
+      }
+    }
+
+  /** Client middleware that sets the destination attribute of every request to the specified value. */
+  def setRequestDestination[F[_]: Sync](client: Client[F], destination: String): Client[F] =
+    client.copy(open = Kleisli(r => client.open(r.withAttribute(Destination, destination))))
+}


### PR DESCRIPTION
Client middleware that collects a few Prometheus metrics, very similar to the `prometheus-server-metrics` module. Hopefully this will be useful to the http4s community. This is my first http4s PR, feedback would be greatly appreciated.

Currently, four client metrics are collected:
- Counter for total number of responses received
- Histogram for response duration/latency
- Gauge for number of active requests
- Counter for total number of client errors

At Banno, we often use the same `Client` instance to send requests to multiple destinations (e.g. endpoints, services) and want to track metrics separately based on destination, so several of the metrics use a `destination` label. This PR uses the value of the request attribute `PrometheusClientMetrics.Destination` as the `destination` label value, if it is set. User code can set this attribute to some meaningful value when creating the `Request`. Otherwise, a fallback value can be specified when creating the middleware. This may be a bit specific to our own use cases, but hopefully is a common need for client metric collection.

A few things I'm a bit unsure about:
- Is the `destination` label sufficiently generic and useful to many users of http4s-client?
- Is the `destination` label stuff a misuse of the attribute system? Is there a better way to track metrics separately per-destination?
- Should `onClientError` also update the response counter and histogram?
- Other client metrics that should be collected?