### PR TITLE
Separate Http4sDsl's base into a minimal DSL class

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -3,7 +3,9 @@ package org.http4s.dsl
 import org.http4s.{Http4s, Method}
 import org.http4s.dsl.impl._
 
-trait Http4sDsl[F[_]] extends Http4s with Methods with Statuses with Responses[F] with Auth {
+trait Http4sDsl[F[_]] extends Http4sMinimalDsl with Responses[F] {}
+
+trait Http4sMinimalDsl extends Http4s with Methods with Statuses with Auth {
   import Http4sDsl._
 
   type Path = impl.Path

--- a/dsl/src/main/scala/org/http4s/dsl/minimal.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/minimal.scala
@@ -1,0 +1,3 @@
+package org.http4s.dsl
+
+object minimal extends Http4sMinimalDsl


### PR DESCRIPTION
This adds a new import under `org.http4s.dsl.minimal._` which allows you to import all of the DSL other than the `Response` related classes.

Is this a valuable addition to the DSL? does this help people who want to be careful with their `F` and avoid mixing in `Http4sDsl`? Should we also offer a syntax which lets people do `Ok[IO]` so that none of the DSL requires a type parameter to import?