### PR TITLE
Send Disconnect event on EOF

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -87,7 +87,7 @@ private[blaze] class Http1ServerStage[F[_]](
 
   private val handleReqRead: Try[ByteBuffer] => Unit = {
     case Success(buff) => reqLoopCallback(buff)
-    case Failure(Cmd.EOF) => stageShutdown()
+    case Failure(Cmd.EOF) => closeConnection()
     case Failure(t) => fatalError(t, "Error in requestLoop()")
   }
 


### PR DESCRIPTION
When we read an EOF, request a disconnect.  This signals outbound that we're done and allows a chance to clean up.

Before this change, when a client disconnects without either the server or client signalling the end of the connection, the HTTP stage is shut down but no command is passed out.  This delays the cleanup of the middle stages, such as `QuietTimeoutStage`.
