### PR TITLE
[WIP] initial support for the JDK 11+ Http Client API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val modules: List[ProjectReference] = List(
   asyncHttpClient,
   jettyClient,
   okHttpClient,
+  jdkHttpClient,
   servlet,
   jetty,
   tomcat,
@@ -237,6 +238,17 @@ lazy val okHttpClient = libraryProject("okhttp-client")
     libraryDependencies ++= Seq(
       Http4sPlugin.okhttp
     ),
+  )
+  .dependsOn(core, testing % "test->test", client % "compile;test->test")
+
+lazy val jdkHttpClient = libraryProject("jdk-http-client")
+  .settings(crossScalaAll)
+  .settings(
+    description := "JDK 11+ http client implementation for http4s clients",
+    libraryDependencies ++= Seq(
+      fs2ReactiveStreams,
+      reactiveStreamsFlowAdapters
+    )
   )
   .dependsOn(core, testing % "test->test", client % "compile;test->test")
 

--- a/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -1,17 +1,20 @@
 package org.http4s.client.jdkhttpclient
 
-import java.net.URI
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.HttpResponse.BodyHandlers
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.net.{ProxySelector, URI}
 import java.nio.ByteBuffer
+import java.time.{Duration => JDuration}
 import java.util
-import java.util.concurrent.Flow
+import java.util.concurrent.{Executor, Flow}
 
+import cats.ApplicativeError
 import cats.effect._
 import cats.implicits._
 import fs2.interop.reactivestreams._
 import fs2.{Chunk, Stream}
+import javax.net.ssl.SSLContext
 import org.http4s.client.Client
 import org.http4s.internal.fromCompletableFuture
 import org.http4s.util.CaseInsensitiveString
