### PR TITLE
Changed Response.timeout from 500 to 503 - ServiceUnavailable

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -380,5 +380,5 @@ object Response {
     Response(Status.NotFound).withEntity(s"${request.pathInfo} not found").pure[F]
 
   def timeout[F[_]]: Response[F] =
-    Response[F](Status.InternalServerError).withEntity("Response timed out")
+    Response[F](Status.ServiceUnavailable).withEntity("Response timed out")
 }


### PR DESCRIPTION
Response.timeout is currently only used by AsyncHttp4sServlet, so I think this change is extremely low risk.

A 503 ("The server is currently unavailable (because it is overloaded or down for maintenance). Generally, this is a temporary state") code is more appropriate to a timeout than the generic 500 ("A generic error message" that something broke horribly). We also considered and rejected 429 ("The user has sent too many requests") because it blames the client for a server problem. 