### PR TITLE
Add New Function to AuthMiddleware to Use Either, not Option, for Determining Response  

### DIFF
--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -100,9 +100,9 @@ package object server {
     }
 
     def noSpiderWithEither[F[_]: Monad, E, T](
-                                  authUserWithError: Kleisli[EitherT[F, E, ?], Request[F], T],
-                                  onAuthFailure: (Request[F], E) => F[Response[F]]
-                                ): AuthMiddleware[F, T] = { service =>
+        authUserWithError: Kleisli[EitherT[F, E, ?], Request[F], T],
+        onAuthFailure: (Request[F], E) => F[Response[F]]
+    ): AuthMiddleware[F, T] = { service =>
       Kleisli { r: Request[F] =>
         val resp = authUserWithError(r).value.flatMap {
           case Right(authReq) =>

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -1,7 +1,6 @@
 package org.http4s
 
 import cats._
-import cats.arrow.Choice
 import cats.data.{EitherT, Kleisli, OptionT}
 import cats.implicits._
 import cats.effect._

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
@@ -230,7 +230,9 @@ class AuthMiddlewareSpec extends Http4sSpec {
 
       val authUserWithError: Kleisli[EitherT[IO, Error, ?], Request[IO], User] = Kleisli {
         case r @ GET -> Root / "hello" =>
-          if (r.headers.toList.map(_.name).contains[CaseInsensitiveString](CaseInsensitiveString("authorization")))
+          if (r.headers.toList
+              .map(_.name)
+              .contains[CaseInsensitiveString](CaseInsensitiveString("authorization")))
             EitherT.right[Error](IO.pure(42))
           else
             EitherT.left[User](IO.pure(NoAuth))
@@ -254,11 +256,18 @@ class AuthMiddlewareSpec extends Http4sSpec {
       val service = middleware(authedService)
 
       //Unauthenticated but path matches
-      service.orNotFound(Request[IO](method = Method.GET, uri = Uri.unsafeFromString("hello"))) must returnStatus(Unauthorized)
+      service.orNotFound(Request[IO](method = Method.GET, uri = Uri.unsafeFromString("hello"))) must returnStatus(
+        Unauthorized)
       //Matched normally
-      service.orNotFound(Request[IO](method = Method.GET, uri = Uri.unsafeFromString("hello"), headers = Headers.of((Header("Authorization", "..."))))) must returnStatus(Ok)
+      service.orNotFound(
+        Request[IO](
+          method = Method.GET,
+          uri = Uri.unsafeFromString("hello"),
+          headers = Headers.of((Header("Authorization", "..."))))) must returnStatus(Ok)
       //Unauthenticated and path does not match
-      service.orNotFound(Request[IO](method = Method.GET, uri = Uri.unsafeFromString("not-matched"))) must returnStatus(ServiceUnavailable)
+      service.orNotFound(Request[IO](
+        method = Method.GET,
+        uri = Uri.unsafeFromString("not-matched"))) must returnStatus(ServiceUnavailable)
 
     }
 

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
@@ -235,9 +235,9 @@ class AuthMiddlewareSpec extends Http4sSpec {
               .contains[CaseInsensitiveString](CaseInsensitiveString("authorization")))
             EitherT.right[Error](IO.pure(42))
           else
-            EitherT.left[User](IO.pure(NoAuth))
+            EitherT.left[User](IO.pure[Error](NoAuth))
         case _ =>
-          EitherT.left[User](IO.pure(NoPathMatch))
+          EitherT.left[User](IO.pure[Error](NoPathMatch))
       }
 
       val authedService: AuthedService[User, IO] =

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
@@ -220,7 +220,7 @@ class AuthMiddlewareSpec extends Http4sSpec {
 
     }
 
-    "return 'error' response for EitherT.left for noSpiderWithEither" in {
+    "behave as expected for noSpiderWithEither" in {
 
       import org.http4s.util.CaseInsensitiveString
 


### PR DESCRIPTION
Attempts to provide a somewhat cleaner way to address https://github.com/http4s/http4s/issues/2560.

I've intended to show a use case via the unit test that I added.