### PR TITLE
Implement a response line timeout for blaze server

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -68,7 +68,7 @@ class BlazeBuilder[F[_]](
     serviceMounts: Vector[ServiceMount[F]],
     serviceErrorHandler: ServiceErrorHandler[F],
     banner: immutable.Seq[String]
-)(implicit protected val F: ConcurrentEffect[F])
+)(implicit protected val F: ConcurrentEffect[F], timer: Timer[F])
     extends ServerBuilder[F]
     with IdleTimeoutSupport[F]
     with SSLKeyStoreSupport[F]
@@ -209,7 +209,8 @@ class BlazeBuilder[F[_]](
               enableWebSockets,
               maxRequestLineLen,
               maxHeadersLen,
-              serviceErrorHandler
+              serviceErrorHandler,
+              Duration.Inf
             )
 
           def http2Stage(engine: SSLEngine): ALPNServerSelector =
@@ -220,7 +221,8 @@ class BlazeBuilder[F[_]](
               maxHeadersLen,
               requestAttributes(secure = true),
               executionContext,
-              serviceErrorHandler
+              serviceErrorHandler,
+              Duration.Inf
             )
 
           def prependIdleTimeout(lb: LeafBuilder[ByteBuffer]) =
@@ -325,7 +327,7 @@ class BlazeBuilder[F[_]](
 }
 
 object BlazeBuilder {
-  def apply[F[_]](implicit F: ConcurrentEffect[F]): BlazeBuilder[F] =
+  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F]): BlazeBuilder[F] =
     new BlazeBuilder(
       socketAddress = ServerBuilder.DefaultSocketAddress,
       executionContext = ExecutionContext.global,

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -33,6 +33,9 @@ import scala.concurrent.duration._
   * @param socketAddress: Socket Address the server will be mounted at
   * @param executionContext: Execution Context the underlying blaze futures
   *    will be executed upon.
+  * @param responseLineTimeout: Time from when the request is made until a
+  *    response line is generated before a 503 response is returned and the
+  *    `HttpApp` is canceled
   * @param idleTimeout: Period of Time a connection can remain idle before the
   *    connection is timed out and disconnected.
   *    Duration.Inf disables this feature.
@@ -57,6 +60,7 @@ import scala.concurrent.duration._
 class BlazeServerBuilder[F[_]](
     socketAddress: InetSocketAddress,
     executionContext: ExecutionContext,
+    responseLineTimeout: Duration,
     idleTimeout: Duration,
     isNio2: Boolean,
     connectorPoolSize: Int,
@@ -69,7 +73,7 @@ class BlazeServerBuilder[F[_]](
     httpApp: HttpApp[F],
     serviceErrorHandler: ServiceErrorHandler[F],
     banner: immutable.Seq[String]
-)(implicit protected val F: ConcurrentEffect[F])
+)(implicit protected val F: ConcurrentEffect[F], timer: Timer[F])
     extends ServerBuilder[F]
     with IdleTimeoutSupport[F]
     with SSLKeyStoreSupport[F]
@@ -83,6 +87,7 @@ class BlazeServerBuilder[F[_]](
       socketAddress: InetSocketAddress = socketAddress,
       executionContext: ExecutionContext = executionContext,
       idleTimeout: Duration = idleTimeout,
+      responseLineTimeout: Duration = responseLineTimeout,
       isNio2: Boolean = isNio2,
       connectorPoolSize: Int = connectorPoolSize,
       bufferSize: Int = bufferSize,
@@ -98,6 +103,7 @@ class BlazeServerBuilder[F[_]](
     new BlazeServerBuilder(
       socketAddress,
       executionContext,
+      responseLineTimeout,
       idleTimeout,
       isNio2,
       connectorPoolSize,
@@ -145,6 +151,9 @@ class BlazeServerBuilder[F[_]](
     copy(executionContext = executionContext)
 
   override def withIdleTimeout(idleTimeout: Duration): Self = copy(idleTimeout = idleTimeout)
+
+  def withResponseLineTimeout(responseLineTimeout: Duration): Self =
+    copy(responseLineTimeout = responseLineTimeout)
 
   def withConnectorPoolSize(size: Int): Self = copy(connectorPoolSize = size)
 
@@ -198,7 +207,8 @@ class BlazeServerBuilder[F[_]](
               enableWebSockets,
               maxRequestLineLen,
               maxHeadersLen,
-              serviceErrorHandler
+              serviceErrorHandler,
+              responseLineTimeout
             )
 
           def http2Stage(engine: SSLEngine): ALPNServerSelector =
@@ -209,7 +219,8 @@ class BlazeServerBuilder[F[_]](
               maxHeadersLen,
               requestAttributes(secure = true),
               executionContext,
-              serviceErrorHandler
+              serviceErrorHandler,
+              responseLineTimeout
             )
 
           def prependIdleTimeout(lb: LeafBuilder[ByteBuffer]) =
@@ -314,10 +325,11 @@ class BlazeServerBuilder[F[_]](
 }
 
 object BlazeServerBuilder {
-  def apply[F[_]](implicit F: ConcurrentEffect[F]): BlazeServerBuilder[F] =
+  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F]): BlazeServerBuilder[F] =
     new BlazeServerBuilder(
       socketAddress = ServerBuilder.DefaultSocketAddress,
       executionContext = ExecutionContext.global,
+      responseLineTimeout = 1.minute,
       idleTimeout = IdleTimeoutSupport.DefaultIdleTimeout,
       isNio2 = false,
       connectorPoolSize = channel.DefaultPoolSize,
@@ -328,7 +340,7 @@ object BlazeServerBuilder {
       maxRequestLineLen = 4 * 1024,
       maxHeadersLen = 40 * 1024,
       httpApp = defaultApp[F],
-      serviceErrorHandler = DefaultServiceErrorHandler,
+      serviceErrorHandler = DefaultServiceErrorHandler[F],
       banner = ServerBuilder.DefaultBanner
     )
 

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
@@ -6,11 +6,15 @@ import cats.effect.IO
 import java.net.{HttpURLConnection, URL}
 import java.nio.charset.StandardCharsets
 import org.http4s.dsl.io._
+import scala.concurrent.duration._
 import scala.io.Source
 
 class BlazeServerSpec extends Http4sSpec {
 
-  def builder = BlazeServerBuilder[IO].withExecutionContext(testExecutionContext)
+  def builder =
+    BlazeServerBuilder[IO]
+      .withResponseLineTimeout(1.second)
+      .withExecutionContext(testExecutionContext)
 
   val service: HttpApp[IO] = HttpApp {
     case GET -> Root / "thread" / "routing" =>
@@ -22,6 +26,10 @@ class BlazeServerSpec extends Http4sSpec {
 
     case req @ POST -> Root / "echo" =>
       Ok(req.body)
+
+    case _ -> Root / "never" =>
+      IO.never
+
     case _ => NotFound()
   }
 
@@ -38,6 +46,16 @@ class BlazeServerSpec extends Http4sSpec {
         .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
         .getLines
         .mkString
+
+    // This should be in IO and shifted but I'm tired of fighting this.
+    def getStatus(path: String): IO[Status] = {
+      val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
+      for {
+        conn <- IO(url.openConnection().asInstanceOf[HttpURLConnection])
+        _ = conn.setRequestMethod("GET")
+        status <- IO.fromEither(Status.fromInt(conn.getResponseCode()))
+      } yield status
+    }
 
     // This too
     def post(path: String, body: String): String = {
@@ -63,6 +81,10 @@ class BlazeServerSpec extends Http4sSpec {
       "be able to echo its input" in {
         val input = """{ "Hello": "world" }"""
         post("/echo", input) must startWith(input)
+      }
+
+      "return a 503 if the server doesn't respond" in {
+        getStatus("/never") must returnValue(Status.ServiceUnavailable)
       }
     }
   }

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -46,7 +46,8 @@ class Http1ServerStageSpec extends Http4sSpec {
       enableWebSockets = true,
       maxReqLine,
       maxHeaders,
-      DefaultServiceErrorHandler)
+      DefaultServiceErrorHandler,
+      30.seconds)
 
     pipeline.LeafBuilder(httpStage).base(head)
     head.sendInboundCommand(Connected)

--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -40,6 +40,7 @@ in an [[`IOApp`]]:
 ```tut:book:silent
 import scala.concurrent.ExecutionContext.global
 implicit val cs: ContextShift[IO] = IO.contextShift(global)
+implicit val timer: Timer[IO] = IO.timer(global)
 ```
 
 Finish setting up our server:

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -55,10 +55,12 @@ Wherever you are in your studies, let's create our first
 import cats.effect._, org.http4s._, org.http4s.dsl.io._, scala.concurrent.ExecutionContext.Implicits.global
 ```
 
-You also will need a `ContextShift`.
+You also will need a `ContextShift` and a `Timer`.  These come for
+free if you are in an `IOApp`.
 
 ```tut:book:silent
 implicit val cs: ContextShift[IO] = IO.contextShift(global)
+implicit val timer: Timer[IO] = IO.timer(global)
 ```
 
 Using the [http4s-dsl], we can construct an `HttpRoutes` by pattern

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
@@ -20,7 +20,7 @@ object BlazeSslExampleWithRedirect extends IOApp {
 
 object BlazeSslExampleWithRedirectApp {
 
-  def redirectStream[F[_]: ConcurrentEffect]: Stream[F, ExitCode] =
+  def redirectStream[F[_]: ConcurrentEffect: Timer]: Stream[F, ExitCode] =
     BlazeServerBuilder[F]
       .bindHttp(8080)
       .withHttpApp(ssl.redirectApp(8443))

--- a/examples/docker/src/main/scala/com/example/http4s/Example.scala
+++ b/examples/docker/src/main/scala/com/example/http4s/Example.scala
@@ -15,7 +15,7 @@ object Main extends IOApp {
 
 object ExampleApp {
 
-  def serverStream[F[_]: ConcurrentEffect]: Stream[F, ExitCode] =
+  def serverStream[F[_]: ConcurrentEffect: Timer]: Stream[F, ExitCode] =
     BlazeServerBuilder[F]
       .bindHttp(port = 8080, host = "0.0.0.0")
       .withHttpApp(ExampleRoutes[F]().routes.orNotFound)

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -84,6 +84,10 @@ object Http4sPlugin extends AutoPlugin {
 
     http4sMimaVersion := {
       version.value match {
+        case VersionNumber(Seq(0, 19, patch), _, _) if patch.toInt > 1 =>
+          Some(s"0.19.${patch.toInt - 1}")
+        case VersionNumber(Seq(0, 19, _), _, _) =>
+          None
         case VersionNumber(Seq(major, minor, patch), _, _) if patch.toInt > 0 =>
           Some(s"${major}.${minor}.${patch.toInt - 1}")
         case _ =>


### PR DESCRIPTION
If an `HttpApp` takes too long to respond, cancel it and respond with a 503.