### PR TITLE
Silence expected exceptions

### DIFF
--- a/testing/src/main/scala/org/http4s/testing/ErrorReportingUtils.scala
+++ b/testing/src/main/scala/org/http4s/testing/ErrorReportingUtils.scala
@@ -5,7 +5,6 @@ import scala.util.control.NonFatal
 
 trait ErrorReportingUtils {
 
-
   /**
     * Silences `System.err`, only printing the output in case exceptions are
     * thrown by the executed `thunk`.

--- a/testing/src/main/scala/org/http4s/testing/ErrorReportingUtils.scala
+++ b/testing/src/main/scala/org/http4s/testing/ErrorReportingUtils.scala
@@ -1,3 +1,21 @@
+/*
+ * Derived from :https://github.com/typelevel/cats-effect/blob/v1.0.0/core/shared/src/test/scala/cats/effect/internals/TestUtils.scala
+ *
+ * Copyright (c) 2017-2018 The Typelevel Cats-effect Project Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.testing
 import java.io.{ByteArrayOutputStream, PrintStream}
 
@@ -8,8 +26,6 @@ trait ErrorReportingUtils {
   /**
     * Silences `System.err`, only printing the output in case exceptions are
     * thrown by the executed `thunk`.
-    * Credit: Typelevel - Cats Effect developers
-    *
     */
   def silenceSystemErr[A](thunk: => A): A = synchronized {
     // Silencing System.err
@@ -34,7 +50,6 @@ trait ErrorReportingUtils {
 
   /**
     * Catches `System.err` output, for testing purposes.
-    * Credit: Typelevel - Cats Effect developers
     */
   def catchSystemErr(thunk: => Unit): String = synchronized {
     val oldErr = System.err

--- a/testing/src/main/scala/org/http4s/testing/ErrorReportingUtils.scala
+++ b/testing/src/main/scala/org/http4s/testing/ErrorReportingUtils.scala
@@ -1,0 +1,54 @@
+package org.http4s.testing
+import java.io.{ByteArrayOutputStream, PrintStream}
+
+import scala.util.control.NonFatal
+
+trait ErrorReportingUtils {
+
+
+  /**
+    * Silences `System.err`, only printing the output in case exceptions are
+    * thrown by the executed `thunk`.
+    * Credit: Typelevel - Cats Effect developers
+    *
+    */
+  def silenceSystemErr[A](thunk: => A): A = synchronized {
+    // Silencing System.err
+    val oldErr = System.err
+    val outStream = new ByteArrayOutputStream()
+    val fakeErr = new PrintStream(outStream)
+    System.setErr(fakeErr)
+    try {
+      val result = thunk
+      System.setErr(oldErr)
+      result
+    } catch {
+      case NonFatal(e) =>
+        System.setErr(oldErr)
+        // In case of errors, print whatever was caught
+        fakeErr.close()
+        val out = outStream.toString("utf-8")
+        if (out.nonEmpty) oldErr.println(out)
+        throw e
+    }
+  }
+
+  /**
+    * Catches `System.err` output, for testing purposes.
+    * Credit: Typelevel - Cats Effect developers
+    */
+  def catchSystemErr(thunk: => Unit): String = synchronized {
+    val oldErr = System.err
+    val outStream = new ByteArrayOutputStream()
+    val fakeErr = new PrintStream(outStream)
+    System.setErr(fakeErr)
+    try {
+      thunk
+    } finally {
+      System.setErr(oldErr)
+      fakeErr.close()
+    }
+    outStream.toString("utf-8")
+  }
+
+}

--- a/tests/src/test/scala/org/http4s/util/ExecutionSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/ExecutionSpec.scala
@@ -1,10 +1,12 @@
 package org.http4s
 package util
 
+import org.http4s.testing.ErrorReportingUtils
 import org.specs2.mutable.Specification
+
 import scala.concurrent.ExecutionContext
 
-abstract class ExecutionSpec extends Specification {
+abstract class ExecutionSpec extends Specification with ErrorReportingUtils {
   def ec: ExecutionContext
   def ecName: String
 
@@ -54,8 +56,11 @@ abstract class ExecutionSpec extends Specification {
     "submit a failing job" in {
       val i = 0
 
-      submit {
-        sys.error("Boom")
+
+      silenceSystemErr {
+        submit {
+          sys.error("Boom")
+        }
       }
 
       (i must be).equalTo(0)
@@ -64,10 +69,12 @@ abstract class ExecutionSpec extends Specification {
     "interleave failing and successful `Runnables`" in {
       var i = 0
 
-      submit {
-        for (j <- 0 until 10) {
-          submit {
-            if (j % 2 == 0) submit { i += 1 } else submit { sys.error("Boom") }
+      silenceSystemErr {
+        submit {
+          for (j <- 0 until 10) {
+            submit {
+              if (j % 2 == 0) submit { i += 1 } else submit { sys.error("Boom") }
+            }
           }
         }
       }

--- a/tests/src/test/scala/org/http4s/util/ExecutionSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/ExecutionSpec.scala
@@ -56,7 +56,6 @@ abstract class ExecutionSpec extends Specification with ErrorReportingUtils {
     "submit a failing job" in {
       val i = 0
 
-
       silenceSystemErr {
         submit {
           sys.error("Boom")


### PR DESCRIPTION
Stack trace that print directly to stderr are suppressed, while exceptions logged at error level are still logged.
Should these logs be suppressed too?
Any advice on the "copyright" for the copied function from cats-effect?

Closes issue  #2049 