### PR TITLE
Add simple `ResponseTiming` middleware and test

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/ResponseTiming.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseTiming.scala
@@ -1,0 +1,38 @@
+package org.http4s
+package server
+package middleware
+
+import cats.data.Kleisli
+import cats.effect._
+import cats.implicits._
+import org.http4s.util.CaseInsensitiveString
+
+import scala.concurrent.duration._
+
+object ResponseTiming {
+
+  /**
+    * Simple middleware for adding a custom header with timing information to a response.
+    *
+    * This middleware captures the time from when the request headers are parsed and supplied
+    * to the wrapped service to when the response is started. Metrics middleware, like this one,
+    * work best as the outer layer to ensure work done by other middleware is also included.
+    *
+    * @param http [[HttpApp]] to transform
+    * @param timeUnit the units of measure for this timing
+    * @param headerName the name to use for the header containing the timing info
+    */
+  def apply[F[_]: Sync](
+      http: HttpApp[F],
+      timeUnit: TimeUnit = MILLISECONDS,
+      headerName: CaseInsensitiveString = CaseInsensitiveString("X-Response-Time"))(
+      implicit clock: Clock[F]): HttpApp[F] =
+    Kleisli { req =>
+      for {
+        before <- clock.monotonic(timeUnit)
+        resp <- http(req)
+        after <- clock.monotonic(timeUnit)
+        header = Header(headerName.value, s"${after - before}")
+      } yield resp.copy(headers = resp.headers.put(header))
+    }
+}

--- a/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSpec.scala
@@ -1,0 +1,52 @@
+package org.http4s.server.middleware
+
+import cats.implicits._
+import cats.effect._
+import cats.effect.concurrent.Ref
+import org.http4s._
+import org.http4s.dsl.io._
+import org.http4s.util.CaseInsensitiveString
+
+import scala.concurrent.duration.TimeUnit
+
+class ResponseTimingSpec extends Http4sSpec {
+  import Sys.clock
+
+  private val artificialDelay = 10
+
+  private val thisService = HttpApp[IO] {
+    case GET -> Root / "request" =>
+      List.fill(artificialDelay)(Sys.tick()).sequence_ *>
+        Ok("request response")
+  }
+
+  "ResponseTiming middleware" should {
+    "add a custom header with timing info" in {
+      val req = Request[IO](uri = uri("/request"))
+      val app = ResponseTiming(thisService)
+      val res = app(req)
+
+      val header = res
+        .map(_.headers.find(_.name == CaseInsensitiveString("X-Response-Time")))
+        .unsafeRunSync()
+
+      header.nonEmpty must_== true
+      header.get.value.toInt must_== artificialDelay
+    }
+  }
+
+}
+
+object Sys {
+
+  private val currentTime: Ref[IO, Long] = Ref.unsafe[IO, Long](System.currentTimeMillis())
+
+  def tick(): IO[Long] = currentTime.modify(l => (l + 1L, l))
+
+  implicit val clock: Clock[IO] = new Clock[IO] {
+
+    override def realTime(unit: TimeUnit): IO[Long] = currentTime.get
+
+    override def monotonic(unit: TimeUnit): IO[Long] = currentTime.get
+  }
+}


### PR DESCRIPTION
- Uses implicit `Clock[F]` to time from headers parsed to response started
- Adds header to `Response`, named "X-Response-Time" by default

For #2014 