### PR TITLE
Align coloring of legdend and table

### DIFF
--- a/website/src/hugo/content/versions.md
+++ b/website/src/hugo/content/versions.md
@@ -41,7 +41,7 @@ title: Versions
   <tbody>
     <tr>
       <td><a href="/v0.19">{{% latestInSeries "0.19" %}}</a></td>
-      <td class="text-center"><span class="badge badge-danger">Milestone</span></td>
+      <td class="text-center"><span class="badge badge-warning">Milestone</span></td>
       <td class="text-center"><i class="fa fa-ban"></i></td>
       <td class="text-center"><i class="fa fa-check"></i></td>
       <td class="text-center"><i class="fa fa-check"></i></td>


### PR DESCRIPTION
Hi I just try http4s and found this minor flaw in the version documentation: The legend gives milestones a yellow (warning) badge but the table showed a red (error) badge for the last milestone.

