### PR TITLE
`Retry` client middleware: don't retry on `WaitQueueTimeoutException`

### DIFF
--- a/client/src/main/scala/org/http4s/client/PoolManager.scala
+++ b/client/src/main/scala/org/http4s/client/PoolManager.scala
@@ -16,7 +16,8 @@ final case class WaitQueueFullFailure() extends RuntimeException {
   def message: String = "Wait queue is full"
 }
 
-case object WaitQueueTimeoutException extends TimeoutException("In wait queue for too long, timing out request.")
+case object WaitQueueTimeoutException
+    extends TimeoutException("In wait queue for too long, timing out request.")
 
 private final class PoolManager[F[_], A <: Connection[F]](
     builder: ConnectionBuilder[F, A],

--- a/client/src/main/scala/org/http4s/client/PoolManager.scala
+++ b/client/src/main/scala/org/http4s/client/PoolManager.scala
@@ -16,6 +16,8 @@ final case class WaitQueueFullFailure() extends RuntimeException {
   def message: String = "Wait queue is full"
 }
 
+case object WaitQueueTimeoutException extends TimeoutException("In wait queue for too long, timing out request.")
+
 private final class PoolManager[F[_], A <: Connection[F]](
     builder: ConnectionBuilder[F, A],
     maxTotal: Int,
@@ -204,9 +206,7 @@ private final class PoolManager[F[_], A <: Connection[F]](
       case Some(Waiting(_, callback, at)) =>
         if (isExpired(at)) {
           F.delay(logger.debug(s"Request expired")) *>
-            F.delay(
-              callback(
-                Left(new TimeoutException("In wait queue for too long, timing out request."))))
+            F.delay(callback(Left(WaitQueueTimeoutException)))
         } else {
           F.delay(logger.debug(s"Fulfilling waiting connection request: $stats")) *>
             F.delay(callback(Right(NextConnection(connection, fresh = false))))
@@ -285,8 +285,7 @@ private final class PoolManager[F[_], A <: Connection[F]](
 
   private def findFirstAllowedWaiter: F[Option[Waiting]] = F.delay {
     val (expired, rest) = waitQueue.span(w => isExpired(w.at))
-    expired.foreach(
-      _.callback(Left(new TimeoutException("In wait queue for too long, timing out request."))))
+    expired.foreach(_.callback(Left(WaitQueueTimeoutException)))
     if (expired.nonEmpty) {
       logger.debug(s"expired requests: ${expired.length}")
       waitQueue = rest

--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -10,7 +10,6 @@ import org.http4s.Status._
 import org.http4s.headers.`Retry-After`
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger
-import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.math.{min, pow, random}
 
@@ -146,7 +145,7 @@ object RetryPolicy {
   private def isErrorOrRetriableStatus[F[_]](result: Either[Throwable, Response[F]]): Boolean =
     result match {
       case Right(resp) => RetriableStatuses(resp.status)
-      case Left(_: TimeoutException) => false
+      case Left(WaitQueueTimeoutException) => false
       case _ => true
     }
 

--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -10,6 +10,7 @@ import org.http4s.Status._
 import org.http4s.headers.`Retry-After`
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger
+import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.math.{min, pow, random}
 
@@ -145,6 +146,7 @@ object RetryPolicy {
   private def isErrorOrRetriableStatus[F[_]](result: Either[Throwable, Response[F]]): Boolean =
     result match {
       case Right(resp) => RetriableStatuses(resp.status)
+      case Left(_: TimeoutException) => false
       case _ => true
     }
 

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -9,6 +9,7 @@ import fs2.Stream
 import org.http4s.dsl.io._
 import org.http4s.Uri.uri
 import org.specs2.specification.Tables
+import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
 class RetrySpec extends Http4sSpec with Tables {
@@ -104,6 +105,11 @@ class RetrySpec extends Http4sSpec with Tables {
     "retry exceptions" in {
       val failClient = Client[IO](_ => Resource.liftF(IO.raiseError(new Exception("boom"))))
       countRetries(failClient, GET, InternalServerError, EmptyBody) must_== 2
+    }
+
+    "not retry a TimeoutException" in {
+      val failClient = Client[IO](_ => Resource.liftF(IO.raiseError(new TimeoutException("Timed out request"))))
+      countRetries(failClient, GET, InternalServerError, EmptyBody) must_== 1
     }
   }
 }

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -9,7 +9,6 @@ import fs2.Stream
 import org.http4s.dsl.io._
 import org.http4s.Uri.uri
 import org.specs2.specification.Tables
-import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
 class RetrySpec extends Http4sSpec with Tables {
@@ -108,7 +107,7 @@ class RetrySpec extends Http4sSpec with Tables {
     }
 
     "not retry a TimeoutException" in {
-      val failClient = Client[IO](_ => Resource.liftF(IO.raiseError(new TimeoutException("Timed out request"))))
+      val failClient = Client[IO](_ => Resource.liftF(IO.raiseError(WaitQueueTimeoutException)))
       countRetries(failClient, GET, InternalServerError, EmptyBody) must_== 1
     }
   }


### PR DESCRIPTION
It seems odd to retry on a `TimeoutException`.

`PoolManager` throws a `TimeoutException` when a request has been in the wait queue for too long: https://github.com/http4s/http4s/blob/master/client/src/main/scala/org/http4s/client/PoolManager.scala#L209 so is something that might be a problem.