### PR TITLE
Don't check for dependency updates on load

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,6 @@ enablePlugins(PrivateProjectPlugin)
 
 cancelable in Global := true
 
-// check for library updates whenever the project is [re]load
-onLoad in Global := { s =>
-  "dependencyUpdates" :: s
-}
-
 lazy val core = libraryProject("core")
   .enablePlugins(BuildInfoPlugin)
   .settings(


### PR DESCRIPTION
We've got @scala-steward working for us.  It's less important to have this in our face.

Arguably this is still useful on maintenance branches, where @scala-steward doesn't operate.  Discuss.