### PR TITLE
kind-projector has moved to typelevel org

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -103,7 +103,12 @@ object Http4sPlugin extends AutoPlugin {
       organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % _
     }).toSet,
 
-    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.10.0" cross CrossVersion.binary),
+    libraryDependencies += compilerPlugin(
+      CrossVersion.binaryScalaVersion(scalaVersion.value) match {
+        case "2.13.0-M5" => "org.spire-math" %% "kind-projector" % "0.9.9" cross CrossVersion.binary
+        case _ => "org.typelevel" %% "kind-projector" % "0.10.0"
+      }
+    ),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M4"),
 
     scalafmtVersion := "1.5.1",

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -103,7 +103,7 @@ object Http4sPlugin extends AutoPlugin {
       organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % _
     }).toSet,
 
-    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.9" cross CrossVersion.binary),
+    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.10.0" cross CrossVersion.binary),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M4"),
 
     scalafmtVersion := "1.5.1",


### PR DESCRIPTION
perhaps there is some other in-flight PR with this change, but
regardless, it would helpful for the Scala community build to have
just this change land on master