### PR TITLE
Narrow Imports from Cats in Core package

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -2,10 +2,10 @@ package org.http4s
 package server
 package blaze
 
-import cats._
+import cats.{Alternative, Applicative}
 import cats.data.Kleisli
 import cats.implicits._
-import cats.effect._
+import cats.effect.{ConcurrentEffect, Resource, Timer}
 import java.io.FileInputStream
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -3,9 +3,9 @@ package circe
 
 import java.nio.ByteBuffer
 
-import cats._
+import cats.Applicative
 import cats.data.NonEmptyList
-import cats.effect._
+import cats.effect.Sync
 import cats.implicits._
 import fs2.Chunk
 import io.circe._

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -1,11 +1,11 @@
 package org.http4s
 package client
 
-import cats._
+import cats.Applicative
 import cats.data.{Kleisli, OptionT}
-import cats.effect._
+import cats.effect.{Bracket, Resource}
 import cats.implicits._
-import fs2._
+import fs2.Stream
 import org.http4s.Status.Successful
 import org.http4s.headers.{Accept, MediaRangeAndQValue}
 

--- a/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
+++ b/client/src/main/scala/org/http4s/client/impl/RequestGenerator.scala
@@ -1,6 +1,6 @@
 package org.http4s.client.impl
 
-import cats._
+import cats.Applicative
 import org.http4s._
 import org.http4s.headers.`Content-Length`
 

--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package client
 
-import cats._
+import cats.MonadError
 import cats.data.NonEmptyList
 import cats.implicits._
 import java.nio.charset.StandardCharsets

--- a/core/src/main/scala/org/http4s/AuthedRequest.scala
+++ b/core/src/main/scala/org/http4s/AuthedRequest.scala
@@ -1,7 +1,7 @@
 package org.http4s
 
-import cats._
-import cats.data._
+import cats.Functor
+import cats.data.Kleisli
 import cats.implicits._
 
 final case class AuthedRequest[F[_], A](authInfo: A, req: Request[F])

--- a/core/src/main/scala/org/http4s/DecodeResult.scala
+++ b/core/src/main/scala/org/http4s/DecodeResult.scala
@@ -1,22 +1,22 @@
 package org.http4s
 
-import cats._
-import cats.data._
+import cats.{Applicative, Functor}
+import cats.data.EitherT
 import cats.implicits._
 
 object DecodeResult {
   def apply[F[_], A](fa: F[Either[DecodeFailure, A]]): DecodeResult[F, A] =
     EitherT(fa)
 
-  def success[F[_], A](a: F[A])(implicit F: Functor[F]): DecodeResult[F, A] =
-    DecodeResult(a.map(Either.right(_)))
+  def success[F[_], A](fa: F[A])(implicit F: Functor[F]): DecodeResult[F, A] =
+    EitherT(fa.map(Right(_)))
 
   def success[F[_], A](a: A)(implicit F: Applicative[F]): DecodeResult[F, A] =
-    success(F.pure(a))
+    EitherT(F.pure(Right(a)))
 
-  def failure[F[_], A](e: F[DecodeFailure])(implicit F: Functor[F]): DecodeResult[F, A] =
-    DecodeResult(e.map(Either.left(_)))
+  def failure[F[_], A](fe: F[DecodeFailure])(implicit F: Functor[F]): DecodeResult[F, A] =
+    EitherT(fe.map(Left(_)))
 
   def failure[F[_], A](e: DecodeFailure)(implicit F: Applicative[F]): DecodeResult[F, A] =
-    failure(F.pure(e))
+    EitherT(F.pure(Left(e)))
 }

--- a/core/src/main/scala/org/http4s/Entity.scala
+++ b/core/src/main/scala/org/http4s/Entity.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.Monoid
 import cats.implicits._
 
 final case class Entity[+F[_]](body: EntityBody[F], length: Option[Long] = None)

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.{Applicative, Functor, Monad, SemigroupK}
 import cats.effect.{ContextShift, Sync}
 import cats.implicits._
 import fs2._

