### PR TITLE
Chunk Aggregator: rework

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -3,13 +3,13 @@ package server
 package middleware
 
 import cats.arrow.FunctionK
-import cats.{FlatMap, Functor, ~>}
+import cats.{FlatMap, ~>}
 import cats.data.{Kleisli, NonEmptyList, OptionT}
 import cats.effect.Sync
 import cats.implicits._
 import fs2._
 import org.http4s.headers._
-import org.http4s.headers._
+import scala.collection.mutable.ListBuffer
 
 object ChunkAggregator {
   def apply[F[_]: FlatMap, G[_]: Sync, A](f: G ~> F)(
@@ -19,9 +19,9 @@ object ChunkAggregator {
         response.body.chunks.compile.toVector
           .map { vec =>
             val body = Chunk.concatBytes(vec)
-            removeChunkedTransferEncoding[G](
-              response.withBodyStream(Stream.chunk(body)),
-              body.size.toLong)
+            response
+              .withBodyStream(Stream.chunk(body))
+              .transformHeaders(removeChunkedTransferEncoding(body.size.toLong))
           })
     }
 
@@ -31,24 +31,22 @@ object ChunkAggregator {
   def httpApp[F[_]: Sync](httpApp: HttpApp[F]): HttpApp[F] =
     apply(FunctionK.id[F])(httpApp)
 
-  private def removeChunkedTransferEncoding[G[_]: Functor](
-      resp: Response[G],
-      len: Long): Response[G] =
-    resp.transformHeaders { headers =>
-      val hs = Headers(headers.toList.flatMap {
-        // Remove the `TransferCoding.chunked` value from the `Transfer-Encoding` header,
-        // leaving the remaining values unchanged
-        case e: `Transfer-Encoding` =>
-          NonEmptyList
-            .fromList(e.values.filterNot(_ === TransferCoding.chunked))
-            .map(`Transfer-Encoding`.apply)
-            .toList
-        case `Content-Length`(_) =>
-          Nil
-        case header =>
-          List(header)
-      })
-      if (len > 0L) hs.put(`Content-Length`.unsafeFromLong(len))
-      else hs
+  /* removes the `TransferCoding.chunked` value from the `Transfer-Encoding` header,
+   removes the `Content-Length` header, and leaves the other headers unchanged */
+  private[this] def removeChunkedTransferEncoding(len: Long)(headers: Headers): Headers = {
+    val hh: ListBuffer[Header] = ListBuffer.empty[Header]
+    headers.toList.foreach {
+      case e: `Transfer-Encoding` =>
+        e.values.filterNot(_ === TransferCoding.chunked) match {
+          case v :: vs =>
+            hh += `Transfer-Encoding`(NonEmptyList(v, vs))
+          case Nil => // do nothing
+        }
+      case `Content-Length`(_) => // do nothing
+      case header => hh += header
     }
+    if (len > 0L)
+      hh += `Content-Length`.unsafeFromLong(len)
+    Headers(hh.toList)
+  }
 }


### PR DESCRIPTION
- Change the inner function removeChunkedTransferEncoding from
  function of `Response` to `Response` (which was asking for an
  unused `Functor` parameter) into a `Headers` to `Headers` function.

- Since `List.flatMap` would allocates two objects for each element of
  the result list, we use instead a mutable ListBuffer and a foreach.
  This "imperative" code is no longer than the "functional" one.