### PR TITLE
Initial implementation of Throttle middleware

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/Throttle.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Throttle.scala
@@ -1,0 +1,125 @@
+package org.http4s.server.middleware
+
+import org.http4s.{Headers, Http, Response, Status}
+import cats.data.Kleisli
+import cats.effect.{Clock, Sync}
+import cats.effect.concurrent.Ref
+import scala.concurrent.duration.FiniteDuration
+import cats.implicits._
+import java.util.concurrent.TimeUnit.NANOSECONDS
+import org.http4s.headers.`Retry-After`
+import scala.concurrent.duration._
+
+/**
+  * Transform a service to reject any calls the go over a given rate.
+  */
+object Throttle {
+
+  sealed abstract class TokenAvailability extends Product with Serializable
+  case object TokenAvailable extends TokenAvailability
+  final case class TokenUnavailable(retryAfter: Option[FiniteDuration]) extends TokenAvailability
+
+  /**
+    * A token bucket for use with the [[Throttle]] middleware.  Consumers can take tokens which will be refilled over time.
+    * Implementations are required to provide their own refill mechanism.
+    *
+    * Possible implementations include a remote TokenBucket service to coordinate between different application instances.
+    */
+  trait TokenBucket[F[_]] {
+    def takeToken: F[TokenAvailability]
+  }
+
+  object TokenBucket {
+
+    /**
+      * Creates an in-memory [[TokenBucket]].
+      *
+      * @param capacity the number of tokens the bucket can hold and starts with.
+      * @param refillEvery the frequency with which to add another token if there is capacity spare.
+      * @return A task to create the [[TokenBucket]].
+      */
+    def local[F[_]](capacity: Int, refillEvery: FiniteDuration)(
+        implicit F: Sync[F],
+        clock: Clock[F]): F[TokenBucket[F]] = {
+
+      def getTime = clock.monotonic(NANOSECONDS)
+      val bucket = getTime.flatMap(time => Ref[F].of((capacity.toDouble, time)))
+
+      bucket.map { counter =>
+        new TokenBucket[F] {
+          override def takeToken: F[TokenAvailability] = {
+            val attemptUpdate = counter.access.flatMap {
+              case ((previousTokens, previousTime), setter) =>
+                getTime.flatMap(currentTime => {
+                  val timeDifference = currentTime - previousTime
+                  val tokensToAdd = timeDifference.toDouble / refillEvery.toNanos.toDouble
+                  val newTokenTotal = Math.min(previousTokens + tokensToAdd, capacity.toDouble)
+
+                  val attemptSet: F[Option[TokenAvailability]] = if (newTokenTotal >= 1) {
+                    setter((newTokenTotal - 1, currentTime))
+                      .map(_.guard[Option].as(TokenAvailable))
+                  } else {
+                    val timeToFull = (refillEvery.toNanos * capacity) - timeDifference
+                    val successResponse = TokenUnavailable(timeToFull.nanos.some)
+                    setter((newTokenTotal, currentTime)).map(_.guard[Option].as(successResponse))
+                  }
+
+                  attemptSet
+                })
+            }
+
+            def loop: F[TokenAvailability] = attemptUpdate.flatMap { attempt =>
+              attempt.fold(loop)(token => token.pure[F])
+            }
+            loop
+          }
+
+        }
+      }
+
+    }
+
+  }
+
+  /**
+    * Limits the supplied service to a given rate of calls using an in-memory [[TokenBucket]]
+    *
+    * @param amount the number of calls to the service to permit within the given time period.
+    * @param per the time period over which a given number of calls is permitted.
+    * @param http the service to transform.
+    * @return a task containing the transformed service.
+    */
+  def apply[F[_], G[_]](amount: Int, per: FiniteDuration)(
+      http: Http[F, G])(implicit F: Sync[F], timer: Clock[F]): F[Http[F, G]] = {
+    val refillFrequency = per / amount.toLong
+    val createBucket = TokenBucket.local(amount, refillFrequency)
+    createBucket.map(bucket => apply(bucket)(http))
+  }
+
+  def defaultResponse[F[_]](retryAfter: Option[FiniteDuration]): Response[F] = retryAfter match {
+    case Some(retryTime) => {
+      val retryHeader = `Retry-After`.unsafeFromDuration(retryTime)
+      Response[F](Status.TooManyRequests, headers = Headers(retryHeader))
+    }
+    case None => Response[F](Status.TooManyRequests)
+  }
+
+  /**
+    * Limits the supplied service using a provided [[TokenBucket]]
+    *
+    * @param bucket a [[TokenBucket]] to use to track the rate of incoming requests.
+    * @param throttleResponse a function that defines the response when throttled, may be supplied a suggested retry time depending on bucket implementation.
+    * @param http the service to transform.
+    * @return a task containing the transformed service.
+    */
+  def apply[F[_], G[_]](
+      bucket: TokenBucket[F],
+      throttleResponse: Option[FiniteDuration] => Response[G] = defaultResponse[G] _)(
+      http: Http[F, G])(implicit F: Sync[F]): Http[F, G] =
+    Kleisli { req =>
+      bucket.takeToken.flatMap {
+        case TokenAvailable => http(req)
+        case TokenUnavailable(retryAfter) => throttleResponse(retryAfter).pure[F]
+      }
+    }
+}

