### PR TITLE
Docs: Use :silent on import statements

### DIFF
--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -11,7 +11,7 @@ For this section, remember that, like mentioned in the [service] section, a serv
 
 Lets start by defining all the imports we will need in the examples below:
 
-```tut:book:silent
+```tut:silent
 import cats._, cats.effect._, cats.implicits._, cats.data._
 import org.http4s._
 import org.http4s.dsl.io._
@@ -25,7 +25,7 @@ such object, and is the equivalent to `(User, Request[F])`. _http4s_ provides yo
 but you have to provide your own _user_, or _authInfo_ representation. For our purposes here we will
 use the following definition:
 
-```tut:book:silent
+```tut:silent
 case class User(id: Long, name: String)
 ```
 
@@ -38,7 +38,7 @@ With that we can represent a service that requires authentication, but to actual
 to define how to extract the authentication information from the request. For that, we need a function
 with the following signature: `Request[F] => OptionT[F, User]`. Here is an example of how to define it:
 
-```tut:book:silent
+```tut:silent
 val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] =
   Kleisli(_ => OptionT.liftF(IO(???)))
 ```
@@ -50,7 +50,7 @@ IO operations.
 Now we need a middleware that can bridge a "normal" service into an `AuthedService`, which is quite easy to
 get using our function defined above. We use `AuthMiddleware` for that:
 
-```tut:book:silent
+```tut:silent
 val middleware: AuthMiddleware[IO, User] =
   AuthMiddleware(authUser)
 ```
@@ -65,7 +65,7 @@ wish to always return 401, use `AuthMiddleware.noSpider` and specify the `onAuth
 Finally, we can create our `AuthedService`, and wrap it with our authentication middleware, getting the
 final `HttpRoutes` to be exposed. Notice that we now have access to the user object in the service implementation:
 
