### PR TITLE
Docs: Add a simple example of building server using Resource

### DIFF
--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -197,6 +197,21 @@ object Main extends IOApp {
 }
 ```
 
+You may also create the server within an `IOApp` using resource:
+
+```tut:book
+object MainWithResource extends IOApp {
+
+  def run(args: List[String]): IO[ExitCode] =
+    BlazeServerBuilder[IO]
+      .bindHttp(8080, "localhost")
+      .withHttpApp(Main.helloWorldService)
+      .resource
+      .use(_ => IO.never)
+      .as(ExitCode.Success)
+}
+```
+
 [blaze]: https://github.com/http4s/blaze
 [tut]: https://github.com/tpolecat/tut
 [Cats Kleisli Datatype]: https://typelevel.org/cats/datatypes/kleisli.html


### PR DESCRIPTION
Motivated by this example, where a user tried to lift
a server created in IO via `.stream` into a `Resource`,
then was left with a process that appeared to work
but could not exit

https://gitter.im/http4s/http4s?at=5c2550d7d945b968820580ef