### PR TITLE
Parameterize selectorThreadFactory for blaze server

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -306,7 +306,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.13.v20181017"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.3"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.8.1"
-  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0-RC1"
+  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.0"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.6.0"
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.1.0"


### PR DESCRIPTION
Inspired by [Twitter conversation](https://twitter.com/djspiewak/status/1116371300765847552) with @djspiewak.  I'm not changing the default at this stage in the release cycle, but making it possible for Daniel (or others) to get empirical evidence that it's the right thing to do.  We can tweak the default in 0.20.1 or later, but this needs to go in now.

Pending release of https://github.com/http4s/blaze/pull/282 before it will compile.
