### PR TITLE
Lower Constraint on Retry to Sync

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -2,7 +2,7 @@ package org.http4s
 package client
 package middleware
 
-import cats.effect.{Effect, Resource, Timer}
+import cats.effect.{Resource, Sync, Timer}
 import cats.implicits._
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -20,7 +20,7 @@ object Retry {
   def apply[F[_]](
       policy: RetryPolicy[F],
       redactHeaderWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
-      client: Client[F])(implicit F: Effect[F], T: Timer[F]): Client[F] = {
+      client: Client[F])(implicit F: Sync[F], T: Timer[F]): Client[F] = {
     def prepareLoop(req: Request[F], attempts: Int): Resource[F, Response[F]] =
       client.run(req).attempt.flatMap {
         case right @ Right(response) =>
@@ -80,7 +80,7 @@ object Retry {
   def retryWithRedactedHeaders[F[_]](
       policy: RetryPolicy[F],
       redactHeaderWhen: CaseInsensitiveString => Boolean)(
-      client: Client[F])(implicit F: Effect[F], T: Timer[F]): Client[F] =
+      client: Client[F])(implicit F: Sync[F], T: Timer[F]): Client[F] =
     apply(policy, redactHeaderWhen)(client)
 }
 


### PR DESCRIPTION
Effect is totally unnecesarry. We don't use Sync, but only bracket. But if we want to be honest in the future about logging/etc then the Sync constraint will be necessary.