### PR TITLE
Fix deadlocks on failures with parTraverse and parSequence

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -59,70 +59,72 @@ object BlazeClient {
             .invalidate(connection)
             .handleError(e => logger.error(e)("Error invalidating connection"))
 
-        def loop(next: manager.NextConnection): F[Resource[F, Response[F]]] = {
-          // Add the timeout stage to the pipeline
-          val res: F[Resource[F, Response[F]]] = {
-
-            val idleTimeoutF = idleTimeout match {
-              case timeout: FiniteDuration =>
-                F.cancelable[TimeoutException] { cb =>
-                  val stage = new IdleTimeoutStage[ByteBuffer](timeout, cb, scheduler, ec)
-                  next.connection.spliceBefore(stage)
-                  stage.stageStartup()
-                  F.delay(stage.removeStage)
-                }
-              case _ =>
-                F.never[TimeoutException]
-            }
-
-            next.connection
-              .runRequest(req, idleTimeoutF)
-              .flatMap { r =>
-                val dispose = manager.release(next.connection)
-                F.pure(Resource(F.pure(r -> dispose)))
+        def loop: F[Resource[F, Response[F]]] =
+          manager
+            .borrow(key)
+            .bracketCase({ next =>
+              // Add the timeout stage to the pipeline
+              val idleTimeoutF = idleTimeout match {
+                case timeout: FiniteDuration =>
+                  F.cancelable[TimeoutException] { cb =>
+                    val stage = new IdleTimeoutStage[ByteBuffer](timeout, cb, scheduler, ec)
+                    next.connection.spliceBefore(stage)
+                    stage.stageStartup()
+                    F.delay(stage.removeStage)
+                  }
+                case _ =>
+                  F.never[TimeoutException]
               }
-              .recoverWith {
-                case Command.EOF =>
-                  invalidate(next.connection).flatMap { _ =>
-                    if (next.fresh)
-                      F.raiseError(
-                        new java.net.ConnectException(s"Failed to connect to endpoint: $key"))
-                    else {
-                      manager.borrow(key).flatMap { newConn =>
-                        loop(newConn)
+
+              val res = next.connection
+                .runRequest(req, idleTimeoutF)
+                .flatMap { r =>
+                  val dispose = manager.release(next.connection)
+                  F.pure(Resource(F.pure(r -> dispose)))
+                }
+                .recoverWith {
+                  case Command.EOF =>
+                    invalidate(next.connection).flatMap { _ =>
+                      if (next.fresh)
+                        F.raiseError(
+                          new java.net.ConnectException(s"Failed to connect to endpoint: $key"))
+                      else {
+                        loop
                       }
                     }
-                  }
-              }
-              .guaranteeCase {
-                case ExitCase.Completed =>
-                  F.unit
-                case ExitCase.Error(_) | ExitCase.Canceled =>
-                  invalidate(next.connection)
-              }
-          }
-
-          Deferred[F, Unit].flatMap { gate =>
-            val responseHeaderTimeoutF =
-              F.delay {
-                  val stage =
-                    new ResponseHeaderTimeoutStage[ByteBuffer](responseHeaderTimeout, scheduler, ec)
-                  next.connection.spliceBefore(stage)
-                  stage
                 }
-                .bracket(stage =>
-                  F.asyncF[TimeoutException] { cb =>
-                    F.delay(stage.init(cb)) >> gate.complete(())
-                })(stage => F.delay(stage.removeStage()))
 
-            F.racePair(gate.get *> res, responseHeaderTimeoutF).flatMap {
-              case Left((r, fiber)) => fiber.cancel.as(r)
-              case Right((fiber, t)) => fiber.cancel >> F.raiseError(t)
+              Deferred[F, Unit].flatMap {
+                gate =>
+                  val responseHeaderTimeoutF: F[TimeoutException] =
+                    F.delay {
+                        val stage =
+                          new ResponseHeaderTimeoutStage[ByteBuffer](
+                            responseHeaderTimeout,
+                            scheduler,
+                            ec)
+                        next.connection.spliceBefore(stage)
+                        stage
+                      }
+                      .bracket(stage =>
+                        F.asyncF[TimeoutException] { cb =>
+                          F.delay(stage.init(cb)) >> gate.complete(())
+                      })(stage => F.delay(stage.removeStage()))
+
+                  F.racePair(gate.get *> res, responseHeaderTimeoutF)
+                    .flatMap[Resource[F, Response[F]]] {
+                      case Left((r, fiber)) => fiber.cancel.as(r)
+                      case Right((fiber, t)) => fiber.cancel >> F.raiseError(t)
+                    }
+              }
+            }) {
+              case (_, ExitCase.Completed) =>
+                F.unit
+              case (next, ExitCase.Error(_) | ExitCase.Canceled) =>
+                invalidate(next.connection)
             }
-          }
-        }
 
-        val res = manager.borrow(key).flatMap(loop)
+        val res = loop
         requestTimeout match {
           case d: FiniteDuration =>
             F.racePair(

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -146,11 +146,6 @@ class BlazeClientSpec extends Http4sSpec {
 
           val allRequests = for {
             _ <- failedRequests.handleErrorWith(_ => IO.unit)
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
             r <- sucessRequests
           } yield r
 
@@ -183,10 +178,6 @@ class BlazeClientSpec extends Http4sSpec {
           }.parSequence
 
           val allRequests = for {
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
             _ <- failedRequests.handleErrorWith(_ => IO.unit)
             r <- sucessRequests
           } yield r

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -132,17 +132,19 @@ class BlazeClientSpec extends Http4sSpec {
             Uri.fromString(s"http://$name:$port/simple").yolo
           }
 
-          val failedRequests = (1 to Runtime.getRuntime.availableProcessors * 5).toList.parTraverse { _ =>
-            val h = failedHosts(Random.nextInt(failedHosts.length))
-            parClient.expect[String](h)
-          }
+          val failedRequests =
+            (1 to Runtime.getRuntime.availableProcessors * 5).toList.parTraverse { _ =>
+              val h = failedHosts(Random.nextInt(failedHosts.length))
+              parClient.expect[String](h)
+            }
 
-          val sucessRequests = (1 to Runtime.getRuntime.availableProcessors * 5).toList.parTraverse { _ =>
-            val h = successHosts(Random.nextInt(successHosts.length))
-            parClient.expect[String](h).map(_.nonEmpty)
-          }
+          val sucessRequests =
+            (1 to Runtime.getRuntime.availableProcessors * 5).toList.parTraverse { _ =>
+              val h = successHosts(Random.nextInt(successHosts.length))
+              parClient.expect[String](h).map(_.nonEmpty)
+            }
 
-            val allRequests = for {
+          val allRequests = for {
             _ <- failedRequests.handleErrorWith(_ => IO.unit)
             _ <- failedRequests.handleErrorWith(_ => IO.unit)
             _ <- failedRequests.handleErrorWith(_ => IO.unit)
@@ -152,7 +154,8 @@ class BlazeClientSpec extends Http4sSpec {
             r <- sucessRequests
           } yield r
 
-          allRequests.map(_.forall(identity))
+          allRequests
+            .map(_.forall(identity))
             .unsafeRunTimed(timeout) must beSome(true)
         }
 
@@ -170,14 +173,14 @@ class BlazeClientSpec extends Http4sSpec {
           }
 
           val failedRequests = (1 to Runtime.getRuntime.availableProcessors * 5).toList.map { _ =>
-              val h = failedHosts(Random.nextInt(failedHosts.length))
-              seqClient.expect[String](h)
-            }.parSequence
+            val h = failedHosts(Random.nextInt(failedHosts.length))
+            seqClient.expect[String](h)
+          }.parSequence
 
           val sucessRequests = (1 to Runtime.getRuntime.availableProcessors * 5).toList.map { _ =>
-              val h = successHosts(Random.nextInt(successHosts.length))
-              seqClient.expect[String](h).map(_.nonEmpty)
-            }.parSequence
+            val h = successHosts(Random.nextInt(successHosts.length))
+            seqClient.expect[String](h).map(_.nonEmpty)
+          }.parSequence
 
           val allRequests = for {
             _ <- failedRequests.handleErrorWith(_ => IO.unit)
@@ -188,7 +191,8 @@ class BlazeClientSpec extends Http4sSpec {
             r <- sucessRequests
           } yield r
 
-          allRequests.map(_.forall(identity))
+          allRequests
+            .map(_.forall(identity))
             .unsafeRunTimed(timeout) must beSome(true)
         }
 

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -144,6 +144,11 @@ class BlazeClientSpec extends Http4sSpec {
 
             val allRequests = for {
             _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit)
             r <- sucessRequests
           } yield r
 
@@ -175,6 +180,10 @@ class BlazeClientSpec extends Http4sSpec {
             }.parSequence
 
           val allRequests = for {
+            _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit)
             _ <- failedRequests.handleErrorWith(_ => IO.unit)
             r <- sucessRequests
           } yield r

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -145,7 +145,7 @@ class BlazeClientSpec extends Http4sSpec {
             }
 
           val allRequests = for {
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit).replicateA(5)
             r <- sucessRequests
           } yield r
 
@@ -178,7 +178,7 @@ class BlazeClientSpec extends Http4sSpec {
           }.parSequence
 
           val allRequests = for {
-            _ <- failedRequests.handleErrorWith(_ => IO.unit)
+            _ <- failedRequests.handleErrorWith(_ => IO.unit).replicateA(5)
             r <- sucessRequests
           } yield r
 

--- a/client/src/main/scala/org/http4s/client/PoolManager.scala
+++ b/client/src/main/scala/org/http4s/client/PoolManager.scala
@@ -287,9 +287,11 @@ private final class PoolManager[F[_], A <: Connection[F]](
     val (expired, rest) = waitQueue.span(w => isExpired(w.at))
     expired.foreach(
       _.callback(Left(new TimeoutException("In wait queue for too long, timing out request."))))
-    logger.debug(s"expired requests: ${expired.length}")
-    waitQueue = rest
-    logger.debug(s"Dropped expired requests: $stats")
+    if (expired.nonEmpty) {
+      logger.debug(s"expired requests: ${expired.length}")
+      waitQueue = rest
+      logger.debug(s"Dropped expired requests: $stats")
+    }
     waitQueue.dequeueFirst { waiter =>
       allocated.getOrElse(waiter.key, 0) < maxConnectionsPerRequestKey(waiter.key)
     }

--- a/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -14,6 +14,7 @@ object GetRoutes {
   val NoContentPath = "/no-content"
   val NotFoundPath = "/not-found"
   val EmptyNotFoundPath = "/empty-not-found"
+  val InternalServerErrorPath = "/internal-server-error"
 
   def getPaths(implicit timer: Timer[IO]): Map[String, Response[IO]] =
     Map(
@@ -26,6 +27,7 @@ object GetRoutes {
           Response[IO](Ok).withEntity("delayed path").pure[IO],
       NoContentPath -> Response[IO](NoContent).pure[IO],
       NotFoundPath -> Response[IO](NotFound).withEntity("not found").pure[IO],
-      EmptyNotFoundPath -> Response[IO](NotFound).pure[IO]
+      EmptyNotFoundPath -> Response[IO](NotFound).pure[IO],
+      InternalServerErrorPath -> Response[IO](InternalServerError).pure[IO]
     ).mapValues(_.unsafeRunSync())
 }


### PR DESCRIPTION
Both of these tests fail by timing out on my local machine:

```scala
[info] BlazeClientSpec                                                                                     
[info] Blaze Http1Client should                                     
[info]   + raise error NoConnectionAllowedException if no connections are permitted for key (789 ms)
[info]   + make simple https requests (966 ms)                                                                                                      
[info]   + behave and not deadlock (1 second, 34 ms)                                         
[error]   x behave and not deadlock on failures with parTraverse (30 seconds, 245 ms)                      
[error]    None is not Some (BlazeClientSpec.scala:151)                               
[error] org.http4s.client.blaze.BlazeClientSpec.$anonfun$new$18(BlazeClientSpec.scala:151)
[error]   x behave and not deadlock on failures with parSequence (30 seconds, 308 ms)                              
[error]    None is not Some (BlazeClientSpec.scala:184)                                                                                  
[error] org.http4s.client.blaze.BlazeClientSpec.$anonfun$new$31(BlazeClientSpec.scala:184)                                                                                                                  
[info]   + obey response header timeout (30 seconds, 374 ms)                                                                                                                                                
[info]   + unblock waiting connections (30 seconds, 417 ms)                                                                                                       
[info]   + reset request timeout (30 seconds, 462 ms)                  
[info]   + drain waiting connections after shutdown (1 second, 140 ms)                                                                   
[info]   + cancel infinite request on completion (1 second, 193 ms)                                                                                                                                         
[info] Total for specification BlazeClientSpec                  
[info] Finished in 31 seconds, 904 ms                    
[info] 10 examples, 38 expectations, 2 failures, 0 error  
```