### PR TITLE
CSRF Overhaul

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,7 +7,6 @@
         </array>
       </option>
       <option name="sortAsScalastyle" value="true" />
-      <option name="USE_SCALAFMT_FORMATTER" value="true" />
     </ScalaCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -4,6 +4,7 @@ import cats.effect.{Async, Effect, IO, Timer}
 import cats.implicits._
 import scala.concurrent.ExecutionContext
 import org.log4s.Logger
+import scala.util.control.NoStackTrace
 
 package object internal {
   // Like fs2.async.unsafeRunAsync before 1.0.  Convenient for when we
@@ -23,4 +24,78 @@ package object internal {
       case Left(e) => IO(logger.error(e)("Error in asynchronous callback"))
       case Right(_) => IO.unit
     }
+
+  /** Hex encoding digits. Adapted from apache commons Hex.encodeHex **/
+  private val Digits: Array[Char] =
+    Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
+
+  /** Encode a byte Array into a hexadecimal string
+    *
+    * @param data the array
+    * @return a hexadecimal encoded string
+    */
+  private[http4s] final def encodeHexString(data: Array[Byte]): String =
+    new String(encodeHex(data))
+
+  /** Encode a string to a Hexadecimal string representation
+    * Adapted from apache commons Hex.encodeHex
+    */
+  private[http4s] final def encodeHex(data: Array[Byte]): Array[Char] = {
+    val l = data.length
+    val out = new Array[Char](l << 1)
+    // two characters form the hex value.
+    var i = 0
+    var j = 0
+    while (i < l) {
+      out(j) = Digits((0xF0 & data(i)) >>> 4)
+      j += 1
+      out(j) = Digits(0x0F & data(i))
+      j += 1
+      i += 1
+    }
+    out
+  }
+
+  private[http4s] final def decodeHexString(data: String): Option[Array[Byte]] =
+    decodeHex(data.toCharArray)
+
+  private object HexDecodeException extends Exception with NoStackTrace
+
+  /** Dirty, optimized hex decoding based off of apache
+    * common hex decoding, ported over to scala
+    *
+    * @param data
+    * @return
+    */
+  private[http4s] final def decodeHex(data: Array[Char]): Option[Array[Byte]] = {
+    def toDigit(ch: Char): Int = {
+      val digit = Character.digit(ch, 16)
+      if (digit == -1)
+        throw HexDecodeException
+      else
+        digit
+    }
+
+    val len = data.length
+    if ((len & 0x01) != 0) None
+    val out = new Array[Byte](len >> 1)
+    var f: Int = -1
+    // two characters form the hex value.
+    try {
+      var i = 0
+      var j = 0
+      while (j < len) {
+        f = toDigit(data(j)) << 4
+        j += 1
+        f = f | toDigit(data(j))
+        j += 1
+        out(i) = (f & 0xFF).toByte
+
+        i += 1
+      }
+      Some(out)
+    } catch {
+      case HexDecodeException => None
+    }
+  }
 }

--- a/core/src/main/scala/org/http4s/util/package.scala
+++ b/core/src/main/scala/org/http4s/util/package.scala
@@ -4,7 +4,6 @@ import java.nio.charset.StandardCharsets
 import fs2._
 import java.nio.{ByteBuffer, CharBuffer}
 import scala.concurrent.ExecutionContextExecutor
