### PR TITLE
Upgrade to blaze-0.14.0-M6

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -127,7 +127,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   def withoutAsynchronousChannelGroup: BlazeClientBuilder[F] =
     withAsynchronousChannelGroupOption(None)
 
-  def resource(implicit F: ConcurrentEffect[F]): Resource[F, Client[F]] =
+  def resource(implicit F: ConcurrentEffect[F], clock: Clock[F]): Resource[F, Client[F]] =
     tickWheel.flatMap { scheduler =>
       connectionManager.map { manager =>
         BlazeClient.makeClient(
@@ -143,7 +143,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   private def tickWheel(implicit F: Sync[F]) =
     Resource.make(F.delay(new TickWheelExecutor))(wheel => F.delay(wheel.shutdown()))
 
-  def stream(implicit F: ConcurrentEffect[F]): Stream[F, Client[F]] =
+  def stream(implicit F: ConcurrentEffect[F], clock: Clock[F]): Stream[F, Client[F]] =
     Stream.resource(resource)
 
   private def connectionManager(

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ClientTimeoutStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ClientTimeoutStage.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
 import org.http4s.blaze.pipeline.MidStage
 import org.http4s.blaze.pipeline.Command.{EOF, InboundCommand}
-import org.http4s.blaze.util.{Cancellable, TickWheelExecutor}
+import org.http4s.blaze.util.{Cancelable, TickWheelExecutor}
 import scala.annotation.tailrec
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration.Duration
@@ -24,12 +24,12 @@ final private[blaze] class ClientTimeoutStage(
 
   // The timeout between request body completion and response header
   // completion.
-  private val activeResponseHeaderTimeout = new AtomicReference[Cancellable](null)
+  private val activeResponseHeaderTimeout = new AtomicReference[Cancelable](null)
 
   // The total timeout for the request. Lasts the lifetime of the stage.
-  private val activeReqTimeout = new AtomicReference[Cancellable](null)
+  private val activeReqTimeout = new AtomicReference[Cancelable](null)
 
-  // The timeoutState contains a Cancellable, null, or a TimeoutException
+  // The timeoutState contains a Cancelable, null, or a TimeoutException
   // It will also act as the point of synchronization
   private val timeoutState = new AtomicReference[AnyRef](null)
 
@@ -44,7 +44,7 @@ final private[blaze] class ClientTimeoutStage(
       // check the idle timeout conditions
       timeoutState.getAndSet(new TimeoutException(s"Client $name timeout after $timeout.")) match {
         case null => // noop
-        case c: Cancellable => c.cancel() // this should be the registration of us
+        case c: Cancelable => c.cancel() // this should be the registration of us
         case _: TimeoutException => // Interesting that we got here.
       }
 
@@ -124,7 +124,7 @@ final private[blaze] class ClientTimeoutStage(
       case eof @ Failure(EOF) =>
         timeoutState.get() match {
           case t: TimeoutException => p.tryFailure(t)
-          case c: Cancellable =>
+          case c: Cancelable =>
             c.cancel()
             p.tryComplete(eof)
 
@@ -137,13 +137,13 @@ final private[blaze] class ClientTimeoutStage(
     p.future
   }
 
-  private def setAndCancel(next: Cancellable): Unit = {
+  private def setAndCancel(next: Cancelable): Unit = {
     @tailrec
     def go(): Unit = timeoutState.get() match {
       case null =>
         if (!timeoutState.compareAndSet(null, next)) go()
 
-      case c: Cancellable =>
+      case c: Cancelable =>
         if (!timeoutState.compareAndSet(c, next)) go()
         else c.cancel()
 
@@ -177,7 +177,7 @@ private[blaze] object ClientTimeoutStage {
   }
 
   // Make sure we have our own _stable_ copy for synchronization purposes
-  private val Closed = new Cancellable {
+  private val Closed = new Cancelable {
     def cancel() = ()
     override def toString = "Closed"
   }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -15,7 +15,8 @@ object Http1Client {
     * @param config blaze client configuration options
     */
   private def resource[F[_]](config: BlazeClientConfig)(
-      implicit F: ConcurrentEffect[F]): Resource[F, Client[F]] = {
+      implicit F: ConcurrentEffect[F],
+      clock: Clock[F]): Resource[F, Client[F]] = {
     val http1: ConnectionBuilder[F, BlazeConnection[F]] = new Http1Support(
       sslContextOption = config.sslContext,
       bufferSize = config.bufferSize,
@@ -44,7 +45,8 @@ object Http1Client {
       .map(pool => BlazeClient(pool, config, pool.shutdown()))
   }
 
-  def stream[F[_]: ConcurrentEffect](
-      config: BlazeClientConfig = BlazeClientConfig.defaultConfig): Stream[F, Client[F]] =
+  def stream[F[_]](config: BlazeClientConfig = BlazeClientConfig.defaultConfig)(
+      implicit F: ConcurrentEffect[F],
+      clock: Clock[F]): Stream[F, Client[F]] =
     Stream.resource(resource(config))
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -16,7 +16,6 @@ import org.http4s.blazecore.Http1Stage
 import org.http4s.blazecore.util.Http1Writer
 import org.http4s.headers.{Connection, Host, `Content-Length`, `User-Agent`}
 import org.http4s.util.{StringWriter, Writer}
-import org.log4s.getLogger
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -334,8 +333,6 @@ private final class Http1Connection[F[_]](
 }
 
 private object Http1Connection {
-  private[this] val logger = getLogger
-
   case object InProgressException extends Exception("Stage has request in progress")
 
   // ADT representing the state that the ClientStage can be in
@@ -367,8 +364,7 @@ private object Http1Connection {
   }
 
   private val NullEventListener = new ClientTimeoutStage.EventListener {
-    def onRequestSendComplete() = logger.warn("Called `onRequestSendComplete()` without a listener")
-    def onResponseHeaderComplete() =
-      logger.warn("Called `onResponseHeaderComplete()` without a listener")
+    def onRequestSendComplete() = ()
+    def onResponseHeaderComplete() = ()
   }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
@@ -17,6 +17,7 @@ private[blaze] object bits {
   val DefaultMaxTotalConnections = 10
   val DefaultMaxWaitQueueLimit = 256
 
+  @deprecated("Manage as a resource", "0.19.1")
   lazy val ClientTickWheel = new TickWheelExecutor()
 
   /** Caution: trusts all certificates and disables endpoint identification */

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
@@ -20,7 +20,8 @@ private[blaze] object ProtocolSelector {
       maxHeadersLen: Int,
       requestAttributes: AttributeMap,
       executionContext: ExecutionContext,
-      serviceErrorHandler: ServiceErrorHandler[F]): ALPNServerSelector = {
+      serviceErrorHandler: ServiceErrorHandler[F],
+      timedOut: F[Unit]): ALPNServerSelector = {
 
     def http2Stage(): TailStage[ByteBuffer] = {
       val newNode = { streamId: Int =>
@@ -31,7 +32,8 @@ private[blaze] object ProtocolSelector {
             executionContext,
             requestAttributes,
             httpApp,
-            serviceErrorHandler))
+            serviceErrorHandler,
+            timedOut))
       }
 
       val localSettings =
@@ -53,7 +55,8 @@ private[blaze] object ProtocolSelector {
         enableWebSockets = false,
         maxRequestLineLen,
         maxHeadersLen,
-        serviceErrorHandler
+        serviceErrorHandler,
+        timedOut
       )
 
     def preference(protos: Set[String]): String =

--- a/client/src/main/scala/org/http4s/client/ClientTimeout.scala
+++ b/client/src/main/scala/org/http4s/client/ClientTimeout.scala
@@ -1,0 +1,12 @@
+package org.http4s.client
+
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.Duration
+
+sealed abstract class ClientTimeoutException extends TimeoutException {
+  def timeout: Duration
+}
+
+final case class RequestTimeoutException(timeout: Duration) extends ClientTimeoutException
+final case class ResponseHeaderTimeoutException(timeout: Duration) extends ClientTimeoutException
+final case class IdleTimeoutException(timeout: Duration) extends ClientTimeoutException

--- a/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -22,7 +22,7 @@ object GetRoutes {
         .withEntity(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
         .pure[IO],
       DelayedPath ->
-        timer.sleep(1.second) *>
+        timer.sleep(2.seconds) *>
           Response[IO](Ok).withEntity("delayed path").pure[IO],
       NoContentPath -> Response[IO](NoContent).pure[IO],
       NotFoundPath -> Response[IO](NotFound).withEntity("not found").pure[IO],

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -159,6 +159,9 @@ class ExampleService[F[_]](implicit F: Effect[F], cs: ContextShift[F]) extends H
         req.decode[Multipart[F]] { m =>
           Ok(s"""Multipart Data\nParts:${m.parts.length}\n${m.parts.map(_.name).mkString("\n")}""")
         }
+
+      case _ -> Root / "timeout" =>
+        F.never
     }
 
   def helloWorldService: F[Response[F]] = Ok("Hello World!")

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -277,7 +277,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.12.v20180117"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.2"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.5.4"
-  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0-M5"
+  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0-M6"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.0"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.4.0"
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.0.0"


### PR DESCRIPTION
- Responds with a 503 when blaze times out
- Cancels the response when blaze times out
- Use a `Clock` to manage elapsed time (fixes #2142)