### PR TITLE
Add authorization header in allowed headers

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -23,7 +23,7 @@ final case class CORSConfig(
     anyMethod: Boolean = true,
     allowedOrigins: String => Boolean = _ => false,
     allowedMethods: Option[Set[String]] = None,
-    allowedHeaders: Option[Set[String]] = Set("Content-Type", "*").some,
+    allowedHeaders: Option[Set[String]] = Set("Content-Type", "Authorization", "*").some,
     exposedHeaders: Option[Set[String]] = Set("*").some
 )
 


### PR DESCRIPTION
Firefox doesn't allow * in allowed headers for a cors request. [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1309358)

Authorization is a pretty common header and it would make sense to have it in the default set.
I was recently bitten by this.