### PR TITLE
Streamline instances

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
@@ -5,6 +5,7 @@ package blaze
 import cats.effect._
 import cats.implicits._
 import fs2.Stream._
+import org.http4s.implicits._
 import org.http4s.Charset._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers._

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -10,6 +10,7 @@ import org.http4s.MediaType
 import org.http4s.Status.{BadRequest, Created, InternalServerError, Ok}
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers.Accept
+import org.http4s.Uri.uri
 import org.specs2.matcher.MustThrownMatchers
 
 class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThrownMatchers {

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic._
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.dsl.io._
 import org.http4s.headers._
+import org.http4s.Uri.uri
 import org.specs2.mutable.Tables
 
 class FollowRedirectSpec extends Http4sSpec with Http4sClientDsl[IO] with Tables {

--- a/client/src/test/scala/org/http4s/client/middleware/LoggerSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/LoggerSpec.scala
@@ -4,6 +4,7 @@ package middleware
 
 import cats.effect._
 import fs2.io.readInputStream
+import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import scala.io.Source
 

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -7,6 +7,7 @@ import cats.effect.concurrent.Ref
 import cats.implicits.{catsSyntaxEither => _, _}
 import fs2.Stream
 import org.http4s.dsl.io._
+import org.http4s.Uri.uri
 import org.specs2.specification.Tables
 import scala.concurrent.duration._
 

--- a/core/src/main/scala/org/http4s/CharsetRange.scala
+++ b/core/src/main/scala/org/http4s/CharsetRange.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.{Eq, Show}
 import org.http4s.util._
 
 sealed abstract class CharsetRange extends HasQValue with Renderable {
@@ -20,7 +20,7 @@ sealed abstract class CharsetRange extends HasQValue with Renderable {
   }
 }
 
-object CharsetRange extends CharsetRangeInstances {
+object CharsetRange {
   sealed case class `*`(qValue: QValue) extends CharsetRange {
     final override def withQValue(q: QValue): CharsetRange.`*` = copy(qValue = q)
 
@@ -43,12 +43,7 @@ object CharsetRange extends CharsetRangeInstances {
   }
 
   implicit def fromCharset(cs: Charset): CharsetRange.Atom = cs.toRange
-}
 
-trait CharsetRangeInstances {
-  implicit val http4sEqForCharsetRange: Eq[CharsetRange] =
-    Eq.fromUniversalEquals
-
-  implicit val http4sShowForCharsetRange: Show[Charset] =
-    Show.fromToString
+  implicit val http4sCharsetRangeEq: Eq[CharsetRange] = Eq.fromUniversalEquals
+  implicit val http4sCharsetRangeShow: Show[CharsetRange] = Show.fromToString
 }

--- a/core/src/main/scala/org/http4s/CharsetRange.scala
+++ b/core/src/main/scala/org/http4s/CharsetRange.scala
@@ -44,6 +44,6 @@ object CharsetRange {
 
   implicit def fromCharset(cs: Charset): CharsetRange.Atom = cs.toRange
 
-  implicit val http4sCharsetRangeEq: Eq[CharsetRange] = Eq.fromUniversalEquals
-  implicit val http4sCharsetRangeShow: Show[CharsetRange] = Show.fromToString
+  implicit val http4sEqForCharsetRange: Eq[CharsetRange] = Eq.fromUniversalEquals
+  implicit val http4sShowForCharsetRange: Show[CharsetRange] = Show.fromToString
 }

--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -18,10 +18,10 @@
  */
 package org.http4s
 
-import cats.{Order, Show}
-import cats.syntax.eq._
-import cats.instances.tuple._
 import cats.instances.string._
+import cats.instances.tuple._
+import cats.syntax.eq._
+import cats.{Order, Show}
 import org.http4s.QValue.QValueParser
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
 import org.http4s.parser.Http4sParser
@@ -65,7 +65,7 @@ class ContentCoding private (val coding: String, override val qValue: QValue = Q
     ContentCoding.http4sOrderForContentCoding.compare(this, other)
 
   override def render(writer: Writer): writer.type =
-    ContentCoding.http4sInstancesForContentCoding.render(writer, this)
+    ContentCoding.http4sHttpCodecForContentCoding.render(writer, this)
 }
 
 object ContentCoding {
@@ -116,19 +116,16 @@ object ContentCoding {
     }
   }
 
-  implicit val http4sInstancesForContentCoding: Show[ContentCoding] with HttpCodec[ContentCoding] =
-    new Show[ContentCoding] with HttpCodec[ContentCoding] {
-      override def show(s: ContentCoding): String = s.toString
-
+  implicit val http4sOrderForContentCoding: Order[ContentCoding] =
+    Order.by(c => (c.coding.toLowerCase, c.qValue))
+  implicit val http4sShowForContentCoding: Show[ContentCoding] =
+    Show.fromToString
+  implicit val http4sHttpCodecForContentCoding: HttpCodec[ContentCoding] =
+    new HttpCodec[ContentCoding] {
       override def parse(s: String): ParseResult[ContentCoding] =
         ContentCoding.parse(s)
 
       override def render(writer: Writer, coding: ContentCoding): writer.type =
         writer << coding.coding.toLowerCase << coding.qValue
-
     }
-
-  implicit val http4sOrderForContentCoding: Order[ContentCoding] =
-    Order.by(c => (c.coding.toLowerCase, c.qValue))
-
 }

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -16,6 +16,7 @@ import scala.concurrent.ExecutionContext
   * entire resulting A. If an error occurs it will result in a failed effect.
   * The default decoders provided here are not streaming, but one could implement
   * a streaming decoder by having the value of A be some kind of streaming construct.
+  *
   * @tparam T result type produced by the decoder
   */
 @implicitNotFound(
@@ -93,6 +94,7 @@ trait EntityDecoder[F[_], T] { self =>
     *
     * The new [[EntityDecoder]] will first attempt to determine if it can perform the decode,
     * and if not, defer to the second [[EntityDecoder]]
+    *
     * @param other backup [[EntityDecoder]]
     */
   def orElse[T2 >: T](other: EntityDecoder[F, T2])(implicit F: Functor[F]): EntityDecoder[F, T2] =
@@ -110,7 +112,7 @@ trait EntityDecoder[F[_], T] { self =>
   * This companion object provides a way to create `new EntityDecoder`s along
   * with some commonly used instances which can be resolved implicitly.
   */
-object EntityDecoder extends EntityDecoderInstances {
+object EntityDecoder {
 
   // This is not a real media type but will still be matched by `*/*`
   private val UndefinedMediaType = new MediaType("UNKNOWN", "UNKNOWN")
@@ -185,11 +187,6 @@ object EntityDecoder extends EntityDecoderInstances {
   def decodeString[F[_]: Sync](msg: Message[F])(
       implicit defaultCharset: Charset = DefaultCharset): F[String] =
     msg.bodyAsText.compile.foldMonoid
-}
-
-/** Implementations of the EntityDecoder instances */
-trait EntityDecoderInstances {
-  import org.http4s.EntityDecoder._
 
   /////////////////// Instances //////////////////////////////////////////////
 

--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -3,8 +3,8 @@ package org.http4s
 import cats._
 import cats.effect.{ContextShift, Effect, Sync}
 import cats.implicits._
-import fs2._
 import fs2.Stream._
+import fs2._
 import fs2.io.file.readAll
 import fs2.io.readInputStream
 import java.io._
@@ -48,7 +48,9 @@ trait EntityEncoder[F[_], A] { self =>
   }
 }
 
-object EntityEncoder extends EntityEncoderInstances {
+object EntityEncoder {
+
+  private val DefaultChunkSize = 4096
 
   /** summon an implicit [[EntityEncoder]] */
   def apply[F[_], A](implicit ev: EntityEncoder[F, A]): EntityEncoder[F, A] = ev
@@ -75,10 +77,6 @@ object EntityEncoder extends EntityEncoderInstances {
       val c = toChunk(a)
       Entity[F](chunk(c).covary[F], Some(c.size.toLong))
     }
-}
-
-trait EntityEncoderInstances0 {
-  import EntityEncoder._
 
   /** Encodes a value from its Show instance.  Too broad to be implicit, too useful to not exist. */
   def showEncoder[F[_], A](
@@ -113,12 +111,6 @@ trait EntityEncoderInstances0 {
             W.headers.put(`Transfer-Encoding`(TransferCoding.chunked))
         }
     }
-}
-
-trait EntityEncoderInstances extends EntityEncoderInstances0 {
-  import EntityEncoder._
-
-  private val DefaultChunkSize = 4096
 
   implicit def unitEncoder[F[_]]: EntityEncoder[F, Unit] =
     emptyEncoder[F, Unit]

--- a/core/src/main/scala/org/http4s/Http4s.scala
+++ b/core/src/main/scala/org/http4s/Http4s.scala
@@ -7,7 +7,7 @@ trait Http4s extends Http4sInstances with Http4sFunctions with syntax.AllSyntax
 object Http4s extends Http4s
 
 @deprecated("Import from or use EntityDecoder/EntityEncoder directly instead", "0.20.0-M2")
-trait Http4sInstances extends EntityDecoderInstances with EntityEncoderInstances
+trait Http4sInstances
 
 @deprecated("Import from or use EntityDecoder/EntityEncoder directly instead", "0.20.0-M2")
 object Http4sInstances extends Http4sInstances

--- a/core/src/main/scala/org/http4s/Http4s.scala
+++ b/core/src/main/scala/org/http4s/Http4s.scala
@@ -7,15 +7,13 @@ trait Http4s extends Http4sInstances with Http4sFunctions with syntax.AllSyntax
 object Http4s extends Http4s
 
 @deprecated("Import from or use EntityDecoder/EntityEncoder directly instead", "0.20.0-M2")
-trait Http4sInstances
-    extends EntityDecoderInstances
-    with EntityEncoderInstances
+trait Http4sInstances extends EntityDecoderInstances with EntityEncoderInstances
 
 @deprecated("Import from or use EntityDecoder/EntityEncoder directly instead", "0.20.0-M2")
 object Http4sInstances extends Http4sInstances
 
 @deprecated("Use org.http4s.qvalue._ or org.http4s.Uri._ instead", "0.20.0-M2")
-trait Http4sFunctions extends UriFunctions
+trait Http4sFunctions
 
 @deprecated("Use org.http4s.qvalue._ or org.http4s.Uri._ instead", "0.20.0-M2")
 object Http4sFunctions extends Http4sFunctions

--- a/core/src/main/scala/org/http4s/Http4s.scala
+++ b/core/src/main/scala/org/http4s/Http4s.scala
@@ -1,9 +1,12 @@
 package org.http4s
 
+@deprecated("Use org.http4s.implicits._ instead", "0.20.0-M2")
 trait Http4s extends Http4sInstances with Http4sFunctions with syntax.AllSyntax
 
+@deprecated("Use org.http4s.implicits._ instead", "0.20.0-M2")
 object Http4s extends Http4s
 
+@deprecated("Import from or use EntityDecoder/EntityEncoder directly instead", "0.20.0-M2")
 trait Http4sInstances
     extends EntityDecoderInstances
     with HttpVersionInstances
@@ -13,8 +16,11 @@ trait Http4sInstances
     with MethodInstances
     with StatusInstances
 
+@deprecated("Import from or use EntityDecoder/EntityEncoder directly instead", "0.20.0-M2")
 object Http4sInstances extends Http4sInstances
 
+@deprecated("Use org.http4s.qvalue._ or org.http4s.Uri._ instead", "0.20.0-M2")
 trait Http4sFunctions extends QValueFunctions with UriFunctions
 
+@deprecated("Use org.http4s.qvalue._ or org.http4s.Uri._ instead", "0.20.0-M2")
 object Http4sFunctions extends Http4sFunctions

--- a/core/src/main/scala/org/http4s/Http4s.scala
+++ b/core/src/main/scala/org/http4s/Http4s.scala
@@ -9,18 +9,13 @@ object Http4s extends Http4s
 @deprecated("Import from or use EntityDecoder/EntityEncoder directly instead", "0.20.0-M2")
 trait Http4sInstances
     extends EntityDecoderInstances
-    with HttpVersionInstances
     with EntityEncoderInstances
-    with CharsetRangeInstances
-    with QValueInstances
-    with MethodInstances
-    with StatusInstances
 
 @deprecated("Import from or use EntityDecoder/EntityEncoder directly instead", "0.20.0-M2")
 object Http4sInstances extends Http4sInstances
 
 @deprecated("Use org.http4s.qvalue._ or org.http4s.Uri._ instead", "0.20.0-M2")
-trait Http4sFunctions extends QValueFunctions with UriFunctions
+trait Http4sFunctions extends UriFunctions
 
 @deprecated("Use org.http4s.qvalue._ or org.http4s.Uri._ instead", "0.20.0-M2")
 object Http4sFunctions extends Http4sFunctions

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -52,7 +52,7 @@ object HttpVersion {
     else ParseResult.success(new HttpVersion(major, minor))
 
   implicit val http4sHttpOrderForVersion: Order[HttpVersion] =
-    Order.fromOrdering[HttpVersion]
+    Order.fromComparable
   implicit val http4sHttpShowForVersion: Show[HttpVersion] =
-    Show.fromToString[HttpVersion]
+    Show.fromToString
 }

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -1,8 +1,8 @@
 package org.http4s
 
-import cats._
 import cats.data.{Writer => _}
 import cats.implicits._
+import cats.{Order, Show}
 import org.http4s.internal.parboiled2._
 import org.http4s.parser._
 import org.http4s.util._
@@ -20,7 +20,7 @@ final case class HttpVersion private[HttpVersion] (major: Int, minor: Int)
     (this.major, this.minor).compare((that.major, that.minor))
 }
 
-object HttpVersion extends HttpVersionInstances {
+object HttpVersion {
   val `HTTP/1.0` = new HttpVersion(1, 0)
   val `HTTP/1.1` = new HttpVersion(1, 1)
   val `HTTP/2.0` = new HttpVersion(2, 0)
@@ -50,9 +50,7 @@ object HttpVersion extends HttpVersionInstances {
     else if (minor < 0) ParseResult.fail("Invalid HTTP version", s"major must be > 0: $minor")
     else if (minor > 9) ParseResult.fail("Invalid HTTP version", s"major must be <= 9: $minor")
     else ParseResult.success(new HttpVersion(major, minor))
-}
 
-trait HttpVersionInstances {
-  implicit val HttpVersionShow = Show.fromToString[HttpVersion]
-  implicit val HttpVersionOrder = Order.fromOrdering[HttpVersion]
+  implicit val http4sHttpVersionOrder: Order[HttpVersion] = Order.fromOrdering[HttpVersion]
+  implicit val http4sHttpVersionShow: Show[HttpVersion] = Show.fromToString[HttpVersion]
 }

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -51,6 +51,8 @@ object HttpVersion {
     else if (minor > 9) ParseResult.fail("Invalid HTTP version", s"major must be <= 9: $minor")
     else ParseResult.success(new HttpVersion(major, minor))
 
-  implicit val http4sHttpVersionOrder: Order[HttpVersion] = Order.fromOrdering[HttpVersion]
-  implicit val http4sHttpVersionShow: Show[HttpVersion] = Show.fromToString[HttpVersion]
+  implicit val http4sHttpOrderForVersion: Order[HttpVersion] =
+    Order.fromOrdering[HttpVersion]
+  implicit val http4sHttpShowForVersion: Show[HttpVersion] =
+    Show.fromToString[HttpVersion]
 }

--- a/core/src/main/scala/org/http4s/Method.scala
+++ b/core/src/main/scala/org/http4s/Method.scala
@@ -145,6 +145,6 @@ object Method {
 
   private val allByKey: Map[String, Right[Nothing, Method]] = all.map(m => (m.name, Right(m))).toMap
 
-  implicit val http4sMethodEq: Eq[Method] = Eq.fromUniversalEquals
-  implicit val http4sShowEq: Show[Method] = Show.fromToString
+  implicit val http4sEqForMethod: Eq[Method] = Eq.fromUniversalEquals
+  implicit val http4sShowForMethod: Show[Method] = Show.fromToString
 }

--- a/core/src/main/scala/org/http4s/Method.scala
+++ b/core/src/main/scala/org/http4s/Method.scala
@@ -1,10 +1,10 @@
 package org.http4s
 
-import cats._
 import cats.implicits._
+import cats.{Eq, Show}
+import org.http4s.Method.Semantics
 import org.http4s.parser.Rfc2616BasicRules
 import org.http4s.util.{Renderable, Writer}
-import org.http4s.Method.Semantics
 
 /**
   * An HTTP method.
@@ -16,7 +16,7 @@ sealed abstract case class Method private (name: String) extends Renderable with
   final override def render(writer: Writer): writer.type = writer << name
 }
 
-object Method extends MethodInstances {
+object Method {
   sealed trait Semantics {
     def isIdempotent: Boolean
     def isSafe: Boolean
@@ -144,12 +144,7 @@ object Method extends MethodInstances {
   )
 
   private val allByKey: Map[String, Right[Nothing, Method]] = all.map(m => (m.name, Right(m))).toMap
-}
 
-trait MethodInstances {
-  implicit val http4sEqForMethod: Eq[Method] =
-    Eq.fromUniversalEquals
-
-  implicit val http4sShowForMethod: Show[Method] =
-    Show.fromToString
+  implicit val http4sMethodEq: Eq[Method] = Eq.fromUniversalEquals
+  implicit val http4sShowEq: Show[Method] = Show.fromToString
 }

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -125,10 +125,9 @@ object QValue {
     */
   def q(d: Double): QValue = macro Macros.qValueLiteral
 
-
-  implicit val http4sQValueOrder: Order[QValue] = Order.fromOrdering[QValue]
-  implicit val http4sQValueShow: Show[QValue] = Show.fromToString[QValue]
-  implicit val http4sQValueHttpCodec: HttpCodec[QValue] = new HttpCodec[QValue] {
+  implicit val http4sOrderForQValue: Order[QValue] = Order.fromOrdering[QValue]
+  implicit val http4sShowForQValue: Show[QValue] = Show.fromToString[QValue]
+  implicit val http4sHttpCodecForQValue: HttpCodec[QValue] = new HttpCodec[QValue] {
     def parse(s: String): ParseResult[QValue] = QValue.parse(s)
     def render(writer: Writer, q: QValue): writer.type = q.render(writer)
   }

--- a/core/src/main/scala/org/http4s/Status.scala
+++ b/core/src/main/scala/org/http4s/Status.scala
@@ -194,6 +194,6 @@ object Status {
     Status(511, "Network Authentication Required"))
   // scalastyle:on magic.number
 
-  implicit val http4sStatusOrder: Order[Status] = Order.fromOrdering[Status]
-  implicit val http4sStatusShow: Show[Status] = Show.fromToString[Status]
+  implicit val http4sOrderForStatus: Order[Status] = Order.fromOrdering[Status]
+  implicit val http4sShowForStatus: Show[Status] = Show.fromToString[Status]
 }

--- a/core/src/main/scala/org/http4s/Status.scala
+++ b/core/src/main/scala/org/http4s/Status.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.{Order, Show}
 import org.http4s.Status.ResponseClass
 import org.http4s.util.Renderable
 
@@ -10,7 +10,6 @@ import org.http4s.util.Renderable
   *
   * @param code HTTP status code
   * @param reason reason for the response. eg, OK
-  *
   * @see [http://tools.ietf.org/html/rfc7231#section-6 RFC7231, Section 6]
   * @see [http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml IANA Status Code Registry]
   */
@@ -195,9 +194,6 @@ object Status {
     Status(511, "Network Authentication Required"))
   // scalastyle:on magic.number
 
-}
-
-trait StatusInstances {
-  implicit val StatusShow = Show.fromToString[Status]
-  implicit val StatusOrder = Order.fromOrdering[Status]
+  implicit val http4sStatusOrder: Order[Status] = Order.fromOrdering[Status]
+  implicit val http4sStatusShow: Show[Status] = Show.fromToString[Status]
 }

--- a/core/src/main/scala/org/http4s/TransferCoding.scala
+++ b/core/src/main/scala/org/http4s/TransferCoding.scala
@@ -18,11 +18,11 @@
  */
 package org.http4s
 
-import cats.{Order, Show}
 import cats.data.NonEmptyList
-import org.http4s.util._
-import org.http4s.parser.{Http4sParser, Rfc2616BasicRules}
+import cats.{Order, Show}
 import org.http4s.internal.parboiled2.{Parser => PbParser}
+import org.http4s.parser.{Http4sParser, Rfc2616BasicRules}
+import org.http4s.util._
 
 class TransferCoding private (val coding: String) extends Ordered[TransferCoding] with Renderable {
   override def equals(o: Any) = o match {
@@ -87,19 +87,17 @@ object TransferCoding {
     }
   }
 
-  implicit val http4sInstancesForTransferCoding
-    : Show[TransferCoding] with HttpCodec[TransferCoding] with Order[TransferCoding] =
-    new Show[TransferCoding] with HttpCodec[TransferCoding] with Order[TransferCoding] {
-      override def show(s: TransferCoding): String = s.coding
-
+  implicit val http4sOrderForTransferCoding: Order[TransferCoding] =
+    Order.fromComparable
+  implicit val http4sShowForTransferCoding: Show[TransferCoding] =
+    Show.show(_.coding)
+  implicit val http4sInstancesForTransferCoding: HttpCodec[TransferCoding] =
+    new HttpCodec[TransferCoding] {
       override def parse(s: String): ParseResult[TransferCoding] =
         TransferCoding.parse(s)
 
       override def render(writer: Writer, coding: TransferCoding): writer.type =
         writer << coding.coding
-
-      override def compare(x: TransferCoding, y: TransferCoding): Int =
-        x.compareTo(y)
     }
 
 }

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -11,7 +11,7 @@ import org.http4s.syntax.string._
 import org.http4s.util._
 import scala.language.experimental.macros
 import scala.math.Ordered
-import scala.reflect.macros.whitebox.Context
+import scala.reflect.macros.whitebox
 
 /** Representation of the [[Request]] URI
   * @param scheme     optional Uri Scheme. eg, http, https
@@ -118,7 +118,7 @@ final case class Uri(
 }
 
 object Uri extends UriFunctions {
-  class Macros(val c: Context) {
+  class Macros(val c: whitebox.Context) {
     import c.universe._
 
     def uriLiteral(s: c.Expr[String]): Tree =
@@ -260,17 +260,6 @@ object Uri extends UriFunctions {
   object IPv4 { def apply(address: String): IPv4 = new IPv4(address.ci) }
   object IPv6 { def apply(address: String): IPv6 = new IPv6(address.ci) }
 
-  implicit val eqInstance: Eq[Uri] = Eq.fromUniversalEquals
-}
-
-trait UriFunctions {
-
-  /**
-    * Literal syntax for URIs.  Invalid or non-literal arguments are rejected
-    * at compile time.
-    */
-  def uri(s: String): Uri = macro Uri.Macros.uriLiteral
-
   /**
     * Resolve a relative Uri reference, per RFC 3986 sec 5.2
     */
@@ -381,4 +370,14 @@ trait UriFunctions {
       case -1 => b.setLength(0)
       case n => b.setLength(n)
     }
+
+  implicit val http4sUriEq: Eq[Uri] = Eq.fromUniversalEquals
+}
+
+trait UriFunctions {
+  /**
+    * Literal syntax for URIs.  Invalid or non-literal arguments are rejected
+    * at compile time.
+    */
+  def uri(s: String): Uri = macro Uri.Macros.uriLiteral
 }

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -202,18 +202,17 @@ object Uri extends UriFunctions {
       }
     }
 
-    implicit val http4sInstancesForScheme: Show[Scheme] with HttpCodec[Scheme] with Order[Scheme] =
-      new Show[Scheme] with HttpCodec[Scheme] with Order[Scheme] {
-        def show(s: Scheme): String = s.toString
-
+    implicit val http4sOrderForScheme: Order[Scheme] =
+      Order.fromComparable
+    implicit val http4sShowForScheme: Show[Scheme] =
+      Show.fromToString
+    implicit val http4sInstancesForScheme: HttpCodec[Scheme] =
+      new HttpCodec[Scheme] {
         def parse(s: String): ParseResult[Scheme] =
           Scheme.parse(s)
 
         def render(writer: Writer, scheme: Scheme): writer.type =
           writer << scheme.value
-
-        def compare(x: Scheme, y: Scheme) =
-          x.compare(y)
       }
   }
 

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -4,8 +4,8 @@ import cats._
 import cats.implicits.{catsSyntaxEither => _, _}
 import java.nio.charset.StandardCharsets
 import org.http4s.Uri._
-import org.http4s.internal.parboiled2.{Parser => PbParser}
 import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit}
+import org.http4s.internal.parboiled2.{Parser => PbParser}
 import org.http4s.parser._
 import org.http4s.syntax.string._
 import org.http4s.util._
@@ -14,6 +14,7 @@ import scala.math.Ordered
 import scala.reflect.macros.whitebox
 
 /** Representation of the [[Request]] URI
+  *
   * @param scheme     optional Uri Scheme. eg, http, https
   * @param authority  optional Uri Authority. eg, localhost:8080, www.foo.bar
   * @param path       url-encoded string representation of the path component of the Uri.
@@ -117,7 +118,7 @@ final case class Uri(
   override protected def replaceQuery(query: Query): Self = copy(query = query)
 }
 
-object Uri extends UriFunctions {
+object Uri {
   class Macros(val c: whitebox.Context) {
     import c.universe._
 
@@ -370,13 +371,11 @@ object Uri extends UriFunctions {
       case n => b.setLength(n)
     }
 
-  implicit val http4sUriEq: Eq[Uri] = Eq.fromUniversalEquals
-}
-
-trait UriFunctions {
   /**
     * Literal syntax for URIs.  Invalid or non-literal arguments are rejected
     * at compile time.
     */
   def uri(s: String): Uri = macro Uri.Macros.uriLiteral
+
+  implicit val http4sUriEq: Eq[Uri] = Eq.fromUniversalEquals
 }

--- a/core/src/main/scala/org/http4s/headers/Content-Type.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Type.scala
@@ -18,7 +18,7 @@ final case class `Content-Type` private (mediaType: MediaType, charset: Option[C
   override def key: `Content-Type`.type = `Content-Type`
   override def renderValue(writer: Writer): writer.type = charset match {
     case Some(cs) => writer << mediaType << "; charset=" << cs
-    case _ => MediaRange.http4sInstancesForMediaRange.render(writer, mediaType)
+    case _ => MediaRange.http4sHttpCodecForMediaRange.render(writer, mediaType)
   }
 
   def withMediaType(mediaType: MediaType): `Content-Type` =

--- a/docs/src/main/tut/cors.md
+++ b/docs/src/main/tut/cors.md
@@ -33,7 +33,7 @@ val service = HttpRoutes.of[IO] {
     Ok()
 }
 
-val request = Request[IO](Method.GET, uri("/"))
+val request = Request[IO](Method.GET, Uri.uri("/"))
 
 service.orNotFound(request).unsafeRunSync
 ```
@@ -70,9 +70,9 @@ First, we'll create some requests to use in our example. We want these requests
 have a variety of origins and methods.
 
 ```tut:book
-val googleGet = Request[IO](Method.GET, uri("/"), headers = Headers(Header("Origin", "google.com")))
-val yahooPut = Request[IO](Method.PUT, uri("/"), headers = Headers(Header("Origin", "yahoo.com")))
-val duckPost = Request[IO](Method.POST, uri("/"), headers = Headers(Header("Origin", "duckduckgo.com")))
+val googleGet = Request[IO](Method.GET, Uri.uri("/"), headers = Headers(Header("Origin", "google.com")))
+val yahooPut = Request[IO](Method.PUT, Uri.uri("/"), headers = Headers(Header("Origin", "yahoo.com")))
+val duckPost = Request[IO](Method.POST, Uri.uri("/"), headers = Headers(Header("Origin", "duckduckgo.com")))
 ```
 
 Now, we'll create a configuration that limits the allowed methods to `GET`

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -66,7 +66,7 @@ need a server to test our route.  We can construct our own request
 and experiment directly in the REPL.
 
 ```tut
-val getRoot = Request[IO](Method.GET, uri("/"))
+val getRoot = Request[IO](Method.GET, Uri.uri("/"))
 
 val io = service.orNotFound.run(getRoot)
 ```

--- a/docs/src/main/tut/gzip.md
+++ b/docs/src/main/tut/gzip.md
@@ -22,6 +22,7 @@ And we need some imports.
 import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._
+import org.http4s.implicits._
 ```
 
 Let's start by making a simple service that returns a (relatively) large string
@@ -33,7 +34,7 @@ val service = HttpRoutes.of[IO] {
     Ok("I repeat myself when I'm under stress. " * 3)
 }
 
-val request = Request[IO](Method.GET, uri("/"))
+val request = Request[IO](Method.GET, Uri.uri("/"))
 
 // Do not call 'unsafeRun' in your code - see note at bottom.
 val response = service.orNotFound(request).unsafeRunSync

--- a/docs/src/main/tut/hsts.md
+++ b/docs/src/main/tut/hsts.md
@@ -22,6 +22,7 @@ And we need some imports.
 ```tut:silent
 import org.http4s._
 import org.http4s.dsl.io._
+import org.http4s.implicits._
 import cats.effect.IO
 ```
 
@@ -33,7 +34,7 @@ val service = HttpRoutes.of[IO] {
     Ok("ok")
 }
 
-val request = Request[IO](Method.GET, uri("/"))
+val request = Request[IO](Method.GET, Uri.uri("/"))
 
 // Do not call 'unsafeRunSync' in your code
 val response = service.orNotFound(request).unsafeRunSync

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -104,7 +104,7 @@ useful on client requests:
 import org.http4s.client._
 import org.http4s.client.dsl.io._
 
-POST(uri("/hello"), json"""{"name": "Alice"}""").unsafeRunSync
+POST(Uri.uri("/hello"), json"""{"name": "Alice"}""").unsafeRunSync
 ```
 
 ## Encoding case classes as JSON
@@ -159,7 +159,7 @@ and responses for our case classes:
 
 ```tut:book
 Ok(Hello("Alice").asJson).unsafeRunSync
-POST(uri("/hello"), User("Bob").asJson).unsafeRunSync
+POST(Uri.uri("/hello"), User("Bob").asJson).unsafeRunSync
 ```
 
 If within some route we serve json only, we can use:
@@ -185,7 +185,7 @@ response body to JSON using the [`as` syntax]:
 
 ```tut:book
 Ok("""{"name":"Alice"}""").flatMap(_.as[Json]).unsafeRunSync
-POST(uri("/hello"),"""{"name":"Bob"}""").flatMap(_.as[Json]).unsafeRunSync
+POST(Uri.uri("/hello"),"""{"name":"Bob"}""").flatMap(_.as[Json]).unsafeRunSync
 ```
 
 Like sending raw JSON, this is useful to a point, but we typically
@@ -202,7 +202,7 @@ an implicit `Decoder[A]` and makes a `EntityDecoder[A]`:
 ```tut:book
 implicit val userDecoder = jsonOf[IO, User]
 Ok("""{"name":"Alice"}""").flatMap(_.as[User]).unsafeRunSync
-POST(uri("/hello"), """{"name":"Bob"}""").flatMap(_.as[User]).unsafeRunSync
+POST(Uri.uri("/hello"), """{"name":"Bob"}""").flatMap(_.as[User]).unsafeRunSync
 ```
 
 If we are always decoding from JSON to a typed model, we can use
@@ -242,6 +242,7 @@ import io.circe.syntax._
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.io._
+import org.http4s.implicits._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -284,7 +285,7 @@ import fs2.Stream
 // Decode the Hello response
 def helloClient(name: String): Stream[IO, Hello] = {
   // Encode a User request
-  val req = POST(uri("http://localhost:8080/hello"), User(name).asJson)
+  val req = POST(Uri.uri("http://localhost:8080/hello"), User(name).asJson)
   // Create a client
   BlazeClientBuilder[IO](global).stream.flatMap { httpClient =>
     // Decode a Hello response

--- a/docs/src/main/tut/middleware.md
+++ b/docs/src/main/tut/middleware.md
@@ -28,8 +28,8 @@ import cats.data.Kleisli
 import cats.effect._
 import cats.implicits._
 import org.http4s._
-import org.http4s.implicits._
 import org.http4s.dsl.io._
+import org.http4s.implicits._
 ```
 
 Then, we can create a middleware that adds a header to successful responses from
@@ -64,8 +64,8 @@ val service = HttpRoutes.of[IO] {
     Ok()
 }
 
-val goodRequest = Request[IO](Method.GET, uri("/"))
-val badRequest = Request[IO](Method.GET, uri("/bad"))
+val goodRequest = Request[IO](Method.GET, Uri.uri("/"))
+val badRequest = Request[IO](Method.GET, Uri.uri("/bad"))
 
 service.orNotFound(goodRequest).unsafeRunSync
 service.orNotFound(badRequest).unsafeRunSync
@@ -127,7 +127,7 @@ val apiService = HttpRoutes.of[IO] {
 
 val aggregateService = apiService <+> MyMiddle(service, Header("SomeKey", "SomeValue"))
 
-val apiRequest = Request[IO](Method.GET, uri("/api"))
+val apiRequest = Request[IO](Method.GET, Uri.uri("/api"))
 
 aggregateService.orNotFound(goodRequest).unsafeRunSync
 aggregateService.orNotFound(apiRequest).unsafeRunSync

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -176,6 +176,7 @@ import cats.implicits._
 import org.http4s.HttpRoutes
 import org.http4s.syntax._
 import org.http4s.dsl.io._
+import org.http4s.implicits._
 import org.http4s.server.blaze._
 
 object Main extends IOApp {

--- a/docs/src/main/tut/testing.md
+++ b/docs/src/main/tut/testing.md
@@ -22,6 +22,7 @@ import cats.effect._
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.io._
+import org.http4s.implicits._
 
 final case class User(name: String, age: Int) 
 implicit val UserEncoder: Encoder[User] = deriveEncoder[User]

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSpec.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSpec.scala
@@ -9,6 +9,7 @@ import org.http4s.client.{Client, UnexpectedStatus}
 import org.http4s.client.middleware.Metrics
 import org.http4s.dsl.io._
 import org.http4s.metrics.dropwizard.util._
+import org.http4s.Uri.uri
 
 class DropwizardMetricsSpec extends Http4sSpec {
 

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSpec.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSpec.scala
@@ -2,10 +2,11 @@ package org.http4s.metrics.dropwizard
 
 import cats.effect.IO
 import com.codahale.metrics.{MetricRegistry, SharedMetricRegistries}
-import org.http4s.{Http4sSpec, HttpRoutes, Request, Status}
+import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.http4s.metrics.dropwizard.util._
 import org.http4s.server.middleware.Metrics
+import org.http4s.{Http4sSpec, HttpRoutes, Request, Status}
 
 class DropwizardServerMetricsSpec extends Http4sSpec {
 

--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -1,9 +1,9 @@
 package org.http4s.dsl
 
-import org.http4s.{Http4s, Method}
+import org.http4s.{Method, UriFunctions}
 import org.http4s.dsl.impl._
 
-trait Http4sDsl[F[_]] extends Http4s with Methods with Statuses with Responses[F] with Auth {
+trait Http4sDsl[F[_]] extends UriFunctions with Methods with Statuses with Responses[F] with Auth {
   import Http4sDsl._
 
   type Path = impl.Path

--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -1,9 +1,9 @@
 package org.http4s.dsl
 
-import org.http4s.{Method, UriFunctions}
+import org.http4s.Method
 import org.http4s.dsl.impl._
 
-trait Http4sDsl[F[_]] extends UriFunctions with Methods with Statuses with Responses[F] with Auth {
+trait Http4sDsl[F[_]] extends Methods with Statuses with Responses[F] with Auth {
   import Http4sDsl._
 
   type Path = impl.Path

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
@@ -5,6 +5,7 @@ import cats.data.Validated._
 import cats.effect.IO
 import cats.implicits._
 import org.http4s.dsl.io._
+import org.http4s.Uri.uri
 
 object PathInHttpRoutesSpec extends Http4sSpec {
 

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -9,6 +9,7 @@ package dsl
 
 import cats.effect.IO
 import org.http4s.dsl.io._
+import org.http4s.Uri.uri
 
 class PathSpec extends Http4sSpec {
   "Path" should {

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -5,6 +5,7 @@ import cats.implicits._
 import fs2._
 import fs2.concurrent.Queue
 import org.http4s._
+import org.http4s.implicits._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.websocket._

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
@@ -3,7 +3,7 @@ package com.example.http4s.blaze
 import cats.effect._
 import cats.implicits._
 import io.circe.generic.auto._
-import org.http4s.Http4s._
+import org.http4s.Uri
 import org.http4s.Status.{NotFound, Successful}
 import org.http4s.circe._
 import org.http4s.client.Client
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext.global
 object ClientExample extends IOApp {
 
   def getSite(client: Client[IO]): IO[Unit] = IO {
-    val page: IO[String] = client.expect[String](uri("https://www.google.com/"))
+    val page: IO[String] = client.expect[String](Uri.uri("https://www.google.com/"))
 
     for (_ <- 1 to 2)
       println(page.map(_.take(72)).unsafeRunSync()) // each execution of the effect will refetch the page!
@@ -24,7 +24,7 @@ object ClientExample extends IOApp {
     final case class Foo(bar: String)
 
     // Match on response code!
-    val page2 = client.get(uri("http://http4s.org/resources/foo.json")) {
+    val page2 = client.get(Uri.uri("http://http4s.org/resources/foo.json")) {
       case Successful(resp) =>
         // decodeJson is defined for Json4s, Argonuat, and Circe, just need the right decoder!
         resp.decodeJson[Foo].map("Received response: " + _)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
@@ -6,6 +6,7 @@ import org.http4s._
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.dsl.io._
+import org.http4s.Uri.uri
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object ClientPostExample extends IOApp with Http4sClientDsl[IO] {

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/MultipartHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/MultipartHttpEndpoint.scala
@@ -3,6 +3,7 @@ package com.example.http4s.blaze.demo.server.endpoints
 import cats.effect.Sync
 import cats.implicits._
 import com.example.http4s.blaze.demo.server.service.FileService
+import org.http4s.EntityDecoder.multipart
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.multipart.Part

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -53,7 +53,7 @@ class ExampleService[F[_]](implicit F: Effect[F], cs: ContextShift[F]) extends H
 
       case GET -> Root / "redirect" =>
         // Not every response must be Ok using a EntityEncoder: some have meaning only for specific types
-        TemporaryRedirect(Location(uri("/http4s/")))
+        TemporaryRedirect(Location(Uri.uri("/http4s/")))
 
       case GET -> Root / "content-change" =>
         // EntityEncoder typically deals with appropriate headers, but they can be overridden

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSpec.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSpec.scala
@@ -7,6 +7,7 @@ import org.http4s.dsl.io._
 import org.http4s.metrics.prometheus.util._
 import org.http4s.server.middleware.Metrics
 import org.http4s.Method.GET
+import org.http4s.Uri.uri
 
 class PrometheusServerMetricsSpec extends Http4sSpec {
 

--- a/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSpec.scala
+++ b/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSpec.scala
@@ -35,7 +35,7 @@ class ScalatagsSpec extends Http4sSpec {
 
     "render the body" in {
       val resp = Response[IO](Ok).withEntity(testBody())
-      text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
         "<div><p>this is my testBody</p></div>")
     }
   }

--- a/server/src/test/scala/org/http4s/server/HttpRoutesSpec.scala
+++ b/server/src/test/scala/org/http4s/server/HttpRoutesSpec.scala
@@ -3,6 +3,7 @@ package server
 
 import cats.effect._
 import cats.implicits._
+import org.http4s.Uri.uri
 
 class HttpRoutesSpec extends Http4sSpec {
 

--- a/server/src/test/scala/org/http4s/server/MockRoute.scala
+++ b/server/src/test/scala/org/http4s/server/MockRoute.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import org.http4s.Status.{Accepted, Ok}
 import org.http4s.server.middleware.PushSupport._
 
-object MockRoute extends Http4s {
+object MockRoute {
 
   def route(): HttpRoutes[IO] = HttpRoutes.of {
     case req if req.uri.path === "/ping" =>

--- a/server/src/test/scala/org/http4s/server/RouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSpec.scala
@@ -2,6 +2,7 @@ package org.http4s
 package server
 
 import cats.effect._
+import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 
 class RouterSpec extends Http4sSpec {

--- a/server/src/test/scala/org/http4s/server/middleware/AutoSlashSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/AutoSlashSpec.scala
@@ -3,6 +3,7 @@ package org.http4s.server.middleware
 import cats.effect._
 import org.http4s.{Http4sSpec, HttpRoutes, Request, Status}
 import org.http4s.server.{MockRoute, Router}
+import org.http4s.Uri.uri
 
 class AutoSlashSpec extends Http4sSpec {
 

--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
@@ -5,6 +5,7 @@ package middleware
 import cats.effect._
 import fs2.Stream._
 import org.http4s.dsl.io._
+import org.http4s.Uri.uri
 
 class DefaultHeadSpec extends Http4sSpec {
   val app = DefaultHead(HttpRoutes.of[IO] {

--- a/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets
 import org.http4s.server.middleware.EntityLimiter.EntityTooLarge
 import org.http4s.Method._
 import org.http4s.Status._
+import org.http4s.Uri.uri
 
 class EntityLimiterSpec extends Http4sSpec {
 

--- a/server/src/test/scala/org/http4s/server/middleware/HeaderEchoSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HeaderEchoSpec.scala
@@ -3,6 +3,7 @@ package org.http4s.server.middleware
 import cats.effect.IO
 import org.http4s._
 import org.http4s.dsl.io._
+import org.http4s.Uri.uri
 import org.http4s.util.CaseInsensitiveString
 
 class HeaderEchoSpec extends Http4sSpec {

--- a/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/LoggerSpec.scala
@@ -5,6 +5,7 @@ package middleware
 import cats.effect._
 import fs2.io.readInputStream
 import org.http4s.dsl.io._
+import org.http4s.Uri.uri
 import scala.io.Source
 
 /**

--- a/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSpec.scala
@@ -22,7 +22,7 @@ class ResponseTimingSpec extends Http4sSpec {
 
   "ResponseTiming middleware" should {
     "add a custom header with timing info" in {
-      val req = Request[IO](uri = uri("/request"))
+      val req = Request[IO](uri = Uri.uri("/request"))
       val app = ResponseTiming(thisService)
       val res = app(req)
 

--- a/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSpec.scala
@@ -3,6 +3,7 @@ package org.http4s.server.middleware
 import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._
+import org.http4s.Uri.uri
 
 class StaticHeadersSpec extends Http4sSpec {
 

--- a/server/src/test/scala/org/http4s/server/middleware/ThrottleSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ThrottleSpec.scala
@@ -1,15 +1,16 @@
 package org.http4s.server.middleware
 
-import cats.effect.{IO, Timer}
-import cats.effect.laws.util.TestContext
-import org.http4s.{Http4sSpec, HttpApp, Request, Status}
-import cats.implicits._
-import org.http4s.dsl.io._
 import cats.effect.IO.ioEffect
+import cats.effect.laws.util.TestContext
+import cats.effect.{IO, Timer}
+import cats.implicits._
+import org.http4s.Uri.uri
+import org.http4s.dsl.io._
+import org.http4s.server.middleware.Throttle._
+import org.http4s.{Http4sSpec, HttpApp, Request, Status}
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import scala.concurrent.duration._
-import org.specs2.concurrent.ExecutionEnv
-import Throttle._
 
 class ThrottleSpec(implicit ee: ExecutionEnv) extends Http4sSpec with FutureMatchers {
   "LocalTokenBucket" should {

--- a/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/TimeoutSpec.scala
@@ -7,6 +7,7 @@ import cats.effect._
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 import org.http4s.dsl.io._
+import org.http4s.Uri.uri
 import scala.concurrent.duration._
 
 class TimeoutSpec extends Http4sSpec {

--- a/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/VirtualHostSpec.scala
@@ -5,8 +5,9 @@ package middleware
 import cats.effect._
 import cats.syntax.applicative._
 import org.http4s.Method._
-import org.http4s.headers.Host
 import org.http4s.Status.{BadRequest, NotFound, Ok}
+import org.http4s.Uri.uri
+import org.http4s.headers.Host
 
 class VirtualHostSpec extends Http4sSpec {
 

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSpec.scala
@@ -5,6 +5,7 @@ package staticcontent
 import cats.effect._
 import fs2._
 import java.io.File
+import org.http4s.Uri.uri
 import org.http4s.server.middleware.TranslateUri
 
 class FileServiceSpec extends Http4sSpec with StaticContentShared {

--- a/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSpec.scala
@@ -5,6 +5,7 @@ package staticcontent
 import cats.effect._
 import org.http4s.headers.{`Accept-Encoding`, `If-Modified-Since`}
 import org.http4s.server.middleware.TranslateUri
+import org.http4s.Uri.uri
 
 class ResourceServiceSpec extends Http4sSpec with StaticContentShared {
 

--- a/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSpec.scala
@@ -4,6 +4,7 @@ package staticcontent
 
 import cats.effect._
 import org.http4s.Method.{GET, POST}
+import org.http4s.Uri.uri
 import org.http4s.server.staticcontent.WebjarService.Config
 
 object WebjarServiceSpec extends Http4sSpec with StaticContentShared {

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -40,7 +40,6 @@ trait Http4sSpec
     with AnyMatchers
     with OptionMatchers
     with syntax.AllSyntax
-    with UriFunctions
     with EntityDecoderInstances
     with EntityEncoderInstances
     with ArbitraryInstances

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -40,8 +40,6 @@ trait Http4sSpec
     with AnyMatchers
     with OptionMatchers
     with syntax.AllSyntax
-    with EntityDecoderInstances
-    with EntityEncoderInstances
     with ArbitraryInstances
     with FragmentsDsl
     with Discipline

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -39,7 +39,10 @@ trait Http4sSpec
     with ScalaCheck
     with AnyMatchers
     with OptionMatchers
-    with Http4s
+    with syntax.AllSyntax
+    with UriFunctions
+    with EntityDecoderInstances
+    with EntityEncoderInstances
     with ArbitraryInstances
     with FragmentsDsl
     with Discipline

--- a/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
@@ -48,7 +48,7 @@ class ContentCodingSpec extends Http4sSpec {
       ContentCoding.parse("mycoding") must_== ContentCoding.fromString("mycoding")
     }
     "parse with quality" in {
-      ContentCoding.parse("gzip;q=0.8") must_== Right(ContentCoding.gzip.withQValue(q(0.8)))
+      ContentCoding.parse("gzip;q=0.8") must_== Right(ContentCoding.gzip.withQValue(QValue.q(0.8)))
     }
     "fail on empty" in {
       ContentCoding.parse("") must beLeft
@@ -65,7 +65,7 @@ class ContentCodingSpec extends Http4sSpec {
       ContentCoding.parse("*fahon") must_== ParseResult.success(
         ContentCoding.unsafeFromString("*fahon"))
       ContentCoding.parse("*fahon;q=0.1") must_== ParseResult.success(
-        ContentCoding.unsafeFromString("*fahon").withQValue(q(0.1)))
+        ContentCoding.unsafeFromString("*fahon").withQValue(QValue.q(0.1)))
     }
   }
 

--- a/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -370,7 +370,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
       val tmpFile = File.createTempFile("foo", "bar")
       try {
         val response = mockServe(Request()) { req =>
-          req.decodeWith(textFile(tmpFile, testBlockingExecutionContext), strict = false) { _ =>
+          req.decodeWith(EntityDecoder.textFile(tmpFile, testBlockingExecutionContext), strict = false) { _ =>
             Response[IO](Ok).withEntity("Hello").pure[IO]
           }
         }.unsafeRunSync
@@ -389,7 +389,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
       try {
         val response = mockServe(Request()) {
           case req =>
-            req.decodeWith(binFile(tmpFile, testBlockingExecutionContext), strict = false) { _ =>
+            req.decodeWith(EntityDecoder.binFile(tmpFile, testBlockingExecutionContext), strict = false) { _ =>
               Response[IO](Ok).withEntity("Hello").pure[IO]
             }
         }.unsafeRunSync
@@ -407,7 +407,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
   "binary EntityDecoder" should {
     "yield an empty array on a bodyless message" in {
       val msg = Request[IO]()
-      binary[IO].decode(msg, strict = false) must returnRight(Chunk.empty[Byte])
+      EntityDecoder.binary[IO].decode(msg, strict = false) must returnRight(Chunk.empty[Byte])
     }
 
     "concat Chunks" in {
@@ -415,11 +415,11 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
       val body = chunk(Chunk.bytes(d1)) ++ chunk(Chunk.bytes(d2))
       val msg = Request[IO](body = body)
       val expected = Chunk.bytes(Array[Byte](1, 2, 3, 4, 5, 6))
-      binary[IO].decode(msg, strict = false) must returnRight(expected)
+      EntityDecoder.binary[IO].decode(msg, strict = false) must returnRight(expected)
     }
 
     "Match any media type" in {
-      binary[IO].matchesMediaType(MediaType.text.plain) must_== true
+      EntityDecoder.binary[IO].matchesMediaType(MediaType.text.plain) must_== true
     }
   }
 

--- a/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -370,7 +370,9 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
       val tmpFile = File.createTempFile("foo", "bar")
       try {
         val response = mockServe(Request()) { req =>
-          req.decodeWith(EntityDecoder.textFile(tmpFile, testBlockingExecutionContext), strict = false) { _ =>
+          req.decodeWith(
+            EntityDecoder.textFile(tmpFile, testBlockingExecutionContext),
+            strict = false) { _ =>
             Response[IO](Ok).withEntity("Hello").pure[IO]
           }
         }.unsafeRunSync
@@ -389,7 +391,9 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
       try {
         val response = mockServe(Request()) {
           case req =>
-            req.decodeWith(EntityDecoder.binFile(tmpFile, testBlockingExecutionContext), strict = false) { _ =>
+            req.decodeWith(
+              EntityDecoder.binFile(tmpFile, testBlockingExecutionContext),
+              strict = false) { _ =>
               Response[IO](Ok).withEntity("Hello").pure[IO]
             }
         }.unsafeRunSync

--- a/tests/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/tests/src/test/scala/org/http4s/ResponderSpec.scala
@@ -2,7 +2,7 @@ package org.http4s
 
 import cats.effect.IO
 import org.http4s.Charset._
-import org.http4s.Http4s._
+import org.http4s.implicits._
 import org.http4s.headers._
 import org.specs2.mutable.Specification
 

--- a/tests/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptEncodingSpec.scala
@@ -2,7 +2,6 @@ package org.http4s
 package parser
 
 import org.http4s.headers.`Accept-Encoding`
-import org.http4s.Http4s._
 import org.specs2.mutable.Specification
 
 class AcceptEncodingSpec extends Specification with HeaderParserHelper[`Accept-Encoding`] {
@@ -10,11 +9,11 @@ class AcceptEncodingSpec extends Specification with HeaderParserHelper[`Accept-E
     HttpHeaderParser.ACCEPT_ENCODING(value)
 
   val gzip = `Accept-Encoding`(ContentCoding.gzip)
-  val gzip5 = `Accept-Encoding`(ContentCoding.gzip.withQValue(q(0.5)))
-  val gzip55 = `Accept-Encoding`(ContentCoding.gzip.withQValue(q(0.55)))
-  val gzip555 = `Accept-Encoding`(ContentCoding.gzip.withQValue(q(0.555)))
+  val gzip5 = `Accept-Encoding`(ContentCoding.gzip.withQValue(QValue.q(0.5)))
+  val gzip55 = `Accept-Encoding`(ContentCoding.gzip.withQValue(QValue.q(0.55)))
+  val gzip555 = `Accept-Encoding`(ContentCoding.gzip.withQValue(QValue.q(0.555)))
 
-  val gzip1 = `Accept-Encoding`(ContentCoding.gzip.withQValue(q(1.0)))
+  val gzip1 = `Accept-Encoding`(ContentCoding.gzip.withQValue(QValue.q(1.0)))
 
   "Accept-Encoding parser" should {
 

--- a/tests/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
@@ -64,7 +64,8 @@ class AcceptHeaderSpec extends Specification with HeaderParserHelper[Accept] {
 
       // Go through all of them with q and extensions
       {
-        val samples = MediaRange.standard.values.map(_.withExtensions(ext).withQValue(QValue.q(0.2)))
+        val samples =
+          MediaRange.standard.values.map(_.withExtensions(ext).withQValue(QValue.q(0.2)))
         foreach(samples.sliding(4).toArray) { sample =>
           val h = Accept(sample.head, sample.tail.toSeq: _*)
           parse(h.value) must be_===(h)

--- a/tests/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
@@ -1,14 +1,14 @@
 package org.http4s
 package parser
 
-import org.http4s.headers.{Accept, MediaRangeAndQValue}
+import cats.syntax.show._
 import org.http4s.MediaRange._
 import org.http4s.MediaType._
+import org.http4s.headers.{Accept, MediaRangeAndQValue}
 import org.http4s.testing._
-import cats.syntax.show._
 import org.specs2.mutable.Specification
 
-class AcceptHeaderSpec extends Specification with HeaderParserHelper[Accept] with Http4s {
+class AcceptHeaderSpec extends Specification with HeaderParserHelper[Accept] {
   def hparse(value: String): ParseResult[Accept] = HttpHeaderParser.ACCEPT(value)
 
   def ext = Map("foo" -> "bar", "baz" -> "whatever")
@@ -50,7 +50,7 @@ class AcceptHeaderSpec extends Specification with HeaderParserHelper[Accept] wit
       val accept = Accept(`audio/*`, `video/*`)
       parse(accept.value) must be_===(accept)
 
-      val accept2 = Accept(`audio/*`.withQValue(q(0.2)), `video/*`)
+      val accept2 = Accept(`audio/*`.withQValue(QValue.q(0.2)), `video/*`)
       parse(accept2.value) must be_===(accept2)
 
       // Go through all of them
@@ -64,7 +64,7 @@ class AcceptHeaderSpec extends Specification with HeaderParserHelper[Accept] wit
 
       // Go through all of them with q and extensions
       {
-        val samples = MediaRange.standard.values.map(_.withExtensions(ext).withQValue(q(0.2)))
+        val samples = MediaRange.standard.values.map(_.withExtensions(ext).withQValue(QValue.q(0.2)))
         foreach(samples.sliding(4).toArray) { sample =>
           val h = Accept(sample.head, sample.tail.toSeq: _*)
           parse(h.value) must be_===(h)
@@ -90,13 +90,13 @@ class AcceptHeaderSpec extends Specification with HeaderParserHelper[Accept] wit
       val value = "text/*;q=0.3, text/html;q=0.7, text/html;level=1"
       parse(value) must be_===(
         Accept(
-          `text/*`.withQValue(q(0.3)),
-          MediaType.text.html.withQValue(q(0.7)),
+          `text/*`.withQValue(QValue.q(0.3)),
+          MediaType.text.html.withQValue(QValue.q(0.7)),
           MediaType.text.html.withExtensions(Map("level" -> "1"))
         ))
 
       // Go through all of them
-      val samples = MediaType.all.values.map(_.withExtensions(ext).withQValue(q(0.2)))
+      val samples = MediaType.all.values.map(_.withExtensions(ext).withQValue(QValue.q(0.2)))
       foreach(samples.sliding(4).toArray) { sample =>
         val h = Accept(sample.head, sample.tail.toSeq: _*)
         parse(h.value) must be_===(h)

--- a/tests/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
@@ -4,9 +4,7 @@ package parser
 import org.http4s.headers.`Accept-Language`
 import org.specs2.mutable.Specification
 
-class AcceptLanguageSpec
-    extends Specification
-    with HeaderParserHelper[`Accept-Language`] {
+class AcceptLanguageSpec extends Specification with HeaderParserHelper[`Accept-Language`] {
 
   def hparse(value: String): ParseResult[`Accept-Language`] =
     HttpHeaderParser.ACCEPT_LANGUAGE(value)

--- a/tests/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptLanguageSpec.scala
@@ -6,15 +6,14 @@ import org.specs2.mutable.Specification
 
 class AcceptLanguageSpec
     extends Specification
-    with HeaderParserHelper[`Accept-Language`]
-    with Http4s {
+    with HeaderParserHelper[`Accept-Language`] {
 
   def hparse(value: String): ParseResult[`Accept-Language`] =
     HttpHeaderParser.ACCEPT_LANGUAGE(value)
 
   val en = `Accept-Language`(LanguageTag("en"))
   val fr = `Accept-Language`(LanguageTag("fr"))
-  val enq5 = `Accept-Language`(LanguageTag("en").withQValue(q(0.5)))
+  val enq5 = `Accept-Language`(LanguageTag("en").withQValue(QValue.q(0.5)))
   val en_cool = `Accept-Language`(LanguageTag("en", "cool"))
 
   val all = `Accept-Language`(LanguageTag.`*`)

--- a/tests/src/test/scala/org/http4s/parser/MediaRangeSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/MediaRangeSpec.scala
@@ -6,7 +6,7 @@ import org.http4s.MediaType
 import org.http4s.testing._
 import org.specs2.mutable.Specification
 
-class MediaRangeSpec extends Specification with Http4s {
+class MediaRangeSpec extends Specification {
   def ext = Map("foo" -> "bar")
 
   "MediaRanges" should {
@@ -27,8 +27,8 @@ class MediaRangeSpec extends Specification with Http4s {
     }
 
     "Be satisfiedBy MediaTypes correctly" in {
-      `text/*`.satisfiedBy(MediaType.text css) must be_==(true)
-      `text/*`.satisfiedBy(MediaType.text css) must be_==(true)
+      `text/*`.satisfiedBy(MediaType.text.css) must be_==(true)
+      `text/*`.satisfiedBy(MediaType.text.css) must be_==(true)
       `text/*`.satisfiedBy(`audio/aiff`) must be_==(false)
     }
 
@@ -45,14 +45,14 @@ class MediaRangeSpec extends Specification with Http4s {
 
       MediaType.text.html.withExtensions(ext) must be_!=(MediaType.text.html)
 
-      MediaType.text.html must be_!=(MediaType.text css)
+      MediaType.text.html must be_!=(MediaType.text.css)
     }
 
     "Be satisfiedBy MediaTypes correctly" in {
-      MediaType.text.html.satisfiedBy(MediaType.text css) must be_==(false)
+      MediaType.text.html.satisfiedBy(MediaType.text.css) must be_==(false)
       MediaType.text.html.satisfiedBy(MediaType.text.html) must be_==(true)
 
-      MediaType.text.html.satisfies(MediaType.text css) must be_==(false)
+      MediaType.text.html.satisfies(MediaType.text.css) must be_==(false)
     }
 
     "Not be satisfied by MediaRanges" in {

--- a/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
+++ b/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
@@ -22,7 +22,7 @@ class TwirlSpec extends Http4sSpec {
   "HTML encoder" should {
     "return Content-Type text/html with proper charset" in prop { implicit cs: Charset =>
       val headers = EntityEncoder[IO, Html].headers
-      headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.text.html, Some(cs)))
+      headers.get(`Content-Type`) must beSome(`Content-Type`(MediaType.text.html, Some(cs)))
     }
 
     "render the body" in prop { implicit cs: Charset =>
@@ -35,8 +35,7 @@ class TwirlSpec extends Http4sSpec {
     "return Content-Type application/javascript with proper charset" in prop {
       implicit cs: Charset =>
         val headers = EntityEncoder[IO, JavaScript].headers
-        headers.get(`Content-Type`) must_== Some(
-          `Content-Type`(MediaType.application.javascript, Some(cs)))
+        headers.get(`Content-Type`) must beSome(`Content-Type`(MediaType.application.javascript, Some(cs)))
     }
 
     "render the body" in prop { implicit cs: Charset =>
@@ -48,7 +47,7 @@ class TwirlSpec extends Http4sSpec {
   "Text encoder" should {
     "return Content-Type text/plain with proper charset" in prop { implicit cs: Charset =>
       val headers = EntityEncoder[IO, Txt].headers
-      headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.text.plain, Some(cs)))
+      headers.get(`Content-Type`) must beSome(`Content-Type`(MediaType.text.plain, Some(cs)))
     }
 
     "render the body" in prop { implicit cs: Charset =>
@@ -60,7 +59,7 @@ class TwirlSpec extends Http4sSpec {
   "XML encoder" should {
     "return Content-Type application/xml with proper charset" in prop { implicit cs: Charset =>
       val headers = EntityEncoder[IO, Xml].headers
-      headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.application.xml, Some(cs)))
+      headers.get(`Content-Type`) must beSome(`Content-Type`(MediaType.application.xml, Some(cs)))
     }
 
     "render the body" in prop { implicit cs: Charset =>

--- a/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
+++ b/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
@@ -27,7 +27,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(html.test())
-      text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("<h1>test html</h1>")
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("<h1>test html</h1>")
     }
   }
 
@@ -40,7 +40,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(js.test())
-      text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(""""test js"""")
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(""""test js"""")
     }
   }
 
@@ -52,7 +52,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(txt.test())
-      text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("""test text""")
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("""test text""")
     }
   }
 
@@ -64,7 +64,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(_root_.xml.test())
-      text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
         "<test>test xml</test>")
     }
   }

--- a/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
+++ b/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
@@ -27,7 +27,8 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(html.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("<h1>test html</h1>")
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+        "<h1>test html</h1>")
     }
   }
 
@@ -35,12 +36,14 @@ class TwirlSpec extends Http4sSpec {
     "return Content-Type application/javascript with proper charset" in prop {
       implicit cs: Charset =>
         val headers = EntityEncoder[IO, JavaScript].headers
-        headers.get(`Content-Type`) must beSome(`Content-Type`(MediaType.application.javascript, Some(cs)))
+        headers.get(`Content-Type`) must beSome(
+          `Content-Type`(MediaType.application.javascript, Some(cs)))
     }
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(js.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(""""test js"""")
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+        """"test js"""")
     }
   }
 
@@ -52,7 +55,8 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(txt.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight("""test text""")
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+        """test text""")
     }
   }
 


### PR DESCRIPTION
Continuing on from the discussions in #2203, this PR is an exploration that does the following:

- Deprecates `Http4s`, `Http4sInstances`, and `Http4sFunctions`
- Moves instances for cats typeclasses into the corresponding classes' companion objects
- Makes `Http4sDsl` extends `UriFunctions`, `EntityEncoderInstances` and `EntityDecoderInstances` instead of `Http4s`*
- Updates tests and examples

I put the single function in `QValueFunctions` into the `QValue` object. I wanted to do the same for `UriFunctions`, but `Uri.uri` is used in a lot of places and examples unqualified, so I kept it and added it to the DSL and some test traits (but moved the two other functions in the trait).
If the DSL should still bring in the `uri` function, that could be solved by adding it directly in the DSL trait (since it's a macro invocation, it can't just be called), so the `UriFunctions` trait could be removed.

`EntityEncoderInstances` and `EntityDecoderInstances` are mixed into the DSL, but when not using that, getting both of them in scope requires imports. I'm fine with that, and I think I might even prefer imports.

Since some of the traits mixed into the deprecated traits have been removed, it might cause breaking changes, but there will be a deprecation notice at least.

Closes #2203