### PR TITLE
Stop leaking IdleTimeoutStages

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -113,9 +113,9 @@ private[blaze] class Http1ServerStage[F[_]](
             logger.debug("Shutting down due to idle timeout")
             closePipeline(None)
         }
-        val stage = new IdleTimeoutStage[ByteBuffer](f, cb, scheduler, executionContext)
+        val stage = new IdleTimeoutStage[ByteBuffer](f, scheduler, executionContext)
         spliceBefore(stage)
-        stage.stageStartup()
+        stage.init(cb)
       case _ =>
     }
 

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
@@ -56,9 +56,9 @@ private class Http2NodeStage[F[_]](
             logger.debug("Shutting down due to idle timeout")
             closePipeline(None)
         }
-        val stage = new IdleTimeoutStage[StreamFrame](f, cb, scheduler, executionContext)
+        val stage = new IdleTimeoutStage[StreamFrame](f, scheduler, executionContext)
         spliceBefore(stage)
-        stage.stageStartup()
+        stage.init(cb)
       case _ =>
     }
 


### PR DESCRIPTION
Multiple IdleTimeoutStages, whose timers have been canceled, are piling up on recycled connections.  This ensures that we clean up what we add.

It's sloppy, but so is the problem.  It's another case of trying to shift life cycles outside a traditional bracket, and I haven't yet figured out how to make it work as a bracket.

I expect that this fixes #2289.