### PR TITLE
Remove Redundant Braces.

### DIFF
--- a/core/src/main/scala/org/http4s/Credentials.scala
+++ b/core/src/main/scala/org/http4s/Credentials.scala
@@ -83,10 +83,9 @@ object BasicCredentials {
 
   def unapply(creds: Credentials): Option[(String, String)] =
     creds match {
-      case Credentials.Token(AuthScheme.Basic, token) => {
+      case Credentials.Token(AuthScheme.Basic, token) =>
         val basicCredentials = BasicCredentials(token)
         Some((basicCredentials.username, basicCredentials.password))
-      }
       case _ =>
         None
     }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -341,12 +341,11 @@ abstract class OptionalQueryParamMatcher[T: QueryParamDecoder: QueryParam]
   *
   *  object FooMatcher extends ValidatingQueryParamDecoderMatcher[Foo]("foo")
   *  val routes: HttpRoutes.of = {
-  *    case GET -> Root / "closest" :? FooMatcher(fooValue) => {
+  *    case GET -> Root / "closest" :? FooMatcher(fooValue) =>
   *      fooValue.fold(
   *        nelE => BadRequest(nelE.toList.map(_.sanitized).mkString("\n")),
   *        foo  => { ... }
   *      )
-  *    }
   * }}}
   */
 abstract class ValidatingQueryParamDecoderMatcher[T: QueryParamDecoder](name: String) {
@@ -371,14 +370,13 @@ abstract class ValidatingQueryParamDecoderMatcher[T: QueryParamDecoder](name: St
   *  object BarMatcher extends OptionalValidatingQueryParamDecoderMatcher[Bar]("bar")
   *
   *  val routes = HttpRoutes.of {
-  *    case GET -> Root / "closest" :? FooMatcher(fooValue) +& BarMatcher(barValue) => {
+  *    case GET -> Root / "closest" :? FooMatcher(fooValue) +& BarMatcher(barValue) =>
   *      ^(fooValue, barValue getOrElse 42.right) { (foo, bar) =>
   *        ...
   *      }.fold(
   *        nelE => BadRequest(nelE.toList.map(_.sanitized).mkString("\n")),
   *        baz  => { ... }
   *      )
-  *    }
   * }}}
   */
 abstract class OptionalValidatingQueryParamDecoderMatcher[T: QueryParamDecoder](name: String) {

--- a/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -17,12 +17,8 @@ object DefaultHead {
   def apply[F[_]: Functor, G[_]](http: Http[F, G])(implicit F: MonoidK[F]): Http[F, G] =
     Kleisli { req =>
       req.method match {
-        case Method.HEAD => {
-          (http <+> headAsTruncatedGet(http))(req)
-        }
-        case _ => {
-          http(req)
-        }
+        case Method.HEAD => (http <+> headAsTruncatedGet(http))(req)
+        case _ => http(req)
       }
     }
 

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
@@ -82,13 +82,12 @@ private[authentication] class NonceKeeper(
       checkStale()
       nonces.get(data) match {
         case null => NonceKeeper.StaleReply
-        case n: Nonce => {
+        case n: Nonce =>
           if (nc > n.nc) {
             n.nc = n.nc + 1
             NonceKeeper.OKReply
           } else
             NonceKeeper.BadNCReply
-        }
       }
     }
 }


### PR DESCRIPTION
Apparently redundant braces around the body of a `case` are not  detected and removed by ScalaFmt