### PR TITLE
Skip Travis on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: scala
 dist: xenial
 sudo: required
 
+if: tag IS blank
+
 stages:
   - name: test
   - name: publish


### PR DESCRIPTION
As it stands, Travis CI is responsible for the tagging, so we shouldn't let it build tags.