### PR TITLE
Remove or privatize server builder *support traits

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -69,11 +69,7 @@ class BlazeBuilder[F[_]](
     serviceErrorHandler: ServiceErrorHandler[F],
     banner: immutable.Seq[String]
 )(implicit protected val F: ConcurrentEffect[F], timer: Timer[F])
-    extends ServerBuilder[F]
-    with IdleTimeoutSupport[F]
-    with SSLKeyStoreSupport[F]
-    with SSLContextSupport[F]
-    with server.WebSocketSupport[F] {
+    extends ServerBuilder[F] {
   type Self = BlazeBuilder[F]
 
   private[this] val logger = getLogger
@@ -124,17 +120,17 @@ class BlazeBuilder[F[_]](
       maxHeadersLen: Int = maxHeadersLen): Self =
     copy(maxRequestLineLen = maxRequestLineLen, maxHeadersLen = maxHeadersLen)
 
-  override def withSSL(
+  def withSSL(
       keyStore: StoreInfo,
       keyManagerPassword: String,
-      protocol: String,
-      trustStore: Option[StoreInfo],
-      clientAuth: Boolean): Self = {
+      protocol: String = "TLS",
+      trustStore: Option[StoreInfo] = None,
+      clientAuth: Boolean = false): Self = {
     val bits = KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)
     copy(sslBits = Some(bits))
   }
 
-  override def withSSLContext(sslContext: SSLContext, clientAuth: Boolean): Self =
+  def withSSLContext(sslContext: SSLContext, clientAuth: Boolean = false): Self =
     copy(sslBits = Some(SSLContextBits(sslContext, clientAuth)))
 
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
@@ -143,7 +139,7 @@ class BlazeBuilder[F[_]](
   def withExecutionContext(executionContext: ExecutionContext): BlazeBuilder[F] =
     copy(executionContext = executionContext)
 
-  override def withIdleTimeout(idleTimeout: Duration): Self = copy(idleTimeout = idleTimeout)
+  def withIdleTimeout(idleTimeout: Duration): Self = copy(idleTimeout = idleTimeout)
 
   def withConnectorPoolSize(size: Int): Self = copy(connectorPoolSize = size)
 
@@ -151,7 +147,7 @@ class BlazeBuilder[F[_]](
 
   def withNio2(isNio2: Boolean): Self = copy(isNio2 = isNio2)
 
-  override def withWebSockets(enableWebsockets: Boolean): Self =
+  def withWebSockets(enableWebsockets: Boolean): Self =
     copy(enableWebSockets = enableWebsockets)
 
   def enableHttp2(enabled: Boolean): Self = copy(http2Support = enabled)

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -74,11 +74,7 @@ class BlazeServerBuilder[F[_]](
     serviceErrorHandler: ServiceErrorHandler[F],
     banner: immutable.Seq[String]
 )(implicit protected val F: ConcurrentEffect[F], timer: Timer[F])
-    extends ServerBuilder[F]
-    with IdleTimeoutSupport[F]
-    with SSLKeyStoreSupport[F]
-    with SSLContextSupport[F]
-    with server.WebSocketSupport[F] {
+    extends ServerBuilder[F] {
   type Self = BlazeServerBuilder[F]
 
   private[this] val logger = getLogger
@@ -131,17 +127,17 @@ class BlazeServerBuilder[F[_]](
       maxHeadersLen: Int = maxHeadersLen): Self =
     copy(maxRequestLineLen = maxRequestLineLen, maxHeadersLen = maxHeadersLen)
 
-  override def withSSL(
+  def withSSL(
       keyStore: StoreInfo,
       keyManagerPassword: String,
-      protocol: String,
-      trustStore: Option[StoreInfo],
-      clientAuth: Boolean): Self = {
+      protocol: String = "TLS",
+      trustStore: Option[StoreInfo] = None,
+      clientAuth: Boolean = false): Self = {
     val bits = KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)
     copy(sslBits = Some(bits))
   }
 
-  override def withSSLContext(sslContext: SSLContext, clientAuth: Boolean): Self =
+  def withSSLContext(sslContext: SSLContext, clientAuth: Boolean = false): Self =
     copy(sslBits = Some(SSLContextBits(sslContext, clientAuth)))
 
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
@@ -150,7 +146,7 @@ class BlazeServerBuilder[F[_]](
   def withExecutionContext(executionContext: ExecutionContext): BlazeServerBuilder[F] =
     copy(executionContext = executionContext)
 
-  override def withIdleTimeout(idleTimeout: Duration): Self = copy(idleTimeout = idleTimeout)
+  def withIdleTimeout(idleTimeout: Duration): Self = copy(idleTimeout = idleTimeout)
 
   def withResponseHeaderTimeout(responseHeaderTimeout: Duration): Self =
     copy(responseHeaderTimeout = responseHeaderTimeout)
@@ -161,7 +157,7 @@ class BlazeServerBuilder[F[_]](
 
   def withNio2(isNio2: Boolean): Self = copy(isNio2 = isNio2)
 
-  override def withWebSockets(enableWebsockets: Boolean): Self =
+  def withWebSockets(enableWebsockets: Boolean): Self =
     copy(enableWebSockets = enableWebsockets)
 
   def enableHttp2(enabled: Boolean): Self = copy(http2Support = enabled)
@@ -327,10 +323,10 @@ class BlazeServerBuilder[F[_]](
 object BlazeServerBuilder {
   def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F]): BlazeServerBuilder[F] =
     new BlazeServerBuilder(
-      socketAddress = ServerBuilder.DefaultSocketAddress,
+      socketAddress = defaults.SocketAddress,
       executionContext = ExecutionContext.global,
       responseHeaderTimeout = 1.minute,
-      idleTimeout = IdleTimeoutSupport.DefaultIdleTimeout,
+      idleTimeout = defaults.IdleTimeout,
       isNio2 = false,
       connectorPoolSize = channel.DefaultPoolSize,
       bufferSize = 64 * 1024,
@@ -341,7 +337,7 @@ object BlazeServerBuilder {
       maxHeadersLen = 40 * 1024,
       httpApp = defaultApp[F],
       serviceErrorHandler = DefaultServiceErrorHandler[F],
-      banner = ServerBuilder.DefaultBanner
+      banner = defaults.Banner
     )
 
   private def defaultApp[F[_]: Applicative]: HttpApp[F] =

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -10,23 +10,20 @@ import java.net.{InetAddress, InetSocketAddress}
 import javax.net.ssl.SSLContext
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import scala.collection.immutable
-import scala.concurrent.duration._
 
-trait ServerBuilder[F[_]] {
-  import ServerBuilder._
-
+private[http4s] trait ServerBuilder[F[_]] {
   type Self <: ServerBuilder[F]
 
   protected implicit def F: Concurrent[F]
 
   def bindSocketAddress(socketAddress: InetSocketAddress): Self
 
-  final def bindHttp(port: Int = DefaultHttpPort, host: String = DefaultHost): Self =
+  final def bindHttp(port: Int = defaults.HttpPort, host: String = defaults.Host): Self =
     bindSocketAddress(InetSocketAddress.createUnresolved(host, port))
 
-  final def bindLocal(port: Int): Self = bindHttp(port, DefaultHost)
+  final def bindLocal(port: Int): Self = bindHttp(port, defaults.Host)
 
-  final def bindAny(host: String = DefaultHost): Self = bindHttp(0, host)
+  final def bindAny(host: String = defaults.Host): Self = bindHttp(0, host)
 
   /** Sets the handler for errors thrown invoking the service.  Is not
     * guaranteed to be invoked on errors on the server backend, such as
@@ -74,31 +71,26 @@ trait ServerBuilder[F[_]] {
 }
 
 object ServerBuilder {
-  // Defaults for core server builder functionality
+  @deprecated("Use InetAddress.getLoopbackAddress.getHostAddress", "0.20.0-M2")
   val LoopbackAddress = InetAddress.getLoopbackAddress.getHostAddress
-  val DefaultHost = LoopbackAddress
-  val DefaultHttpPort = 8080
-  val DefaultSocketAddress = InetSocketAddress.createUnresolved(DefaultHost, DefaultHttpPort)
-  val DefaultBanner =
-    """|  _   _   _        _ _     
-       | | |_| |_| |_ _ __| | | ___
-       | | ' \  _|  _| '_ \_  _(_-<
-       | |_||_\__|\__| .__/ |_|/__/
-       |             |_|""".stripMargin.split("\n").toList
+  @deprecated("Use org.http4s.server.defaults.Host", "0.20.0-M2")
+  val DefaultHost = defaults.Host
+  @deprecated("Use org.http4s.server.defaults.HttpPort", "0.20.0-M2")
+  val DefaultHttpPort = defaults.HttpPort
+  @deprecated("Use org.http4s.server.defaults.SocketAddress", "0.20.0-M2")
+  val DefaultSocketAddress = defaults.SocketAddress
+  @deprecated("Use org.http4s.server.defaults.Banner", "0.20.0-M2")
+  val DefaultBanner = defaults.Banner
 }
 
-trait IdleTimeoutSupport[F[_]] { this: ServerBuilder[F] =>
-  def withIdleTimeout(idleTimeout: Duration): Self
-}
 object IdleTimeoutSupport {
-  val DefaultIdleTimeout = 30.seconds
+  @deprecated("Moved to org.http4s.server.defaults.IdleTimeout", "0.20.0-M2")
+  val DefaultIdleTimeout = defaults.IdleTimeout
 }
 
-trait AsyncTimeoutSupport[F[_]] { this: ServerBuilder[F] =>
-  def withAsyncTimeout(asyncTimeout: Duration): Self
-}
 object AsyncTimeoutSupport {
-  val DefaultAsyncTimeout = 30.seconds
+  @deprecated("Moved to org.http4s.server.defaults.AsyncTimeout", "0.20.0-M2")
+  val DefaultAsyncTimeout = defaults.AsyncTimeout
 }
 
 sealed trait SSLConfig
@@ -113,38 +105,6 @@ final case class KeyStoreBits(
 
 final case class SSLContextBits(sslContext: SSLContext, clientAuth: Boolean) extends SSLConfig
 
-trait SSLKeyStoreSupport[F[_]] { this: ServerBuilder[F] =>
-  def withSSL(
-      keyStore: StoreInfo,
-      keyManagerPassword: String,
-      protocol: String = "TLS",
-      trustStore: Option[StoreInfo] = None,
-      clientAuth: Boolean = false): Self
-}
 object SSLKeyStoreSupport {
   final case class StoreInfo(path: String, password: String)
-}
-
-trait SSLContextSupport[F[_]] { this: ServerBuilder[F] =>
-  def withSSLContext(sslContext: SSLContext, clientAuth: Boolean = false): Self
-}
-
-/*
-trait MetricsSupport { this: ServerBuilder =>
-  /**
- * Triggers collection of backend-specific Metrics into the specified `MetricRegistry`.
- */
-  def withMetricRegistry(metricRegistry: MetricRegistry): Self
-
-  /** Sets the prefix for metrics gathered by the server.*/
-  def withMetricPrefix(metricPrefix: String): Self
-}
-object MetricsSupport {
-  val DefaultPrefix = "org.http4s.server"
-}
- */
-
-trait WebSocketSupport[F[_]] { this: ServerBuilder[F] =>
-  /* Enable websocket support */
-  def withWebSockets(enableWebsockets: Boolean): Self
 }

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -10,12 +10,25 @@ import org.log4s.getLogger
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
+import java.net.{InetAddress, InetSocketAddress}
+
 package object server {
 
   object defaults {
+    val AsyncTimeout: Duration = 30.seconds
+    val Banner =
+      """|  _   _   _        _ _
+         | | |_| |_| |_ _ __| | | ___
+         | | ' \  _|  _| '_ \_  _(_-<
+         | |_||_\__|\__| .__/ |_|/__/
+         |             |_|""".stripMargin.split("\n").toList
+    val Host = InetAddress.getLoopbackAddress.getHostAddress
+    val HttpPort = 8080
+    val IdleTimeout: Duration = 30.seconds
 
     /** The time to wait for a graceful shutdown */
     val ShutdownTimeout: Duration = 30.seconds
+    val SocketAddress = InetSocketAddress.createUnresolved(Host, HttpPort)
   }
 
   /**

--- a/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
@@ -5,9 +5,9 @@ import cats.effect._
 import java.util
 import javax.servlet.{DispatcherType, Filter}
 import javax.servlet.http.HttpServlet
-import org.http4s.server.{AsyncTimeoutSupport, ServerBuilder}
+import org.http4s.server.ServerBuilder
 
-abstract class ServletContainer[F[_]: Async] extends ServerBuilder[F] with AsyncTimeoutSupport[F] {
+abstract class ServletContainer[F[_]: Async] extends ServerBuilder[F] {
   type Self <: ServletContainer[F]
 
   /**

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -4,7 +4,8 @@ package syntax
 
 import cats.effect._
 import javax.servlet.{ServletContext, ServletRegistration}
-import org.http4s.server.{AsyncTimeoutSupport, DefaultServiceErrorHandler}
+import org.http4s.server.DefaultServiceErrorHandler
+import org.http4s.server.defaults
 
 trait ServletContextSyntax {
   implicit def ToServletContextOps(self: ServletContext): ServletContextOps =
@@ -23,7 +24,7 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
       mapping: String = "/*"): ServletRegistration.Dynamic = {
     val servlet = new AsyncHttp4sServlet(
       service = service,
-      asyncTimeout = AsyncTimeoutSupport.DefaultAsyncTimeout,
+      asyncTimeout = defaults.AsyncTimeout,
       servletIo = NonBlockingServletIo(DefaultChunkSize),
       serviceErrorHandler = DefaultServiceErrorHandler[F]
     )

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -32,9 +32,7 @@ sealed class TomcatBuilder[F[_]] private (
     banner: immutable.Seq[String]
 )(implicit protected val F: ConcurrentEffect[F])
     extends ServletContainer[F]
-    with ServerBuilder[F]
-    with IdleTimeoutSupport[F]
-    with SSLKeyStoreSupport[F] {
+    with ServerBuilder[F] {
 
   type Self = TomcatBuilder[F]
 
@@ -62,12 +60,12 @@ sealed class TomcatBuilder[F[_]] private (
       serviceErrorHandler,
       banner)
 
-  override def withSSL(
+  def withSSL(
       keyStore: StoreInfo,
       keyManagerPassword: String,
-      protocol: String,
-      trustStore: Option[StoreInfo],
-      clientAuth: Boolean): Self =
+      protocol: String = "TLS",
+      trustStore: Option[StoreInfo] = None,
+      clientAuth: Boolean = false): Self =
     copy(
       sslBits = Some(KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)))
 
@@ -135,10 +133,10 @@ sealed class TomcatBuilder[F[_]] private (
    * attribute worker.maintain with a default interval of 60 seconds. In the worst case the connection
    * may not timeout for an additional 59.999 seconds from the specified Duration
    */
-  override def withIdleTimeout(idleTimeout: Duration): Self =
+  def withIdleTimeout(idleTimeout: Duration): Self =
     copy(idleTimeout = idleTimeout)
 
-  override def withAsyncTimeout(asyncTimeout: Duration): Self =
+  def withAsyncTimeout(asyncTimeout: Duration): Self =
     copy(asyncTimeout = asyncTimeout)
 
   override def withServletIo(servletIo: ServletIo[F]): Self =
@@ -235,15 +233,15 @@ object TomcatBuilder {
 
   def apply[F[_]: ConcurrentEffect]: TomcatBuilder[F] =
     new TomcatBuilder[F](
-      socketAddress = ServerBuilder.DefaultSocketAddress,
+      socketAddress = defaults.SocketAddress,
       externalExecutor = None,
-      idleTimeout = IdleTimeoutSupport.DefaultIdleTimeout,
-      asyncTimeout = AsyncTimeoutSupport.DefaultAsyncTimeout,
+      idleTimeout = defaults.IdleTimeout,
+      asyncTimeout = defaults.AsyncTimeout,
       servletIo = ServletContainer.DefaultServletIo[F],
       sslBits = None,
       mounts = Vector.empty,
       serviceErrorHandler = DefaultServiceErrorHandler,
-      banner = ServerBuilder.DefaultBanner
+      banner = defaults.Banner
     )
 }
 


### PR DESCRIPTION
The server builder traits were a poor means of abstraction that few were using in the wild anyway.

* Eliminate marker traits for server builders
* Privatize `ServerBuilder`, which does still contribute to consistency
* Move defaults into `org.http4s.server.defaults` package
