### PR TITLE
Release v0.19.0-M4; explain v0.19.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.19.1-SNAPSHOT"
+version in ThisBuild := "0.19.0-M4"

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -8,6 +8,10 @@ Maintenance branches are merged before each new release. This change log is
 ordered chronologically, so each release contains all changes described below
 it.
 
+# v0.19.0 (2018-10-05)
+
+This release is identical to v0.19.0-M4.  It was intended to be the last milestone before we declared the 0.19.x branch stable, but we mistagged it.  Please give it a try, but treat it like the milestone it was intended to be.  *We reserve the right to break binary compatibility until 0.19.1*.
+
 # v0.19.0-M4 (2018-10-05)
 
 ## Breaking changes


### PR DESCRIPTION
Republishes v0.19.0 as v0.19.0-M4, as was originally intended.  Explains our mistake and our recovery plan in the changelog.

version.sbt will need to be manually bumped to 0.19.1-SNAPSHOT after this is merged.

Thanks to @bpholt and @Daenyth for their suggestions on how to deal with this.

