### PR TITLE
Make double slashes more reasonable in DSL

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -24,15 +24,45 @@ trait Path {
 }
 
 object Path {
+  /** Constructs a path from a single string by splitting on the `'/'`
+    * character.
+    *   
+    * Leading slashes do not create an empty path segment.  This is to
+    * reflect that there is no distinction between a request to
+    * `http://www.example.com` from `http://www.example.com/`.
+    * 
+    * Trailing slashes result in a path with an empty final segment,
+    * unless the path is `"/"`, which is `Root`.
+    * 
+    * Segments are URL decoded.
+    * 
+    * {{{
+    * scala> Path("").toList
+    * res0: List[String] = List()
+    * scala> Path("/").toList
+    * res1: List[String] = List()
+    * scala> Path("a").toList
+    * res2: List[String] = List(a)
+    * scala> Path("/a").toList
+    * res3: List[String] = List(a)
+    * scala> Path("/a/").toList
+    * res4: List[String] = List(a, "")
+    * scala> Path("//a").toList
+    * res5: List[String] = List("", a)
+    * scala> Path("/%2F").toList
+    * res0: List[String] = List(/)
+    * }}}
+    */
   def apply(str: String): Path =
     if (str == "" || str == "/")
       Root
-    else if (!str.startsWith("/"))
-      Path("/" + str)
     else {
-      val slash = str.lastIndexOf('/')
-      val prefix = Path(str.substring(0, slash))
-      prefix / UrlCodingUtils.urlDecode(str.substring(slash + 1))
+      def loop(str: String): Path = {
+        val slash = str.lastIndexOf('/')
+        val prefix = if (slash <= 0) Root else loop(str.substring(0, slash))
+        prefix / UrlCodingUtils.urlDecode(str.substring(slash + 1))
+      }
+      loop(str)
     }
 
   def apply(first: String, rest: String*): Path =

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -59,6 +59,7 @@ object Path {
       Root
     else {
       val segments = str.split("/", -1)
+      // .head is safe because split always returns non-empty array
       val segments0 = if (segments.head == "") segments.drop(1) else segments
       segments0.foldLeft(Root: Path)((path, seg) => path / UrlCodingUtils.urlDecode(seg))
     }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -24,18 +24,19 @@ trait Path {
 }
 
 object Path {
+
   /** Constructs a path from a single string by splitting on the `'/'`
     * character.
-    *   
+    *
     * Leading slashes do not create an empty path segment.  This is to
     * reflect that there is no distinction between a request to
     * `http://www.example.com` from `http://www.example.com/`.
-    * 
+    *
     * Trailing slashes result in a path with an empty final segment,
     * unless the path is `"/"`, which is `Root`.
-    * 
+    *
     * Segments are URL decoded.
-    * 
+    *
     * {{{
     * scala> Path("").toList
     * res0: List[String] = List()
@@ -57,12 +58,9 @@ object Path {
     if (str == "" || str == "/")
       Root
     else {
-      def loop(str: String): Path = {
-        val slash = str.lastIndexOf('/')
-        val prefix = if (slash <= 0) Root else loop(str.substring(0, slash))
-        prefix / UrlCodingUtils.urlDecode(str.substring(slash + 1))
-      }
-      loop(str)
+      val segments = str.split("/", -1)
+      val segments0 = if (segments.head == "") segments.drop(1) else segments
+      segments0.foldLeft(Root: Path)((path, seg) => path / UrlCodingUtils.urlDecode(seg))
     }
 
   def apply(first: String, rest: String*): Path =

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -235,5 +235,9 @@ class PathSpec extends Http4sSpec {
     "consistent apply / toList" in prop { p: Path =>
       Path(p.toList) must_== p
     }
+
+    "Path.apply is stack safe" in {
+      Path("/" * 1000000) must beAnInstanceOf[Path]
+    }
   }
 }

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -8,18 +8,29 @@ package org.http4s
 package dsl
 
 import cats.effect.IO
-import org.http4s.dsl.io._
 import org.http4s.Uri.uri
+import org.http4s.dsl.io._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
 
 class PathSpec extends Http4sSpec {
+  implicit val arbitraryPath: Arbitrary[Path] =
+    Arbitrary {
+      arbitrary[List[String]].map(Path(_))
+    }
+
   "Path" should {
 
     "/foo/bar" in {
-      Path("/foo/bar").toList must_== (List("foo", "bar"))
+      Path("/foo/bar") must_== Path("foo", "bar")
     }
 
     "foo/bar" in {
-      Path("foo/bar").toList must_== (List("foo", "bar"))
+      Path("foo/bar") must_== Path("foo", "bar")
+    }
+
+    "//foo/bar" in {
+      Path("//foo/bar") must_== Path("", "foo", "bar")
     }
 
     "~ extractor on Path" in {
@@ -219,6 +230,10 @@ class PathSpec extends Http4sSpec {
           }) must beFalse
         }
       }
+    }
+
+    "consistent apply / toList" in prop { p: Path =>
+      Path(p.toList) must_== p
     }
   }
 }


### PR DESCRIPTION
Leading slashes in the DSL `Path` do not create an empty segment, because we can't distinguish `www.example.com` from `www.example.com/`.  In other words, `Path("/") == Path("") == Root`.

Currently, we drop the leading slash not once, not repeatedly, but twice:
* `Path("//a") == Root / "a"`
* `Path("///a") == Root / "" / "a"`

This change consistently drops the leading slash once:
* `Path("//a") == Root / "" / "a"`
* `Path("///a") == Root / "" / "" / "a"`

Adds a scaladoc, with doctests, and a property test about consistency between `apply(String)` and `apply(List[String])`.

This is inspired by the discussion on #2273.