### PR TITLE
Include scheme in CORS middleware examples

### DIFF
--- a/docs/src/main/tut/cors.md
+++ b/docs/src/main/tut/cors.md
@@ -51,10 +51,10 @@ corsService.orNotFound(request).unsafeRunSync
 ```
 
 So far, there was no change. That's because an `Origin` header is required
-in the requests. This, of course, is the responsibility of the caller.
+in the requests and it must include a scheme. This, of course, is the responsibility of the caller.
 
 ```tut:book
-val originHeader = Header("Origin", "somewhere.com")
+val originHeader = Header("Origin", "https://somewhere.com")
 val corsRequest = request.putHeaders(originHeader)
 
 corsService.orNotFound(corsRequest).unsafeRunSync
@@ -73,9 +73,9 @@ First, we'll create some requests to use in our example. We want these requests
 have a variety of origins and methods.
 
 ```tut:book
-val googleGet = Request[IO](Method.GET, Uri.uri("/"), headers = Headers(Header("Origin", "google.com")))
-val yahooPut = Request[IO](Method.PUT, Uri.uri("/"), headers = Headers(Header("Origin", "yahoo.com")))
-val duckPost = Request[IO](Method.POST, Uri.uri("/"), headers = Headers(Header("Origin", "duckduckgo.com")))
+val googleGet = Request[IO](Method.GET, Uri.uri("/"), headers = Headers(Header("Origin", "https://google.com")))
+val yahooPut = Request[IO](Method.PUT, Uri.uri("/"), headers = Headers(Header("Origin", "https://yahoo.com")))
+val duckPost = Request[IO](Method.POST, Uri.uri("/"), headers = Headers(Header("Origin", "https://duckduckgo.com")))
 ```
 
 Now, we'll create a configuration that limits the allowed methods to `GET`
@@ -107,7 +107,7 @@ Next, we'll create a configuration that limits the origins to "yahoo.com" and
 ```tut:book
 val originConfig = CORSConfig(
   anyOrigin = false,
-  allowedOrigins = Set("yahoo.com", "duckduckgo.com"),
+  allowedOrigins = Set("https://yahoo.com", "https://duckduckgo.com"),
   allowCredentials = false,
   maxAge = 1.day.toSeconds)
 


### PR DESCRIPTION
Clarifies CORS documentation based on a comment in

https://github.com/http4s/http4s/issues/2361#issuecomment-457558974

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)
the scheme is a required part of the header so a change in the underlying header
parser to reflect this makes sense.

Connects #2361 