### PR TITLE
Revert "Avoid closing the previously connection if no errors occurred."

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -276,14 +276,13 @@ private final class Http1Connection[F[_]](
             cleanup()
             attributes -> rawBody
           } else {
-            attributes -> rawBody.onFinalizeCase {
-              case ExitCase.Completed =>
-                Async.shift(executionContext) *> F.delay { trailerCleanup(); cleanup(); }
-              case ExitCase.Error(_) | ExitCase.Canceled =>
-                Async.shift(executionContext) *> F.delay {
+            attributes -> rawBody.onFinalize(
+              Stream
+                .eval_(Async.shift(executionContext) *> F.delay {
                   trailerCleanup(); cleanup(); stageShutdown()
-                }
-            }
+                })
+                .compile
+                .drain)
           }
         }
         cb(


### PR DESCRIPTION
This reverts commit 95ad428488381750cb7e9e30f1fa4811a16af90e.

===================

When sharing a client + connection pool among requests against
multiple hosts this commit causes a regression.

conditions:

- client calls A to a.com and B to b.com
- single shared connection pool size 5.

steps to reproduce:

- perform 10+ successful parallel requests A

final state:
```
org.http4s.client.PoolManager Returning idle connection to pool:
curAllocated=5 idleQueues.size=1 waitQueue.size=0 maxWaitQueueLimit=256
closed=false
```

- perform 1 request B

final state:
```
org.http4s.client.PoolManager No connections available for the desired
key, RequestKey(Scheme(https),xB.comx). Evicting random and
creating a new connection: curAllocated=5 idleQueues.size=1
waitQueue.size=0 maxWaitQueueLimit=256 closed=false
```

no further actions are then taken by the client and in our case on
a server:

```o.http4s.blazecore.IdleTimeoutStage Idle timeout after 30000 ms.```

from this point request B starts to work again (the eviction was
indeed performed).

Both with this revert and in 0.20-M6 prior the parallel connections
are released and the pool is left in a clean state for request B.

```
org.http4s.client.PoolManager Connection could not be recycled
, no pending requests. Shrinking pool: curAllocated=0 idleQueues.size=0
waitQueue.size=0 maxWaitQueueLimit=256 closed=false
````

Maintaining connections open is a good idea for performance in many
cases but it seems like the pool manager needs further work before
this behaviour can be changed.