@@ -19,19 +22,89 @@ import org.http4s.{Header, Headers, HttpVersion, Request, Response, Status}
 import org.reactivestreams.FlowAdapters
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
+// TODO documentation
 object JdkHttpClient {
 
-  def apply[F[_]](builder: HttpClient.Builder = HttpClient.newBuilder)(
-      implicit F: ConcurrentEffect[F]): F[Client[F]] =
-    F.delay(builder.build).map { jdkHttpClient =>
-      Client[F] { req =>
-        Resource.liftF(
-          fromCompletableFuture(
-            F.delay(jdkHttpClient.sendAsync(convertRequest(req), BodyHandlers.ofPublisher)))
-            .flatMap(convertResponse(_)))
+  def apply[F[_]](
+      jdkHttpClient: HttpClient,
+      ignoredHeaders: Set[CaseInsensitiveString] = restrictedHeaders
+  )(implicit F: ConcurrentEffect[F]): Client[F] = {
+
+    def convertRequest(req: Request[F]): F[HttpRequest] =
+      convertHttpVersionFromHttp4s[F](req.httpVersion).map { version =>
+        val rb = HttpRequest.newBuilder
+          .method(
+            req.method.name, {
+              val publisher = FlowAdapters.toFlowPublisher(
+                StreamUnicastPublisher(req.body.chunks.map(_.toByteBuffer)))
+              if (req.isChunked)
+                BodyPublishers.fromPublisher(publisher)
+              else
+                req.contentLength.fold(BodyPublishers.noBody)(
+                  BodyPublishers.fromPublisher(publisher, _))
+            }
+          )
+          .uri(URI.create(req.uri.renderString))
+          .version(version)
+        val headers = req.headers.iterator
+        // hacky workaround (see e.g. https://stackoverflow.com/questions/53979173)
+          .filterNot(h => ignoredHeaders.contains(h.name))
+          .flatMap(h => Iterator(h.name.value, h.value))
+          .toArray
+        (if (headers.isEmpty) rb else rb.headers(headers: _*)).build
       }
+
+    def convertResponse(res: HttpResponse[Flow.Publisher[util.List[ByteBuffer]]]): F[Response[F]] =
+      F.fromEither(Status.fromInt(res.statusCode)).map { status =>
+        Response(
+          status = status,
+          headers = Headers(res.headers.map.asScala.flatMap {
+            case (k, vs) => vs.asScala.map(Header(k, _))
+          }.toList),
+          httpVersion = res.version match {
+            case HttpClient.Version.HTTP_1_1 => HttpVersion.`HTTP/1.1`
+            case HttpClient.Version.HTTP_2 => HttpVersion.`HTTP/2.0`
+          },
+          body = FlowAdapters
+            .toPublisher(res.body)
+            .toStream[F]
+            .flatMap(bs =>
+              Stream.fromIterator(bs.asScala.map(Chunk.byteBuffer).iterator).flatMap(Stream.chunk))
+        )
+      }
+
+    Client[F] { req =>
+      Resource.liftF(
+        convertRequest(req)
+          .flatMap(r =>
+            fromCompletableFuture(F.delay(jdkHttpClient.sendAsync(r, BodyHandlers.ofPublisher))))
+          .flatMap(convertResponse))
     }
+  }
+
+  def createUnderlyingClient[F[_]](
+      httpVersion: HttpVersion = HttpVersion.`HTTP/1.1`,
+      connectTimeout: Duration = 10.seconds,
+      redirectPolicy: HttpClient.Redirect = HttpClient.Redirect.NEVER,
+      sslContext: => SSLContext = SSLContext.getDefault,
+      proxySelector: => ProxySelector = ProxySelector.getDefault,
+      customEC: Option[Executor] = None
+  )(implicit F: Sync[F]): F[HttpClient] =
+    convertHttpVersionFromHttp4s[F](httpVersion).flatMap(version =>
+      F.delay {
+        val builder = HttpClient.newBuilder
+          .version(version)
+          .connectTimeout(JDuration.ofNanos(connectTimeout.toNanos))
+          .followRedirects(redirectPolicy)
+          .sslContext(sslContext)
+          .proxy(proxySelector)
+        customEC.fold(builder)(builder.executor).build()
+    })
+
+  def simple[F[_]: ConcurrentEffect]: F[Client[F]] =
+    createUnderlyingClient[F]().map(apply[F](_))
 
   // see jdk.internal.net.http.common.Utils#DISALLOWED_HEADERS_SET
   private val restrictedHeaders =
@@ -47,51 +120,12 @@ object JdkHttpClient {
       "warning"
     ).map(CaseInsensitiveString(_))
 
-  def convertRequest[F[_]: ConcurrentEffect](req: Request[F]): HttpRequest = {
-    val rb = HttpRequest.newBuilder
-      .method(
-        req.method.name, {
-          val publisher = FlowAdapters.toFlowPublisher(
-            StreamUnicastPublisher(req.body.chunks.map(_.toByteBuffer)))
-          if (req.isChunked)
-            BodyPublishers.fromPublisher(publisher)
-          else
-            req.contentLength.fold(BodyPublishers.noBody)(
-              BodyPublishers.fromPublisher(publisher, _))
-        }
-      )
-      .uri(URI.create(req.uri.renderString))
-      .version(req.httpVersion match {
-        case HttpVersion.`HTTP/1.1` => HttpClient.Version.HTTP_1_1
-        case HttpVersion.`HTTP/2.0` => HttpClient.Version.HTTP_2
-        case _ => HttpClient.Version.HTTP_1_1
-      })
-    val headers = req.headers.iterator
-    // hacky workaround (see e.g. https://stackoverflow.com/questions/53979173)
-      .filterNot(h => restrictedHeaders.contains(h.name))
-      .flatMap(h => Iterator(h.name.value, h.value))
-      .toArray
-    (if (headers.isEmpty) rb else rb.headers(headers: _*)).build
-  }
-
-  def convertResponse[F[_]: ConcurrentEffect](
-      res: HttpResponse[Flow.Publisher[util.List[ByteBuffer]]]): F[Response[F]] =
-    ConcurrentEffect[F].fromEither(Status.fromInt(res.statusCode)).map { status =>
-      Response(
-        status = status,
-        headers = Headers(res.headers.map.asScala.flatMap {
-          case (k, vs) => vs.asScala.map(Header(k, _))
-        }.toList),
-        httpVersion = res.version match {
-          case HttpClient.Version.HTTP_1_1 => HttpVersion.`HTTP/1.1`
-          case HttpClient.Version.HTTP_2 => HttpVersion.`HTTP/2.0`
-        },
-        body = FlowAdapters
-          .toPublisher(res.body)
-          .toStream[F]
-          .flatMap(bs =>
-            Stream.fromIterator(bs.asScala.map(Chunk.byteBuffer).iterator).flatMap(Stream.chunk))
-      )
-    }
+  private def convertHttpVersionFromHttp4s[F[_]](version: HttpVersion)(
+      implicit F: ApplicativeError[F, Throwable]): F[HttpClient.Version] =
+    F.fromEither(version match {
+      case HttpVersion.`HTTP/1.1` => Right(HttpClient.Version.HTTP_1_1)
+      case HttpVersion.`HTTP/2.0` => Right(HttpClient.Version.HTTP_2)
+      case _ => Left(new IllegalArgumentException("invalid HTTP version"))
+    })
 
 }

--- a/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -1,0 +1,109 @@
+package org.http4s.client.jdkhttpclient
+
+import java.net.URI
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpResponse.BodyHandlers
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.nio.ByteBuffer
+import java.util
+import java.util.concurrent.{CancellationException, CompletableFuture, CompletionException, Flow}
+import java.util.function.BiFunction
+
+import cats.effect._
+import cats.implicits._
+import fs2.interop.reactivestreams._
+import fs2.{Chunk, Stream}
+import org.http4s.client.Client
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.{Header, Headers, HttpVersion, Request, Response, Status}
+import org.reactivestreams.FlowAdapters
+
+import scala.collection.JavaConverters._
+
+object JdkHttpClient {
+
+  def apply[F[_]](builder: HttpClient.Builder = HttpClient.newBuilder)(
+      implicit F: ConcurrentEffect[F]): F[Client[F]] =
+    F.delay(builder.build).map { jdkHttpClient =>
+      Client[F] { req =>
+        Resource.liftF {
+          F.delay(jdkHttpClient.sendAsync(convertRequest(req), BodyHandlers.ofPublisher))
+            .flatMap(fromJavaFuture(_).map(convertResponse(_)))
+        }
+      }
+    }
+
+  private def fromJavaFuture[F[_], A](cf: CompletableFuture[A])(implicit F: Concurrent[F]): F[A] =
+    F.cancelable(cb => {
+      cf.handle[Unit](new BiFunction[A, Throwable, Unit] {
+        override def apply(result: A, err: Throwable): Unit = err match {
+          case null => cb(Right(result))
+          case _: CancellationException => ()
+          case ex: CompletionException if ex.getCause ne null => cb(Left(ex.getCause))
+          case ex => cb(Left(ex))
+        }
+      })
+      F.delay { cf.cancel(true); () }
+    })
+
+  // see jdk.internal.net.http.common.Utils#DISALLOWED_HEADERS_SET
+  private val restrictedHeaders =
+    Set(
+      "connection",
+      "content-length",
+      "date",
+      "expect",
+      "from",
+      "host",
+      "upgrade",
+      "via",
+      "warning"
+    ).map(CaseInsensitiveString(_))
+
+  def convertRequest[F[_]: ConcurrentEffect](req: Request[F]): HttpRequest = {
+    val rb = HttpRequest.newBuilder
+      .method(
+        req.method.name, {
+          val publisher = FlowAdapters.toFlowPublisher(
+            StreamUnicastPublisher(req.body.chunks.map(_.toByteBuffer)))
+          if (req.isChunked)
+            BodyPublishers.fromPublisher(publisher)
+          else
+            req.contentLength.fold(BodyPublishers.noBody)(
+              BodyPublishers.fromPublisher(publisher, _))
+        }
+      )
+      .uri(URI.create(req.uri.renderString))
+      .version(req.httpVersion match {
+        case HttpVersion.`HTTP/1.1` => HttpClient.Version.HTTP_1_1
+        case HttpVersion.`HTTP/2.0` => HttpClient.Version.HTTP_2
+        case _ =>
+          throw new IllegalStateException("unsupported http version") // TODO better error handling
+      })
+    val headers = req.headers.iterator.flatMap { h =>
+      // hacky workaround (see e.g. https://stackoverflow.com/questions/53979173)
+      if (restrictedHeaders.contains(h.name)) Iterator.empty
+      else Iterator(h.name.value, h.value)
+    }.toArray
+    (if (headers.isEmpty) rb else rb.headers(headers: _*)).build
+  }
+
+  def convertResponse[F[_]: ConcurrentEffect](
+      res: HttpResponse[Flow.Publisher[util.List[ByteBuffer]]]): Response[F] =
+    Response(
+      status = Status.fromInt(res.statusCode).valueOr(throw _), // TODO better error handling
+      headers = Headers(res.headers.map.asScala.flatMap {
+        case (k, vs) => vs.asScala.map(Header(k, _))
+      }.toList),
+      httpVersion = res.version match {
+        case HttpClient.Version.HTTP_1_1 => HttpVersion.`HTTP/1.1`
+        case HttpClient.Version.HTTP_2 => HttpVersion.`HTTP/2.0`
+      },
+      body = FlowAdapters
+        .toPublisher(res.body)
+        .toStream[F]
+        .flatMap(bs =>
+          Stream.fromIterator(bs.asScala.map(Chunk.byteBuffer).iterator).flatMap(Stream.chunk))
+    )
+
+}

--- a/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -80,11 +80,11 @@ object JdkHttpClient {
         case HttpVersion.`HTTP/2.0` => HttpClient.Version.HTTP_2
         case _ => HttpClient.Version.HTTP_1_1
       })
-    val headers = req.headers.iterator.flatMap { h =>
-      // hacky workaround (see e.g. https://stackoverflow.com/questions/53979173)
-      if (restrictedHeaders.contains(h.name)) Iterator.empty
-      else Iterator(h.name.value, h.value)
-    }.toArray
+    val headers = req.headers.iterator
+    // hacky workaround (see e.g. https://stackoverflow.com/questions/53979173)
+      .filterNot(h => restrictedHeaders.contains(h.name))
+      .flatMap(h => Iterator(h.name.value, h.value))
+      .toArray
     (if (headers.isEmpty) rb else rb.headers(headers: _*)).build
   }
 

