### PR TITLE
Ignore http4s updates in scalafix-inputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -314,7 +314,10 @@ lazy val scalafixInputs = http4sProject("scalafix-inputs")
     ),
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions in Compile -= "-Xfatal-warnings",
-    scalacOptions in Test -= "-Xfatal-warnings"  )
+    scalacOptions in Test -= "-Xfatal-warnings",
+    // These dependencies are purposefully old
+    dependencyUpdatesFilter -= moduleFilter(organization = "org.http4s")
+  )
 
 lazy val scalafixOutputs= http4sProject("scalafix-outputs")
   .enablePlugins(PrivateProjectPlugin)


### PR DESCRIPTION
So we don't get a redux of #2246.