### PR TITLE
Replace Client.streaming with Client.stream

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -80,8 +80,14 @@ trait Client[F[_]] {
   @deprecated("Use toHttpApp. Call `.mapF(OptionT.liftF)` if OptionT is really desired.", "0.19")
   def toHttpService: HttpService[F]
 
+  /** Run the request as a stream.  The response lifecycle is equivalent
+    * to the returned Stream's. */
+  def stream(req: Request[F]): Stream[F, Response[F]]
+
+  @deprecated("Use `client.stream(req).flatMap(f)`", "0.19.0-RC1")
   def streaming[A](req: Request[F])(f: Response[F] => Stream[F, A]): Stream[F, A]
 
+  @deprecated("Use `Stream.eval(req).flatMap(client.stream).flatMap(f)`", "0.19.0-RC1")
   def streaming[A](req: F[Request[F]])(f: Response[F] => Stream[F, A]): Stream[F, A]
 
   def expectOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -237,28 +237,21 @@ class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThro
         EntityDecoder.text[IO].orElse(edec)) must returnValue("Accept: text/*, image/jpeg")
     }
 
-    "streaming returns a stream" in {
+    "stream returns a stream" in {
       client
-        .streaming(req)(_.body.through(fs2.text.utf8Decode))
-        .compile
-        .toVector
-        .unsafeRunSync() must_== Vector("hello")
-    }
-
-    "streaming returns a stream from a request task" in {
-      client
-        .streaming(req)(_.body.through(fs2.text.utf8Decode))
+        .stream(req)
+        .flatMap(_.body.through(fs2.text.utf8Decode))
         .compile
         .toVector
         .unsafeRunSync() must_== Vector("hello")
     }
 
     "streaming disposes of the response on success" in {
-      assertDisposes(_.streaming(req)(_.body).compile.drain)
+      assertDisposes(_.stream(req).compile.drain)
     }
 
     "streaming disposes of the response on failure" in {
-      assertDisposes(_.streaming(req)(_ => Stream.raiseError[IO](SadTrombone)).compile.drain)
+      assertDisposes(_.stream(req).flatMap(_ => Stream.raiseError[IO](SadTrombone)).compile.drain)
     }
 
     "toService disposes of the response on success" in {

--- a/docs/src/main/tut/streaming.md
+++ b/docs/src/main/tut/streaming.md
@@ -51,7 +51,7 @@ function, which takes a `Request[F]` and a `Response[F] => Stream[F, A]` and ret
 to consume a stream is just:
 
 ```scala
-client.streaming(req)(resp => resp.body)
+client.stream(req).flatMap(_)
 ```
 
 That gives you a `Stream[F, Byte]`, but you probably want something other than a `Byte`.
@@ -117,7 +117,7 @@ class TWStream[F[_]](implicit F: ConcurrentEffect[F], cs: ContextShift[F]) {
     for {
       client <- BlazeClientBuilder(global).stream
       sr  <- Stream.eval(sign(consumerKey, consumerSecret, accessToken, accessSecret)(req))
-      res <- client.streaming(sr)(resp => resp.body.chunks.parseJsonStream)
+      res <- client.stream(sr).flatMap(_.body.chunks.parseJsonStream)
     } yield res
 
   /* Stream the sample statuses.


### PR DESCRIPTION
Based on @ChristopherDavenport's good idea in #1714.  The abstract method is still based on `Resource`, but a `Stream[F, Response[F]]` is simpler than `.streaming`, and `.streaming` can be easily derived from it.