### PR TITLE
Include chunked Transfer-Encoding header in multipart requests

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -10,6 +10,7 @@ import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import org.http4s.client.testroutes.GetRoutes
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.dsl.io._
+import org.http4s.multipart.{Multipart, Part}
 import org.specs2.specification.core.Fragments
 import scala.collection.compat._
 import scala.concurrent.duration._
@@ -93,6 +94,14 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSpec with Http
           val req = POST(Stream("This is chunked.").covary[IO], uri)
           val body = client.expect[String](req)
           body must returnValue("This is chunked.")
+        }
+
+        "POST a multipart body" in {
+          val uri = Uri.fromString(s"http://${address.getHostName}:${address.getPort}/echo").yolo
+          val multipart = Multipart[IO](Vector(Part.formData("text", "This is text.")))
+          val req = POST(multipart, uri).map(_.withHeaders(multipart.headers))
+          val body = client.expect[String](req)
+          body must returnValue(containing("This is text."))
         }
       }
     }

--- a/core/src/main/scala/org/http4s/multipart/Multipart.scala
+++ b/core/src/main/scala/org/http4s/multipart/Multipart.scala
@@ -5,5 +5,7 @@ import org.http4s.headers._
 
 final case class Multipart[F[_]](parts: Vector[Part[F]], boundary: Boundary = Boundary.create) {
   def headers: Headers =
-    Headers(`Content-Type`(MediaType.multipartType("form-data", Some(boundary.value))))
+    Headers(
+      `Transfer-Encoding`(TransferCoding.chunked),
+      `Content-Type`(MediaType.multipartType("form-data", Some(boundary.value))))
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
@@ -20,8 +20,8 @@ object ClientMultipartPostExample extends IOApp with Http4sClientDsl[IO] {
     // n.b. This service does not appear to gracefully handle chunked requests.
     val url = Uri(
       scheme = Some(Scheme.http),
-      authority = Some(Authority(host = RegName("www.posttestserver.com"))),
-      path = "/post.php?dir=http4s")
+      authority = Some(Authority(host = RegName("ptsv2.com"))),
+      path = "/t/http4s/post")
 
     val multipart = Multipart[IO](
       Vector(

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -182,6 +182,12 @@ I am a big moose
         )
         part.filename must beEqualTo(Some("file.txt"))
       }
+
+      "include chunked transfer encoding header so that body is streamed by client" in {
+        val multipart = Multipart(Vector())
+        val request = Request(method = Method.POST, uri = url, headers = multipart.headers)
+        request.isChunked must beTrue
+      }
     }
   }
 


### PR DESCRIPTION
I discovered that the java.net/Async/Ok clients would not send the body of a multipart request, nor do any request logging. Fundamentally, this turned out to be related to issue #2348, where these clients do not send the body of a request unless Transfer-Encoding or Content-Length headers have been set, however this fix just adds the request header for multipart.