### PR TITLE
Request and response concurrent in blaze-client

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -282,7 +282,7 @@ class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThro
         Client[IO] { _ =>
           for {
             _ <- List(1, 2, 3).traverse { i =>
-              Resource(IO.pure(() -> (IO(println("FART")) *> released.update(_ :+ i))))
+              Resource(IO.pure(() -> released.update(_ :+ i)))
             }
           } yield Response()
         }.toHttpApp(req).flatMap(_.as[Unit]) >> released.get
@@ -294,7 +294,7 @@ class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThro
         Client[IO] { _ =>
           for {
             _ <- List(1, 2, 3).traverse { i =>
-              Resource(IO.pure(() -> (IO(println("FART")) *> released.update(_ :+ i))))
+              Resource(IO.pure(() -> released.update(_ :+ i)))
             }
             _ <- Resource.liftF[IO, Unit](IO.raiseError(SadTrombone))
           } yield Response()


### PR DESCRIPTION
Start receiving the response concurrently with rendering the request.  Many responses can be generated without consuming the body in its entirety, so there's no need to finish the write before trying to read. 