### PR TITLE
re-start => reStart

### DIFF
--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -95,7 +95,7 @@ Content-Length: 26
 To shut down your server, simply press `^C` in your console. Note that
 when running interactive SBT, `^C` will kill the SBT process. For rapid
 application development, you may wish to add the [sbt-revolver] plugin
-to your project and starting the server from the SBT prompt with `re-start`.
+to your project and starting the server from the SBT prompt with `reStart`.
 
 With just a few commands, we have a fully functional app for creating
 a simple JSON service.


### PR DESCRIPTION
Looks like sbt-revolver launches with `reStart` now.