### PR TITLE
Release v0.20.1, take 2: fix publishable test

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -306,7 +306,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.13.v20181017"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.3"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.8.1"
-  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0"
+  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.1"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.0"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.6.0"
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.3.0"

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -45,7 +45,7 @@ object Http4sPlugin extends AutoPlugin {
       sys.env.get("TRAVIS").contains("true") &&
         sys.env.get("TRAVIS_PULL_REQUEST").contains("false") &&
         sys.env.get("TRAVIS_REPO_SLUG").contains("http4s/http4s") &&
-        sys.env.get("TRAVIS_JDK_VERSION").contains("oraclejdk8") &&
+        sys.env.get("TRAVIS_JDK_VERSION").contains("openjdk8") &&
         (sys.env.get("TRAVIS_BRANCH") match {
            case Some("master") => true
            case Some(branch) if branch.startsWith("series/") => true

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -8,7 +8,7 @@ Maintenance branches are merged before each new release. This change log is
 ordered chronologically, so each release contains all changes described below
 it.
 
-# v0.20.1 (2019-05-15)
+# v0.20.1 (2019-05-16)
 
 Users of blaze-client are strongly urged to upgrade.  This patch fixes a bug and passes new tests, but we still lack 100% confidence in it.  The async-http-client backend has proven stable for a large number of users.
 
@@ -33,6 +33,7 @@ Users of blaze-client are strongly urged to upgrade.  This patch fixes a bug and
 * [#2549](https://github.com/http4s/http4s/pull/2549): Remove workarounds in `BlazeClient` for [typelevel/cats-effect#487](https://github.com/typelevel/cats-effect/issues/487)
 
 ## Dependency updates
+* blaze-0.14.1
 * cats-effect-1.3.0
 * jetty-server-9.4.18.v20190429
 * metrics-core-4.1.0


### PR DESCRIPTION
This PR will again try to release v0.20.1 on merge.

We failed to publish 0.20.1 because it was looking for oraclejdk8 instead of openjdk8.  I think our build steps render that whole check unnecessary, but this is the easy fix shortly before midnight.

Threw in blaze-0.14.1, which I regretted missing earlier today.  Easier to do that in one PR than revert to a snapshot and then release again.