### PR TITLE
change UrlForm to use Chain instead of Seq

### DIFF
--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -113,7 +113,7 @@ package object oauth1 {
             t.mediaType == MediaType.application.`x-www-form-urlencoded` =>
         req.as[UrlForm].map { urlform =>
           val bodyparams = urlform.values.toSeq
-            .flatMap { case (k, vs) => if (vs.isEmpty) Seq(k -> "") else vs.map((k, _)) }
+            .flatMap { case (k, vs) => if (vs.isEmpty) Seq(k -> "") else vs.toList.map((k, _)) }
 
           implicit val charset = req.charset.getOrElse(Charset.`UTF-8`)
           req.withEntity(urlform) -> (qparams ++ bodyparams)

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -85,8 +85,8 @@ class ExampleService[F[_]](implicit F: Effect[F], cs: ContextShift[F]) extends H
         // EntityDecoders allow turning the body into something useful
         req
           .decode[UrlForm] { data =>
-            data.values.get("sum") match {
-              case Some(Seq(s, _*)) =>
+            data.values.get("sum").flatMap(_.uncons) match {
+              case Some((s, _)) =>
                 val sum = s.split(' ').filter(_.length > 0).map(_.trim.toInt).sum
                 Ok(sum.toString)
 

--- a/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
@@ -21,7 +21,9 @@ object UrlFormLifter {
       strictDecode: Boolean = false): Kleisli[F, Request[G], Response[G]] =
     Kleisli { req =>
       def addUrlForm(form: UrlForm): F[Response[G]] = {
-        val flatForm = form.values.toVector.flatMap { case (k, vs) => vs.map(v => (k, Some(v))) }
+        val flatForm = form.values.toVector.flatMap {
+          case (k, vs) => vs.toVector.map(v => (k, Some(v)))
+        }
         val params = req.uri.query.toVector ++ flatForm: Vector[(String, Option[String])]
         val newQuery = Query(params: _*)
 

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -2,7 +2,8 @@ package org.http4s
 package testing
 
 import cats._
-import cats.data.NonEmptyList
+import cats.data.{Chain, NonEmptyList}
+import cats.laws.discipline.arbitrary.catsLawsArbitraryForChain
 import cats.effect.{Effect, IO}
 import cats.effect.laws.discipline.arbitrary._
 import cats.effect.laws.util.TestContext
@@ -360,7 +361,7 @@ trait ArbitraryInstances {
   implicit val http4sTestingArbitraryForUrlForm: Arbitrary[UrlForm] = Arbitrary {
     // new String("\ufffe".getBytes("UTF-16"), "UTF-16") != "\ufffe".
     // Ain't nobody got time for that.
-    arbitrary[Map[String, Seq[String]]]
+    arbitrary[Map[String, Chain[String]]]
       .map(UrlForm.apply)
       .suchThat(!_.toString.contains('\ufffe'))
   }

--- a/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -13,6 +13,7 @@ import fs2._
 import fs2.Stream._
 import java.io.{File, FileInputStream, InputStreamReader}
 import java.nio.charset.StandardCharsets
+import cats.data.Chain
 import org.http4s.Status.Ok
 import org.http4s.testing._
 import org.http4s.headers.`Content-Type`
@@ -326,9 +327,9 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
     "Decode form encoded body" in {
       val urlForm = UrlForm(
         Map(
-          "Formula" -> Seq("a + b == 13%!"),
-          "Age" -> Seq("23"),
-          "Name" -> Seq("Jonathan Doe")
+          "Formula" -> Chain("a + b == 13%!"),
+          "Age" -> Chain("23"),
+          "Name" -> Chain("Jonathan Doe")
         ))
       val resp: IO[Response[IO]] = Request[IO]()
         .withEntity(urlForm)(UrlForm.entityEncoder(Charset.`UTF-8`))


### PR DESCRIPTION
Chain has a Monoid instance available to it, while Seq does not. Partially addresses #2096.

This was a pretty mechanical conversion and might be able to be optimized.