### PR TITLE
Kill Kleisli

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -54,7 +54,9 @@ trait Client[F[_]] {
     */
   def toKleisli[A](f: Response[F] => F[A]): Kleisli[F, Request[F], A]
 
-  @deprecated("Use toKleisli", "0.18")
+  def toFunction[A](f: Response[F] => F[A]): Request[F] => F[A]
+
+  @deprecated("Use toFunction", "0.18")
   def toService[A](f: Response[F] => F[A]): Service[F, Request[F], A]
 
   /**

--- a/core/src/main/scala/org/http4s/AuthedRequest.scala
+++ b/core/src/main/scala/org/http4s/AuthedRequest.scala
@@ -1,13 +1,12 @@
 package org.http4s
 
-import cats._
-import cats.data._
-import cats.implicits._
+import cats.Functor
+import cats.syntax.functor._
 
 final case class AuthedRequest[F[_], A](authInfo: A, req: Request[F])
 
 object AuthedRequest {
-  def apply[F[_]: Functor, T](
-      getUser: Request[F] => F[T]): Kleisli[F, Request[F], AuthedRequest[F, T]] =
-    Kleisli(request => getUser(request).map(user => AuthedRequest(user, request)))
+  def apply[F[_]: Functor, T](getUser: Request[F] => F[T])
+      : Request[F] => F[AuthedRequest[F, T]] =
+    request => getUser(request).map(user => AuthedRequest(user, request))
 }

--- a/core/src/main/scala/org/http4s/AuthedService.scala
+++ b/core/src/main/scala/org/http4s/AuthedService.scala
@@ -1,7 +1,7 @@
 package org.http4s
 
 import cats.{Applicative, Functor}
-import cats.data.{Kleisli, OptionT}
+import cats.data.OptionT
 
 object AuthedService {
 
@@ -12,7 +12,7 @@ object AuthedService {
     */
   @deprecated("Use liftF with an OptionT[F, Response[F]] instead", "0.18")
   def lift[F[_]: Functor, T](f: AuthedRequest[F, T] => F[Response[F]]): AuthedService[T, F] =
-    Kleisli(f.andThen(OptionT.liftF(_)))
+    f.andThen(OptionT.liftF(_))
 
   /** Lifts a partial function to an `AuthedService`.  Responds with
     * [[org.http4s.Response.notFoundFor]], which generates a 404, for any request
@@ -20,7 +20,7 @@ object AuthedService {
     */
   def apply[T, F[_]](pf: PartialFunction[AuthedRequest[F, T], F[Response[F]]])(
       implicit F: Applicative[F]): AuthedService[T, F] =
-    Kleisli(req => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none)))
+    req => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none))
 
   /**
     * The empty service (all requests fallthrough).
@@ -29,6 +29,6 @@ object AuthedService {
     * @return
     */
   def empty[T, F[_]: Applicative]: AuthedService[T, F] =
-    Kleisli.liftF(OptionT.none)
+    _ => OptionT.none[F, Response[F]]
 
 }

--- a/core/src/main/scala/org/http4s/HttpApp.scala
+++ b/core/src/main/scala/org/http4s/HttpApp.scala
@@ -1,7 +1,6 @@
 package org.http4s
 
 import cats.Applicative
-import cats.data.Kleisli
 import cats.effect.Sync
 
 /** Functions for creating [[HttpApp]] kleislis. */