-import scala.util.control.NoStackTrace
 
 package object util {
   def decode[F[_]](charset: Charset): Pipe[F, Byte, String] = {
@@ -54,80 +53,6 @@ package object util {
       }
 
     in.flatMap(c => tailRecAsciiCheck(0, c.toArray))
-  }
-
-  /** Hex encoding digits. Adapted from apache commons Hex.encodeHex **/
-  private val Digits: Array[Char] =
-    Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
-
-  /** Encode a byte Array into a hexadecimal string
-    *
-    * @param data the array
-    * @return a hexadecimal encoded string
-    */
-  def encodeHexString(data: Array[Byte]): String =
-    new String(encodeHex(data))
-
-  /** Encode a string to a Hexadecimal string representation
-    * Adapted from apache commons Hex.encodeHex
-    */
-  def encodeHex(data: Array[Byte]): Array[Char] = {
-    val l = data.length
-    val out = new Array[Char](l << 1)
-    // two characters form the hex value.
-    var i = 0
-    var j = 0
-    while (i < l) {
-      out(j) = Digits((0xF0 & data(i)) >>> 4)
-      j += 1
-      out(j) = Digits(0x0F & data(i))
-      j += 1
-      i += 1
-    }
-    out
-  }
-
-  def decodeHexString(data: String): Option[Array[Byte]] =
-    decodeHex(data.toCharArray)
-
-  private object HexDecodeException extends Exception with NoStackTrace
-
-  /** Dirty, optimized hex decoding based off of apache
-    * common hex decoding, ported over to scala
-    *
-    * @param data
-    * @return
-    */
-  def decodeHex(data: Array[Char]): Option[Array[Byte]] = {
-    def toDigit(ch: Char): Int = {
-      val digit = Character.digit(ch, 16)
-      if (digit == -1)
-        throw HexDecodeException
-      else
-        digit
-    }
-
-    val len = data.length
-    if ((len & 0x01) != 0) None
-    val out = new Array[Byte](len >> 1)
-    var f: Int = -1
-    // two characters form the hex value.
-    try {
-      var i = 0
-      var j = 0
-      while (j < len) {
-        f = toDigit(data(j)) << 4
-        j += 1
-        f = f | toDigit(data(j))
-        j += 1
-        out(i) = (f & 0xFF).toByte
-
-        i += 1
-      }
-      Some(out)
-    } catch {
-      case HexDecodeException => None
-    }
   }
 
   /** Constructs an assertion error with a reference back to our issue tracker. Use only with head hung low. */

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -309,7 +309,12 @@ object CSRF {
       port: Option[Int]): Boolean =
     r.headers
       .get(Origin)
-      .flatMap(o => Uri.fromString(o.value).toOption)
+      .flatMap(o =>
+        //Hack to get around 2.11 compat
+        Uri.fromString(o.value) match {
+          case Right(uri) => Some(uri)
+          case Left(_) => None
+      })
       .exists(u => u.host.exists(_.value == host) && u.scheme.contains(sc) && u.port == port) || r.headers
       .get(Referer)
       .exists(u =>

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -9,11 +9,12 @@ import cats.syntax.all._
 import java.nio.charset.StandardCharsets
 import java.security.{MessageDigest, SecureRandom}
 import java.time.Clock
-import java.util.Base64
 import javax.crypto.spec.SecretKeySpec
 import javax.crypto.{KeyGenerator, Mac, SecretKey}
 import org.http4s.headers.{Cookie => HCookie}
-import org.http4s.util.{CaseInsensitiveString, encodeHex}
+import org.http4s.headers.{Host, Origin, Referer, `X-Forwarded-For`}
+import org.http4s.util.{CaseInsensitiveString, decodeHexString, encodeHexString}
+import org.http4s.Uri.Scheme
 
 /** Middleware to avoid Cross-site request forgery attacks.
   * More info on CSRF at: https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)
@@ -27,12 +28,12 @@ import org.http4s.util.{CaseInsensitiveString, encodeHex}
   * By default, for requests that are unsafe (PUT, POST, DELETE, PATCH), services protected by the `validated` method in the
   * middleware will check that the csrf token is present in both the header `headerName` and the cookie `cookieName`.
   * Due to the Same-Origin policy, an attacker will be unable to reproduce this value in a
-  * custom header, resulting in a `401 Unauthorized` response.
+  * custom header, resulting in a `403 Forbidden` response.
   *
   * By default, requests with safe methods (such as GET, OPTIONS, HEAD) will have a new token embedded in them if there isn't one,
   * or will receive a refreshed token based off of the previous token to mitigate the BREACH vulnerability. If a request
   * contains an invalid token, regardless of whether it is a safe method, this middleware will fail it with
-  * `401 Unauthorized`. In this situation, your user(s) should clear their cookies for your page, to receive a new
+  * `403 Forbidden`. In this situation, your user(s) should clear their cookies for your page, to receive a new
   * token.
   *
   * The default can be overridden by modifying the `predicate` in `validate`. It will, by default, check if the method is safe.
@@ -52,83 +53,128 @@ final class CSRF[F[_], G[_]] private[middleware] (
     val headerName: String = "X-Csrf-Token",
     val cookieName: String = "csrf-token",
     key: SecretKey,
-    clock: Clock = Clock.systemUTC())(implicit F: Sync[F], G: Applicative[G]) {
+    clock: Clock = Clock.systemUTC(),
+    headerCheck: Request[G] => Boolean,
+    onFailure: Response[G],
+    secure: Boolean,
+    createIfNotFound: Boolean)(implicit F: Sync[F], G: Applicative[G]) { self =>
+  import CSRF._
 
   /** Sign our token using the current time in milliseconds as a nonce
     * Signing and generating a token is potentially a unsafe operation
     * if constructed with a bad key.
     */
-  private[middleware] def signToken(token: String): F[String] =
+  private[middleware] def signToken(rawToken: String): F[CSRFToken] =
     F.delay {
-      val joined = token + "-" + clock.millis()
+      val joined = rawToken + "-" + clock.millis()
       val mac = Mac.getInstance(CSRF.SigningAlgo)
       mac.init(key)
       val out = mac.doFinal(joined.getBytes(StandardCharsets.UTF_8))
-      joined + "-" + Base64.getEncoder.encodeToString(out)
+      lift(joined + "-" + encodeHexString(out))
     }
 
   /** Generate a new token **/
-  private[middleware] def generateToken: F[String] =
+  def generateToken: F[CSRFToken] =
     signToken(CSRF.genTokenString)
+
+  /** Create a Response cookie from a signed CSRF token
+    *
+    * @param token the signed csrf token
+    * @return
+    */
+  def createResponseCookie(token: CSRFToken): ResponseCookie =
+    ResponseCookie(name = cookieName, content = token, httpOnly = true, secure = self.secure)
+
+  /** Extract a csrftoken, if present, from the request,
+    * then generate a new token signature
+    * @return newly refreshed toen
+    */
+  def refreshedToken(r: Request[G]): OptionT[F, CSRFToken] =
+    OptionT
+      .fromOption[F](CSRF.cookieFromHeaders(r, cookieName))
+      .flatMap(c => extractRaw(c.content))
+      .semiflatMap(signToken)
 
   /** Decode our CSRF token and extract the original token string to sign
     */
-  private[middleware] def extractRaw(token: String): OptionT[F, String] =
-    token.split("-") match {
+  def extractRaw(rawToken: String): OptionT[F, String] =
+    rawToken.split("-") match {
       case Array(raw, nonce, signed) =>
-        OptionT(F.delay {
-          val mac = Mac.getInstance(CSRF.SigningAlgo)
-          mac.init(key)
-          val out = mac.doFinal((raw + "-" + nonce).getBytes(StandardCharsets.UTF_8))
-          if (MessageDigest.isEqual(out, Base64.getDecoder.decode(signed))) {
-            Some(raw)
-          } else {
-            None
-          }
-        })
+        val mac = Mac.getInstance(CSRF.SigningAlgo)
+        mac.init(key)
+        val out = mac.doFinal((raw + "-" + nonce).getBytes(StandardCharsets.UTF_8))
+        decodeHexString(signed) match {
+          case Some(decoded) =>
+            if (MessageDigest.isEqual(out, decoded)) {
+              OptionT(F.pure(Some(raw)))
+            } else {
+              OptionT(F.pure(None))
+            }
+          case None =>
+            OptionT(F.pure(None))
+        }
       case _ =>
-        OptionT.none
+        OptionT(F.pure(None))
     }
 
-  /** To be only used on safe methods: if the method is safe (i.e doesn't modify data),
-    * embed a new token if not present, or regenerate the current one to mitigate
-    * BREACH
+  /** To be only used on safe methods: if the method is safe (i.e doesn't modify data)
+    * and a token is present, validate and regenerate it for BREACH to be impractical
     */
-  private[middleware] def validateOrEmbed(r: Request[G], http: Http[F, G]): F[Response[G]] =
+  private[middleware] def validate(r: Request[G], response: F[Response[G]]): F[Response[G]] =
     CSRF.cookieFromHeaders(r, cookieName) match {
       case Some(c) =>
         (for {
           raw <- extractRaw(c.content)
-          res <- OptionT.liftF(http(r))
+          res <- OptionT.liftF(response)
           newToken <- OptionT.liftF(signToken(raw))
-        } yield res.addCookie(ResponseCookie(name = cookieName, content = newToken)))
-          .getOrElse(Response[G](Status.Unauthorized))
+        } yield res.addCookie(createResponseCookie(newToken)))
+          .getOrElse(Response[G](Status.Forbidden))
       case None =>
-        http(r).flatMap(embedNew)
+        if (createIfNotFound)
+          response.flatMap(embedNew)
+        else response
     }
 
-  /** Check for CSRF validity for an unsafe action. **/
-  private[middleware] def checkCSRF(r: Request[G], http: Http[F, G]): F[Response[G]] =
-    (for {
-      c1 <- OptionT.fromOption[F](CSRF.cookieFromHeaders(r, cookieName))
-      c2 <- OptionT.fromOption[F](r.headers.get(CaseInsensitiveString(headerName)))
-      raw1 <- extractRaw(c1.content)
-      raw2 <- extractRaw(c2.value)
-      response <- if (CSRF.isEqual(raw1, raw2)) OptionT.liftF(http(r))
-      else OptionT.none[F, Response[G]]
-      newToken <- OptionT.liftF(signToken(raw1)) //Generate a new token to guard against BREACH.
-    } yield response.addCookie(ResponseCookie(name = cookieName, content = newToken)))
-      .getOrElse(Response[G](Status.Unauthorized))
+  /** Check for CSRF validity for an unsafe action.
+    *
+    * Exposed to users in case of manual plumbing of csrf token
+    * (i.e websocket or query param)
+    */
+  def checkCSRFToken(r: Request[G], respAction: F[Response[G]], rawToken: String): F[Response[G]] =
+    if (!headerCheck(r))
+      F.pure(onFailure)
+    else
+      (for {
+        c1 <- OptionT.fromOption[F](CSRF.cookieFromHeaders(r, cookieName))
+        raw1 <- extractRaw(c1.content)
+        raw2 <- extractRaw(rawToken)
+        response <- if (CSRF.isEqual(raw1, raw2)) OptionT.liftF(respAction)
+        else OptionT.none[F, Response[G]]
+        newToken <- OptionT.liftF(signToken(raw1)) //Generate a new token to guard against BREACH.
+      } yield response.addCookie(ResponseCookie(name = cookieName, content = newToken)))
+        .getOrElse(onFailure)
+
+  /** Check for CSRF validity for an unsafe action.
+    *
+    * Check for the default header value
+    */
+  def checkCSRFDefault(r: Request[G], http: F[Response[G]]): F[Response[G]] =
+    r.headers.get(CaseInsensitiveString(headerName)) match {
+      case Some(h) =>
+        checkCSRFToken(r, http, h.value)
+      case None =>
+        F.pure(onFailure)
+    }
 
   /** Check predicate, then apply the correct csrf policy **/
-  private[middleware] def filter(
-      predicate: Request[G] => Boolean,
+  def filter(
+      predicate: Request[G] => Boolean = _.method.isSafe,
       r: Request[G],
       http: Http[F, G]): F[Response[G]] =
     if (predicate(r)) {
-      validateOrEmbed(r, http)
+      validate(r, http.run(r))
     } else {
-      checkCSRF(r, http)
+      checkCSRFDefault(r, http(r))
     }
 
   /** Constructs a middleware that will check for the csrf token
@@ -161,28 +207,101 @@ final class CSRF[F[_], G[_]] private[middleware] (
 
 object CSRF {
 
+  //Newtype hax
+  type CSRFToken <: String
+  private[CSRF] def lift(s: String): CSRFToken = s.asInstanceOf[CSRFToken]
+
   /** Default method for constructing CSRF middleware **/
   def apply[F[_]: Sync, G[_]: Applicative](
       headerName: String = "X-Csrf-Token",
       cookieName: String = "csrf-token",
       key: SecretKey,
-      clock: Clock = Clock.systemUTC()): CSRF[F, G] =
-    new CSRF[F, G](headerName, cookieName, key, clock)
+      clock: Clock = Clock.systemUTC(),
+      onFailure: Response[G] = Response[G](Status.Forbidden),
+      secure: Boolean = false,
+      createIfNotFound: Boolean = true,
+      headerCheck: Request[G] => Boolean): CSRF[F, G] =
+    new CSRF[F, G](
+      headerName,
+      cookieName,
+      key,
+      clock,
+      headerCheck,
+      onFailure,
+      secure,
+      createIfNotFound)
+
+  /** Default method for constructing CSRF middleware **/
+  def default[F[_]: Sync, G[_]: Applicative](
+      headerName: String = "X-Csrf-Token",
+      cookieName: String = "csrf-token",
+      key: SecretKey,
+      clock: Clock = Clock.systemUTC(),
+      onFailure: Response[G] = Response[G](Status.Forbidden),
+      host: String,
+      sc: Scheme,
+      port: Option[Int],
+      secure: Boolean = false,
+      createIfNotFound: Boolean = true): CSRF[F, G] =
+    new CSRF[F, G](
+      headerName,
+      cookieName,
+      key,
+      clock,
+      defaultOriginCheck(_, host, sc, port),
+      onFailure,
+      secure,
+      createIfNotFound)
+
+  /** Check origin matches our proposed origin.
+    *
+    * @param r
+    * @param host
+    * @param sc
+    * @param port
+    * @tparam F
+    * @return
+    */
+  def defaultOriginCheck[F[_]](
+      r: Request[F],
+      host: String,
+      sc: Scheme,
+      port: Option[Int]): Boolean =
+    r.headers
+      .get(Origin)
+      .flatMap(o => Uri.fromString(o.value).toOption)
+      .exists(u => u.host.exists(_.value == host) && u.scheme.contains(sc) && u.port == port) || r.headers
+      .get(Referer)
+      .exists(u =>
+        u.uri.host.exists(_.value == host) && u.uri.scheme.contains(sc) && u.uri.port == port)
+
+  def proxyOriginCheck[F[_]](r: Request[F], host: Host, xff: `X-Forwarded-For`): Boolean =
+    r.headers.get(Host).contains(host) || r.headers.get(`X-Forwarded-For`).contains(xff)
 
   /** Sugar for instantiating a middleware by generating a key **/
   def withGeneratedKey[F[_]: Sync, G[_]: Applicative](
       headerName: String = "X-Csrf-Token",
       cookieName: String = "csrf-token",
-      clock: Clock = Clock.systemUTC()): F[CSRF[F, G]] =
-    generateSigningKey().map(apply(headerName, cookieName, _, clock))
+      clock: Clock = Clock.systemUTC(),
+      onFailure: Response[G] = Response[G](Status.Forbidden),
+      secure: Boolean = false,
+      createIfNotFound: Boolean = true,
+      headerCheck: Request[G] => Boolean): F[CSRF[F, G]] =
+    generateSigningKey().map(
+      apply(headerName, cookieName, _, clock, onFailure, secure, createIfNotFound, headerCheck))
 
   /** Sugar for pre-loading a key **/
   def withKeyBytes[F[_]: Sync, G[_]: Applicative](
       keyBytes: Array[Byte],
       headerName: String = "X-Csrf-Token",
       cookieName: String = "csrf-token",
-      clock: Clock = Clock.systemUTC()): F[CSRF[F, G]] =
-    buildSigningKey(keyBytes).map(apply(headerName, cookieName, _, clock))
+      clock: Clock = Clock.systemUTC(),
+      onFailure: Response[G] = Response[G](Status.Forbidden),
+      secure: Boolean = false,
+      createIfNotFound: Boolean = true,
+      headerCheck: Request[G] => Boolean): F[CSRF[F, G]] =
+    buildSigningKey(keyBytes).map(
+      apply(headerName, cookieName, _, clock, onFailure, secure, createIfNotFound, headerCheck))
 
   val SigningAlgo: String = "HmacSHA1"
   val SHA1ByteLen: Int = 20
