### PR TITLE
improve WS stream, add `onClose` handler

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,6 +7,7 @@
         </array>
       </option>
       <option name="sortAsScalastyle" value="true" />
+      <option name="USE_SCALAFMT_FORMATTER" value="true" />
     </ScalaCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,7 +7,6 @@
         </array>
       </option>
       <option name="sortAsScalastyle" value="true" />
-      <option name="USE_SCALAFMT_FORMATTER" value="true" />
     </ScalaCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />

--- a/core/src/main/scala/org/http4s/websocket/Websocket.scala
+++ b/core/src/main/scala/org/http4s/websocket/Websocket.scala
@@ -5,7 +5,8 @@ import org.http4s.websocket.WebsocketBits.WebSocketFrame
 
 private[http4s] final case class Websocket[F[_]](
     @deprecatedName('read) send: Stream[F, WebSocketFrame],
-    @deprecatedName('write) receive: Sink[F, WebSocketFrame]
+    @deprecatedName('write) receive: Sink[F, WebSocketFrame],
+    onClose: F[Unit]
 ) {
 
   @deprecated("Parameter has been renamed to `send`", "0.18.0-M7")

--- a/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -52,13 +52,14 @@ object WebSocketBuilder {
           Response[F](Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F],
         onHandshakeFailure: F[Response[F]] = Response[F](Status.BadRequest)
           .withEntity("WebSocket handshake failed.")
-          .pure[F]): F[Response[F]] =
+          .pure[F],
+        onClose: F[Unit] = Applicative[F].unit): F[Response[F]] =
       WebSocketBuilder(send, receive, headers, onNonWebSocketRequest, onHandshakeFailure).onNonWebSocketRequest
         .map(
           _.withAttribute(
             AttributeEntry(
               websocketKey[F],
-              WebSocketContext(Websocket(send, receive), headers, onHandshakeFailure))))
+              WebSocketContext(Websocket(send, receive, onClose), headers, onHandshakeFailure))))
   }
   def apply[F[_]: Applicative]: Builder[F] = new Builder[F]
 }

--- a/server/src/main/scala/org/http4s/server/websocket/package.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/package.scala
@@ -1,11 +1,7 @@
 package org.http4s
 package server
 
-import cats._
-import cats.implicits._
-import fs2._
 import org.http4s.websocket.WebSocketContext
-import org.http4s.websocket.WebsocketBits.WebSocketFrame
 
 package object websocket {
   private[this] object Keys {
@@ -14,49 +10,4 @@ package object websocket {
 
   def websocketKey[F[_]]: AttributeKey[WebSocketContext[F]] =
     Keys.WebSocket.asInstanceOf[AttributeKey[WebSocketContext[F]]]
-
-  /**
-    * Build a response which will accept an HTTP websocket upgrade request and initiate a websocket connection using the
-    * supplied exchange to process and respond to websocket messages.
-    * @param send     The send side of the Exchange represents the outgoing stream of messages that should be sent to the client
-    * @param receive  The receive side of the Exchange is a sink to which the framework will push the incoming websocket messages
-    *                 Once both streams have terminated, the server will initiate a close of the websocket connection.
-    *                 As defined in the websocket specification, this means the server
-    *                 will send a CloseFrame to the client and wait for a CloseFrame in response before closing the
-    *                 connection, this ensures that no messages are lost in flight. The server will shutdown the
-    *                 connection when it receives the `CloseFrame` message back from the client. The connection will also
-    *                 be closed if the client does not respond with a `CloseFrame` after some reasonable amount of
-    *                 time.
-    *                 Another way of closing the connection is by emitting a `CloseFrame` in the stream of messages
-    *                 heading to the client. This method allows one to attach a message to the `CloseFrame` as defined
-    *                 by the websocket protocol.
-    *                 Unfortunately the current implementation does not quite respect the description above, it violates
-    *                 the websocket protocol by terminating the connection immediately upon reception
-    *                 of a `CloseFrame`. This bug will be addressed soon in an upcoming release and this message will be
-    *                 removed.
-    *                 Currently, there is no way for the server to be notified when the connection is closed, neither in
-    *                 the case of a normal disconnection such as a Close handshake or due to a connection error. There
-    *                 are plans to address this limitation in the future.
-    * @param status The status code to return to a client making a non-websocket HTTP request to this route
-    */
-  @deprecated("Use WebSocketBuilder", "0.18.0-M7")
-  def WS[F[_]](
-      send: Stream[F, WebSocketFrame],
-      receive: Sink[F, WebSocketFrame],
-      status: F[Response[F]])(implicit F: Monad[F]): F[Response[F]] =
-    WebSocketBuilder[F].build(
-      send,
-      receive,
-      Headers.empty,
-      status,
-      Response[F](Status.BadRequest).withEntity("WebSocket handshake failed.").pure[F])
-
-  @deprecated("Use WebSocketBuilder", "0.18.0-M7")
-  def WS[F[_]](send: Stream[F, WebSocketFrame], receive: Sink[F, WebSocketFrame])(
-      implicit F: Monad[F],
-      W: EntityEncoder[F, String]): F[Response[F]] =
-    WS(
-      send,
-      receive,
-      Response[F](Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F])
 }


### PR DESCRIPTION
This PR should optimize some of the websocket stream code, as well as providing clients a finalizer to run when the websocket closes. 

Breaking down the old inputStream:

```scala
 val wsStream = inputstream
      .to(ws.receive)
      .onFinalize(onStreamFinalize)
      .mergeHaltR(ws.send.onFinalize(onStreamFinalize).to(snk).drain)
      .interruptWhen(deadSignal)
      .onFinalize(sendClose)
      .compile
      .drain
```

Problems with this code:
- We do not need to end the stream because we decided to stop sending elements. we can choose to not send any more on the server. If anything, we can also give a handler to shutting down manually if necessary, and I can add this.
- `onStreamFinalize` is a moot check: the stream will be interrupted regardless once it receives a close frame since that will set the signal.
- `onClose` can be added as a finalizer before `sendClose`

Similarly:

```scala
    unsafeRunAsync {
      wsStream.attempt.flatMap {
        case Left(_) => sendClose
        case Right(_) => ().pure[F]
      }
    } {
      case Left(t) =>
        IO(logger.error(t)("Error closing Web Socket"))
      case Right(_) =>
        // Nothing to do here
        IO.unit
    }
  }
```

The left case will almost surely fail, as `sendClose` is guaranteed to be run by the finalizer. 

We are lacking websocket tests. I'm unsure whether to add them in this PR.