### PR TITLE
Static content documentation

### DIFF
--- a/docs/src/main/tut/static.md
+++ b/docs/src/main/tut/static.md
@@ -2,6 +2,7 @@
 menu: main
 weight: 140
 title: Static Files
+---
 
 Http4s can serve static files, subject to a configuration policy. There are three 
 locations that Http4s can serve static content from: the filesystem, resources 

--- a/docs/src/main/tut/static.md
+++ b/docs/src/main/tut/static.md
@@ -2,31 +2,59 @@
 menu: main
 weight: 140
 title: Static Files
----
 
-## On static data and HTTP
+Http4s can serve static files, subject to a configuration policy. There are three 
+locations that Http4s can serve static content from: the filesystem, resources 
+using the classloader, and WebJars. 
+
+All of these solutions are most likely slower than the equivalent in nginx or a
+similar static file hoster, but they're often fast enough.
+
+## Getting Started
+
+To use fileService, the only configuration required is the relative path to the directory to serve. 
+The service will automatically serve index.html if the request path is not a file. This service will also 
+remove dot segments, to prevent attackers from reading files not contained in the directory 
+being served. 
+
+```tut:book
+import cats.effect._
+import cats.implicits._
+import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.server.staticcontent._
+import org.http4s.syntax.kleisli._
+
+object SimpleHttpServer extends IOApp {
+  override def run(args: List[String]): IO[ExitCode] =
+    BlazeServerBuilder[IO]
+      .bindHttp(8080)
+      .withHttpApp(fileService[IO](FileService.Config(".")).orNotFound)
+      .serve
+      .compile.drain.as(ExitCode.Success)
+}
+```
+
+Static content services can be composed into a larger application by using a `Router`:
+```tut:book:nofail
+val httpApp: HttpApp[IO] =
+    Router(
+      "api"    -> anotherService
+      "assets" -> fileService(FileService.Config("./assets))
+    ).orNotFound
+```
+
+## ETags
+
 Usually, if you fetch a file via HTTP, it ships with an ETag. An ETag specifies
 a file version. So the next time the browser requests that information, it sends
 the ETag along, and gets a 304 Not Modified back, so you don't have to send the
 data over the wire again.
 
-All of these solutions are most likely slower than the equivalent in nginx or a
-similar static file hoster, but they're often fast enough.
-
-## Serving static files
-Http4s provides a few helpers to handle ETags for you, they're located in [StaticFile].
-
-```tut:silent
-import cats.effect._
-import org.http4s._
-import org.http4s.dsl.io._
-import java.io.File
-```
-
-### Prerequisites
+### Execution Context
 
 Static file support uses a blocking API, so we'll need a blocking execution
-context:
+context. The helpers in `org.http4s.server.staticcontent._` will use the global execution context, but
+for best results this should overriden according to the desired characteristics of your server.  
 
 ```tut:silent
 import java.util.concurrent._
@@ -43,6 +71,15 @@ implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 ```
 
 ```tut:silent
+val routes = fileService[IO](FileService.Config(".", executionContext = blockingEc))
+```
+
+For custom behaviour, `StaticFile.fromFile` can also be used directly in a route, to respond with a file:
+```tut:silent
+import org.http4s._
+import org.http4s.dsl.io._
+import java.io.File
+
 val routes = HttpRoutes.of[IO] {
   case request @ GET -> Root / "index.html" =>
     StaticFile.fromFile(new File("relative/path/to/index.html"), blockingEc, Some(request))
@@ -51,8 +88,16 @@ val routes = HttpRoutes.of[IO] {
 ```
 
 ## Serving from jars
+
 For simple file serving, it's possible to package resources with the jar and
-deliver them from there. Append to the `List` as needed.
+deliver them from there. For example, for all resources in the classpath under `assets`:
+
+```tut:book
+val routes = resourceService[IO](ResourceService.Config("/assets", ExecutionContext.global))
+```
+
+For custom behaviour, `StaticFile.fromResource` can be used. In this example, 
+only files matching a list of extensions are served. Append to the `List` as needed.
 
 ```tut:book
 def static(file: String, blockingEc: ExecutionContext, request: Request[IO]) =


### PR DESCRIPTION
I didn't know (until recently) about the org.http4s.server.staticcontent package object. It seems to be a much more convenient way to host static content (one line, like wai-middleware-static). I've updated the docs to include it.