### PR TITLE
Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,12 @@
-Please see the [Code of Conduct] at http4s.org.
+# Code of Conduct
 
-[Code of Conduct]: https://http4s.org/code-of-conduct/
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when discussing the project on the available communication channels. If you are being harassed, please contact us immediately so that we can support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests, please contact a member of the [community staff](https://http4s.org/code-of-conduct/#moderation)
+
+[Scala Code of Conduct]: https://http4s.org/code-of-conduct/
+[Community staff]: https://http4s.org/code-of-conduct/#moderation

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ scalacOptions ++= Seq("-Ypartial-unification")
 ## Code of Conduct
 
 http4s is proud to be a [Typelevel](https://typelevel.org/) incubator
-project.  We are dedicated to providing a harassment-free community
-for everyone, and ask that the community adhere to the
-[code of conduct](https://typelevel.org/conduct.html).
+project.  We are committed to providing a friendly, safe and welcoming
+environment for all, and ask that the community adhere to the [Scala
+Code of Conduct](https://http4s.org/code-of-conduct/).
 
 ## License
 

--- a/website/src/hugo/content/code-of-conduct.md
+++ b/website/src/hugo/content/code-of-conduct.md
@@ -4,25 +4,88 @@ weight: 450
 title: Code of conduct
 ---
 
-http4s is a [Typelevel] incubator project.  We hope that our community
-will be respectful, helpful, and kind.  We are dedicated to providing
-a harassment-free community for everyone, regardless of gender or
-anything to do with it (identity, history, expression, non-binary
-gender, etc.), sexual orientation, disability, physical appearance,
-body size, race, religion, and programming background.
+## Scala Code of Conduct
 
-People are expected to follow the [Typelevel Code of Conduct] when
-discussing http4s on [GitHub], [Gitter], and other venues provided by
-the http4s project.
+We are committed to providing a friendly, safe and welcoming environment for
+all, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity,
+age, religion, nationality, or other such characteristics.
 
-If you have any questions or concerns, please contact a member of the
-community staff, such as:
+### Our Standards
+
+**Whether you’re a regular contributor or a newcomer, we care about making this community a welcoming and safe place for you and we’ve got your back.**
+
+As a member of the community, you agree to the following:
+
+**Encouraged:**
+
+- Be kind and courteous.
+- Respect differences of opinion and remember that every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer.
+- Remember that everyone was new to Scala at some point. We want to encourage newcomers to join our community and learn the Scala language and ecosystem. Assume competence.
+- Show empathy towards other community members.
+
+**Discouraged:**
+
+- Keep unstructured critique to a minimum. We encourage sharing ideas and perspectives, so please ensure that your feedback is constructive and relevant. If you have solid ideas you want to experiment with, make a fork and see how it works.
+- Avoid aggressive and micro-aggressive behavior, such as unconstructive criticism, providing corrections that do not improve the conversation (sometimes referred to as "well actually"s), repeatedly interrupting or talking over someone else, feigning surprise at someone’s lack of knowledge or awareness about a topic, or subtle prejudice (for example, comments like “That’s so easy my grandmother could do it.”). For more examples of this kind of behavior, [see the Recurse Center's user manual](https://www.recurse.com/manual#sec-environment).
+- We will exclude you from interaction if you insult, demean or harass anyone. The term “Harassment” includes “Unacceptable Behavior” described in the [Citizen Code of Conduct](http://citizencodeofconduct.org/). **In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.**
+- Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member's behavior, please contact one of the [moderators](https://contributors.scala-lang.org/about) or any member of the [Scala Center](http://scala.epfl.ch/) immediately.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing behaviour is not welcome.
+
+### Moderation
+
+These are the policies for upholding our community’s standards of conduct. If
+you feel that a thread needs moderation, please contact anyone on the
+moderation team:
 
 - [Bryce Anderson](mailto:bryce.anderson22@gmail.com)
 - [Ross A. Baker](mailto:ross@rossabaker.com)
 - [Christopher Davenport](mailto:chris@christopherdavenport.tech)
 
-[Typelevel]: https://typelevel.org/
-[Typelevel code of conduct]: https://typelevel.org/conduct.html
-[GitHub]: https://github.com/http4s
-[Gitter]: https://gitter.im/http4s/http4s
+- Remarks that violate the above code of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
+- Moderators will warn users who make remarks inconsistent with the above code of conduct.
+- If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool off.
+- If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.
+- Moderators may choose at their discretion to un-ban the user if it was a first offense and they if they make suitable amends with the offended party.
+- If you think a ban is unjustified, please take it up with that moderator, or with a different moderator, in private. Complaints about bans in-channel are not allowed.
+- Moderators are held to a higher standard than other community members. If a moderator acts inappropriately, they should expect less leeway than others.
+
+In the Scala community we strive to go the extra step to look out for each
+other. Don’t just aim to be technically unimpeachable; try to be your best self.
+In particular, avoid exacerbating offensive or sensitive issues, particularly if
+they’re off-topic; this all too often leads to unnecessary fights, hurt
+feelings, and damaged trust; worse, it can drive people away from the community
+entirely.
+
+If someone takes issue with something you said or did, resist the urge to be
+defensive. Rather, stop the offending behavior, apologize, and be sensitive
+thereafter. Even if you feel you were misinterpreted or unfairly accused,
+chances are good there was something you could’ve communicated better — remember
+that it’s your responsibility to make your fellow Scala developers comfortable.
+We are all here first and foremost because we want to talk about cool
+technology, and everyone wants to get along in doing so. People are generally
+eager to assume good intent and forgive.
+
+### Domain
+
+The enforcement policies listed above apply to all official http4s channels:
+
+* All [http4s GitHub repositories](https://github.com/http4s)
+* The [Gitter channel](https://gitter.im/http4s/http4s)
+* Any venues and hackathons organized by or in conjunction with the http4s organization
+
+For other projects adopting the Scala Code of Conduct, please contact
+the maintainers of those projects for enforcement. If you wish to use
+this code of conduct for your own project, consider explicitly
+mentioning your moderation policy or making a copy with your own
+moderation policy so as to avoid confusion.
+
+### Credits
+
+Adapted from and/or inspired by multiple successful Codes of Conduct, including:
+
+* [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html)
+* [The Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling)
+* [The Contributor Covenant v1.4.0](http://contributor-covenant.org/version/1/4/)
+* [The Recurse Center's User Manual](https://www.recurse.com/manual#sec-environment)
+* [The 18F Code of Conduct](https://18f.gsa.gov/code-of-conduct/)

--- a/website/src/hugo/content/getting-help.md
+++ b/website/src/hugo/content/getting-help.md
@@ -20,13 +20,12 @@ development.
 [blaze] and [rho] do not yet have dedicated channels.  Questions about
 these projects are welcome in the http4s channel.
 
-We expect users to observe the [code of conduct] while on the Gitter
+We expect users to observe the [Scala Code of Conduct] while on the Gitter
 channel.
 
 [Gitter]: https://gitter.im/http4s/http4s
 [blaze]: https://github.com/http4s/blaze
 [rho]: https://github.com/http4s/rho
-[code of conduct]: ../code-of-conduct/
 
 ## Issues
 
@@ -38,7 +37,7 @@ feature request, or something to improve in the documentation, we
 appreciate it if you open an issue.  Pull requests with documentation
 fixes are a great way to start [contributing].
 
-We expect users to observe the [code of conduct] on our GitHub
+We expect users to observe the [Scala Code of Conduct] on our GitHub
 organization.
 
 [GitHub issues]: https://github.com/http4s/http4s/issues
@@ -51,4 +50,5 @@ encourage you to follow for release announcements.  Your likes and
 retweets help grow our community.
 
 [@http4s]: https://twitter.com/http4s
+[Scala Code of Conduct]: ../code-of-conduct/
 


### PR DESCRIPTION
The Scala Code of Conduct is clearer, [endorsed by Typelevel], and aligned with our foundation of [cats-effect], [fs2], and [Scala] itself.

[endorsed by Typelevel]: https://typelevel.org/blog/2016/12/17/scala-coc.html
[cats-effect]: https://github.com/typelevel/cats-effect/pull/356
[fs2]: https://github.com/functional-streams-for-scala/fs2/blob/267e9debd206a6f1df5cfdc7ce1aa5d3112051ac/CODE_OF_CONDUCT.md
[Scala]: https://www.scala-lang.org/conduct/