### PR TITLE
ChunkAggregator for HttpRoutes and HttpApp

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -25,13 +25,11 @@ object ChunkAggregator {
           })
     }
 
-  def httpRoutes[F[_]: Sync](httpRoutes: HttpRoutes[F]): HttpRoutes[F] = {
+  def httpRoutes[F[_]: Sync](httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
     apply(OptionT.liftK[F])(httpRoutes)
-  }
 
-  def httpApp[F[_]: Sync](httpApp: HttpApp[F]): HttpApp[F] = {
+  def httpApp[F[_]: Sync](httpApp: HttpApp[F]): HttpApp[F] =
     apply(FunctionK.id[F])(httpApp)
-  }
 
   private def removeChunkedTransferEncoding[G[_]: Functor](
       resp: Response[G],

--- a/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -2,8 +2,9 @@ package org.http4s
 package server
 package middleware
 
+import cats.arrow.FunctionK
 import cats.{FlatMap, Functor, ~>}
-import cats.data.{Kleisli, NonEmptyList}
+import cats.data.{Kleisli, NonEmptyList, OptionT}
 import cats.effect.Sync
 import cats.implicits._
 import fs2._
@@ -23,6 +24,14 @@ object ChunkAggregator {
               body.size.toLong)
           })
     }
+
+  def httpRoutes[F[_]: Sync](httpRoutes: HttpRoutes[F]): HttpRoutes[F] = {
+    apply(OptionT.liftK[F])(httpRoutes)
+  }
+
+  def httpApp[F[_]: Sync](httpApp: HttpApp[F]): HttpApp[F] = {
+    apply(FunctionK.id[F])(httpApp)
+  }
 
   private def removeChunkedTransferEncoding[G[_]: Functor](
       resp: Response[G],

--- a/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
@@ -22,14 +22,29 @@ class ChunkAggregatorSpec extends Http4sSpec {
   implicit val transferCodingArbitrary = Arbitrary(transferCodingGen.map(_.toList))
 
   "ChunkAggregator" should {
-    def checkResponse(body: EntityBody[IO], transferCodings: List[TransferCoding])(
-        responseCheck: Response[IO] => MatchResult[Any]): MatchResult[Any] = {
-      val routes: HttpRoutes[IO] = HttpRoutes.liftF(
-        OptionT.liftF(
-          Ok(body, `Transfer-Encoding`(NonEmptyList(TransferCoding.chunked, transferCodings)))
-            .map(_.removeHeader(`Content-Length`))))
+    def response(body: EntityBody[IO], transferCodings: List[TransferCoding]) =
+      Ok(body, `Transfer-Encoding`(NonEmptyList(TransferCoding.chunked, transferCodings)))
+        .map(_.removeHeader(`Content-Length`))
 
-      ChunkAggregator(OptionT.liftK[IO])(routes).run(Request()).value.unsafeRunSync must beSome
+    def httpRoutes(body: EntityBody[IO], transferCodings: List[TransferCoding]): HttpRoutes[IO] =
+      HttpRoutes.liftF(OptionT.liftF(response(body, transferCodings)))
+
+    def httpApp(body: EntityBody[IO], transferCodings: List[TransferCoding]): HttpApp[IO] = {
+      HttpApp.liftF(response(body, transferCodings))
+    }
+
+    def checkAppResponse(app: HttpApp[IO])(responseCheck: Response[IO] => MatchResult[Any]): MatchResult[Any] = {
+      ChunkAggregator.httpApp(app).run(Request()).unsafeRunSync must beLike
+        {
+          case response =>
+            response.status must_== Ok
+            responseCheck(response)
+        }
+    }
+
+    def checkRoutesResponse(routes: HttpRoutes[IO])(responseCheck: Response[IO] => MatchResult[Any]): MatchResult[Any] = {
+
+      ChunkAggregator.httpRoutes(routes).run(Request()).value.unsafeRunSync must beSome
         .like {
           case response =>
             response.status must_== Ok
@@ -38,7 +53,7 @@ class ChunkAggregatorSpec extends Http4sSpec {
     }
 
     "handle an empty body" in {
-      checkResponse(EmptyBody, Nil) { response =>
+      checkRoutesResponse(httpRoutes(EmptyBody, Nil)) { response =>
         response.contentLength must beNone
         response.body.compile.toVector.unsafeRunSync() must_=== Vector.empty
       }
@@ -46,13 +61,15 @@ class ChunkAggregatorSpec extends Http4sSpec {
 
     "handle a none" in {
       val routes: HttpRoutes[IO] = HttpRoutes.empty
-      ChunkAggregator(OptionT.liftK[IO])(routes).run(Request()).value must returnValue(None)
+      ChunkAggregator.httpRoutes(routes).run(Request()).value must returnValue(None)
     }
 
     "handle chunks" in {
       prop { (chunks: NonEmptyList[Chunk[Byte]], transferCodings: List[TransferCoding]) =>
         val totalChunksSize = chunks.foldMap(_.size)
-        checkResponse(chunks.map(Stream.chunk).reduceLeft(_ ++ _), transferCodings) { response =>
+        val body = chunks.map(Stream.chunk).reduceLeft(_ ++ _)
+
+        def check(response: Response[IO]) = {
           if (totalChunksSize > 0) {
             response.contentLength must beSome(totalChunksSize.toLong)
             response.headers.get(`Transfer-Encoding`).map(_.values) must_=== NonEmptyList
@@ -60,6 +77,9 @@ class ChunkAggregatorSpec extends Http4sSpec {
           }
           response.body.compile.toVector.unsafeRunSync() must_=== chunks.foldMap(_.toVector)
         }
+
+        checkRoutesResponse(httpRoutes(body, transferCodings))(check)
+        checkAppResponse(httpApp(body, transferCodings))(check)
       }
     }
   }

--- a/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
@@ -29,28 +29,25 @@ class ChunkAggregatorSpec extends Http4sSpec {
     def httpRoutes(body: EntityBody[IO], transferCodings: List[TransferCoding]): HttpRoutes[IO] =
       HttpRoutes.liftF(OptionT.liftF(response(body, transferCodings)))
 
-    def httpApp(body: EntityBody[IO], transferCodings: List[TransferCoding]): HttpApp[IO] = {
+    def httpApp(body: EntityBody[IO], transferCodings: List[TransferCoding]): HttpApp[IO] =
       HttpApp.liftF(response(body, transferCodings))
-    }
 
-    def checkAppResponse(app: HttpApp[IO])(responseCheck: Response[IO] => MatchResult[Any]): MatchResult[Any] = {
-      ChunkAggregator.httpApp(app).run(Request()).unsafeRunSync must beLike
-        {
-          case response =>
-            response.status must_== Ok
-            responseCheck(response)
-        }
-    }
+    def checkAppResponse(app: HttpApp[IO])(
+        responseCheck: Response[IO] => MatchResult[Any]): MatchResult[Any] =
+      ChunkAggregator.httpApp(app).run(Request()).unsafeRunSync must beLike {
+        case response =>
+          response.status must_== Ok
+          responseCheck(response)
+      }
 
-    def checkRoutesResponse(routes: HttpRoutes[IO])(responseCheck: Response[IO] => MatchResult[Any]): MatchResult[Any] = {
-
+    def checkRoutesResponse(routes: HttpRoutes[IO])(
+        responseCheck: Response[IO] => MatchResult[Any]): MatchResult[Any] =
       ChunkAggregator.httpRoutes(routes).run(Request()).value.unsafeRunSync must beSome
         .like {
           case response =>
             response.status must_== Ok
             responseCheck(response)
         }
-    }
 
     "handle an empty body" in {
       checkRoutesResponse(httpRoutes(EmptyBody, Nil)) { response =>


### PR DESCRIPTION
This PR adds convenience shortcuts to the ChunkAggregattor to apply the middleware on HttpRoutes and HttpApps.

Related issue: #2402 