### PR TITLE
Make "behave and not deadlock" test parallel

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -49,8 +49,7 @@ class BlazeClientSpec extends Http4sSpec {
             .compile
             .drain
           val flushOutputStream: IO[Unit] = IO(os.flush())
-          (writeBody *> IO.sleep(Random.nextInt(1000).millis) *> flushOutputStream)
-            .unsafeRunSync()
+          (writeBody *> flushOutputStream).unsafeRunSync()
 
         case None => srv.sendError(404)
       }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -106,7 +106,7 @@ class BlazeClientSpec extends Http4sSpec {
             Uri.fromString(s"http://$name:$port/simple").yolo
           }
 
-          (1 to 100).toList
+          (1 to Runtime.getRuntime.availableProcessors * 5).toList
             .parTraverse { _ =>
               val h = hosts(Random.nextInt(hosts.length))
               client.expect[String](h).map(_.nonEmpty)

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -107,14 +107,13 @@ class BlazeClientSpec extends Http4sSpec {
             Uri.fromString(s"http://$name:$port/simple").yolo
           }
 
-          (0 until 42)
-            .map { _ =>
+          (1 to 100).toList
+            .parTraverse { _ =>
               val h = hosts(Random.nextInt(hosts.length))
-              val resp =
-                client.expect[String](h).unsafeRunTimed(timeout)
-              resp.map(_.length > 0)
+              client.expect[String](h).map(_.nonEmpty)
             }
-            .forall(_.contains(true)) must beTrue
+            .map(_.forall(identity))
+            .unsafeRunTimed(timeout) must beSome(true)
         }
 
         "obey response header timeout" in {


### PR DESCRIPTION
Fix "behave and not deadlock" test:
* Run in parallel, which is a more interesting test.
* Scale the size of the test to the number of processors.  We may just be asking too much of Travis.
* Remove random sleep in test servlet.  I can reproduce the failure with a long enough sleep.

Fixes #2199, I hope.