### PR TITLE
Custom Json Error messages for Argonaut and Circe

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -8,7 +8,7 @@ import cats.effect.Sync
 import org.http4s.argonaut.Parser.facade
 import org.http4s.headers.`Content-Type`
 import jawn.JawnInstances
-import _root_.jawn.ParseException
+import org.typelevel.jawn.ParseException
 import org.http4s.argonaut.ArgonautInstances.DecodeFailureMessage
 
 trait ArgonautInstances extends JawnInstances {

--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -7,10 +7,11 @@ import cats.Applicative
 import cats.effect.Sync
 import org.http4s.argonaut.Parser.facade
 import org.http4s.headers.`Content-Type`
+import org.http4s.jawn.JawnInstances
 
-trait ArgonautInstances {
+trait ArgonautInstances extends JawnInstances {
   implicit def jsonDecoder[F[_]: Sync]: EntityDecoder[F, Json] =
-    jawn.jawnDecoder
+    jawnDecoder
 
   def jsonOf[F[_]: Sync, A](implicit decoder: DecodeJson[A]): EntityDecoder[F, A] =
     jsonDecoder[F].flatMapR { json =>

--- a/argonaut/src/main/scala/org/http4s/argonaut/package.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/package.scala
@@ -1,8 +1,3 @@
 package org.http4s
 
-import _root_.argonaut.PrettyParams
-
-package object argonaut extends ArgonautInstances {
-  protected def defaultPrettyParams: PrettyParams =
-    PrettyParams.nospace
-}
+package object argonaut extends ArgonautInstances

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -24,7 +24,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
   testJsonDecoder(jsonDecoder)
   testJsonDecoderError(ArgonautInstancesWithCustomErrors.jsonDecoder)(
     emptyBody = { case MalformedMessageBodyFailure("Custom Invalid JSON: empty body", _) => ok },
-    parseError = { case MalformedMessageBodyFailure("Custom Invalid JSON", _) => ok },
+    parseError = { case MalformedMessageBodyFailure("Custom Invalid JSON", _) => ok }
   )
 
   sealed case class Foo(bar: Int)

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -19,6 +19,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     .withJsonDecodeError((json, message, history) =>
       InvalidMessageBodyFailure(
         s"Custom Could not decode JSON: $json, error: $message, cursor: $history"))
+    .build
 
   testJsonDecoder(jsonDecoder)
   testJsonDecoderError(ArgonautInstancesWithCustomErrors.jsonDecoder)(
@@ -43,7 +44,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     }
 
     "write JSON according to custom encoders" in {
-      val custom = ArgonautInstances.withPrettyParams(PrettyParams.spaces2)
+      val custom = ArgonautInstances.withPrettyParams(PrettyParams.spaces2).build
       import custom._
       writeToString(json) must_== ("""{
                                      |  "test" : "ArgonautSupport"
@@ -68,7 +69,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     }
 
     "write JSON according to custom encoders" in {
-      val custom = ArgonautInstances.withPrettyParams(PrettyParams.spaces2)
+      val custom = ArgonautInstances.withPrettyParams(PrettyParams.spaces2).build
       import custom._
       writeToString(foo)(jsonEncoderOf) must_== ("""{
                                                    |  "bar" : 42

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -167,10 +167,8 @@ sealed abstract case class CirceInstancesBuilder private[circe] (
 }
 
 object CirceInstances {
-  def withPrinter(p: Printer): CirceInstances =
-    new CirceInstances {
-      override val defaultPrinter: Printer = p
-    }
+  def withPrinter(p: Printer): CirceInstancesBuilder =
+    builder.withPrinter(p)
 
   val builder: CirceInstancesBuilder = new CirceInstancesBuilder() {}
 

--- a/circe/src/main/scala/org/http4s/circe/package.scala
+++ b/circe/src/main/scala/org/http4s/circe/package.scala
@@ -1,12 +1,3 @@
 package org.http4s
 
-import cats.effect.Sync
-import io.circe.{Json, Printer}
-
-package object circe extends CirceInstances {
-  override val defaultPrinter: Printer =
-    Printer.noSpaces
-
-  override def jsonDecoder[F[_]: Sync]: EntityDecoder[F, Json] =
-    CirceInstances.defaultJsonDecoder
-}
+package object circe extends CirceInstances

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -4,6 +4,7 @@ package circe.test // Get out of circe package so we can import custom instances
 import cats.effect.IO
 import cats.effect.laws.util.TestContext
 import cats.syntax.applicative._
+import cats.syntax.foldable._
 import io.circe._
 import io.circe.syntax._
 import io.circe.testing.instances._
@@ -22,16 +23,23 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
 
   val CirceInstancesWithCustomErrors = CirceInstances.builder
     .withEmptyBodyMessage(MalformedMessageBodyFailure("Custom Invalid JSON: empty body"))
-    .withJawnParseExceptionMessage(_ => MalformedMessageBodyFailure("Custom Invalid JSON"))
-    .withCirceParseExceptionMessage(_ => MalformedMessageBodyFailure("Custom Invalid JSON"))
-    .withJsonDecodeError((json, failures) =>
-      InvalidMessageBodyFailure(s"Custom Could not decode JSON: $json, errors: $failures"))
+    .withJawnParseExceptionMessage(_ => MalformedMessageBodyFailure("Custom Invalid JSON jawn"))
+    .withCirceParseExceptionMessage(_ => MalformedMessageBodyFailure("Custom Invalid JSON circe"))
+    .withJsonDecodeError({ (json, failures) =>
+      val failureStr = failures.mkString_("", ", ", "")
+      InvalidMessageBodyFailure(
+        s"Custom Could not decode JSON: ${json.noSpaces}, errors: $failureStr")
+    })
     .build
 
   testJsonDecoder(jsonDecoder)
-  testJsonDecoderError(CirceInstancesWithCustomErrors.jsonDecoder)(
+  testJsonDecoderError(CirceInstancesWithCustomErrors.jsonDecoderIncremental)(
     emptyBody = { case MalformedMessageBodyFailure("Custom Invalid JSON: empty body", _) => ok },
-    parseError = { case MalformedMessageBodyFailure("Custom Invalid JSON", _) => ok }
+    parseError = { case MalformedMessageBodyFailure("Custom Invalid JSON jawn", _) => ok }
+  )
+  testJsonDecoderError(CirceInstancesWithCustomErrors.jsonDecoderByteBuffer)(
+    emptyBody = { case MalformedMessageBodyFailure("Custom Invalid JSON: empty body", _) => ok },
+    parseError = { case MalformedMessageBodyFailure("Custom Invalid JSON circe", _) => ok }
   )
 
   sealed case class Foo(bar: Int)
@@ -62,7 +70,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
     }
 
     "write JSON according to custom encoders" in {
-      val custom = CirceInstances.withPrinter(Printer.spaces2)
+      val custom = CirceInstances.withPrinter(Printer.spaces2).build
       import custom._
       writeToString(json) must_== ("""{
           |  "test" : "CirceSupport"
@@ -87,7 +95,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
     }
 
     "write JSON according to custom encoders" in {
-      val custom = CirceInstances.withPrinter(Printer.spaces2)
+      val custom = CirceInstances.withPrinter(Printer.spaces2).build
       import custom._
       writeToString(foo)(jsonEncoderOf) must_== ("""{
           |  "bar" : 42
@@ -140,6 +148,14 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
         result.value.unsafeRunSync must_== Right(Umlaut(wort))
       }
     }
+
+    "fail with custom message from a decoder" in {
+      val result = CirceInstancesWithCustomErrors
+        .jsonOf[IO, Bar]
+        .decode(Request[IO]().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
+      result.value.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
+        "Custom Could not decode JSON: {\"bar1\":42}, errors: DecodingFailure at .a: Attempt to decode value on failed cursor"))
+    }
   }
 
   "accumulatingJsonOf" should {
@@ -158,6 +174,14 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
       result.value.unsafeRunSync must beLike {
         case Left(InvalidMessageBodyFailure(_, Some(DecodingFailures(NonEmptyList(_, _))))) => ok
       }
+    }
+
+    "fail with custom message from a decoder" in {
+      val result = CirceInstancesWithCustomErrors
+        .accumulatingJsonOf[IO, Bar]
+        .decode(Request[IO]().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
+      result.value.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
+        "Custom Could not decode JSON: {\"bar1\":42}, errors: DecodingFailure at .a: Attempt to decode value on failed cursor, DecodingFailure at .b: Attempt to decode value on failed cursor"))
     }
   }
 

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -11,6 +11,11 @@ trait JawnInstances {
   def jawnDecoder[F[_]: Sync, J: RawFacade]: EntityDecoder[F, J] =
     EntityDecoder.decodeBy(MediaType.application.json)(jawnDecoderImpl[F, J])
 
+  def jawnParseExceptionMessage(pe: ParseException): DecodeFailure =
+    MalformedMessageBodyFailure("Invalid JSON", Some(pe))
+  def jawnEmptyBodyMessage: DecodeFailure =
+    MalformedMessageBodyFailure("Invalid JSON: empty body")
+
   // some decoders may reuse it and avoid extra content negotiation
   private[http4s] def jawnDecoderImpl[F[_]: Sync, J: RawFacade](
       msg: Message[F]): DecodeResult[F, J] =
@@ -20,12 +25,12 @@ trait JawnInstances {
         .map(Either.right)
         .handleErrorWith {
           case pe: ParseException =>
-            Stream.emit(Left(MalformedMessageBodyFailure("Invalid JSON", Some(pe))))
+            Stream.emit(Left(jawnParseExceptionMessage(pe)))
           case e =>
             Stream.raiseError[F](e)
         }
         .compile
         .last
-        .map(_.getOrElse(Left(MalformedMessageBodyFailure("Invalid JSON: empty body"))))
+        .map(_.getOrElse(Left(jawnEmptyBodyMessage)))
     }
 }

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -11,10 +11,10 @@ trait JawnInstances {
   def jawnDecoder[F[_]: Sync, J: RawFacade]: EntityDecoder[F, J] =
     EntityDecoder.decodeBy(MediaType.application.json)(jawnDecoderImpl[F, J])
 
-  def jawnParseExceptionMessage(pe: ParseException): DecodeFailure =
-    MalformedMessageBodyFailure("Invalid JSON", Some(pe))
-  def jawnEmptyBodyMessage: DecodeFailure =
-    MalformedMessageBodyFailure("Invalid JSON: empty body")
+  protected def jawnParseExceptionMessage: ParseException => DecodeFailure =
+    JawnInstances.defaultJawnParseExceptionMessage
+  protected def jawnEmptyBodyMessage: DecodeFailure =
+    JawnInstances.defaultJawnEmptyBodyMessage
 
   // some decoders may reuse it and avoid extra content negotiation
   private[http4s] def jawnDecoderImpl[F[_]: Sync, J: RawFacade](
@@ -33,4 +33,12 @@ trait JawnInstances {
         .last
         .map(_.getOrElse(Left(jawnEmptyBodyMessage)))
     }
+}
+
+object JawnInstances {
+  private[http4s] def defaultJawnParseExceptionMessage: ParseException => DecodeFailure =
+    pe => MalformedMessageBodyFailure("Invalid JSON", Some(pe))
+
+  private[http4s] def defaultJawnEmptyBodyMessage: DecodeFailure =
+    MalformedMessageBodyFailure("Invalid JSON: empty body")
 }

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
@@ -2,8 +2,9 @@ package org.http4s
 package jawn
 
 import cats.effect.IO
+import org.specs2.matcher.MatchResult
 
-trait JawnDecodeSupportSpec[J] extends Http4sSpec with JawnInstances {
+trait JawnDecodeSupportSpec[J] extends Http4sSpec {
   def testJsonDecoder(decoder: EntityDecoder[IO, J]) =
     "json decoder" should {
       "return right when the entity is valid" in {
@@ -11,18 +12,36 @@ trait JawnDecodeSupportSpec[J] extends Http4sSpec with JawnInstances {
         decoder.decode(resp, strict = false).value.unsafeRunSync must beRight
       }
 
-      "return a ParseFailure when the entity is invalid" in {
-        val resp = Response[IO](Status.Ok).withEntity("""garbage""")
-        decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like {
+      testErrors(decoder)(
+        emptyBody = {
+          case MalformedMessageBodyFailure("Invalid JSON: empty body", _) => ok
+        },
+        parseError = {
           case MalformedMessageBodyFailure("Invalid JSON", _) => ok
         }
-      }
-
-      "return a ParseFailure when the entity is empty" in {
-        val resp = Response[IO](Status.Ok).withEntity("")
-        decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like {
-          case MalformedMessageBodyFailure("Invalid JSON: empty body", _) => ok
-        }
-      }
+      )
     }
+
+  def testJsonDecoderError(decoder: EntityDecoder[IO, J])(
+      emptyBody: PartialFunction[DecodeFailure, MatchResult[Any]],
+      parseError: PartialFunction[DecodeFailure, MatchResult[Any]]
+  ) =
+    "json decoder with custom errors" should {
+      testErrors(decoder)(emptyBody = emptyBody, parseError = parseError)
+    }
+
+  private def testErrors(decoder: EntityDecoder[IO, J])(
+      emptyBody: PartialFunction[DecodeFailure, MatchResult[Any]],
+      parseError: PartialFunction[DecodeFailure, MatchResult[Any]]
+  ) = {
+    "return a ParseFailure when the entity is invalid" in {
+      val resp = Response[IO](Status.Ok).withEntity("""garbage""")
+      decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like(parseError)
+    }
+
+    "return a ParseFailure when the entity is empty" in {
+      val resp = Response[IO](Status.Ok).withEntity("")
+      decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like(emptyBody)
+    }
+  }
 }


### PR DESCRIPTION
The direction I was taking was to allow overriding of the error messages in the traits .
I'm open to using implicits instead, just need suggestions.

- [X] Jawn Custom Parse Error Messages
- [x] Argonaut Custom Decode Errors
- [x] Circe Custom Decode Errors
