### PR TITLE
Move requestTimeout into BlazeClient

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -126,7 +126,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   def withoutAsynchronousChannelGroup: BlazeClientBuilder[F] =
     withAsynchronousChannelGroupOption(None)
 
-  def allocate(implicit F: ConcurrentEffect[F], clock: Clock[F]): F[(Client[F], F[Unit])] =
+  def allocate(implicit F: ConcurrentEffect[F], timer: Timer[F]): F[(Client[F], F[Unit])] =
     connectionManager.map {
       case (manager, shutdown) =>
         (
@@ -139,10 +139,10 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
           shutdown)
     }
 
-  def resource(implicit F: ConcurrentEffect[F], clock: Clock[F]): Resource[F, Client[F]] =
+  def resource(implicit F: ConcurrentEffect[F], timer: Timer[F]): Resource[F, Client[F]] =
     Resource(allocate)
 
-  def stream(implicit F: ConcurrentEffect[F], clock: Clock[F]): Stream[F, Client[F]] =
+  def stream(implicit F: ConcurrentEffect[F], timer: Timer[F]): Stream[F, Client[F]] =
     Stream.resource(resource)
 
   private def connectionManager(

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -16,7 +16,7 @@ object Http1Client {
     */
   private def resource[F[_]](config: BlazeClientConfig)(
       implicit F: ConcurrentEffect[F],
-      clock: Clock[F]): Resource[F, Client[F]] = {
+      timer: Timer[F]): Resource[F, Client[F]] = {
     val http1: ConnectionBuilder[F, BlazeConnection[F]] = new Http1Support(
       sslContextOption = config.sslContext,
       bufferSize = config.bufferSize,
@@ -47,6 +47,6 @@ object Http1Client {
 
   def stream[F[_]](config: BlazeClientConfig = BlazeClientConfig.defaultConfig)(
       implicit F: ConcurrentEffect[F],
-      clock: Clock[F]): Stream[F, Client[F]] =
+      timer: Timer[F]): Stream[F, Client[F]] =
     Stream.resource(resource(config))
 }


### PR DESCRIPTION
Pulls the request timeout implementation out of an imperative blaze stage and into a cats-effect implementation.

The response line timeout can be pulled out next.