### PR TITLE
Only add the idle timeout stage when idleTimeout is finite

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/IdleTimeoutStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/IdleTimeoutStage.scala
@@ -7,10 +7,10 @@ import org.http4s.blaze.pipeline.MidStage
 import org.http4s.blaze.util.{Cancelable, TickWheelExecutor}
 import org.log4s.getLogger
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 final private[http4s] class IdleTimeoutStage[A](
-    timeout: Duration,
+    timeout: FiniteDuration,
     cb: Callback[TimeoutException],
     exec: TickWheelExecutor,
     ec: ExecutionContext)


### PR DESCRIPTION
When debug logging is on, an infinite idleTimeout crashes, and an infinite idle timeout is useless anyway.