### PR TITLE
Remove ExecutionContext and Timer from async-http-client

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -39,7 +39,7 @@ object AsyncHttpClient {
     * @param config configuration for the client
     * @param ec The ExecutionContext to run responses on
     */
-  def apply[F[_]: Timer](config: AsyncHttpClientConfig = defaultConfig)(
+  def apply[F[_]](config: AsyncHttpClientConfig = defaultConfig)(
       implicit F: ConcurrentEffect[F]): Client[F] = {
     val client = new DefaultAsyncHttpClient(config)
     Client(
@@ -63,10 +63,10 @@ object AsyncHttpClient {
     */
   def stream[F[_]](config: AsyncHttpClientConfig = defaultConfig)(
       implicit F: ConcurrentEffect[F],
-      timer: Timer[F]): Stream[F, Client[F]] =
+  ): Stream[F, Client[F]] =
     Stream.bracket(F.delay(apply(config)))(_.shutdown)
 
-  private def asyncHandler[F[_]: Timer](cb: Callback[DisposableResponse[F]])(
+  private def asyncHandler[F[_]](cb: Callback[DisposableResponse[F]])(
       implicit F: ConcurrentEffect[F]) =
     new StreamedAsyncHandler[Unit] {
       var state: State = State.CONTINUE
@@ -117,7 +117,7 @@ object AsyncHttpClient {
       }
     }
 
-  private def toAsyncRequest[F[_]: ConcurrentEffect: Timer](request: Request[F]): AsyncRequest = {
+  private def toAsyncRequest[F[_]: ConcurrentEffect](request: Request[F]): AsyncRequest = {
     val headers = new DefaultHttpHeaders
     for (h <- request.headers)
       headers.add(h.name.toString, h.value)
@@ -128,7 +128,7 @@ object AsyncHttpClient {
       .build()
   }
 
-  private def getBodyGenerator[F[_]: ConcurrentEffect: Timer](req: Request[F]): BodyGenerator = {
+  private def getBodyGenerator[F[_]: ConcurrentEffect](req: Request[F]): BodyGenerator = {
     val publisher = StreamUnicastPublisher(
       req.body.chunks.map(chunk => Unpooled.wrappedBuffer(chunk.toArray)))
     if (req.isChunked) new ReactiveStreamsBodyGenerator(publisher, -1)

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -15,12 +15,14 @@ import org.asynchttpclient.AsyncHandler.State
 import org.asynchttpclient.handler.StreamedAsyncHandler
 import org.asynchttpclient.request.body.generator.{BodyGenerator, ReactiveStreamsBodyGenerator}
 import org.asynchttpclient.{Request => AsyncRequest, Response => _, _}
+import org.http4s.internal.invokeCallback
 import org.http4s.util.threads._
+import org.log4s.getLogger
 import org.reactivestreams.Publisher
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
 
 object AsyncHttpClient {
+  private[this] val logger = getLogger
 
   val defaultConfig = new DefaultAsyncHttpClientConfig.Builder()
     .setMaxConnectionsPerHost(200)
@@ -38,8 +40,7 @@ object AsyncHttpClient {
     * @param ec The ExecutionContext to run responses on
     */
   def apply[F[_]: Timer](config: AsyncHttpClientConfig = defaultConfig)(
-      implicit F: ConcurrentEffect[F],
-      ec: ExecutionContext): Client[F] = {
+      implicit F: ConcurrentEffect[F]): Client[F] = {
     val client = new DefaultAsyncHttpClient(config)
     Client(
       Kleisli { req =>
@@ -62,12 +63,11 @@ object AsyncHttpClient {
     */
   def stream[F[_]](config: AsyncHttpClientConfig = defaultConfig)(
       implicit F: ConcurrentEffect[F],
-      ec: ExecutionContext,
       timer: Timer[F]): Stream[F, Client[F]] =
     Stream.bracket(F.delay(apply(config)))(_.shutdown)
 
-  private def asyncHandler[F[_]: Timer](
-      cb: Callback[DisposableResponse[F]])(implicit F: ConcurrentEffect[F], ec: ExecutionContext) =
+  private def asyncHandler[F[_]: Timer](cb: Callback[DisposableResponse[F]])(
+      implicit F: ConcurrentEffect[F]) =
     new StreamedAsyncHandler[Unit] {
       var state: State = State.CONTINUE
       var dr: DisposableResponse[F] =
@@ -89,7 +89,7 @@ object AsyncHttpClient {
             // callback, rather than waiting for onComplete, or else we'll
             // buffer the entire response before we return it for
             // streaming consumption.
-            ec.execute(new Runnable { def run(): Unit = cb(Right(dr)) })
+            invokeCallback(logger)(cb(Right(dr)))
           }
           .runAsync(_ => IO.unit)
           .unsafeRunSync()
@@ -110,7 +110,7 @@ object AsyncHttpClient {
       }
 
       override def onThrowable(throwable: Throwable): Unit =
-        ec.execute(new Runnable { def run(): Unit = cb(Left(throwable)) })
+        invokeCallback(logger)(cb(Left(throwable)))
 
       override def onCompleted(): Unit = {
         // Don't close here.  onStream may still be being called.

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -62,7 +62,7 @@ object AsyncHttpClient {
     * shutdown when the stream terminates.
     */
   def stream[F[_]](config: AsyncHttpClientConfig = defaultConfig)(
-      implicit F: ConcurrentEffect[F],
+      implicit F: ConcurrentEffect[F]
   ): Stream[F, Client[F]] =
     Stream.bracket(F.delay(apply(config)))(_.shutdown)
 

--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
@@ -5,5 +5,5 @@ package asynchttpclient
 import cats.effect.{IO, Resource}
 
 class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient") {
-  def clientResource = Resource.make(IO(AsyncHttpClient()))(_.shutdown)
+  def clientResource = Resource.make(IO(AsyncHttpClient[IO]()))(_.shutdown)
 }


### PR DESCRIPTION
More to come, but I'm trying to keep things smaller.