### PR TITLE
Add HttpMethodOverrider middleware

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
@@ -1,21 +1,13 @@
-package org.http4s.server.middleware
+package org.http4s
+package server
+package middleware
 
 import cats.data.Kleisli
 import cats.effect.Sync
 import cats.implicits._
 import cats.{Monad, ~>}
+import org.http4s.Http
 import org.http4s.util.CaseInsensitiveString
-import org.http4s.{
-  AttributeKey,
-  Header,
-  Http,
-  Method,
-  ParseResult,
-  Request,
-  Response,
-  Status,
-  UrlForm
-}
 
 import scala.reflect.runtime.universe._
 

--- a/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
@@ -4,25 +4,59 @@ import cats.Applicative
 import cats.data.Kleisli
 import cats.implicits._
 import org.http4s.util.CaseInsensitiveString
-import org.http4s.{AttributeKey, Header, HttpApp, Method, ParseResult, Request, Response, Status}
+import org.http4s.{
+  AttributeKey,
+  Header,
+  Http,
+  HttpApp,
+  Method,
+  ParseResult,
+  Request,
+  Response,
+  Status
+}
 
 object HttpMethodOverrider {
 
   /**
     * HttpMethodOverrider middleware config options.
     */
-  final case class HttpMethodOverriderConfig(
-      overrideStrategy: OverrideStrategy,
-      overridableMethods: List[Method])
+  class HttpMethodOverriderConfig(
+      val overrideStrategy: OverrideStrategy,
+      val overridableMethods: Set[Method]) {
+
+    type Self = HttpMethodOverriderConfig
+
+    private def copy(
+        overrideStrategy: OverrideStrategy = overrideStrategy,
+        overridableMethods: Set[Method] = overridableMethods
+    ): Self =
+      new HttpMethodOverriderConfig(overrideStrategy, overridableMethods)
+
+    def withOverrideStrategy(overrideStrategy: OverrideStrategy): Self =
+      copy(overrideStrategy = overrideStrategy)
+
+    def withOverridableMethods(overridableMethods: Set[Method]): Self =
+      copy(overridableMethods = overridableMethods)
+  }
+
+  object HttpMethodOverriderConfig {
+    def apply(
+        overrideStrategy: OverrideStrategy,
+        overridableMethods: Set[Method]): HttpMethodOverriderConfig =
+      new HttpMethodOverriderConfig(overrideStrategy, overridableMethods)
+  }
 
   sealed trait OverrideStrategy
   final case class HeaderOverrideStrategy(headerName: CaseInsensitiveString)
       extends OverrideStrategy
   final case class QueryOverrideStrategy(paramName: String) extends OverrideStrategy
+  // TODO: tory to fit this inside the main logic
+  //  final case class FunctionOverrideStrategy[G[_]](fn: Request[G] => Method) extends OverrideStrategy
 
   val defaultConfig = HttpMethodOverriderConfig(
     HeaderOverrideStrategy(CaseInsensitiveString("X-HTTP-Method-Override")),
-    List(Method.POST))
+    Set(Method.POST))
 
   val overriddenMethodAttrKey: AttributeKey[Method] = AttributeKey[Method]
 
