### PR TITLE
Making the Status.register method non-public, only for internal use

### DIFF
--- a/core/src/main/scala/org/http4s/Status.scala
+++ b/core/src/main/scala/org/http4s/Status.scala
@@ -100,7 +100,7 @@ object Status {
       status <- Option(registry.get(code)).map(_.right.get)
     } yield status
 
-  def register(status: Status): status.type = {
+  private def register(status: Status): status.type = {
     registry.set(status.code, Right(status))
     status
   }


### PR DESCRIPTION
https://github.com/http4s/http4s/issues/2015