### PR TITLE
Remove EitherT from the DecodeResult.

### DIFF
--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -103,7 +103,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     "decode JSON from an Argonaut decoder" in {
       val result = jsonOf[IO, Foo]
         .decode(Request[IO]().withEntity(jObjectFields("bar" -> jNumberOrNull(42))), strict = true)
-      result.value.unsafeRunSync must beRight(Foo(42))
+      result.unsafeRunSync must beRight(Foo(42))
     }
 
     // https://github.com/http4s/http4s/issues/514
@@ -114,7 +114,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
         val json = Json("wort" -> jString(wort))
         val result =
           jsonOf[IO, Umlaut].decode(Request[IO]().withEntity(json), strict = true)
-        result.value.unsafeRunSync must_== Right(Umlaut(wort))
+        result.unsafeRunSync must_== Right(Umlaut(wort))
       }
     }
 
@@ -122,7 +122,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
       val result = ArgonautInstancesWithCustomErrors
         .jsonOf[IO, Foo]
         .decode(Request[IO]().withEntity(jObjectFields("bar1" -> jNumberOrNull(42))), strict = true)
-      result.value.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
+      result.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
         "Custom Could not decode JSON: {\"bar1\":42.0}, error: Attempt to decode value on failed cursor., cursor: CursorHistory(List(El(CursorOpDownField(bar),false)))"))
     }
   }

--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -17,17 +17,16 @@ class CirceJsonBench {
 
   @Benchmark
   def decode_byte_buffer(in: BenchState): Either[DecodeFailure, Json] =
-    jsonDecoderByteBuffer[IO].decode(in.req, strict = true).value.unsafeRunSync
+    jsonDecoderByteBuffer[IO].decode(in.req, strict = true).unsafeRunSync
 
   @Benchmark
   def decode_incremental(in: BenchState): Either[DecodeFailure, Json] =
-    jsonDecoderIncremental[IO].decode(in.req, strict = true).value.unsafeRunSync
+    jsonDecoderIncremental[IO].decode(in.req, strict = true).unsafeRunSync
 
   @Benchmark
   def decode_adaptive(in: BenchState): Either[DecodeFailure, Json] =
     jsonDecoderAdaptive[IO](in.cutoff, MediaType.application.json)
       .decode(in.req, strict = true)
-      .value
       .unsafeRunSync
 }
 

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
@@ -64,7 +64,7 @@ class BoopickleSpec extends Http4sSpec with BooPickleInstances {
     "decode a class from a boopickle decoder" in {
       val result = booOf[IO, Fruit]
         .decode(Request[IO]().withEntity(Banana(10.0): Fruit), strict = true)
-      result.value.unsafeRunSync must_== Right(Banana(10.0))
+      result.unsafeRunSync must_== Right(Banana(10.0))
     }
   }
 

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -134,7 +134,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
         .decode(
           Request[IO]().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42))),
           strict = true)
-      result.value.unsafeRunSync must_== Right(Foo(42))
+      result.unsafeRunSync must_== Right(Foo(42))
     }
 
     // https://github.com/http4s/http4s/issues/514
@@ -145,7 +145,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
         val json = Json.obj("wort" -> Json.fromString(wort))
         val result =
           jsonOf[IO, Umlaut].decode(Request[IO]().withEntity(json), strict = true)
-        result.value.unsafeRunSync must_== Right(Umlaut(wort))
+        result.unsafeRunSync must_== Right(Umlaut(wort))
       }
     }
 
@@ -153,7 +153,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
       val result = CirceInstancesWithCustomErrors
         .jsonOf[IO, Bar]
         .decode(Request[IO]().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
-      result.value.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
+      result.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
         "Custom Could not decode JSON: {\"bar1\":42}, errors: DecodingFailure at .a: Attempt to decode value on failed cursor"))
     }
   }
@@ -164,14 +164,14 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
         .decode(
           Request[IO]().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42))),
           strict = true)
