### PR TITLE
Proposal: Make `orNotFound` return a `Http`

### DIFF
--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -5,12 +5,12 @@ import cats._
 import cats.data.{Kleisli, OptionT}
 
 trait KleisliSyntax {
-  implicit def http4sKleisliResponseSyntax[F[_]: Functor, A](
-      service: Kleisli[OptionT[F, ?], A, Response[F]]): KleisliResponseOps[F, A] =
-    new KleisliResponseOps[F, A](service)
+  implicit def http4sKleisliResponseSyntax[F[_]: Functor](
+      service: Kleisli[OptionT[F, ?], Request[F], Response[F]]): KleisliResponseOps[F] =
+    new KleisliResponseOps[F](service)
 }
 
-final class KleisliResponseOps[F[_]: Functor, A](self: Kleisli[OptionT[F, ?], A, Response[F]]) {
-  def orNotFound: Kleisli[F, A, Response[F]] =
+final class KleisliResponseOps[F[_]: Functor](val self: Kleisli[OptionT[F, ?], Request[F], Response[F]]) extends AnyVal{
+  def orNotFound: Http[F, F] =
     Kleisli(a => self.run(a).getOrElse(Response.notFound))
 }

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -10,7 +10,7 @@ trait KleisliSyntax {
     new KleisliResponseOps[F](service)
 }
 
-final class KleisliResponseOps[F[_]: Functor](val self: Kleisli[OptionT[F, ?], Request[F], Response[F]]) extends AnyVal{
+final class KleisliResponseOps[F[_]: Functor](self: Kleisli[OptionT[F, ?], Request[F], Response[F]]){
   def orNotFound: Http[F, F] =
     Kleisli(a => self.run(a).getOrElse(Response.notFound))
 }

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -10,7 +10,8 @@ trait KleisliSyntax {
     new KleisliResponseOps[F](service)
 }
 
-final class KleisliResponseOps[F[_]: Functor](self: Kleisli[OptionT[F, ?], Request[F], Response[F]]){
+final class KleisliResponseOps[F[_]: Functor](
+    self: Kleisli[OptionT[F, ?], Request[F], Response[F]]) {
   def orNotFound: Http[F, F] =
     Kleisli(a => self.run(a).getOrElse(Response.notFound))
 }


### PR DESCRIPTION
This will most likely be incompatible in a variety of ways, but maybe we can make this kind of change since 0.20 is breaking anyway.

This should be fine, unless we assume that there are users who call `orNotFound` on Kleislis that don't have `Request[F]` in the input.