@@ -36,17 +70,17 @@ object HttpMethodOverrider {
     * @param http [[HttpApp]] to transform
     * @param config http method overrider config
     */
-  def apply[F[_]](http: HttpApp[F], config: HttpMethodOverriderConfig)(
-      implicit F: Applicative[F]): HttpApp[F] = {
+  def apply[F[_], G[_]](http: Http[F, G], config: HttpMethodOverriderConfig)(
+      implicit F: Applicative[F]): Http[F, G] = {
 
     def processRequestWithMethod(
-        req: Request[F],
-        parseResult: ParseResult[Method]): F[Response[F]] = parseResult match {
-      case Left(_) => F.pure(Response[F](Status.MethodNotAllowed))
+        req: Request[G],
+        parseResult: ParseResult[Method]): F[Response[G]] = parseResult match {
+      case Left(_) => F.pure(Response[G](Status.BadRequest))
       case Right(om) => http(updateRequestWithMethod(req, om)).map(updateVaryHeader)
     }
 
-    def updateVaryHeader(resp: Response[F]): Response[F] = {
+    def updateVaryHeader(resp: Response[G]): Response[G] = {
       val varyHeaderName = CaseInsensitiveString("Vary")
       config.overrideStrategy match {
         case HeaderOverrideStrategy(headerName) =>
@@ -61,24 +95,26 @@ object HttpMethodOverrider {
       }
     }
 
-    def updateRequestWithMethod(req: Request[F], om: Method): Request[F] = {
+    def updateRequestWithMethod(req: Request[G], om: Method): Request[G] = {
       val attrs = req.attributes ++ Seq(overriddenMethodAttrKey(req.method))
       req.withAttributes(attrs).withMethod(om)
     }
 
-    def ignoresOverrideIfNotAllowed(req: Request[F]): Option[Unit] =
-      if (config.overridableMethods.contains(req.method)) Some(()) else None
+    def ignoresOverrideIfNotAllowed(req: Request[G]): Option[Unit] =
+      config.overridableMethods.contains(req.method).guard[Option].as(())
 
-    def getUnsafeOverrideMethod(req: Request[F]): Option[String] =
+    def parseMethod(m: String): ParseResult[Method] = Method.fromString(m.toUpperCase)
+
+    def getUnsafeOverrideMethod(req: Request[G]): Option[String] =
       config.overrideStrategy match {
         case HeaderOverrideStrategy(headerName) => req.headers.get(headerName).map(_.value)
         case QueryOverrideStrategy(parameter) => req.params.get(parameter)
       }
 
-    Kleisli { req: Request[F] =>
+    Kleisli { req: Request[G] =>
       {
         (ignoresOverrideIfNotAllowed(req) *> getUnsafeOverrideMethod(req))
-          .map(m => Method.fromString(m.toUpperCase))
+          .map(parseMethod)
           .map(processRequestWithMethod(req, _))
           .getOrElse(http(req))
       }

--- a/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
@@ -4,17 +4,7 @@ import cats.Applicative
 import cats.data.Kleisli
 import cats.implicits._
 import org.http4s.util.CaseInsensitiveString
-import org.http4s.{
-  AttributeKey,
-  Header,
-  Http,
-  HttpApp,
-  Method,
-  ParseResult,
-  Request,
-  Response,
-  Status
-}
+import org.http4s.{AttributeKey, Header, Http, Method, ParseResult, Request, Response, Status}
 
 object HttpMethodOverrider {
 

--- a/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
@@ -1,0 +1,87 @@
+package org.http4s.server.middleware
+
+import cats.Applicative
+import cats.data.Kleisli
+import cats.implicits._
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.{AttributeKey, Header, HttpApp, Method, ParseResult, Request, Response, Status}
+
+object HttpMethodOverrider {
+
+  /**
+    * HttpMethodOverrider middleware config options.
+    */
+  final case class HttpMethodOverriderConfig(
+      overrideStrategy: OverrideStrategy,
+      overridableMethods: List[Method])
+
+  sealed trait OverrideStrategy
+  final case class HeaderOverrideStrategy(headerName: CaseInsensitiveString)
+      extends OverrideStrategy
+  final case class QueryOverrideStrategy(paramName: String) extends OverrideStrategy
+
+  val defaultConfig = HttpMethodOverriderConfig(
+    HeaderOverrideStrategy(CaseInsensitiveString("X-HTTP-Method-Override")),
+    List(Method.POST))
+
+  val overriddenMethodAttrKey: AttributeKey[Method] = AttributeKey[Method]
+
+  /** Simple middleware for HTTP Method Override.
+    *
+    * This middleware lets you use  HTTP verbs such as PUT or DELETE in places where the client
+    * doesn't support it. Camouflage your request with another HTTP verb(usually POST) and sneak
+    * the desired one using a custom header or request parameter. The middleware will '''override'''
+    * the original verb with the new one for you, allowing the request the be dispatched properly.
+    *
+    * @param http [[HttpApp]] to transform
+    * @param config http method overrider config
+    */
+  def apply[F[_]](http: HttpApp[F], config: HttpMethodOverriderConfig)(
+      implicit F: Applicative[F]): HttpApp[F] = {
+
+    def processRequestWithMethod(
+        req: Request[F],
+        parseResult: ParseResult[Method]): F[Response[F]] = parseResult match {
+      case Left(_) => F.pure(Response[F](Status.MethodNotAllowed))
+      case Right(om) => http(updateRequestWithMethod(req, om)).map(updateVaryHeader)
+    }
+
+    def updateVaryHeader(resp: Response[F]): Response[F] = {
+      val varyHeaderName = CaseInsensitiveString("Vary")
+      config.overrideStrategy match {
+        case HeaderOverrideStrategy(headerName) =>
+          val updatedVaryHeader =
+            resp.headers
+              .get(varyHeaderName)
+              .map((h: Header) => Header(h.name.value, s"${h.value}, ${headerName.value}"))
+              .getOrElse(Header(varyHeaderName.value, headerName.value))
+
+          resp.withHeaders(resp.headers.put(updatedVaryHeader))
+        case QueryOverrideStrategy(_) => resp
+      }
+    }
+
+    def updateRequestWithMethod(req: Request[F], om: Method): Request[F] = {
+      val attrs = req.attributes ++ Seq(overriddenMethodAttrKey(req.method))
+      req.withAttributes(attrs).withMethod(om)
+    }
+
+    def ignoresOverrideIfNotAllowed(req: Request[F]): Option[Unit] =
+      if (config.overridableMethods.contains(req.method)) Some(()) else None
+
+    def getUnsafeOverrideMethod(req: Request[F]): Option[String] =
+      config.overrideStrategy match {
+        case HeaderOverrideStrategy(headerName) => req.headers.get(headerName).map(_.value)
+        case QueryOverrideStrategy(parameter) => req.params.get(parameter)
+      }
+
+    Kleisli { req: Request[F] =>
+      {
+        (ignoresOverrideIfNotAllowed(req) *> getUnsafeOverrideMethod(req))
+          .map(m => Method.fromString(m.toUpperCase))
+          .map(processRequestWithMethod(req, _))
+          .getOrElse(http(req))
+      }
+    }
+  }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
@@ -4,7 +4,10 @@ package middleware
 
 import cats.data.Kleisli
 import cats.effect.Sync
-import cats.implicits._
+import cats.instances.option._
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+import cats.syntax.alternative._
 import cats.{Monad, ~>}
 import org.http4s.Http
 import org.http4s.util.CaseInsensitiveString

--- a/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSpec.scala
@@ -24,13 +24,13 @@ class HttpMethodOverriderSpec extends Http4sSpec {
 
   private val postHeaderOverriderConfig = defaultConfig
   private val postQueryOverridersConfig =
-    HttpMethodOverriderConfig(queryOverrideStrategy, List(POST))
+    HttpMethodOverriderConfig(queryOverrideStrategy, Set(POST))
   private val deleteHeaderOverriderConfig =
-    HttpMethodOverriderConfig(headerOverrideStrategy, List(DELETE))
+    HttpMethodOverriderConfig(headerOverrideStrategy, Set(DELETE))
   private val deleteQueryOverridersConfig =
-    HttpMethodOverriderConfig(queryOverrideStrategy, List(DELETE))
+    HttpMethodOverriderConfig(queryOverrideStrategy, Set(DELETE))
   private val noMethodHeaderOverriderConfig =
-    HttpMethodOverriderConfig(headerOverrideStrategy, List.empty)
+    HttpMethodOverriderConfig(headerOverrideStrategy, Set.empty)
 
   private val testApp = Router("/" -> HttpRoutes.of[IO] {
     case r @ GET -> Root / "resources" / "id" =>
@@ -141,13 +141,13 @@ class HttpMethodOverriderSpec extends Http4sSpec {
       res must returnStatus(Status.BadRequest)
     }
 
-    "return 405 when using query method overrider strategy if override method provided is duped" in {
+    "return 400 when using query method overrider strategy if override method provided is duped" in {
       val req = Request[IO](uri = Uri.uri("/resources/id?_method="))
         .withMethod(POST)
       val app = HttpMethodOverrider(testApp, postQueryOverridersConfig)
 
       val res = app(req)
-      res must returnStatus(Status.MethodNotAllowed)
+      res must returnStatus(Status.BadRequest)
     }
 
     "override request method when using header method overrider strategy and be case insensitive" in {

--- a/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSpec.scala
@@ -1,0 +1,204 @@
+package org.http4s.server.middleware
+
+import cats.effect.IO
+import org.http4s._
+import org.http4s.dsl.io._
+import org.http4s.server.Router
+import org.http4s.server.middleware.HttpMethodOverrider.{
+  HeaderOverrideStrategy,
+  HttpMethodOverriderConfig,
+  QueryOverrideStrategy,
+  defaultConfig
+}
+import org.http4s.util.CaseInsensitiveString
+
+class HttpMethodOverriderSpec extends Http4sSpec {
+
+  private final val overrideHeader = "X-HTTP-Method-Override"
+  private final val overrideParam = "_method"
+  private final val varyHeader = "Vary"
+  private final val customHeader = "X-Custom-Header"
+
+  private val headerOverrideStrategy = HeaderOverrideStrategy(CaseInsensitiveString(overrideHeader))
+  private val queryOverrideStrategy = QueryOverrideStrategy(overrideParam)
+
+  private val postHeaderOverriderConfig = defaultConfig
+  private val postQueryOverridersConfig =
+    HttpMethodOverriderConfig(queryOverrideStrategy, List(POST))
+  private val deleteHeaderOverriderConfig =
+    HttpMethodOverriderConfig(headerOverrideStrategy, List(DELETE))
+  private val deleteQueryOverridersConfig =
+    HttpMethodOverriderConfig(queryOverrideStrategy, List(DELETE))
+  private val noMethodHeaderOverriderConfig =
+    HttpMethodOverriderConfig(headerOverrideStrategy, List.empty)
+
+  private val testApp = Router("/" -> HttpRoutes.of[IO] {
+    case r @ GET -> Root / "resources" / "id" =>
+      Ok(responseText[IO](msg = "resource's details", r))
+    case r @ PUT -> Root / "resources" / "id" =>
+      Ok(responseText(msg = "resource updated", r), Header(varyHeader, customHeader))
+    case r @ DELETE -> Root / "resources" / "id" =>
+      Ok(responseText(msg = "resource deleted", r))
+  }).orNotFound
+
+  private def mkResponseText(
+      msg: String,
+      reqMethod: Method,
+      overriddenMethod: Option[Method]): String =
+    overriddenMethod
+      .map(om => s"[$om ~> $reqMethod] => $msg")
+      .getOrElse(s"[$reqMethod] => $msg")
+
+  private def responseText[F[_]](msg: String, req: Request[F]): String = {
+    val overriddenMethod = req.attributes.get(HttpMethodOverrider.overriddenMethodAttrKey)
+    mkResponseText(msg, req.method, overriddenMethod)
+  }
+
+  "MethodOverrider middleware" should {
+    "ignore method override if request method not in the overridable method list" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id"))
+        .withMethod(GET)
+        .withHeaders(Header(overrideHeader, "PUT"))
+      val app = HttpMethodOverrider(testApp, noMethodHeaderOverriderConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(
+        mkResponseText(msg = "resource's details", reqMethod = GET, overriddenMethod = None))
+    }
+
+    "override request method when using header method overrider strategy if override method provided" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id"))
+        .withMethod(POST)
+        .withHeaders(Header(overrideHeader, "PUT"))
+      val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(
+        mkResponseText(msg = "resource updated", reqMethod = PUT, overriddenMethod = Some(POST)))
+    }
+
+    "not override request method when using header method overrider strategy if override method not provided" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id"))
+        .withMethod(DELETE)
+      val app = HttpMethodOverrider(testApp, deleteHeaderOverriderConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(
+        mkResponseText(msg = "resource deleted", reqMethod = DELETE, overriddenMethod = None))
+    }
+
+    "override request method and store the original method if using query method overrider strategy" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id?_method=PUT"))
+        .withMethod(POST)
+      val app = HttpMethodOverrider(testApp, postQueryOverridersConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(
+        mkResponseText(msg = "resource updated", reqMethod = PUT, overriddenMethod = Some(POST)))
+    }
+
+    "not override request method when using query method overrider strategy if override method not provided" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id"))
+        .withMethod(DELETE)
+      val app = HttpMethodOverrider(testApp, deleteQueryOverridersConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(
+        mkResponseText(msg = "resource deleted", reqMethod = DELETE, overriddenMethod = None))
+    }
+
+    "return 404 when using header method overrider strategy if override method provided is not recognized" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id"))
+        .withMethod(POST)
+        .withHeaders(Header(overrideHeader, "INVALID"))
+      val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.NotFound)
+    }
+
+    "return 404 when using query method overrider strategy if override method provided is not recognized" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id?_method=INVALID"))
+        .withMethod(POST)
+      val app = HttpMethodOverrider(testApp, postQueryOverridersConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.NotFound)
+    }
+
+    "return 405 when using header method overrider strategy if override method provided is duped" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id"))
+        .withMethod(POST)
+        .withHeaders(Header(overrideHeader, ""))
+      val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.MethodNotAllowed)
+    }
+
+    "return 405 when using query method overrider strategy if override method provided is duped" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id?_method="))
+        .withMethod(POST)
+      val app = HttpMethodOverrider(testApp, postQueryOverridersConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.MethodNotAllowed)
+    }
+
+    "override request method when using header method overrider strategy and be case insensitive" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id"))
+        .withMethod(POST)
+        .withHeaders(Header(overrideHeader, "pUt"))
+      val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(
+        mkResponseText(msg = "resource updated", reqMethod = PUT, overriddenMethod = Some(POST)))
+    }
+
+    "override request method when using query method overrider strategy and be case insensitive" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id?_method=pUt"))
+        .withMethod(POST)
+      val app = HttpMethodOverrider(testApp, postQueryOverridersConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(
+        mkResponseText(msg = "resource updated", reqMethod = PUT, overriddenMethod = Some(POST)))
+    }
+
+    "updates vary header when using query method overrider strategy and vary header comes pre-populated" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id"))
+        .withMethod(POST)
+        .withHeaders(Header(overrideHeader, "PUT"))
+      val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(
+        mkResponseText(msg = "resource updated", reqMethod = PUT, overriddenMethod = Some(POST)))
+
+      res must returnValue(containHeader(Header(varyHeader, s"$customHeader, $overrideHeader")))
+    }
+
+    "set vary header when using query method overrider strategy and vary header has not been set" in {
+      val req = Request[IO](uri = Uri.uri("/resources/id"))
+        .withMethod(POST)
+        .withHeaders(Header(overrideHeader, "DELETE"))
+      val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
+
+      val res = app(req)
+      res must returnStatus(Status.Ok)
+      res must returnBody(
+        mkResponseText(msg = "resource deleted", reqMethod = DELETE, overriddenMethod = Some(POST)))
+
+      res must returnValue(containHeader(Header(varyHeader, s"$overrideHeader")))
+    }
+  }
+}

--- a/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSpec.scala
@@ -131,14 +131,14 @@ class HttpMethodOverriderSpec extends Http4sSpec {
       res must returnStatus(Status.NotFound)
     }
 
-    "return 405 when using header method overrider strategy if override method provided is duped" in {
+    "return 400 when using header method overrider strategy if override method provided is duped" in {
       val req = Request[IO](uri = Uri.uri("/resources/id"))
         .withMethod(POST)
         .withHeaders(Header(overrideHeader, ""))
       val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
 
       val res = app(req)
-      res must returnStatus(Status.MethodNotAllowed)
+      res must returnStatus(Status.BadRequest)
     }
 
     "return 405 when using query method overrider strategy if override method provided is duped" in {

--- a/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSpec.scala
@@ -184,7 +184,7 @@ class HttpMethodOverriderSpec extends Http4sSpec {
       res must returnBody(
         mkResponseText(msg = "resource updated", reqMethod = PUT, overriddenMethod = Some(POST)))
 
-      res must returnValue(containHeader(Header(varyHeader, s"$customHeader, $overrideHeader")))
+      res must returnValue(containsHeader(Header(varyHeader, s"$customHeader, $overrideHeader")))
     }
 
     "set vary header when using query method overrider strategy and vary header has not been set" in {
@@ -198,7 +198,7 @@ class HttpMethodOverriderSpec extends Http4sSpec {
       res must returnBody(
         mkResponseText(msg = "resource deleted", reqMethod = DELETE, overriddenMethod = Some(POST)))
 
-      res must returnValue(containHeader(Header(varyHeader, s"$overrideHeader")))
+      res must returnValue(containsHeader(Header(varyHeader, s"$overrideHeader")))
     }
   }
 }

--- a/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
@@ -34,6 +34,11 @@ trait Http4sMatchers[F[_]] extends Matchers with RunTimedMatchers[F] {
       m.headers.aka("the headers")
     }
 
+  def containHeader(h: Header): Matcher[Message[F]] =
+    beSome(h.value) ^^ { m: Message[F] =>
+      m.headers.get(h.name).map(_.value).aka("the particular header")
+    }
+
   def haveMediaType(mt: MediaType): Matcher[Message[F]] =
     beSome(mt) ^^ { m: Message[F] =>
       m.headers.get(`Content-Type`).map(_.mediaType).aka("the media type header")

--- a/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
@@ -4,6 +4,7 @@ package testing
 import cats.syntax.flatMap._
 import cats.data.EitherT
 import org.http4s.headers._
+import org.http4s.util.CaseInsensitiveString
 import org.specs2.matcher._
 
 /** This might be useful in a testkit spinoff.  Let's see what they do for us. */
@@ -37,6 +38,11 @@ trait Http4sMatchers[F[_]] extends Matchers with RunTimedMatchers[F] {
   def containsHeader(h: Header): Matcher[Message[F]] =
     beSome(h.value) ^^ { m: Message[F] =>
       m.headers.get(h.name).map(_.value).aka("the particular header")
+    }
+
+  def doesntContainHeader(h: CaseInsensitiveString): Matcher[Message[F]] =
+    beNone ^^ { m: Message[F] =>
+      m.headers.get(h).aka("the particular header")
     }
 
   def haveMediaType(mt: MediaType): Matcher[Message[F]] =

--- a/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
@@ -34,7 +34,7 @@ trait Http4sMatchers[F[_]] extends Matchers with RunTimedMatchers[F] {
       m.headers.aka("the headers")
     }
 
-  def containHeader(h: Header): Matcher[Message[F]] =
+  def containsHeader(h: Header): Matcher[Message[F]] =
     beSome(h.value) ^^ { m: Message[F] =>
       m.headers.get(h.name).map(_.value).aka("the particular header")
     }


### PR DESCRIPTION
This one adds an Http Method Overrider middleware(to contribute with #2014) in order to allow using  HTTP verbs such as **PUT** or **DELETE** in places where the client doesn't support it. 

It takes some ideas from [django-method-override](https://pypi.org/project/django-method-override/) and from [ExpressJS method override](https://github.com/expressjs/method-override).

Let me know what you guys think of it and if it requires some changes, specially in the test description since I'm new with the predominant testing style.

PS: Also, I just realized of the existence of the `headers` package and its particular way of representing/encoding **Headers**. 
Do you think that should be necessary for **Vary** taking into consideration how I'm using it? 

Cheers!! 😴 

