### PR TITLE
Fix haveHeaders matcher to work on value equality

### DIFF
--- a/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
@@ -30,7 +30,7 @@ trait Http4sMatchers extends Matchers with IOMatchers {
     }
 
   def haveHeaders(a: Headers): Matcher[Message[IO]] =
-    be(a) ^^ { m: Message[IO] =>
+    be_===(a) ^^ { m: Message[IO] =>
       m.headers.aka("the headers")
     }
 

--- a/testing/src/test/scala/org/http4s/testing/Http4sMatchersSpec.scala
+++ b/testing/src/test/scala/org/http4s/testing/Http4sMatchersSpec.scala
@@ -1,0 +1,19 @@
+package org.http4s
+package testing
+
+import cats.effect.IO
+import org.http4s.headers._
+
+class ResponseGeneratorSpec extends Http4sSpec {
+  "haveHeaders" should {
+    "work on value equality" in {
+      val resp = Response[IO]().withBody("test")
+      resp must returnValue(
+        haveHeaders(
+          Headers(
+            `Content-Length`.unsafeFromLong(4L),
+            `Content-Type`(MediaType.`text/plain`, Charset.`UTF-8`)
+          )))
+    }
+  }
+}


### PR DESCRIPTION
The `haveHeaders` matcher was using reference equality, not value equality.

Fixes #2099.