### PR TITLE
Generalize AuthedRequest to ContextRequest

### DIFF
--- a/core/src/main/scala/org/http4s/AuthedRequest.scala
+++ b/core/src/main/scala/org/http4s/AuthedRequest.scala
@@ -1,16 +1,13 @@
 package org.http4s
 
-import cats.{Functor, ~>}
+import cats.Functor
 import cats.data.Kleisli
-import cats.implicits._
-
-final case class AuthedRequest[F[_], A](authInfo: A, req: Request[F]) {
-  def mapK[G[_]](fk: F ~> G): AuthedRequest[G, A] =
-    AuthedRequest(authInfo, req.mapK(fk))
-}
 
 object AuthedRequest {
   def apply[F[_]: Functor, T](
       getUser: Request[F] => F[T]): Kleisli[F, Request[F], AuthedRequest[F, T]] =
-    Kleisli(request => getUser(request).map(user => AuthedRequest(user, request)))
+    ContextRequest[F, T](getUser)
+
+  def apply[F[_], T](context: T, req: Request[F]): AuthedRequest[F, T] =
+    ContextRequest[F, T](context, req)
 }

--- a/core/src/main/scala/org/http4s/AuthedRoutes.scala
+++ b/core/src/main/scala/org/http4s/AuthedRoutes.scala
@@ -29,7 +29,8 @@ object AuthedRoutes {
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
   def of[T, F[_]](pf: PartialFunction[AuthedRequest[F, T], F[Response[F]]])(
-      implicit F: Defer[F], FA: Applicative[F]): AuthedRoutes[T, F] =
+      implicit F: Defer[F],
+      FA: Applicative[F]): AuthedRoutes[T, F] =
     Kleisli(req => OptionT(F.defer(pf.lift(req).sequence)))
 
   /**

--- a/core/src/main/scala/org/http4s/ContextRequest.scala
+++ b/core/src/main/scala/org/http4s/ContextRequest.scala
@@ -6,8 +6,9 @@ import cats.data.Kleisli
 
 final case class ContextRequest[F[_], A](context: A, req: Request[F]) {
   def mapK[G[_]](fk: F ~> G): ContextRequest[G, A] =
-    ContextRequest(authInfo, req.mapK(fk))
+    ContextRequest(context, req.mapK(fk))
 
+  @deprecated("Use context instead", "0.21.0")
   def authInfo: A = context
 
 }

--- a/core/src/main/scala/org/http4s/ContextRequest.scala
+++ b/core/src/main/scala/org/http4s/ContextRequest.scala
@@ -1,0 +1,19 @@
+package org.http4s
+
+import cats.syntax.functor._
+import cats.{Functor, ~>}
+import cats.data.Kleisli
+
+final case class ContextRequest[F[_], A](context: A, req: Request[F]) {
+  def mapK[G[_]](fk: F ~> G): ContextRequest[G, A] =
+    ContextRequest(authInfo, req.mapK(fk))
+
+  def authInfo: A = context
+
+}
+
+object ContextRequest {
+  def apply[F[_]: Functor, T](
+      getContext: Request[F] => F[T]): Kleisli[F, Request[F], ContextRequest[F, T]] =
+    Kleisli(request => getContext(request).map(ctx => ContextRequest(ctx, request)))
+}

--- a/core/src/main/scala/org/http4s/ContextRoutes.scala
+++ b/core/src/main/scala/org/http4s/ContextRoutes.scala
@@ -1,0 +1,44 @@
+package org.http4s
+
+import cats.data.{Kleisli, OptionT}
+import cats.Applicative
+import cats.effect.Sync
+
+object ContextRoutes {
+
+  /** Lifts a function into an [[ContextRoutes]].  The application of `run`
+    * is suspended in `F` to permit more efficient combination of
+    * routes via `SemigroupK`.
+    *
+    * @tparam F the effect of the [[ContextRoutes]]
+    * @tparam T the type of the auth info in the [[ContextRequest]] accepted by the [[ContextRoutes]]
+    * @param run the function to lift
+    * @return an [[ContextRoutes]] that wraps `run`
+    */
+  def apply[T, F[_]](run: ContextRequest[F, T] => OptionT[F, Response[F]])(
+      implicit F: Sync[F]): ContextRoutes[T, F] =
+    Kleisli(req => OptionT(F.suspend(run(req).value)))
+
+  /** Lifts a partial function into an [[ContextRoutes]].  The application of the
+    * partial function is suspended in `F` to permit more efficient combination
+    * of authed services via `SemigroupK`.
+    *
+    * @tparam F the base effect of the [[ContextRoutes]]
+    * @param pf the partial function to lift
+    * @return An [[ContextRoutes]] that returns some [[Response]] in an `OptionT[F, ?]`
+    * wherever `pf` is defined, an `OptionT.none` wherever it is not
+    */
+  def of[T, F[_]](pf: PartialFunction[ContextRequest[F, T], F[Response[F]]])(
+      implicit F: Applicative[F]): ContextRoutes[T, F] =
+    Kleisli(req => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none)))
+
+  /**
+    * The empty service (all requests fallthrough).
+    *
+    * @tparam T - ignored.
+    * @return
+    */
+  def empty[T, F[_]: Applicative]: ContextRoutes[T, F] =
+    Kleisli.liftF(OptionT.none)
+
+}

