### PR TITLE
Don't depend on laziness of SSLContext in blaze-client

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -128,7 +128,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
   /** Disable secure calls */
   def withoutSslContext: BlazeClientBuilder[F] =
-    withDefaultSslContext
+    copy(sslContext = None)
 
   def withCheckEndpointAuthentication(checkEndpointIdentification: Boolean): BlazeClientBuilder[F] =
     copy(checkEndpointIdentification = checkEndpointIdentification)

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -11,6 +11,7 @@ import org.http4s.headers.{AgentProduct, `User-Agent`}
 import org.http4s.internal.BackendBuilder
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import scala.util.control.NonFatal
 
 /**
   * @param sslContext Some custom `SSLContext`, or `None` if the
@@ -112,21 +113,20 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
   /** Use the provided `SSLContext` when making secure calls */
   def withSslContext(sslContext: SSLContext): BlazeClientBuilder[F] =
-    copy(sslContext = Some(sslContext))
+    withSslContextOption(Some(sslContext))
 
   /** Use an `SSLContext` obtained by `SSLContext.getDefault()` when making secure calls.
     *
-    * The creation of the context is lazy, as `SSLContext.getDefault()` throws on some
-    * platforms.  The context creation is deferred until the first secure client call.
+    * Since 0.21, the creation is not deferred.
     */
   def withDefaultSslContext: BlazeClientBuilder[F] =
-    copy(sslContext = None)
+    withSslContext(SSLContext.getDefault())
 
-  @deprecated("Use `withSslContext` or `withDefaultSslContext`", "0.20.2")
+  /** Use some provided `SSLContext` when making secure calls, or disable secure calls with `None` */
   def withSslContextOption(sslContext: Option[SSLContext]): BlazeClientBuilder[F] =
     copy(sslContext = sslContext)
 
-  @deprecated("Use `withDefaultSslContext`", "0.20.2")
+  /** Disable secure calls */
   def withoutSslContext: BlazeClientBuilder[F] =
     withDefaultSslContext
 
@@ -207,9 +207,15 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 }
 
 object BlazeClientBuilder {
+
+  /** Creates a BlazeClientBuilder
+    *
+    * @param executionContext the ExecutionContext for blaze's internal Futures
+    * @param sslContext Some `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
+    */
   def apply[F[_]: ConcurrentEffect](
       executionContext: ExecutionContext,
-      sslContext: Option[SSLContext] = None): BlazeClientBuilder[F] =
+      sslContext: Option[SSLContext] = tryDefaultSslContext): BlazeClientBuilder[F] =
     new BlazeClientBuilder[F](
       responseHeaderTimeout = 10.seconds,
       idleTimeout = 1.minute,
@@ -230,4 +236,10 @@ object BlazeClientBuilder {
       asynchronousChannelGroup = None,
       channelOptions = ChannelOptions(Vector.empty)
     ) {}
+
+  private def tryDefaultSslContext: Option[SSLContext] =
+    try Some(SSLContext.getDefault())
+    catch {
+      case NonFatal(_) => None
+    }
 }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -103,8 +103,8 @@ class BlazeClientSpec extends Http4sSpec {
           val resp = mkClient(1, sslContextOption = None)
             .use(_.expect[String](u))
             .attempt
-            .unsafeRunTimed(timeout)
-          resp must beSome(beLeft(beAnInstanceOf[IllegalStateException]))
+            .unsafeRunTimed(1.second)
+          resp must beSome(beLeft[Throwable](beAnInstanceOf[IllegalStateException]))
         }
 
         "behave and not deadlock" in {

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -6,6 +6,7 @@ import cats.effect.concurrent.{Deferred, Ref}
 import cats.implicits._
 import fs2.Stream
 import java.util.concurrent.TimeoutException
+import javax.net.ssl.SSLContext
 import javax.servlet.ServletOutputStream
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import org.http4s._
@@ -23,10 +24,11 @@ class BlazeClientSpec extends Http4sSpec {
       maxTotalConnections: Int = 5,
       responseHeaderTimeout: Duration = 1.minute,
       requestTimeout: Duration = 1.minute,
-      chunkBufferMaxSize: Int = 1024
+      chunkBufferMaxSize: Int = 1024,
+      sslContextOption: Option[SSLContext] = Some(bits.TrustingSslContext)
   ) =
     BlazeClientBuilder[IO](testExecutionContext)
-      .withSslContext(bits.TrustingSslContext)
+      .withSslContextOption(sslContextOption)
       .withCheckEndpointAuthentication(false)
       .withResponseHeaderTimeout(responseHeaderTimeout)
       .withRequestTimeout(requestTimeout)
@@ -92,6 +94,17 @@ class BlazeClientSpec extends Http4sSpec {
           val u = Uri.fromString(s"https://$name:$port/simple").yolo
           val resp = mkClient(1).use(_.expect[String](u)).unsafeRunTimed(timeout)
           resp.map(_.length > 0) must beSome(true)
+        }
+
+        "reject https requests when no SSLContext is configured" in {
+          val name = sslAddress.getHostName
+          val port = sslAddress.getPort
+          val u = Uri.fromString(s"https://$name:$port/simple").yolo
+          val resp = mkClient(1, sslContextOption = None)
+            .use(_.expect[String](u))
+            .attempt
+            .unsafeRunTimed(timeout)
+          resp must beSome(beLeft(beAnInstanceOf[IllegalStateException]))
         }
 
         "behave and not deadlock" in {

--- a/core/src/main/scala/org/http4s/AuthedRequest.scala
+++ b/core/src/main/scala/org/http4s/AuthedRequest.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats.{~>, Functor}
+import cats.{Functor, ~>}
 import cats.data.Kleisli
 import cats.implicits._
 


### PR DESCRIPTION
Changes the `Option[SSLContext]` to be truly optional instead of a sneaky laziness in the innards of the client.

The default remains `Some(SSLContext.getDefault())`, except on systems where this fails, in which case the error is caught and SSL is disabled.  Any client may now opt out of SSL support by calling `withoutSslContext`.  Making an https call on a client where SSL is disabled now results in an `IllegalStateException` with suggestions how to configure it, rather than throwing whatever exception may come from `SSLContext.getDefault()`.

Refines the changes in #2604.  Is binary compatible, but changes the behavior of weird cases.