### PR TITLE
Add status Methods Which Use `String` or `URI`

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -141,6 +141,12 @@ trait Client[F[_]] {
   /** Submits a request and returns the response status */
   def status(req: F[Request[F]]): F[Status]
 
+  /** Submits a GET request to the URI and returns the response status */
+  def statusFromUri(uri: Uri): F[Status]
+
+  /** Submits a GET request to the URI and returns the response status */
+  def statusFromString(s: String): F[Status]
+
   /** Submits a request and returns true if and only if the response status is
     * successful */
   def successful(req: Request[F]): F[Boolean]

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -193,6 +193,14 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
   def status(req: F[Request[F]]): F[Status] =
     req.flatMap(status)
 
+  /** Submits a GET request to the URI and returns the response status */
+  override def statusFromUri(uri: Uri): F[Status] =
+    status(Request[F](uri = uri))
+
+  /** Submits a GET request to the URI and returns the response status */
+  override def statusFromString(s: String): F[Status] =
+    F.fromEither(Uri.fromString(s)).flatMap(statusFromUri)
+
   /** Submits a request and returns true if and only if the response status is
     * successful */
   def successful(req: Request[F]): F[Boolean] =


### PR DESCRIPTION
These are similar to the `expect` methods which take the same arguments. They are particularly useful for test.