### PR TITLE
Refactor Http4sMatchers to be generic on F-Type

### DIFF
--- a/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
@@ -1,56 +1,56 @@
 package org.http4s
 package testing
 
+import cats.syntax.flatMap._
 import cats.data.EitherT
-import cats.effect.IO
 import org.http4s.headers._
 import org.specs2.matcher._
 
 /** This might be useful in a testkit spinoff.  Let's see what they do for us. */
 // TODO these akas might be all wrong.
-trait Http4sMatchers extends Matchers with IOMatchers {
-  def haveStatus(expected: Status): Matcher[Response[IO]] =
-    be_===(expected) ^^ { r: Response[IO] =>
+trait Http4sMatchers[F[_]] extends Matchers with RunTimedMatchers[F] {
+  def haveStatus(expected: Status): Matcher[Response[F]] =
+    be_===(expected) ^^ { r: Response[F] =>
       r.status.aka("the response status")
     }
 
-  def returnStatus(s: Status): Matcher[IO[Response[IO]]] =
-    haveStatus(s) ^^ { r: IO[Response[IO]] =>
-      r.unsafeRunSync.aka("the returned")
+  def returnStatus(s: Status): Matcher[F[Response[F]]] =
+    haveStatus(s) ^^ { r: F[Response[F]] =>
+      runAwait(r).aka("the returned")
     }
 
-  def haveBody[A: EntityDecoder[IO, ?]](a: ValueCheck[A]): Matcher[Message[IO]] =
-    returnValue(a) ^^ { m: Message[IO] =>
+  def haveBody[A: EntityDecoder[F, ?]](a: ValueCheck[A]): Matcher[Message[F]] =
+    returnValue(a) ^^ { m: Message[F] =>
       m.as[A].aka("the message body")
     }
 
-  def returnBody[A: EntityDecoder[IO, ?]](a: ValueCheck[A]): Matcher[IO[Message[IO]]] =
-    returnValue(a) ^^ { m: IO[Message[IO]] =>
+  def returnBody[A: EntityDecoder[F, ?]](a: ValueCheck[A]): Matcher[F[Message[F]]] =
+    returnValue(a) ^^ { m: F[Message[F]] =>
       m.flatMap(_.as[A]).aka("the returned message body")
     }
 
-  def haveHeaders(a: Headers): Matcher[Message[IO]] =
-    be_===(a) ^^ { m: Message[IO] =>
+  def haveHeaders(a: Headers): Matcher[Message[F]] =
+    be_===(a) ^^ { m: Message[F] =>
       m.headers.aka("the headers")
     }
 
-  def haveMediaType(mt: MediaType): Matcher[Message[IO]] =
-    beSome(mt) ^^ { m: Message[IO] =>
+  def haveMediaType(mt: MediaType): Matcher[Message[F]] =
+    beSome(mt) ^^ { m: Message[F] =>
       m.headers.get(`Content-Type`).map(_.mediaType).aka("the media type header")
     }
 
-  def haveContentCoding(c: ContentCoding): Matcher[Message[IO]] =
-    beSome(c) ^^ { m: Message[IO] =>
+  def haveContentCoding(c: ContentCoding): Matcher[Message[F]] =
+    beSome(c) ^^ { m: Message[F] =>
       m.headers.get(`Content-Encoding`).map(_.contentCoding).aka("the content encoding header")
     }
 
-  def returnRight[A, B](m: ValueCheck[B]): Matcher[EitherT[IO, A, B]] =
-    beRight(m) ^^ { et: EitherT[IO, A, B] =>
-      et.value.unsafeRunSync.aka("the either task")
+  def returnRight[A, B](m: ValueCheck[B]): Matcher[EitherT[F, A, B]] =
+    beRight(m) ^^ { et: EitherT[F, A, B] =>
+      runAwait(et.value).aka("the either task")
     }
 
-  def returnLeft[A, B](m: ValueCheck[A]): Matcher[EitherT[IO, A, B]] =
-    beLeft(m) ^^ { et: EitherT[IO, A, B] =>
-      et.value.unsafeRunSync.aka("the either task")
+  def returnLeft[A, B](m: ValueCheck[A]): Matcher[EitherT[F, A, B]] =
+    beLeft(m) ^^ { et: EitherT[F, A, B] =>
+      runAwait(et.value).aka("the either task")
     }
 }

--- a/testing/src/main/scala/org/http4s/testing/IOMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/IOMatchers.scala
@@ -3,69 +3,18 @@
  */
 package org.http4s.testing
 
-import cats.effect.IO
-import org.specs2.matcher._
-import org.specs2.matcher.ValueChecks._
+import cats.effect.{IO, Sync}
 import scala.concurrent.duration.FiniteDuration
 
 /**
   * Matchers for cats.effect.IO
   */
-trait IOMatchers {
-  // This comes from a private trait in real IOMatchers
-  implicit class NotNullSyntax(s: String) {
-    def notNull: String =
-      Option(s).getOrElse("null")
-  }
+trait IOMatchers extends RunTimedMatchers[IO] {
 
-  def returnOk[T]: IOMatcher[T] =
-    attemptRun(ValueCheck.alwaysOk, None)
+  protected implicit def F: Sync[IO] = IO.ioConcurrentEffect
+  protected def runWithTimeout[A](fa: IO[A], timeout: FiniteDuration): Option[A] = fa.unsafeRunTimed(timeout)
+  protected def runAwait[A](fa: IO[A]) : A = fa.unsafeRunSync
 
-  def returnValue[T](check: ValueCheck[T]): IOMatcher[T] =
-    attemptRun(check, None)
-
-  def returnBefore[T](duration: FiniteDuration): IOMatcher[T] =
-    attemptRun(ValueCheck.alwaysOk, Some(duration))
-
-  private def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): IOMatcher[T] =
-    IOMatcher(check, duration)
-
-  case class IOMatcher[T](check: ValueCheck[T], duration: Option[FiniteDuration])
-      extends Matcher[IO[T]] {
-    def apply[S <: IO[T]](e: Expectable[S]): MatchResult[S] =
-      duration match {
-        case Some(d) =>
-          e.value.attempt
-            .unsafeRunTimed(d)
-            .fold(failedAttemptWithTimeout(e, d))(_.fold(failedAttempt(e), checkResult(e)))
-        case None => e.value.attempt.unsafeRunSync.fold(failedAttempt(e), checkResult(e))
-      }
-
-    def before(d: FiniteDuration): IOMatcher[T] =
-      copy(duration = Some(d))
-
-    def withValue(check: ValueCheck[T]): IOMatcher[T] =
-      copy(check = check)
-
-    def withValue(t: T): IOMatcher[T] =
-      withValue(valueIsTypedValueCheck(t))
-
-    private def failedAttemptWithTimeout[S <: IO[T]](
-        e: Expectable[S],
-        d: FiniteDuration): MatchResult[S] = {
-      val message = s"Timeout after ${d.toMillis} milliseconds"
-      result(false, message, message, e)
-    }
-
-    private def failedAttempt[S <: IO[T]](e: Expectable[S])(t: Throwable): MatchResult[S] = {
-      val message = s"an exception was thrown ${t.getMessage.notNull}"
-      result(false, message, message, e)
-    }
-
-    private def checkResult[S <: IO[T]](e: Expectable[S])(t: T): MatchResult[S] =
-      result(check.check(t), e)
-
-  }
 }
 
 object IOMatchers extends IOMatchers

--- a/testing/src/main/scala/org/http4s/testing/IOMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/IOMatchers.scala
@@ -12,8 +12,9 @@ import scala.concurrent.duration.FiniteDuration
 trait IOMatchers extends RunTimedMatchers[IO] {
 
   protected implicit def F: Sync[IO] = IO.ioEffect
-  protected def runWithTimeout[A](fa: IO[A], timeout: FiniteDuration): Option[A] = fa.unsafeRunTimed(timeout)
-  protected def runAwait[A](fa: IO[A]) : A = fa.unsafeRunSync
+  protected def runWithTimeout[A](fa: IO[A], timeout: FiniteDuration): Option[A] =
+    fa.unsafeRunTimed(timeout)
+  protected def runAwait[A](fa: IO[A]): A = fa.unsafeRunSync
 
 }
 

--- a/testing/src/main/scala/org/http4s/testing/IOMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/IOMatchers.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.FiniteDuration
   */
 trait IOMatchers extends RunTimedMatchers[IO] {
 
-  protected implicit def F: Sync[IO] = IO.ioConcurrentEffect
+  protected implicit def F: Sync[IO] = IO.ioEffect
   protected def runWithTimeout[A](fa: IO[A], timeout: FiniteDuration): Option[A] = fa.unsafeRunTimed(timeout)
   protected def runAwait[A](fa: IO[A]) : A = fa.unsafeRunSync
 

--- a/testing/src/main/scala/org/http4s/testing/RunTimedMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/RunTimedMatchers.scala
@@ -1,0 +1,78 @@
+/* Derived from https://raw.githubusercontent.com/etorreborre/specs2/c0cbfc71390b644db1a5deeedc099f74a237ebde/matcher-extra/src/main/scala-scalaz-7.0.x/org/specs2/matcher/TaskMatchers.scala
+ * License: https://raw.githubusercontent.com/etorreborre/specs2/master/LICENSE.txt
+ */
+package org.http4s.testing
+
+import cats.effect.Sync
+import org.specs2.matcher._
+import org.specs2.matcher.ValueChecks._
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Matchers for cats.effect.F_
+  */
+trait RunTimedMatchers[F[_]] {
+
+  protected implicit def F: Sync[F]
+  protected def runWithTimeout[A](fa: F[A], timeout: FiniteDuration): Option[A]
+  protected def runAwait[A](fa: F[A]) : A
+
+  // This comes from a private trait in real IOMatchers
+  implicit class NotNullSyntax(s: String) {
+    def notNull: String =
+      Option(s).getOrElse("null")
+  }
+
+  def returnOk[T]: TimedMatcher[T] =
+    attemptRun(ValueCheck.alwaysOk, None)
+
+  def returnValue[T](check: ValueCheck[T]): TimedMatcher[T] =
+    attemptRun(check, None)
+
+  def returnBefore[T](duration: FiniteDuration): TimedMatcher[T] =
+    attemptRun(ValueCheck.alwaysOk, Some(duration))
+
+  private def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): TimedMatcher[T] =
+    TimedMatcher(check, duration)
+
+  case class TimedMatcher[T](
+    check: ValueCheck[T],
+    duration: Option[FiniteDuration]
+  ) extends Matcher[F[T]] {
+
+    override final def apply[S <: F[T]](expected: Expectable[S]): MatchResult[S] = {
+
+      def checkOrFail[A](res: Either[Throwable, T]): MatchResult[S] = res match {
+        case Left(error) =>
+          val message = s"an exception was thrown ${error.getMessage.notNull}"
+          result(false, message, message, expected)
+        case Right(actual) =>
+          result(check.check(actual), expected)
+      }
+
+      val theAttempt = F.attempt(expected.value)
+      duration match {
+        case Some(timeout) =>
+          runWithTimeout(theAttempt, timeout) match {
+            case None =>
+              val message = s"Timeout after ${timeout.toMillis} milliseconds"
+              result(false, message, message, expected)
+            case Some(result) => checkOrFail(result)
+          }
+        case None =>
+          checkOrFail( runAwait( theAttempt))
+      }
+
+    }
+
+    def before(d: FiniteDuration): TimedMatcher[T] =
+      copy(duration = Some(d))
+
+    def withValue(check: ValueCheck[T]): TimedMatcher[T] =
+      copy(check = check)
+
+    def withValue(t: T): TimedMatcher[T] =
+      withValue(valueIsTypedValueCheck(t))
+
+  }
+}

--- a/testing/src/main/scala/org/http4s/testing/RunTimedMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/RunTimedMatchers.scala
@@ -15,7 +15,7 @@ trait RunTimedMatchers[F[_]] {
 
   protected implicit def F: Sync[F]
   protected def runWithTimeout[A](fa: F[A], timeout: FiniteDuration): Option[A]
-  protected def runAwait[A](fa: F[A]) : A
+  protected def runAwait[A](fa: F[A]): A
 
   // This comes from a private trait in real IOMatchers
   implicit class NotNullSyntax(s: String) {
@@ -32,12 +32,14 @@ trait RunTimedMatchers[F[_]] {
   def returnBefore[T](duration: FiniteDuration): TimedMatcher[T] =
     attemptRun(ValueCheck.alwaysOk, Some(duration))
 
-  private def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): TimedMatcher[T] =
+  private def attemptRun[T](
+      check: ValueCheck[T],
+      duration: Option[FiniteDuration]): TimedMatcher[T] =
     TimedMatcher(check, duration)
 
   case class TimedMatcher[T](
-    check: ValueCheck[T],
-    duration: Option[FiniteDuration]
+      check: ValueCheck[T],
+      duration: Option[FiniteDuration]
   ) extends Matcher[F[T]] {
 
     override final def apply[S <: F[T]](expected: Expectable[S]): MatchResult[S] = {
@@ -60,7 +62,7 @@ trait RunTimedMatchers[F[_]] {
             case Some(result) => checkOrFail(result)
           }
         case None =>
-          checkOrFail( runAwait( theAttempt))
+          checkOrFail(runAwait(theAttempt))
       }
 
     }

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -44,7 +44,7 @@ trait Http4sSpec
     with FragmentsDsl
     with Discipline
     with IOMatchers
-    with Http4sMatchers {
+    with Http4sMatchers[IO] {
   implicit def testExecutionContext: ExecutionContext = Http4sSpec.TestExecutionContext
   val testBlockingExecutionContext: ExecutionContext = Http4sSpec.TestBlockingExecutionContext
   implicit val contextShift: ContextShift[IO] = Http4sSpec.TestContextShift


### PR DESCRIPTION
Resolves #1430.

As described in issue #1430, the `Http4sMatchers` trait is  not generic on the _effect_ `F[_]` type, and neither was a parent trait `IOMatchers` trait. We try to address this situation doing the following: 

- We factor out the trait `IOMatchers` into a `RunTimedMatchers` trait, which keeps most fo the IOMatchers trait methods and logic, but is generic on the effect type `F[_]`. Since IOMatchers was using some specific methods of `cats.effect.IO`, we need to extract those as abstract method, following the GoD template-method pattern. 
- We turn `IOMatchers` into an extension of `RunTimedMatchers` that specialises those abstract methods, to the methods of IO.
- We make `Http4sMatchers` generic on the F type. Luckily, this is just replacing "IO" with F

#### Other issues and related or future work. 

One thing to note is that, in the `RunTimedMatchers`, we need to declare `F`-generic abstractions for two methods in the `IO` class:
-  `unsafeRunSync`, which takes an `IO[A]` and returns an `A` (or throws an exception); and 
- `unsafeRunTimed`, which takes an `IO[A]` and a timeout, and either returns an `A` in time or throws a timeout error. 

These methods have no type-class capturing them, although an issue was opened in `cats-effect` that proposed creating a type-class that would have included the first method: https://github.com/typelevel/cats-effect/issues/230

It should be noted that, since the existing design is a lattice of inheritance and mixins, the solution only adds two more nodes to that lattice. While it may be possible to replace the design by one with less inheritance, which would avoid the inner (path-dependent) class `TimedMatcher`, that would exceed the scope of the original ticket IMHO.