### PR TITLE
Support flag query parameters in DSL

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -44,6 +44,7 @@ trait Http4sDsl[F[_]] extends Methods with Statuses with Responses[F] with Auth 
   type OptionalMultiQueryParamDecoderMatcher[T] = impl.OptionalMultiQueryParamDecoderMatcher[T]
   type OptionalQueryParamMatcher[T] = impl.OptionalQueryParamMatcher[T]
   type ValidatingQueryParamDecoderMatcher[T] = impl.ValidatingQueryParamDecoderMatcher[T]
+  type FlagQueryParamMatcher = impl.FlagQueryParamMatcher
   type OptionalValidatingQueryParamDecoderMatcher[T] =
     impl.OptionalValidatingQueryParamDecoderMatcher[T]
 

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -262,6 +262,11 @@ abstract class OptionalQueryParamDecoderMatcher[T: QueryParamDecoder](name: Stri
       .toOption
 }
 
+abstract class FlagQueryParamMatcher(name: String) {
+  def unapply(params: Map[String, Seq[String]]): Option[Option[Unit]] =
+    Some(params.get(name).map(_ => ()))
+}
+
 /**
   * Capture a query parameter that appears 0 or more times.
   *

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -262,9 +262,12 @@ abstract class OptionalQueryParamDecoderMatcher[T: QueryParamDecoder](name: Stri
       .toOption
 }
 
+/**
+  * Flag (value-less) query param extractor
+  */
 abstract class FlagQueryParamMatcher(name: String) {
-  def unapply(params: Map[String, Seq[String]]): Option[Option[Unit]] =
-    Some(params.get(name).map(_ => ()))
+  def unapply(params: Map[String, Seq[String]]): Option[Boolean] =
+    Some(params.contains(name))
 }
 
 /**

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
@@ -32,6 +32,8 @@ object PathInHttpRoutesSpec extends Http4sSpec {
 
   object MultiOptCounter extends OptionalMultiQueryParamDecoderMatcher[Int]("counter")
 
+  object Flag extends FlagQueryParamMatcher("flag")
+
   val app: HttpApp[IO] = HttpApp {
     case GET -> Root :? I(start) +& L(limit) =>
       Ok(s"start: $start, limit: ${limit.l}")
@@ -67,6 +69,11 @@ object PathInHttpRoutesSpec extends Http4sSpec {
         case Valid(cs @ (_ :: _)) => Ok(s"${cs.length}: ${cs.mkString(",")}")
         case Valid(Nil) => Ok("absent")
         case Invalid(errors) => BadRequest(errors.toList.map(_.details).mkString("\n"))
+      }
+    case GET -> Root / "flagparam" :? Flag(flag) =>
+      flag match {
+        case Some(_) => Ok("flag present")
+        case None => Ok("flag not present")
       }
     case r =>
       NotFound(s"404 Not Found: ${r.pathInfo}")
@@ -234,6 +241,24 @@ object PathInHttpRoutesSpec extends Http4sSpec {
           """For input string: "foo"""",
           """For input string: "bar""""
         ))
+    }
+    "optional flag parameter when present" in {
+      val response =
+        serve(Request(GET, Uri(path = "/flagparam", query = Query.fromString("flag"))))
+      response.status must_== Ok
+      response.as[String] must returnValue("flag present")
+    }
+    "optional flag parameter when present with a value" in {
+      val response =
+        serve(Request(GET, Uri(path = "/flagparam", query = Query.fromString("flag=1"))))
+      response.status must_== (Ok)
+      response.as[String] must returnValue("flag present")
+    }
+    "optional flag parameter when not present" in {
+      val response =
+        serve(Request(GET, Uri(path = "/flagparam", query = Query.fromString(""))))
+      response.status must_== (Ok)
+      response.as[String] must returnValue("flag not present")
     }
   }
 }

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
@@ -71,7 +71,7 @@ object PathInHttpRoutesSpec extends Http4sSpec {
         case Invalid(errors) => BadRequest(errors.toList.map(_.details).mkString("\n"))
       }
     case GET -> Root / "flagparam" :? Flag(flag) =>
-      if(flag) Ok("flag present")
+      if (flag) Ok("flag present")
       else Ok("flag not present")
     case r =>
       NotFound(s"404 Not Found: ${r.pathInfo}")

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
@@ -71,10 +71,8 @@ object PathInHttpRoutesSpec extends Http4sSpec {
         case Invalid(errors) => BadRequest(errors.toList.map(_.details).mkString("\n"))
       }
     case GET -> Root / "flagparam" :? Flag(flag) =>
-      flag match {
-        case Some(_) => Ok("flag present")
-        case None => Ok("flag not present")
-      }
+      if(flag) Ok("flag present")
+      else Ok("flag not present")
     case r =>
       NotFound(s"404 Not Found: ${r.pathInfo}")
   }


### PR DESCRIPTION
Adds an new matcher to the DSL supporting option flag-style query parameters as discussed in  #2254.