### PR TITLE
Remove outbound commands, get on blaze master

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ClientTimeoutStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ClientTimeoutStage.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
 import org.http4s.blaze.pipeline.MidStage
-import org.http4s.blaze.pipeline.Command.{Disconnect, EOF, Error, OutboundCommand}
+import org.http4s.blaze.pipeline.Command.{EOF, InboundCommand}
 import org.http4s.blaze.util.{Cancellable, TickWheelExecutor}
 import scala.annotation.tailrec
 import scala.concurrent.{Future, Promise}
@@ -54,13 +54,13 @@ final private[blaze] class ClientTimeoutStage(
       activeReqTimeout.getAndSet(Closed) match {
         case null =>
           /* We beat the startup. Maybe timeout is 0? */
-          sendOutboundCommand(Disconnect)
+          closePipeline(None)
 
         case Closed => /* Already closed, no need to disconnect */
 
         case timeout =>
           timeout.cancel()
-          sendOutboundCommand(Disconnect)
+          closePipeline(None)
       }
     }
   }
@@ -84,20 +84,6 @@ final private[blaze] class ClientTimeoutStage(
   override def writeRequest(data: Seq[ByteBuffer]): Future[Unit] =
     checkTimeout(channelWrite(data))
 
-  override def outboundCommand(cmd: OutboundCommand): Unit = cmd match {
-    // We want to swallow `TimeoutException`'s we have created
-    case Error(t: TimeoutException) if t eq timeoutState.get() =>
-      sendOutboundCommand(Disconnect)
-
-    case RequestSendComplete =>
-      activateResponseHeaderTimeout()
-
-    case ResponseHeaderComplete =>
-      cancelResponseHeaderTimeout()
-
-    case cmd => super.outboundCommand(cmd)
-  }
-
   /////////// Protected impl bits //////////////////////////////////////////
 
   override protected def stageShutdown(): Unit = {
@@ -118,6 +104,11 @@ final private[blaze] class ClientTimeoutStage(
         case _ => logger.error("Shouldn't get here.")
       }
     } else resetTimeout()
+
+    sendInboundCommand(new EventListener {
+      def onResponseHeaderComplete(): Unit = cancelResponseHeaderTimeout()
+      def onRequestSendComplete(): Unit = activateResponseHeaderTimeout()
+    })
   }
 
   /////////// Private stuff ////////////////////////////////////////////////