-      result.value.unsafeRunSync must_== Right(Foo(42))
+      result.unsafeRunSync must_== Right(Foo(42))
     }
 
     "return an InvalidMessageBodyFailure with a list of failures on invalid JSON messages" in {
       val json = Json.obj("a" -> Json.fromString("sup"), "b" -> Json.fromInt(42))
       val result = accumulatingJsonOf[IO, Bar]
         .decode(Request[IO]().withEntity(json), strict = true)
-      result.value.unsafeRunSync must beLike {
+      result.unsafeRunSync must beLike {
         case Left(InvalidMessageBodyFailure(_, Some(DecodingFailures(NonEmptyList(_, _))))) => ok
       }
     }
@@ -180,7 +180,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
       val result = CirceInstancesWithCustomErrors
         .accumulatingJsonOf[IO, Bar]
         .decode(Request[IO]().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
-      result.value.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
+      result.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
         "Custom Could not decode JSON: {\"bar1\":42}, errors: DecodingFailure at .a: Attempt to decode value on failed cursor, DecodingFailure at .b: Attempt to decode value on failed cursor"))
     }
   }
@@ -210,7 +210,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
       import org.http4s.circe.CirceEntityDecoder._
       val request = Request[IO]().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42)))
       val result = request.attemptAs[Foo]
-      result.value.unsafeRunSync must_== Right(Foo(42))
+      result.unsafeRunSync must_== Right(Foo(42))
     }
 
     "encode without defining EntityEncoder using default printer" in {
@@ -226,7 +226,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
         .withContentType(`Content-Type`(MediaType.application.json))
 
       val decoder = CirceInstances.builder.build.jsonOf[IO, Int]
-      val result = decoder.decode(req, true).value.unsafeRunSync
+      val result = decoder.decode(req, true).unsafeRunSync
 
       result must beLeft.like {
         case _: MalformedMessageBodyFailure => ok
@@ -238,7 +238,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
         .withEntity(Json.obj())
 
       val decoder = CirceInstances.builder.build.jsonOf[IO, Int]
-      val result = decoder.decode(req, true).value.unsafeRunSync
+      val result = decoder.decode(req, true).unsafeRunSync
 
       result must beLeft.like {
         case _: InvalidMessageBodyFailure => ok

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 import fs2._
 import org.http4s.Status.Successful
 import org.http4s.headers.{Accept, MediaRangeAndQValue}
+import org.http4s.util.FEither._
 
 private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwable])
     extends Client[F] {
@@ -96,7 +97,7 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     } else req
     fetch(r) {
       case Successful(resp) =>
-        d.decode(resp, strict = false).leftWiden[Throwable].rethrowT
+        d.decode(resp, strict = false).leftWiden[Throwable].rethrow
       case failedResponse =>
         onError(failedResponse).flatMap(F.raiseError)
     }
@@ -149,7 +150,7 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     } else req
     fetch(r) {
       case Successful(resp) =>
-        d.decode(resp, strict = false).leftWiden[Throwable].rethrowT.map(_.some)
+        d.decode(resp, strict = false).leftWiden[Throwable].rethrow.map(_.some)
       case failedResponse =>
         failedResponse.status match {
           case Status.NotFound => Option.empty[A].pure[F]
@@ -173,7 +174,7 @@ private[client] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
       req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
     } else req
     fetch(r) { resp =>
-      d.decode(resp, strict = false).leftWiden[Throwable].rethrowT
+      d.decode(resp, strict = false).leftWiden[Throwable].rethrow
     }
   }
 

--- a/client/src/main/scala/org/http4s/client/Http4sClientDsl.scala
+++ b/client/src/main/scala/org/http4s/client/Http4sClientDsl.scala
@@ -5,6 +5,7 @@ package dsl
 import cats.Applicative
 import org.http4s.Method.{NoBody, PermitsBody}
 import org.http4s.client.impl.{EmptyRequestGenerator, EntityRequestGenerator}
+import org.http4s.util.FEither._
 
 trait Http4sClientDsl[F[_]] {
   import Http4sClientDsl._
@@ -20,7 +21,7 @@ trait Http4sClientDsl[F[_]] {
       decoder: EntityDecoder[F, T]): EntityDecoder[F, (Headers, T)] = {
     val s = decoder.consumes.toList
     EntityDecoder.decodeBy(s.head, s.tail: _*)(resp =>
-      decoder.decode(resp, strict = true).map(t => (resp.headers, t)))
+      decoder.decode(resp, strict = true).rightMap(t => (resp.headers, t)))
   }
 }
 

