### PR TITLE
Client: avoid throwing outside of effect system

### DIFF
--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -96,7 +96,7 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     } else req
     fetch(r) {
       case Successful(resp) =>
-        d.decode(resp, strict = false).fold(throw _, identity)
+        d.decode(resp, strict = false).leftWiden[Throwable].rethrowT
       case failedResponse =>
         onError(failedResponse).flatMap(F.raiseError)
     }

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -149,7 +149,7 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     } else req
     fetch(r) {
       case Successful(resp) =>
-        d.decode(resp, strict = false).fold(throw _, identity).map(_.some)
+        d.decode(resp, strict = false).leftWiden[Throwable].rethrowT.map(_.some)
       case failedResponse =>
         failedResponse.status match {
           case Status.NotFound => Option.empty[A].pure[F]
@@ -173,7 +173,7 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
       req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
     } else req
     fetch(r) { resp =>
-      d.decode(resp, strict = false).fold(throw _, identity)
+      d.decode(resp, strict = false).leftWiden[Throwable].rethrowT
     }
   }
 


### PR DESCRIPTION
A json decoding failure was causing fiber death when used with ZIO. 