### PR TITLE
Drop redundant enable web sockets

### DIFF
--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -67,7 +67,6 @@ class BlazeWebSocketExampleApp[F[_]](implicit F: ConcurrentEffect[F], timer: Tim
   def stream: Stream[F, ExitCode] =
     BlazeServerBuilder[F]
       .bindHttp(8080)
-      .withWebSockets(true)
       .withHttpApp(routes.orNotFound)
       .serve
 }


### PR DESCRIPTION
The current `BlazeServerBuilder` enables web sockets by default. Should that really be the case? I feel like opting-in for features is a better interface.

If not, then the following line can be elided.