### PR TITLE
Prevent never ending wait for cancelation of a failed (timed-out) attempt to acquire a connection.

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -60,11 +60,13 @@ object BlazeClient {
             .handleError(e => logger.error(e)("Error invalidating connection"))
 
         def borrow =
-          Resource.makeCase(manager.borrow(key)) {
-            case (_, ExitCase.Completed) =>
-              F.unit
-            case (next, ExitCase.Error(_) | ExitCase.Canceled) =>
+        // TODO: The `attempt` here is a workaround for https://github.com/typelevel/cats-effect/issues/487 .
+        //  It can be removed once the issue is resolved.
+          Resource.makeCase(manager.borrow(key).attempt) {
+            case (Right(next), ExitCase.Error(_) | ExitCase.Canceled) =>
               invalidate(next.connection)
+            case _ =>
+              F.unit
           }
 
         def idleTimeoutStage(conn: A) =
@@ -82,39 +84,41 @@ object BlazeClient {
           }
 
         def loop: F[Resource[F, Response[F]]] =
-          borrow.use { next =>
-            idleTimeoutStage(next.connection).use { stageOpt =>
-              val idleTimeoutF = stageOpt match {
-                case Some(stage) => F.async[TimeoutException](stage.init)
-                case None => F.never[TimeoutException]
-              }
-              val res = next.connection
-                .runRequest(req, idleTimeoutF)
-                .map { r =>
-                  Resource.makeCase(F.pure(r)) {
-                    case (_, ExitCase.Completed) =>
-                      F.delay(stageOpt.foreach(_.removeStage()))
-                        .guarantee(manager.release(next.connection))
-                    case _ =>
-                      F.delay(stageOpt.foreach(_.removeStage()))
-                        .guarantee(manager.invalidate(next.connection))
-                  }
+          borrow.use {
+            case Left(t) => F.raiseError(t)
+            case Right(next) =>
+              idleTimeoutStage(next.connection).use { stageOpt =>
+                val idleTimeoutF = stageOpt match {
+                  case Some(stage) => F.async[TimeoutException](stage.init)
+                  case None => F.never[TimeoutException]
                 }
-                .recoverWith {
-                  case Command.EOF =>
-                    invalidate(next.connection).flatMap { _ =>
-                      if (next.fresh)
-                        F.raiseError(
-                          new java.net.ConnectException(s"Failed to connect to endpoint: $key"))
-                      else {
-                        loop
-                      }
+                val res = next.connection
+                  .runRequest(req, idleTimeoutF)
+                  .map { r =>
+                    Resource.makeCase(F.pure(r)) {
+                      case (_, ExitCase.Completed) =>
+                        F.delay(stageOpt.foreach(_.removeStage()))
+                          .guarantee(manager.release(next.connection))
+                      case _ =>
+                        F.delay(stageOpt.foreach(_.removeStage()))
+                          .guarantee(manager.invalidate(next.connection))
                     }
-                }
+                  }
+                  .recoverWith {
+                    case Command.EOF =>
+                      invalidate(next.connection).flatMap { _ =>
+                        if (next.fresh)
+                          F.raiseError(
+                            new java.net.ConnectException(s"Failed to connect to endpoint: $key"))
+                        else {
+                          loop
+                        }
+                      }
+                  }
 
-              Deferred[F, Unit].flatMap { gate =>
-                val responseHeaderTimeoutF: F[TimeoutException] =
-                  F.delay {
+                Deferred[F, Unit].flatMap { gate =>
+                  val responseHeaderTimeoutF: F[TimeoutException] =
+                    F.delay {
                       val stage =
                         new ResponseHeaderTimeoutStage[ByteBuffer](
                           responseHeaderTimeout,
@@ -123,18 +127,18 @@ object BlazeClient {
                       next.connection.spliceBefore(stage)
                       stage
                     }
-                    .bracket(stage =>
-                      F.asyncF[TimeoutException] { cb =>
-                        F.delay(stage.init(cb)) >> gate.complete(())
-                    })(stage => F.delay(stage.removeStage()))
+                      .bracket(stage =>
+                        F.asyncF[TimeoutException] { cb =>
+                          F.delay(stage.init(cb)) >> gate.complete(())
+                        })(stage => F.delay(stage.removeStage()))
 
-                F.racePair(gate.get *> res, responseHeaderTimeoutF)
-                  .flatMap[Resource[F, Response[F]]] {
+                  F.racePair(gate.get *> res, responseHeaderTimeoutF)
+                    .flatMap[Resource[F, Response[F]]] {
                     case Left((r, fiber)) => fiber.cancel.as(r)
                     case Right((fiber, t)) => fiber.cancel >> F.raiseError(t)
                   }
+                }
               }
-            }
           }
 
         val res = loop

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -163,23 +163,23 @@ class ClientTimeoutSpec extends Http4sSpec {
     "Eventually timeout on connect timeout" in {
       val manager = ConnectionManager.basic[IO, BlazeConnection[IO]]({ _ =>
         // In a real use case this timeout is under OS's control (AsynchronousSocketChannel.connect)
-        IO.sleep(2.seconds) *> IO.raiseError[BlazeConnection[IO]](new IOException())
+        IO.sleep(1000.millis) *> IO.raiseError[BlazeConnection[IO]](new IOException())
       })
       val c = BlazeClient.makeClient(
         manager = manager,
         responseHeaderTimeout = Duration.Inf,
         idleTimeout = Duration.Inf,
-        requestTimeout = 1.second,
+        requestTimeout = 50.millis,
         scheduler = tickWheel,
         ec = testExecutionContext
       )
 
-      // if the 5.seconds timeout is hit, it's a NoSuchElementException,
-      // if the requestTimeout = 1.second is hit then it's a TimeoutException
+      // if the unsafeRunTimed timeout is hit, it's a NoSuchElementException,
+      // if the requestTimeout is hit then it's a TimeoutException
       // if establishing connection fails first then it's an IOException
 
       // The expected behaviour is that the requestTimeout will happen first, but fetchAs will additionally wait for the IO.sleep(2.seconds) to complete.
-      c.fetchAs[String](FooRequest).unsafeRunTimed(5.seconds).get must throwA[TimeoutException]
+      c.fetchAs[String](FooRequest).unsafeRunTimed(1500.millis).get must throwA[TimeoutException]
     }
   }
 }


### PR DESCRIPTION
This is a workaround for https://github.com/typelevel/cats-effect/issues/487 causing blaze client to wait indefinitely if a `requestTimeout` occurs while `manager.borrow(key)` is running and the borrow eventually fails. This is what happens when we try to send a request to an unreachable host (incorrect IP address, firewalls, etc.).

IMO this is a solution for #2338. It literally implements "a reasonable timeout, even if hardcoded" as @rossabaker described it ;).

This is also a partial solution for #2386 . The requestTimeout still isn't enforced,  instead we wait for an OS level timeout of an attempt to establish TCP connection, but at least the request fails eventually, instead of waiting indefinitely. I want to follow up with a more complete solution, but I feel it requires making some design decisions, which should be discussed with the maintainers.

