### PR TITLE
Deprecate async syntax

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -12,7 +12,7 @@ import org.http4s.blaze.channel.nio2.ClientChannelFactory
 import org.http4s.blaze.pipeline.{Command, LeafBuilder}
 import org.http4s.blaze.pipeline.stages.SSLStage
 import org.http4s.headers.`User-Agent`
-import org.http4s.syntax.async._
+import org.http4s.internal.fromFuture
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -39,7 +39,7 @@ final private class Http1Support[F[_]](
 
   def makeClient(requestKey: RequestKey): F[BlazeConnection[F]] =
     getAddress(requestKey) match {
-      case Right(a) => F.fromFuture(buildPipeline(requestKey, a))(executionContext)
+      case Right(a) => fromFuture(F.delay(buildPipeline(requestKey, a)))
       case Left(t) => F.raiseError(t)
     }
 

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
@@ -5,14 +5,14 @@ package util
 import cats.implicits._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
-import org.http4s.syntax.async._
+import org.http4s.internal.fromFuture
 import org.http4s.util.StringWriter
 import org.log4s.getLogger
 import scala.concurrent._
 
 private[http4s] trait Http1Writer[F[_]] extends EntityBodyWriter[F] {
   final def write(headerWriter: StringWriter, body: EntityBody[F]): F[Boolean] =
-    F.fromFuture(writeHeaders(headerWriter)).attempt.flatMap {
+    fromFuture(F.delay(writeHeaders(headerWriter))).attempt.flatMap {
       case Right(()) =>
         writeEntityBody(body)
       case Left(t) =>

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -6,6 +6,7 @@ import scala.concurrent.ExecutionContext
 import org.http4s.util.execution.direct
 import org.log4s.Logger
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 import scala.util.control.NoStackTrace
 
 package object internal {
@@ -109,7 +110,10 @@ package object internal {
           F.fromTry(value)
         case None =>
           F.async { cb =>
-            future.onComplete(r => cb(r.toEither))(direct)
+            future.onComplete {
+              case Success(a) => cb(Right(a))
+              case Failure(t) => cb(Left(t))
+            }(direct)
           }
       }
     }

--- a/core/src/main/scala/org/http4s/syntax/AsyncSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/AsyncSyntax.scala
@@ -5,11 +5,13 @@ import cats.effect.Async
 import scala.concurrent.{ExecutionContext, Future}
 
 trait AsyncSyntax {
+  @deprecated("Has nothing to do with HTTP", "0.19.1")
   implicit def asyncSyntax[F[_], A](async: Async[F]): AsyncOps[F, A] =
     new AsyncOps[F, A](async)
 }
 
 final class AsyncOps[F[_], A](val self: Async[F]) extends AnyVal {
+  @deprecated("Has nothing to do with HTTP. Use `IO.fromFuture(IO(future)).to[F]`", "0.19.1")
   def fromFuture(future: Eval[Future[A]])(implicit ec: ExecutionContext): F[A] =
     self.async { cb =>
       import scala.util.{Failure, Success}
@@ -20,6 +22,7 @@ final class AsyncOps[F[_], A](val self: Async[F]) extends AnyVal {
       }
     }
 
+  @deprecated("Has nothing to do with HTTP. Use `IO.fromFuture(IO(future)).to[F]`", "0.19.1")
   def fromFuture(future: => Future[A])(implicit ec: ExecutionContext): F[A] =
     fromFuture(Eval.always(future))
 }

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -2,6 +2,7 @@ package org.http4s
 
 package object syntax {
   object all extends AllSyntax
+  @deprecated("Has nothing to do with HTTP.", "0.19.1")
   object async extends AsyncSyntax
   @deprecated("Use map or flatMap on the request instead", "0.18.0-M2")
   object effectRequest extends EffectRequestSyntax


### PR DESCRIPTION
The proper place for this is cats-effect.  We should not pollute the namespace or take long term support burden on things unrelated to HTTP.