### PR TITLE
Remove MiMa opt-outs for recent modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,9 +53,9 @@ lazy val testing = libraryProject("testing")
 
 // Defined outside core/src/test so it can depend on published testing
 lazy val tests = libraryProject("tests")
+  .enablePlugins(PrivateProjectPlugin)
   .settings(
     description := "Tests for core project",
-    mimaPreviousArtifacts := Set.empty
   )
   .dependsOn(core, testing % "test->test")
 
@@ -132,7 +132,6 @@ lazy val okHttpClient = libraryProject("okhttp-client")
     libraryDependencies ++= Seq(
       Http4sPlugin.okhttp
     ),
-    mimaPreviousArtifacts := Set.empty // remove me once merged
   )
   .dependsOn(core, testing % "test->test", client % "compile;test->test")
 
@@ -241,7 +240,6 @@ lazy val playJson = libraryProject("play-json")
       jawnPlay,
       Http4sPlugin.playJson(scalaBinaryVersion.value)
     ),
-    mimaPreviousArtifacts := Set.empty // remove me once merged
   )
   .dependsOn(jawn % "compile;test->test")
 
@@ -268,7 +266,6 @@ lazy val scalatags = http4sProject("scalatags")
   .settings(
     description := "Scalatags template support for http4s",
     libraryDependencies += scalatagsApi,
-    mimaPreviousArtifacts := Set.empty
   )
   .dependsOn(core, testing % "test->test")
 


### PR DESCRIPTION
When we add a new module in the middle of a series, we have to disable the `mimaPreviousArtifacts`.  We neglected to clean these up later.