### PR TITLE
Deprecate `AuthedService`, replace it with `AuthedRoutes` with updated API

### DIFF
--- a/core/src/main/scala/org/http4s/AuthedRequest.scala
+++ b/core/src/main/scala/org/http4s/AuthedRequest.scala
@@ -4,7 +4,10 @@ import cats._
 import cats.data._
 import cats.implicits._
 
-final case class AuthedRequest[F[_], A](authInfo: A, req: Request[F])
+final case class AuthedRequest[F[_], A](authInfo: A, req: Request[F]) {
+  def mapK[G[_]](fk: F ~> G): AuthedRequest[G, A] =
+    AuthedRequest(authInfo, req.mapK(fk))
+}
 
 object AuthedRequest {
   def apply[F[_]: Functor, T](

--- a/core/src/main/scala/org/http4s/AuthedRoutes.scala
+++ b/core/src/main/scala/org/http4s/AuthedRoutes.scala
@@ -1,0 +1,44 @@
+package org.http4s
+
+import cats.Applicative
+import cats.data.{Kleisli, OptionT}
+import cats.implicits._
+import cats.effect.Sync
+
+object AuthedRoutes {
+
+  /** Lifts a function into an [[AuthedRoutes]].  The application of `run`
+    * is suspended in `F` to permit more efficient combination of
+    * routes via `SemigroupK`.
+    *
+    * @tparam F the effect of the [[AuthedRoutes]]
+    * @tparam T the type of the auth info in the [[AuthedRequest]] accepted by the [[AuthedRoutes]]
+    * @param run the function to lift
+    * @return an [[AuthedRoutes]] that wraps `run`
+    */
+  def apply[T, F[_]](run: AuthedRequest[F, T] => OptionT[F, Response[F]])(
+      implicit F: Sync[F]): AuthedRoutes[T, F] =
+    Kleisli(req => OptionT(F.suspend(run(req).value)))
+
+  /** Lifts a partial function into an [[AuthedRoutes]].  The application of the
+    * partial function is suspended in `F` to permit more efficient combination
+    * of authed services via `SemigroupK`.
+    *
+    * @tparam F the base effect of the [[AuthedRoutes]]
+    * @param pf the partial function to lift
+    * @return An [[AuthedRoutes]] that returns some [[Response]] in an `OptionT[F, ?]`
+    * wherever `pf` is defined, an `OptionT.none` wherever it is not
+    */
+  def of[T, F[_]](pf: PartialFunction[AuthedRequest[F, T], F[Response[F]]])(
+      implicit F: Sync[F]): AuthedRoutes[T, F] =
+    Kleisli(req => OptionT(F.suspend(pf.lift(req).sequence)))
+
+  /**
+    * The empty service (all requests fallthrough).
+    *
+    * @tparam T - ignored.
+    * @return
+    */
+  def empty[T, F[_]: Applicative]: AuthedRoutes[T, F] =
+    Kleisli.liftF(OptionT.none)
+}

--- a/core/src/main/scala/org/http4s/AuthedService.scala
+++ b/core/src/main/scala/org/http4s/AuthedService.scala
@@ -3,7 +3,7 @@ package org.http4s
 import cats.{Applicative, Functor}
 import cats.data.{Kleisli, OptionT}
 
-@deprecated("Use AuthedRoutes instead", "0.20.1")
+@deprecated("Use AuthedRoutes instead", "0.20.2")
 object AuthedService {
 
   /**
@@ -19,7 +19,7 @@ object AuthedService {
     * [[org.http4s.Response.notFoundFor]], which generates a 404, for any request
     * where `pf` is not defined.
     */
-  @deprecated("Use AuthedRoutes.of instead", "0.20.1")
+  @deprecated("Use AuthedRoutes.of instead", "0.20.2")
   def apply[T, F[_]](pf: PartialFunction[AuthedRequest[F, T], F[Response[F]]])(
       implicit F: Applicative[F]): AuthedService[T, F] =
     Kleisli(req => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none)))
@@ -30,7 +30,7 @@ object AuthedService {
     * @tparam T - ignored.
     * @return
     */
-  @deprecated("Use AuthedRoutes.empty instead", "0.20.1")
+  @deprecated("Use AuthedRoutes.empty instead", "0.20.2")
   def empty[T, F[_]: Applicative]: AuthedService[T, F] =
     Kleisli.liftF(OptionT.none)
 

--- a/core/src/main/scala/org/http4s/AuthedService.scala
+++ b/core/src/main/scala/org/http4s/AuthedService.scala
@@ -2,9 +2,8 @@ package org.http4s
 
 import cats.{Applicative, Functor}
 import cats.data.{Kleisli, OptionT}
-import cats.implicits._
-import cats.effect.Sync
 
+@deprecated("Use AuthedRoutes instead", "0.20.1")
 object AuthedService {
 
   /**
@@ -16,39 +15,14 @@ object AuthedService {
   def lift[F[_]: Functor, T](f: AuthedRequest[F, T] => F[Response[F]]): AuthedService[T, F] =
     Kleisli(f.andThen(OptionT.liftF(_)))
 
-  /** Lifts a function into an [[AuthedService]].  The application of `run`
-    * is suspended in `F` to permit more efficient combination of
-    * routes via `SemigroupK`.
-    *
-    * @tparam F the effect of the [[AuthedService]]
-    * @tparam T the type of the auth info in the [[AuthedRequest]] accepted by the [[AuthedService]]
-    * @param run the function to lift
-    * @return an [[AuthedService]] that wraps `run`
-    */
-  def apply_[F[_], T](run: AuthedRequest[F, T] => OptionT[F, Response[F]])(
-      implicit F: Sync[F]): AuthedService[T, F] =
-    Kleisli(req => OptionT(F.suspend(run(req).value)))
-
   /** Lifts a partial function to an `AuthedService`.  Responds with
     * [[org.http4s.Response.notFoundFor]], which generates a 404, for any request
     * where `pf` is not defined.
     */
+  @deprecated("Use AuthedRoutes.of instead", "0.20.1")
   def apply[T, F[_]](pf: PartialFunction[AuthedRequest[F, T], F[Response[F]]])(
       implicit F: Applicative[F]): AuthedService[T, F] =
     Kleisli(req => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none)))
-
-  /** Lifts a partial function into an [[AuthedService]].  The application of the
-    * partial function is suspended in `F` to permit more efficient combination
-    * of authed services via `SemigroupK`.
-    *
-    * @tparam F the base effect of the [[AuthedService]]
-    * @param pf the partial function to lift
-    * @return An [[AuthedService]] that returns some [[Response]] in an `OptionT[F, ?]`
-    * wherever `pf` is defined, an `OptionT.none` wherever it is not
-    */
-  def of[F[_], T](pf: PartialFunction[AuthedRequest[F, T], F[Response[F]]])(
-      implicit F: Sync[F]): AuthedService[T, F] =
-    Kleisli(req => OptionT(F.suspend(pf.lift(req).sequence)))
 
   /**
     * The empty service (all requests fallthrough).
@@ -56,6 +30,7 @@ object AuthedService {
     * @tparam T - ignored.
     * @return
     */
+  @deprecated("Use AuthedRoutes.empty instead", "0.20.1")
   def empty[T, F[_]: Applicative]: AuthedService[T, F] =
     Kleisli.liftF(OptionT.none)
 

--- a/core/src/main/scala/org/http4s/AuthedService.scala
+++ b/core/src/main/scala/org/http4s/AuthedService.scala
@@ -25,7 +25,7 @@ object AuthedService {
     * @param run the function to lift
     * @return an [[AuthedService]] that wraps `run`
     */
-  def apply[F[_], T](run: AuthedRequest[F, T] => OptionT[F, Response[F]])(
+  def apply_[F[_], T](run: AuthedRequest[F, T] => OptionT[F, Response[F]])(
       implicit F: Sync[F]): AuthedService[T, F] =
     Kleisli(req => OptionT(F.suspend(run(req).value)))
 

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -56,10 +56,13 @@ package object http4s { // scalastyle:ignore
   type HttpService[F[_]] = HttpRoutes[F]
 
   /**
-    * We need to change the order of type parameters to make partial unification
+    * The type parameters need to be in this order to make partial unification
     * trigger. See https://github.com/http4s/http4s/issues/1506
     */
-  type AuthedService[T, F[_]] = Kleisli[OptionT[F, ?], AuthedRequest[F, T], Response[F]]
+  type AuthedRoutes[T, F[_]] = Kleisli[OptionT[F, ?], AuthedRequest[F, T], Response[F]]
+
+  @deprecated("Deprecated in favor of AuthedRoutes", "0.20.1")
+  type AuthedService[T, F[_]] = AuthedRoutes[T, F]
 
   type Callback[A] = Either[Throwable, A] => Unit
 

--- a/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
@@ -1,7 +1,7 @@
 package org.http4s
 package syntax
 
-abstract class AllSyntaxBinCompat extends AllSyntax with KleisliSyntaxBinCompat0
+abstract class AllSyntaxBinCompat extends AllSyntax with KleisliSyntaxBinCompat0 with KleisliSyntaxBinCompat1
 
 trait AllSyntax
     extends AnyRef

--- a/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
@@ -1,7 +1,10 @@
 package org.http4s
 package syntax
 
-abstract class AllSyntaxBinCompat extends AllSyntax with KleisliSyntaxBinCompat0 with KleisliSyntaxBinCompat1
+abstract class AllSyntaxBinCompat
+    extends AllSyntax
+    with KleisliSyntaxBinCompat0
+    with KleisliSyntaxBinCompat1
 
 trait AllSyntax
     extends AnyRef

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -19,7 +19,9 @@ trait KleisliSyntaxBinCompat0 {
 
   implicit def http4sKleisliHttpAppSyntax[F[_]: Sync](app: HttpApp[F]): KleisliHttpAppOps[F] =
     new KleisliHttpAppOps[F](app)
+}
 
+trait KleisliSyntaxBinCompat1 {
   implicit def http4sKleisliAuthedRoutesSyntax[F[_]: Sync, A](
       authedRoutes: AuthedRoutes[A, F]): KleisliAuthedRoutesOps[F, A] =
     new KleisliAuthedRoutesOps[F, A](authedRoutes)

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -42,5 +42,5 @@ final class KleisliHttpAppOps[F[_]: Sync](self: HttpApp[F]) {
 
 final class KleisliAuthedServiceOps[F[_]: Sync, A](self: AuthedService[A, F]) {
   def translate[G[_]: Sync](fk: F ~> G)(gK: G ~> F): AuthedService[A, G] =
-    AuthedService(authedReq => self.run(authedReq.mapK(gK)).mapK(fk).map(_.mapK(fk)))
+    AuthedService.apply_(authedReq => self.run(authedReq.mapK(gK)).mapK(fk).map(_.mapK(fk)))
 }

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -20,9 +20,9 @@ trait KleisliSyntaxBinCompat0 {
   implicit def http4sKleisliHttpAppSyntax[F[_]: Sync](app: HttpApp[F]): KleisliHttpAppOps[F] =
     new KleisliHttpAppOps[F](app)
 
-  implicit def http4sKleisliAuthedServiceSyntax[F[_]: Sync, A](
-      authedService: AuthedService[A, F]): KleisliAuthedServiceOps[F, A] =
-    new KleisliAuthedServiceOps[F, A](authedService)
+  implicit def http4sKleisliAuthedRoutesSyntax[F[_]: Sync, A](
+      authedRoutes: AuthedRoutes[A, F]): KleisliAuthedRoutesOps[F, A] =
+    new KleisliAuthedRoutesOps[F, A](authedRoutes)
 }
 
 final class KleisliResponseOps[F[_]: Functor, A](self: Kleisli[OptionT[F, ?], A, Response[F]]) {
@@ -40,7 +40,7 @@ final class KleisliHttpAppOps[F[_]: Sync](self: HttpApp[F]) {
     HttpApp(request => fk(self.run(request.mapK(gK)).map(_.mapK(fk))))
 }
 
-final class KleisliAuthedServiceOps[F[_]: Sync, A](self: AuthedService[A, F]) {
-  def translate[G[_]: Sync](fk: F ~> G)(gK: G ~> F): AuthedService[A, G] =
-    AuthedService.apply_(authedReq => self.run(authedReq.mapK(gK)).mapK(fk).map(_.mapK(fk)))
+final class KleisliAuthedRoutesOps[F[_]: Sync, A](self: AuthedRoutes[A, F]) {
+  def translate[G[_]: Sync](fk: F ~> G)(gK: G ~> F): AuthedRoutes[A, G] =
+    AuthedRoutes(authedReq => self.run(authedReq.mapK(gK)).mapK(fk).map(_.mapK(fk)))
 }

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -4,7 +4,7 @@ package object syntax {
   object all extends AllSyntaxBinCompat
   @deprecated("Has nothing to do with HTTP.", "0.19.1")
   object async extends AsyncSyntax
-  object kleisli extends KleisliSyntax with KleisliSyntaxBinCompat0
+  object kleisli extends KleisliSyntax with KleisliSyntaxBinCompat0 with KleisliSyntaxBinCompat1
   object literals extends LiteralsSyntax
   @deprecated("Use cats.foldable._", "0.18.5")
   object nonEmptyList extends NonEmptyListSyntax

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -29,7 +29,7 @@ use the following definition:
 case class User(id: Long, name: String)
 ```
 
-With the request representation defined, we can move on to the `AuthedService[User, F]`, a shortcut to
+With the request representation defined, we can move on to the `AuthedRoutes[User, F]`, an alias for
 `AuthedRequest[F, User] => OptionT[F, Response[F]]`. Notice the similarity to a "normal" service, which
 would be the equivalent to `Request[F] => OptionT[F, Response[F]]` - in other words, we are lifting the
 `Request` into an `AuthedRequest`, and adding authentication information in the mix.
@@ -47,7 +47,7 @@ It is worth noting that we are still wrapping the user fetch in `F` (`IO` in thi
 discovering the user might require reading from a database or calling some other service - i.e. performing
 IO operations.
 
-Now we need a middleware that can bridge a "normal" service into an `AuthedService`, which is quite easy to
+Now we need a middleware that can bridge a "normal" service into an `AuthedRoutes`, which is quite easy to
 get using our function defined above. We use `AuthMiddleware` for that:
 
 ```tut:silent
@@ -62,16 +62,16 @@ your api for possible unprotected points. To allow fallthrough,
 use `AuthMiddleware.withFallThrough`. Alternatively, to customize the behavior on not authenticated if you do not
 wish to always return 401, use `AuthMiddleware.noSpider` and specify the `onAuthFailure` handler.
 
-Finally, we can create our `AuthedService`, and wrap it with our authentication middleware, getting the
+Finally, we can create our `AuthedRoutes`, and wrap it with our authentication middleware, getting the
 final `HttpRoutes` to be exposed. Notice that we now have access to the user object in the service implementation:
 
 ```tut:silent
-val authedService: AuthedService[User, IO] =
-  AuthedService {
+val authedRoutes: AuthedRoutes[User, IO] =
+  AuthedRoutes.of {
     case GET -> Root / "welcome" as user => Ok(s"Welcome, ${user.name}")
   }
 
-val service: HttpRoutes[IO] = middleware(authedService)
+val service: HttpRoutes[IO] = middleware(authedRoutes)
 ```
 
 ## Returning an Error Response
@@ -88,12 +88,12 @@ To allow for failure, the `authUser` function has to be adjusted to a `Request[F
 error handling, we recommend an error [ADT] instead of a `String`.
 
 ```tut:silent
-val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli(_ => IO(???))
+val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli.pure(_ => IO(???))
 
-val onFailure: AuthedService[String, IO] = Kleisli(req => OptionT.liftF(Forbidden(req.authInfo)))
+val onFailure: AuthedRoutes[String, IO] = Kleisli(req => OptionT.liftF(Forbidden(req.authInfo)))
 val middleware = AuthMiddleware(authUser, onFailure)
 
-val service: HttpRoutes[IO] = middleware(authedService)
+val service: HttpRoutes[IO] = middleware(authedRoutes)
 ```
 
 ## Implementing authUser

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -88,7 +88,7 @@ To allow for failure, the `authUser` function has to be adjusted to a `Request[F
 error handling, we recommend an error [ADT] instead of a `String`.
 
 ```tut:silent
-val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli.pure(_ => IO(???))
+val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli(_ => IO(???))
 
 val onFailure: AuthedRoutes[String, IO] = Kleisli(req => OptionT.liftF(Forbidden(req.authInfo)))
 val middleware = AuthMiddleware(authUser, onFailure)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/auth/BasicAuthHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/auth/BasicAuthHttpEndpoint.scala
@@ -10,7 +10,7 @@ import org.http4s.server.middleware.authentication.BasicAuth
 class BasicAuthHttpEndpoint[F[_]](implicit F: Sync[F], R: AuthRepository[F, BasicCredentials])
     extends Http4sDsl[F] {
 
-  private val authedService: AuthedService[BasicCredentials, F] = AuthedService {
+  private val authedRoutes: AuthedRoutes[BasicCredentials, F] = AuthedRoutes.of {
     case GET -> Root as user =>
       Ok(s"Access Granted: ${user.username}")
   }
@@ -18,6 +18,6 @@ class BasicAuthHttpEndpoint[F[_]](implicit F: Sync[F], R: AuthRepository[F, Basi
   private val authMiddleware: AuthMiddleware[F, BasicCredentials] =
     BasicAuth[F, BasicCredentials]("Protected Realm", R.find)
 
-  val service: HttpRoutes[F] = authMiddleware(authedService)
+  val service: HttpRoutes[F] = authMiddleware(authedRoutes)
 
 }

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -182,14 +182,14 @@ class ExampleService[F[_]](implicit F: Effect[F], cs: ContextShift[F]) extends H
     if (creds.username == "username" && creds.password == "password") F.pure(Some(creds.username))
     else F.pure(None)
 
-  // An AuthedService[A, F] is a Service[F, (A, Request[F]), Response[F]] for some
+  // An AuthedRoutes[A, F] is a Service[F, (A, Request[F]), Response[F]] for some
   // user type A.  `BasicAuth` is an auth middleware, which binds an
-  // AuthedService to an authentication store.
+  // AuthedRoutes to an authentication store.
   val basicAuth: AuthMiddleware[F, String] = BasicAuth(realm, authStore)
 
   def authRoutes: HttpRoutes[F] =
-    basicAuth(AuthedService[String, F] {
-      // AuthedServices look like Services, but the user is extracted with `as`.
+    basicAuth(AuthedRoutes.of[String, F] {
+      // AuthedRoutes look like HttpRoutes, but the user is extracted with `as`.
       case GET -> Root / "protected" as user =>
         Ok(s"This page is protected using HTTP authentication; logged in as $user")
     })

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/package.scala
@@ -9,7 +9,7 @@ import org.http4s.headers._
 package object authentication {
   def challenged[F[_], A](
       challenge: Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]])(
-      routes: AuthedService[A, F])(implicit F: Sync[F]): HttpRoutes[F] =
+      routes: AuthedRoutes[A, F])(implicit F: Sync[F]): HttpRoutes[F] =
     Kleisli { req =>
       OptionT[F, Response[F]] {
         F.flatMap(challenge(req)) {

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -104,10 +104,10 @@ package object server {
 
     def apply[F[_], Err, T](
         authUser: Kleisli[F, Request[F], Either[Err, T]],
-        onFailure: AuthedService[Err, F]
+        onFailure: AuthedRoutes[Err, F]
     )(implicit F: Monad[F], C: Choice[Kleisli[OptionT[F, ?], ?, ?]]): AuthMiddleware[F, T] = {
-      service: AuthedService[T, F] =>
-        C.choice(onFailure, service)
+      routes: AuthedRoutes[T, F] =>
+        C.choice(onFailure, routes)
           .local { authed: AuthedRequest[F, Either[Err, T]] =>
             authed.authInfo.bimap(
               err => AuthedRequest(err, authed.req),

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 
 class AuthenticationSpec extends Http4sSpec {
 
-  def nukeService(launchTheNukes: => Unit) = AuthedService[String, IO] {
+  def nukeService(launchTheNukes: => Unit) = AuthedRoutes.of[String, IO] {
     case GET -> Root / "launch-the-nukes" as user =>
       for {
         _ <- IO(launchTheNukes)
@@ -35,7 +35,7 @@ class AuthenticationSpec extends Http4sSpec {
     else None
   }
 
-  val service = AuthedService[String, IO] {
+  val service = AuthedRoutes.of[String, IO] {
     case GET -> Root as user => Ok(user)
     case req as _ => Response.notFoundFor(req)
   }


### PR DESCRIPTION
- Add `of` and `apply` methods to `AuthedService` companion that are consistent with those for `HttpRoutes`
- Add `mapK` to AuthedRequest
- Add `mapK` extension method for AuthedService

AuthedService seems to have fallen behind `HttpRoutes` - perhaps it's worth a breaking PR to rename it to `AuthedRoutes` and change the order of the type params?

EDIT: The overloaded `apply` method on `AuthedService` caused a bunch of things to break. I've renamed the new one to `apply_` for now, but I'm not very happy with that name - thoughts? 