### PR TITLE
Fix shutdown in BlazeClientBuilder

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -179,9 +179,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
         responseHeaderTimeout = responseHeaderTimeout,
         requestTimeout = requestTimeout,
         executionContext = executionContext
-      )) { pool =>
-      F.delay { val _ = pool.shutdown() }
-    }
+      ))(_.shutdown)
   }
 }
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -43,7 +43,7 @@ object Http1Client {
             requestTimeout = config.requestTimeout,
             executionContext = config.executionContext
           ))(_.shutdown)
-      .map(pool => BlazeClient(pool, config, pool.shutdown(), config.executionContext))
+      .map(pool => BlazeClient(pool, config, pool.shutdown, config.executionContext))
   }
 
   def stream[F[_]](config: BlazeClientConfig = BlazeClientConfig.defaultConfig)(

--- a/client/src/main/scala/org/http4s/client/BasicManager.scala
+++ b/client/src/main/scala/org/http4s/client/BasicManager.scala
@@ -10,7 +10,7 @@ private final class BasicManager[F[_], A <: Connection[F]](builder: ConnectionBu
   def borrow(requestKey: RequestKey): F[NextConnection] =
     builder(requestKey).map(NextConnection(_, fresh = true))
 
-  override def shutdown(): F[Unit] =
+  override def shutdown: F[Unit] =
     F.unit
 
   override def invalidate(connection: A): F[Unit] =

--- a/client/src/main/scala/org/http4s/client/ConnectionManager.scala
+++ b/client/src/main/scala/org/http4s/client/ConnectionManager.scala
@@ -22,7 +22,7 @@ trait ConnectionManager[F[_], A <: Connection[F]] {
   sealed case class NextConnection(connection: A, fresh: Boolean)
 
   /** Shutdown this client, closing any open connections and freeing resources */
-  def shutdown(): F[Unit]
+  def shutdown: F[Unit]
 
   /** Get a connection for the provided request key. */
   def borrow(requestKey: RequestKey): F[NextConnection]

--- a/client/src/main/scala/org/http4s/client/PoolManager.scala
+++ b/client/src/main/scala/org/http4s/client/PoolManager.scala
@@ -345,7 +345,7 @@ private final class PoolManager[F[_], A <: Connection[F]](
     *
     * @return An effect Of Unit
     */
-  def shutdown(): F[Unit] = semaphore.withPermit {
+  def shutdown: F[Unit] = semaphore.withPermit {
     F.delay {
       logger.info(s"Shutting down connection pool: $stats")
       if (!isClosed) {


### PR DESCRIPTION
We were throwing away the `F[Unit]` instead of returning it.

Bonus: removed parens on `shutdown()`, since it's a pure value, not a side effect.