### PR TITLE
Mark case classes final

### DIFF
--- a/client-metrics/src/main/scala/org/http4s/client/metrics/Metrics.scala
+++ b/client-metrics/src/main/scala/org/http4s/client/metrics/Metrics.scala
@@ -64,7 +64,7 @@ object Metrics {
 
 }
 
-private case class MetricsCollection(
+private final case class MetricsCollection(
     activeRequests: Counter,
     requestsHeaders: MetricTimer,
     requestsTotal: MetricTimer,

--- a/client/src/main/scala/org/http4s/client/PoolManager.scala
+++ b/client/src/main/scala/org/http4s/client/PoolManager.scala
@@ -357,5 +357,5 @@ private final class PoolManager[F[_], A <: Connection[F]](
   }
 }
 
-case class NoConnectionAllowedException(key: RequestKey)
+final case class NoConnectionAllowedException(key: RequestKey)
     extends IllegalArgumentException(s"No client connections allowed to $key")

--- a/core/src/main/scala/org/http4s/AuthedRequest.scala
+++ b/core/src/main/scala/org/http4s/AuthedRequest.scala
@@ -4,7 +4,7 @@ import cats._
 import cats.data._
 import cats.implicits._
 
-case class AuthedRequest[F[_], A](authInfo: A, req: Request[F])
+final case class AuthedRequest[F[_], A](authInfo: A, req: Request[F])
 
 object AuthedRequest {
   def apply[F[_]: Functor, T](

--- a/core/src/main/scala/org/http4s/ServerSentEvent.scala
+++ b/core/src/main/scala/org/http4s/ServerSentEvent.scala
@@ -7,7 +7,7 @@ import org.http4s.ServerSentEvent._
 import org.http4s.util.{Renderable, Writer}
 import scala.util.Try
 
-case class ServerSentEvent(
+final case class ServerSentEvent(
     data: String,
     eventType: Option[String] = None,
     id: Option[EventId] = None,
@@ -32,7 +32,7 @@ case class ServerSentEvent(
 object ServerSentEvent {
   val empty = ServerSentEvent("")
 
-  case class EventId(value: String)
+  final case class EventId(value: String)
 
   object EventId {
     val reset: EventId = EventId("")

--- a/core/src/main/scala/org/http4s/headers/Origin.scala
+++ b/core/src/main/scala/org/http4s/headers/Origin.scala
@@ -20,7 +20,7 @@ object Origin extends HeaderKey.Internal[Origin] with HeaderKey.Singleton {
 
   // If the Origin is not "null", it is a non-empty list of Hosts:
   // http://tools.ietf.org/html/rfc6454#section-7
-  case class HostList(hosts: NonEmptyList[Host]) extends Origin {
+  final case class HostList(hosts: NonEmptyList[Host]) extends Origin {
     def renderValue(writer: Writer): writer.type = {
       writer << hosts.head
       hosts.tail.foreach { host =>

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -84,7 +84,7 @@ object ~ {
     }
 }
 
-case class /(parent: Path, child: String) extends Path {
+final case class /(parent: Path, child: String) extends Path {
   lazy val toList: List[String] = parent.toList ++ List(child)
 
   def lastOption: Some[String] = Some(child)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
@@ -19,7 +19,7 @@ class GitHubService[F[_]: Sync](client: Client[F]) extends Http4sClientDsl[F] {
 
   private val RedirectUri = s"http://localhost:8080/$ApiVersion/login/github"
 
-  case class AccessTokenResponse(access_token: String)
+  final case class AccessTokenResponse(access_token: String)
 
   val authorize: Stream[F, Byte] = {
     val uri = Uri

--- a/jetty-client/src/main/scala/org/http4s/client/jetty/ResponseListener.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/ResponseListener.scala
@@ -17,7 +17,7 @@ import org.log4s.getLogger
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
-private[jetty] case class ResponseListener[F[_]](
+private[jetty] final case class ResponseListener[F[_]](
     queue: Queue[F, Option[ByteBuffer]],
     cb: Callback[DisposableResponse[F]])(implicit val F: Effect[F], ec: ExecutionContext)
     extends JettyResponse.Listener.Adapter {

--- a/jetty-client/src/main/scala/org/http4s/client/jetty/StreamRequestContentProvider.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/StreamRequestContentProvider.scala
@@ -12,7 +12,8 @@ import org.eclipse.jetty.util.{Callback => JettyCallback}
 import org.http4s.internal.loggingAsyncCallback
 import org.log4s.getLogger
 
-private[jetty] case class StreamRequestContentProvider[F[_]](s: Semaphore[F])(implicit F: Effect[F])
+private[jetty] final case class StreamRequestContentProvider[F[_]](s: Semaphore[F])(
+    implicit F: Effect[F])
     extends DeferredContentProvider {
 
   import StreamRequestContentProvider.logger

--- a/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
+++ b/prometheus-client-metrics/src/main/scala/org/http4s/client/prometheus/PrometheusClientMetrics.scala
@@ -29,7 +29,7 @@ object PrometheusClientMetrics {
     }
   }
 
-  private case class ClientMetrics[F[_]](
+  private final case class ClientMetrics[F[_]](
       destination: Request[F] => String,
       responseDuration: Histogram,
       activeRequests: Gauge,

--- a/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
+++ b/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
@@ -51,7 +51,7 @@ object PrometheusMetrics {
     }
   }
 
-  private case class ServiceMetrics(
+  private final case class ServiceMetrics(
       requestDuration: Histogram,
       activeRequests: Gauge,
       requestCounter: Counter,

--- a/server-metrics/src/main/scala/org/http4s/server/metrics/Metrics.scala
+++ b/server-metrics/src/main/scala/org/http4s/server/metrics/Metrics.scala
@@ -155,7 +155,7 @@ object Metrics {
       Sync[F].delay(active_requests.dec())
   }
 
-  private case class RequestTimers(
+  private final case class RequestTimers(
       getReq: Timer,
       postReq: Timer,
       putReq: Timer,
@@ -169,7 +169,7 @@ object Metrics {
       totalReq: Timer
   )
 
-  private case class ResponseTimers(
+  private final case class ResponseTimers(
       resp1xx: Timer,
       resp2xx: Timer,
       resp3xx: Timer,
@@ -177,14 +177,14 @@ object Metrics {
       resp5xx: Timer
   )
 
-  private case class GeneralServiceMetrics(
+  private final case class GeneralServiceMetrics(
       activeRequests: Counter,
       abnormalTerminations: Timer,
       serviceErrors: Timer,
       headersTimes: Timer
   )
 
-  private case class ServiceMetrics(
+  private final case class ServiceMetrics(
       generalMetrics: GeneralServiceMetrics,
       requestTimers: RequestTimers,
       responseTimers: ResponseTimers

--- a/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -35,7 +35,7 @@ import org.http4s.{AttributeEntry, Headers, Response, Status}
   * @param onHandshakeFailure The status code to return when failing to handle a websocket HTTP request to this route.
   *                           default: BadRequest
   */
-case class WebSocketBuilder[F[_]](
+final case class WebSocketBuilder[F[_]](
     send: Stream[F, WebSocketFrame],
     receive: Sink[F, WebSocketFrame],
     headers: Headers,


### PR DESCRIPTION
Co-authored-by: Andrea Magnorsky <roundcrisis@gmail.com>

Adds the `final` modifier to case classes that are not already `final` or `sealed abstract`. Exceptions listed below:

- `TimedMatcher` in `/testing/src/main/scala/org/http4s/testing/RunTimedMatchers.scala`
- Anything under a `src/test` path

Adding the `final` or `sealed abstract` modifiers to the following case classes fails to compile, so these have also been excluded from this refactor:
- `/core/src/main/scala/org/http4s/parser/StrictTransportSecurityParser.scala:  private case class StrictTransportSecurityParser(override val input: ParserInput)` 
- `./examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/JsonXmlHttpEndpoint.scala:  case class Person(name: String, age: Int)`

Fixes #2074