--- a/core/src/main/scala/org/http4s/DecodeResult.scala
+++ b/core/src/main/scala/org/http4s/DecodeResult.scala
@@ -1,22 +1,19 @@
 package org.http4s
 
-import cats._
-import cats.data._
-import cats.implicits._
+import cats.{Applicative, Functor}
+import cats.syntax.functor._
 
 object DecodeResult {
-  def apply[F[_], A](fa: F[Either[DecodeFailure, A]]): DecodeResult[F, A] =
-    EitherT(fa)
 
   def success[F[_], A](a: F[A])(implicit F: Functor[F]): DecodeResult[F, A] =
-    DecodeResult(a.map(Either.right(_)))
+    a.map(Right(_))
 
   def success[F[_], A](a: A)(implicit F: Applicative[F]): DecodeResult[F, A] =
-    success(F.pure(a))
+    F.pure(Right(a))
 
   def failure[F[_], A](e: F[DecodeFailure])(implicit F: Functor[F]): DecodeResult[F, A] =
-    DecodeResult(e.map(Either.left(_)))
+    e.map(Left(_))
 
   def failure[F[_], A](e: DecodeFailure)(implicit F: Applicative[F]): DecodeResult[F, A] =
-    failure(F.pure(e))
+    F.pure(Left(e))
 }

