### PR TITLE
Using literall interpolators triggers Wartremover error

### DIFF
--- a/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
@@ -12,21 +12,21 @@ object LiteralSyntaxMacros {
       args,
       "Uri",
       Uri.fromString(_).isRight,
-      s => c.universe.reify(Uri.fromString(s.splice).right.get))
+      s => c.universe.reify(Uri.unsafeFromString(s.splice)))
 
   def mediaTypeInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[MediaType] =
     singlePartInterpolator(c)(
       args,
       "MediaType",
       MediaType.parse(_).isRight,
-      s => c.universe.reify(MediaType.parse(s.splice).right.get))
+      s => c.universe.reify(MediaType.unsafeParse(s.splice)))
 
   def qValueInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[QValue] =
     singlePartInterpolator(c)(
       args,
       "QValue",
       QValue.fromString(_).isRight,
-      s => c.universe.reify(QValue.fromString(s.splice).right.get))
+      s => c.universe.reify(QValue.unsafeFromString(s.splice)))
 
   private def singlePartInterpolator[A](c: blackbox.Context)(
       args: Seq[c.Expr[Any]],

--- a/core/src/main/scala/org/http4s/MediaType.scala
+++ b/core/src/main/scala/org/http4s/MediaType.scala
@@ -18,7 +18,7 @@
  */
 package org.http4s
 
-import cats.implicits._
+import cats.implicits.{catsSyntaxEither => _, _}
 import cats.{Eq, Order, Show}
 import org.http4s.headers.MediaRangeAndQValue
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
@@ -247,6 +247,14 @@ object MediaType extends MimeDB {
     new Http4sParser[MediaType](s, "Invalid Media Type") with MediaTypeParser {
       def main = MediaTypeFull
     }.parse
+
+  /** Parse a MediaType
+    *
+    * For totality, call [[#parse]]. For compile-time
+    * verification of literals, call [[#mediaType]].
+    */
+  def unsafeParse(s: String): MediaType =
+    parse(s).valueOr(throw _)
 
   private[http4s] trait MediaTypeParser extends MediaParser {
     def MediaTypeFull: Rule1[MediaType] = rule {

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -80,6 +80,9 @@ object QValue {
       case _: NumberFormatException => ParseResult.fail("Invalid q-value", s"${s} is not a number")
     }
 
+  def unsafeFromString(s: String): QValue =
+    fromString(s).valueOr(throw _)
+
   def parse(s: String): ParseResult[QValue] =
     new Http4sParser[QValue](s, "Invalid q-value") with QValueParser {
       def main = QualityValue


### PR DESCRIPTION
Change literal interpolator macros to use unsafe methods to avoid
triggering Wartremover EitherProjectionPartial warning.