### PR TITLE
Use scalafmt directly from IntelliJ

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,6 +7,7 @@
         </array>
       </option>
       <option name="sortAsScalastyle" value="true" />
+      <option name="USE_SCALAFMT_FORMATTER" value="true" />
     </ScalaCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />


### PR DESCRIPTION
With IntelliJ 18.2, scalafmt is supported directly by the scala plugin.

This PR enables that.