### PR TITLE
Unify org.http4s.websocket package, use ByteVector

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
@@ -7,16 +7,16 @@ import cats.implicits._
 import fs2._
 import fs2.concurrent.SignallingRef
 import java.util.concurrent.atomic.AtomicBoolean
-import org.http4s.{websocket => ws4s}
 import org.http4s.blaze.pipeline.{Command, LeafBuilder, TailStage, TrunkBuilder}
 import org.http4s.blaze.util.Execution.{directec, trampoline}
 import org.http4s.internal.unsafeRunAsync
-import org.http4s.websocket.WebsocketBits._
+import org.http4s.websocket.{WebSocket, WebSocketFrame}
+import org.http4s.websocket.WebSocketFrame._
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 private[http4s] class Http4sWSStage[F[_]](
-    ws: ws4s.Websocket[F],
+    ws: WebSocket[F],
     sentClose: AtomicBoolean,
     deadSignal: SignallingRef[F, Boolean]
 )(implicit F: ConcurrentEffect[F], val ec: ExecutionContext)

--- a/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
@@ -8,8 +8,8 @@ import cats.implicits._
 import java.util.concurrent.atomic.AtomicBoolean
 import org.http4s.Http4sSpec
 import org.http4s.blaze.pipeline.LeafBuilder
-import org.http4s.websocket.Websocket
-import org.http4s.websocket.WebsocketBits._
+import org.http4s.websocket.{WebSocket, WebSocketFrame}
+import org.http4s.websocket.WebSocketFrame._
 import org.http4s.blaze.pipeline.Command
 import scala.concurrent.ExecutionContext
 