--- a/server/src/test/scala/org/http4s/server/middleware/ThrottleSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ThrottleSpec.scala
@@ -1,0 +1,155 @@
+package org.http4s.server.middleware
+
+import cats.effect.{IO, Timer}
+import cats.effect.laws.util.TestContext
+import org.http4s.{Http4sSpec, HttpApp, Request, Status}
+import cats.implicits._
+import org.http4s.dsl.io._
+import cats.effect.IO.ioEffect
+import org.http4s.headers.`Retry-After`
+import org.specs2.matcher.FutureMatchers
+import scala.concurrent.duration._
+import org.specs2.concurrent.ExecutionEnv
+import Throttle._
+
+class ThrottleSpec(implicit ee: ExecutionEnv) extends Http4sSpec with FutureMatchers {
+  "LocalTokenBucket" should {
+
+    "contain initial number of tokens equal to specified capacity" in {
+      val ctx = TestContext()
+      val testTimer: Timer[IO] = ctx.timer[IO]
+
+      val someRefillTime = 1234.milliseconds
+      val capacity = 5
+      val createBucket =
+        TokenBucket.local[IO](capacity, someRefillTime)(ioEffect, testTimer.clock)
+
+      val takeExtraToken = createBucket
+        .flatMap(testee => {
+          val takeFiveTokens: IO[List[TokenAvailability]] =
+            (1 to 5).toList.traverse(_ => testee.takeToken)
+          val checkTokensUpToCapacity =
+            takeFiveTokens.map(tokens =>
+              tokens must contain(TokenAvailable: TokenAvailability).forall)
+          checkTokensUpToCapacity *> testee.takeToken
+        })
+
+      val result = takeExtraToken.unsafeToFuture()
+
+      result must haveClass[TokenUnavailable].await
+    }
+
+    "add another token at specified interval when not at capacity" in {
+      val ctx = TestContext()
+      val testTimer: Timer[IO] = ctx.timer[IO]
+
+      val capacity = 1
+      val createBucket =
+        TokenBucket.local[IO](capacity, 100.milliseconds)(ioEffect, testTimer.clock)
+
+      val takeTokenAfterRefill = createBucket.flatMap(testee => {
+        testee.takeToken *> testTimer.sleep(101.milliseconds) *> testee.takeToken
+      })
+
+      val result = takeTokenAfterRefill.unsafeToFuture()
+
+      ctx.tick(101.milliseconds)
+
+      result must beEqualTo(TokenAvailable).await
+    }
+
+    "not add another token at specified interval when at capacity" in {
+      val ctx = TestContext()
+      val testTimer: Timer[IO] = ctx.timer[IO]
+      val capacity = 5
+      val createBucket =
+        TokenBucket.local[IO](capacity, 100.milliseconds)(ioEffect, testTimer.clock)
+
+      val takeExtraToken = createBucket.flatMap(testee => {
+        val takeFiveTokens: IO[List[TokenAvailability]] = (1 to 5).toList.traverse(_ => {
+          testee.takeToken
+        })
+        testTimer.sleep(300.milliseconds) >> takeFiveTokens >> testee.takeToken
+      })
+
+      val result = takeExtraToken.unsafeToFuture()
+
+      ctx.tick(300.milliseconds)
+
+      result must haveClass[TokenUnavailable].await
+    }
+
+    "only return a single token when only one token available and there are multiple concurrent requests" in {
+      val ctx = TestContext()
+      val testTimer: Timer[IO] = ctx.timer[IO]
+      val capacity = 1
+      val createBucket =
+        TokenBucket.local[IO](capacity, 100.milliseconds)(ioEffect, testTimer.clock)
+
+      val takeTokensSimultaneously = createBucket.flatMap(testee => {
+        (1 to 5).toList.parTraverse(_ => testee.takeToken)
+      })
+
+      val result = takeTokensSimultaneously.unsafeToFuture()
+
+      result must contain(TokenAvailable: TokenAvailability).exactly(1.times).await
+    }
+
+    "return the time until the bucket is refilled when no token is available" in {
+      val ctx = TestContext()
+      val testTimer: Timer[IO] = ctx.timer[IO]
+      val capacity = 1
+      val createBucket =
+        TokenBucket.local[IO](capacity, 1234.milliseconds)(ioEffect, testTimer.clock)
+
+      val takeTwoTokens = createBucket.flatMap(testee => {
+        testee.takeToken *> testee.takeToken
+      })
+
+      val result = takeTwoTokens.unsafeToFuture()
+
+      result must beEqualTo(TokenUnavailable(Some(1234.milliseconds))).await
+    }
+  }
+
+  "Throttle" should {
+    val alwaysOkApp = HttpApp[IO] { _ =>
+      Ok()
+    }
+
+    "allow a request to proceed when the rate limit has not been reached" in {
+      val limitNotReachedBucket = new TokenBucket[IO] {
+        override def takeToken: IO[TokenAvailability] = TokenAvailable.pure[IO]
+      }
+
+      val testee = Throttle(limitNotReachedBucket)(alwaysOkApp)
+      val req = Request[IO](uri = uri("/"))
+
+      testee(req) must returnStatus(Status.Ok)
+    }
+
+    "deny a request when the rate limit had been reached" in {
+      val limitReachedBucket = new TokenBucket[IO] {
+        override def takeToken: IO[TokenAvailability] = TokenUnavailable(None).pure[IO]
+      }
+
+      val testee = Throttle(limitReachedBucket)(alwaysOkApp)
+      val req = Request[IO](uri = uri("/"))
+
+      testee(req) must returnStatus(Status.TooManyRequests)
+    }
+
+    "include a retry-after time in the response to a denied request when provided one by the token provider" in {
+      val someRetryTime = Some(1234.seconds)
+      val result = Throttle.defaultResponse(someRetryTime)
+
+      result.headers.get(`Retry-After`) must beSome(`Retry-After`.unsafeFromLong(1234))
+    }
+
+    "not include a retry-after time in the response to a denied request when the token provider does not supply one" in {
+      val result = Throttle.defaultResponse(None)
+
+      result.headers.get(`Retry-After`) must beNone
+    }
+  }
+}


### PR DESCRIPTION
Feedback appreciated!

There is definitely room for more features, in a subsequent PR I'd like to make taking tokens a function of the `Request` so that throttling can be based on request sizes or IPs rather than just simply the number of requests.  I'd also like to enable customisation of the response to throttled requests.  If these are considered essential then I can add them to this PR however my preference would be to get this merged before iterating further.