### PR TITLE
Model Server header

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -10,7 +10,8 @@ import javax.net.ssl.SSLContext
 import org.http4s.blaze.channel.ChannelOptions
 import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.blazecore.{BlazeBackendBuilder, tickWheelResource}
-import org.http4s.headers.{AgentProduct, `User-Agent`}
+import org.http4s.headers.`User-Agent`
+import org.http4s.ProductId
 import org.http4s.internal.BackendBuilder
 import org.log4s.getLogger
 
@@ -283,7 +284,7 @@ object BlazeClientBuilder {
       idleTimeout = 1.minute,
       requestTimeout = defaults.RequestTimeout,
       connectTimeout = defaults.ConnectTimeout,
-      userAgent = Some(`User-Agent`(AgentProduct("http4s-blaze", Some(BuildInfo.version)))),
+      userAgent = Some(`User-Agent`(ProductId("http4s-blaze", Some(BuildInfo.version)))),
       maxTotalConnections = 10,
       maxWaitQueueLimit = 256,
       maxConnectionsPerRequestKey = Function.const(256),

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/bits.scala
@@ -5,7 +5,8 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.{SSLContext, X509TrustManager}
 import org.http4s.BuildInfo
 import org.http4s.blaze.util.TickWheelExecutor
-import org.http4s.headers.{AgentProduct, `User-Agent`}
+import org.http4s.headers.`User-Agent`
+import org.http4s.ProductId
 import scala.concurrent.duration._
 
 private[blaze] object bits {
@@ -13,7 +14,7 @@ private[blaze] object bits {
   val DefaultResponseHeaderTimeout: Duration = 10.seconds
   val DefaultTimeout: Duration = 60.seconds
   val DefaultBufferSize: Int = 8 * 1024
-  val DefaultUserAgent = Some(`User-Agent`(AgentProduct("http4s-blaze", Some(BuildInfo.version))))
+  val DefaultUserAgent = Some(`User-Agent`(ProductId("http4s-blaze", Some(BuildInfo.version))))
   val DefaultMaxTotalConnections = 10
   val DefaultMaxWaitQueueLimit = 256
 

--- a/core/src/main/scala/org/http4s/ProductIdOrComment.scala
+++ b/core/src/main/scala/org/http4s/ProductIdOrComment.scala
@@ -1,0 +1,24 @@
+package org.http4s
+
+import org.http4s.util.{Renderable, Writer}
+
+sealed trait ProductIdOrComment extends Renderable
+
+final case class ProductId(value: String, version: Option[String] = None)
+    extends ProductIdOrComment {
+
+  override def render(writer: Writer): writer.type = {
+    writer << value
+    version.foreach { v =>
+      writer << '/' << v
+    }
+    writer
+  }
+}
+
+final case class ProductComment(value: String) extends ProductIdOrComment {
+  override def render(writer: Writer): writer.type = {
+    writer << '(' << value << ')'
+    writer
+  }
+}

--- a/core/src/main/scala/org/http4s/headers/Server.scala
+++ b/core/src/main/scala/org/http4s/headers/Server.scala
@@ -1,4 +1,28 @@
 package org.http4s
 package headers
 
-object Server extends HeaderKey.Default
+import org.http4s.parser.HttpHeaderParser
+import org.http4s.util.Writer
+
+object Server extends HeaderKey.Internal[Server] with HeaderKey.Singleton {
+  override def parse(s: String): ParseResult[Server] =
+    HttpHeaderParser.SERVER(s)
+}
+
+/**
+  * Server header
+  * https://tools.ietf.org/html/rfc7231#section-7.4.2
+  */
+final case class Server(product: ProductId, rest: List[ProductIdOrComment]) extends Header.Parsed {
+  def key: Server.type = Server
+
+  override def renderValue(writer: Writer): writer.type = {
+    writer << product
+    rest.foreach {
+      case p: ProductId => writer << ' ' << p
+      case ProductComment(c) => writer << ' ' << '(' << c << ')'
+    }
+    writer
+  }
+
+}

--- a/core/src/main/scala/org/http4s/headers/Server.scala
+++ b/core/src/main/scala/org/http4s/headers/Server.scala
@@ -5,6 +5,9 @@ import org.http4s.parser.HttpHeaderParser
 import org.http4s.util.Writer
 
 object Server extends HeaderKey.Internal[Server] with HeaderKey.Singleton {
+  def apply(id: ProductId): Server =
+    new Server(id, Nil)
+
   override def parse(s: String): ParseResult[Server] =
     HttpHeaderParser.SERVER(s)
 }

--- a/core/src/main/scala/org/http4s/headers/User-Agent.scala
+++ b/core/src/main/scala/org/http4s/headers/User-Agent.scala
@@ -2,38 +2,29 @@ package org.http4s
 package headers
 
 import org.http4s.parser.HttpHeaderParser
-import org.http4s.util.{Renderable, Writer}
+import org.http4s.util.Writer
 
 object `User-Agent` extends HeaderKey.Internal[`User-Agent`] with HeaderKey.Singleton {
+  def apply(id: ProductId): `User-Agent` =
+    new `User-Agent`(id, Nil)
+
   override def parse(s: String): ParseResult[`User-Agent`] =
     HttpHeaderParser.USER_AGENT(s)
 }
 
-sealed trait AgentToken extends Renderable
-
-final case class AgentProduct(name: String, version: Option[String] = None) extends AgentToken {
-  override def render(writer: Writer): writer.type = {
-    writer << name
-    version.foreach { v =>
-      writer << '/' << v
-    }
-    writer
-  }
-}
-final case class AgentComment(comment: String) extends AgentToken {
-  override def renderString: String = comment
-  override def render(writer: Writer): writer.type = writer << comment
-}
-
-final case class `User-Agent`(product: AgentProduct, other: List[AgentToken] = Nil)
+/**
+  * User-Agent header
+  * https://tools.ietf.org/html/rfc7231#section-5.5.3
+  */
+final case class `User-Agent`(product: ProductId, rest: List[ProductIdOrComment])
     extends Header.Parsed {
   def key: `User-Agent`.type = `User-Agent`
 
   override def renderValue(writer: Writer): writer.type = {
     writer << product
-    other.foreach {
-      case p: AgentProduct => writer << ' ' << p
-      case AgentComment(c) => writer << ' ' << '(' << c << ')'
+    rest.foreach {
+      case p: ProductId => writer << ' ' << p
+      case ProductComment(c) => writer << ' ' << '(' << c << ')'
     }
     writer
   }

--- a/core/src/main/scala/org/http4s/headers/package.scala
+++ b/core/src/main/scala/org/http4s/headers/package.scala
@@ -48,4 +48,13 @@ package object headers {
             .append(idMostSigBits.toHexString)
         }
     }
+
+  @deprecated("Deprecated in favor of HttpToken", "0.18")
+  type AgentToken = ProductIdOrComment
+
+  @deprecated("Deprecated in favor of HttpComment", "0.18")
+  type AgentComment = ProductComment
+
+  @deprecated("Deprecated in favor of HttpProduct", "0.18")
+  type AgentProduct = ProductId
 }

--- a/core/src/main/scala/org/http4s/headers/package.scala
+++ b/core/src/main/scala/org/http4s/headers/package.scala
@@ -49,12 +49,12 @@ package object headers {
         }
     }
 
-  @deprecated("Deprecated in favor of HttpToken", "0.18")
+  @deprecated("Deprecated in favor of HttpToken", "0.22")
   type AgentToken = ProductIdOrComment
 
-  @deprecated("Deprecated in favor of HttpComment", "0.18")
+  @deprecated("Deprecated in favor of HttpComment", "0.22")
   type AgentComment = ProductComment
 
-  @deprecated("Deprecated in favor of HttpProduct", "0.18")
+  @deprecated("Deprecated in favor of HttpProduct", "0.22")
   type AgentProduct = ProductId
 }

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -112,7 +112,8 @@ private[parser] trait CookieHeader {
     def StringValue: Rule1[String] = rule { capture(oneOrMore((!(CTL | ch(';'))) ~ Char)) }
 
     def SameSite: Rule1[SameSite] = rule {
-      ignoreCase("strict") ~ push(Strict) | ignoreCase("lax") ~ push(Lax) | ignoreCase("none") ~ push(None)
+      ignoreCase("strict") ~ push(Strict) | ignoreCase("lax") ~ push(Lax) | ignoreCase("none") ~ push(
+        None)
     }
   }
   // scalastyle:on public.methods.have.type

--- a/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
+++ b/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
@@ -145,6 +145,7 @@ object HttpHeaderParser
     addParser_("RANGE".ci, `RANGE`)
     addParser_("REFERER".ci, `REFERER`)
     addParser_("RETRY-AFTER".ci, `RETRY_AFTER`)
+    addParser_("SERVER".ci, `SERVER`)
     addParser_("SET-COOKIE".ci, `SET_COOKIE`)
     addParser_("STRICT-TRANSPORT-SECURITY".ci, `STRICT_TRANSPORT_SECURITY`)
     addParser_("TRANSFER-ENCODING".ci, `TRANSFER_ENCODING`)


### PR DESCRIPTION
This is a model for the Server header as for #2011. `User-Agent` and `Server` parse the same way so I unified the parsers and component classes:
`AgentProduct` -> `HeaderProduct`
`AgentToken` -> `HeaderToken`
`AgentComment` -> `HeaderComment`

I'm not sure if this is the right approach an it breaks mima. Feel free to comment

Should Blaze return a server header like
`Server: blaze-http4s/0.21.0`?
