### PR TITLE
Create an expiring test scheduler

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -15,10 +15,10 @@ import scala.concurrent.duration._
 
 class ClientTimeoutSpec extends Http4sSpec {
 
-  val scheduler = new TickWheelExecutor
+  val tickWheel = new TickWheelExecutor
 
   /** the map method allows to "post-process" the fragments after their creation */
-  override def map(fs: => Fragments) = super.map(fs) ^ step(scheduler.shutdown())
+  override def map(fs: => Fragments) = super.map(fs) ^ step(tickWheel.shutdown())
 
   val www_foo_com = Uri.uri("http://www.foo.com")
   val FooRequest = Request[IO](uri = www_foo_com)
@@ -51,7 +51,7 @@ class ClientTimeoutSpec extends Http4sSpec {
   "Http1ClientStage responses" should {
     "Timeout immediately with an idle timeout of 0 seconds" in {
       val c = mkClient(
-        new SlowTestHead(List(mkBuffer(resp)), 0.seconds, scheduler),
+        new SlowTestHead(List(mkBuffer(resp)), 0.seconds, tickWheel),
         mkConnection())(idleTimeout = Duration.Zero)
 
       c.fetchAs[String](FooRequest).unsafeRunSync() must throwA[TimeoutException]
@@ -59,7 +59,7 @@ class ClientTimeoutSpec extends Http4sSpec {
 
     "Timeout immediately with a request timeout of 0 seconds" in {
       val tail = mkConnection()
-      val h = new SlowTestHead(List(mkBuffer(resp)), 0.seconds, scheduler)
+      val h = new SlowTestHead(List(mkBuffer(resp)), 0.seconds, tickWheel)
       val c = mkClient(h, tail)(requestTimeout = 0.milli)
 
       c.fetchAs[String](FooRequest).unsafeRunSync() must throwA[TimeoutException]
@@ -67,7 +67,7 @@ class ClientTimeoutSpec extends Http4sSpec {
 
     "Idle timeout on slow response" in {
       val tail = mkConnection()
-      val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds, scheduler)
+      val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds, tickWheel)
       val c = mkClient(h, tail)(idleTimeout = 1.second)
 
       c.fetchAs[String](FooRequest).unsafeRunSync() must throwA[TimeoutException]
@@ -75,7 +75,7 @@ class ClientTimeoutSpec extends Http4sSpec {
 
     "Request timeout on slow response" in {
       val tail = mkConnection()
-      val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds, scheduler)
+      val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds, tickWheel)
       val c = mkClient(h, tail)(requestTimeout = 1.second)
 
       c.fetchAs[String](FooRequest).unsafeRunSync() must throwA[TimeoutException]
@@ -144,7 +144,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     "Request timeout on slow response body" in {
       val tail = mkConnection()
       val (f, b) = resp.splitAt(resp.length - 1)
-      val h = new SlowTestHead(Seq(f, b).map(mkBuffer), 1500.millis, scheduler)
+      val h = new SlowTestHead(Seq(f, b).map(mkBuffer), 1500.millis, tickWheel)
       val c = mkClient(h, tail)(requestTimeout = 1.second)
 
       tail.runRequest(FooRequest).flatMap(_.as[String])
@@ -154,7 +154,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     "Idle timeout on slow response body" in {
       val tail = mkConnection()
       val (f, b) = resp.splitAt(resp.length - 1)
-      val h = new SlowTestHead(Seq(f, b).map(mkBuffer), 1500.millis, scheduler)
+      val h = new SlowTestHead(Seq(f, b).map(mkBuffer), 1500.millis, tickWheel)
       val c = mkClient(h, tail)(idleTimeout = 1.second)
 
       tail.runRequest(FooRequest).flatMap(_.as[String])
@@ -164,7 +164,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     "Response head timeout on slow header" in {
       val tail = mkConnection()
       val (f, b) = resp.splitAt(resp.indexOf("\r\n\r\n"))
-      val h = new SlowTestHead(Seq(f, b).map(mkBuffer), 500.millis, scheduler)
+      val h = new SlowTestHead(Seq(f, b).map(mkBuffer), 500.millis, tickWheel)
       // header is split into two chunks, we wait for 1.5x
       val c = mkClient(h, tail)(responseHeaderTimeout = 750.millis)
 
@@ -174,7 +174,7 @@ class ClientTimeoutSpec extends Http4sSpec {
     "No Response head timeout on fast header" in {
       val tail = mkConnection()
       val (f, b) = resp.splitAt(resp.indexOf("\r\n\r\n" + 4))
-      val h = new SlowTestHead(Seq(f, b).map(mkBuffer), 125.millis, scheduler)
+      val h = new SlowTestHead(Seq(f, b).map(mkBuffer), 125.millis, tickWheel)
       // header is split into two chunks, we wait for 10x
       val c = mkClient(h, tail)(responseHeaderTimeout = 1250.millis)
 

--- a/client/src/test/scala/org/http4s/client/JavaNetClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/JavaNetClientSpec.scala
@@ -8,4 +8,4 @@ class JavaNetClientSpec
     extends ClientRouteTestBattery(
       "JavaNetClient",
       JavaNetClient(TestBlockingExecutionContext)
-        .create[IO](implicitly, IO.timer(TestExecutionContext)))
+        .create[IO](implicitly, IO.timer(TestExecutionContext, TestScheduler)))


### PR DESCRIPTION
If we aggressively use this one, we won't leak two threads every test run.

`AsyncHttpClient` will still leak until #1993 is merged.