@@ -48,7 +48,7 @@ class Http4sWSStageSpec extends Http4sSpec {
       for {
         outQ <- Queue.unbounded[IO, WebSocketFrame]
         closeHook = new AtomicBoolean(false)
-        ws = Websocket[IO](outQ.dequeue, _.drain, IO(closeHook.set(true)))
+        ws = WebSocket[IO](outQ.dequeue, _.drain, IO(closeHook.set(true)))
         deadSignal <- SignallingRef[IO, Boolean](false)
         head = LeafBuilder(new Http4sWSStage[IO](ws, closeHook, deadSignal)).base(WSTestHead())
         _ <- IO(head.sendInboundCommand(Command.Connected))

--- a/blaze-core/src/test/scala/org/http4s/blazecore/websocket/WSTestHead.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/websocket/WSTestHead.scala
@@ -3,7 +3,7 @@ package org.http4s.blazecore.websocket
 import cats.effect.{ContextShift, IO, Timer}
 import fs2.concurrent.Queue
 import org.http4s.blaze.pipeline.HeadStage
-import org.http4s.websocket.WebsocketBits.WebSocketFrame
+import org.http4s.websocket.WebSocketFrame
 import scala.concurrent.Future
 import scala.concurrent.duration._
 

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketDecoder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketDecoder.scala
@@ -2,8 +2,7 @@ package org.http4s.server.blaze
 
 import java.nio.ByteBuffer
 import org.http4s.blaze.pipeline.stages.ByteToObjectStage
-import org.http4s.websocket.FrameTranscoder
-import org.http4s.websocket.WebsocketBits.WebSocketFrame
+import org.http4s.websocket.{FrameTranscoder, WebSocketFrame}
 import org.http4s.websocket.FrameTranscoder.TranscodeError
 
 private class WebSocketDecoder

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,6 @@ lazy val core = libraryProject("core")
       cats,
       catsEffect,
       fs2Io,
-      http4sWebsocket,
       log4s,
       parboiled,
       scalaReflect(scalaOrganization.value, scalaVersion.value) % "provided",

--- a/core/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
+++ b/core/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
@@ -1,0 +1,167 @@
+package org.http4s.websocket
+
+import java.nio.ByteBuffer
+import scodec.bits.ByteVector
+
+private[http4s] object FrameTranscoder {
+  final class TranscodeError(val message: String) extends Exception(message)
+
+  private def decodeBinary(in: ByteBuffer, mask: Array[Byte]) = {
+    val data = new Array[Byte](in.remaining)
+    in.get(data)
+    if (mask != null) { // We can use the charset decode
+      for (i <- 0 until data.length) {
+        data(i) = (data(i) ^ mask(i & 0x3)).toByte // i mod 4 is the same as i & 0x3 but slower
+      }
+    }
+    data
+  }
+
+  private def lengthOffset(in: ByteBuffer) = {
+    val len = in.get(1) & LENGTH
+    if (len < 126) 2
+    else if (len == 126) 4
+    else if (len == 127) 10
+    else throw new FrameTranscoder.TranscodeError("Length error!")
+  }
+
+  private def getMask(in: ByteBuffer): Array[Byte] = {
+    val m = new Array[Byte](4)
+    in.mark
+    in.position(lengthOffset(in))
+    in.get(m)
+    in.reset
+    m
+  }
+
+  private def bodyLength(in: ByteBuffer) = {
+    val len = in.get(1) & LENGTH
+    if (len < 126) len
+    else if (len == 126) (in.get(2) << 8 & 0xff00) | (in.get(3) & 0xff)
+    else if (len == 127) {
+      val l = in.getLong(2)
+      if (l > Integer.MAX_VALUE) throw new FrameTranscoder.TranscodeError("Frame is too long")
+      else l.toInt
+    } else throw new FrameTranscoder.TranscodeError("Length error")
+  }
+
+  private def getMsgLength(in: ByteBuffer) = {
+    var totalLen = 2
+    if ((in.get(1) & MASK) != 0) totalLen += 4
+
+    val len = in.get(1) & LENGTH
+
+    if (len == 126) totalLen += 2
+    if (len == 127) totalLen += 8
+
+    if (in.remaining < totalLen) {
+      -1
+    } else {
+      totalLen += bodyLength(in)
+
+      if (in.remaining < totalLen) -1
+      else totalLen
+    }
+  }
+}
+
+class FrameTranscoder(val isClient: Boolean) {
+  def frameToBuffer(in: WebSocketFrame): Array[ByteBuffer] = {
+    var size = 2
+
+    if (isClient) size += 4 // for the mask
+
+    if (in.length < 126) { /* NOOP */ } else if (in.length <= 0xffff) size += 2
+    else size += 8
+
+    val buff = ByteBuffer.allocate(if (isClient) size + in.length else size)
+
+    val opcode = in.opcode
+
+    if (in.length > 125 && (opcode == PING || opcode == PONG || opcode == CLOSE))
+      throw new FrameTranscoder.TranscodeError("Invalid PING frame: frame too long: " + in.length)
+
+    // First byte. Finished, reserved, and OP CODE
+    val b1 = if (in.last) opcode | FINISHED else opcode
+
+    buff.put(b1.byteValue)
+
+    // Second byte. Mask bit and length
+    var b2 = 0x0
+
+    if (isClient) b2 = MASK
+
+    if (in.length < 126) b2 |= in.length
+    else if (in.length <= 0xffff) b2 |= 126
+    else b2 |= 127
+
+    buff.put(b2.byteValue)
+
+    // Put the length if we have an extended length packet
+    if (in.length > 125 && in.length <= 0xffff) {
+      buff.put((in.length >>> 8 & 0xff).toByte).put((in.length & 0xff).toByte)
+    } else if (in.length > 0xffff) buff.putLong(in.length.toLong)
+
+    // If we are a client, we need to mask the data, else just wrap it in a buffer and done
+    if (isClient && in.length > 0) { // need to mask outgoing bytes
+      val mask = (Math.random * Integer.MAX_VALUE).toInt
+      val maskBits = Array(
+        ((mask >>> 24) & 0xff).toByte,
+        ((mask >>> 16) & 0xff).toByte,
+        ((mask >>> 8) & 0xff).toByte,
+        ((mask >>> 0) & 0xff).toByte)
+
+      buff.put(maskBits)
+
+      val data = in.data
+
+      for (i <- 0 until in.length.toInt) {
+        buff.put((data(i.toLong) ^ maskBits(i & 0x3)).toByte) // i & 0x3 is the same as i % 4 but faster
+      }
+      buff.flip
+      Array[ByteBuffer](buff)
+    } else {
+      buff.flip
+      Array[ByteBuffer](buff, in.data.toByteBuffer)
+    }
+  }
+
+  /** Method that decodes ByteBuffers to objects. None reflects not enough data to decode a message
+    * Any unused data in the ByteBuffer will be recycled and available for the next read
+    *
+    * @param in ByteBuffer of immediately available data
+    * @return optional message if enough data was available
+    */
+  def bufferToFrame(in: ByteBuffer): WebSocketFrame =
+    if (in.remaining < 2 || FrameTranscoder.getMsgLength(in) < 0) {
+      null
+    } else {
+      val opcode = in.get(0) & OP_CODE
+      val finished = (in.get(0) & FINISHED) != 0
+      val masked = (in.get(1) & MASK) != 0
+
+      if (masked && isClient)
+        throw new FrameTranscoder.TranscodeError("Client received a masked message")
+
+      var bodyOffset = FrameTranscoder.lengthOffset(in)
+
+      val m = if (masked) {
+        bodyOffset += 4
+        FrameTranscoder.getMask(in)
+      } else {
+        null
+      }
+
+      val oldLim = in.limit()
+      val bodylen = FrameTranscoder.bodyLength(in)
+
+      in.position(bodyOffset)
+      in.limit(in.position() + bodylen)
+
+      val slice = in.slice
+      in.position(in.limit)
+      in.limit(oldLim)
+
+      makeFrame(opcode, ByteVector.view(FrameTranscoder.decodeBinary(slice, m)), finished)
+    }
+}

--- a/core/src/main/scala/org/http4s/websocket/WebSocket.scala
+++ b/core/src/main/scala/org/http4s/websocket/WebSocket.scala
@@ -1,9 +1,8 @@
 package org.http4s.websocket
 
 import fs2._
-import org.http4s.websocket.WebsocketBits.WebSocketFrame
 
-private[http4s] final case class Websocket[F[_]](
+private[http4s] final case class WebSocket[F[_]](
     @deprecatedName('read) send: Stream[F, WebSocketFrame],
     @deprecatedName('write) receive: Sink[F, WebSocketFrame],
     onClose: F[Unit]

--- a/core/src/main/scala/org/http4s/websocket/WebSocketContext.scala
+++ b/core/src/main/scala/org/http4s/websocket/WebSocketContext.scala
@@ -3,6 +3,6 @@ package org.http4s.websocket
 import org.http4s.{Headers, Response}
 
 final case class WebSocketContext[F[_]](
-    webSocket: Websocket[F],
+    webSocket: WebSocket[F],
     headers: Headers,
     failureResponse: F[Response[F]])

--- a/core/src/main/scala/org/http4s/websocket/WebSocketFrame.scala
+++ b/core/src/main/scala/org/http4s/websocket/WebSocketFrame.scala
@@ -1,0 +1,126 @@
+package org.http4s.websocket
+
+import java.nio.charset.StandardCharsets.UTF_8
+import scala.util.hashing.MurmurHash3
+import scodec.bits.ByteVector
+
+abstract class WebSocketFrame {
+  def opcode: Int
+  def data: ByteVector
+  def last: Boolean
+
+  final def length: Int = data.length.toInt
+
+  override def equals(obj: Any): Boolean = obj match {
+    case wf: WebSocketFrame =>
+      this.opcode == wf.opcode &&
+        this.last == wf.last &&
+        this.data == wf.data
+    case _ => false
+  }
+
+  override def hashCode: Int = {
+    var hash = WebSocketFrame.hashSeed
+    hash = MurmurHash3.mix(hash, opcode.##)
+    hash = MurmurHash3.mix(hash, data.##)
+    hash = MurmurHash3.mixLast(hash, last.##)
+    hash
+  }
+}
+
+object WebSocketFrame {
+  private val hashSeed = MurmurHash3.stringHash("WebSocketFrame")
+
+  sealed abstract class ControlFrame extends WebSocketFrame {
+    final def last: Boolean = true
+  }
+
+  sealed abstract class Text extends WebSocketFrame {
+    def str: String
+    def opcode = TEXT
+
+    override def toString: String = s"Text('$str', last: $last)"
+  }
+
+  private class BinaryText(val data: ByteVector, val last: Boolean) extends Text {
+    lazy val str: String = new String(data.toArray, UTF_8)
+  }
+
+  private class StringText(override val str: String, val last: Boolean) extends Text {
+    lazy val data: ByteVector = ByteVector.view(str.getBytes(UTF_8))
+  }
+
+  object Text {
+    def apply(str: String, last: Boolean = true): Text = new StringText(str, last)
+    def apply(data: ByteVector, last: Boolean): Text = new BinaryText(data, last)
+    def apply(data: ByteVector): Text = new BinaryText(data, true)
+    def unapply(txt: Text): Option[(String, Boolean)] = Some((txt.str, txt.last))
+  }
+
+  final case class Binary(data: ByteVector, last: Boolean = true) extends WebSocketFrame {
+    def opcode = BINARY
+    override def toString: String = s"Binary(Array(${data.length}), last: $last)"
+  }
+
+  final case class Continuation(data: ByteVector, last: Boolean) extends WebSocketFrame {
+    def opcode: Int = CONTINUATION
+    override def toString: String = s"Continuation(Array(${data.length}), last: $last)"
+  }
+
+  final case class Ping(data: ByteVector = ByteVector.empty) extends ControlFrame {
+    def opcode = PING
+    override def toString: String =
+      if (data.length > 0) s"Ping(Array(${data.length}))"
+      else s"Ping"
+  }
+
+  final case class Pong(data: ByteVector = ByteVector.empty) extends ControlFrame {
+    def opcode = PONG
+    override def toString: String =
+      if (data.length > 0) s"Pong(Array(${data.length}))"
+      else s"Pong"
+  }
+
+  final case class Close(data: ByteVector = ByteVector.empty) extends ControlFrame {
+    def opcode = CLOSE
+
+    def closeCode: Int =
+      if (data.length > 0) {
+        (data(0) << 8 & 0xff00) | (data(1) & 0xff) // 16-bit unsigned
+      } else 1005 // No code present
+
+    override def toString: String =
+      if (data.length > 0) s"Close(Array(${data.length}))"
+      else s"Close"
+  }
+
+  sealed abstract class InvalidCloseDataException extends RuntimeException
+  class InvalidCloseCodeException(val i: Int) extends InvalidCloseDataException
+  class ReasonTooLongException(val s: String) extends InvalidCloseDataException
+
+  private def toUnsignedShort(x: Int) = Array[Byte](((x >> 8) & 0xFF).toByte, (x & 0xFF).toByte)
+
+  private def reasonToBytes(reason: String) = {
+    val asBytes = ByteVector.view(reason.getBytes(UTF_8))
+    if (asBytes.length > 123) {
+      Left(new ReasonTooLongException(reason))
+    } else {
+      Right(asBytes)
+    }
+  }
+
+  private def closeCodeToBytes(code: Int): Either[InvalidCloseCodeException, ByteVector] =
+    if (code < 1000 || code > 4999) Left(new InvalidCloseCodeException(code))
+    else Right(ByteVector.view(toUnsignedShort(code)))
+
+  object Close {
+    def apply(code: Int): Either[InvalidCloseDataException, Close] =
+      closeCodeToBytes(code).right.map(Close(_))
+
+    def apply(code: Int, reason: String): Either[InvalidCloseDataException, Close] =
+      for {
+        c <- closeCodeToBytes(code).right
+        r <- reasonToBytes(reason).right
+      } yield Close(c ++ r)
+  }
+}

--- a/core/src/main/scala/org/http4s/websocket/package.scala
+++ b/core/src/main/scala/org/http4s/websocket/package.scala
@@ -1,0 +1,42 @@
+package org.http4s
+
+import java.net.ProtocolException
+import scodec.bits.ByteVector
+
+package object websocket {
+
+  // Masks for extracting fields
+  private[websocket] val OP_CODE = 0xf
+  private[websocket] val FINISHED = 0x80
+  private[websocket] val MASK = 0x80
+  private[websocket] val LENGTH = 0x7f
+  private[websocket] val RESERVED = 0xe
+
+  // message op codes
+  private[websocket] val CONTINUATION = 0x0
+  private[websocket] val TEXT = 0x1
+  private[websocket] val BINARY = 0x2
+  private[websocket] val CLOSE = 0x8
+  private[websocket] val PING = 0x9
+  private[websocket] val PONG = 0xa
+
+  // Type constructors
+  @throws[ProtocolException]
+  private[websocket] def makeFrame(opcode: Int, data: ByteVector, last: Boolean): WebSocketFrame =
+    opcode match {
+      case TEXT => WebSocketFrame.Text(data, last)
+      case BINARY => WebSocketFrame.Text(data, last)
+      case CONTINUATION => WebSocketFrame.Continuation(data, last)
+      case PING =>
+        if (!last) throw new ProtocolException("Control frame cannot be fragmented: Ping")
+        else WebSocketFrame.Ping(data)
+      case PONG =>
+        if (!last) throw new ProtocolException("Control frame cannot be fragmented: Pong")
+        else WebSocketFrame.Pong(data)
+      case CLOSE =>
+        if (data.length == 1)
+          throw new ProtocolException("Close frame must have 0 data bits or at least 2")
+        if (!last) throw new ProtocolException("Control frame cannot be fragmented: Close")
+        WebSocketFrame.Close(data)
+    }
+}

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -8,7 +8,8 @@ import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.websocket._
-import org.http4s.websocket.WebsocketBits._
+import org.http4s.websocket.WebSocketFrame
+import org.http4s.websocket.WebSocketFrame._
 import scala.concurrent.duration._
 
 object BlazeWebSocketExample extends IOApp {

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -293,7 +293,6 @@ object Http4sPlugin extends AutoPlugin {
   lazy val discipline                       = "org.typelevel"          %% "discipline"                % "0.9.0"
   lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "1.0.0-RC2"
   lazy val fs2ReactiveStreams               = "co.fs2"                 %% "fs2-reactive-streams"      % fs2Io.revision
-  lazy val http4sWebsocket                  = "org.http4s"             %% "http4s-websocket"          % "0.2.1"
   lazy val javaxServletApi                  = "javax.servlet"          %  "javax.servlet-api"         % "3.1.0"
   lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "0.13.0-RC1"
   lazy val jawnJson4s                       = "org.spire-math"         %% "jawn-json4s"               % "0.13.0"

--- a/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -3,8 +3,7 @@ package org.http4s.server.websocket
 import cats._
 import cats.implicits._
 import fs2._
-import org.http4s.websocket.WebsocketBits.WebSocketFrame
-import org.http4s.websocket.{WebSocketContext, Websocket}
+import org.http4s.websocket.{WebSocket, WebSocketContext, WebSocketFrame}
 import org.http4s.{AttributeEntry, Headers, Response, Status}
 
 /**
@@ -59,7 +58,7 @@ object WebSocketBuilder {
           _.withAttribute(
             AttributeEntry(
               websocketKey[F],
-              WebSocketContext(Websocket(send, receive, onClose), headers, onHandshakeFailure))))
+              WebSocketContext(WebSocket(send, receive, onClose), headers, onHandshakeFailure))))
   }
   def apply[F[_]: Applicative]: Builder[F] = new Builder[F]
 }


### PR DESCRIPTION
The `org.http4s.websocket` package is awkwardly split across the http4s-websocket repo and http4s-core.  No package should ever live in two artifacts.

The reason for the http4s-websocket repo was to share a model between blaze and http4s without adding any dependencies to the former.  Since then, the blaze repo dropped websocket support entirely.  If we unify it here, we can use a model with all our dependencies.  This includes `ByteVector`, which is back on our classpath since fs2-core again depends on scodec-bits.  That gives us an immutable model.

There are all kinds of shady numeric truncations and widenings going on here, and it's worth looking closely at the `WebSocketFrame` class.

Additionally, standardizes on the `WebSocket` capitalization in place of `Websocket`