### PR TITLE
Change clientAuthMode to an enum

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -114,12 +114,14 @@ class BlazeBuilder[F[_]](
       keyManagerPassword: String,
       protocol: String = "TLS",
       trustStore: Option[StoreInfo] = None,
-      clientAuth: Boolean = false): Self = {
+      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested): Self = {
     val bits = KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)
     copy(sslBits = Some(bits))
   }
 
-  def withSSLContext(sslContext: SSLContext, clientAuth: Boolean = false): Self =
+  def withSSLContext(
+      sslContext: SSLContext,
+      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested): Self =
     copy(sslBits = Some(SSLContextBits(sslContext, clientAuth)))
 
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
@@ -183,7 +185,7 @@ class BlazeBuilder[F[_]](
     b.resource
   }
 
-  private def getContext(): Option[(SSLContext, Boolean)] = sslBits.map {
+  private def getContext(): Option[(SSLContext, SSLClientAuthMode.Value)] = sslBits.map {
     case KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth) =>
       val ksStream = new FileInputStream(keyStore.path)
       val ks = KeyStore.getInstance("JKS")

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -114,14 +114,14 @@ class BlazeBuilder[F[_]](
       keyManagerPassword: String,
       protocol: String = "TLS",
       trustStore: Option[StoreInfo] = None,
-      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested): Self = {
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested): Self = {
     val bits = KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)
     copy(sslBits = Some(bits))
   }
 
   def withSSLContext(
       sslContext: SSLContext,
-      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested): Self =
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested): Self =
     copy(sslBits = Some(SSLContextBits(sslContext, clientAuth)))
 
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
@@ -185,7 +185,7 @@ class BlazeBuilder[F[_]](
     b.resource
   }
 
-  private def getContext(): Option[(SSLContext, SSLClientAuthMode.Value)] = sslBits.map {
+  private def getContext(): Option[(SSLContext, SSLClientAuthMode)] = sslBits.map {
     case KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth) =>
       val ksStream = new FileInputStream(keyStore.path)
       val ks = KeyStore.getInstance("JKS")

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -138,14 +138,14 @@ class BlazeServerBuilder[F[_]](
       keyManagerPassword: String,
       protocol: String = "TLS",
       trustStore: Option[StoreInfo] = None,
-      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested): Self = {
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested): Self = {
     val bits = KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)
     copy(sslBits = Some(bits))
   }
 
   def withSSLContext(
       sslContext: SSLContext,
-      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested): Self =
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested): Self =
     copy(sslBits = Some(SSLContextBits(sslContext, clientAuth)))
 
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
@@ -330,7 +330,7 @@ class BlazeServerBuilder[F[_]](
     })
   }
 
-  private def getContext(): Option[(SSLContext, SSLClientAuthMode.Value)] = sslBits.map {
+  private def getContext(): Option[(SSLContext, SSLClientAuthMode)] = sslBits.map {
     case KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth) =>
       val ksStream = new FileInputStream(keyStore.path)
       val ks = KeyStore.getInstance("JKS")

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
@@ -137,7 +137,7 @@ class BlazeServerMtlsSpec extends Http4sSpec {
       }
 
       "fail for invalid client auth" in {
-        get("/dummy", clientAuth = false) shouldEqual "Connection reset"
+        get("/dummy", clientAuth = false) shouldNotEqual "CN=Test,OU=Test,O=Test,L=CA,ST=CA,C=US"
       }
     }
   }

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
@@ -7,8 +7,7 @@ import java.security.KeyStore
 import cats.effect.{IO, Resource}
 import javax.net.ssl._
 import org.http4s.dsl.io._
-import org.http4s.server.Server
-import org.http4s.server.ServerRequestKeys
+import org.http4s.server.{SSLClientAuthMode, Server, ServerRequestKeys}
 import org.http4s.{Http4sSpec, HttpApp}
 
 import scala.concurrent.duration._
