### PR TITLE
Log request if service terminates due to async cancellation

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -62,7 +62,7 @@ object ResponseLogger {
         }
         .guaranteeCase {
           case ExitCase.Error(t) => fk(log(s"service raised an error: ${t.getClass}"))
-          case ExitCase.Canceled => fk(log(s"service cancelled response"))
+          case ExitCase.Canceled => fk(log(s"service cancelled response for request [$req]"))
           case ExitCase.Completed => G.unit
         }
     }


### PR DESCRIPTION
Make ResponseLogger log request if service terminates due to async cancellation to help error analysis