### PR TITLE
[WIP] Alternate websocket interface

### DIFF
--- a/server/src/main/scala/org/http4s/server/websocket/FSMAlgebra.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/FSMAlgebra.scala
@@ -1,0 +1,121 @@
+package org.http4s.server.websocket
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import fs2.async.mutable.Queue
+import fs2.Stream
+import org.http4s.server.websocket.WebsocketMsg._
+import org.http4s.websocket.WebsocketBits._
+
+private[http4s] abstract class FSMAlgebra[F[_]] {
+
+  def getState: F[State]
+
+  def clearState(): F[Unit]
+
+  def lastText(content: Array[Byte]): F[WebsocketMsg]
+
+  def lastBinary(content: Array[Byte]): F[WebsocketMsg]
+
+  def fragmentedBinary(content: Array[Byte]): F[Unit]
+
+  def fragmentedText(content: String): F[Unit]
+
+  def enqueueMsg(w: WebSocketFrame): F[Unit]
+
+  def out: Stream[F, WebSocketFrame]
+}
+
+private[http4s] object FSMAlgebra {
+
+  def apply[F[_]](implicit F: Concurrent[F]): F[FSMAlgebra[F]] =
+    for {
+      byteQueue <- Queue.unbounded[F, Option[Array[Byte]]]
+      msgQueue <- Queue.unbounded[F, WebSocketFrame]
+      stateRef <- F.delay(new AtomicReference[State](Empty))
+      len <- F.delay(new AtomicInteger(0))
+    } yield new Impl[F](byteQueue, msgQueue, stateRef, len)
+
+  private class Impl[F[_]](
+      byteQueue: Queue[F, Option[Array[Byte]]],
+      msgQueue: Queue[F, WebSocketFrame],
+      state: AtomicReference[State],
+      msgLen: AtomicInteger,
+  )(implicit F: Sync[F])
+      extends FSMAlgebra[F] {
+    private[this] def terminateBytes: F[Unit] =
+      byteQueue.enqueue1(None)
+
+    private[this] def foldBytesToArray(lastBytes: Array[Byte]): F[Array[Byte]] =
+      F.delay(msgLen.get()).flatMap { len =>
+        byteQueue.dequeue.unNoneTerminate.compile
+          .fold(new ByteArrayAggregator(len + lastBytes.length))(_.aggregate(_))
+          .map(_.aggregate(lastBytes).emit)
+      }
+
+    private[this] def compareAndSetState(old: State, ns: State): F[Boolean] =
+      F.delay(state.compareAndSet(old, ns))
+
+    private[this] def clearMsgLen(): F[Unit] =
+      F.delay(msgLen.set(0))
+
+    private[this] def incrementMsgLen(i: Int) =
+      F.delay({ msgLen.getAndAdd(i); () })
+
+    def getState: F[State] = F.delay(state.get())
+
+    def clearState(): F[Unit] = F.delay(state.set(Empty))
+
+    def lastText(content: Array[Byte]): F[WebsocketMsg] =
+      for {
+        _ <- terminateBytes
+        bytes <- foldBytesToArray(content)
+        _ <- clearMsgLen()
+      } yield TextMsg(new String(bytes, UTF_8))
+
+    def lastBinary(content: Array[Byte]): F[WebsocketMsg] =
+      for {
+        _ <- terminateBytes
+        bytes <- foldBytesToArray(content)
+        _ <- clearMsgLen()
+      } yield BinaryMsg(bytes)
+
+    def fragmentedBinary(content: Array[Byte]): F[Unit] =
+      for {
+        _ <- compareAndSetState(Empty, BufferingBinary)
+        _ <- incrementMsgLen(content.length)
+        _ <- byteQueue.enqueue1(Some(content))
+      } yield ()
+
+    def fragmentedText(content: String): F[Unit] = {
+      val bytes = content.getBytes(UTF_8)
+      for {
+        _ <- compareAndSetState(Empty, BufferingText)
+        _ <- incrementMsgLen(bytes.length)
+        _ <- byteQueue.enqueue1(Some(bytes))
+      } yield ()
+    }
+
+    def enqueueMsg(w: WebSocketFrame): F[Unit] = msgQueue.enqueue1(w)
+
+    def out: Stream[F, WebSocketFrame] = msgQueue.dequeue
+  }
+
+  private class ByteArrayAggregator(size: Int) {
+    require(size > 0)
+    private[this] val internal = new Array[Byte](size)
+    private[this] var nextIx: Int = 0
+    def aggregate(arr: Array[Byte]): ByteArrayAggregator =
+      if (nextIx + arr.length > size)
+        throw new ArrayIndexOutOfBoundsException("Size will exceed append size")
+      else {
+        System.arraycopy(arr, 0, internal, nextIx, arr.length)
+        nextIx += arr.length
+        this
+      }
+
+    def emit: Array[Byte] = internal
+  }
+}

