### PR TITLE
Redact headers in Retry logging

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -26,7 +26,8 @@ object Retry {
       executionContext: ExecutionContext): Client[F] =
     retryWithRedactedHeaders(policy, Headers.SensitiveHeaders.contains)(client)
 
-  def retryWithRedactedHeaders[F[_]](policy: RetryPolicy[F],
+  def retryWithRedactedHeaders[F[_]](
+      policy: RetryPolicy[F],
       redactHeaderWhen: CaseInsensitiveString => Boolean)(client: Client[F])(
       implicit F: Effect[F],
       scheduler: Scheduler,

--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -20,7 +20,7 @@ object Retry {
 
   private[this] val logger = getLogger
 
-  def apply[F[_]](policy: RetryPolicy[F])(client: Client[F])(redactHeaderWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
+  def apply[F[_]](policy: RetryPolicy[F], redactHeaderWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(client: Client[F])(
       implicit F: Effect[F],
       scheduler: Scheduler,
       executionContext: ExecutionContext): Client[F] = {
@@ -54,9 +54,9 @@ object Retry {
 
     def showRequest(request: Request[F], redactWhen: CaseInsensitiveString => Boolean): String = {
       val headers = request.headers.redactSensitive(redactWhen).toList.mkString(",")
-      val url     = request.uri.renderString
+      val uri     = request.uri.renderString
       val method  = request.method
-      s"method=$method uri=$url headers=$headers"
+      s"method=$method uri=$uri headers=$headers"
     }
 
     def nextAttempt(


### PR DESCRIPTION
It'd be nice to have a little bit more control on what's logged in `Retry`, specially in the headers.

This is not nice, but it captures the intention. Ideally I'd like to use the `Logger.logMessage` that's in master so I can format the string representation of the request. Would we possible to have in in .18?
