### PR TITLE
Raise DecodeFailure with MonadError instead of throwing

### DIFF
--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -31,7 +31,9 @@ package object oauth1 {
       consumer: Consumer,
       callback: Option[Uri],
       verifier: Option[String],
-      token: Option[Token])(implicit F: Monad[F], W: EntityDecoder[F, UrlForm]): F[Request[F]] =
+      token: Option[Token])(
+      implicit F: MonadError[F, Throwable],
+      W: EntityDecoder[F, UrlForm]): F[Request[F]] =
     getUserParams(req).map {
       case (req, params) =>
         val auth = genAuthHeader(req.method, req.uri, params, consumer, callback, verifier, token)
@@ -106,7 +108,7 @@ package object oauth1 {
     UrlCodingUtils.urlEncode(str, spaceIsPlus = false, toSkip = UrlCodingUtils.Unreserved)
 
   private[oauth1] def getUserParams[F[_]](req: Request[F])(
-      implicit F: Monad[F],
+      implicit F: MonadError[F, Throwable],
       W: EntityDecoder[F, UrlForm]): F[(Request[F], immutable.Seq[(String, String)])] = {
     val qparams = req.uri.query.pairs.map { case (k, ov) => (k, ov.getOrElse("")) }
 

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -208,12 +208,12 @@ sealed trait Message[F[_]] { self =>
     * If no valid [[Status]] has been described, allow Ok
     *
     * @param decoder [[EntityDecoder]] used to decode the [[Message]]
-    * @tparam T type of the result
-    * @return the effect which will generate the T
+    * @tparam A type of the result
+    * @return the effect which will generate the A
     */
-  def as[T](implicit F: Functor[F], decoder: EntityDecoder[F, T]): F[T] =
-    attemptAs.fold(throw _, identity)
-
+  def as[A](implicit F: MonadError[F, Throwable], decoder: EntityDecoder[F, A]): F[A] =
+    // n.b. this is foldF in cats master, and will eventually be further optimized with redeem
+    attemptAs.value.flatMap(_.fold(F.raiseError(_), F.pure(_)))
 }
 
 object Message {


### PR DESCRIPTION
Fixes #2504. Similar to #2502.

This code was written before the effect was polymorphic, and relies on now undefined behavior.  The `MonadError` constraint lets us raise the error into `F` lawfully.  Optimization coming in cats is noted. This rippled to the oauth1 client.