### PR TITLE
Add optional argument to override Histogram's buckets.

### DIFF
--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/Prometheus.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/Prometheus.scala
@@ -62,7 +62,10 @@ object Prometheus {
     * * @param registry a metrics collector registry
     * * @param prefix a prefix that will be added to all metrics
     **/
-  def apply[F[_]](registry: CollectorRegistry, prefix: String = "org_http4s_server", responseDurationSecondsHistogramBuckets: NonEmptyList[Double] = DefaultHistogramBuckets)(
+  def apply[F[_]](
+      registry: CollectorRegistry,
+      prefix: String = "org_http4s_server",
+      responseDurationSecondsHistogramBuckets: NonEmptyList[Double] = DefaultHistogramBuckets)(
       implicit F: Sync[F]): F[MetricsOps[F]] = F.delay {
     new MetricsOps[F] {
 
@@ -157,7 +160,7 @@ object Prometheus {
         MetricsCollection(
           responseDuration = Histogram
             .build()
-            .buckets(responseDurationSecondsHistogramBuckets.toList : _*)
+            .buckets(responseDurationSecondsHistogramBuckets.toList: _*)
             .name(prefix + "_" + "response_duration_seconds")
             .help("Response Duration in seconds.")
             .labelNames("classifier", "method", "phase")


### PR DESCRIPTION
Closes #2423

Note that I chose NonEmptyList[Double] instead of List[Double] due to:

```scala
$amm
Loading...
Welcome to the Ammonite Repl 1.0.3
(Scala 2.12.4 Java 1.8.0_112)
If you like Ammonite, please support our development at www.patreon.com/lihaoyi
@ import $ivy.`io.prometheus:simpleclient:0.6.0`
import $ivy.$

@ import io.prometheus.client.{Histogram, CollectorRegistry}
import io.prometheus.client.{Histogram, CollectorRegistry}

@ val c = new CollectorRegistry()
c: CollectorRegistry = io.prometheus.client.CollectorRegistry@fa11fda

@ Histogram.build().buckets(List.empty[Double] : _*).name("foo").help("help").labelNames("bar").register(c)
java.lang.IllegalStateException: Histogram must have at least one bucket.
  io.prometheus.client.Histogram$Builder.create(Histogram.java:84)
  io.prometheus.client.Histogram$Builder.create(Histogram.java:72)
  io.prometheus.client.SimpleCollector$Builder.register(SimpleCollector.java:245)
  ammonite.$sess.cmd3$.<init>(cmd3.sc:1)
  ammonite.$sess.cmd3$.<clinit>(cmd3.sc)
```

I'm opening this PR against `master` due to @rossabaker's good point in  https://github.com/http4s/http4s/pull/2510#issuecomment-482818105.