### PR TITLE
Fix scaladoc github url with tagged version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -349,7 +349,7 @@ lazy val docs = http4sProject("docs")
             else if (isSnapshot)
               s"${s.browseUrl}/blob/${gitHeadCommit.get}€{FILE_PATH}.scala"
             else
-              s"${s.browseUrl}/blob/v${version}€{FILE_PATH}.scala"
+              s"${s.browseUrl}/blob/v${v}€{FILE_PATH}.scala"
 
           Seq(
             "-implicits",


### PR DESCRIPTION
The link looks like
https://github.com/http4s/http4s/blob/vSettingKey(This%20/%20This%20/%20This%20/%20version)/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
instead of https://github.com/http4s/http4s/blob/v0.20.0-M6/circe/src/main/scala/org/http4s/circe/CirceInstances.scala