@@ -194,6 +313,7 @@ object CSRF {
     */
   private val InitialSeedArraySize: Int = 20
   private val CachedRandom: SecureRandom = {
+    //Todo: OS dependent check to use /urandom instead
     val r = new SecureRandom()
     r.nextBytes(new Array[Byte](InitialSeedArraySize))
     r
@@ -214,7 +334,7 @@ object CSRF {
   private[middleware] def genTokenString: String = {
     val bytes = new Array[Byte](CSRFTokenLength)
     CachedRandom.nextBytes(bytes)
-    new String(encodeHex(bytes))
+    encodeHexString(bytes)
   }
 
   /** Generate a signing Key for the CSRF token **/

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -163,7 +163,7 @@ final class CSRF[F[_], G[_]] private[middleware] (
           }
       case None =>
         if (createIfNotFound) {
-          response.flatMap(r => embedNewInCookie(r))
+          response.flatMap(r => embedNewInResponseCookie(r))
         } else response
     }
 
@@ -238,7 +238,7 @@ final class CSRF[F[_], G[_]] private[middleware] (
     r.addCookie(createRequestCookie(token))
 
   /** Embed a token into a response **/
-  def embedNewInCookie[M[_]: Sync](res: Response[G]): M[Response[G]] =
+  def embedNewInResponseCookie[M[_]: Sync](res: Response[G]): M[Response[G]] =
     generateToken[M].map(embedInResponseCookie(res, _))
 }
 

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -13,7 +13,8 @@ import javax.crypto.spec.SecretKeySpec
 import javax.crypto.{KeyGenerator, Mac, SecretKey}
 import org.http4s.headers.{Cookie => HCookie}
 import org.http4s.headers.{Host, Origin, Referer, `X-Forwarded-For`}
-import org.http4s.util.{CaseInsensitiveString, decodeHexString, encodeHexString}
+import org.http4s.util.{CaseInsensitiveString}
+import org.http4s.internal.{decodeHexString, encodeHexString}
 import org.http4s.Uri.Scheme
 import scala.util.control.NoStackTrace
 
@@ -93,9 +94,9 @@ final class CSRF[F[_], G[_]] private[middleware] (
   def createRequestCookie(token: CSRFToken): RequestCookie =
     RequestCookie(name = cookieName, content = unlift(token))
 
-  /** Extract a csrftoken, if present, from the request,
+  /** Extract a `CsrfToken`, if present, from the request,
     * then generate a new token signature
-    * @return newly refreshed toen
+    * @return newly refreshed token
     */
   def refreshedToken[M[_]](r: Request[G])(
       implicit F: Sync[M]): EitherT[M, CSRFCheckFailed, CSRFToken] =

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -223,8 +223,7 @@ class CSRFSpec extends Http4sSpec {
               .putHeaders(Header(csrf.headerName, token))
               .addCookie(csrf.cookieName, token)
           ))
-        r <- OptionT.fromOption[IO](
-          res.cookies.find(_.name == csrf.cookieName).map(_.content))
+        r <- OptionT.fromOption[IO](res.cookies.find(_.name == csrf.cookieName).map(_.content))
         raw2 <- csrf.extractRaw(r)
       } yield r != token && raw1 == raw2).value.unsafeRunSync() must beSome(true)
     }

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -134,7 +134,7 @@ class CSRFSpec extends Http4sSpec {
         token <- csrf.generateToken[IO]
         res <- csrf.validate()(dummyRoutes)(
           dummyRequest
-            .putHeaders(Header(csrf.headerName, unlift(token)))
+            .putHeaders(Header(csrf.headerName.value, unlift(token)))
             .addCookie(csrf.cookieName, unlift(token))
         )
       } yield res