@@ -54,7 +53,7 @@ class BlazeServerMtlsSpec extends Http4sSpec {
   val serverR: Resource[IO, Server[IO]] =
     builder
       .bindAny()
-      .withSSLContext(sslContext, clientAuth = true)
+      .withSSLContext(sslContext, clientAuth = SSLClientAuthMode.Required)
       .withHttpApp(service)
       .resource
 

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
@@ -12,6 +12,7 @@ import org.http4s.{Http4sSpec, HttpApp}
 
 import scala.concurrent.duration._
 import scala.io.Source
+import scala.util.Try
 
 /**
   * Test cases for mTLS support in blaze server
@@ -47,13 +48,25 @@ class BlazeServerMtlsSpec extends Http4sSpec {
 
       Ok(output)
 
+    case req @ GET -> Root / "noauth" =>
+      req
+        .attributes(ServerRequestKeys.SecureSession)
+        .foreach { session =>
+          session.sslSessionId shouldNotEqual ""
+          session.cipherSuite shouldNotEqual ""
+          session.keySize shouldNotEqual 0
+          session.X509Certificate.size shouldEqual 0
+        }
+
+      Ok("success")
+
     case _ => NotFound()
   }
 
-  val serverR: Resource[IO, Server[IO]] =
+  def serverR(clientAuthMode: SSLClientAuthMode): Resource[IO, Server[IO]] =
     builder
       .bindAny()
-      .withSSLContext(sslContext, clientAuth = SSLClientAuthMode.Required)
+      .withSSLContext(sslContext, clientAuth = clientAuthMode)
       .withHttpApp(service)
       .resource
 
@@ -76,19 +89,92 @@ class BlazeServerMtlsSpec extends Http4sSpec {
     sc
   }
 
-  withResource(serverR) { server =>
-    def get(path: String): String = {
+  /**
+    * Used for no mTLS client. Required to trust self-signed certificate.
+    */
+  lazy val noAuthClientContext: SSLContext = {
+
+    val js = KeyStore.getInstance("JKS")
+    js.load(getClass.getResourceAsStream("/keystore.jks"), "password".toCharArray)
+
+    val tmf = TrustManagerFactory.getInstance("SunX509")
+    tmf.init(js)
+
+    val sc = SSLContext.getInstance("TLSv1.2")
+    sc.init(null, tmf.getTrustManagers, null)
+
+    sc
+  }
+
+  /**
+    * Test "required" auth mode
+    */
+  withResource(serverR(SSLClientAuthMode.Required)) { server =>
+    def get(path: String, clientAuth: Boolean = true): String = {
       val url = new URL(s"https://localhost:${server.address.getPort}$path")
       val conn = url.openConnection().asInstanceOf[HttpsURLConnection]
       conn.setRequestMethod("GET")
-      conn.setSSLSocketFactory(sslContext.getSocketFactory)
 
-      Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+      if (clientAuth) {
+        conn.setSSLSocketFactory(sslContext.getSocketFactory)
+      } else {
+        conn.setSSLSocketFactory(noAuthClientContext.getSocketFactory)
+      }
+
+      Try {
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+      }.recover {
+          case ex: Throwable =>
+            ex.getMessage
+        }
+        .toOption
+        .getOrElse("")
     }
 
     "Server" should {
       "send mTLS request correctly" in {
         get("/dummy") shouldEqual "CN=Test,OU=Test,O=Test,L=CA,ST=CA,C=US"
+      }
+
+      "fail for invalid client auth" in {
+        get("/dummy", clientAuth = false) shouldEqual "Connection reset"
+      }
+    }
+  }
+
+  /**
+    * Test "requested" auth mode
+    */
+  withResource(serverR(SSLClientAuthMode.Requested)) { server =>
+    def get(path: String, clientAuth: Boolean = true): String = {
+      val url = new URL(s"https://localhost:${server.address.getPort}$path")
+      val conn = url.openConnection().asInstanceOf[HttpsURLConnection]
+      conn.setRequestMethod("GET")
+
+      if (clientAuth) {
+        conn.setSSLSocketFactory(sslContext.getSocketFactory)
+      } else {
+        conn.setSSLSocketFactory(noAuthClientContext.getSocketFactory)
+      }
+
+      Try {
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+      }.recover {
+          case ex: Throwable =>
+            ex.getMessage
+        }
+        .toOption
+        .getOrElse("")
+    }
+
+    "Server" should {
+
+      "send mTLS request correctly with optional auth" in {
+        get("/dummy") shouldEqual "CN=Test,OU=Test,O=Test,L=CA,ST=CA,C=US"
+      }
+
+      "send mTLS request correctly without clientAuth" in {
+        get("/noauth", clientAuth = false) shouldEqual "success"
       }
     }
   }

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -68,14 +68,14 @@ sealed class JettyBuilder[F[_]] private (
       keyManagerPassword: String,
       protocol: String = "TLS",
       trustStore: Option[StoreInfo] = None,
-      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested
   ): Self =
     copy(
       sslBits = Some(KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)))
 
   def withSSLContext(
       sslContext: SSLContext,
-      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested): Self =
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested): Self =
     copy(sslBits = Some(SSLContextBits(sslContext, clientAuth)))
 
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
@@ -177,17 +177,17 @@ sealed class JettyBuilder[F[_]] private (
 
   private def updateClientAuth(
       sslContextFactory: SslContextFactory,
-      clientAuthMode: SSLClientAuthMode.Value): Unit =
+      clientAuthMode: SSLClientAuthMode): Unit =
     clientAuthMode match {
       case SSLClientAuthMode.NotRequested =>
         sslContextFactory.setWantClientAuth(false)
         sslContextFactory.setNeedClientAuth(false)
 
       case SSLClientAuthMode.Requested =>
-        sslContextFactory.setWantClientAuth(false)
+        sslContextFactory.setWantClientAuth(true)
 
       case SSLClientAuthMode.Required =>
-        sslContextFactory.setNeedClientAuth(false)
+        sslContextFactory.setNeedClientAuth(true)
     }
 
   def resource: Resource[F, Server[F]] =

