### PR TITLE
Handle unsuccessful responses in JavaNetClient

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -42,7 +42,7 @@ abstract class ClientRouteTestBattery(name: String, client: Client[IO])
         val port = address.getPort
         val req = Request[IO](uri = Uri.fromString(s"http://$name:$port$path").yolo)
         client
-          .fetch(req)(resp => IO(checkResponse(resp, expected)))
+          .fetch(req)(resp => checkResponse(resp, expected))
           .unsafeRunTimed(timeout)
           .get
       }
@@ -103,16 +103,16 @@ abstract class ClientRouteTestBattery(name: String, client: Client[IO])
       }
     )
 
-  private def checkResponse(rec: Response[IO], expected: Response[IO]) = {
+  private def checkResponse(rec: Response[IO], expected: Response[IO]): IO[Boolean] = {
     val hs = rec.headers.toSeq
-
-    rec.status must be_==(expected.status)
-
-    collectBody(rec.body) must be_==(collectBody(expected.body))
-
-    expected.headers.foreach(h => h must beOneOf(hs: _*))
-
-    rec.httpVersion must be_==(expected.httpVersion)
+    for {
+      _ <- IO(rec.status must be_==(expected.status))
+      body <- rec.body.compile.to[Array]
+      expBody <- expected.body.compile.to[Array]
+      _ <- IO(body must_== expBody)
+      _ <- IO(expected.headers.foreach(h => h must beOneOf(hs: _*)))
+      _ <- IO(rec.httpVersion must be_==(expected.httpVersion))
+    } yield true
   }
 
   private def renderResponse(srv: HttpServletResponse, resp: Response[IO]): Unit = {
@@ -126,7 +126,4 @@ abstract class ClientRouteTestBattery(name: String, client: Client[IO])
       .drain
       .unsafeRunSync()
   }
-
-  private def collectBody(body: EntityBody[IO]): Array[Byte] =
-    body.compile.toVector.unsafeRunSync().toArray
 }

--- a/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -12,6 +12,9 @@ object GetRoutes {
   val SimplePath = "/simple"
   val ChunkedPath = "/chunked"
   val DelayedPath = "/delayed"
+  val NoContentPath = "/no-content"
+  val NotFoundPath = "/not-found"
+  val EmptyNotFoundPath = "/empty-not-found"
 
   def getPaths(implicit ec: ExecutionContext): Map[String, Response[IO]] =
     Map(
@@ -19,6 +22,9 @@ object GetRoutes {
       ChunkedPath -> Response[IO](Ok).withBody(
         Stream.emits("chunk".toSeq.map(_.toString)).covary[IO]),
       DelayedPath ->
-        IO.sleep(1.seconds) *> Response[IO](Ok).withBody("delayed path")
+        IO.sleep(1.seconds) *> Response[IO](Ok).withBody("delayed path"),
+      NoContentPath -> Response[IO](NoContent).pure[IO],
+      NotFoundPath -> Response[IO](NotFound).withBody("not found"),
+      EmptyNotFoundPath -> Response[IO](NotFound).pure[IO]
     ).mapValues(_.unsafeRunSync())
 }


### PR DESCRIPTION
`HttpUrlConnection` returns the body in `getErrorStream` rather than `getInputStream` when the response code is unsuccessful.  Well, sometimes.  Sometimes it returns `null`.

1. Try to read the body from `getInputStream`
2. If that throws, try to read an error from `getErrorStream`, if it's there.
3. Otherwise, return an empty body.
4. Close whatever we can find to close on dispose.

Fixes #2114.