### PR TITLE
Extensible dsl

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -3,7 +3,7 @@ package org.http4s.dsl
 import org.http4s.Method
 import org.http4s.dsl.impl._
 
-trait Http4sDsl[F[_]] extends Methods with Statuses with Responses[F] with Auth {
+trait Http4sDsl2[F[_], G[_]] extends Methods with Statuses with Responses[F, G] with Auth {
   import Http4sDsl._
 
   type Path = impl.Path
@@ -55,6 +55,8 @@ trait Http4sDsl[F[_]] extends Methods with Statuses with Responses[F] with Auth 
     new MethodConcatOps(methods)
 
 }
+
+trait Http4sDsl[F[_]] extends Http4sDsl2[F, F]
 
 object Http4sDsl {
 

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
@@ -6,329 +6,346 @@ import cats.Applicative
 import org.http4s.Status._
 import org.http4s.headers.`Content-Length`
 
-trait Responses[F[_]] {
+trait Responses[F[_], G[_]] {
   import Responses._
 
-  implicit def http4sContinueSyntax(status: Continue.type): ContinueOps[F] =
-    new ContinueOps[F](status)
+  implicit def http4sContinueSyntax(status: Continue.type): ContinueOps[F, G] =
+    new ContinueOps[F, G](status)
   implicit def http4sSwitchingProtocolsSyntax(
-      status: SwitchingProtocols.type): SwitchingProtocolsOps[F] =
-    new SwitchingProtocolsOps[F](status)
-  implicit def http4sEarlyHintsSyntax(status: EarlyHints.type): EarlyHintsOps[F] =
-    new EarlyHintsOps[F](status)
-  implicit def http4sOkSyntax(status: Ok.type): OkOps[F] = new OkOps[F](status)
+      status: SwitchingProtocols.type): SwitchingProtocolsOps[F, G] =
+    new SwitchingProtocolsOps[F, G](status)
+  implicit def http4sEarlyHintsSyntax(status: EarlyHints.type): EarlyHintsOps[F, G] =
+    new EarlyHintsOps[F, G](status)
+  implicit def http4sOkSyntax(status: Ok.type): OkOps[F, G] = new OkOps[F, G](status)
 
-  implicit def http4sCreatedSyntax(status: Created.type): CreatedOps[F] = new CreatedOps[F](status)
-  implicit def http4sAcceptedSyntax(status: Accepted.type): AcceptedOps[F] =
-    new AcceptedOps[F](status)
+  implicit def http4sCreatedSyntax(status: Created.type): CreatedOps[F, G] =
+    new CreatedOps[F, G](status)
+  implicit def http4sAcceptedSyntax(status: Accepted.type): AcceptedOps[F, G] =
+    new AcceptedOps[F, G](status)
   implicit def http4sNonAuthoritativeInformationSyntax(
-      status: NonAuthoritativeInformation.type): NonAuthoritativeInformationOps[F] =
-    new NonAuthoritativeInformationOps[F](status)
-  implicit def http4sNoContentSyntax(status: NoContent.type): NoContentOps[F] =
-    new NoContentOps[F](status)
-  implicit def http4sResetContentSyntax(status: ResetContent.type): ResetContentOps[F] =
-    new ResetContentOps[F](status)
-  implicit def http4sPartialContentSyntax(status: PartialContent.type): PartialContentOps[F] =
-    new PartialContentOps[F](status)
-  implicit def http4sMultiStatusSyntax(status: Status.MultiStatus.type): MultiStatusOps[F] =
-    new MultiStatusOps[F](status)
-  implicit def http4sAlreadyReportedSyntax(status: AlreadyReported.type): AlreadyReportedOps[F] =
-    new AlreadyReportedOps[F](status)
-  implicit def http4sIMUsedSyntax(status: IMUsed.type): IMUsedOps[F] = new IMUsedOps[F](status)
+      status: NonAuthoritativeInformation.type): NonAuthoritativeInformationOps[F, G] =
+    new NonAuthoritativeInformationOps[F, G](status)
+  implicit def http4sNoContentSyntax(status: NoContent.type): NoContentOps[F, G] =
+    new NoContentOps[F, G](status)
+  implicit def http4sResetContentSyntax(status: ResetContent.type): ResetContentOps[F, G] =
+    new ResetContentOps[F, G](status)
+  implicit def http4sPartialContentSyntax(status: PartialContent.type): PartialContentOps[F, G] =
+    new PartialContentOps[F, G](status)
+  implicit def http4sMultiStatusSyntax(status: Status.MultiStatus.type): MultiStatusOps[F, G] =
+    new MultiStatusOps[F, G](status)
+  implicit def http4sAlreadyReportedSyntax(status: AlreadyReported.type): AlreadyReportedOps[F, G] =
+    new AlreadyReportedOps[F, G](status)
+  implicit def http4sIMUsedSyntax(status: IMUsed.type): IMUsedOps[F, G] =
+    new IMUsedOps[F, G](status)
 
-  implicit def http4sMultipleChoicesSyntax(status: MultipleChoices.type): MultipleChoicesOps[F] =
-    new MultipleChoicesOps[F](status)
-  implicit def http4sMovedPermanentlySyntax(status: MovedPermanently.type): MovedPermanentlyOps[F] =
-    new MovedPermanentlyOps[F](status)
-  implicit def http4sFoundSyntax(status: Found.type): FoundOps[F] = new FoundOps[F](status)
-  implicit def http4sSeeOtherSyntax(status: SeeOther.type): SeeOtherOps[F] =
-    new SeeOtherOps[F](status)
-  implicit def http4sNotModifiedSyntax(status: NotModified.type): NotModifiedOps[F] =
-    new NotModifiedOps[F](status)
+  implicit def http4sMultipleChoicesSyntax(status: MultipleChoices.type): MultipleChoicesOps[F, G] =
+    new MultipleChoicesOps[F, G](status)
+  implicit def http4sMovedPermanentlySyntax(
+      status: MovedPermanently.type): MovedPermanentlyOps[F, G] =
+    new MovedPermanentlyOps[F, G](status)
+  implicit def http4sFoundSyntax(status: Found.type): FoundOps[F, G] = new FoundOps[F, G](status)
+  implicit def http4sSeeOtherSyntax(status: SeeOther.type): SeeOtherOps[F, G] =
+    new SeeOtherOps[F, G](status)
+  implicit def http4sNotModifiedSyntax(status: NotModified.type): NotModifiedOps[F, G] =
+    new NotModifiedOps[F, G](status)
   implicit def http4sTemporaryRedirectSyntax(
-      status: TemporaryRedirect.type): TemporaryRedirectOps[F] = new TemporaryRedirectOps[F](status)
+      status: TemporaryRedirect.type): TemporaryRedirectOps[F, G] =
+    new TemporaryRedirectOps[F, G](status)
   implicit def http4sPermanentRedirectSyntax(
-      status: PermanentRedirect.type): PermanentRedirectOps[F] = new PermanentRedirectOps[F](status)
+      status: PermanentRedirect.type): PermanentRedirectOps[F, G] =
+    new PermanentRedirectOps[F, G](status)
 
