### PR TITLE
add Monoid instance for UrlForm

### DIFF
--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -106,6 +106,19 @@ object UrlForm {
     x.values.mapValues(_.toList).view.force === y.values.mapValues(_.toList).view.force
   }
 
+  implicit val monoidInstance: Monoid[UrlForm] = new Monoid[UrlForm] {
+    override def empty: UrlForm = UrlForm.empty
+
+    override def combine(x: UrlForm, y: UrlForm): UrlForm =
+      UrlForm(x.values.foldLeft(y.values) {
+        case (my, (k, x)) =>
+          my.updated(k, my.get(k) match {
+            case Some(y) => x ++ y
+            case None => x
+          })
+      })
+  }
+
   /** Attempt to decode the `String` to a [[UrlForm]] */
   def decodeString(charset: Charset)(
       urlForm: String): Either[MalformedMessageBodyFailure, UrlForm] =

--- a/tests/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -1,8 +1,10 @@
 package org.http4s
 
-import cats.syntax.applicative._
+import cats._
 import cats.data._
 import cats.effect.IO
+import cats.implicits._
+import cats.kernel.laws.discipline.MonoidTests
 
 class UrlFormSpec extends Http4sSpec {
 //  // TODO: arbitrary charsets would be nice
@@ -107,6 +109,19 @@ class UrlFormSpec extends Http4sSpec {
           v <- vs.toList
         } yield (k -> v)
         UrlForm.fromSeq(flattened) must_== UrlForm(map.mapValues(_.toList))
+    }
+  }
+
+  checkAll("monoid", MonoidTests[UrlForm].monoid)
+
+  "UrlForm monoid" should {
+    "use the obvious empty" in {
+      Monoid[UrlForm].empty must_== UrlForm.empty
+    }
+
+    "combine two UrlForm instances" in {
+      val combined = UrlForm("foo" -> "1") |+| UrlForm("bar" -> "2", "foo" -> "3")
+      combined must_== UrlForm("foo" -> "1", "bar" -> "2", "foo" -> "3")
     }
   }
 }


### PR DESCRIPTION
The tests I added are pretty rudimentary. I'm open to suggestions or even just a pointer to another Monoid instance's tests that would be good to emulate.