--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -97,11 +97,9 @@ object UrlForm {
       implicit F: Sync[F],
       defaultCharset: Charset = DefaultCharset): EntityDecoder[F, UrlForm] =
     EntityDecoder.decodeBy(MediaType.application.`x-www-form-urlencoded`) { m =>
-      DecodeResult(
-        EntityDecoder
-          .decodeString(m)
-          .map(decodeString(m.charset.getOrElse(defaultCharset)))
-      )
+      EntityDecoder
+        .decodeString(m)
+        .map(decodeString(m.charset.getOrElse(defaultCharset)))
     }
 
   implicit val eqInstance: Eq[UrlForm] = Eq.instance { (x: UrlForm, y: UrlForm) =>

--- a/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -7,24 +7,22 @@ import scala.concurrent.ExecutionContext
 
 private[http4s] object MultipartDecoder {
 
-  def decoder[F[_]: Sync]: EntityDecoder[F, Multipart[F]] =
+  def decoder[F[_]](implicit F: Sync[F]): EntityDecoder[F, Multipart[F]] =
     EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
       msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
         case Some(boundary) =>
-          DecodeResult {
-            msg.body
-              .through(MultipartParser.parseToPartsStream[F](Boundary(boundary)))
-              .compile
-              .toVector
-              .map[Either[DecodeFailure, Multipart[F]]](parts =>
-                Right(Multipart(parts, Boundary(boundary))))
-              .handleError {
-                case e: InvalidMessageBodyFailure => Left(e)
-                case e => Left(InvalidMessageBodyFailure("Invalid multipart body", Some(e)))
-              }
-          }
+          msg.body
+            .through(MultipartParser.parseToPartsStream[F](Boundary(boundary)))
+            .compile
+            .toVector
+            .map[Either[DecodeFailure, Multipart[F]]](parts =>
+              Right(Multipart(parts, Boundary(boundary))))
+            .handleError {
+              case e: InvalidMessageBodyFailure => Left(e)
+              case e => Left(InvalidMessageBodyFailure("Invalid multipart body", Some(e)))
+            }
         case None =>
-          DecodeResult.failure(
+          DecodeResult.failure[F, Multipart[F]](
             InvalidMessageBodyFailure("Missing boundary extension to Content-Type"))
       }
     }
@@ -64,27 +62,25 @@ private[http4s] object MultipartDecoder {
     EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
       msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
         case Some(boundary) =>
-          DecodeResult {
-            msg.body
-              .through(
-                MultipartParser.parseToPartsStreamedFile[F](
-                  Boundary(boundary),
-                  blockingExecutionContext,
-                  headerLimit,
-                  maxSizeBeforeWrite,
-                  maxParts,
-                  failOnLimit))
-              .compile
-              .toVector
-              .map[Either[DecodeFailure, Multipart[F]]](parts =>
-                Right(Multipart(parts, Boundary(boundary))))
-              .handleError {
-                case e: InvalidMessageBodyFailure => Left(e)
-                case e => Left(InvalidMessageBodyFailure("Invalid multipart body", Some(e)))
-              }
-          }
+          msg.body
+            .through(
+              MultipartParser.parseToPartsStreamedFile[F](
+                Boundary(boundary),
+                blockingExecutionContext,
+                headerLimit,
+                maxSizeBeforeWrite,
+                maxParts,
+                failOnLimit))
+            .compile
+            .toVector
+            .map[Either[DecodeFailure, Multipart[F]]](parts =>
+              Right(Multipart(parts, Boundary(boundary))))
+            .handleError {
+              case e: InvalidMessageBodyFailure => Left(e)
+              case e => Left(InvalidMessageBodyFailure("Invalid multipart body", Some(e)))
+            }
         case None =>
-          DecodeResult.failure(
+          DecodeResult.failure[F, Multipart[F]](
             InvalidMessageBodyFailure("Missing boundary extension to Content-Type"))
       }
     }

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -13,7 +13,7 @@ package object http4s { // scalastyle:ignore
 
   val ApiVersion: Http4sVersion = Http4sVersion(BuildInfo.apiVersion._1, BuildInfo.apiVersion._2)
 
-  type DecodeResult[F[_], A] = EitherT[F, DecodeFailure, A]
+  type DecodeResult[F[_], A] = F[Either[DecodeFailure, A]]
 
   type ParseResult[+A] = Either[ParseFailure, A]
 

--- a/core/src/main/scala/org/http4s/util/FEither.scala
+++ b/core/src/main/scala/org/http4s/util/FEither.scala
@@ -1,0 +1,50 @@
+package org.http4s.util
+
+import cats.{Functor, Monad}
+
+object FEither {
+
+  implicit class FEitherOps[F[_], L, R](val felr: F[Either[L, R]]) extends AnyVal {
+
+    def swap(implicit F: Functor[F]): F[Either[R, L]] = F.map(felr)(_.swap)
+
+    def rightMap[RR](f: R => RR)(implicit F: Functor[F]): F[Either[L, RR]] =
+      F.map(felr) {
+        case Right(r) => Right(f(r))
+        case Left(l) => Left(l)
+      }
+
+    def leftMap[LL](f: L => LL)(implicit F: Functor[F]): F[Either[LL, R]] =
+      F.map(felr) {
+        case Right(r) => Right(r)
+        case Left(l) => Left(f(l))
+      }
+
+    def rightTransform[RR](f: R => Either[L, RR])(implicit F: Functor[F]): F[Either[L, RR]] =
+      F.map(felr) {
+        case Right(r) => f(r)
+        case Left(l) => Left(l)
+      }
+
+    def leftWiden[LL >: L]: F[Either[LL, R]] = felr.asInstanceOf[F[Either[LL, R]]]
+
+    def rightFlatMap[RR](f: R => F[Either[L, RR]])(implicit F: Monad[F]): F[Either[L, RR]] =
+      F.flatMap(felr) {
+        case Right(r) => f(r)
+        case Left(l) => F.pure(Left(l))
+      }
+
+    def leftFlatMap[LL](f: L => F[Either[LL, R]])(implicit F: Monad[F]): F[Either[LL, R]] =
+      F.flatMap(felr) {
+        case Right(r) => F.pure(Right(r))
+        case Left(l) => f(l)
+      }
+
+    def semiflatMap[RR](f: R => F[RR])(implicit F: Monad[F]): F[Either[L, RR]] =
+      F.flatMap(felr) {
+        case Right(r) => F.map(f(r))(Right(_))
+        case Left(l) => F.pure(Left(l))
+      }
+  }
+
+}

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSpec.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSpec.scala
@@ -191,7 +191,7 @@ class DropwizardMetricsSpec extends Http4sSpec {
         .run(Request[IO](uri = Uri.unsafeFromString("ok")))
         .use { resp =>
           IO {
-            (EntityDecoder[IO, String].decode(resp, false).value.unsafeRunSync() must beRight {
+            (EntityDecoder[IO, String].decode(resp, false).unsafeRunSync() must beRight {
               contain("200 OK")
             }).and(count(registry, Counter("client.default.active-requests")) must beEqualTo(1))
               .and(valuesOf(registry, Timer("client.default.requests.headers")) must beSome(

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -19,20 +19,18 @@ trait JawnInstances {
   // some decoders may reuse it and avoid extra content negotiation
   private[http4s] def jawnDecoderImpl[F[_]: Sync, J: RawFacade](
       msg: Message[F]): DecodeResult[F, J] =
-    DecodeResult {
-      msg.body.chunks
-        .parseJson(AsyncParser.SingleValue)
-        .map(Either.right)
-        .handleErrorWith {
-          case pe: ParseException =>
-            Stream.emit(Left(jawnParseExceptionMessage(pe)))
-          case e =>
-            Stream.raiseError[F](e)
-        }
-        .compile
-        .last
-        .map(_.getOrElse(Left(jawnEmptyBodyMessage)))
-    }
+    msg.body.chunks
+      .parseJson(AsyncParser.SingleValue)
+      .map(Either.right)
+      .handleErrorWith {
+        case pe: ParseException =>
+          Stream.emit(Left(jawnParseExceptionMessage(pe)))
+        case e =>
+          Stream.raiseError[F](e)
+      }
+      .compile
+      .last
+      .map(_.getOrElse(Left(jawnEmptyBodyMessage)))
 }
 
 object JawnInstances {

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
@@ -9,7 +9,7 @@ trait JawnDecodeSupportSpec[J] extends Http4sSpec {
     "json decoder" should {
       "return right when the entity is valid" in {
         val resp = Response[IO](Status.Ok).withEntity("""{"valid": true}""")
-        decoder.decode(resp, strict = false).value.unsafeRunSync must beRight
+        decoder.decode(resp, strict = false).unsafeRunSync must beRight
       }
 
       testErrors(decoder)(
@@ -36,12 +36,12 @@ trait JawnDecodeSupportSpec[J] extends Http4sSpec {
   ) = {
     "return a ParseFailure when the entity is invalid" in {
       val resp = Response[IO](Status.Ok).withEntity("""garbage""")
-      decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like(parseError)
+      decoder.decode(resp, strict = false).unsafeRunSync must beLeft.like(parseError)
     }
 
     "return a ParseFailure when the entity is empty" in {
       val resp = Response[IO](Status.Ok).withEntity("")
-      decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like(emptyBody)
+      decoder.decode(resp, strict = false).unsafeRunSync must beLeft.like(emptyBody)
     }
   }
 }

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -17,13 +17,12 @@ trait Json4sInstances[J] {
 
   def jsonOf[F[_], A](implicit reader: Reader[A], F: Sync[F]): EntityDecoder[F, A] =
     jsonDecoder.flatMapR { json =>
-      DecodeResult(
-        F.delay(reader.read(json))
-          .map[Either[DecodeFailure, A]](Right(_))
-          .recover {
-            case e: MappingException =>
-              Left(InvalidMessageBodyFailure("Could not map JSON", Some(e)))
-          })
+      F.delay(reader.read(json))
+        .map[Either[DecodeFailure, A]](Right(_))
+        .recover {
+          case e: MappingException =>
+            Left(InvalidMessageBodyFailure("Could not map JSON", Some(e)))
+        }
     }
 
   /**
@@ -37,9 +36,8 @@ trait Json4sInstances[J] {
       formats: Formats,
       manifest: Manifest[A]): EntityDecoder[F, A] =
     jsonDecoder.flatMapR { json =>
-      DecodeResult(
-        F.delay[Either[DecodeFailure, A]](Right(json.extract[A]))
-          .handleError(e => Left(InvalidMessageBodyFailure("Could not extract JSON", Some(e)))))
+      F.delay[Either[DecodeFailure, A]](Right(json.extract[A]))
+        .handleError(e => Left(InvalidMessageBodyFailure("Could not extract JSON", Some(e))))
     }
 
   protected def jsonMethods: JsonMethods[J]

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -43,13 +43,13 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
     "decode JSON from an json4s reader" in {
       val result =
         jsonOf[IO, Int].decode(Request[IO]().withEntity("42"), strict = false)
-      result.value.unsafeRunSync must beRight(42)
+      result.unsafeRunSync must beRight(42)
     }
 
     "handle reader failures" in {
       val result =
         jsonOf[IO, Int].decode(Request[IO]().withEntity(""""oops""""), strict = false)
-      result.value.unsafeRunSync must beLeft.like {
+      result.unsafeRunSync must beLeft.like {
         case InvalidMessageBodyFailure("Could not map JSON", _) => ok
       }
     }
@@ -61,13 +61,13 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
     "extract JSON from formats" in {
       val result = jsonExtract[IO, Foo]
         .decode(Request[IO]().withEntity(JObject("bar" -> JInt(42))), strict = false)
-      result.value.unsafeRunSync must beRight(Foo(42))
+      result.unsafeRunSync must beRight(Foo(42))
     }
 
     "handle extract failures" in {
       val result = jsonExtract[IO, Foo]
         .decode(Request[IO]().withEntity(""""oops""""), strict = false)
-      result.value.unsafeRunSync must beLeft.like {
+      result.unsafeRunSync must beLeft.like {
         case InvalidMessageBodyFailure("Could not extract JSON", _) => ok
       }
     }

--- a/play-json/src/test/scala/org/http4s/play/PlaySpec.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySpec.scala
@@ -48,7 +48,7 @@ class PlaySpec extends JawnDecodeSupportSpec[JsValue] {
     "decode JSON from a Play decoder" in {
       val result = jsonOf[IO, Foo]
         .decode(Request[IO]().withEntity(Json.obj("bar" -> JsNumber(42)): JsValue), strict = true)
-      result.value.unsafeRunSync must_== Right(Foo(42))
+      result.unsafeRunSync must_== Right(Foo(42))
     }
   }
 

--- a/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSpec.scala
+++ b/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSpec.scala
@@ -35,7 +35,7 @@ class ScalatagsSpec extends Http4sSpec {
 
     "render the body" in {
       val resp = Response[IO](Ok).withEntity(testBody())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).unsafeRunSync must beRight(
         "<div><p>this is my testBody</p></div>")
     }
   }

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -384,9 +384,10 @@ object CSRF {
     def getFormToken: F[Option[String]] = {
 
       def extractToken: G[Option[String]] =
-        r.attemptAs[UrlForm]
-          .value
-          .map(_.fold(_ => none[String], _.values.get(fieldName).flatMap(_.uncons.map(_._1))))
+        Sync[G].map(r.attemptAs[UrlForm]) {
+          case Left(_) => None
+          case Right(x) => x.values.get(fieldName).flatMap(_.uncons.map(_._1))
+        }
 
       r.headers.get(headers.`Content-Type`) match {
         case Some(headers.`Content-Type`(MediaType.application.`x-www-form-urlencoded`, _)) =>

--- a/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
@@ -113,11 +113,10 @@ object HttpMethodOverrider {
         case FormOverrideStrategy(field, f) =>
           for {
             formFields <- f(
-              UrlForm
-                .entityDecoder[G]
-                .decode(req, strict = true)
-                .value
-                .map(_.toOption.map(_.values)))
+              S.map(
+                UrlForm
+                  .entityDecoder[G]
+                  .decode(req, strict = true))(_.toOption.map(_.values)))
           } yield formFields.flatMap(_.get(field).flatMap(_.uncons.map(_._1)))
       }
 

--- a/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
@@ -37,7 +37,7 @@ object UrlFormLifter {
         case Some(headers.`Content-Type`(MediaType.application.`x-www-form-urlencoded`, _))
             if checkRequest(req) =>
           for {
-            decoded <- f(UrlForm.entityDecoder[G].decode(req, strictDecode).value)
+            decoded <- f(UrlForm.entityDecoder[G].decode(req, strictDecode))
             resp <- decoded.fold(
               mf => f(mf.toHttpResponse[G](req.httpVersion)),
               addUrlForm

--- a/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
@@ -2,7 +2,6 @@ package org.http4s
 package testing
 
 import cats.syntax.flatMap._
-import cats.data.EitherT
 import org.http4s.headers._
 import org.http4s.util.CaseInsensitiveString
 import org.specs2.matcher._
@@ -55,13 +54,13 @@ trait Http4sMatchers[F[_]] extends Matchers with RunTimedMatchers[F] {
       m.headers.get(`Content-Encoding`).map(_.contentCoding).aka("the content encoding header")
     }
 
-  def returnRight[A, B](m: ValueCheck[B]): Matcher[EitherT[F, A, B]] =
-    beRight(m) ^^ { et: EitherT[F, A, B] =>
-      runAwait(et.value).aka("the either task")
+  def returnRight[A, B](m: ValueCheck[B]): Matcher[F[Either[A, B]]] =
+    beRight(m) ^^ { et: F[Either[A, B]] =>
+      runAwait(et).aka("the either task")
     }
 
-  def returnLeft[A, B](m: ValueCheck[A]): Matcher[EitherT[F, A, B]] =
-    beLeft(m) ^^ { et: EitherT[F, A, B] =>
-      runAwait(et.value).aka("the either task")
+  def returnLeft[A, B](m: ValueCheck[A]): Matcher[F[Either[A, B]]] =
+    beLeft(m) ^^ { et: F[Either[A, B]] =>
+      runAwait(et).aka("the either task")
     }
 }

--- a/tests/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -4,6 +4,7 @@ import cats.Monoid
 import cats.data._
 import cats.effect.IO
 import cats.implicits._
+import org.http4s.util.FEither._
 import cats.kernel.laws.discipline.MonoidTests
 import org.http4s.internal.CollectionCompat
 
@@ -27,10 +28,9 @@ class UrlFormSpec extends Http4sSpec {
           Request[IO]()
             .withEntity(urlForm)(UrlForm.entityEncoder(charset))
             .pure[IO])
-        .flatMap { req =>
+        .rightFlatMap { req =>
           UrlForm.entityDecoder[IO].decode(req, strict = false)
         }
-        .value
         .unsafeRunSync() === Right(urlForm)
     }
 

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -50,7 +50,7 @@ class MultipartSpec extends Specification {
         val request =
           Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
         val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value.unsafeRunSync()
+        val result = decoded.unsafeRunSync()
 
         result must beRight.like {
           case mp =>
@@ -68,7 +68,7 @@ class MultipartSpec extends Specification {
         val request =
           Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
         val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value.unsafeRunSync()
+        val result = decoded.unsafeRunSync()
 
         result must beRight.like {
           case mp =>
@@ -96,7 +96,7 @@ class MultipartSpec extends Specification {
           Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
 
         val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value.unsafeRunSync()
+        val result = decoded.unsafeRunSync()
 
         result must beRight.like {
           case mp =>
@@ -134,7 +134,7 @@ Content-Type: application/pdf
           headers = header)
 
         val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value.unsafeRunSync()
+        val result = decoded.unsafeRunSync()
 
         result must beRight
       }
@@ -162,7 +162,7 @@ I am a big moose
           body = Stream.emit(body).through(text.utf8Encode),
           headers = header)
         val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value.unsafeRunSync()
+        val result = decoded.unsafeRunSync()
 
         result must beRight
       }

--- a/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
+++ b/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
@@ -27,7 +27,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(html.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).unsafeRunSync must beRight(
         "<h1>test html</h1>")
     }
   }
@@ -42,7 +42,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(js.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).unsafeRunSync must beRight(
         """"test js"""")
     }
   }
@@ -55,7 +55,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(txt.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).unsafeRunSync must beRight(
         """test text""")
     }
   }
@@ -68,7 +68,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(_root_.xml.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).unsafeRunSync must beRight(
         "<test>test xml</test>")
     }
   }


### PR DESCRIPTION
The type of `DecodeResult[F[_], A]` was defined as `EitherT[F, DecodeFailure, A]` , which is just a wrapper for `F[Either[L, R]]`. It turns out that, for most operations, the full api of `EitherT`
is not used, and at each point only one or two operations are.

For this reason, we drop the use of `EitherT`. We reduce the type `DecodeResult[F, A]` to be just the `F[Either[DecodeResult, A]`, without the `EitherT`. 

To keep the convenience we have at certain places, we introduce a syntax extension (an implicit class), "FEither", which replicates some methods of `EitherT`, but without colliding with `map` and `flatMap`.

This breaks both source and binary compatibility.

_Note for reviewers:_ A bit over +50-50 line changes are whitespace changes, introduced by automatic formatting by `scalafmt`. 