--- a/core/src/main/scala/org/http4s/ContextRoutes.scala
+++ b/core/src/main/scala/org/http4s/ContextRoutes.scala
@@ -1,8 +1,8 @@
 package org.http4s
 
 import cats.data.{Kleisli, OptionT}
-import cats.Applicative
-import cats.effect.Sync
+import cats.{Applicative, Defer}
+import cats.implicits._
 
 object ContextRoutes {
 
@@ -16,8 +16,8 @@ object ContextRoutes {
     * @return an [[ContextRoutes]] that wraps `run`
     */
   def apply[T, F[_]](run: ContextRequest[F, T] => OptionT[F, Response[F]])(
-      implicit F: Sync[F]): ContextRoutes[T, F] =
-    Kleisli(req => OptionT(F.suspend(run(req).value)))
+      implicit F: Defer[F]): ContextRoutes[T, F] =
+    Kleisli(req => OptionT(F.defer(run(req).value)))
 
   /** Lifts a partial function into an [[ContextRoutes]].  The application of the
     * partial function is suspended in `F` to permit more efficient combination
@@ -29,8 +29,8 @@ object ContextRoutes {
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
   def of[T, F[_]](pf: PartialFunction[ContextRequest[F, T], F[Response[F]]])(
-      implicit F: Applicative[F]): ContextRoutes[T, F] =
-    Kleisli(req => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none)))
+      implicit F: Defer[F], FA: Applicative[F]): ContextRoutes[T, F] =
+    Kleisli(req => OptionT(F.defer(pf.lift(req).sequence)))
 
   /**
     * The empty service (all requests fallthrough).

--- a/core/src/main/scala/org/http4s/ContextRoutes.scala
+++ b/core/src/main/scala/org/http4s/ContextRoutes.scala
@@ -29,7 +29,8 @@ object ContextRoutes {
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
   def of[T, F[_]](pf: PartialFunction[ContextRequest[F, T], F[Response[F]]])(
-      implicit F: Defer[F], FA: Applicative[F]): ContextRoutes[T, F] =
+      implicit F: Defer[F],
+      FA: Applicative[F]): ContextRoutes[T, F] =
     Kleisli(req => OptionT(F.defer(pf.lift(req).sequence)))
 
   /**

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -55,6 +55,8 @@ package object http4s { // scalastyle:ignore
   @deprecated("Deprecated in favor of HttpRoutes", "0.19")
   type HttpService[F[_]] = HttpRoutes[F]
 
+  type AuthedRequest[F[_], T] = ContextRequest[F, T]
+
   /**
     * The type parameters need to be in this order to make partial unification
     * trigger. See https://github.com/http4s/http4s/issues/1506
@@ -63,6 +65,8 @@ package object http4s { // scalastyle:ignore
 
   @deprecated("Deprecated in favor of AuthedRoutes", "0.20.1")
   type AuthedService[T, F[_]] = AuthedRoutes[T, F]
+
+  type ContextRoutes[T, F[_]] = Kleisli[OptionT[F, ?], ContextRequest[F, T], Response[F]]
 
   type Callback[A] = Either[Throwable, A] => Unit
 

--- a/docs/src/main/tut/auth.md
+++ b/docs/src/main/tut/auth.md
@@ -131,7 +131,7 @@ error handling, we recommend an error [ADT] instead of a `String`.
 ```tut:silent
 val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli(_ => IO(???))
 
-val onFailure: AuthedRoutes[String, IO] = Kleisli(req => OptionT.liftF(Forbidden(req.authInfo)))
+val onFailure: AuthedRoutes[String, IO] = Kleisli(req => OptionT.liftF(Forbidden(req.context)))
 val middleware = AuthMiddleware(authUser, onFailure)
 
 val service: HttpRoutes[IO] = middleware(authedRoutes)

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Auth.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Auth.scala
@@ -5,6 +5,6 @@ import org.http4s.{AuthedRequest, Request}
 trait Auth {
   object as {
     def unapply[F[_], A](ar: AuthedRequest[F, A]): Option[(Request[F], A)] =
-      Some(ar.req -> ar.authInfo)
+      Some(ar.req -> ar.context)
   }
 }

--- a/server/src/main/scala/org/http4s/server/ContextMiddleware.scala
+++ b/server/src/main/scala/org/http4s/server/ContextMiddleware.scala
@@ -1,0 +1,11 @@
+package org.http4s
+package server
+
+import cats.Monad
+import cats.data.{Kleisli, OptionT}
+
+object ContextMiddleware {
+  def apply[F[_]: Monad, T](
+      getContext: Kleisli[OptionT[F, ?], Request[F], T]): ContextMiddleware[F, T] =
+    _.compose(Kleisli((r: Request[F]) => getContext(r).map(ContextRequest(_, r))))
+}

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -72,6 +72,12 @@ package object server {
     Middleware[OptionT[F, ?], AuthedRequest[F, T], Response[F], Request[F], Response[F]]
 
   /**
+    * An HTTP middleware that adds a context.
+    */
+  type ContextMiddleware[F[_], T] =
+    Middleware[OptionT[F, ?], ContextRequest[F, T], Response[F], Request[F], Response[F]]
+
+  /**
     * Old name for SSLConfig
     */
   @deprecated("Use SSLConfig", "2016-12-31")

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSpec.scala
@@ -18,7 +18,7 @@ class AuthMiddlewareSpec extends Http4sSpec {
         Kleisli.pure(Left("Unauthorized"))
 
       val onAuthFailure: AuthedRoutes[String, IO] =
-        Kleisli(req => OptionT.liftF(Forbidden(req.authInfo)))
+        Kleisli(req => OptionT.liftF(Forbidden(req.context)))
 
       val authedRoutes: AuthedRoutes[User, IO] =
         AuthedRoutes.of {
@@ -41,7 +41,7 @@ class AuthMiddlewareSpec extends Http4sSpec {
         Kleisli.pure(Right(userId))
 
       val onAuthFailure: AuthedRoutes[String, IO] =
-        Kleisli(req => OptionT.liftF(Forbidden(req.authInfo)))
+        Kleisli(req => OptionT.liftF(Forbidden(req.context)))
 
       val authedRoutes: AuthedRoutes[User, IO] =
         AuthedRoutes.of {
@@ -63,7 +63,7 @@ class AuthMiddlewareSpec extends Http4sSpec {
         Kleisli.pure(Right(userId))
 
       val onAuthFailure: AuthedRoutes[String, IO] =
-        Kleisli(req => OptionT.liftF(Forbidden(req.authInfo)))
+        Kleisli(req => OptionT.liftF(Forbidden(req.context)))
 
       val authedRoutes: AuthedRoutes[User, IO] =
         AuthedRoutes.of {


### PR DESCRIPTION
A ContextRequest is defined as a request with some data.

AuthedRequest can be defined as a ContextRequest with auth data
as the context.

AuthedRequest signals that it should only be used for auth stuff, but
ContextRequest opens up possibility to reuse it to other things.