### PR TITLE
Switch to more standard series/x.y naming convention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ stages:
     branches:
       only:
         - master
-        - /^release-/
+        - /^series\//
     if: type = push
 
 env:

--- a/docs/src/hugo/layouts/partials/edit-button.html
+++ b/docs/src/hugo/layouts/partials/edit-button.html
@@ -1,4 +1,4 @@
 {{ $apiVer := index .Site.Data.build.versions "http4s.api" }}
-<a href="https://github.com/http4s/http4s/edit/release-{{ $apiVer }}.x/docs/src/main/tut/{{ replace .File.Path (print "v" $apiVer) ""}}" class="btn btn-secondary btn-sm">
+<a href="https://github.com/http4s/http4s/edit/series/{{ $apiVer }}/docs/src/main/tut/{{ replace .File.Path (print "v" $apiVer) ""}}" class="btn btn-secondary btn-sm">
   <i class="fa fa-edit"></i>
 </a>

--- a/docs/src/hugo/layouts/partials/edit-link.html
+++ b/docs/src/hugo/layouts/partials/edit-link.html
@@ -1,2 +1,2 @@
 {{ $apiVer := index .Site.Data.build.versions "http4s.api" }}
-<a href="https://github.com/http4s/http4s/edit/release-{{ $apiVer }}.x/docs/src/main/tut/{{ replace .File.Path (print "v" $apiVer) ""}}"><i class="fa fa-pencil"></i> Edit this page</a>
+<a href="https://github.com/http4s/http4s/edit/series/{{ $apiVer }}/docs/src/main/tut/{{ replace .File.Path (print "v" $apiVer) ""}}"><i class="fa fa-pencil"></i> Edit this page</a>

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -48,7 +48,7 @@ object Http4sPlugin extends AutoPlugin {
         sys.env.get("TRAVIS_JDK_VERSION").contains("oraclejdk8") &&
         (sys.env.get("TRAVIS_BRANCH") match {
            case Some("master") => true
-           case Some(branch) if branch.startsWith("release-") => true
+           case Some(branch) if branch.startsWith("series/") => true
            case _ => false
          })
     },

--- a/website/src/hugo/content/contributing.md
+++ b/website/src/hugo/content/contributing.md
@@ -217,7 +217,7 @@ markdown via GitHub.
 
 ### `docs` documentation
 
-Each branch `master` and `release-X.Y`, publishes documentation per
+Each branch `master` and `series/X.Y`, publishes documentation per
 minor version into the `/vX.Y` directory of http4s.org.  The Hugo site
 chrome lives in the `docs/src/hugo` directory, and the [tut] content
 lives in `docs/src/main/tut`.  Tut is used to typecheck our


### PR DESCRIPTION
Lots of our ecosystem (e.g., cats, cats-effect, fs2) use a `series/x.y` naming convention for maintenance branches.  Proposing this before we open `series/0.20` instead of `release-0.20.x`

"Not worth it" is a totally legitimate answer, but we need to get it open one way or the other.