### PR TITLE
Enable unusedCompileDependenciesTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -317,7 +317,8 @@ lazy val bench = http4sProject("bench")
   .enablePlugins(PrivateProjectPlugin)
   .settings(
     description := "Benchmarks for http4s",
-    libraryDependencies += circeParser
+    libraryDependencies += circeParser,
+    unusedCompileDependenciesTest := {},
   )
   .dependsOn(core, circe)
 
@@ -328,7 +329,8 @@ lazy val loadTest = http4sProject("load-test")
     libraryDependencies ++= Seq(
       gatlingHighCharts,
       gatlingTest
-    ).map(_ % "it,test")
+    ).map(_ % "it,test"),
+    unusedCompileDependenciesTest := {},
   )
   .enablePlugins(GatlingPlugin)
 
@@ -414,7 +416,8 @@ lazy val docs = http4sProject("docs")
           f.getCanonicalPath.startsWith(
             (ghpagesRepository.value / s"${docsPrefix}").getCanonicalPath)
       }
-    }
+    },
+    unusedCompileDependenciesTest := {},
   )
   .dependsOn(client, core, theDsl, blazeServer, blazeClient, circe)
 

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val testing = libraryProject("testing")
 
 // Defined outside core/src/test so it can depend on published testing
 lazy val tests = libraryProject("tests")
+  .enablePlugins(PrivateProjectPlugin)
   .settings(
     description := "Tests for core project",
     mimaPreviousArtifacts := Set.empty
@@ -318,7 +319,6 @@ lazy val bench = http4sProject("bench")
   .settings(
     description := "Benchmarks for http4s",
     libraryDependencies += circeParser,
-    unusedCompileDependenciesTest := {},
   )
   .dependsOn(core, circe)
 
@@ -330,7 +330,6 @@ lazy val loadTest = http4sProject("load-test")
       gatlingHighCharts,
       gatlingTest
     ).map(_ % "it,test"),
-    unusedCompileDependenciesTest := {},
   )
   .enablePlugins(GatlingPlugin)
 
@@ -417,7 +416,6 @@ lazy val docs = http4sProject("docs")
             (ghpagesRepository.value / s"${docsPrefix}").getCanonicalPath)
       }
     },
-    unusedCompileDependenciesTest := {},
   )
   .dependsOn(client, core, theDsl, blazeServer, blazeClient, circe)
 

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -181,6 +181,7 @@ object Http4sPlugin extends AutoPlugin {
         tagRelease.when(primary && release),
         runTestWithCoverage,
         releaseStepCommand("mimaReportBinaryIssues"),
+        releaseStepCommand("unusedCompileDependenciesTest"),
         releaseStepCommand("test:scalafmt::test").when(primary),
         releaseStepCommand("docs/makeSite").when(primary),
         releaseStepCommand("website/makeSite").when(primary),

--- a/project/PrivateProject.scala
+++ b/project/PrivateProject.scala
@@ -3,6 +3,7 @@ package org.http4s.build
 import com.typesafe.sbt.pgp.PgpKeys.{publishLocalSigned, publishSigned}
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
+import explicitdeps.ExplicitDepsPlugin.autoImport._
 import sbt._
 import scoverage.ScoverageSbtPlugin
 import scoverage.ScoverageSbtPlugin.autoImport._
@@ -18,6 +19,7 @@ object PrivateProjectPlugin extends AutoPlugin {
       coverageExcludedPackages := ".*",
       mimaPreviousArtifacts := Set.empty,
       publishLocalSigned := {},
-      publishSigned := {}
+      publishSigned := {},
+      unusedCompileDependenciesTest := {},
     )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.earldouglas"     %  "xsbt-web-plugin"           % "4.0.2")
-addSbtPlugin("com.github.cb372"    %  "sbt-explicit-dependencies" % "0.2.5")
+addSbtPlugin("com.github.cb372"    %  "sbt-explicit-dependencies" % "0.2.6")
 addSbtPlugin("com.github.tkawachi" %  "sbt-doctest"               % "0.7.2")
 addSbtPlugin("com.lucidchart"      %  "sbt-scalafmt-coursier"     % "1.15")
 addSbtPlugin("org.scalastyle"      %% "scalastyle-sbt-plugin"     % "1.0.0")


### PR DESCRIPTION
Fails the build if we declare a dependency we don't use.  Prevents us from passing liabilities downstream.

Not enforced on private (e.g. unpublished) projects.

Bonus: stop publishing empty http4s-tests module.