-  implicit def http4sBadRequestSyntax(status: BadRequest.type): BadRequestOps[F] =
-    new BadRequestOps[F](status)
-  implicit def http4sUnauthorizedSyntax(status: Unauthorized.type): UnauthorizedOps[F] =
-    new UnauthorizedOps[F](status)
-  implicit def http4sPaymentRequiredSyntax(status: PaymentRequired.type): PaymentRequiredOps[F] =
-    new PaymentRequiredOps[F](status)
-  implicit def http4sForbiddenSyntax(status: Forbidden.type): ForbiddenOps[F] =
-    new ForbiddenOps[F](status)
-  implicit def http4sNotFoundSyntax(status: NotFound.type): NotFoundOps[F] =
-    new NotFoundOps[F](status)
-  implicit def http4sMethodNotAllowedSyntax(status: MethodNotAllowed.type): MethodNotAllowedOps[F] =
-    new MethodNotAllowedOps[F](status)
-  implicit def http4sNotAcceptableSyntax(status: NotAcceptable.type): NotAcceptableOps[F] =
-    new NotAcceptableOps[F](status)
+  implicit def http4sBadRequestSyntax(status: BadRequest.type): BadRequestOps[F, G] =
+    new BadRequestOps[F, G](status)
+  implicit def http4sUnauthorizedSyntax(status: Unauthorized.type): UnauthorizedOps[F, G] =
+    new UnauthorizedOps[F, G](status)
+  implicit def http4sPaymentRequiredSyntax(status: PaymentRequired.type): PaymentRequiredOps[F, G] =
+    new PaymentRequiredOps[F, G](status)
+  implicit def http4sForbiddenSyntax(status: Forbidden.type): ForbiddenOps[F, G] =
+    new ForbiddenOps[F, G](status)
+  implicit def http4sNotFoundSyntax(status: NotFound.type): NotFoundOps[F, G] =
+    new NotFoundOps[F, G](status)
+  implicit def http4sMethodNotAllowedSyntax(
+      status: MethodNotAllowed.type): MethodNotAllowedOps[F, G] =
+    new MethodNotAllowedOps[F, G](status)
+  implicit def http4sNotAcceptableSyntax(status: NotAcceptable.type): NotAcceptableOps[F, G] =
+    new NotAcceptableOps[F, G](status)
   implicit def http4sProxyAuthenticationRequiredSyntax(
-      status: ProxyAuthenticationRequired.type): ProxyAuthenticationRequiredOps[F] =
-    new ProxyAuthenticationRequiredOps[F](status)
-  implicit def http4sRequestTimeoutSyntax(status: RequestTimeout.type): RequestTimeoutOps[F] =
-    new RequestTimeoutOps[F](status)
-  implicit def http4sConflictSyntax(status: Conflict.type): ConflictOps[F] =
-    new ConflictOps[F](status)
-  implicit def http4sGoneSyntax(status: Gone.type): GoneOps[F] = new GoneOps[F](status)
-  implicit def http4sLengthRequiredSyntax(status: LengthRequired.type): LengthRequiredOps[F] =
-    new LengthRequiredOps[F](status)
+      status: ProxyAuthenticationRequired.type): ProxyAuthenticationRequiredOps[F, G] =
+    new ProxyAuthenticationRequiredOps[F, G](status)
+  implicit def http4sRequestTimeoutSyntax(status: RequestTimeout.type): RequestTimeoutOps[F, G] =
+    new RequestTimeoutOps[F, G](status)
+  implicit def http4sConflictSyntax(status: Conflict.type): ConflictOps[F, G] =
+    new ConflictOps[F, G](status)
+  implicit def http4sGoneSyntax(status: Gone.type): GoneOps[F, G] = new GoneOps[F, G](status)
+  implicit def http4sLengthRequiredSyntax(status: LengthRequired.type): LengthRequiredOps[F, G] =
+    new LengthRequiredOps[F, G](status)
   implicit def http4sPreconditionFailedSyntax(
-      status: PreconditionFailed.type): PreconditionFailedOps[F] =
-    new PreconditionFailedOps[F](status)
-  implicit def http4sPayloadTooLargeSyntax(status: PayloadTooLarge.type): PayloadTooLargeOps[F] =
-    new PayloadTooLargeOps[F](status)
-  implicit def http4sUriTooLongSyntax(status: UriTooLong.type): UriTooLongOps[F] =
-    new UriTooLongOps[F](status)
+      status: PreconditionFailed.type): PreconditionFailedOps[F, G] =
+    new PreconditionFailedOps[F, G](status)
+  implicit def http4sPayloadTooLargeSyntax(status: PayloadTooLarge.type): PayloadTooLargeOps[F, G] =
+    new PayloadTooLargeOps[F, G](status)
+  implicit def http4sUriTooLongSyntax(status: UriTooLong.type): UriTooLongOps[F, G] =
+    new UriTooLongOps[F, G](status)
   implicit def http4sUnsupportedMediaTypeSyntax(
-      status: UnsupportedMediaType.type): UnsupportedMediaTypeOps[F] =
-    new UnsupportedMediaTypeOps[F](status)
+      status: UnsupportedMediaType.type): UnsupportedMediaTypeOps[F, G] =
+    new UnsupportedMediaTypeOps[F, G](status)
   implicit def http4sRangeNotSatisfiableSyntax(
-      status: RangeNotSatisfiable.type): RangeNotSatisfiableOps[F] =
-    new RangeNotSatisfiableOps[F](status)
+      status: RangeNotSatisfiable.type): RangeNotSatisfiableOps[F, G] =
+    new RangeNotSatisfiableOps[F, G](status)
   implicit def http4sExpectationFailedSyntax(
-      status: ExpectationFailed.type): ExpectationFailedOps[F] = new ExpectationFailedOps[F](status)
+      status: ExpectationFailed.type): ExpectationFailedOps[F, G] =
+    new ExpectationFailedOps[F, G](status)
   implicit def http4sMisdirectedRequestSyntax(
-      status: MisdirectedRequest.type): MisdirectedRequestOps[F] =
-    new MisdirectedRequestOps[F](status)
+      status: MisdirectedRequest.type): MisdirectedRequestOps[F, G] =
+    new MisdirectedRequestOps[F, G](status)
   implicit def http4sUnprocessableEntitySyntax(
-      status: UnprocessableEntity.type): UnprocessableEntityOps[F] =
-    new UnprocessableEntityOps[F](status)
-  implicit def http4sLockedSyntax(status: Locked.type): LockedOps[F] = new LockedOps[F](status)
-  implicit def http4sFailedDependencySyntax(status: FailedDependency.type): FailedDependencyOps[F] =
-    new FailedDependencyOps[F](status)
-  implicit def http4sTooEarlySyntax(status: TooEarly.type): TooEarlyOps[F] =
-    new TooEarlyOps[F](status)
-  implicit def http4sUpgradeRequiredSyntax(status: UpgradeRequired.type): UpgradeRequiredOps[F] =
-    new UpgradeRequiredOps[F](status)
+      status: UnprocessableEntity.type): UnprocessableEntityOps[F, G] =
+    new UnprocessableEntityOps[F, G](status)
+  implicit def http4sLockedSyntax(status: Locked.type): LockedOps[F, G] =
+    new LockedOps[F, G](status)
+  implicit def http4sFailedDependencySyntax(
+      status: FailedDependency.type): FailedDependencyOps[F, G] =
+    new FailedDependencyOps[F, G](status)
+  implicit def http4sTooEarlySyntax(status: TooEarly.type): TooEarlyOps[F, G] =
+    new TooEarlyOps[F, G](status)
+  implicit def http4sUpgradeRequiredSyntax(status: UpgradeRequired.type): UpgradeRequiredOps[F, G] =
+    new UpgradeRequiredOps[F, G](status)
   implicit def http4sPreconditionRequiredSyntax(
-      status: PreconditionRequired.type): PreconditionRequiredOps[F] =
-    new PreconditionRequiredOps[F](status)
-  implicit def http4sTooManyRequestsSyntax(status: TooManyRequests.type): TooManyRequestsOps[F] =
-    new TooManyRequestsOps[F](status)
+      status: PreconditionRequired.type): PreconditionRequiredOps[F, G] =
+    new PreconditionRequiredOps[F, G](status)
+  implicit def http4sTooManyRequestsSyntax(status: TooManyRequests.type): TooManyRequestsOps[F, G] =
+    new TooManyRequestsOps[F, G](status)
   implicit def http4sRequestHeaderFieldsTooLargeSyntax(
-      status: RequestHeaderFieldsTooLarge.type): RequestHeaderFieldsTooLargeOps[F] =
-    new RequestHeaderFieldsTooLargeOps[F](status)
+      status: RequestHeaderFieldsTooLarge.type): RequestHeaderFieldsTooLargeOps[F, G] =
+    new RequestHeaderFieldsTooLargeOps[F, G](status)
   implicit def http4sUnavailableForLegalReasonsSyntax(
-      status: UnavailableForLegalReasons.type): UnavailableForLegalReasonsOps[F] =
-    new UnavailableForLegalReasonsOps[F](status)
+      status: UnavailableForLegalReasons.type): UnavailableForLegalReasonsOps[F, G] =
+    new UnavailableForLegalReasonsOps[F, G](status)
 
   implicit def http4sInternalServerErrorSyntax(
-      status: InternalServerError.type): InternalServerErrorOps[F] =
-    new InternalServerErrorOps[F](status)
-  implicit def http4sNotImplementedSyntax(status: NotImplemented.type): NotImplementedOps[F] =
-    new NotImplementedOps[F](status)
-  implicit def http4sBadGatewaySyntax(status: BadGateway.type): BadGatewayOps[F] =
-    new BadGatewayOps[F](status)
+      status: InternalServerError.type): InternalServerErrorOps[F, G] =
+    new InternalServerErrorOps[F, G](status)
+  implicit def http4sNotImplementedSyntax(status: NotImplemented.type): NotImplementedOps[F, G] =
+    new NotImplementedOps[F, G](status)
+  implicit def http4sBadGatewaySyntax(status: BadGateway.type): BadGatewayOps[F, G] =
+    new BadGatewayOps[F, G](status)
   implicit def http4sServiceUnavailableSyntax(
-      status: ServiceUnavailable.type): ServiceUnavailableOps[F] =
-    new ServiceUnavailableOps[F](status)
-  implicit def http4sGatewayTimeoutSyntax(status: GatewayTimeout.type): GatewayTimeoutOps[F] =
-    new GatewayTimeoutOps[F](status)
+      status: ServiceUnavailable.type): ServiceUnavailableOps[F, G] =
+    new ServiceUnavailableOps[F, G](status)
+  implicit def http4sGatewayTimeoutSyntax(status: GatewayTimeout.type): GatewayTimeoutOps[F, G] =
+    new GatewayTimeoutOps[F, G](status)
   implicit def http4sHttpVersionNotSupportedSyntax(
-      status: HttpVersionNotSupported.type): HttpVersionNotSupportedOps[F] =
-    new HttpVersionNotSupportedOps[F](status)
+      status: HttpVersionNotSupported.type): HttpVersionNotSupportedOps[F, G] =
+    new HttpVersionNotSupportedOps[F, G](status)
   implicit def http4sVariantAlsoNegotiatesSyntax(
-      status: VariantAlsoNegotiates.type): VariantAlsoNegotiatesOps[F] =
-    new VariantAlsoNegotiatesOps[F](status)
+      status: VariantAlsoNegotiates.type): VariantAlsoNegotiatesOps[F, G] =
+    new VariantAlsoNegotiatesOps[F, G](status)
   implicit def http4sInsufficientStorageSyntax(
-      status: InsufficientStorage.type): InsufficientStorageOps[F] =
-    new InsufficientStorageOps[F](status)
-  implicit def http4sLoopDetectedSyntax(status: LoopDetected.type): LoopDetectedOps[F] =
-    new LoopDetectedOps[F](status)
-  implicit def http4sNotExtendedSyntax(status: NotExtended.type): NotExtendedOps[F] =
-    new NotExtendedOps[F](status)
+      status: InsufficientStorage.type): InsufficientStorageOps[F, G] =
+    new InsufficientStorageOps[F, G](status)
+  implicit def http4sLoopDetectedSyntax(status: LoopDetected.type): LoopDetectedOps[F, G] =
+    new LoopDetectedOps[F, G](status)
+  implicit def http4sNotExtendedSyntax(status: NotExtended.type): NotExtendedOps[F, G] =
+    new NotExtendedOps[F, G](status)
   implicit def http4sNetworkAuthenticationRequiredSyntax(
-      status: NetworkAuthenticationRequired.type): NetworkAuthenticationRequiredOps[F] =
-    new NetworkAuthenticationRequiredOps[F](status)
+      status: NetworkAuthenticationRequired.type): NetworkAuthenticationRequiredOps[F, G] =
+    new NetworkAuthenticationRequiredOps[F, G](status)
 }
 
 object Responses {
-  final class ContinueOps[F[_]](val status: Continue.type)
+  final class ContinueOps[F[_], G[_]](val status: Continue.type)
       extends AnyVal
-      with EmptyResponseGenerator[F]
+      with EmptyResponseGenerator[F, G]
   // TODO support Upgrade header
-  final class SwitchingProtocolsOps[F[_]](val status: SwitchingProtocols.type)
+  final class SwitchingProtocolsOps[F[_], G[_]](val status: SwitchingProtocols.type)
       extends AnyVal
-      with EmptyResponseGenerator[F]
-  final class EarlyHintsOps[F[_]](val status: EarlyHints.type)
+      with EmptyResponseGenerator[F, G]
+  final class EarlyHintsOps[F[_], G[_]](val status: EarlyHints.type)
       extends AnyVal
-      with EmptyResponseGenerator[F]
-  final class OkOps[F[_]](val status: Ok.type) extends AnyVal with EntityResponseGenerator[F]
+      with EmptyResponseGenerator[F, G]
+  final class OkOps[F[_], G[_]](val status: Ok.type)
+      extends AnyVal
+      with EntityResponseGenerator[F, G]
 
-  final class CreatedOps[F[_]](val status: Created.type)
+  final class CreatedOps[F[_], G[_]](val status: Created.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class AcceptedOps[F[_]](val status: Accepted.type)
+      with EntityResponseGenerator[F, G]
+  final class AcceptedOps[F[_], G[_]](val status: Accepted.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class NonAuthoritativeInformationOps[F[_]](val status: NonAuthoritativeInformation.type)
+      with EntityResponseGenerator[F, G]
+  final class NonAuthoritativeInformationOps[F[_], G[_]](
+      val status: NonAuthoritativeInformation.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class NoContentOps[F[_]](val status: NoContent.type)
+      with EntityResponseGenerator[F, G]
+  final class NoContentOps[F[_], G[_]](val status: NoContent.type)
       extends AnyVal
-      with EmptyResponseGenerator[F]
-  final class ResetContentOps[F[_]](val status: ResetContent.type)
+      with EmptyResponseGenerator[F, G]
+  final class ResetContentOps[F[_], G[_]](val status: ResetContent.type)
       extends AnyVal
-      with EmptyResponseGenerator[F] {
-    override def apply(headers: Header*)(implicit F: Applicative[F]): F[Response[F]] =
+      with EmptyResponseGenerator[F, G] {
+    override def apply(headers: Header*)(implicit F: Applicative[F]): F[Response[G]] =
       F.pure(Response(ResetContent, headers = Headers(`Content-Length`.zero +: headers: _*)))
   }
   // TODO helpers for Content-Range and multipart/byteranges
-  final class PartialContentOps[F[_]](val status: PartialContent.type)
+  final class PartialContentOps[F[_], G[_]](val status: PartialContent.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class MultiStatusOps[F[_]](val status: Status.MultiStatus.type)
+      with EntityResponseGenerator[F, G]
+  final class MultiStatusOps[F[_], G[_]](val status: Status.MultiStatus.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class AlreadyReportedOps[F[_]](val status: AlreadyReported.type)
+      with EntityResponseGenerator[F, G]
+  final class AlreadyReportedOps[F[_], G[_]](val status: AlreadyReported.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class IMUsedOps[F[_]](val status: IMUsed.type)
+      with EntityResponseGenerator[F, G]
+  final class IMUsedOps[F[_], G[_]](val status: IMUsed.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
+      with EntityResponseGenerator[F, G]
 
-  final class MultipleChoicesOps[F[_]](val status: MultipleChoices.type)
+  final class MultipleChoicesOps[F[_], G[_]](val status: MultipleChoices.type)
       extends AnyVal
-      with LocationResponseGenerator[F]
-  final class MovedPermanentlyOps[F[_]](val status: MovedPermanently.type)
+      with LocationResponseGenerator[F, G]
+  final class MovedPermanentlyOps[F[_], G[_]](val status: MovedPermanently.type)
       extends AnyVal
-      with LocationResponseGenerator[F]
-  final class FoundOps[F[_]](val status: Found.type)
+      with LocationResponseGenerator[F, G]
+  final class FoundOps[F[_], G[_]](val status: Found.type)
       extends AnyVal
-      with LocationResponseGenerator[F]
-  final class SeeOtherOps[F[_]](val status: SeeOther.type)
+      with LocationResponseGenerator[F, G]
+  final class SeeOtherOps[F[_], G[_]](val status: SeeOther.type)
       extends AnyVal
-      with LocationResponseGenerator[F]
-  final class NotModifiedOps[F[_]](val status: NotModified.type)
+      with LocationResponseGenerator[F, G]
+  final class NotModifiedOps[F[_], G[_]](val status: NotModified.type)
       extends AnyVal
-      with EmptyResponseGenerator[F]
+      with EmptyResponseGenerator[F, G]
   // Note: UseProxy is deprecated in RFC7231, so we will not ease its creation here.
-  final class TemporaryRedirectOps[F[_]](val status: TemporaryRedirect.type)
+  final class TemporaryRedirectOps[F[_], G[_]](val status: TemporaryRedirect.type)
       extends AnyVal
-      with LocationResponseGenerator[F]
-  final class PermanentRedirectOps[F[_]](val status: PermanentRedirect.type)
+      with LocationResponseGenerator[F, G]
+  final class PermanentRedirectOps[F[_], G[_]](val status: PermanentRedirect.type)
       extends AnyVal
-      with LocationResponseGenerator[F]
+      with LocationResponseGenerator[F, G]
 
-  final class BadRequestOps[F[_]](val status: BadRequest.type)
+  final class BadRequestOps[F[_], G[_]](val status: BadRequest.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class UnauthorizedOps[F[_]](val status: Unauthorized.type)
+      with EntityResponseGenerator[F, G]
+  final class UnauthorizedOps[F[_], G[_]](val status: Unauthorized.type)
       extends AnyVal
-      with WwwAuthenticateResponseGenerator[F]
-  final class PaymentRequiredOps[F[_]](val status: PaymentRequired.type)
+      with WwwAuthenticateResponseGenerator[F, G]
+  final class PaymentRequiredOps[F[_], G[_]](val status: PaymentRequired.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class ForbiddenOps[F[_]](val status: Forbidden.type)
+      with EntityResponseGenerator[F, G]
+  final class ForbiddenOps[F[_], G[_]](val status: Forbidden.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class NotFoundOps[F[_]](val status: NotFound.type)
+      with EntityResponseGenerator[F, G]
+  final class NotFoundOps[F[_], G[_]](val status: NotFound.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class MethodNotAllowedOps[F[_]](val status: MethodNotAllowed.type)
+      with EntityResponseGenerator[F, G]
+  final class MethodNotAllowedOps[F[_], G[_]](val status: MethodNotAllowed.type)
       extends AnyVal
-      with AllowResponseGenerator[F]
-  final class NotAcceptableOps[F[_]](val status: NotAcceptable.type)
+      with AllowResponseGenerator[F, G]
+  final class NotAcceptableOps[F[_], G[_]](val status: NotAcceptable.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class ProxyAuthenticationRequiredOps[F[_]](val status: ProxyAuthenticationRequired.type)
+      with EntityResponseGenerator[F, G]
+  final class ProxyAuthenticationRequiredOps[F[_], G[_]](
+      val status: ProxyAuthenticationRequired.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
+      with EntityResponseGenerator[F, G]
   // TODO send Connection: close?
-  final class RequestTimeoutOps[F[_]](val status: RequestTimeout.type)
+  final class RequestTimeoutOps[F[_], G[_]](val status: RequestTimeout.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class ConflictOps[F[_]](val status: Conflict.type)
+      with EntityResponseGenerator[F, G]
+  final class ConflictOps[F[_], G[_]](val status: Conflict.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class GoneOps[F[_]](val status: Gone.type) extends AnyVal with EntityResponseGenerator[F]
-  final class LengthRequiredOps[F[_]](val status: LengthRequired.type)
+      with EntityResponseGenerator[F, G]
+  final class GoneOps[F[_], G[_]](val status: Gone.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class PreconditionFailedOps[F[_]](val status: PreconditionFailed.type)
+      with EntityResponseGenerator[F, G]
+  final class LengthRequiredOps[F[_], G[_]](val status: LengthRequired.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class PayloadTooLargeOps[F[_]](val status: PayloadTooLarge.type)
+      with EntityResponseGenerator[F, G]
+  final class PreconditionFailedOps[F[_], G[_]](val status: PreconditionFailed.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class UriTooLongOps[F[_]](val status: UriTooLong.type)
+      with EntityResponseGenerator[F, G]
+  final class PayloadTooLargeOps[F[_], G[_]](val status: PayloadTooLarge.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class UnsupportedMediaTypeOps[F[_]](val status: UnsupportedMediaType.type)
+      with EntityResponseGenerator[F, G]
+  final class UriTooLongOps[F[_], G[_]](val status: UriTooLong.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class RangeNotSatisfiableOps[F[_]](val status: RangeNotSatisfiable.type)
+      with EntityResponseGenerator[F, G]
+  final class UnsupportedMediaTypeOps[F[_], G[_]](val status: UnsupportedMediaType.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class ExpectationFailedOps[F[_]](val status: ExpectationFailed.type)
+      with EntityResponseGenerator[F, G]
+  final class RangeNotSatisfiableOps[F[_], G[_]](val status: RangeNotSatisfiable.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class MisdirectedRequestOps[F[_]](val status: MisdirectedRequest.type)
+      with EntityResponseGenerator[F, G]
+  final class ExpectationFailedOps[F[_], G[_]](val status: ExpectationFailed.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class UnprocessableEntityOps[F[_]](val status: UnprocessableEntity.type)
+      with EntityResponseGenerator[F, G]
+  final class MisdirectedRequestOps[F[_], G[_]](val status: MisdirectedRequest.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class LockedOps[F[_]](val status: Locked.type)
+      with EntityResponseGenerator[F, G]
+  final class UnprocessableEntityOps[F[_], G[_]](val status: UnprocessableEntity.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class FailedDependencyOps[F[_]](val status: FailedDependency.type)
+      with EntityResponseGenerator[F, G]
+  final class LockedOps[F[_], G[_]](val status: Locked.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class TooEarlyOps[F[_]](val status: TooEarly.type)
+      with EntityResponseGenerator[F, G]
+  final class FailedDependencyOps[F[_], G[_]](val status: FailedDependency.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
+      with EntityResponseGenerator[F, G]
+  final class TooEarlyOps[F[_], G[_]](val status: TooEarly.type)
+      extends AnyVal
+      with EntityResponseGenerator[F, G]
   // TODO Mandatory upgrade field
-  final class UpgradeRequiredOps[F[_]](val status: UpgradeRequired.type)
+  final class UpgradeRequiredOps[F[_], G[_]](val status: UpgradeRequired.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class PreconditionRequiredOps[F[_]](val status: PreconditionRequired.type)
+      with EntityResponseGenerator[F, G]
+  final class PreconditionRequiredOps[F[_], G[_]](val status: PreconditionRequired.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class TooManyRequestsOps[F[_]](val status: TooManyRequests.type)
+      with EntityResponseGenerator[F, G]
+  final class TooManyRequestsOps[F[_], G[_]](val status: TooManyRequests.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class RequestHeaderFieldsTooLargeOps[F[_]](val status: RequestHeaderFieldsTooLarge.type)
+      with EntityResponseGenerator[F, G]
+  final class RequestHeaderFieldsTooLargeOps[F[_], G[_]](
+      val status: RequestHeaderFieldsTooLarge.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class UnavailableForLegalReasonsOps[F[_]](val status: UnavailableForLegalReasons.type)
+      with EntityResponseGenerator[F, G]
+  final class UnavailableForLegalReasonsOps[F[_], G[_]](val status: UnavailableForLegalReasons.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
+      with EntityResponseGenerator[F, G]
 
-  final class InternalServerErrorOps[F[_]](val status: InternalServerError.type)
+  final class InternalServerErrorOps[F[_], G[_]](val status: InternalServerError.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class NotImplementedOps[F[_]](val status: NotImplemented.type)
+      with EntityResponseGenerator[F, G]
+  final class NotImplementedOps[F[_], G[_]](val status: NotImplemented.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class BadGatewayOps[F[_]](val status: BadGateway.type)
+      with EntityResponseGenerator[F, G]
+  final class BadGatewayOps[F[_], G[_]](val status: BadGateway.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class ServiceUnavailableOps[F[_]](val status: ServiceUnavailable.type)
+      with EntityResponseGenerator[F, G]
+  final class ServiceUnavailableOps[F[_], G[_]](val status: ServiceUnavailable.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class GatewayTimeoutOps[F[_]](val status: GatewayTimeout.type)
+      with EntityResponseGenerator[F, G]
+  final class GatewayTimeoutOps[F[_], G[_]](val status: GatewayTimeout.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class HttpVersionNotSupportedOps[F[_]](val status: HttpVersionNotSupported.type)
+      with EntityResponseGenerator[F, G]
+  final class HttpVersionNotSupportedOps[F[_], G[_]](val status: HttpVersionNotSupported.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class VariantAlsoNegotiatesOps[F[_]](val status: VariantAlsoNegotiates.type)
+      with EntityResponseGenerator[F, G]
+  final class VariantAlsoNegotiatesOps[F[_], G[_]](val status: VariantAlsoNegotiates.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class InsufficientStorageOps[F[_]](val status: InsufficientStorage.type)
+      with EntityResponseGenerator[F, G]
+  final class InsufficientStorageOps[F[_], G[_]](val status: InsufficientStorage.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class LoopDetectedOps[F[_]](val status: LoopDetected.type)
+      with EntityResponseGenerator[F, G]
+  final class LoopDetectedOps[F[_], G[_]](val status: LoopDetected.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class NotExtendedOps[F[_]](val status: NotExtended.type)
+      with EntityResponseGenerator[F, G]
+  final class NotExtendedOps[F[_], G[_]](val status: NotExtended.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
-  final class NetworkAuthenticationRequiredOps[F[_]](val status: NetworkAuthenticationRequired.type)
+      with EntityResponseGenerator[F, G]
+  final class NetworkAuthenticationRequiredOps[F[_], G[_]](
+      val status: NetworkAuthenticationRequired.type)
       extends AnyVal
-      with EntityResponseGenerator[F]
+      with EntityResponseGenerator[F, G]
 
 }


### PR DESCRIPTION
Add new type constructor to be able to construct this DSL for http4s-directives.

```
trait DirectivesDsl[F[_]] extends Http4sDsl2[Directive[F, ?], F]

object DirectivesDsl {
  def apply[F[_]]: DirectivesDsl[F] = new DirectivesDsl[F] {}
}


object io extends DirectivesDsl[IO]
```