### PR TITLE
Throw ConnectException on connection failure in blaze client

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -63,7 +63,7 @@ object BlazeClient {
               case Left(Command.EOF) =>
                 invalidate(next.connection).flatMap { _ =>
                   if (next.fresh)
-                    F.raiseError(new java.io.IOException(s"Failed to connect to endpoint: $key"))
+                    F.raiseError(new java.net.ConnectException(s"Failed to connect to endpoint: $key"))
                   else {
                     manager.borrow(key).flatMap { newConn =>
                       loop(newConn)

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -63,7 +63,8 @@ object BlazeClient {
               case Left(Command.EOF) =>
                 invalidate(next.connection).flatMap { _ =>
                   if (next.fresh)
-                    F.raiseError(new java.net.ConnectException(s"Failed to connect to endpoint: $key"))
+                    F.raiseError(
+                      new java.net.ConnectException(s"Failed to connect to endpoint: $key"))
                   else {
                     manager.borrow(key).flatMap { newConn =>
                       loop(newConn)


### PR DESCRIPTION
This currently throws an `IOException`, which is far too general.