### PR TITLE
Add translate extension methods for HttpRoutes and HttpApp

### DIFF
--- a/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
@@ -1,6 +1,10 @@
 package org.http4s
 package syntax
 
+abstract class AllSyntaxBinCompat
+    extends AllSyntax
+    with KleisliSyntaxBinCompat0
+
 trait AllSyntax
     extends AnyRef
     with AsyncSyntax

--- a/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
@@ -1,9 +1,7 @@
 package org.http4s
 package syntax
 
-abstract class AllSyntaxBinCompat
-    extends AllSyntax
-    with KleisliSyntaxBinCompat0
+abstract class AllSyntaxBinCompat extends AllSyntax with KleisliSyntaxBinCompat0
 
 trait AllSyntax
     extends AnyRef

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -10,7 +10,9 @@ trait KleisliSyntax {
   implicit def http4sKleisliResponseSyntax[F[_]: Functor, A](
       service: Kleisli[OptionT[F, ?], A, Response[F]]): KleisliResponseOps[F, A] =
     new KleisliResponseOps[F, A](service)
+}
 
+trait KleisliSyntaxBinCompat0 {
   implicit def http4sKleisliHttpRoutesSyntax[F[_]: Sync](
       routes: HttpRoutes[F]): KleisliHttpRoutesOps[F] =
     new KleisliHttpRoutesOps[F](routes)

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -17,7 +17,7 @@ trait KleisliSyntaxBinCompat0 {
       routes: HttpRoutes[F]): KleisliHttpRoutesOps[F] =
     new KleisliHttpRoutesOps[F](routes)
 
-  implicit def http4sKleisliHttpAppOps[F[_]: Sync](app: HttpApp[F]): KleisliHttpAppOps[F] =
+  implicit def http4sKleisliHttpAppSyntax[F[_]: Sync](app: HttpApp[F]): KleisliHttpAppOps[F] =
     new KleisliHttpAppOps[F](app)
 }
 
@@ -27,11 +27,11 @@ final class KleisliResponseOps[F[_]: Functor, A](self: Kleisli[OptionT[F, ?], A,
 }
 
 final class KleisliHttpRoutesOps[F[_]: Sync](self: HttpRoutes[F]) {
-  def imapK[G[_]: Sync](fk: F ~> G)(gK: G ~> F): HttpRoutes[G] =
+  def translate[G[_]: Sync](fk: F ~> G)(gK: G ~> F): HttpRoutes[G] =
     HttpRoutes(request => self.run(request.mapK(gK)).mapK(fk).map(_.mapK(fk)))
 }
 
 final class KleisliHttpAppOps[F[_]: Sync](self: HttpApp[F]) {
-  def imapK[G[_]: Sync](fk: F ~> G)(gK: G ~> F): HttpApp[G] =
+  def translate[G[_]: Sync](fk: F ~> G)(gK: G ~> F): HttpApp[G] =
     HttpApp(request => fk(self.run(request.mapK(gK)).map(_.mapK(fk))))
 }

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -2,15 +2,35 @@ package org.http4s
 package syntax
 
 import cats._
+import cats.syntax.functor._
+import cats.effect.Sync
 import cats.data.{Kleisli, OptionT}
 
 trait KleisliSyntax {
   implicit def http4sKleisliResponseSyntax[F[_]: Functor, A](
       service: Kleisli[OptionT[F, ?], A, Response[F]]): KleisliResponseOps[F, A] =
     new KleisliResponseOps[F, A](service)
+
+  implicit def http4sKleisliHttpRoutesSyntax[F[_]: Sync](
+      routes: HttpRoutes[F]): KleisliHttpRoutesOps[F] =
+    new KleisliHttpRoutesOps[F](routes)
+
+  implicit def http4sKleisliHttpAppOps[F[_]: Sync](
+      app: HttpApp[F]): KleisliHttpAppOps[F] =
+    new KleisliHttpAppOps[F](app)
 }
 
 final class KleisliResponseOps[F[_]: Functor, A](self: Kleisli[OptionT[F, ?], A, Response[F]]) {
   def orNotFound: Kleisli[F, A, Response[F]] =
     Kleisli(a => self.run(a).getOrElse(Response.notFound))
+}
+
+final class KleisliHttpRoutesOps[F[_] : Sync](self: HttpRoutes[F]) {
+  def imapK[G[_] : Sync](fk: F ~> G)(gK: G ~> F): HttpRoutes[G] =
+    HttpRoutes(request => self.run(request.mapK(gK)).mapK(fk).map(_.mapK(fk)))
+}
+
+final class KleisliHttpAppOps[F[_] : Sync](self: HttpApp[F]) {
+  def imapK[G[_] : Sync](fk: F ~> G)(gK: G ~> F): HttpApp[G] =
+    HttpApp(request => fk(self.run(request.mapK(gK)).map(_.mapK(fk))))
 }

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -17,8 +17,7 @@ trait KleisliSyntaxBinCompat0 {
       routes: HttpRoutes[F]): KleisliHttpRoutesOps[F] =
     new KleisliHttpRoutesOps[F](routes)
 
-  implicit def http4sKleisliHttpAppOps[F[_]: Sync](
-      app: HttpApp[F]): KleisliHttpAppOps[F] =
+  implicit def http4sKleisliHttpAppOps[F[_]: Sync](app: HttpApp[F]): KleisliHttpAppOps[F] =
     new KleisliHttpAppOps[F](app)
 }
 
@@ -27,12 +26,12 @@ final class KleisliResponseOps[F[_]: Functor, A](self: Kleisli[OptionT[F, ?], A,
     Kleisli(a => self.run(a).getOrElse(Response.notFound))
 }
 
-final class KleisliHttpRoutesOps[F[_] : Sync](self: HttpRoutes[F]) {
-  def imapK[G[_] : Sync](fk: F ~> G)(gK: G ~> F): HttpRoutes[G] =
+final class KleisliHttpRoutesOps[F[_]: Sync](self: HttpRoutes[F]) {
+  def imapK[G[_]: Sync](fk: F ~> G)(gK: G ~> F): HttpRoutes[G] =
     HttpRoutes(request => self.run(request.mapK(gK)).mapK(fk).map(_.mapK(fk)))
 }
 
-final class KleisliHttpAppOps[F[_] : Sync](self: HttpApp[F]) {
-  def imapK[G[_] : Sync](fk: F ~> G)(gK: G ~> F): HttpApp[G] =
+final class KleisliHttpAppOps[F[_]: Sync](self: HttpApp[F]) {
+  def imapK[G[_]: Sync](fk: F ~> G)(gK: G ~> F): HttpApp[G] =
     HttpApp(request => fk(self.run(request.mapK(gK)).map(_.mapK(fk))))
 }

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -1,10 +1,10 @@
 package org.http4s
 
 package object syntax {
-  object all extends AllSyntax
+  object all extends AllSyntaxBinCompat
   @deprecated("Has nothing to do with HTTP.", "0.19.1")
   object async extends AsyncSyntax
-  object kleisli extends KleisliSyntax
+  object kleisli extends KleisliSyntax with KleisliSyntaxBinCompat0
   object literals extends LiteralsSyntax
   @deprecated("Use cats.foldable._", "0.18.5")
   object nonEmptyList extends NonEmptyListSyntax


### PR DESCRIPTION
Adds `imapK` extension methods to the `Kleisli` syntax module to change the effect type of `HttpRoutes` and `HttpApp`.