### PR TITLE
Source helpers in before_install stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,8 +98,8 @@ jobs:
         - PATH="$HOME/bin:$PATH"
         - export PATH=${PATH}:./vendor/bundle
       script:
-        - sbt ++$TRAVIS_SCALA_VERSION docs/ghpagesPushSite
-        - sbt ++$TRAVIS_SCALA_VERSION website/ghpagesPushSite
+        - sbt ++$TRAVIS_SCALA_VERSION docs/makeSite docs/ghpagesPushSite
+        - sbt ++$TRAVIS_SCALA_VERSION website/makeSite website/ghpagesPushSite
   allow_failures:
     jdk: *java_11
     scala: *scala_version_212

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
     - env: TEST="docs"
       scala: *scala_version_212
       jdk: *java_8
-      before_script:
+      before_install:
         - source scripts/helpers
         - PATH="$HOME/bin:$PATH"
         - export PATH=${PATH}:./vendor/bundle
@@ -74,7 +74,7 @@ jobs:
       env: TEST="publish"
       scala: *scala_version_212
       jdk: *java_8
-      before_script:
+      before_install:
         - source scripts/helpers
         - PATH="$HOME/bin:$PATH"
         - export PATH=${PATH}:./vendor/bundle
@@ -88,7 +88,7 @@ jobs:
     - env: TEST="publish docs"
       scala: *scala_version_212
       jdk: *java_8
-      before_script:
+      before_install:
         - source scripts/helpers
         - PATH="$HOME/bin:$PATH"
         - export PATH=${PATH}:./vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,11 @@ jobs:
       jdk: *java_8
       before_install:
         - source scripts/helpers
-        - PATH="$HOME/bin:$PATH"
-        - export PATH=${PATH}:./vendor/bundle
       install:
         - scripts/install-hugo
+      before_script:
+        - PATH="$HOME/bin:$PATH"
+        - export PATH=${PATH}:./vendor/bundle
       script:
         - sbt ++$TRAVIS_SCALA_VERSION docs/makeSite
         - sbt ++$TRAVIS_SCALA_VERSION website/makeSite
@@ -76,8 +77,6 @@ jobs:
       jdk: *java_8
       before_install:
         - source scripts/helpers
-        - PATH="$HOME/bin:$PATH"
-        - export PATH=${PATH}:./vendor/bundle
       install:
         - scripts/install-hugo
         - decrypt_deploy_key
@@ -90,13 +89,14 @@ jobs:
       jdk: *java_8
       before_install:
         - source scripts/helpers
-        - PATH="$HOME/bin:$PATH"
-        - export PATH=${PATH}:./vendor/bundle
       install:
         - scripts/install-hugo
         - decrypt_deploy_key
         - decrypt_pgp_secrets
         - configure_git
+      before_script:
+        - PATH="$HOME/bin:$PATH"
+        - export PATH=${PATH}:./vendor/bundle
       script:
         - sbt ++$TRAVIS_SCALA_VERSION docs/ghpagesPushSite
         - sbt ++$TRAVIS_SCALA_VERSION website/ghpagesPushSite


### PR DESCRIPTION
We need to source `scripts/helpers` before calling `decrypt_deploy_key`.  I think it's to blame for [this error](https://travis-ci.org/http4s/http4s/jobs/515220273).