### PR TITLE
JettyBuilder: Clean up HTTP/HTTPS configuration

### DIFF
--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -8,7 +8,7 @@ import java.util
 import javax.net.ssl.SSLContext
 import javax.servlet.{DispatcherType, Filter}
 import javax.servlet.http.HttpServlet
-import org.eclipse.jetty.server.{ServerConnector, Server => JServer, _}
+import org.eclipse.jetty.server.{ServerConnector, Server => JServer}
 import org.eclipse.jetty.servlet.{FilterHolder, ServletContextHandler, ServletHolder}
 import org.eclipse.jetty.util.component.AbstractLifeCycle.AbstractLifeCycleListener
 import org.eclipse.jetty.util.component.LifeCycle
@@ -135,22 +135,11 @@ sealed class JettyBuilder[F[_]: Effect] private (
     copy(banner = banner)
 
   private def getConnector(jetty: JServer): ServerConnector = {
-    def serverConnector(sslContextFactory: SslContextFactory) = {
-      // SSL HTTP Configuration
-      val https_config = new HttpConfiguration()
-
-      https_config.setSecureScheme("https")
-      https_config.setSecurePort(socketAddress.getPort)
-      https_config.addCustomizer(new SecureRequestCustomizer())
-
-      val connectionFactory = new HttpConnectionFactory(https_config)
+    def httpsConnector(sslContextFactory: SslContextFactory) =
       new ServerConnector(
         jetty,
-        new SslConnectionFactory(
-          sslContextFactory,
-          org.eclipse.jetty.http.HttpVersion.HTTP_1_1.asString()),
-        connectionFactory)
-    }
+        sslContextFactory
+      )
 
     sslBits match {
       case Some(KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)) =>
@@ -167,18 +156,17 @@ sealed class JettyBuilder[F[_]: Effect] private (
           sslContextFactory.setTrustStorePassword(trustManagerBits.password)
         }
 
-        serverConnector(sslContextFactory)
+        httpsConnector(sslContextFactory)
 
       case Some(SSLContextBits(sslContext, clientAuth)) =>
         val sslContextFactory = new SslContextFactory()
         sslContextFactory.setSslContext(sslContext)
         sslContextFactory.setNeedClientAuth(clientAuth)
 
-        serverConnector(sslContextFactory)
+        httpsConnector(sslContextFactory)
 
       case None =>
-        val connectionFactory = new HttpConnectionFactory
-        new ServerConnector(jetty, connectionFactory)
+        new ServerConnector(jetty)
     }
   }
 


### PR DESCRIPTION
1. `HttpConfiguration.setSecurePort` and `HttpConfiguration.setSecureScheme` are a part of the mechanism for redirecting some requests to another (secure) port/scheme. Setting them for HTTPS connector doesn't do anything. See this [example](https://github.com/eclipse/jetty.project/blob/21365234f8cf036829f7a03e5c7b89a9572444f9/examples/embedded/src/main/java/org/eclipse/jetty/embedded/ManyConnectors.java#L71-L72).
2. `ServerConnector` has constructors that build an `SslConnectionFactory` and `HttpConnectionFactory` automatically.
3. `SecureRequestCustomizer` is [automatically added](https://github.com/eclipse/jetty.project/blob/21365234f8cf036829f7a03e5c7b89a9572444f9/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnectionFactory.java#L123-L128) for HTTP connection factories if an SSL context factory is provided - no need to do this manually.