### PR TITLE
Upgade to async-http-client-2.5.3

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -9,7 +9,8 @@ import cats.implicits.{catsSyntaxEither => _, _}
 import fs2.Stream._
 import fs2._
 import fs2.interop.reactivestreams.{StreamSubscriber, StreamUnicastPublisher}
-import java.nio.ByteBuffer
+import _root_.io.netty.buffer.Unpooled
+import _root_.io.netty.handler.codec.http.{DefaultHttpHeaders, HttpHeaders}
 import org.asynchttpclient.AsyncHandler.State
 import org.asynchttpclient.handler.StreamedAsyncHandler
 import org.asynchttpclient.request.body.generator.{
@@ -106,7 +107,7 @@ object AsyncHttpClient {
         state
       }
 
-      override def onHeadersReceived(headers: HttpResponseHeaders): State = {
+      override def onHeadersReceived(headers: HttpHeaders): State = {
         dr = dr.copy(response = dr.response.copy(headers = getHeaders(headers)))
         state
       }
@@ -120,21 +121,21 @@ object AsyncHttpClient {
     }
 
   private def toAsyncRequest[F[_]: Effect](request: Request[F])(
-      implicit ec: ExecutionContext): AsyncRequest =
+      implicit ec: ExecutionContext): AsyncRequest = {
+    val headers = new DefaultHttpHeaders
+    for (h <- request.headers)
+      headers.add(h.name.toString, h.value)
     new RequestBuilder(request.method.toString)
       .setUrl(request.uri.toString)
-      .setHeaders(
-        request.headers
-          .groupBy(_.name.toString)
-          .mapValues(_.map(_.value).asJavaCollection)
-          .asJava)
+      .setHeaders(headers)
       .setBody(getBodyGenerator(request))
       .build()
+  }
 
   private def getBodyGenerator[F[_]: Effect](req: Request[F])(
       implicit ec: ExecutionContext): BodyGenerator = {
     val publisher = StreamUnicastPublisher(
-      req.body.chunks.map(chunk => ByteBuffer.wrap(chunk.toArray)))
+      req.body.chunks.map(chunk => Unpooled.wrappedBuffer(chunk.toArray)))
     if (req.isChunked) new ReactiveStreamsBodyGenerator(publisher, -1)
     else
       req.contentLength match {
@@ -146,8 +147,8 @@ object AsyncHttpClient {
   private def getStatus(status: HttpResponseStatus): Status =
     Status.fromInt(status.getStatusCode).valueOr(throw _)
 
-  private def getHeaders(headers: HttpResponseHeaders): Headers =
-    Headers(headers.getHeaders.iterator.asScala.map { header =>
+  private def getHeaders(headers: HttpHeaders): Headers =
+    Headers(headers.asScala.map { header =>
       Header(header.getKey, header.getValue)
     }.toList)
 }

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -139,7 +139,6 @@ object Http4sPlugin extends AutoPlugin {
 
     dependencyUpdatesFilter -= moduleFilter(organization = "com.github.zainab-ali", name = "fs2-reactive-streams"), // fs2-reactive-streams-0.5 is incompatible with fs2-0.10
     dependencyUpdatesFilter -= moduleFilter(organization = "javax.servlet"), // servlet-4.0 is not yet supported by jetty-9 or tomcat-9, so don't accidentally depend on its new features
-    dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", name = "async-http-client"), // asynchttpclient-2.2 is incompatible with http4s-0.18
     dependencyUpdatesFilter -= moduleFilter(organization = "org.http4s", name = "blaze-http"), // blaze-0.13 dropped websocket support
     dependencyUpdatesFilter -= moduleFilter(organization = "org.json4s"), // json4s-3.6 is not binary compatible with json4s-3.5
     dependencyUpdatesFilter -= moduleFilter(organization = "org.scalacheck"), // scalacheck-1.14 is incompatible with cats-laws-1.1
@@ -276,7 +275,7 @@ object Http4sPlugin extends AutoPlugin {
 
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.12.v20180117"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.2"
-  lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.0.39"
+  lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.5.3"
   lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.12.13"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.0"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.4.0"


### PR DESCRIPTION
This is an incompatible version of async-http-client (2.0 -> 2.5) built on an incompatible version of netty (4.0 -> 4.1), but those projects didn't bump their major version numbers.  And us being behind might be causing more pain than not.

Alternatives:
* Continue to tell people "too bad, 0.19 is almost here."  But that's a big upgrade.
* Publish in a side repo, like we used to do with argonaut. I'm not interested in doing this work myself.

This is binary compatible for http4s itself, and I'll bet anyone using this module would appreciate this upgrade.

/cc @VolodymyrPolishchuk