### PR TITLE
Make UriTranslation check prefix contents before matching

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
@@ -4,7 +4,6 @@ package middleware
 
 import cats._
 import cats.data.{Kleisli, OptionT}
-import org.http4s.server.middleware.URITranslation.translateRoot
 
 /** Removes a trailing slash from [[Request]] path
   *
@@ -26,7 +25,7 @@ object AutoSlash {
           service.apply(req.withPathInfo(pathInfo.substring(0, pathInfo.length - 1)))
         } else {
           // Request has been translated at least once, redo the translation
-          val translated = translateRoot(scriptName)(service)
+          val translated = TranslateUri(scriptName)(service)
           translated.apply(req.withPathInfo(pathInfo.substring(0, pathInfo.length - 1)))
         }
       }

--- a/server/src/main/scala/org/http4s/server/middleware/TranslateUri.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/TranslateUri.scala
@@ -1,0 +1,36 @@
+package org.http4s
+package server.middleware
+
+import cats.data.{Kleisli, OptionT}
+import cats.{Applicative, Functor}
+
+/** Removes the given prefix from the beginning of the path of the [[Request]].
+  */
+object TranslateUri {
+
+  def apply[F[_]: Applicative](prefix: String)(service: HttpService[F]): HttpService[F] =
+    if (prefix.isEmpty || prefix == "/") service
+    else {
+      val (slashedPrefix, unslashedPrefix) =
+        if (prefix.startsWith("/")) (prefix, prefix.substring(1))
+        else (s"/$prefix", prefix)
+
+      val newCaret = slashedPrefix.length
+
+      Kleisli { req: Request[F] =>
+        val shouldTranslate =
+          req.pathInfo.startsWith(unslashedPrefix) || req.pathInfo.startsWith(slashedPrefix)
+
+        if (shouldTranslate) service(setCaret(req, newCaret))
+        else OptionT.none
+      }
+
+    }
+
+  private def setCaret[F[_]: Functor](req: Request[F], newCaret: Int): Request[F] = {
+    val oldCaret = req.attributes
+      .get(Request.Keys.PathInfoCaret)
+      .getOrElse(0)
+    req.withAttribute(Request.Keys.PathInfoCaret(oldCaret + newCaret))
+  }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/URITranslation.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/URITranslation.scala
@@ -4,7 +4,7 @@ package middleware
 
 import cats.Functor
 
-@deprecated("Use org.http4s.server.middleware.UriTranslation instead", since = "0.18.16")
+@deprecated("Use org.http4s.server.middleware.TranslateUri instead", since = "0.18.16")
 object URITranslation {
   def translateRoot[F[_]: Functor](prefix: String)(service: HttpService[F]): HttpService[F] = {
     val newCaret = prefix match {

--- a/server/src/main/scala/org/http4s/server/middleware/URITranslation.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/URITranslation.scala
@@ -2,21 +2,37 @@ package org.http4s
 package server
 package middleware
 
-import cats.Functor
+import cats.{Applicative, Functor}
+import cats.data.{Kleisli, OptionT}
 
 object URITranslation {
-  def translateRoot[F[_]: Functor](prefix: String)(service: HttpService[F]): HttpService[F] = {
-    val newCaret = prefix match {
-      case "/" => 0
-      case x if x.startsWith("/") => x.length
-      case x => x.length + 1
+  def translateRoot[F[_]: Applicative](prefix: String)(service: HttpService[F]): HttpService[F] =
+    prefix match {
+      case "" | "/" => service
+      case prefix if prefix.startsWith("/") =>
+        val newCaret = prefix.length
+
+        Kleisli { req: Request[F] =>
+          if (req.pathInfo.startsWith(prefix)) service(setCaret(req, newCaret))
+          else OptionT.none
+        }
+      case prefix =>
+        val newCaret = prefix.length + 1
+
+        Kleisli { req: Request[F] =>
+          val pi = req.pathInfo
+          val shouldTranslate =
+            if (pi.startsWith("/")) pi.substring(1).startsWith(prefix)
+            else pi.startsWith(prefix)
+          if (shouldTranslate) service(setCaret(req, newCaret))
+          else OptionT.none
+        }
     }
 
-    service.local { req: Request[F] =>
-      val oldCaret = req.attributes
-        .get(Request.Keys.PathInfoCaret)
-        .getOrElse(0)
-      req.withAttribute(Request.Keys.PathInfoCaret(oldCaret + newCaret))
-    }
+  private def setCaret[F[_]: Functor](req: Request[F], newCaret: Int): Request[F] = {
+    val oldCaret = req.attributes
+      .get(Request.Keys.PathInfoCaret)
+      .getOrElse(0)
+    req.withAttribute(Request.Keys.PathInfoCaret(oldCaret + newCaret))
   }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/URITranslation.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/URITranslation.scala
@@ -2,33 +2,22 @@ package org.http4s
 package server
 package middleware
 
-import cats.{Applicative, Functor}
-import cats.data.{Kleisli, OptionT}
+import cats.Functor
 
+@deprecated("Use org.http4s.server.middleware.UriTranslation instead", since = "0.18.16")
 object URITranslation {
-  def translateRoot[F[_]: Applicative](prefix: String)(service: HttpService[F]): HttpService[F] =
-    if (prefix.isEmpty || prefix == "/") service
-    else {
-      val (slashedPrefix, unslashedPrefix) =
-        if (prefix.startsWith("/")) (prefix, prefix.substring(1))
-        else (s"/$prefix", prefix)
-
-      val newCaret = slashedPrefix.length
-
-      Kleisli { req: Request[F] =>
-        val shouldTranslate =
-          req.pathInfo.startsWith(unslashedPrefix) || req.pathInfo.startsWith(slashedPrefix)
-
-        if (shouldTranslate) service(setCaret(req, newCaret))
-        else OptionT.none
-      }
-
+  def translateRoot[F[_]: Functor](prefix: String)(service: HttpService[F]): HttpService[F] = {
+    val newCaret = prefix match {
+      case "/" => 0
+      case x if x.startsWith("/") => x.length
+      case x => x.length + 1
     }
 
-  private def setCaret[F[_]: Functor](req: Request[F], newCaret: Int): Request[F] = {
-    val oldCaret = req.attributes
-      .get(Request.Keys.PathInfoCaret)
-      .getOrElse(0)
-    req.withAttribute(Request.Keys.PathInfoCaret(oldCaret + newCaret))
+    service.local { req: Request[F] =>
+      val oldCaret = req.attributes
+        .get(Request.Keys.PathInfoCaret)
+        .getOrElse(0)
+      req.withAttribute(Request.Keys.PathInfoCaret(oldCaret + newCaret))
+    }
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/TranslateUriSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/TranslateUriSpec.scala
@@ -5,7 +5,7 @@ package middleware
 import cats.effect._
 import org.http4s.dsl.io._
 
-class UriTranslationSpec extends Http4sSpec {
+class TranslateUriSpec extends Http4sSpec {
 
   val service = HttpService[IO] {
     case _ -> Root / "foo" =>
@@ -16,8 +16,8 @@ class UriTranslationSpec extends Http4sSpec {
       Ok(s)
   }
 
-  val trans1 = URITranslation.translateRoot("/http4s")(service)
-  val trans2 = URITranslation.translateRoot("http4s")(service)
+  val trans1 = TranslateUri("/http4s")(service)
+  val trans2 = TranslateUri("http4s")(service)
 
   "UriTranslation" should {
     "match a matching request" in {
@@ -49,8 +49,8 @@ class UriTranslationSpec extends Http4sSpec {
     }
 
     "do nothing for an empty or / prefix" in {
-      val emptyPrefix = URITranslation.translateRoot("")(service)
-      val slashPrefix = URITranslation.translateRoot("/")(service)
+      val emptyPrefix = TranslateUri("")(service)
+      val slashPrefix = TranslateUri("/")(service)
 
       val req = Request[IO](uri = Uri(path = "/foo"))
       emptyPrefix.orNotFound(req) must returnStatus(Ok)

--- a/server/src/test/scala/org/http4s/server/middleware/UriTranslationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/UriTranslationSpec.scala
@@ -27,25 +27,34 @@ class UriTranslationSpec extends Http4sSpec {
       service.orNotFound(req) must returnStatus(NotFound)
     }
 
-    "Not match a request missing the prefix" in {
+    "not match a request missing the prefix" in {
       val req = Request[IO](uri = Uri(path = "/foo"))
       trans1.orNotFound(req) must returnStatus(NotFound)
       trans2.orNotFound(req) must returnStatus(NotFound)
       service.orNotFound(req) must returnStatus(Ok)
     }
 
-    "Not match a request with a different prefix" in {
+    "not match a request with a different prefix" in {
       val req = Request[IO](uri = Uri(path = "/http5s/foo"))
       trans1.orNotFound(req) must returnStatus(NotFound)
       trans2.orNotFound(req) must returnStatus(NotFound)
       service.orNotFound(req) must returnStatus(NotFound)
     }
 
-    "Split the Uri into scriptName and pathInfo" in {
+    "split the Uri into scriptName and pathInfo" in {
       val req = Request[IO](uri = Uri(path = "/http4s/checkattr"))
       val resp = trans1.orNotFound(req).unsafeRunSync()
       resp.status must be(Ok)
       resp must haveBody("/http4s /checkattr")
+    }
+
+    "do nothing for an empty or / prefix" in {
+      val emptyPrefix = URITranslation.translateRoot("")(service)
+      val slashPrefix = URITranslation.translateRoot("/")(service)
+
+      val req = Request[IO](uri = Uri(path = "/foo"))
+      emptyPrefix.orNotFound(req) must returnStatus(Ok)
+      slashPrefix.orNotFound(req) must returnStatus(Ok)
     }
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/UriTranslationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/UriTranslationSpec.scala
@@ -34,6 +34,13 @@ class UriTranslationSpec extends Http4sSpec {
       service.orNotFound(req) must returnStatus(Ok)
     }
 
+    "Not match a request with a different prefix" in {
+      val req = Request[IO](uri = Uri(path = "/http5s/foo"))
+      trans1.orNotFound(req) must returnStatus(NotFound)
+      trans2.orNotFound(req) must returnStatus(NotFound)
+      service.orNotFound(req) must returnStatus(NotFound)
+    }
+
     "Split the Uri into scriptName and pathInfo" in {
       val req = Request[IO](uri = Uri(path = "/http4s/checkattr"))
       val resp = trans1.orNotFound(req).unsafeRunSync()

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
@@ -5,7 +5,7 @@ package staticcontent
 import cats.effect._
 import fs2._
 import java.io.File
-import org.http4s.server.middleware.URITranslation
+import org.http4s.server.middleware.TranslateUri
 
 class FileServiceSpec extends Http4sSpec with StaticContentShared {
   val s = fileService(FileService.Config[IO](new File(getClass.getResource("/").toURI).getPath))
@@ -13,7 +13,7 @@ class FileServiceSpec extends Http4sSpec with StaticContentShared {
   "FileService" should {
 
     "Respect UriTranslation" in {
-      val s2 = URITranslation.translateRoot("/foo")(s)
+      val s2 = TranslateUri("/foo")(s)
 
       {
         val req = Request[IO](uri = uri("foo/testresource.txt"))

--- a/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
@@ -4,7 +4,7 @@ package staticcontent
 
 import cats.effect._
 import org.http4s.headers.{`Accept-Encoding`, `If-Modified-Since`}
-import org.http4s.server.middleware.URITranslation
+import org.http4s.server.middleware.TranslateUri
 
 class ResourceServiceSpec extends Http4sSpec with StaticContentShared {
 
@@ -14,7 +14,7 @@ class ResourceServiceSpec extends Http4sSpec with StaticContentShared {
   "ResourceService" should {
 
     "Respect UriTranslation" in {
-      val s2 = URITranslation.translateRoot("/foo")(s)
+      val s2 = TranslateUri("/foo")(s)
 
       {
         val req = Request[IO](uri = uri("foo/testresource.txt"))


### PR DESCRIPTION
This PR changes the behaviour of `UriTranslation` to take the contents of the prefix into account as well.

It inlines the old implementation in `Router`, to not do the check twice.

Fixes #1962