### PR TITLE
Record Metrics after `client.run` Resource has released 

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -48,7 +48,7 @@ object Metrics {
       start <- Resource.liftF(clock.monotonic(TimeUnit.NANOSECONDS))
       _ <- Resource.make(ops.increaseActiveRequests(classifierF(req)))(_ =>
         ops.decreaseActiveRequests(classifierF(req)))
-      _ <- Resource.make(F.delay(())) { _ =>
+      _ <- Resource.make(F.unit) { _ =>
         clock
           .monotonic(TimeUnit.NANOSECONDS)
           .flatMap(now =>

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSpec.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSpec.scala
@@ -205,6 +205,7 @@ class DropwizardMetricsSpec extends Http4sSpec {
       clientRunResource.isSuccess
       count(registry, Timer("client.default.2xx-responses")) must beEqualTo(1)
       count(registry, Counter("client.default.active-requests")) must beEqualTo(0)
+      valuesOf(registry, Timer("client.default.requests.headers")) must beSome(Array(50000000L))
       valuesOf(registry, Timer("client.default.requests.total")) must beSome(Array(100000000L))
     }
   }

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/util.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/util.scala
@@ -51,7 +51,7 @@ object util {
         unit.convert(count, TimeUnit.MILLISECONDS)
       }
 
-      override def monotonic(unit: TimeUnit): F[Long] = Sync[F].delay{
+      override def monotonic(unit: TimeUnit): F[Long] = Sync[F].delay {
         count += 50
         unit.convert(count, TimeUnit.MILLISECONDS)
       }

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/util.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/util.scala
@@ -46,14 +46,14 @@ object util {
     def apply[F[_]: Sync] = new Clock[F] {
       private var count = 0L
 
-      override def realTime(unit: TimeUnit): F[Long] = {
+      override def realTime(unit: TimeUnit): F[Long] = Sync[F].delay {
         count += 50
-        Sync[F].delay(unit.convert(count, TimeUnit.MILLISECONDS))
+        unit.convert(count, TimeUnit.MILLISECONDS)
       }
 
-      override def monotonic(unit: TimeUnit): F[Long] = {
+      override def monotonic(unit: TimeUnit): F[Long] = Sync[F].delay{
         count += 50
-        Sync[F].delay(unit.convert(count, TimeUnit.MILLISECONDS))
+        unit.convert(count, TimeUnit.MILLISECONDS)
       }
     }
   }

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/util.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/util.scala
@@ -111,14 +111,14 @@ object util {
     def apply[F[_]: Sync] = new Clock[F] {
       private var count = 0L
 
-      override def realTime(unit: TimeUnit): F[Long] = {
+      override def realTime(unit: TimeUnit): F[Long] = Sync[F].delay {
         count += 50
-        Sync[F].delay(unit.convert(count, TimeUnit.MILLISECONDS))
+        unit.convert(count, TimeUnit.MILLISECONDS)
       }
 
-      override def monotonic(unit: TimeUnit): F[Long] = {
+      override def monotonic(unit: TimeUnit): F[Long] = Sync[F].delay {
         count += 50
-        Sync[F].delay(unit.convert(count, TimeUnit.MILLISECONDS))
+        unit.convert(count, TimeUnit.MILLISECONDS)
       }
     }
   }


### PR DESCRIPTION
Fixes a bug with the `Client` `Metrics` code where we would decrement active requests and record total time before the `Resource` returned from the `client.run` was actually `release`d. This means our metrics were not accurate. 

The fix here is to perform both of these actions _after_ the `client.run` has `.release`d. To do so, both the `recordTotalTime` and incr/decr of the active requests have been turned into `Resource`s of their own, that `.release` after the `client.run`. This results in the behavior we expect. A test has been added to demonstrate the bug, and to show that it is now fixed. 


fixes https://github.com/http4s/http4s/issues/2282