### PR TITLE
Deprecate BlazeServer companion, forward to BlazeServerBuilder

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -178,6 +178,12 @@ class BlazeServerBuilder[F[_]](
   def withChannelOptions(channelOptions: ChannelOptions): BlazeServerBuilder[F] =
     copy(channelOptions = channelOptions)
 
+  def withMaxRequestLineLength(maxRequestLineLength: Int): BlazeServerBuilder[F] =
+    copy(maxRequestLineLen = maxRequestLineLength)
+
+  def withMaxHeadersLength(maxHeadersLength: Int): BlazeServerBuilder[F] =
+    copy(maxHeadersLen = maxHeadersLength)
+
   def resource: Resource[F, Server[F]] = tickWheelResource.flatMap { scheduler =>
     Resource(F.delay {
 

--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -25,11 +25,12 @@ libraryDependencies ++= Seq(
 ```
 
 Then we create the [service] again so tut picks it up:
-
+>
 ```tut:book:silent
 import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._
+import org.http4s.implicits._
 import org.http4s.server.blaze._
 ```
 
@@ -46,12 +47,12 @@ implicit val timer: Timer[IO] = IO.timer(global)
 Finish setting up our server:
 
 ```tut:book
-val routes = HttpRoutes.of[IO] {
+val app = HttpRoutes.of[IO] {
   case GET -> Root / "hello" / name =>
     Ok(s"Hello, $name.")
-}
+}.orNotFound
 
-val server = BlazeBuilder[IO].bindHttp(8080, "localhost").mountService(routes, "/").resource
+val server = BlazeServerBuilder[IO].bindHttp(8080, "localhost").withHttpApp(app).resource
 ```
 
 We'll start the server in the background.  The `IO.never` keeps it

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -110,10 +110,10 @@ val tweetService = HttpRoutes.of[IO] {
 http4s supports multiple server backends.  In this example, we'll use
 [blaze], the native backend supported by http4s.
 
-We start from a `BlazeBuilder`, and then mount the `helloWorldService` under
+We start from a `BlazeServerBuilder`, and then mount the `helloWorldService` under
 the base path of `/` and the remainder of the services under the base
 path of `/api`. The services can be mounted in any order as the request will be
-matched against the longest base paths first. The `BlazeBuilder` is immutable
+matched against the longest base paths first. The `BlazeServerBuilder` is immutable
 with chained methods, each returning a new builder.
 
 Multiple `HttpRoutes` can be combined with the `combineK` method (or its alias


### PR DESCRIPTION
We deprecated `BlazeBuilder` without deprecating its companion.  It used the old `QuietTimeoutStage`, which was broken by other changes.

Now the companion is also deprecated, so people are warned not to use it, and the deprecated implementation now forwards to the maintained version.

Fixes the redux of #2253.