### PR TITLE
Use cats-effect 1.3.0 and remove workarounds introduced in #2470

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -178,7 +178,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       // if the requestTimeout is hit then it's a TimeoutException
       // if establishing connection fails first then it's an IOException
 
-      // The expected behaviour is that the requestTimeout will happen first, but fetchAs will additionally wait for the IO.sleep(2.seconds) to complete.
+      // The expected behaviour is that the requestTimeout will happen first, but fetchAs will additionally wait for the IO.sleep(1000.millis) to complete.
       c.fetchAs[String](FooRequest).unsafeRunTimed(1500.millis).get must throwA[TimeoutException]
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,7 @@ lazy val core = libraryProject("core")
       "https://oss.sonatype.org/content/repositories/snapshots"),
     libraryDependencies ++= Seq(
       cats,
+      catsEffect,
       fs2Io,
       log4s,
       parboiled,

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -309,7 +309,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.0"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.6.0"
-  lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.1.0"
+  lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.3.0"
   lazy val catsEffectLaws                   = "org.typelevel"          %% "cats-effect-laws"          % catsEffect.revision
   lazy val catsKernelLaws                   = "org.typelevel"          %% "cats-kernel-laws"          % cats.revision
   lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % cats.revision


### PR DESCRIPTION
- use cats-effect 1.3.0
- remove the workarounds for https://github.com/typelevel/cats-effect/issues/487 introduced in #2470 as the issue is fix in cats-effects 1.3.0 (https://github.com/typelevel/cats-effect/releases/tag/v1.3.0)

