### PR TITLE
Change MultipartParser to drain the multipart epilogue

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
@@ -2,6 +2,7 @@ package org.http4s
 package server
 package blaze
 
+import cats.implicits._
 import cats.effect.IO
 import java.net.{HttpURLConnection, URL}
 import java.nio.charset.StandardCharsets
@@ -9,6 +10,8 @@ import org.http4s.blaze.channel.ChannelOptions
 import org.http4s.dsl.io._
 import scala.concurrent.duration._
 import scala.io.Source
+import org.specs2.execute.Result
+import org.http4s.multipart.Multipart
 
 class BlazeServerSpec extends Http4sSpec {
 
@@ -30,6 +33,11 @@ class BlazeServerSpec extends Http4sSpec {
 
     case _ -> Root / "never" =>
       IO.never
+
+    case req @ POST -> Root / "issue2610" =>
+      req.decode[Multipart[IO]] { mp =>
+        Ok(mp.parts.foldMap(_.body))
+      }
 
     case _ => NotFound()
   }
@@ -70,6 +78,19 @@ class BlazeServerSpec extends Http4sSpec {
       Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
     }
 
+    // This too
+    def postChunkedMultipart(path: String, boundary: String, body: String): IO[String] = IO {
+      val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
+      val conn = url.openConnection().asInstanceOf[HttpURLConnection]
+      val bytes = body.getBytes(StandardCharsets.UTF_8)
+      conn.setRequestMethod("POST")
+      conn.setChunkedStreamingMode(-1)
+      conn.setRequestProperty("Content-Type", s"""multipart/form-data; boundary="$boundary"""")
+      conn.setDoOutput(true)
+      conn.getOutputStream.write(bytes)
+      Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+    }
+
     "A server" should {
       "route requests on the service executor" in {
         get("/thread/routing") must startWith("http4s-spec-")
@@ -86,6 +107,25 @@ class BlazeServerSpec extends Http4sSpec {
 
       "return a 503 if the server doesn't respond" in {
         getStatus("/never") must returnValue(Status.ServiceUnavailable)
+      }
+
+      "reliably handle multipart requests" in {
+        val body =
+          """|--aa
+             |Content-Disposition: form-data; name="a"
+             |Content-Length: 1
+             |
+             |a
+             |--aa--""".stripMargin.replace("\n", "\r\n")
+
+        // This is flaky due to Blaze threading and Java connection pooling.
+        Result.foreach(1 to 100) { _ =>
+          postChunkedMultipart(
+            "/issue2610",
+            "aa",
+            body
+          ) must returnValue("a")
+        }
       }
     }
   }

--- a/tests/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartParserSpec.scala
@@ -4,6 +4,7 @@ package multipart
 import java.nio.charset.StandardCharsets
 
 import cats.effect._
+import cats.effect.concurrent.Ref
 import cats.instances.string._
 import fs2._
 import org.http4s.headers._
@@ -531,6 +532,33 @@ object MultipartParserSpec extends Specification {
           .foldMonoid
           .unsafeRunSync() must_== "Text_Field_1"
         confirmedError must beAnInstanceOf[Left[MalformedMessageBodyFailure, _]]
+      }
+
+      Fragments.foreach(List(1, 2, 3, 5, 8, 13, 21, 987)) { chunkSize =>
+        s"drain the epilogue with chunk size $chunkSize" in {
+          val unprocessedInput =
+            """
+            |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI
+            |Content-Disposition: form-data; name="foo"
+            |
+            |bar
+            |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI--
+            |This should be ignored, but still drained!""".stripMargin
+
+          val input = ruinDelims(unprocessedInput)
+
+          val checkReachedTheEnd: IO[Boolean] = for {
+            // This should be false until we drain the whole input.
+            ref <- Ref[IO].of(false)
+            trackedInput = unspool(input, chunkSize) ++ Stream.eval_(ref.set(true))
+
+            _ <- trackedInput.through(multipartPipe(boundary)).compile.drain
+
+            reachedTheEnd <- ref.get
+          } yield reachedTheEnd
+
+          checkReachedTheEnd.unsafeRunSync() must_=== true
+        }
       }
 
       "fail with an MalformedMessageBodyFailure without an end line" in {


### PR DESCRIPTION
Fixes #2610 

This is a slightly hacky (although technically correct) way to make sure the `chunked` parser pulls the terminating zero-length "chunk" when working with the `MultipartParser`. See #2610 for more information. This also includes a test for #2610, but I only got it to work (that is, to fail on `master`) with Java 8. With Java 11 everything seems to work OK as is. Not sure what that's about.

I'm also not sure I got all the points where `MultipartParser` finishes parsing - I'd appreciate if someone familiar with it took a look. That whole file looks completely alien to me. :smile:
