### PR TITLE
Add emap and emapValidatedNel to QueryParamDecoder

### DIFF
--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -118,6 +118,17 @@ trait QueryParamDecoder[T] { outer =>
         outer.decode(value).orElse(qpd.decode(value))
     }
 
+  /** Validate the currently parsed value a function to Either[ParseFailure, ?]. */
+  def emap[U](f: T => Either[ParseFailure, U]): QueryParamDecoder[U] =
+    emapValidatedNel(f.andThen(_.toValidatedNel))
+
+  /** Validate the currently parsed value using a function to ValidatedNel[ParseFailure, ?]. */
+  def emapValidatedNel[U](f: T => ValidatedNel[ParseFailure, U]): QueryParamDecoder[U] =
+    new QueryParamDecoder[U] {
+      override def decode(value: QueryParameterValue) =
+        outer.decode(value).andThen(f)
+    }
+
 }
 
 object QueryParamDecoder {


### PR DESCRIPTION
Allows to create `QueryParamDecoder` instances more easily by starting from a simple type and validate & lift into something more specific, for example using some function like `String` => `Either[BadFormat, TelephoneNumber]`.

More details on #1997 