### PR TITLE
add method to set max header length to BlazeClientBuilder

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -76,6 +76,9 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   def withResponseHeaderTimeout(responseHeaderTimeout: Duration): BlazeClientBuilder[F] =
     copy(responseHeaderTimeout = responseHeaderTimeout)
 
+  def withMaxHeaderLength(maxHeaderLength: Int): BlazeClientBuilder[F] =
+    copy(maxHeaderLength = maxHeaderLength)
+
   def withIdleTimeout(idleTimeout: Duration): BlazeClientBuilder[F] =
     copy(idleTimeout = idleTimeout)
 

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientBuilderSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientBuilderSpec.scala
@@ -56,6 +56,11 @@ class BlazeClientBuilderSpec extends Http4sSpec {
         .withSocketSendBufferSize(4096)
         .socketSendBufferSize must beSome(4096)
     }
+  }
 
+  "Header options" should {
+    "set header max length" in {
+      builder.withMaxHeaderLength(64).maxHeaderLength must_== 64
+    }
   }
 }


### PR DESCRIPTION
fixes: #2217