@@ -150,7 +150,7 @@ class CSRFSpec extends Http4sSpec {
             csrf.embedInRequestCookie(
               Request[IO](POST)
                 .putHeaders(
-                  Header(csrf.headerName, unlift(token)),
+                  Header(csrf.headerName.value, unlift(token)),
                   Referer(Uri.unsafeFromString("http://localhost/lol"))),
               token)
           )
@@ -175,7 +175,7 @@ class CSRFSpec extends Http4sSpec {
         res <- csrf.validate()(dummyRoutes)(
           Request[IO](POST)
             .putHeaders(
-              Header(csrf.headerName, unlift(token)),
+              Header(csrf.headerName.value, unlift(token)),
               Header("Origin", "http://example.com"),
               Referer(Uri.unsafeFromString("http://example.com/lol")))
             .addCookie(csrf.cookieName, unlift(token))
@@ -203,7 +203,7 @@ class CSRFSpec extends Http4sSpec {
       (for {
         token <- csrf.generateToken[IO]
         res <- csrf.validate()(dummyRoutes)(
-          dummyRequest.putHeaders(Header(csrf.headerName, unlift(token)))
+          dummyRequest.putHeaders(Header(csrf.headerName.value, unlift(token)))
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
     }
@@ -214,7 +214,7 @@ class CSRFSpec extends Http4sSpec {
         token2 <- csrf.generateToken[IO]
         res <- csrf.validate()(dummyRoutes)(
           dummyRequest
-            .withHeaders(Headers(Header(csrf.headerName, unlift(token1))))
+            .withHeaders(Headers(Header(csrf.headerName.value, unlift(token1))))
             .addCookie(csrf.cookieName, unlift(token2))
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
@@ -227,7 +227,7 @@ class CSRFSpec extends Http4sSpec {
           raw1 <- IO.fromEither(csrf.extractRaw(unlift(token)))
           res <- csrf.validate()(dummyRoutes)(
             dummyRequest
-              .putHeaders(Header(csrf.headerName, unlift(token)))
+              .putHeaders(Header(csrf.headerName.value, unlift(token)))
               .addCookie(csrf.cookieName, unlift(token))
           )
           rawContent = res.cookies.find(_.name == csrf.cookieName).map(_.content).getOrElse("")
@@ -243,7 +243,7 @@ class CSRFSpec extends Http4sSpec {
         token2 <- csrf.generateToken[IO]
         res <- csrf.validate()(dummyRoutes)(
           dummyRequest
-            .putHeaders(Header(csrf.headerName, unlift(token1)))
+            .putHeaders(Header(csrf.headerName.value, unlift(token1)))
             .addCookie(csrf.cookieName, unlift(token2))
         )
       } yield res).unsafeRunSync()

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -40,7 +40,7 @@ class CSRFSpec extends Http4sSpec {
     Request[IO](method = Method.POST).putHeaders(Header("Origin", "http://localhost"))
   val passThroughRequest: Request[IO] = Request[IO]()
 
-  val csrfDefault: CSRF[IO, IO] = CSRF
+  val csrf: CSRF[IO, IO] = CSRF
     .withGeneratedKey[IO, IO](
       clock = testClock,
       headerCheck = CSRF.defaultOriginCheck[IO](_, "localhost", Uri.Scheme.http, None))
@@ -48,10 +48,10 @@ class CSRFSpec extends Http4sSpec {
 
   "CSRF" should {
     "pass through and embed a new token for a safe, fresh request if set" in {
-      val response = csrfDefault.validate()(dummyRoutes)(passThroughRequest).unsafeRunSync()
+      val response = csrf.validate()(dummyRoutes)(passThroughRequest).unsafeRunSync()
 
       response.status must_== Status.Ok
-      response.cookies.exists(_.name == csrfDefault.cookieName) must_== true
+      response.cookies.exists(_.name == csrf.cookieName) must_== true
     }
 
     "pass through and not embed a new token for a safe, fresh request" in {
@@ -65,27 +65,27 @@ class CSRFSpec extends Http4sSpec {
       val response = csrfNoEmbed.validate()(dummyRoutes)(passThroughRequest).unsafeRunSync()
 
       response.status must_== Status.Ok
-      response.cookies.exists(_.name == csrfDefault.cookieName) must_== false
+      response.cookies.exists(_.name == csrf.cookieName) must_== false
     }
 
     "Extract a valid token, with a slightly changed nonce, if present" in {
       val program = for {
-        t <- csrfDefault.generateToken
-        req = dummyRequest.addCookie(RequestCookie(csrfDefault.cookieName, t))
-        newToken <- csrfDefault.refreshedToken(req).value
+        t <- csrf.generateToken
+        req = dummyRequest.addCookie(RequestCookie(csrf.cookieName, t))
+        newToken <- csrf.refreshedToken(req).value
       } yield newToken
 
       val newToken = program.unsafeRunSync()
       newToken.isDefined must_== true
       //Checks whether it was properly signed
-      csrfDefault.extractRaw(newToken.get).value.unsafeRunSync().isDefined must_== true
+      csrf.extractRaw(newToken.get).value.unsafeRunSync().isDefined must_== true
     }
 
     "pass a request with valid origin a request without any origin, even with a token" in {
       val program: IO[Response[IO]] = for {
-        token <- csrfDefault.generateToken
-        req = Request[IO](POST).addCookie(RequestCookie(csrfDefault.cookieName, token))
-        v <- csrfDefault.checkCSRFDefault(req, dummyRoutes.run(req))
+        token <- csrf.generateToken
+        req = Request[IO](POST).addCookie(RequestCookie(csrf.cookieName, token))
+        v <- csrf.checkCSRFDefault(req, dummyRoutes.run(req))
       } yield v
 
       program.unsafeRunSync().status must_== Status.Forbidden
@@ -93,27 +93,27 @@ class CSRFSpec extends Http4sSpec {
 
     "fail a request with an invalid cookie, despite it being a safe method" in {
       val response =
-        csrfDefault
+        csrf
           .validate()(dummyRoutes)(
-            passThroughRequest.addCookie(RequestCookie(csrfDefault.cookieName, "MOOSE")))
+            passThroughRequest.addCookie(RequestCookie(csrf.cookieName, "MOOSE")))
           .unsafeRunSync()
 
       response.status must_== Status.Forbidden // Must fail
-      !response.cookies.exists(_.name == csrfDefault.cookieName) must_== true //Must not embed a new token
+      !response.cookies.exists(_.name == csrf.cookieName) must_== true //Must not embed a new token
     }
 
     "pass through and embed a slightly different token for a safe request" in {
       val (oldToken, oldRaw, response, newToken, newRaw) =
         (for {
-          oldToken <- csrfDefault.generateToken
-          raw1 <- csrfDefault.extractRaw(oldToken).getOrElse("Invalid1")
-          response <- csrfDefault
-            .validate()(dummyRoutes)(passThroughRequest.addCookie(csrfDefault.cookieName, oldToken))
+          oldToken <- csrf.generateToken
+          raw1 <- csrf.extractRaw(oldToken).getOrElse("Invalid1")
+          response <- csrf
+            .validate()(dummyRoutes)(passThroughRequest.addCookie(csrf.cookieName, oldToken))
           newCookie <- IO.pure(
             response.cookies
-              .find(_.name == csrfDefault.cookieName)
+              .find(_.name == csrf.cookieName)
               .getOrElse(ResponseCookie("invalid", "Invalid2")))
-          raw2 <- csrfDefault.extractRaw(newCookie.content).getOrElse("Invalid1")
+          raw2 <- csrf.extractRaw(newCookie.content).getOrElse("Invalid1")
         } yield (oldToken, raw1, response, newCookie, raw2)).unsafeRunSync()
 
       response.status must_== Status.Ok
@@ -123,40 +123,40 @@ class CSRFSpec extends Http4sSpec {
 
     "not validate different tokens" in {
       (for {
-        t1 <- csrfDefault.generateToken
-        t2 <- csrfDefault.generateToken
+        t1 <- csrf.generateToken
+        t2 <- csrf.generateToken
       } yield CSRF.isEqual(t1, t2)).unsafeRunSync() must_== false
     }
 
     "validate for the correct csrf token and origin" in {
       (for {
-        token <- csrfDefault.generateToken
-        res <- csrfDefault.validate()(dummyRoutes)(
+        token <- csrf.generateToken
+        res <- csrf.validate()(dummyRoutes)(
           dummyRequest
-            .putHeaders(Header(csrfDefault.headerName, token))
-            .addCookie(csrfDefault.cookieName, token)
+            .putHeaders(Header(csrf.headerName, token))
+            .addCookie(csrf.cookieName, token)
         )
       } yield res).unsafeRunSync().status must_== Status.Ok
     }
 
     "validate for the correct csrf token, no origin but with a referrer" in {
       (for {
-        token <- csrfDefault.generateToken
-        res <- csrfDefault.validate()(dummyRoutes)(
+        token <- csrf.generateToken
+        res <- csrf.validate()(dummyRoutes)(
           Request[IO](POST)
             .putHeaders(
-              Header(csrfDefault.headerName, token),
+              Header(csrf.headerName, token),
               Referer(Uri.unsafeFromString("http://localhost/lol")))
-            .addCookie(csrfDefault.cookieName, token)
+            .addCookie(csrf.cookieName, token)
         )
       } yield res).unsafeRunSync().status must_== Status.Ok
     }
 
     "fail a request without any origin, even with a token" in {
       val program: IO[Response[IO]] = for {
-        token <- csrfDefault.generateToken
-        req = Request[IO](POST).addCookie(RequestCookie(csrfDefault.cookieName, token))
-        v <- csrfDefault.checkCSRFDefault(req, dummyRoutes.run(req))
+        token <- csrf.generateToken
+        req = Request[IO](POST).addCookie(RequestCookie(csrf.cookieName, token))
+        v <- csrf.checkCSRFDefault(req, dummyRoutes.run(req))
       } yield v
 
       program.unsafeRunSync().status must_== Status.Forbidden
@@ -164,20 +164,20 @@ class CSRFSpec extends Http4sSpec {
 
     "fail a request with an incorrect origin and incorrect referrer, even with a token" in {
       (for {
-        token <- csrfDefault.generateToken
-        res <- csrfDefault.validate()(dummyRoutes)(
+        token <- csrf.generateToken
+        res <- csrf.validate()(dummyRoutes)(
           Request[IO](POST)
             .putHeaders(
-              Header(csrfDefault.headerName, token),
+              Header(csrf.headerName, token),
               Header("Origin", "http://example.com"),
               Referer(Uri.unsafeFromString("http://example.com/lol")))
-            .addCookie(csrfDefault.cookieName, token)
+            .addCookie(csrf.cookieName, token)
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
     }
 
     "not validate if token is missing in both" in {
-      csrfDefault
+      csrf
         .validate()(dummyRoutes)(dummyRequest)
         .unsafeRunSync()
         .status must_== Status.Forbidden
@@ -185,64 +185,64 @@ class CSRFSpec extends Http4sSpec {
 
     "not validate for token missing in header" in {
       (for {
-        token <- csrfDefault.generateToken
-        res <- csrfDefault.validate()(dummyRoutes)(
-          dummyRequest.addCookie(csrfDefault.cookieName, token)
+        token <- csrf.generateToken
+        res <- csrf.validate()(dummyRoutes)(
+          dummyRequest.addCookie(csrf.cookieName, token)
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
     }
 
     "not validate for token missing in cookie" in {
       (for {
-        token <- csrfDefault.generateToken
-        res <- csrfDefault.validate()(dummyRoutes)(
-          dummyRequest.putHeaders(Header(csrfDefault.headerName, token))
+        token <- csrf.generateToken
+        res <- csrf.validate()(dummyRoutes)(
+          dummyRequest.putHeaders(Header(csrf.headerName, token))
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
     }
 
     "not validate for different tokens" in {
       (for {
-        token1 <- csrfDefault.generateToken
-        token2 <- csrfDefault.generateToken
-        res <- csrfDefault.validate()(dummyRoutes)(
+        token1 <- csrf.generateToken
+        token2 <- csrf.generateToken
+        res <- csrf.validate()(dummyRoutes)(
           dummyRequest
-            .withHeaders(Headers(Header(csrfDefault.headerName, token1)))
-            .addCookie(csrfDefault.cookieName, token2)
+            .withHeaders(Headers(Header(csrf.headerName, token1)))
+            .addCookie(csrf.cookieName, token2)
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
     }
 
     "not return the same token to mitigate BREACH" in {
       (for {
-        token <- OptionT.liftF(csrfDefault.generateToken)
-        raw1 <- csrfDefault.extractRaw(token)
+        token <- OptionT.liftF(csrf.generateToken)
+        raw1 <- csrf.extractRaw(token)
         res <- OptionT.liftF(
-          csrfDefault.validate()(dummyRoutes)(
+          csrf.validate()(dummyRoutes)(
             dummyRequest
-              .putHeaders(Header(csrfDefault.headerName, token))
-              .addCookie(csrfDefault.cookieName, token)
+              .putHeaders(Header(csrf.headerName, token))
+              .addCookie(csrf.cookieName, token)
           ))
         r <- OptionT.fromOption[IO](
-          res.cookies.find(_.name == csrfDefault.cookieName).map(_.content))
-        raw2 <- csrfDefault.extractRaw(r)
+          res.cookies.find(_.name == csrf.cookieName).map(_.content))
+        raw2 <- csrf.extractRaw(r)
       } yield r != token && raw1 == raw2).value.unsafeRunSync() must beSome(true)
     }
 
     "not return a token for a failed CSRF check" in {
       val response = (for {
-        token1 <- OptionT.liftF(csrfDefault.generateToken)
-        token2 <- OptionT.liftF(csrfDefault.generateToken)
+        token1 <- OptionT.liftF(csrf.generateToken)
+        token2 <- OptionT.liftF(csrf.generateToken)
         res <- OptionT.liftF(
-          csrfDefault.validate()(dummyRoutes)(
+          csrf.validate()(dummyRoutes)(
             dummyRequest
-              .putHeaders(Header(csrfDefault.headerName, token1))
-              .addCookie(csrfDefault.cookieName, token2)
+              .putHeaders(Header(csrf.headerName, token1))
+              .addCookie(csrf.cookieName, token2)
           ))
       } yield res).getOrElse(Response.notFound).unsafeRunSync()
 
       response.status must_== Status.Forbidden
-      !response.cookies.exists(_.name == csrfDefault.cookieName) must_== true
+      !response.cookies.exists(_.name == csrf.cookieName) must_== true
     }
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -2,11 +2,11 @@ package org.http4s.server.middleware
 
 import java.time.{Clock, Instant, ZoneId}
 import java.util.concurrent.atomic.AtomicLong
-import cats.data.OptionT
 import cats.effect.IO
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.headers.Referer
+import CSRF.unlift
 
 class CSRFSpec extends Http4sSpec {
 
@@ -38,6 +38,7 @@ class CSRFSpec extends Http4sSpec {
 
   val dummyRequest: Request[IO] =
     Request[IO](method = Method.POST).putHeaders(Header("Origin", "http://localhost"))
+
   val passThroughRequest: Request[IO] = Request[IO]()
 
   val csrf: CSRF[IO, IO] = CSRF
@@ -70,21 +71,20 @@ class CSRFSpec extends Http4sSpec {
 
     "Extract a valid token, with a slightly changed nonce, if present" in {
       val program = for {
-        t <- csrf.generateToken
-        req = dummyRequest.addCookie(RequestCookie(csrf.cookieName, t))
-        newToken <- csrf.refreshedToken(req).value
+        t <- csrf.generateToken[IO]
+        req = csrf.embedInRequestCookie(dummyRequest, t)
+        newToken <- csrf.refreshedToken[IO](req).valueOrF(IO.raiseError)
       } yield newToken
 
       val newToken = program.unsafeRunSync()
-      newToken.isDefined must_== true
       //Checks whether it was properly signed
-      csrf.extractRaw(newToken.get).value.unsafeRunSync().isDefined must_== true
+      csrf.extractRaw(unlift(newToken)).isRight must_== true
     }
 
     "pass a request with valid origin a request without any origin, even with a token" in {
       val program: IO[Response[IO]] = for {
-        token <- csrf.generateToken
-        req = Request[IO](POST).addCookie(RequestCookie(csrf.cookieName, token))
+        token <- csrf.generateToken[IO]
+        req = csrf.embedInRequestCookie(Request[IO](POST), token)
         v <- csrf.checkCSRFDefault(req, dummyRoutes.run(req))
       } yield v
 
@@ -105,15 +105,14 @@ class CSRFSpec extends Http4sSpec {
     "pass through and embed a slightly different token for a safe request" in {
       val (oldToken, oldRaw, response, newToken, newRaw) =
         (for {
-          oldToken <- csrf.generateToken
-          raw1 <- csrf.extractRaw(oldToken).getOrElse("Invalid1")
-          response <- csrf
-            .validate()(dummyRoutes)(passThroughRequest.addCookie(csrf.cookieName, oldToken))
-          newCookie <- IO.pure(
-            response.cookies
-              .find(_.name == csrf.cookieName)
-              .getOrElse(ResponseCookie("invalid", "Invalid2")))
-          raw2 <- csrf.extractRaw(newCookie.content).getOrElse("Invalid1")
+          oldToken <- csrf.generateToken[IO]
+          raw1 <- IO.fromEither(csrf.extractRaw(unlift(oldToken)))
+          response <- csrf.validate()(dummyRoutes)(
+            csrf.embedInRequestCookie(passThroughRequest, oldToken))
+          newCookie = response.cookies
+            .find(_.name == csrf.cookieName)
+            .getOrElse(ResponseCookie("invalid", "Invalid2"))
+          raw2 <- IO.fromEither(csrf.extractRaw(newCookie.content))
         } yield (oldToken, raw1, response, newCookie, raw2)).unsafeRunSync()
 
       response.status must_== Status.Ok
@@ -122,40 +121,48 @@ class CSRFSpec extends Http4sSpec {
     }
 
     "not validate different tokens" in {
-      (for {
-        t1 <- csrf.generateToken
-        t2 <- csrf.generateToken
-      } yield CSRF.isEqual(t1, t2)).unsafeRunSync() must_== false
+      val program: IO[Boolean] = for {
+        t1 <- csrf.generateToken[IO]
+        t2 <- csrf.generateToken[IO]
+      } yield CSRF.tokensEqual(t1, t2)
+
+      program.unsafeRunSync() must_== false
     }
 
     "validate for the correct csrf token and origin" in {
-      (for {
-        token <- csrf.generateToken
+      val program: IO[Response[IO]] = for {
+        token <- csrf.generateToken[IO]
         res <- csrf.validate()(dummyRoutes)(
           dummyRequest
-            .putHeaders(Header(csrf.headerName, token))
-            .addCookie(csrf.cookieName, token)
+            .putHeaders(Header(csrf.headerName, unlift(token)))
+            .addCookie(csrf.cookieName, unlift(token))
         )
-      } yield res).unsafeRunSync().status must_== Status.Ok
+      } yield res
+
+      program.unsafeRunSync().status must_== Status.Ok
     }
 
     "validate for the correct csrf token, no origin but with a referrer" in {
-      (for {
-        token <- csrf.generateToken
-        res <- csrf.validate()(dummyRoutes)(
-          Request[IO](POST)
-            .putHeaders(
-              Header(csrf.headerName, token),
-              Referer(Uri.unsafeFromString("http://localhost/lol")))
-            .addCookie(csrf.cookieName, token)
-        )
-      } yield res).unsafeRunSync().status must_== Status.Ok
+      val program: IO[Response[IO]] =
+        for {
+          token <- csrf.generateToken[IO]
+          res <- csrf.validate()(dummyRoutes)(
+            csrf.embedInRequestCookie(
+              Request[IO](POST)
+                .putHeaders(
+                  Header(csrf.headerName, unlift(token)),
+                  Referer(Uri.unsafeFromString("http://localhost/lol"))),
+              token)
+          )
+        } yield res
+
+      program.unsafeRunSync().status must_== Status.Ok
     }
 
     "fail a request without any origin, even with a token" in {
       val program: IO[Response[IO]] = for {
-        token <- csrf.generateToken
-        req = Request[IO](POST).addCookie(RequestCookie(csrf.cookieName, token))
+        token <- csrf.generateToken[IO]
+        req = csrf.embedInRequestCookie(Request[IO](POST), token)
         v <- csrf.checkCSRFDefault(req, dummyRoutes.run(req))
       } yield v
 
@@ -164,14 +171,14 @@ class CSRFSpec extends Http4sSpec {
 
     "fail a request with an incorrect origin and incorrect referrer, even with a token" in {
       (for {
-        token <- csrf.generateToken
+        token <- csrf.generateToken[IO]
         res <- csrf.validate()(dummyRoutes)(
           Request[IO](POST)
             .putHeaders(
-              Header(csrf.headerName, token),
+              Header(csrf.headerName, unlift(token)),
               Header("Origin", "http://example.com"),
               Referer(Uri.unsafeFromString("http://example.com/lol")))
-            .addCookie(csrf.cookieName, token)
+            .addCookie(csrf.cookieName, unlift(token))
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
     }
@@ -185,60 +192,61 @@ class CSRFSpec extends Http4sSpec {
 
     "not validate for token missing in header" in {
       (for {
-        token <- csrf.generateToken
+        token <- csrf.generateToken[IO]
         res <- csrf.validate()(dummyRoutes)(
-          dummyRequest.addCookie(csrf.cookieName, token)
+          dummyRequest.addCookie(csrf.cookieName, unlift(token))
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
     }
 
     "not validate for token missing in cookie" in {
       (for {
-        token <- csrf.generateToken
+        token <- csrf.generateToken[IO]
         res <- csrf.validate()(dummyRoutes)(
-          dummyRequest.putHeaders(Header(csrf.headerName, token))
+          dummyRequest.putHeaders(Header(csrf.headerName, unlift(token)))
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
     }
 
     "not validate for different tokens" in {
       (for {
-        token1 <- csrf.generateToken
-        token2 <- csrf.generateToken
+        token1 <- csrf.generateToken[IO]
+        token2 <- csrf.generateToken[IO]
         res <- csrf.validate()(dummyRoutes)(
           dummyRequest
-            .withHeaders(Headers(Header(csrf.headerName, token1)))
-            .addCookie(csrf.cookieName, token2)
+            .withHeaders(Headers(Header(csrf.headerName, unlift(token1))))
+            .addCookie(csrf.cookieName, unlift(token2))
         )
       } yield res).unsafeRunSync().status must_== Status.Forbidden
     }
 
     "not return the same token to mitigate BREACH" in {
-      (for {
-        token <- OptionT.liftF(csrf.generateToken)
-        raw1 <- csrf.extractRaw(token)
-        res <- OptionT.liftF(
-          csrf.validate()(dummyRoutes)(
+      val program: IO[Boolean] =
+        for {
+          token <- csrf.generateToken[IO]
+          raw1 <- IO.fromEither(csrf.extractRaw(unlift(token)))
+          res <- csrf.validate()(dummyRoutes)(
             dummyRequest
-              .putHeaders(Header(csrf.headerName, token))
-              .addCookie(csrf.cookieName, token)
-          ))
-        r <- OptionT.fromOption[IO](res.cookies.find(_.name == csrf.cookieName).map(_.content))
-        raw2 <- csrf.extractRaw(r)
-      } yield r != token && raw1 == raw2).value.unsafeRunSync() must beSome(true)
+              .putHeaders(Header(csrf.headerName, unlift(token)))
+              .addCookie(csrf.cookieName, unlift(token))
+          )
+          rawContent = res.cookies.find(_.name == csrf.cookieName).map(_.content).getOrElse("")
+          raw2 <- IO.fromEither(csrf.extractRaw(rawContent))
+        } yield rawContent != token && raw1 == raw2
+
+      program.unsafeRunSync() must_=== true
     }
 
     "not return a token for a failed CSRF check" in {
       val response = (for {
-        token1 <- OptionT.liftF(csrf.generateToken)
-        token2 <- OptionT.liftF(csrf.generateToken)
-        res <- OptionT.liftF(
-          csrf.validate()(dummyRoutes)(
-            dummyRequest
-              .putHeaders(Header(csrf.headerName, token1))
-              .addCookie(csrf.cookieName, token2)
-          ))
-      } yield res).getOrElse(Response.notFound).unsafeRunSync()
+        token1 <- csrf.generateToken[IO]
+        token2 <- csrf.generateToken[IO]
+        res <- csrf.validate()(dummyRoutes)(
+          dummyRequest
+            .putHeaders(Header(csrf.headerName, unlift(token1)))
+            .addCookie(csrf.cookieName, unlift(token2))
+        )
+      } yield res).unsafeRunSync()
 
       response.status must_== Status.Forbidden
       !response.cookies.exists(_.name == csrf.cookieName) must_== true


### PR DESCRIPTION
closes #1989 

This changes our CSRF middleware significantly. In particular:
- CSRF tokens are now newtyped... because passing around `String` everywhere was honestly giving me a goddamn headache
- CSRF token signatures are encoded in hexadecimal strings, making it url-safe. For example: In the case of websockets, clients (if using a browser) often have no way of embedding the csrf token in the header, forcing sending in a query parameter or as part of the path.
- CSRF Internal functions are now not private, as I've had to define my own combinators with them before. Just in case of a very special use case for whatever reason (i.e csrf token in multipart payload), the functions are exposed to be able to construct csrf actions from a specific endpoint.
- CSRF now takes a conditional `Request[G] => Boolean`, which is meant to be used to check `Origin` headers in particular, [as stated by OWASP](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Verifying_Same_Origin_with_Standard_Headers). However, given that behind a proxy, neither `Origin` nor `Referrer` may be present, the conditional is left open-ended (with a few default constructors), for the sake of custom use cases
- Default error status is `Forbidden`, given that `Unauthorized` (despite being correct in name), [for whatever silly reason is for _Authentication_ Errors](https://stackoverflow.com/questions/3297048/403-forbidden-vs-401-unauthorized-http-responses) (lol http)