### PR TITLE
RequestLogger: drying up some code

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -59,35 +59,19 @@ object RequestLogger {
               // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
                 .observe(_.chunks.flatMap(c => Stream.eval_(vec.update(_ :+ c))))
             )
+            def logRequest: F[Unit] =
+              Logger.logMessage[F, Request[F]](req.withBodyStream(newBody))(
+                logHeaders,
+                logBody,
+                redactHeadersWhen
+              )(log)
             val response: G[Response[F]] =
               http(changedRequest)
                 .guaranteeCase {
-                  case ExitCase.Canceled =>
-                    fk(
-                      Logger.logMessage[F, Request[F]](req.withBodyStream(newBody))(
-                        logHeaders,
-                        logBody,
-                        redactHeadersWhen
-                      )(log))
-                  case ExitCase.Error(_) =>
-                    fk(
-                      Logger.logMessage[F, Request[F]](req.withBodyStream(newBody))(
-                        logHeaders,
-                        logBody,
-                        redactHeadersWhen
-                      )(log))
                   case ExitCase.Completed => G.unit
+                  case _ => fk(logRequest)
                 }
-                .map { resp =>
-                  resp.withBodyStream(
-                    resp.body.onFinalize(
-                      Logger.logMessage[F, Request[F]](req.withBodyStream(newBody))(
-                        logHeaders,
-                        logBody,
-                        redactHeadersWhen)(log)
-                    )
-                  )
-                }
+                .map(resp => resp.withBodyStream(resp.body.onFinalize(logRequest)))
             response
           }
       }


### PR DESCRIPTION
The operation to log the request was repeated three times, so we
extract it as a `def`. Also, folds two cases in the `guaranteeCase`.