--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -1,10 +1,9 @@
 package org.http4s
 
-import cats._
+import cats.{Contravariant, Show}
 import cats.effect.{ContextShift, Effect, Sync}
 import cats.implicits._
-import fs2.Stream._
-import fs2._
+import fs2.{Chunk, Stream}
 import fs2.io.file.readAll
 import fs2.io.readInputStream
 import java.io._
@@ -75,7 +74,7 @@ object EntityEncoder {
   def simple[F[_], A](hs: Header*)(toChunk: A => Chunk[Byte]): EntityEncoder[F, A] =
     encodeBy(hs: _*) { a =>
       val c = toChunk(a)
-      Entity[F](chunk(c).covary[F], Some(c.size.toLong))
+      Entity[F](Stream.chunk(c).covary[F], Some(c.size.toLong))
     }
 
   /** Encodes a value from its Show instance.  Too broad to be implicit, too useful to not exist. */

--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -18,7 +18,7 @@
  */
 package org.http4s
 
-import cats._
+import cats.{Eq, Show}
 import cats.data.NonEmptyList
 import cats.implicits.{catsSyntaxEither => _, _}
 import org.http4s.syntax.string._

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.{Eq, Eval, Foldable, Monoid, Show}
 import cats.implicits._
 import org.http4s.headers.`Set-Cookie`
 import org.http4s.syntax.string._

--- a/core/src/main/scala/org/http4s/HttpService.scala
+++ b/core/src/main/scala/org/http4s/HttpService.scala
@@ -1,7 +1,7 @@
 package org.http4s
 
-import cats._
-import cats.data._
+import cats.{Applicative, Functor}
+import cats.data.{Kleisli, OptionT}
 
 @deprecated("Replaced by HttpRoutes", "0.19")
 object HttpService extends Serializable {

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -1,11 +1,11 @@
 package org.http4s
 
-import cats._
+import cats.{Applicative, Functor, Monad, MonadError, ~>}
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.effect._
-import fs2._
-import fs2.text._
+import cats.effect.IO
+import fs2.{Pure, Stream}
+import fs2.text.{utf8Decode, utf8Encode}
 import java.io.File
 import java.net.{InetAddress, InetSocketAddress}
 import org.http4s.headers._
@@ -516,8 +516,8 @@ object Response {
   private[this] val pureNotFound: Response[Pure] =
     Response(
       Status.NotFound,
-      body = Stream("Not found").through(text.utf8Encode),
-      headers = Headers(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).pure[List]))
+      body = Stream("Not found").through(utf8Encode),
+      headers = Headers(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`) :: Nil))
 
   def notFound[F[_]]: Response[F] = pureNotFound.copy(body = pureNotFound.body.covary[F])
 

--- a/core/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/src/main/scala/org/http4s/MessageFailure.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.{Applicative, Eq, MonadError}
 import cats.implicits._
 import scala.util.control.{NoStackTrace, NonFatal}
 
@@ -52,15 +52,15 @@ object ParseFailure {
 
 object ParseResult {
   def fail(sanitized: String, details: String): ParseResult[Nothing] =
-    Either.left(ParseFailure(sanitized, details))
+    Left(ParseFailure(sanitized, details))
 
   def success[A](a: A): ParseResult[A] =
-    Either.right(a)
+    Right(a)
 
   def fromTryCatchNonFatal[A](sanitized: String)(f: => A): ParseResult[A] =
     try ParseResult.success(f)
     catch {
-      case NonFatal(e) => Either.left(ParseFailure(sanitized, e.getMessage))
+      case NonFatal(e) => Left(ParseFailure(sanitized, e.getMessage))
     }
 
   implicit val parseResultMonad: MonadError[ParseResult, ParseFailure] =

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.{Order, Show}
 import org.http4s.internal.parboiled2.{Parser => PbParser}
 import org.http4s.parser.{AdditionalRules, Http4sParser}
 import org.http4s.util.Writer

--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.{Eval, Foldable}
 import cats.implicits._
 import org.http4s.Query._
 import org.http4s.internal.CollectionCompat
@@ -142,7 +142,7 @@ object Query {
   def fromPairs(xs: (String, String)*): Query =
     new Query(
       xs.toList.foldLeft(Vector.empty[KeyValue]) {
-        case (m, (k, s)) => m :+ (k -> s.some)
+        case (m, (k, s)) => m :+ (k -> Some(s))
       }
     )
 
@@ -162,6 +162,6 @@ object Query {
   def fromMap(map: collection.Map[String, collection.Seq[String]]): Query =
     new Query(map.foldLeft(Vector.empty[KeyValue]) {
       case (m, (k, Seq())) => m :+ (k -> None)
-      case (m, (k, vs)) => vs.toList.foldLeft(m) { case (m, v) => m :+ (k -> v.some) }
+      case (m, (k, vs)) => vs.toList.foldLeft(m) { case (m, v) => m :+ (k -> Some(v)) }
     })
 }

--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -1,6 +1,5 @@
 package org.http4s
 
-import cats.implicits._
 trait QueryOps {
 
   protected type Self <: QueryOps
@@ -99,7 +98,7 @@ trait QueryOps {
     val vec = params.foldLeft(query.toVector) {
       case (m, (k, Seq())) => m :+ (penc.getKey(k).value -> None)
       case (m, (k, vs)) =>
-        vs.foldLeft(m) { case (m, v) => m :+ (penc.getKey(k).value -> venc.encode(v).value.some) }
+        vs.foldLeft(m) { case (m, v) => m :+ (penc.getKey(k).value -> Some(venc.encode(v).value)) }
     }
     replaceQuery(Query.fromVector(vec))
   }
@@ -147,7 +146,7 @@ trait QueryOps {
       if (values.isEmpty) baseQuery :+ (name.value -> None)
       else {
         values.toList.foldLeft(baseQuery) {
-          case (vec, v) => vec :+ (name.value -> v.value.some)
+          case (vec, v) => vec :+ (name.value -> Some(v.value))
         }
       }
 

--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -1,8 +1,9 @@
 package org.http4s
 
-import cats._
-import cats.data._
+import cats.{Contravariant, Functor, MonoidK, Show}
+import cats.data.{Validated, ValidatedNel}
 import cats.implicits._
+
 final case class QueryParameterKey(value: String) extends AnyVal
 
 final case class QueryParameterValue(value: String) extends AnyVal

--- a/core/src/main/scala/org/http4s/Service.scala
+++ b/core/src/main/scala/org/http4s/Service.scala
@@ -1,7 +1,7 @@
 package org.http4s
 
-import cats._
-import cats.data._
+import cats.{Applicative, Monoid, Semigroup}
+import cats.data.Kleisli
 import cats.effect.Sync
 import cats.implicits._
 

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -1,10 +1,10 @@
 package org.http4s
 
 import cats.Semigroup
-import cats.data._
-import cats.effect._
+import cats.data.OptionT
+import cats.effect.{ContextShift, IO, Sync}
 import cats.implicits.{catsSyntaxEither => _, _}
-import fs2.Stream._
+import fs2.Stream
 import fs2.io._
 import fs2.io.file.readRange
 import io.chrisdavenport.vault._
@@ -135,7 +135,7 @@ object StaticFile {
 
           notModified(req, etagCalc, lastModified).orElse {
             val (body, contentLength) =
-              if (f.length() < end) (empty.covary[F], 0L)
+              if (f.length() < end) (Stream.empty.covary[F], 0L)
               else (fileToBody[F](f, start, end, blockingExecutionContext), end - start)
 
             val contentType = nameToContentType(f.getName)

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats._
+import cats.{Eq, Order, Show}
 import cats.implicits.{catsSyntaxEither => _, _}
 import java.nio.charset.StandardCharsets
 import org.http4s.Uri._

--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -1,7 +1,7 @@
 package org.http4s
 
-import cats._
-import cats.data._
+import cats.{Eq, Monoid}
+import cats.data.Chain
 import cats.effect.Sync
 import cats.implicits.{catsSyntaxEither => _, _}
 import org.http4s.headers._

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -3,7 +3,7 @@ package org.http4s
 import java.util.concurrent.{CancellationException, CompletableFuture, CompletionException}
 import java.util.function.BiFunction
 
-import cats.effect._
+import cats.effect.{Async, Concurrent, ConcurrentEffect, Effect, IO}
 import cats.implicits._
 import org.http4s.util.execution.direct
 import org.log4s.Logger

--- a/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package multipart
 
-import cats.effect._
+import cats.effect.{ContextShift, Sync}
 import cats.implicits._
 import scala.concurrent.ExecutionContext
 

--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -1,11 +1,11 @@
 package org.http4s
 package multipart
 
-import cats.effect._
+import cats.effect.{ContextShift, Sync}
 import cats.implicits.{catsSyntaxEither => _, _}
-import fs2._
+import fs2.{Chunk, Pipe, Pull, Pure, Stream}
 import fs2.io.file.{readAll, writeAll}
-import java.nio.file._
+import java.nio.file.{Files, Path, StandardOpenOption}
 import scala.concurrent.ExecutionContext
 
 /** A low-level multipart-parsing pipe.  Most end users will prefer EntityDecoder[Multipart]. */
@@ -789,8 +789,8 @@ object MultipartParser {
       } else if (limitCTR >= maxBeforeWrite) {
         Pull.eval(
           lacc
-            .through(io.file
-              .writeAll[F](fileRef, blockingExecutionContext, List(StandardOpenOption.APPEND)))
+            .through(
+              writeAll[F](fileRef, blockingExecutionContext, List(StandardOpenOption.APPEND)))
             .compile
             .drain) >> streamAndWrite(s, state, Stream.empty, racc, 0, fileRef)
       } else {

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -1,7 +1,7 @@
 package org
 
-import cats.data._
-import fs2._
+import cats.data.{EitherT, Kleisli, OptionT}
+import fs2.Stream
 
 package object http4s { // scalastyle:ignore
 

--- a/core/src/main/scala/org/http4s/parser/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/parser/QueryParser.scala
@@ -1,7 +1,6 @@
 package org.http4s
 package parser
 
-import cats.implicits._
 import java.io.UnsupportedEncodingException
 import java.nio.CharBuffer
 import org.http4s.util.UrlCodingUtils
@@ -108,7 +107,7 @@ private[http4s] object QueryParser {
   private val InitialBufferCapactiy = 32
 
   def parseQueryString(queryString: String, codec: Codec = Codec.UTF8): ParseResult[Query] =
-    if (queryString.isEmpty) Either.right(Query.empty)
+    if (queryString.isEmpty) Right(Query.empty)
     else new QueryParser(codec, true).decode(CharBuffer.wrap(queryString), true)
 
   private sealed trait State

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -1,7 +1,6 @@
 package org.http4s
 package parser
 
-import cats.implicits._
 import java.net.URLDecoder
 import java.nio.charset.Charset
 import org.http4s.{Query => Q}
@@ -39,7 +38,7 @@ private[parser] trait Rfc3986Parser
   def HierPart: Rule2[Option[org.http4s.Uri.Authority], org.http4s.Uri.Path] = rule {
     "//" ~ Authority ~ PathAbempty ~> {
       (auth: org.http4s.Uri.Authority, path: org.http4s.Uri.Path) =>
-        auth.some :: path :: HNil
+        Some(auth) :: path :: HNil
     } |
       PathAbsolute ~> (None :: _ :: HNil) |
       PathRootless ~> (None :: _ :: HNil) |
@@ -51,7 +50,7 @@ private[parser] trait Rfc3986Parser
   def RelativePart: Rule2[Option[org.http4s.Uri.Authority], org.http4s.Uri.Path] = rule {
     "//" ~ Authority ~ PathAbempty ~> {
       (auth: org.http4s.Uri.Authority, path: org.http4s.Uri.Path) =>
-        auth.some :: path :: HNil
+        Some(auth) :: path :: HNil
     } |
       PathAbsolute ~> (None :: _ :: HNil) |
       PathNoscheme ~> (None :: _ :: HNil) |

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package syntax
 
-import cats._
+import cats.{Functor, ~>}
 import cats.syntax.functor._
 import cats.effect.Sync
 import cats.data.{Kleisli, OptionT}

--- a/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/metrics.scala
+++ b/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/metrics.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package metrics
 
-import cats._
+import cats.Applicative
 import cats.effect.Sync
 import cats.syntax.applicative._
 import com.codahale.metrics.MetricRegistry

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -2,7 +2,7 @@ package org.http4s
 package dsl
 package impl
 
-import cats._
+import cats.{Applicative, Monad}
 import org.http4s.headers._
 
 trait ResponseGenerator extends Any {

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package dsl
 
-import cats._
+import cats.Monad
 import cats.effect.IO
 import org.http4s.dsl.io._
 import org.http4s.MediaType

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -1,9 +1,9 @@
 package org.http4s
 package json4s
 
-import cats._
-import cats.effect._
-import cats.syntax.all._
+import cats.Applicative
+import cats.effect.Sync
+import cats.implicits._
 import org.http4s.headers.`Content-Type`
 import org.json4s._
 import org.json4s.JsonAST.JValue

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -1,8 +1,8 @@
 package org.http4s
 package scalaxml
 
-import cats._
-import cats.effect._
+import cats.Applicative
+import cats.effect.Sync
 import cats.implicits._
 import java.io.StringReader
 import javax.xml.parsers.SAXParserFactory
@@ -11,7 +11,7 @@ import cats.data.EitherT
 import org.http4s.headers.`Content-Type`
 
 import scala.util.control.NonFatal
-import scala.xml._
+import scala.xml.{Elem, InputSource, SAXParseException, XML}
 
 trait ElemInstances {
   protected def saxFactory: SAXParserFactory

--- a/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
@@ -2,7 +2,7 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.{Functor, MonoidK}
 import cats.data.Kleisli
 import cats.implicits._
 

--- a/server/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -2,7 +2,7 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.Applicative
 import cats.data.Kleisli
 import cats.implicits._
 import org.http4s.Method.OPTIONS

--- a/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -2,7 +2,7 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.{Functor, MonoidK}
 import cats.data.Kleisli
 import cats.implicits._
 

--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -2,11 +2,11 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.Functor
 import cats.data.Kleisli
-import fs2._
-import fs2.Stream._
-import fs2.compress._
+import fs2.{Chunk, Pipe, Pull, Pure, Stream}
+import fs2.Stream.chunk
+import fs2.compress.deflate
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.zip.{CRC32, Deflater}
 import org.http4s.headers._

--- a/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -2,10 +2,10 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.{Applicative, Functor}
 import cats.data.Kleisli
 import fs2.Stream._
-import fs2._
+import fs2.Chunk
 import java.nio.charset.StandardCharsets
 import cats.implicits._
 import org.http4s.headers._

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -2,13 +2,13 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.~>
 import cats.arrow.FunctionK
 import cats.implicits._
-import cats.data._
-import cats.effect._
+import cats.data.OptionT
+import cats.effect.{Bracket, Concurrent, Sync}
 import cats.effect.Sync._
-import fs2._
+import fs2.Stream
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger
 

--- a/server/src/main/scala/org/http4s/server/middleware/Metrics.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Metrics.scala
@@ -1,7 +1,7 @@
 package org.http4s.server.middleware
 
-import cats.data._
-import cats.effect._
+import cats.data.{Kleisli, OptionT}
+import cats.effect.{Clock, ExitCase, Sync}
 import cats.effect.implicits._
 import cats.implicits._
 import fs2.Stream

--- a/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
@@ -2,9 +2,9 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.{Functor, Monad}
 import cats.data.Kleisli
-import cats.effect._
+import cats.effect.IO
 import cats.implicits._
 import org.log4s.getLogger
 import io.chrisdavenport.vault._

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -2,14 +2,14 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.~>
 import cats.arrow.FunctionK
-import cats.data._
-import cats.effect._
+import cats.data.{Kleisli, OptionT}
+import cats.effect.{Bracket, Concurrent, ExitCase, Sync}
 import cats.effect.implicits._
 import cats.effect.concurrent.Ref
 import cats.implicits._
-import fs2._
+import fs2.{Chunk, Stream}
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger
 import cats.effect.Sync._

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -2,15 +2,15 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.~>
 import cats.arrow.FunctionK
-import cats.data._
-import cats.effect._
+import cats.data.{Kleisli, OptionT}
+import cats.effect.{Bracket, Concurrent, ExitCase, Sync}
 import cats.effect.implicits._
 import cats.effect.Sync._
 import cats.effect.concurrent.Ref
 import cats.implicits._
-import fs2._
+import fs2.{Chunk, Stream}
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger
 

--- a/server/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -2,9 +2,8 @@ package org.http4s
 package server
 package middleware
 
-import cats._
+import cats.Applicative
 import cats.data.Kleisli
-import cats.syntax.applicative._
 import org.http4s.Status.{BadRequest, NotFound}
 import org.http4s.headers.Host
 
@@ -63,7 +62,7 @@ object VirtualHost {
     Kleisli { req =>
       req.headers
         .get(Host)
-        .fold(Response[G](BadRequest).withEntity("Host header required.").pure[F]) { h =>
+        .fold(F.pure(Response[G](BadRequest).withEntity("Host header required."))) { h =>
           // Fill in the host port if possible
           val host: Host = h.port match {
             case Some(_) => h
@@ -72,7 +71,7 @@ object VirtualHost {
           }
           (first +: rest).toVector
             .collectFirst { case HostService(s, p) if p(host) => s(req) }
-            .getOrElse(Response[G](NotFound).withEntity(s"Host '$host' not found.").pure[F])
+            .getOrElse(F.pure(Response[G](NotFound).withEntity(s"Host '$host' not found.")))
         }
     }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
@@ -3,9 +3,9 @@ package server
 package middleware
 package authentication
 
-import cats._
+import cats.Applicative
 import cats.data.Kleisli
-import cats.effect._
+import cats.effect.Sync
 import cats.implicits._
 import org.http4s.headers.Authorization
 

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -3,8 +3,8 @@ package server
 package middleware
 package authentication
 
-import cats._
-import cats.data._
+import cats.Applicative
+import cats.data.{Kleisli, NonEmptyList}
 import cats.effect.Sync
 import cats.implicits._
 import java.math.BigInteger

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -1,9 +1,9 @@
 package org.http4s
 
-import cats._
+import cats.{Applicative, Monad}
 import cats.data.{Kleisli, OptionT}
 import cats.implicits._
-import cats.effect._
+import cats.effect.IO
 import org.http4s.headers.{Connection, `Content-Length`}
 import org.http4s.syntax.string._
 import org.log4s.getLogger

--- a/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -2,8 +2,8 @@ package org.http4s
 package server
 package staticcontent
 
-import cats.data._
-import cats.effect._
+import cats.data.{Kleisli, NonEmptyList, OptionT}
+import cats.effect.{ContextShift, Effect, Sync}
 import java.io.File
 import org.http4s.headers.Range.SubRange
 import org.http4s.headers._

--- a/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -1,8 +1,8 @@
 package org.http4s.server.websocket
 
-import cats._
+import cats.Applicative
 import cats.implicits._
-import fs2._
+import fs2.{Pipe, Stream}
 import org.http4s.websocket.{WebSocket, WebSocketContext, WebSocketFrame}
 import org.http4s.{Headers, Response, Status}
 


### PR DESCRIPTION
- We remove every wild-card import from the `cats`, `cats.data`, or `cats.effect` packages.
- We try to narrow down imports of `cats.implicits._` to one or two specific imports from `cats.syntax` or `cats.instances`.