### PR TITLE
DRAFT: HttpResource

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -27,6 +27,7 @@ import org.http4s.blaze.pipeline.LeafBuilder
 import org.http4s.blaze.pipeline.stages.SSLStage
 import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.blazecore.{BlazeBackendBuilder, tickWheelResource}
+import org.http4s.internal.resourceLiftK
 import org.http4s.server.ServerRequestKeys
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import org.http4s.util.threads.threadFactory
@@ -85,7 +86,7 @@ class BlazeServerBuilder[F[_]](
     maxRequestLineLen: Int,
     maxHeadersLen: Int,
     chunkBufferMaxSize: Int,
-    httpApp: HttpApp[F],
+    httpResource: HttpResource[F],
     serviceErrorHandler: ServiceErrorHandler[F],
     banner: immutable.Seq[String],
     val channelOptions: ChannelOptions
@@ -111,7 +112,7 @@ class BlazeServerBuilder[F[_]](
       maxRequestLineLen: Int = maxRequestLineLen,
       maxHeadersLen: Int = maxHeadersLen,
       chunkBufferMaxSize: Int = chunkBufferMaxSize,
-      httpApp: HttpApp[F] = httpApp,
+      httpResource: HttpResource[F] = httpResource,
       serviceErrorHandler: ServiceErrorHandler[F] = serviceErrorHandler,
       banner: immutable.Seq[String] = banner,
       channelOptions: ChannelOptions = channelOptions
@@ -131,7 +132,7 @@ class BlazeServerBuilder[F[_]](
       maxRequestLineLen,
       maxHeadersLen,
       chunkBufferMaxSize,
-      httpApp,
+      httpResource,
       serviceErrorHandler,
       banner,
       channelOptions
@@ -190,8 +191,11 @@ class BlazeServerBuilder[F[_]](
 
   def enableHttp2(enabled: Boolean): Self = copy(http2Support = enabled)
 
+  def withHttpResource(httpResource: HttpResource[F]): Self =
+    copy(httpResource = httpResource)
+
   def withHttpApp(httpApp: HttpApp[F]): Self =
-    copy(httpApp = httpApp)
+    withHttpResource(httpApp.mapK(resourceLiftK))
 
   def withServiceErrorHandler(serviceErrorHandler: ServiceErrorHandler[F]): Self =
     copy(serviceErrorHandler = serviceErrorHandler)
@@ -250,7 +254,7 @@ class BlazeServerBuilder[F[_]](
 
     def http1Stage(secure: Boolean, engine: Option[SSLEngine]) =
       Http1ServerStage(
-        httpApp,
+        httpResource,
         requestAttributes(secure = secure, engine),
         executionContext,
         enableWebSockets,
@@ -266,7 +270,7 @@ class BlazeServerBuilder[F[_]](
     def http2Stage(engine: SSLEngine): ALPNServerSelector =
       ProtocolSelector(
         engine,
-        httpApp,
+        httpResource,
         maxRequestLineLen,
         maxHeadersLen,
         chunkBufferMaxSize,
@@ -411,14 +415,14 @@ object BlazeServerBuilder {
       maxRequestLineLen = 4 * 1024,
       maxHeadersLen = 40 * 1024,
       chunkBufferMaxSize = 1024 * 1024,
-      httpApp = defaultApp[F],
+      httpResource = defaultHttpResource[F],
       serviceErrorHandler = DefaultServiceErrorHandler[F],
       banner = defaults.Banner,
       channelOptions = ChannelOptions(Vector.empty)
     )
 
-  private def defaultApp[F[_]: Applicative]: HttpApp[F] =
-    Kleisli(_ => Response[F](Status.NotFound).pure[F])
+  private def defaultHttpResource[F[_]: Applicative]: HttpResource[F] =
+    Kleisli(_ => Resource.pure(Response[F](Status.NotFound)))
 
   private def defaultThreadSelectorFactory: ThreadFactory =
     threadFactory(name = n => s"blaze-selector-${n}", daemon = false)

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/ProtocolSelector.scala
@@ -17,7 +17,7 @@ import io.chrisdavenport.vault._
 private[blaze] object ProtocolSelector {
   def apply[F[_]](
       engine: SSLEngine,
-      httpApp: HttpApp[F],
+      httpResource: HttpResource[F],
       maxRequestLineLen: Int,
       maxHeadersLen: Int,
       chunkBufferMaxSize: Int,
@@ -38,7 +38,7 @@ private[blaze] object ProtocolSelector {
             Duration.Inf,
             executionContext,
             requestAttributes,
-            httpApp,
+            httpResource,
             serviceErrorHandler,
             responseHeaderTimeout,
             idleTimeout,
@@ -59,7 +59,7 @@ private[blaze] object ProtocolSelector {
 
     def http1Stage(): TailStage[ByteBuffer] =
       Http1ServerStage[F](
-        httpApp,
+        httpResource,
         requestAttributes,
         executionContext,
         enableWebSockets = false,

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -15,6 +15,7 @@ import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.blazecore.{ResponseParser, SeqTestHead}
 import org.http4s.dsl.io._
 import org.http4s.headers.{Date, `Content-Length`, `Transfer-Encoding`}
+import org.http4s.internal.resourceLiftK
 import org.specs2.specification.AfterAll
 import org.specs2.specification.core.Fragment
 import scala.concurrent.duration._
@@ -51,7 +52,7 @@ class Http1ServerStageSpec extends Http4sSpec with AfterAll {
     val head = new SeqTestHead(
       req.map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.ISO_8859_1))))
     val httpStage = Http1ServerStage[IO](
-      httpApp,
+      httpApp.mapK(resourceLiftK),
       () => Vault.empty,
       testExecutionContext,
       enableWebSockets = true,

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -3,7 +3,8 @@ package org.http4s
 import java.util.concurrent.{CancellationException, CompletableFuture, CompletionException}
 import java.util.function.BiFunction
 
-import cats.effect.{Async, Concurrent, ConcurrentEffect, Effect, IO}
+import cats.{Applicative, ~>}
+import cats.effect.{Async, Concurrent, ConcurrentEffect, Effect, IO, Resource}
 import cats.implicits._
 import org.http4s.util.execution.direct
 import org.log4s.Logger
@@ -139,4 +140,7 @@ package object internal {
         F.delay { cf.cancel(true); () }
       })
     }
+
+  def resourceLiftK[F[_]](implicit F: Applicative[F]): F ~> Resource[F, ?] =
+    λ[F ~> Resource[F, ?]](Resource.liftF(_))
 }

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -1,6 +1,7 @@
 package org
 
 import cats.data.{EitherT, Kleisli, OptionT}
+import cats.effect.Resource
 import fs2.Stream
 
 package object http4s { // scalastyle:ignore
@@ -48,6 +49,8 @@ package object http4s { // scalastyle:ignore
     * and the base monad of the `OptionT` in which the response is returned.
     */
   type HttpRoutes[F[_]] = Http[OptionT[F, ?], F]
+
+  type HttpResource[F[_]] = Http[Resource[F, ?], F]
 
   @deprecated("Deprecated in favor of just using Kleisli", "0.18")
   type Service[F[_], A, B] = Kleisli[F, A, B]


### PR DESCRIPTION
Introduces an `HttpResource`, which is an `Http[Resource[F, ?], F]` based on @nigredo-tori's idea in #2528. A resource acquired in `response.body` is too late for the response header, and a resource released in `response.body`'s finalizer may too easily be skipped.  This gives the backend a chance to manage a resource for the entire lifecycle of the response.

Implemented for the blaze-server backend.  `HttpApp` is `mapK`'ed into it, so everybody pays for this even though relatively few might use it.

Other underexplored thoughts:
* The 2-parameter DSL may come in handy here.
* Haven't begun to explore how this interacts with `HttpRoutes`
* We could maybe provide functions to treat `F[Response[F]]` more like a `Resource` instead, but it's easy to not use them.
