### PR TITLE
use more robust method of checking Scala version

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -271,10 +271,11 @@ object Http4sPlugin extends AutoPlugin {
     }
   }
 
-  def playJsonVersion(scalaBinaryVersion: String) = scalaBinaryVersion match {
-    case "2.11" => "2.5.15"
-    case "2.12" => "2.6.10"
-  }
+  def playJsonVersion(scalaBinaryVersion: String): String =
+    CrossVersion.partialVersion(scalaBinaryVersion) match {
+      case Some((2, 11)) => "2.5.15"
+      case _ => "2.6.10"
+    }
 
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.12.v20180117"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.2"


### PR DESCRIPTION
the old code was breaking in the Scala 2.13 community build, because
in that context we see Scala version numbers such as 2.13.0-pre-abcd123

it's not just that a "2.13" case was missing, it's also that the
`-pre-` indicates a binary incompatible Scala version, and such in a
case scalaBinaryVersion doesn't truncate to "2.13", but is the same as
scalaVersion