### PR TITLE
Option Client Decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ atlassian-ide-plugin.xml
 .ensime_cache
 .cache-main
 .cache-tests
+.metals
+.bloop
 
 project/travis-deploy-key
 project/.gnupg

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -125,7 +125,8 @@ trait Client[F[_]] {
     */
   def expect[A](s: String)(implicit d: EntityDecoder[F, A]): F[A]
 
-  def expectOptionOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
+  def expectOptionOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(
+      implicit d: EntityDecoder[F, A]): F[Option[A]]
   def expectOption[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[Option[A]]
 
   /**
@@ -195,7 +196,6 @@ object Client {
       implicit F: Bracket[F, Throwable]): Client[F] = new DefaultClient[F] {
     def run(req: Request[F]): Resource[F, Response[F]] = f(req)
   }
-
 
   /** Creates a client from the specified service.  Useful for generating
     * pre-determined responses for requests in testing.

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -126,12 +126,8 @@ trait Client[F[_]] {
   def expect[A](s: String)(implicit d: EntityDecoder[F, A]): F[A]
 
   def expectOptionOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
-  def expectOptionOr[A](uri: Uri)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
-  def expectOptionOr[A](s: String)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
   def expectOption[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[Option[A]]
-  def expectOption[A](uri: Uri)(implicit d: EntityDecoder[F, A]): F[Option[A]]
-  def expectOption[A](s: String)(implicit d: EntityDecoder[F, A]): F[Option[A]]
-  
+
   /**
     * Submits a request and decodes the response, regardless of the status code.
     * The underlying HTTP connection is closed at the completion of the

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -125,6 +125,13 @@ trait Client[F[_]] {
     */
   def expect[A](s: String)(implicit d: EntityDecoder[F, A]): F[A]
 
+  def expectOptionOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
+  def expectOptionOr[A](uri: Uri)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
+  def expectOptionOr[A](s: String)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
+  def expectOption[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[Option[A]]
+  def expectOption[A](uri: Uri)(implicit d: EntityDecoder[F, A]): F[Option[A]]
+  def expectOption[A](s: String)(implicit d: EntityDecoder[F, A]): F[Option[A]]
+  
   /**
     * Submits a request and decodes the response, regardless of the status code.
     * The underlying HTTP connection is closed at the completion of the
@@ -192,6 +199,7 @@ object Client {
       implicit F: Bracket[F, Throwable]): Client[F] = new DefaultClient[F] {
     def run(req: Request[F]): Resource[F, Response[F]] = f(req)
   }
+
 
   /** Creates a client from the specified service.  Useful for generating
     * pre-determined responses for requests in testing.

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -141,7 +141,8 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
   def expect[A](s: String)(implicit d: EntityDecoder[F, A]): F[A] =
     expectOr(s)(defaultOnError)
 
-  def expectOptionOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]] = {
+  def expectOptionOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(
+      implicit d: EntityDecoder[F, A]): F[Option[A]] = {
     val r = if (d.consumes.nonEmpty) {
       val m = d.consumes.toList
       req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -152,21 +152,14 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
       case failedResponse =>
         failedResponse.status match {
           case Status.NotFound => Option.empty[A].pure[F]
+          case Status.Gone => Option.empty[A].pure[F]
           case _ => onError(failedResponse).flatMap(F.raiseError)
         }
     }
   }
-  def expectOptionOr[A](uri: Uri)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]] =
-    expectOptionOr(Request[F](Method.GET, uri))(onError)
-  def expectOptionOr[A](s: String)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]] = 
-    Uri.fromString(s).fold(F.raiseError, uri => expectOptionOr[A](uri)(onError))
 
   def expectOption[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[Option[A]] =
     expectOptionOr(req)(defaultOnError)
-  def expectOption[A](uri: Uri)(implicit d: EntityDecoder[F, A]): F[Option[A]] =
-    expectOptionOr(uri)(defaultOnError)
-  def expectOption[A](s: String)(implicit d: EntityDecoder[F, A]): F[Option[A]] =
-    expectOptionOr(s)(defaultOnError)
 
   /**
     * Submits a request and decodes the response, regardless of the status code.

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -141,6 +141,33 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
   def expect[A](s: String)(implicit d: EntityDecoder[F, A]): F[A] =
     expectOr(s)(defaultOnError)
 
+  def expectOptionOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]] = {
+    val r = if (d.consumes.nonEmpty) {
+      val m = d.consumes.toList
+      req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
+    } else req
+    fetch(r) {
+      case Successful(resp) =>
+        d.decode(resp, strict = false).fold(throw _, identity).map(_.some)
+      case failedResponse =>
+        failedResponse.status match {
+          case Status.NotFound => Option.empty[A].pure[F]
+          case _ => onError(failedResponse).flatMap(F.raiseError)
+        }
+    }
+  }
+  def expectOptionOr[A](uri: Uri)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]] =
+    expectOptionOr(Request[F](Method.GET, uri))(onError)
+  def expectOptionOr[A](s: String)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]] = 
+    Uri.fromString(s).fold(F.raiseError, uri => expectOptionOr[A](uri)(onError))
+
+  def expectOption[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[Option[A]] =
+    expectOptionOr(req)(defaultOnError)
+  def expectOption[A](uri: Uri)(implicit d: EntityDecoder[F, A]): F[Option[A]] =
+    expectOptionOr(uri)(defaultOnError)
+  def expectOption[A](s: String)(implicit d: EntityDecoder[F, A]): F[Option[A]] =
+    expectOptionOr(s)(defaultOnError)
+
   /**
     * Submits a request and decodes the response, regardless of the status code.
     * The underlying HTTP connection is closed at the completion of the

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -239,7 +239,8 @@ class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThro
     }
 
     "return empty with expectOption and not found" in {
-      client.expectOption[String](Request[IO](GET, uri("http://www.foo.com/random-not-found"))) must returnValue(Option.empty[String])
+      client.expectOption[String](Request[IO](GET, uri("http://www.foo.com/random-not-found"))) must returnValue(
+        Option.empty[String])
     }
     "return expected value with expectOption and a response" in {
       client.expectOption[String](Request[IO](GET, uri("http://www.foo.com/echoheaders"))) must returnValue(

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -238,6 +238,15 @@ class ClientSyntaxSpec extends Http4sSpec with Http4sClientDsl[IO] with MustThro
         EntityDecoder.text[IO].orElse(edec)) must returnValue("Accept: text/*, image/jpeg")
     }
 
+    "return empty with expectOption and not found" in {
+      client.expectOption[String](Request[IO](GET, uri("http://www.foo.com/random-not-found"))) must returnValue(Option.empty[String])
+    }
+    "return expected value with expectOption and a response" in {
+      client.expectOption[String](Request[IO](GET, uri("http://www.foo.com/echoheaders"))) must returnValue(
+        "Accept: text/*".some
+      )
+    }
+
     "stream returns a stream" in {
       client
         .stream(req)


### PR DESCRIPTION
Adds - 
```
 def expectOptionOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
  def expectOptionOr[A](uri: Uri)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
  def expectOptionOr[A](s: String)(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[Option[A]]
  def expectOption[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[Option[A]]
  def expectOption[A](uri: Uri)(implicit d: EntityDecoder[F, A]): F[Option[A]]
  def expectOption[A](s: String)(implicit d: EntityDecoder[F, A]): F[Option[A]]
```

These methods decode and are Some on Succesful, and return None on 404. And have a failure mechanism similar to the expect line. 

Open Questions - None on `Gone`?