### PR TITLE
Renames incorrect, duplicate withIdleTimeout to withMaxTotalConnections

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -82,7 +82,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   def withoutUserAgent: BlazeClientBuilder[F] =
     withUserAgentOption(None)
 
-  def withIdleTimeout(maxTotalConnections: Int): BlazeClientBuilder[F] =
+  def withMaxTotalConnections(maxTotalConnections: Int): BlazeClientBuilder[F] =
     copy(maxTotalConnections = maxTotalConnections)
 
   def withMaxWaitQueueLimit(maxWaitQueueLimit: Int): BlazeClientBuilder[F] =


### PR DESCRIPTION
This fixes the name of a duplicate function `withIdleTimeout` that should actually be named `withMaxTotalConnections`. The implementation is already correct, and the real `def withIdleTimeout(idleTimeout: Duration): BlazeClientBuilder[F]` remains untouched.