--- a/server/src/main/scala/org/http4s/server/websocket/WSFSM.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WSFSM.scala
@@ -1,0 +1,80 @@
+package org.http4s.server.websocket
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+import cats.Monad
+import cats.effect.Concurrent
+import cats.syntax.all._
+import fs2.{Sink, Stream}
+import org.http4s.{Headers, Response, Status}
+import org.http4s.websocket.WebsocketBits._
+import org.http4s.server.websocket.WebsocketMsg._
+
+final class WSFSM[F[_]](f: WebsocketMsg => F[WebsocketMsg], alg: FSMAlgebra[F])(
+    implicit F: Monad[F]) {
+
+  def handleText(content: String, last: Boolean): F[Unit] =
+    if (last) {
+      for {
+        st <- alg.getState
+        _ <- alg.clearState()
+        msg <- st match {
+          case BufferingBinary =>
+            alg.lastBinary(content.getBytes(UTF_8))
+          case BufferingText =>
+            alg.lastText(content.getBytes(UTF_8))
+          case Empty =>
+            F.pure[WebsocketMsg](TextMsg(content))
+        }
+        out <- f(msg)
+        _ <- alg.enqueueMsg(out.toFrame)
+      } yield ()
+    } else alg.fragmentedText(content)
+
+  def handleBinary(content: Array[Byte], last: Boolean): F[Unit] =
+    if (last) {
+      for {
+        st <- alg.getState
+        _ <- alg.clearState()
+        msg <- st match {
+          case BufferingBinary =>
+            alg.lastBinary(content)
+          case BufferingText =>
+            alg.lastText(content)
+          case Empty =>
+            F.pure[WebsocketMsg](BinaryMsg(content))
+        }
+        out <- f(msg)
+        _ <- alg.enqueueMsg(out.toFrame)
+      } yield ()
+    } else alg.fragmentedBinary(content)
+
+  def send: Stream[F, WebSocketFrame] = alg.out
+
+  def recv: Sink[F, WebSocketFrame] = _.evalMap {
+    case Text(content, last) =>
+      handleText(content, last)
+    case Binary(content, last) =>
+      handleBinary(content, last)
+    case Continuation(content, last) =>
+      handleBinary(content, last)
+    case _ =>
+      F.unit //Do not worry about handling other messages
+  }
+
+  def toWSResponse(
+      headers: Headers = Headers.empty,
+      onNonWebSocketRequest: F[Response[F]] = Response[F](Status.NotImplemented)
+        .withEntity("This is a WebSocket route.")
+        .pure[F],
+      onHandshakeFailure: F[Response[F]] = Response[F](Status.BadRequest)
+        .withEntity("WebSocket handshake failed.")
+        .pure[F]): F[Response[F]] =
+    WebSocketBuilder[F].build(alg.out, recv, headers, onNonWebSocketRequest, onHandshakeFailure)
+
+}
+
+object WSFSM {
+  def apply[F[_]: Concurrent](f: WebsocketMsg => F[WebsocketMsg]): F[WSFSM[F]] =
+    FSMAlgebra[F].map(new WSFSM[F](f, _))
+}

--- a/server/src/main/scala/org/http4s/server/websocket/WebsocketMsg.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebsocketMsg.scala
@@ -1,0 +1,25 @@
+package org.http4s.server.websocket
+
+import org.http4s.websocket.WebsocketBits.{Binary, Text, WebSocketFrame}
+
+/** A simplified websocket message ADT
+  *
+  */
+sealed trait WebsocketMsg {
+  def toFrame: WebSocketFrame
+}
+
+final case class TextMsg(content: String) extends WebsocketMsg {
+  def toFrame: WebSocketFrame = Text(content)
+}
+
+final case class BinaryMsg(content: Array[Byte]) extends WebsocketMsg {
+  def toFrame: WebSocketFrame = Binary(content)
+}
+
+private[http4s] object WebsocketMsg {
+  sealed trait State
+  case object BufferingText extends State
+  case object BufferingBinary extends State
+  case object Empty extends State
+}


### PR DESCRIPTION
We've been asked a bunch of times for a simpler way to handle websockets. Our current websocket approach is very low level and good for people that need granular control over frames, but it does not help the case of constructing an in-out flow easily. 

This PR adds `WSFSM` (I suck at naming so suggestions if you hate it pls), which gives a simple `Msg => F[Msg]` flow to websockets, which should make constructing certain websocket programs easier.

Quips:
- Messages are no longer fragmented, for simplicity
- In [Section 5.4 of the websocket RFC](https://tools.ietf.org/html/rfc6455#section-5.4) (see the last bullet point), fragment types, if aggregated, depend on the first fragment received. As such, the type of the entire fragment aggregation depends on the first fragment, and we treat messages as such. The edge case is continuation frames. If a continuation frame is received first, we treat the whole fragment as binary. 
- I needed `compareAndSet` and `increment` semantics thus I opted for manual use of `AtomicReference` and `AtomicInteger` over `Ref`. 
- `Msg => F[Msg]` isn't great in the "ignore the message" case, so maybe I'd like to consider `Msg => F[Unit]`