### PR TITLE
Upgrade to blaze-0.14.2

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -306,7 +306,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.13.v20181017"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.3"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.8.1"
-  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.0"
+  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.2"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.0"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.6.0"
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.3.0"


### PR DESCRIPTION
blaze-0.14.1 was a cursed release, because I published it with openjdk11.