### PR TITLE
Remove MiMa exceptions on 0.19

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -84,10 +84,6 @@ object Http4sPlugin extends AutoPlugin {
 
     http4sMimaVersion := {
       version.value match {
-        case VersionNumber(Seq(0, 19, patch), _, _) if patch.toInt > 1 =>
-          Some(s"0.19.${patch.toInt - 1}")
-        case VersionNumber(Seq(0, 19, _), _, _) =>
-          None
         case VersionNumber(Seq(major, minor, patch), _, _) if patch.toInt > 0 =>
           Some(s"${major}.${minor}.${patch.toInt - 1}")
         case _ =>


### PR DESCRIPTION
We decided to open an 0.20 series instead, so we don't need this cruft anymore.