### PR TITLE
Restrict MethodNotAllowed constructor in Response Generator DSL.

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
@@ -219,7 +219,7 @@ object Responses {
       with EntityResponseGenerator[F]
   final class MethodNotAllowedOps[F[_]](val status: MethodNotAllowed.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
+      with AllowResponseGenerator[F]
   final class NotAcceptableOps[F[_]](val status: NotAcceptable.type)
       extends AnyVal
       with EntityResponseGenerator[F]

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -34,7 +34,7 @@ class ExampleService[F[_]](implicit F: Effect[F]) extends Http4sDsl[F] {
 
       case _ -> Root =>
         // The default route result is NotFound. Sometimes MethodNotAllowed is more appropriate.
-        MethodNotAllowed()
+        MethodNotAllowed(Allow(GET))
 
       case GET -> Root / "ping" =>
         // EntityEncoder allows for easy conversion of types to a response body


### PR DESCRIPTION
According to [Section 10.4.6 of the RFC 2616](https://tools.ietf.org/html/rfc2616#section-10.4.6), about the HTTP protocol, when using the `405 MethodNotAllowed` status code,

> The response MUST include an Allow header containing a list of valid
>  methods for the requested resource.

We thus restrict the DSL constructions for the MethodNotAllowed status. We add a trait `AllowResponseGenerator`, mostly copied and adapted from the `WwwAuthenticateResponseGenerator` trait.

Resolves #2028.