@@ -16,7 +15,7 @@ object HttpApp {
     * @return an [[HttpApp]] that wraps `run`
     */
   def apply[F[_]: Sync](run: Request[F] => F[Response[F]]): HttpApp[F] =
-    Http(run)
+    run
 
   /** Lifts an effectful [[Response]] into an [[HttpApp]].
     *
@@ -25,7 +24,7 @@ object HttpApp {
     * @return an [[HttpApp]] that always returns `fr`
     */
   def liftF[F[_]](fr: F[Response[F]]): HttpApp[F] =
-    Kleisli.liftF(fr)
+    _ => fr
 
   /** Lifts a [[Response]] into an [[HttpApp]].
     *
@@ -34,7 +33,7 @@ object HttpApp {
     * @return an [[Http]] that always returns `r` in effect `F`
     */
   def pure[F[_]: Applicative](r: Response[F]): HttpApp[F] =
-    Kleisli.pure(r)
+    _ => Applicative[F].pure(r)
 
   /** Transforms an [[HttpApp]] on its input.  The application of the
     * transformed function is suspended in `F` to permit more

--- a/core/src/main/scala/org/http4s/HttpService.scala
+++ b/core/src/main/scala/org/http4s/HttpService.scala
@@ -13,7 +13,7 @@ object HttpService extends Serializable {
     */
   @deprecated("Use liftF with an OptionT[F, Response[F]] instead", "0.18")
   def lift[F[_]: Functor](f: Request[F] => F[Response[F]]): HttpService[F] =
-    Kleisli(f.andThen(OptionT.liftF(_)))
+    f.andThen(OptionT.liftF(_))
 
   /** Lifts a partial function to [[HttpRoutes]].  Responds with
     * `OptionT.none` for any request where `pf` is not defined.
@@ -23,7 +23,7 @@ object HttpService extends Serializable {
   @deprecated("Replaced by `HttpRoutes.of`", "0.19")
   def apply[F[_]](pf: PartialFunction[Request[F], F[Response[F]]])(
       implicit F: Applicative[F]): HttpRoutes[F] =
-    Kleisli(req => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none)))
+    req => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none))
 
   @deprecated("Replaced by `HttpRoutes.empty`", "0.19")
   def empty[F[_]: Applicative]: HttpRoutes[F] =

--- a/core/src/main/scala/org/http4s/Service.scala
+++ b/core/src/main/scala/org/http4s/Service.scala
@@ -1,11 +1,11 @@
 package org.http4s
 
 import cats._
-import cats.data._
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.semigroup._
+import cats.instances.function._
 
-@deprecated("Deprecated in favor of Kleisli", "0.18")
+@deprecated("Deprecated in favor of Functions", "0.18")
 object Service {
 
   /**
@@ -14,7 +14,7 @@ object Service {
     * instead.
     */
   def lift[F[_], A, B](f: A => F[B]): Service[F, A, B] =
-    Kleisli(f)
+    f
 
   /** Lifts a partial function to an `Service`.  Responds with the
     * zero of [B] for any request where `pf` is not defined.

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -1,7 +1,7 @@
 package org
 
-import cats.data._
-import fs2._
+import cats.data.{OptionT, EitherT}
+import fs2.Stream
 
 package object http4s { // scalastyle:ignore
 
@@ -26,7 +26,7 @@ package object http4s { // scalastyle:ignore
     * @tparam F the effect type in which the [[Response]] is returned
     * @tparam G the effect type of the [[Request]] and [[Response]] bodies
     */
-  type Http[F[_], G[_]] = Kleisli[F, Request[G], Response[G]]
+  type Http[F[_], G[_]] = Request[G] => F[Response[G]]
 
   /** A kleisli with a [[Request]] input and a [[Response]] output, such
     * that the response effect is the same as the request and response bodies'.
@@ -49,8 +49,8 @@ package object http4s { // scalastyle:ignore
     */
   type HttpRoutes[F[_]] = Http[OptionT[F, ?], F]
 
-  @deprecated("Deprecated in favor of just using Kleisli", "0.18")
-  type Service[F[_], A, B] = Kleisli[F, A, B]
+  @deprecated("Deprecated in favor of just using Functions", "0.18")
+  type Service[F[_], A, B] = A => F[B]
 
   @deprecated("Deprecated in favor of HttpRoutes", "0.19")
   type HttpService[F[_]] = HttpRoutes[F]
@@ -59,7 +59,7 @@ package object http4s { // scalastyle:ignore
     * We need to change the order of type parameters to make partial unification
     * trigger. See https://github.com/http4s/http4s/issues/1506
     */
-  type AuthedService[T, F[_]] = Kleisli[OptionT[F, ?], AuthedRequest[F, T], Response[F]]
+  type AuthedService[T, F[_]] = AuthedRequest[F, T] => OptionT[F, Response[F]]
 
   type Callback[A] = Either[Throwable, A] => Unit
 

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -1,16 +1,16 @@
 package org.http4s
 package syntax
 
-import cats._
-import cats.data.{Kleisli, OptionT}
+import cats.Functor
+import cats.data.OptionT
 
 trait KleisliSyntax {
   implicit def http4sKleisliResponseSyntax[F[_]: Functor, A](
-      service: Kleisli[OptionT[F, ?], A, Response[F]]): KleisliResponseOps[F, A] =
+    service: A => OptionT[F, Response[F]]): KleisliResponseOps[F, A] =
     new KleisliResponseOps[F, A](service)
 }
 
-final class KleisliResponseOps[F[_]: Functor, A](self: Kleisli[OptionT[F, ?], A, Response[F]]) {
-  def orNotFound: Kleisli[F, A, Response[F]] =
-    Kleisli(a => self.run(a).getOrElse(Response.notFound))
+final class KleisliResponseOps[F[_]: Functor, A](self: A => OptionT[F, Response[F]]) {
+  def orNotFound: A => F[Response[F]] =
+    a => self(a).getOrElse(Response.notFound)
 }

--- a/server/src/main/scala/org/http4s/server/middleware/HeaderEcho.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HeaderEcho.scala
@@ -1,8 +1,7 @@
 package org.http4s.server.middleware
 
 import cats.Functor
-import cats.data.Kleisli
-import org.http4s._
+import org.http4s.{Http, Request}
 import cats.implicits._
 import org.http4s.util.CaseInsensitiveString
 
@@ -16,9 +15,8 @@ object HeaderEcho {
     */
   def apply[F[_]: Functor, G[_]: Functor](echoHeadersWhen: CaseInsensitiveString => Boolean)(
       http: Http[F, G]): Http[F, G] =
-    Kleisli { req: Request[G] =>
+    (req: Request[G]) => {
       val headersToEcho = req.headers.filter(h => echoHeadersWhen(h.name))
-
       http(req).map(_.putHeaders(headersToEcho.toList: _*))
     }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -33,7 +33,7 @@ object RequestLogger {
     val log = logAction.fold({ s: String =>
       Sync[F].delay(logger.info(s))
     })(identity)
-    Kleisli { req =>
+    req =>
       if (!logBody) {
         def logAct = Logger.logMessage[F, Request[F]](req)(logHeaders, logBody)(log)
         // This construction will log on Any Error/Cancellation
@@ -91,7 +91,6 @@ object RequestLogger {
             response
           }
       }
-    }
   }
 
   def httpApp[F[_]: Concurrent](


### PR DESCRIPTION
This is a line of work span off a [comment](https://github.com/typelevel/cats/pull/2801#issuecomment-485488486)  to @rossabaker in a recent PR submitted to `cats`.

That PR deals about an alternative to `Kleisli`. The key question asked to Ross, in that context, was about the benefits that `Kleisli` gives for the developers of `http4s`.

This Draft PR is an exploration, intended to see how far we can get rid of `Kleisli` in `http4s` without damaging the code. It is a work in progress.