@@ -180,11 +171,10 @@ final private[blaze] class ClientTimeoutStage(
 }
 
 private[blaze] object ClientTimeoutStage {
-  // Sent when we have sent the complete request
-  private[blaze] object RequestSendComplete extends OutboundCommand
-
-  // Sent when we have received the complete response
-  private[blaze] object ResponseHeaderComplete extends OutboundCommand
+  trait EventListener extends InboundCommand {
+    def onRequestSendComplete(): Unit
+    def onResponseHeaderComplete(): Unit
+  }
 
   // Make sure we have our own _stable_ copy for synchronization purposes
   private val Closed = new Cancellable {

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -368,6 +368,7 @@ private object Http1Connection {
 
   private val NullEventListener = new ClientTimeoutStage.EventListener {
     def onRequestSendComplete() = logger.warn("Called `onRequestSendComplete()` without a listener")
-    def onResponseHeaderComplete() = logger.warn("Called `onResponseHeaderComplete()` without a listener")
+    def onResponseHeaderComplete() =
+      logger.warn("Called `onResponseHeaderComplete()` without a listener")
   }
 }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ReadBufferStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ReadBufferStageSpec.scala
@@ -86,6 +86,7 @@ class ReadBufferStageSpec extends Http4sSpec {
     }
 
     override def writeRequest(data: Unit): Future[Unit] = ???
+    override def doClosePipeline(cause: Option[Throwable]) = {}
   }
 
   class ReadHead extends HeadStage[Unit] {
@@ -98,6 +99,7 @@ class ReadBufferStageSpec extends Http4sSpec {
     }
     override def writeRequest(data: Unit): Future[Unit] = ???
     override def name: String = "SlowHead"
+    override def doClosePipeline(cause: Option[Throwable]) = {}
   }
 
   class NoopTail extends TailStage[Unit] {

--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -219,7 +219,7 @@ trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
   protected def fatalError(t: Throwable, msg: String): Unit = {
     logger.error(t)(s"Fatal Error: $msg")
     stageShutdown()
-    sendOutboundCommand(Command.Error(t))
+    closePipeline(Some(t))
   }
 
   /** Cleans out any remaining body from the parser */

--- a/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
@@ -8,7 +8,7 @@ import fs2._
 import fs2.concurrent.SignallingRef
 import java.util.concurrent.atomic.AtomicBoolean
 import org.http4s.{websocket => ws4s}
-import org.http4s.blaze.pipeline.{Command, LeafBuilder, TailStage, TrunkBuilder}
+import org.http4s.blaze.pipeline.{LeafBuilder, TailStage, TrunkBuilder}
 import org.http4s.blaze.util.Execution.{directec, trampoline}
 import org.http4s.internal.unsafeRunAsync
 import org.http4s.websocket.WebsocketBits._
@@ -112,7 +112,7 @@ private[http4s] class Http4sWSStage[F[_]](
     super.stageStartup()
 
     // Effect to send a close to the other endpoint
-    val sendClose: F[Unit] = F.delay(sendOutboundCommand(Command.Disconnect))
+    val sendClose: F[Unit] = F.delay(closePipeline(None))
 
     val wsStream = inputstream
       .to(ws.receive)

--- a/blaze-core/src/test/scala/org/http4s/blazecore/websocket/WSTestHead.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/websocket/WSTestHead.scala
@@ -66,6 +66,8 @@ sealed abstract class WSTestHead(
       .timeoutTo(timeoutSeconds.seconds, IO.pure(Nil))
 
   override def name: String = "WS test stage"
+
+  override protected def doClosePipeline(cause: Option[Throwable]): Unit = {}
 }
 
 object WSTestHead {

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -247,7 +247,7 @@ private[blaze] class Http1ServerStage[F[_]](
   private def closeConnection(): Unit = {
     logger.debug("closeConnection()")
     stageShutdown()
-    sendOutboundCommand(Cmd.Disconnect)
+    closePipeline(None)
   }
 
   override protected def stageShutdown(): Unit = {

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
@@ -190,8 +190,7 @@ private class Http2NodeStage[F[_]](
           F.runAsync(action) {
             case Right(()) => IO.unit
             case Left(t) =>
-              IO(logger.error(t)(s"Error running request: $req")).attempt *> IO(
-                closePipeline(None))
+              IO(logger.error(t)(s"Error running request: $req")).attempt *> IO(closePipeline(None))
           }
         }.unsafeRunSync()
       })

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
@@ -38,11 +38,6 @@ private class Http2NodeStage[F[_]](
     readHeaders()
   }
 
-  private def shutdownWithCommand(cmd: Cmd.OutboundCommand): Unit = {
-    stageShutdown()
-    sendOutboundCommand(cmd)
-  }
-
   private def readHeaders(): Unit =
     channelRead(timeout = timeout).onComplete {
       case Success(HeadersFrame(_, endStream, hs)) =>
@@ -50,14 +45,15 @@ private class Http2NodeStage[F[_]](
 
       case Success(frame) =>
         val e = Http2Exception.PROTOCOL_ERROR.rst(streamId, s"Received invalid frame: $frame")
-        shutdownWithCommand(Cmd.Error(e))
+        closePipeline(Some(e))
 
-      case Failure(Cmd.EOF) => shutdownWithCommand(Cmd.Disconnect)
+      case Failure(Cmd.EOF) =>
+        closePipeline(None)
 
       case Failure(t) =>
         logger.error(t)("Unknown error in readHeaders")
         val e = Http2Exception.INTERNAL_ERROR.rst(streamId, s"Unknown error")
-        shutdownWithCommand(Cmd.Error(e))
+        closePipeline(Some(e))
     }
 
   /** collect the body: a maxlen < 0 is interpreted as undefined */
@@ -78,12 +74,12 @@ private class Http2NodeStage[F[_]](
             if (complete && maxlen > 0 && bytesRead != maxlen) {
               val msg = s"Entity too small. Expected $maxlen, received $bytesRead"
               val e = Http2Exception.PROTOCOL_ERROR.rst(streamId, msg)
-              sendOutboundCommand(Cmd.Error(e))
+              closePipeline(Some(e))
               cb(Either.left(InvalidBodyException(msg)))
             } else if (maxlen > 0 && bytesRead > maxlen) {
               val msg = s"Entity too large. Expected $maxlen, received bytesRead"
               val e = Http2Exception.PROTOCOL_ERROR.rst(streamId, msg)
-              sendOutboundCommand((Cmd.Error(e)))
+              closePipeline(Some(e))
               cb(Either.left(InvalidBodyException(msg)))
             } else cb(Either.right(Some(Chunk.bytes(bytes.array))))
 
@@ -95,19 +91,19 @@ private class Http2NodeStage[F[_]](
             val msg = "Received invalid frame while accumulating body: " + other
             logger.info(msg)
             val e = Http2Exception.PROTOCOL_ERROR.rst(streamId, msg)
-            shutdownWithCommand(Cmd.Error(e))
+            closePipeline(Some(e))
             cb(Either.left(InvalidBodyException(msg)))
 
           case Failure(Cmd.EOF) =>
             logger.debug("EOF while accumulating body")
             cb(Either.left(InvalidBodyException("Received premature EOF.")))
-            shutdownWithCommand(Cmd.Disconnect)
+            closePipeline(None)
 
           case Failure(t) =>
             logger.error(t)("Error in getBody().")
             val e = Http2Exception.INTERNAL_ERROR.rst(streamId, "Failed to read body")
             cb(Either.left(e))
-            shutdownWithCommand(Cmd.Error(e))
+            closePipeline(Some(e))
         }
     }
 
@@ -179,7 +175,7 @@ private class Http2NodeStage[F[_]](
     }
 
     if (error.length > 0) {
-      shutdownWithCommand(Cmd.Error(Http2Exception.PROTOCOL_ERROR.rst(streamId, error)))
+      closePipeline(Some(Http2Exception.PROTOCOL_ERROR.rst(streamId, error)))
     } else {
       val body = if (endStream) EmptyBody else getBody(contentLength)
       val hs = HHeaders(headers.result())
@@ -195,7 +191,7 @@ private class Http2NodeStage[F[_]](
             case Right(()) => IO.unit
             case Left(t) =>
               IO(logger.error(t)(s"Error running request: $req")).attempt *> IO(
-                shutdownWithCommand(Cmd.Disconnect))
+                closePipeline(None))
           }
         }.unsafeRunSync()
       })
@@ -216,9 +212,9 @@ private class Http2NodeStage[F[_]](
     }
 
     new Http2Writer(this, hs, executionContext).writeEntityBody(resp.body).attempt.map {
-      case Right(_) => shutdownWithCommand(Cmd.Disconnect)
+      case Right(_) => closePipeline(None)
       case Left(Cmd.EOF) => stageShutdown()
-      case Left(t) => shutdownWithCommand(Cmd.Error(t))
+      case Left(t) => closePipeline(Some(t))
     }
   }
 }

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
@@ -12,7 +12,7 @@ import org.http4s.blazecore.websocket.Http4sWSStage
 import org.http4s.headers._
 import org.http4s.internal.unsafeRunAsync
 import org.http4s.syntax.string._