--- a/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -122,10 +122,10 @@ object JdkHttpClient {
 
   private def convertHttpVersionFromHttp4s[F[_]](version: HttpVersion)(
       implicit F: ApplicativeError[F, Throwable]): F[HttpClient.Version] =
-    F.fromEither(version match {
-      case HttpVersion.`HTTP/1.1` => Right(HttpClient.Version.HTTP_1_1)
-      case HttpVersion.`HTTP/2.0` => Right(HttpClient.Version.HTTP_2)
-      case _ => Left(new IllegalArgumentException("invalid HTTP version"))
-    })
+    version match {
+      case HttpVersion.`HTTP/1.1` => HttpClient.Version.HTTP_1_1.pure[F]
+      case HttpVersion.`HTTP/2.0` => HttpClient.Version.HTTP_2.pure[F]
+      case _ => F.raiseError(new IllegalArgumentException("invalid HTTP version"))
+    }
 
 }

--- a/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
+++ b/jdk-http-client/src/main/scala/org/http4s/client/jdkhttpclient/JdkHttpClient.scala
@@ -92,7 +92,7 @@ object JdkHttpClient {
       res: HttpResponse[Flow.Publisher[util.List[ByteBuffer]]]): F[Response[F]] =
     ConcurrentEffect[F].fromEither(Status.fromInt(res.statusCode)).map { status =>
       Response(
-        status = status, // TODO better error handling
+        status = status,
         headers = Headers(res.headers.map.asScala.flatMap {
           case (k, vs) => vs.asScala.map(Header(k, _))
         }.toList),

--- a/jdk-http-client/src/test/scala/org/http4s/client/jdkhttpclient/JdkHttpClientSpec.scala
+++ b/jdk-http-client/src/test/scala/org/http4s/client/jdkhttpclient/JdkHttpClientSpec.scala
@@ -4,5 +4,5 @@ import cats.effect._
 import org.http4s.client.ClientRouteTestBattery
 
 class JdkHttpClientSpec extends ClientRouteTestBattery("JdkHttpClient") {
-  def clientResource = Resource.liftF(JdkHttpClient[IO]())
+  def clientResource = Resource.liftF(JdkHttpClient.simple[IO])
 }

--- a/jdk-http-client/src/test/scala/org/http4s/client/jdkhttpclient/JdkHttpClientSpec.scala
+++ b/jdk-http-client/src/test/scala/org/http4s/client/jdkhttpclient/JdkHttpClientSpec.scala
@@ -1,0 +1,8 @@
+package org.http4s.client.jdkhttpclient
+
+import cats.effect._
+import org.http4s.client.ClientRouteTestBattery
+
+class JdkHttpClientSpec extends ClientRouteTestBattery("JdkHttpClient") {
+  def clientResource = Resource.liftF(JdkHttpClient[IO]())
+}

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -38,7 +38,7 @@ object Http4sPlugin extends AutoPlugin {
     // secondary builds by the Travis build number.
     isTravisBuild := sys.env.get("TRAVIS").isDefined,
     http4sPrimary := sys.env.get("TRAVIS_JOB_NUMBER").fold(true)(_.endsWith(".1")),
-    
+
     // Publishing to gh-pages and sonatype only done from select branches and
     // never from pull requests.
     http4sPublish := {
@@ -341,6 +341,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val prometheusHotspot                = "io.prometheus"          %  "simpleclient_hotspot"      % prometheusClient.revision
   lazy val parboiled                        = "org.http4s"             %% "parboiled"                 % "1.0.1"
   lazy val quasiquotes                      = "org.scalamacros"        %% "quasiquotes"               % "2.1.0"
+  lazy val reactiveStreamsFlowAdapters      = "org.reactivestreams"    %  "reactive-streams-flow-adapters" % "1.0.2" // TODO formatting
   def scalacheck(sv:String)                 = "org.scalacheck"         %% "scalacheck"                % scalacheckVersion(sv)
   def scalaCompiler(so: String, sv: String) = so             %  "scala-compiler"            % sv
   def scalaReflect(so: String, sv: String)  = so             %  "scala-reflect"             % sv


### PR DESCRIPTION
An HTTP client using the [JDK 11+ Http Client API](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/package-summary.html), based on [this](https://gitter.im/http4s/http4s?at=5ca63bfca84e0c501ad728fa). Only builds on 11+ - the build has to be fixed to conditionally include this subproject only on JDK 11 (I am not sure about the right way to do this - in particular as this module also has to be published).