### PR TITLE
Add renderedLength to Header to support unchunked multipart

### DIFF
--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -67,6 +67,10 @@ sealed trait Header extends Renderable with Product {
         (parsed.productIterator.sameElements(h.parsed.productIterator))
     case _ => false
   }
+
+  /** Length of the rendered header, including name and final '\r\n' */
+  def renderedLength: Long =
+    render(new HeaderLengthCountingWriter).length + 2
 }
 
 object Header {

--- a/core/src/main/scala/org/http4s/util/Renderable.scala
+++ b/core/src/main/scala/org/http4s/util/Renderable.scala
@@ -185,3 +185,13 @@ class StringWriter(size: Int = StringWriter.InitialCapacity) extends Writer {
 object StringWriter {
   private val InitialCapacity = 64
 }
+
+private[http4s] class HeaderLengthCountingWriter extends Writer {
+  var length: Long = 0L
+
+  def append(s: String): this.type = {
+    // Assumption: 1 byte per character. Only US-ASCII is supported.
+    length = length + s.length
+    this
+  }
+}

--- a/tests/src/test/scala/org/http4s/HeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeaderSpec.scala
@@ -1,9 +1,10 @@
 package org.http4s
 
+import java.nio.charset.StandardCharsets.ISO_8859_1
 import org.http4s.headers._
-import org.specs2.mutable.Specification
+import org.http4s.util.StringWriter
 
-class HeaderSpec extends Specification {
+class HeaderSpec extends Http4sSpec {
   "Headers" should {
     "Equate same headers" in {
       val h1 = `Content-Length`.unsafeFromLong(4)
@@ -60,4 +61,12 @@ class HeaderSpec extends Specification {
     }
   }
 
+  "rendered length" should {
+    "is rendered length including \\r\\n" in prop { h: Header =>
+      h.render(new StringWriter << "\r\n")
+        .result
+        .getBytes(ISO_8859_1)
+        .length must_== h.renderedLength
+    }
+  }
 }


### PR DESCRIPTION
Useful for #2620.