### PR TITLE
Remove reference to G type on HttpApp

### DIFF
--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -34,7 +34,6 @@ package object http4s { // scalastyle:ignore
     * and a client can be converted to or from an HTTP app.
     *
     * @tparam F the effect type in which the [[Response]] is returned
-    * @tparam G the effect type of the [[Request]] and [[Response]] bodies
     */
   type HttpApp[F[_]] = Http[F, F]
 


### PR DESCRIPTION
The sacala doc for `HttpApp` has a reference to a `G` typeparam that no longer exists