-```tut:book:silent
+```tut:silent
 val authedService: AuthedService[User, IO] =
   AuthedService {
     case GET -> Root / "welcome" as user => Ok(s"Welcome, ${user.name}")
@@ -87,7 +87,7 @@ To allow for failure, the `authUser` function has to be adjusted to a `Request[F
 => F[Either[String,User]]`. So we'll need to handle that possibility. For advanced
 error handling, we recommend an error [ADT] instead of a `String`.
 
-```tut:book:silent
+```tut:silent
 val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli(_ => IO(???))
 
 val onFailure: AuthedService[String, IO] = Kleisli(req => OptionT.liftF(Forbidden(req.authInfo)))
@@ -118,7 +118,7 @@ use multiple application instances.
 
 The message is simply the user id.
 
-```tut:book:silent
+```tut:silent
 import org.reactormonk.{CryptoBits, PrivateKey}
 import java.time._
 
@@ -141,7 +141,7 @@ val logIn: Kleisli[IO, Request[IO], Response[IO]] = Kleisli({ request =>
 
 Now that the cookie is set, we can retrieve it again in the `authUser`.
 
-```tut:book:silent
+```tut:silent
 def retrieveUser: Kleisli[IO, Long, User] = Kleisli(id => IO(???))
 val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ request =>
   val message = for {
@@ -160,7 +160,7 @@ There is no inherent way to set the Authorization header, send the token in any
 way that your [SPA] understands. Retrieve the header value in the `authUser`
 function.
 
-```tut:book:silent
+```tut:silent
 import org.http4s.util.string._
 import org.http4s.headers.Authorization
 

--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
 
 Then we create the [service] again so tut picks it up:
 >
-```tut:book:silent
+```tut:silent
 import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._
@@ -38,7 +38,7 @@ Blaze needs a [[`ConcurrentEffect`]] instance, which is derived from
 [[`ContextShift`]].  The following lines are not necessary if you are
 in an [[`IOApp`]]:
 
-```tut:book:silent
+```tut:silent
 import scala.concurrent.ExecutionContext.global
 implicit val cs: ContextShift[IO] = IO.contextShift(global)
 implicit val timer: Timer[IO] = IO.timer(global)
@@ -68,7 +68,7 @@ val fiber = server.use(_ => IO.never).start.unsafeRunSync()
 A good default choice is the `BlazeClientBuilder`.  The
 `BlazeClientBuilder` maintains a connection pool and speaks HTTP 1.x.
 
-```tut:book:silent
+```tut:silent
 import org.http4s.client.blaze._
 import org.http4s.client._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -92,7 +92,7 @@ interface!
 It uses blocking IO and is less suited for production, but it is
 highly useful in a REPL:
 
-```tut:book:silent
+```tut:silent
 import scala.concurrent.ExecutionContext
 import java.util.concurrent._
 
@@ -123,7 +123,7 @@ side effects to the end.
 Let's describe how we're going to greet a collection of people in
 parallel:
 
-```tut:book:silent
+```tut:silent
 import cats._, cats.effect._, cats.implicits._
 import org.http4s.Uri
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -231,7 +231,7 @@ libraryDependencies ++= Seq(
 We can create a middleware that registers metrics prefixed with a
 provided prefix like this.
 
-```tut:book:silent
+```tut:silent
 import org.http4s.client.middleware.Metrics
 import org.http4s.metrics.dropwizard.Dropwizard
 import com.codahale.metrics.SharedMetricRegistries
@@ -261,7 +261,7 @@ libraryDependencies ++= Seq(
 We can create a middleware that registers metrics prefixed with a
 provided prefix like this.
 
-```tut:book:silent
+```tut:silent
 import org.http4s.client.middleware.Metrics
 import org.http4s.metrics.prometheus.Prometheus
 import io.prometheus.client.CollectorRegistry
@@ -291,7 +291,7 @@ httpClient.expect[String](Uri.uri("https://google.com/"))
 If you need to do something more complicated like setting request headers, you
 can build up a request object and pass that to `expect`:
 
-```tut:book:silent
+```tut:silent
 import org.http4s.client.dsl.io._
 import org.http4s.headers._
 import org.http4s.MediaType

--- a/docs/src/main/tut/cors.md
+++ b/docs/src/main/tut/cors.md
@@ -40,8 +40,11 @@ service.orNotFound(request).unsafeRunSync
 
 Now we can wrap the service in the `CORS` middleware.
 
-```tut:book
+```tut:silent
 import org.http4s.server.middleware._
+```
+
+```tut:book
 val corsService = CORS(service)
 
 corsService.orNotFound(request).unsafeRunSync
@@ -78,9 +81,11 @@ val duckPost = Request[IO](Method.POST, Uri.uri("/"), headers = Headers(Header("
 Now, we'll create a configuration that limits the allowed methods to `GET`
 and `POST`, pass that to the `CORS` middleware, and try it out on our requests.
 
-```tut:book
+```tut:silent
 import scala.concurrent.duration._
+```
 
+```tut:book
 val methodConfig = CORSConfig(
   anyOrigin = true,
   anyMethod = false,

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -35,7 +35,7 @@ $ sbt console
 
 We'll need the following imports to get started:
 
-```tut:book
+```tut:silent
 import cats.effect._
 import org.http4s._, org.http4s.dsl.io._, org.http4s.implicits._
 ```
@@ -133,7 +133,7 @@ Ok("Ok response.").unsafeRunSync.headers
 
 Extra headers can be added using `putHeaders`, for example to specify cache policies:
 
-```tut:book
+```tut:silent
 import org.http4s.headers.`Cache-Control`
 import org.http4s.CacheDirective.`no-cache`
 import cats.data.NonEmptyList
@@ -208,7 +208,7 @@ NoContent("does not compile")
 While http4s prefers `F[_]: Effect`, you may be working with libraries that
 use standard library `Future`s.  Some relevant imports:
 
-```tut:book
+```tut:silent
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 ```
@@ -253,11 +253,13 @@ An intro to `Stream` is out of scope, but we can glimpse the
 power here.  This stream emits the elapsed time every 100 milliseconds
 for one second:
 
-```tut:book
+```tut:silent
 import fs2.Stream
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+```
 
+```tut:book
 // Provided by `cats.effect.IOApp`
 implicit val timer: Timer[IO] = IO.timer(global)
 
@@ -377,11 +379,13 @@ If you want to extract a variable of type `T`, you can provide a custom extracto
 object which implements `def unapply(str: String): Option[T]`, similar to the way
 in which `IntVar` does it.
 
-```tut:book
+```tut:silent
 import java.time.LocalDate
 import scala.util.Try
 import org.http4s.client.dsl.io._
+```
 
+```tut:book
 object LocalDateVar {
   def unapply(str: String): Option[LocalDate] = {
     if (!str.isEmpty)
@@ -412,10 +416,12 @@ return optional or validated parameter values.
 In the example below we're finding query params named `country` and `year` and
 then parsing them as a `String` and `java.time.Year`.
 
-```tut:book
+```tut:silent
 import java.time.Year
 import cats.data.ValidatedNel
+```
 
+```tut:book
 object CountryQueryParamMatcher extends QueryParamDecoderMatcher[String]("country")
 
 implicit val yearQueryParamDecoder: QueryParamDecoder[Year] =
@@ -435,10 +441,12 @@ val averageTemperatureService = HttpRoutes.of[IO] {
 
 To accept a optional query parameter a `OptionalQueryParamDecoderMatcher` can be used.
 
-```tut:book
+```tut:silent
 import java.time.Year
 import org.http4s.client.dsl.io._
+```
 
+```tut:book
 implicit val yearQueryParamDecoder: QueryParamDecoder[Year] =
   QueryParamDecoder[Int].map(Year.of)
 

--- a/docs/src/main/tut/entity.md
+++ b/docs/src/main/tut/entity.md
@@ -44,7 +44,7 @@ runtime errors.
 Decoders' content types are used when chaining decoders with `orElse` in order to
 determine which of the chained decoders are to be used.
 
-```tut
+```tut:silent
 import org.http4s._
 import org.http4s.headers.`Content-Type`
 import org.http4s.dsl.io._
@@ -53,7 +53,9 @@ import cats._, cats.effect._, cats.implicits._, cats.data._
 sealed trait Resp
 case class Audio(body: String) extends Resp
 case class Video(body: String) extends Resp
+```
 
+```tut:book
 val response = Ok("").map(_.withContentType(`Content-Type`(MediaType.audio.ogg)))
 val audioDec = EntityDecoder.decodeBy(MediaType.audio.ogg) { msg: Message[IO] =>
   EitherT {

--- a/docs/src/main/tut/hsts.md
+++ b/docs/src/main/tut/hsts.md
@@ -43,8 +43,11 @@ response.headers
 
 If we were to wrap this on the `HSTS` middleware.
 
-```tut:book
+```tut:silent
 import org.http4s.server.middleware._
+```
+
+```tut:book
 val hstsService = HSTS(service)
 
 // Do not call 'unsafeRunSync' in your code
@@ -65,10 +68,12 @@ should be done over `https` and it will contain the `includeSubDomains` directiv
 
 If you want to `preload` or change other default values you can pass a custom header, e.g.
 
-```tut:book
+```tut:silent
 import org.http4s.headers._
 import scala.concurrent.duration._
+```
 
+```tut:book
 val hstsHeader = `Strict-Transport-Security`.unsafeFromDuration(30.days, includeSubDomains = true, preload = true)
 val hstsService = HSTS(service, hstsHeader)
 

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -63,7 +63,7 @@ bases its codecs on runtime reflection.
 
 Let's create a function to produce a simple JSON greeting with circe. First, the imports:
 
-```tut:book:silent
+```tut:silent
 import cats.effect._
 import io.circe._
 import io.circe.literal._
@@ -91,19 +91,23 @@ To encode a Scala value of type `A` into an entity, we need an
 `org.http4s.circe` object, which gives us exactly this for an
 `io.circe.Json` value:
 
-```tut:book
+```tut:silent
 import org.http4s.circe._
+```
 
+```tut:book
 Ok(greeting).unsafeRunSync
 ```
 
 The same `EntityEncoder[Json]` we use on server responses is also
 useful on client requests:
 
-```tut:book
+```tut:silent
 import org.http4s.client._
 import org.http4s.client.dsl.io._
+```
 
+```tut:book
 POST(json"""{"name": "Alice"}""", Uri.uri("/hello")).unsafeRunSync
 ```
 
@@ -148,9 +152,11 @@ That was easy, but gets tedious for applications dealing in lots of
 types.  Fortunately, circe can automatically derive an encoder for us,
 using the field names of the case class as key names in a JSON object:
 
-```tut:book
+```tut:silent
 import io.circe.generic.auto._
+```
 
+```tut:book
 User("Alice").asJson
 ```
 
@@ -164,7 +170,7 @@ POST(User("Bob").asJson, Uri.uri("/hello")).unsafeRunSync
 
 If within some route we serve json only, we can use:
 
-```tut:book
+```tut:silent
 {
 import org.http4s.circe.CirceEntityEncoder._
 }
@@ -209,7 +215,7 @@ POST("""{"name":"Bob"}""", Uri.uri("/hello")).flatMap(_.as[User]).unsafeRunSync
 If we are always decoding from JSON to a typed model, we can use
 the following import:
 
-```tut:book
+```tut:silent
 import org.http4s.circe.CirceEntityDecoder._
 ```
 
@@ -222,7 +228,7 @@ from JSON (even if it is XML or plain text, for instance).
 For more convenience there is import combining both encoding 
 and decoding derivation: 
 
-```tut:book
+```tut:silent
 import org.http4s.circe.CirceEntityCodec._
 ```
 

--- a/docs/src/main/tut/methods.md
+++ b/docs/src/main/tut/methods.md
@@ -7,13 +7,15 @@ title: HTTP Methods
 For a REST API, your service will want to support different verbs/methods.
 Http4s has a list of all the [methods] you're familiar with, and a few more.
 
-```tut:book
+```tut:silent
 import cats.effect._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.http4s._, org.http4s.dsl.io._
 import org.http4s.circe._
+```
 
+```tut:book
 case class TweetWithId(id: Int, message: String)
 case class Tweet(message: String)
 

--- a/docs/src/main/tut/middleware.md
+++ b/docs/src/main/tut/middleware.md
@@ -170,7 +170,7 @@ libraryDependencies ++= Seq(
 We can create a middleware that registers metrics prefixed with a
 provided prefix like this.
 
-```tut:book:silent
+```tut:silent
 import org.http4s.server.middleware.Metrics
 import org.http4s.metrics.dropwizard.Dropwizard
 import com.codahale.metrics.SharedMetricRegistries
@@ -196,7 +196,7 @@ libraryDependencies ++= Seq(
 We can create a middleware that registers metrics prefixed with a
 provided prefix like this.
 
-```tut:book:silent
+```tut:silent
 import org.http4s.server.middleware.Metrics
 import org.http4s.metrics.prometheus.Prometheus
 import io.prometheus.client.CollectorRegistry

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -51,14 +51,14 @@ prefer you can read these introductions first:
 Wherever you are in your studies, let's create our first
 `HttpRoutes`.  Start by pasting these imports into your SBT console:
 
-```tut:book:silent
+```tut:silent
 import cats.effect._, org.http4s._, org.http4s.dsl.io._, scala.concurrent.ExecutionContext.Implicits.global
 ```
 
 You also will need a `ContextShift` and a `Timer`.  These come for
 free if you are in an `IOApp`.
 
-```tut:book:silent
+```tut:silent
 implicit val cs: ContextShift[IO] = IO.contextShift(global)
 implicit val timer: Timer[IO] = IO.timer(global)
 ```

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -121,12 +121,14 @@ Multiple `HttpRoutes` can be combined with the `combineK` method (or its alias
 
 `scalacOptions ++= Seq("-Ypartial-unification")`
 
-```tut:book
+```tut:silent
 import cats.implicits._
 import org.http4s.server.blaze._
 import org.http4s.implicits._
 import org.http4s.server.Router
+```
 
+```tut:book
 val services = tweetService <+> helloWorldService
 val httpApp = Router("/" -> helloWorldService, "/api" -> services).orNotFound
 val serverBuilder = BlazeServerBuilder[IO].bindHttp(8080, "localhost").withHttpApp(httpApp)
@@ -170,7 +172,7 @@ with an abstract `run` method that returns a `IO[ExitCode]`.  An
 the infinite process and gracefully shut down your server when a
 SIGTERM is received.
 
-```tut:book:reset
+```tut:silent:reset
 import cats.effect._
 import cats.implicits._
 import org.http4s.HttpRoutes
@@ -178,7 +180,9 @@ import org.http4s.syntax._
 import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.http4s.server.blaze._
+```
 
+```tut:book
 object Main extends IOApp {
 
   val helloWorldService = HttpRoutes.of[IO] {

--- a/docs/src/main/tut/static.md
+++ b/docs/src/main/tut/static.md
@@ -16,7 +16,7 @@ similar static file hoster, but they're often fast enough.
 ## Serving static files
 Http4s provides a few helpers to handle ETags for you, they're located in [StaticFile].
 
-```tut:book
+```tut:silent
 import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._
@@ -28,7 +28,7 @@ import java.io.File
 Static file support uses a blocking API, so we'll need a blocking execution
 context:
 
-```tut:book:silent
+```tut:silent
 import java.util.concurrent._
 import scala.concurrent.ExecutionContext
 
@@ -38,11 +38,11 @@ val blockingEc = ExecutionContext.fromExecutorService(Executors.newFixedThreadPo
 It also needs a main thread pool to shift back to.  This is provided when
 we're in IOApp, but you'll need one if you're following along in a REPL:
 
-```tut:book:silent
+```tut:silent
 implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 ```
 
-```tut:book:silent
+```tut:silent
 val routes = HttpRoutes.of[IO] {
   case request @ GET -> Root / "index.html" =>
     StaticFile.fromFile(new File("relative/path/to/index.html"), blockingEc, Some(request))
@@ -77,10 +77,12 @@ libraryDependencies ++= Seq(
 
 Then, mount the `WebjarService` like any other service:
 
-```tut:book
+```tut:silent
 import org.http4s.server.staticcontent.webjarService
 import org.http4s.server.staticcontent.WebjarService.{WebjarAsset, Config}
+```
 
+```tut:book
 // only allow js assets
 def isJsAsset(asset: WebjarAsset): Boolean =
   asset.asset.endsWith(".js")

--- a/docs/src/main/tut/testing.md
+++ b/docs/src/main/tut/testing.md
@@ -13,7 +13,7 @@ After reading this doc, the reader should feel comfortable writing a unit test u
 
 Now, let's define an `org.http4s.HttpService`.
 
-```tut:book
+```tut:silent
 import cats.implicits._
 import io.circe._
 import io.circe.syntax._
@@ -23,7 +23,9 @@ import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.io._
 import org.http4s.implicits._
+```
 
+```tut:book
 final case class User(name: String, age: Int) 
 implicit val UserEncoder: Encoder[User] = deriveEncoder[User]
 

--- a/docs/src/main/tut/uri.md
+++ b/docs/src/main/tut/uri.md
@@ -10,9 +10,11 @@ http4s is a bit more strict with handling URIs than e.g. the [play http client].
 Instead of passing plain `String`s, http4s operates on URIs. You can construct
 literal URI with
 
-```tut:book
+```tut:silent
 import org.http4s._
+```
 
+```tut:book
 val uri = Uri.uri("http://http4s.org")
 ```
 
@@ -34,9 +36,11 @@ assert(docs == docs2)
 
 ### URI Template
 
-```tut:book
+```tut:silent
 import org.http4s.UriTemplate._
+```
 
+```tut:book
 val template = UriTemplate(
   authority = Some(Uri.Authority(host = Uri.RegName("http4s.org"))),
   scheme = Some(Uri.Scheme.http),


### PR DESCRIPTION
Note: I just applied this change to a single file. Feel free to close this if it's not desired, or let me know if this seems better and I'll happily apply the same change to all the docs.

:silent is desirable to avoid showing the user repl responses
about each individual import. Usually we want to show the
user the types inferred from repl lines, but for import
statements there's no value. The proof the import was
found is in the docs compiling at all.

The tradeoff here is that when the markdown is rendered, there will be a break between blocks that otherwise would be in the same file