### PR TITLE
Handle EOF in web socket by shutting down stage

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
@@ -8,6 +8,7 @@ import fs2._
 import fs2.concurrent.SignallingRef
 import java.util.concurrent.atomic.AtomicBoolean
 import org.http4s.blaze.pipeline.{LeafBuilder, TailStage, TrunkBuilder}
+import org.http4s.blaze.pipeline.Command.EOF
 import org.http4s.blaze.util.Execution.{directec, trampoline}
 import org.http4s.internal.unsafeRunAsync
 import org.http4s.websocket.{WebSocket, WebSocketFrame}
@@ -124,6 +125,8 @@ private[http4s] class Http4sWSStage[F[_]](
       .drain
 
     unsafeRunAsync(wsStream) {
+      case Left(EOF) =>
+        IO(stageShutdown())
       case Left(t) =>
         IO(logger.error(t)("Error closing Web Socket"))
       case Right(_) =>


### PR DESCRIPTION
As described in #2651, we're getting a noisy EOF when shutting down web sockets under certain circumstances.  Usually we call `stageShutdown()` when we receive this to do any cleanup, so added that as a special case.  This may result in `stageShutdown()` being called multiple times, but that's normal.

This feels a tad sloppy, but not as sloppy as scary errors in user logs for situations that should be harmless.