### PR TITLE
Define an allocated that doesn't hang on failure

### DIFF
--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -4,12 +4,11 @@ package client
 import cats._
 import cats.data.{Kleisli, OptionT}
 import cats.effect._
-import cats.effect.implicits._
 import cats.implicits._
 import fs2._
 import org.http4s.Status.Successful
 import org.http4s.headers.{Accept, MediaRangeAndQValue}
-import scala.annotation.tailrec
+import org.http4s.internal.allocated
 
 private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwable])
     extends Client[F] {
@@ -62,45 +61,9 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     * signatures guarantee disposal of the HTTP connection.
     */
   def toHttpApp: HttpApp[F] = Kleisli { req =>
-    /* Derived from https://github.com/typelevel/cats-effect/blob/c62c6c76b3066c500fca2f9e0897605bc12eb2a0/core/shared/src/main/scala/cats/effect/Resource.scala */
-
-    // Indirection for calling `loop` needed because `loop` must be @tailrec
-    def continue(
-        current: Resource[F, Any],
-        stack: List[Any => Resource[F, Any]],
-        release: F[Unit]): F[(Any, F[Unit])] =
-      loop(current, stack, release)
-
-    // Interpreter that knows how to evaluate a Resource data structure;
-    // Maintains its own stack for dealing with Bind chains
-    @tailrec def loop(
-        current: Resource[F, Any],
-        stack: List[Any => Resource[F, Any]],
-        release: F[Unit]): F[(Any, F[Unit])] =
-      current match {
-        case Resource.Allocate(resource) =>
-          F.bracketCase(resource) {
-            case (a, rel) =>
-              stack match {
-                case Nil => F.pure(a -> rel(ExitCase.Completed).guarantee(release))
-                case f0 :: xs => continue(f0(a), xs, rel(ExitCase.Completed).guarantee(release))
-              }
-          } {
-            case (_, ExitCase.Completed) =>
-              F.unit
-            case ((_, release), ec) =>
-              release(ec)
-          }
-        case Resource.Bind(source, f0) =>
-          loop(source, f0.asInstanceOf[Any => Resource[F, Any]] :: stack, release)
-        case Resource.Suspend(resource) =>
-          resource.flatMap(continue(_, stack, release))
-      }
-
-    loop(run(req).asInstanceOf[Resource[F, Any]], Nil, F.unit).map {
-      case (a, release) =>
-        val resp = a.asInstanceOf[Response[F]]
-        resp.copy(body = resp.body.onFinalize(release))
+    allocated(run(req)).map {
+      case (resp, release) =>
+        resp.withBodyStream(resp.body.onFinalize(release))
     }
   }
 

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -1,9 +1,9 @@
 package org.http4s
 
 import cats.effect._
-import cats.effect.concurrent.Deferred
 import cats.effect.implicits._
 import cats.implicits._
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import org.http4s.util.execution.direct
 import org.log4s.Logger
@@ -121,12 +121,45 @@ package object internal {
     }
 
   private[http4s] def allocated[F[_], A](resource: Resource[F, A])(
-      implicit F: Concurrent[F]): F[(A, F[Unit])] =
-    Deferred[F, A].flatMap { deferred =>
-      Deferred[F, Unit].flatMap { shutdown =>
-        resource.use { client =>
-          deferred.complete(client) >> shutdown.get
-        }.start >> deferred.get.map((_, shutdown.complete(())))
+      implicit F: Bracket[F, Throwable]): F[(A, F[Unit])] = {
+    /* Derived from https://github.com/typelevel/cats-effect/blob/c62c6c76b3066c500fca2f9e0897605bc12eb2a0/core/shared/src/main/scala/cats/effect/Resource.scala */
+
+    // Indirection for calling `loop` needed because `loop` must be @tailrec
+    def continue(
+        current: Resource[F, Any],
+        stack: List[Any => Resource[F, Any]],
+        release: F[Unit]): F[(Any, F[Unit])] =
+      loop(current, stack, release)
+
+    // Interpreter that knows how to evaluate a Resource data structure;
+    // Maintains its own stack for dealing with Bind chains
+    @tailrec def loop(
+        current: Resource[F, Any],
+        stack: List[Any => Resource[F, Any]],
+        release: F[Unit]): F[(Any, F[Unit])] =
+      current match {
+        case Resource.Allocate(resource) =>
+          F.bracketCase(resource) {
+            case (a, rel) =>
+              stack match {
+                case Nil => F.pure(a -> rel(ExitCase.Completed).guarantee(release))
+                case f0 :: xs => continue(f0(a), xs, rel(ExitCase.Completed).guarantee(release))
+              }
+          } {
+            case (_, ExitCase.Completed) =>
+              F.unit
+            case ((_, release), ec) =>
+              release(ec)
+          }
+        case Resource.Bind(source, f0) =>
+          loop(source, f0.asInstanceOf[Any => Resource[F, Any]] :: stack, release)
+        case Resource.Suspend(resource) =>
+          resource.flatMap(continue(_, stack, release))
       }
+
+    loop(resource.asInstanceOf[Resource[F, Any]], Nil, F.unit).map {
+      case (a, release) =>
+        (a.asInstanceOf[A], release)
     }
+  }
 }

--- a/tests/src/test/scala/org/http4s/internal/AllocatedSpec.scala
+++ b/tests/src/test/scala/org/http4s/internal/AllocatedSpec.scala
@@ -1,0 +1,31 @@
+package org.http4s
+package internal
+
+import cats.effect.{IO, Resource}
+import cats.effect.laws.discipline.arbitrary._
+import cats.implicits._
+import java.util.concurrent.atomic.AtomicBoolean
+import org.scalacheck.{Arbitrary, Gen}
+
+class AllocatedSpec extends Http4sSpec {
+  "allocated" should {
+    "allocate same value as the resource" in prop { resource: Resource[IO, Int] =>
+      (for {
+        a0 <- Resource(allocated(resource)).use(IO.pure).attempt
+        a1 <- resource.use(IO.pure).attempt
+      } yield a0 must_== a1).unsafeRunSync()
+    }
+
+    "not release until close is invoked" in {
+      val released = new AtomicBoolean(false)
+      prop { resource: Resource[IO, Int] =>
+        released.set(false)
+        (for {
+          att <- allocated(resource).attempt
+          _ <- IO(released.get() must beFalse)
+          a0 <- att.fold(_ => IO.pure(ok), _._2 >> IO(released.get() must beTrue))
+        } yield a0).unsafeRunSync()
+      }.setGen(genResource(implicitly, implicitly, Arbitrary(Gen.const(IO(released.set(true))))))
+    }
+  }
+}


### PR DESCRIPTION
My definition of `allocated` wasn't as clever as I thought it was.  Centralized the bulky interpreter in our internal package for eventual contribution to cats-effect.