-import org.http4s.websocket.WebsocketHandshake
+import org.http4s.websocket.WebSocketHandshake
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
@@ -30,8 +30,8 @@ private[blaze] trait WebSocketSupport[F[_]] extends Http1ServerStage[F] {
       case None => super.renderResponse(req, resp, cleanup)
       case Some(wsContext) =>
         val hdrs = req.headers.map(h => (h.name.toString, h.value))
-        if (WebsocketHandshake.isWebSocketRequest(hdrs)) {
-          WebsocketHandshake.serverHandshake(hdrs) match {
+        if (WebSocketHandshake.isWebSocketRequest(hdrs)) {
+          WebSocketHandshake.serverHandshake(hdrs) match {
             case Left((code, msg)) =>
               logger.info(s"Invalid handshake $code, $msg")
               unsafeRunAsync {

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -8,7 +8,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import org.http4s.{headers => H, _}
 import org.http4s.blaze._
-import org.http4s.blaze.pipeline.Command.{Connected, Disconnect}
+import org.http4s.blaze.pipeline.Command.Connected
 import org.http4s.blazecore.{ResponseParser, SeqTestHead}
 import org.http4s.dsl.io._
 import org.http4s.headers.{Date, `Content-Length`, `Transfer-Encoding`}
@@ -448,6 +448,6 @@ class Http1ServerStageSpec extends Http4sSpec {
   "Disconnect if we read an EOF" in {
     val head = runRequest(Seq.empty, Kleisli.liftF(Ok("")))
     Await.ready(head.result, 10.seconds)
-    head.outboundCommands must_== Seq(Disconnect)
+    head.closeCauses must_== Seq(None)
   }
 }

--- a/core/src/main/scala/org/http4s/websocket/WebSocketHandshake.scala
+++ b/core/src/main/scala/org/http4s/websocket/WebSocketHandshake.scala
@@ -1,0 +1,120 @@
+package org.http4s.websocket
+
+import java.nio.charset.StandardCharsets._
+import java.security.MessageDigest
+import java.util.Base64
+import scala.util.Random
+
+private[http4s] object WebSocketHandshake {
+
+  /** Creates a new [[ClientHandshaker]] */
+  def clientHandshaker(host: String): ClientHandshaker = new ClientHandshaker(host)
+
+  /** Provides the initial headers and a 16 byte Base64 encoded random key for websocket connections */
+  class ClientHandshaker(host: String) {
+
+    /** Randomly generated 16-byte key in Base64 encoded form */
+    val key = {
+      val bytes = new Array[Byte](16)
+      Random.nextBytes(bytes)
+      Base64.getEncoder.encodeToString(bytes)
+    }
+
+    /** Initial headers to send to the server */
+    val initHeaders: List[(String, String)] =
+      ("Host", host) :: ("Sec-WebSocket-Key", key) :: clientBaseHeaders
+
+    /** Check if the server response is a websocket handshake response */
+    def checkResponse(headers: Traversable[(String, String)]): Either[String, Unit] =
+      if (!headers.exists {
+          case (k, v) => k.equalsIgnoreCase("Connection") && valueContains("Upgrade", v)
+        }) {
+        Left("Bad Connection header")
+      } else if (!headers.exists {
+          case (k, v) => k.equalsIgnoreCase("Upgrade") && v.equalsIgnoreCase("websocket")
+        }) {
+        Left("Bad Upgrade header")
+      } else
+        headers
+          .find { case (k, _) => k.equalsIgnoreCase("Sec-WebSocket-Accept") }
+          .map {
+            case (_, v) if genAcceptKey(key) == v => Right(())
+            case (_, v) => Left(s"Invalid key: $v")
+          }
+          .getOrElse(Left("Missing Sec-WebSocket-Accept header"))
+  }
+
+  /** Checks the headers received from the client and if they are valid, generates response headers */
+  def serverHandshake(
+      headers: Traversable[(String, String)]): Either[(Int, String), Seq[(String, String)]] =
+    if (!headers.exists { case (k, _) => k.equalsIgnoreCase("Host") }) {
+      Left((-1, "Missing Host Header"))
+    } else if (!headers.exists {
+        case (k, v) => k.equalsIgnoreCase("Connection") && valueContains("Upgrade", v)
+      }) {
+      Left((-1, "Bad Connection header"))
+    } else if (!headers.exists {
+        case (k, v) => k.equalsIgnoreCase("Upgrade") && v.equalsIgnoreCase("websocket")
+      }) {
+      Left((-1, "Bad Upgrade header"))
+    } else if (!headers.exists {
+        case (k, v) => k.equalsIgnoreCase("Sec-WebSocket-Version") && valueContains("13", v)
+      }) {
+      Left((-1, "Bad Websocket Version header"))
+    } // we are past most of the 'just need them' headers
+    else
+      headers
+        .find {
+          case (k, v) =>
+            k.equalsIgnoreCase("Sec-WebSocket-Key") && decodeLen(v) == 16
+        }
+        .map {
+          case (_, v) =>
+            val respHeaders = Seq(
+              ("Upgrade", "websocket"),
+              ("Connection", "Upgrade"),
+              ("Sec-WebSocket-Accept", genAcceptKey(v))
+            )
+
+            Right(respHeaders)
+        }
+        .getOrElse(Left((-1, "Bad Sec-WebSocket-Key header")))
+
+  /** Check if the headers contain an 'Upgrade: websocket' header */
+  def isWebSocketRequest(headers: Traversable[(String, String)]): Boolean =
+    headers.exists {
+      case (k, v) => k.equalsIgnoreCase("Upgrade") && v.equalsIgnoreCase("websocket")
+    }
+
+  private def decodeLen(key: String): Int = Base64.getDecoder.decode(key).length
+
+  private def genAcceptKey(str: String): String = {
+    val crypt = MessageDigest.getInstance("SHA-1")
+    crypt.reset()
+    crypt.update(str.getBytes(US_ASCII))
+    crypt.update(magicString)
+    val bytes = crypt.digest()
+    Base64.getEncoder.encodeToString(bytes)
+  }
+
+  private[websocket] def valueContains(key: String, value: String): Boolean = {
+    val parts = value.split(",").map(_.trim)
+    parts.foldLeft(false)((b, s) =>
+      b || {
+        s.equalsIgnoreCase(key) ||
+        s.length > 1 &&
+        s.startsWith("\"") &&
+        s.endsWith("\"") &&
+        s.substring(1, s.length - 1).equalsIgnoreCase(key)
+    })
+  }
+
+  private val magicString =
+    "258EAFA5-E914-47DA-95CA-C5AB0DC85B11".getBytes(US_ASCII)
+
+  private val clientBaseHeaders = List(
+    ("Connection", "Upgrade"),
+    ("Upgrade", "websocket"),
+    ("Sec-WebSocket-Version", "13")
+  )
+}

--- a/core/src/main/scala/org/http4s/websocket/package.scala
+++ b/core/src/main/scala/org/http4s/websocket/package.scala
@@ -25,7 +25,7 @@ package object websocket {
   private[websocket] def makeFrame(opcode: Int, data: ByteVector, last: Boolean): WebSocketFrame =
     opcode match {
       case TEXT => WebSocketFrame.Text(data, last)
-      case BINARY => WebSocketFrame.Text(data, last)
+      case BINARY => WebSocketFrame.Binary(data, last)
       case CONTINUATION => WebSocketFrame.Continuation(data, last)
       case PING =>
         if (!last) throw new ProtocolException("Control frame cannot be fragmented: Ping")

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -277,7 +277,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.12.v20180117"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.2"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.5.3"
-  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0-SNAPSHOT"
+  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0-M5"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.0"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.4.0"
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.0.0"

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -277,7 +277,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.12.v20180117"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.2"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.5.3"
-  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0-M4"
+  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0-SNAPSHOT"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.0"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.4.0"
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.0.0"

--- a/tests/src/test/scala/org/http4s/websocket/WebSocketHandshakeSpec.scala
+++ b/tests/src/test/scala/org/http4s/websocket/WebSocketHandshakeSpec.scala
@@ -1,0 +1,28 @@
+package org.http4s.websocket
+
+import org.specs2.mutable.Specification
+
+class WebSocketHandshakeSpec extends Specification {
+
+  "WebSocketHandshake" should {
+
+    "Be able to split multi value header keys" in {
+      val totalValue = "keep-alive, Upgrade"
+      val values = List("upgrade", "Upgrade", "keep-alive", "Keep-alive")
+      values.foldLeft(true) { (b, v) =>
+        b && WebSocketHandshake.valueContains(v, totalValue)
+      } should_== true
+    }
+
+    "Do a round trip" in {
+      val client = WebSocketHandshake.clientHandshaker("www.foo.com")
+      val valid = WebSocketHandshake.serverHandshake(client.initHeaders)
+      valid must beRight
+
+      val Right(headers) = valid
+      client.checkResponse(headers) must beRight
+    }
+
+  }
+
+}

--- a/tests/src/test/scala/org/http4s/websocket/WebSocketSpec.scala
+++ b/tests/src/test/scala/org/http4s/websocket/WebSocketSpec.scala
@@ -1,0 +1,130 @@
+package org.http4s.websocket
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets.UTF_8
+import org.http4s.websocket.WebSocketFrame._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen._
+import org.scalacheck.Prop._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+import scodec.bits.ByteVector
+
+class WebSocketSpec extends Specification with ScalaCheck {
+
+  def helloTxtMasked =
+    Array(0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58).map(_.toByte)
+
+  def helloTxt = Array(0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f).map(_.toByte)
+
+  def decode(msg: Array[Byte], isClient: Boolean): WebSocketFrame =
+    new FrameTranscoder(isClient).bufferToFrame(ByteBuffer.wrap(msg))
+
+  def encode(msg: WebSocketFrame, isClient: Boolean): Array[Byte] = {
+    val msgs = new FrameTranscoder(isClient).frameToBuffer(msg)
+    val sz = msgs.foldLeft(0)((c, i) => c + i.remaining())
+    val b = ByteBuffer.allocate(sz)
+    msgs.foreach(b.put)
+    b.array()
+  }
+
+  "WebSocket decoder" should {
+
+    "equate frames correctly" in {
+      val f1 = Binary(ByteVector(0x2.toByte, 0x3.toByte), true)
+      val f11 = Binary(ByteVector(0x2.toByte, 0x3.toByte), true)
+      val f2 = Binary(ByteVector(0x2.toByte, 0x3.toByte), false)
+      val f3 = Text(ByteVector(0x2.toByte, 0x3.toByte), true)
+      val f4 = Binary(ByteVector(0x2.toByte, 0x4.toByte), true)
+
+      f1 should_== f1
+      f1 should_== f11
+      f1 should_!= f2
+      f1 should_!= f3
+      f1 should_!= f4
+    }
+
+    "decode a hello world message" in {
+
+      val result = decode(helloTxtMasked, false)
+      result.last should_== true
+      new String(result.data.toArray, UTF_8) should_== "Hello"
+
+      val result2 = decode(helloTxt, true)
+      result2.last should_== true
+      new String(result2.data.toArray, UTF_8) should_== "Hello"
+    }
+
+    "encode a hello world message" in {
+      val frame = Text(ByteVector.view("Hello".getBytes(UTF_8)), false)
+      val msg = decode(encode(frame, true), false)
+      msg should_== frame
+      msg.last should_== false
+      new String(msg.data.toArray, UTF_8) should_== "Hello"
+    }
+
+    "encode a continuation message" in {
+      val frame = Continuation(ByteVector.view("Hello".getBytes(UTF_8)), true)
+      val msg = decode(encode(frame, true), false)
+      msg should_== frame
+      msg.last should_== true
+      new String(msg.data.toArray, UTF_8) should_== "Hello"
+    }
+
+    "encode a close message" in {
+
+      val reasonGen = for {
+        length <- choose(0, 30) //UTF-8 chars are at most 4 bytes, byte limit is 123
+        chars <- listOfN(length, arbitrary[Char])
+      } yield chars.mkString
+
+      forAll(choose(1000, 4999), reasonGen) { (validCloseCode: Int, validReason: String) =>
+        val frame = Close(validCloseCode, validReason).right.get
+        val msg = decode(encode(frame, true), false)
+        msg should_== frame
+        msg.last should_== true
+        val closeCode = msg.data.slice(0, 2)
+        (closeCode(0) << 8 & 0xff00) | (closeCode(1) & 0xff) should_== validCloseCode
+        val reason = msg.data.slice(2, msg.data.length)
+        new String(reason.toArray, UTF_8) should_== validReason
+      }
+    }
+
+    "refuse to encode a close message with an invalid close code" in {
+      forAll { closeCode: Int =>
+        (closeCode < 1000 || closeCode > 4999) ==> Close(closeCode).isLeft
+      }
+    }
+
+    "refuse to encode a close message with a reason that is too large" in {
+      val validCloseCode = 1000
+
+      forAll { reason: String =>
+        (reason.getBytes(UTF_8).length > 123) ==> Close(validCloseCode, reason).isLeft
+      }
+    }
+
+    "encode and decode a message with 125 < len <= 0xffff" in {
+      val bytes = ByteVector((0 until 0xfff).map(_.toByte))
+      val frame = Binary(bytes, false)
+
+      val msg = decode(encode(frame, true), false)
+      val msg2 = decode(encode(frame, false), true)
+
+      msg should_== frame
+      msg should_== msg2
+    }
+
+    "encode and decode a message len > 0xffff" in {
+      val bytes = ByteVector((0 until (0xffff + 1)).map(_.toByte))
+      val frame = Binary(bytes, false)
+
+      val msg = decode(encode(frame, true), false)
+      val msg2 = decode(encode(frame, false), true)
+
+      msg should_== frame
+      msg should_== msg2
+    }
+  }
+
+}


### PR DESCRIPTION
This gets us working again off blaze master, so we can release that as blaze-0.14.0 before http4s-0.19.0.