### PR TITLE
Don't start response until after we add async timeout listener

### DIFF
--- a/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
+++ b/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
@@ -2,11 +2,14 @@ package org.http4s
 package server
 package jetty
 
-import cats.effect.IO
+import cats.effect.{IO, Timer}
+import cats.implicits._
 import java.net.{HttpURLConnection, URL}
+import java.io.IOException
 import java.nio.charset.StandardCharsets
 import org.http4s.dsl.io._
 import org.specs2.specification.AfterAll
+import scala.concurrent.duration._
 import scala.io.Source
 
 class JettyServerSpec extends Http4sSpec with AfterAll {
@@ -15,6 +18,7 @@ class JettyServerSpec extends Http4sSpec with AfterAll {
   val server =
     builder
       .bindAny()
+      .withAsyncTimeout(500.millis)
       .mountService(
         HttpRoutes.of {
           case GET -> Root / "thread" / "routing" =>
@@ -26,6 +30,12 @@ class JettyServerSpec extends Http4sSpec with AfterAll {
 
           case req @ POST -> Root / "echo" =>
             Ok(req.body)
+
+          case GET -> Root / "never" =>
+            IO.never
+
+          case GET -> Root / "slow" =>
+            implicitly[Timer[IO]].sleep(50.millis) *> Ok("slow")
         },
         "/"
       )
@@ -65,6 +75,16 @@ class JettyServerSpec extends Http4sSpec with AfterAll {
     "be able to echo its input" in {
       val input = """{ "Hello": "world" }"""
       post("/echo", input) must startWith(input)
+    }
+  }
+
+  "Timeout" should {
+    "not fire prematurely" in {
+      get("/slow") must_== "slow"
+    }
+
+    "fire on timeout" in {
+      get("/never") must throwAn[IOException]
     }
   }
 }

--- a/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
+++ b/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
@@ -44,47 +44,48 @@ class JettyServerSpec extends Http4sSpec with AfterAll {
 
   def afterAll = server.shutdownNow()
 
-  // This should be in IO and shifted but I'm tired of fighting this.
-  private def get(path: String): String =
-    Source
-      .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-      .getLines
-      .mkString
+  private def get(path: String): IO[String] =
+    contextShift.evalOn(testBlockingExecutionContext)(
+      IO(
+        Source
+          .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
+          .getLines
+          .mkString))
 
-  // This too
-  private def post(path: String, body: String): String = {
-    val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
-    val conn = url.openConnection().asInstanceOf[HttpURLConnection]
-    val bytes = body.getBytes(StandardCharsets.UTF_8)
-    conn.setRequestMethod("POST")
-    conn.setRequestProperty("Content-Length", bytes.size.toString)
-    conn.setDoOutput(true)
-    conn.getOutputStream.write(bytes)
-    Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
-  }
+  private def post(path: String, body: String): IO[String] =
+    contextShift.evalOn(testBlockingExecutionContext)(IO {
+      val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
+      val conn = url.openConnection().asInstanceOf[HttpURLConnection]
+      val bytes = body.getBytes(StandardCharsets.UTF_8)
+      conn.setRequestMethod("POST")
+      conn.setRequestProperty("Content-Length", bytes.size.toString)
+      conn.setDoOutput(true)
+      conn.getOutputStream.write(bytes)
+      Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+    })
 
   "A server" should {
     "route requests on the service executor" in {
-      get("/thread/routing") must startWith("http4s-spec-")
+      get("/thread/routing") must returnValue(startWith("http4s-spec-"))
     }
 
     "execute the service task on the service executor" in {
-      get("/thread/effect") must startWith("http4s-spec-")
+      get("/thread/effect") must returnValue(startWith("http4s-spec-"))
     }
 
     "be able to echo its input" in {
       val input = """{ "Hello": "world" }"""
-      post("/echo", input) must startWith(input)
+      post("/echo", input) must returnValue(startWith(input))
     }
   }
 
   "Timeout" should {
     "not fire prematurely" in {
-      get("/slow") must_== "slow"
+      get("/slow") must returnValue("slow")
     }
 
     "fire on timeout" in {
-      get("/never") must throwAn[IOException]
+      get("/never").unsafeRunSync() must throwAn[IOException]
     }
   }
 }

--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -3,6 +3,7 @@ package servlet
 
 import cats.data.OptionT
 import cats.effect._
+import cats.effect.concurrent.Deferred
 import cats.implicits.{catsSyntaxEither => _, _}
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
@@ -57,22 +58,20 @@ class AsyncHttp4sServlet[F[_]](
   private def handleRequest(
       ctx: AsyncContext,
       request: Request[F],
-      bodyWriter: BodyWriter[F]): F[Unit] = {
-    val timeout = F.async[Unit] { cb =>
-      ctx.addListener(new AsyncTimeoutHandler(cb))
-    }
+      bodyWriter: BodyWriter[F]): F[Unit] = Deferred[F, Unit].flatMap { gate =>
+    // It is an error to add a listener to an async context that is
+    // already completed, so we must take care to add the listener
+    // before the response can complete.
+    val timeout =
+      F.asyncF[Response[F]](cb => gate.complete(ctx.addListener(new AsyncTimeoutHandler(cb))))
     val response =
-      optionTSync
-        .suspend(serviceFn(request))
-        .getOrElse(Response.notFound)
-        .recoverWith(serviceErrorHandler(request))
+      gate.get *>
+        optionTSync
+          .suspend(serviceFn(request))
+          .getOrElse(Response.notFound)
+          .recoverWith(serviceErrorHandler(request))
     val servletResponse = ctx.getResponse.asInstanceOf[HttpServletResponse]
-    F.race(timeout, response).flatMap {
-      case Left(()) =>
-        renderResponse(Response.timeout[F], servletResponse, bodyWriter, F.never)
-      case Right(resp) =>
-        renderResponse(resp, servletResponse, bodyWriter, timeout)
-    }
+    F.race(timeout, response).flatMap(r => renderResponse(r.merge, servletResponse, bodyWriter))
   }
 
   private def errorHandler(
@@ -86,7 +85,7 @@ class AsyncHttp4sServlet[F[_]](
       val response = Response[F](Status.InternalServerError)
       // We don't know what I/O mode we're in here, and we're not rendering a body
       // anyway, so we use a NullBodyWriter.
-      val f = renderResponse(response, servletResponse, NullBodyWriter, F.unit) *>
+      val f = renderResponse(response, servletResponse, NullBodyWriter) *>
         F.delay(
           if (servletRequest.isAsyncStarted)
             servletRequest.getAsyncContext.complete()
@@ -94,11 +93,11 @@ class AsyncHttp4sServlet[F[_]](
       F.runAsync(f)(loggingAsyncCallback(logger)).unsafeRunSync()
   }
 
-  private class AsyncTimeoutHandler(cb: Callback[Unit]) extends AbstractAsyncListener {
+  private class AsyncTimeoutHandler(cb: Callback[Response[F]]) extends AbstractAsyncListener {
     override def onTimeout(event: AsyncEvent): Unit = {
       val req = event.getAsyncContext.getRequest.asInstanceOf[HttpServletRequest]
       logger.info(s"Request timed out: ${req.getMethod} ${req.getServletPath}${req.getPathInfo}")
-      cb(Right(()))
+      cb(Right(Response.timeout[F]))
     }
   }
 }

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -43,7 +43,7 @@ class BlockingHttp4sServlet[F[_]](
       .suspend(serviceFn(request))
       .getOrElse(Response.notFound)
       .recoverWith(serviceErrorHandler(request))
-      .flatMap(renderResponse(_, servletResponse, bodyWriter, F.never))
+      .flatMap(renderResponse(_, servletResponse, bodyWriter))
 
   private def errorHandler(servletResponse: HttpServletResponse): PartialFunction[Throwable, Unit] = {
     case t: Throwable if servletResponse.isCommitted =>
@@ -54,7 +54,7 @@ class BlockingHttp4sServlet[F[_]](
       val response = Response[F](Status.InternalServerError)
       // We don't know what I/O mode we're in here, and we're not rendering a body
       // anyway, so we use a NullBodyWriter.
-      val render = renderResponse(response, servletResponse, NullBodyWriter, F.never)
+      val render = renderResponse(response, servletResponse, NullBodyWriter)
       F.runAsync(render)(_ => IO.unit).unsafeRunSync()
   }
 }

--- a/servlet/src/main/scala/org/http4s/servlet/package.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/package.scala
@@ -1,10 +1,12 @@
 package org.http4s
 
-package object servlet {
-  protected[servlet] type BodyWriter[F[_]] = (Response[F], F[Unit]) => F[Unit]
+import cats.effect.Async
 
-  protected[servlet] def NullBodyWriter[F[_]]: BodyWriter[F] =
-    (_, timeout) => timeout
+package object servlet {
+  protected[servlet] type BodyWriter[F[_]] = Response[F] => F[Unit]
+
+  protected[servlet] def NullBodyWriter[F[_]](implicit F: Async[F]): BodyWriter[F] =
+    _ => F.unit
 
   protected[servlet] val DefaultChunkSize = 4096
 }


### PR DESCRIPTION
It is an error to add an async context listener after a context is completed.  We need to install the timeout listener before we race against the response.

The unit test passed before the fix, but shows that we don't break the basic functionality.  The error condition is rendered on an asynchronous, container owned thread, and I don't see that we have access to it.  Furthermore, it only happens under load.

Fixes #2103.