### PR TITLE
In case logHeaders/logBody are both false still log the prelude

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -91,13 +91,16 @@ object Logger {
       Stream("").covary[F]
     }
 
-    if (!logBody && !logHeaders) F.unit
-    else {
-      bodyText
-        .map(body => s"$prelude $headers $body")
-        .evalMap(text => log(text))
-        .compile
-        .drain
-    }
+    def msg(body: String) =
+      (logHeaders, logBody) match {
+        case (false, false) => prelude
+        case _ => s"$prelude $headers $body"
+      }
+
+    bodyText
+      .map(msg)
+      .evalMap(log)
+      .compile
+      .drain
   }
 }


### PR DESCRIPTION
Logger has two flags to indicate if we want to log headers and/or body. However if both are false nothing is logged.
With this PR we still log the prelude in that case

Fixes #2456