--- a/server/src/main/scala/org/http4s/server/SSLClientAuthMode.scala
+++ b/server/src/main/scala/org/http4s/server/SSLClientAuthMode.scala
@@ -3,6 +3,10 @@ package org.http4s.server
 /**
   * Client Auth mode for mTLS
   */
-object SSLClientAuthMode extends Enumeration {
-  val NotRequested, Requested, Required = Value
+sealed trait SSLClientAuthMode extends Product with Serializable
+
+object SSLClientAuthMode {
+  case object NotRequested extends SSLClientAuthMode
+  case object Requested extends SSLClientAuthMode
+  case object Required extends SSLClientAuthMode
 }

--- a/server/src/main/scala/org/http4s/server/SSLClientAuthMode.scala
+++ b/server/src/main/scala/org/http4s/server/SSLClientAuthMode.scala
@@ -1,0 +1,8 @@
+package org.http4s.server
+
+/**
+  * Client Auth mode for mTLS
+  */
+object SSLClientAuthMode extends Enumeration {
+  val NotRequested, Requested, Required = Value
+}

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -96,10 +96,11 @@ final case class KeyStoreBits(
     keyManagerPassword: String,
     protocol: String,
     trustStore: Option[StoreInfo],
-    clientAuth: Boolean)
+    clientAuth: SSLClientAuthMode.Value)
     extends SSLConfig
 
-final case class SSLContextBits(sslContext: SSLContext, clientAuth: Boolean) extends SSLConfig
+final case class SSLContextBits(sslContext: SSLContext, clientAuth: SSLClientAuthMode.Value)
+    extends SSLConfig
 
 object SSLKeyStoreSupport {
   final case class StoreInfo(path: String, password: String)

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -96,10 +96,10 @@ final case class KeyStoreBits(
     keyManagerPassword: String,
     protocol: String,
     trustStore: Option[StoreInfo],
-    clientAuth: SSLClientAuthMode.Value)
+    clientAuth: SSLClientAuthMode)
     extends SSLConfig
 
-final case class SSLContextBits(sslContext: SSLContext, clientAuth: SSLClientAuthMode.Value)
+final case class SSLContextBits(sslContext: SSLContext, clientAuth: SSLClientAuthMode)
     extends SSLConfig
 
 object SSLKeyStoreSupport {

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -65,7 +65,7 @@ sealed class TomcatBuilder[F[_]] private (
       keyManagerPassword: String,
       protocol: String = "TLS",
       trustStore: Option[StoreInfo] = None,
-      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested): Self =
+      clientAuth: SSLClientAuthMode = SSLClientAuthMode.NotRequested): Self =
     copy(
       sslBits = Some(KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)))
 

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -65,7 +65,7 @@ sealed class TomcatBuilder[F[_]] private (
       keyManagerPassword: String,
       protocol: String = "TLS",
       trustStore: Option[StoreInfo] = None,
-      clientAuth: Boolean = false): Self =
+      clientAuth: SSLClientAuthMode.Value = SSLClientAuthMode.NotRequested): Self =
     copy(
       sslBits = Some(KeyStoreBits(keyStore, keyManagerPassword, protocol, trustStore, clientAuth)))
 


### PR DESCRIPTION
With this mTLS can be optional for the request.

Changes as per discussion on #2218.

Note that this is a breaking change. Existing boolean value is changed to an enum. 