### PR TITLE
Remove ill-conceived, zero-timeout unit tests

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -57,22 +57,6 @@ class ClientTimeoutSpec extends Http4sSpec {
   }
 
   "Http1ClientStage responses" should {
-    "Timeout immediately with an idle timeout of 0 seconds" in {
-      val c = mkClient(
-        new SlowTestHead(List(mkBuffer(resp)), 0.seconds, tickWheel),
-        mkConnection(FooRequestKey))(idleTimeout = Duration.Zero)
-
-      c.fetchAs[String](FooRequest).unsafeRunSync() must throwA[TimeoutException]
-    }
-
-    "Timeout immediately with a request timeout of 0 seconds" in {
-      val tail = mkConnection(FooRequestKey)
-      val h = new SlowTestHead(List(mkBuffer(resp)), 0.seconds, tickWheel)
-      val c = mkClient(h, tail)(requestTimeout = 0.milli)
-
-      c.fetchAs[String](FooRequest).unsafeRunSync() must throwA[TimeoutException]
-    }
-
     "Idle timeout on slow response" in {
       val tail = mkConnection(FooRequestKey)
       val h = new SlowTestHead(List(mkBuffer(resp)), 10.seconds, tickWheel)


### PR DESCRIPTION
Fixes #2191.

These are not doing anything but testing a race condition for an obscure scenario that would be better implemented without a blaze client in the first place.