### PR TITLE
Fix 0.19 link in 0.18 docs

### DIFF
--- a/website/src/hugo/themes/http4s.org/layouts/partials/nav-docs.html
+++ b/website/src/hugo/themes/http4s.org/layouts/partials/nav-docs.html
@@ -1,5 +1,5 @@
 <div class="dropdown-menu" aria-labelledby="doc-menu-item">
-  <a class="dropdown-item" href="/v1.0/">v1.0 (development)</a>
+  <a class="dropdown-item" href="/v0.19/">v0.19 (development)</a>
   <a class="dropdown-item" href="/v0.18/">v0.18 (stable)</a>
   <a class="dropdown-item" href="/versions/">Help me choose...</a>
 </div>


### PR DESCRIPTION
Pointed out by @Tomczik76

Ideally, older versions of the docs would pull this from a common place, so we don't need to go back and republish old versions when new series are published.