### PR TITLE
Improved ipv6 support in Uri

### DIFF
--- a/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
@@ -28,6 +28,13 @@ object LiteralSyntaxMacros {
       Uri.Ipv4Address.fromString(_).isRight,
       s => c.universe.reify(Uri.Ipv4Address.unsafeFromString(s.splice)))
 
+  def ipv6AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Ipv6Address] =
+    singlePartInterpolator(c)(
+      args,
+      "Ipv6Address",
+      Uri.Ipv6Address.fromString(_).isRight,
+      s => c.universe.reify(Uri.Ipv6Address.unsafeFromString(s.splice)))
+
   def mediaTypeInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[MediaType] =
     singlePartInterpolator(c)(
       args,

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -223,7 +223,7 @@ object UriTemplate {
   protected def renderHost(h: Host): String = h match {
     case RegName(n) => n.toString
     case a: Ipv4Address => a.value
-    case IPv6(a) => "[" + a.toString + "]"
+    case a: Ipv6Address => "[" + a.value + "]"
     case _ => ""
   }
 

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -15,6 +15,7 @@ private[http4s] trait Rfc3986Parser
     with Uri.Scheme.Parser
     with Uri.UserInfo.Parser
     with Uri.Ipv4Address.Parser
+    with Uri.Ipv6Address.Parser
     with IpParser
     with StringBuilding {
   // scalastyle:off public.methods.have.type
@@ -69,9 +70,7 @@ private[http4s] trait Rfc3986Parser
   def Host: Rule1[org.http4s.Uri.Host] = rule {
     // format: off
     ipv4Address |
-    (IpLiteral | capture(IpV6Address)) ~> { s: String =>
-      org.http4s.Uri.IPv6(s.ci)
-    } |
+    "[" ~ ipv6Address ~ "]" |
     capture(RegName) ~> { s: String =>
       org.http4s.Uri.RegName(decode(s).ci)
     }

--- a/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
@@ -10,6 +10,7 @@ class LiteralsOps(val sc: StringContext) extends AnyVal {
   def uri(args: Any*): Uri = macro LiteralSyntaxMacros.uriInterpolator
   def scheme(args: Any*): Uri.Scheme = macro LiteralSyntaxMacros.schemeInterpolator
   def ipv4(args: Any*): Uri.Ipv4Address = macro LiteralSyntaxMacros.ipv4AddressInterpolator
+  def ipv6(args: Any*): Uri.Ipv6Address = macro LiteralSyntaxMacros.ipv6AddressInterpolator
   def mediaType(args: Any*): MediaType = macro LiteralSyntaxMacros.mediaTypeInterpolator
   def qValue(args: Any*): QValue = macro LiteralSyntaxMacros.qValueInterpolator
 }

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -596,29 +596,27 @@ private[http4s] trait ArbitraryInstances {
     Cogen[(Byte, Byte, Byte, Byte)].contramap(ipv4 => (ipv4.a, ipv4.b, ipv4.c, ipv4.d))
 
   // https://tools.ietf.org/html/rfc3986#appendix-A
-  implicit val http4sTestingArbitraryForIPv6: Arbitrary[Uri.IPv6] = Arbitrary {
-    val h16 = timesBetween(min = 1, max = 4, genHexDigit.map(_.toString))
-    val ls32 = oneOf(h16 |+| const(":") |+| h16, getArbitrary[Uri.Ipv4Address].map(_.value))
-    val h16colon = h16 |+| const(":")
-    val :: = const("::")
-
-    oneOf(
-      times(6, h16colon) |+| ls32,
-      :: |+| times(5, h16colon) |+| ls32,
-      opt(h16) |+| :: |+| times(4, h16colon) |+| ls32,
-      opt(atMost(1, h16colon) |+| h16) |+| :: |+| times(3, h16colon) |+| ls32,
-      opt(atMost(2, h16colon) |+| h16) |+| :: |+| times(2, h16colon) |+| ls32,
-      opt(atMost(3, h16colon) |+| h16) |+| :: |+| opt(h16colon) |+| ls32,
-      opt(atMost(4, h16colon) |+| h16) |+| :: |+| ls32,
-      opt(atMost(5, h16colon) |+| h16) |+| :: |+| h16,
-      opt(atMost(6, h16colon) |+| h16) |+| ::
-    ).map(Uri.IPv6.apply)
+  implicit val http4sTestingArbitraryForIpv6Address: Arbitrary[Uri.Ipv6Address] = Arbitrary {
+    for {
+      a <- getArbitrary[Short]
+      b <- getArbitrary[Short]
+      c <- getArbitrary[Short]
+      d <- getArbitrary[Short]
+      e <- getArbitrary[Short]
+      f <- getArbitrary[Short]
+      g <- getArbitrary[Short]
+      h <- getArbitrary[Short]
+    } yield Uri.Ipv6Address(a, b, c, d, e, f, g, h)
   }
+
+  implicit val http4sTestingCogenForIpv6Address: Cogen[Uri.Ipv6Address] =
+    Cogen[(Short, Short, Short, Short, Short, Short, Short, Short)]
+      .contramap(ipv6 => (ipv6.a, ipv6.b, ipv6.c, ipv6.d, ipv6.e, ipv6.f, ipv6.g, ipv6.h))
 
   implicit val http4sTestingArbitraryForUriHost: Arbitrary[Uri.Host] = Arbitrary {
     val genRegName =
       listOf(oneOf(genUnreserved, genPctEncoded, genSubDelims)).map(rn => Uri.RegName(rn.mkString))
-    oneOf(getArbitrary[Uri.Ipv4Address], http4sTestingArbitraryForIPv6.arbitrary, genRegName)
+    oneOf(getArbitrary[Uri.Ipv4Address], getArbitrary[Uri.Ipv6Address], genRegName)
   }
 
   implicit val http4sTestingArbitraryForUserInfo: Arbitrary[Uri.UserInfo] =

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -567,18 +567,6 @@ private[http4s] trait ArbitraryInstances {
       def combine(g1: Gen[T], g2: Gen[T]): Gen[T] = for { t1 <- g1; t2 <- g2 } yield t1 |+| t2
     }
 
-  private def timesBetween[T: Monoid](min: Int, max: Int, g: Gen[T]): Gen[T] =
-    for {
-      n <- choose(min, max)
-      l <- listOfN(n, g).suchThat(_.length == n)
-    } yield l.foldLeft(Monoid[T].empty)(_ |+| _)
-
-  private def times[T: Monoid](n: Int, g: Gen[T]): Gen[T] =
-    listOfN(n, g).suchThat(_.length == n).map(_.reduce(_ |+| _))
-
-  private def atMost[T: Monoid](n: Int, g: Gen[T]): Gen[T] =
-    timesBetween(min = 0, max = n, g)
-
   private def opt[T](g: Gen[T])(implicit ev: Monoid[T]): Gen[T] =
     oneOf(g, const(ev.empty))
 

--- a/server/src/main/scala/org/http4s/server/Server.scala
+++ b/server/src/main/scala/org/http4s/server/Server.scala
@@ -19,7 +19,7 @@ abstract class Server[F[_]] {
           case ipv4: Inet4Address =>
             Uri.Ipv4Address.fromInet4Address(ipv4)
           case ipv6: Inet6Address =>
-            Uri.IPv6(ipv6.getHostAddress)
+            Uri.Ipv6Address.fromInet6Address(ipv6)
           case weird =>
             logger.warn(s"Unexpected address type ${weird.getClass}: $weird")
             Uri.RegName(weird.getHostAddress)

--- a/tests/src/test/scala/org/http4s/Ipv6AddressSpec.scala
+++ b/tests/src/test/scala/org/http4s/Ipv6AddressSpec.scala
@@ -1,0 +1,69 @@
+package org.http4s
+
+import cats.implicits._
+import cats.kernel.laws.discipline.{HashTests, OrderTests}
+import org.http4s.Uri.Ipv6Address
+import org.http4s.laws.discipline.HttpCodecTests
+import org.http4s.util.Renderer.renderString
+import org.specs2.execute._, Typecheck._
+import org.specs2.matcher.TypecheckMatchers._
+
+class Ipv6AddressSpec extends Http4sSpec {
+  checkAll("Order[Ipv6Address]", OrderTests[Ipv6Address].order)
+  checkAll("Hash[Ipv6Address]", HashTests[Ipv6Address].hash)
+  checkAll("HttpCodec[Ipv6Address]", HttpCodecTests[Ipv6Address].httpCodec)
+
+  "render consistently with RFC5952" should {
+    "4.1: handle leading zeroes in a 16-bit field" in {
+      renderString(ipv6"2001:0db8::0001") must_== "2001:db8::1"
+    }
+    "4.2.1: shorten as much as possible" in {
+      renderString(ipv6"2001:db8:0:0:0:0:2:1") must_== "2001:db8::2:1"
+    }
+    "4.2.2: handle one 16-bit 0 field" in {
+      renderString(ipv6"2001:db8:0:1:1:1:1:1") must_== "2001:db8:0:1:1:1:1:1"
+    }
+    """4.2.3: chose placement of "::"""" in {
+      renderString(ipv6"2001:0:0:1:0:0:0:1") must_== "2001:0:0:1::1"
+      renderString(ipv6"2001:db8:0:0:1:0:0:1") must_== "2001:db8::1:0:0:1"
+    }
+    "4.3: lowercase" in {
+      renderString(ipv6"::A:B:C:D:E:F") must_== "::a:b:c:d:e:f"
+    }
+  }
+
+  "fromInet6Address" should {
+    "round trip with toInet6Address" in prop { ipv6: Ipv6Address =>
+      Ipv6Address.fromInet6Address(ipv6.toInet6Address) must_== ipv6
+    }
+  }
+
+  "fromByteArray" should {
+    "round trip with toByteArray" in prop { ipv6: Ipv6Address =>
+      Ipv6Address.fromByteArray(ipv6.toByteArray) must_== Right(ipv6)
+    }
+  }
+
+  "compare" should {
+    "be consistent with unsigned int" in prop { xs: List[Ipv6Address] =>
+      def tupled(a: Ipv6Address) = (a.a, a.b, a.c, a.d)
+      xs.sorted.map(tupled) must_== xs.map(tupled).sorted
+    }
+
+    "be consistent with Ordered" in prop { (a: Ipv6Address, b: Ipv6Address) =>
+      math.signum(a.compareTo(b)) must_== math.signum(a.compare(b))
+    }
+  }
+
+  "ipv6 interpolator" should {
+    "be consistent with fromString" in {
+      Right(ipv6"::1") must_== Ipv6Address.fromString("::1")
+      Right(ipv6"::") must_== Ipv6Address.fromString("::")
+      Right(ipv6"2001:db8::7") must_== Ipv6Address.fromString("2001:db8::7")
+    }
+
+    "reject invalid values" in {
+      typecheck("""ipv6"127.0.0.1"""") must not succeed
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -192,17 +192,17 @@ http://example.org/a file
     }
 
     "render a IPv6 address, should be wrapped in brackets" in {
-      val variants = "01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab" +: (for {
-        h <- 0 to 7
-        l <- 0 to 7 - h
-        f = List.fill(h)("01ab").mkString(":")
+      val variants = "1ab:1ab:1ab:1ab:1ab:1ab:1ab:1ab" +: (for {
+        h <- 0 to 6
+        l <- 0 to 6 - h
+        f = List.fill(h)("1ab").mkString(":")
         b = List.fill(l)("32ba").mkString(":")
       } yield (f + "::" + b))
 
       foreach(variants) { s =>
         Uri(
           Some(Scheme.http),
-          Some(Authority(host = IPv6(s.ci))),
+          Some(Authority(host = Ipv6Address.unsafeFromString(s))),
           "/foo",
           Query.fromPairs("bar" -> "baz")).toString must_==
           (s"http://[$s]/foo?bar=baz")
@@ -244,7 +244,7 @@ http://example.org/a file
     "render IPv6 URL with parameters" in {
       Uri(
         Some(Scheme.http),
-        Some(Authority(host = IPv6("2001:db8::7".ci))),
+        Some(Authority(host = ipv6"2001:db8::7")),
         "/c",
         Query.fromPairs("GB" -> "object", "Class" -> "one")).toString must_== ("http://[2001:db8::7]/c?GB=object&Class=one")
     }
@@ -252,15 +252,11 @@ http://example.org/a file
     "render IPv6 URL with port" in {
       Uri(
         Some(Scheme.http),
-        Some(Authority(
-          host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci),
-          port = Some(8080)))).toString must_== ("http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080")
+        Some(Authority(host = ipv6"2001:db8:85a3:8d3:1319:8a2e:370:7344", port = Some(8080)))).toString must_== ("http://[2001:db8:85a3:8d3:1319:8a2e:370:7344]:8080")
     }
 
     "render IPv6 URL without port" in {
-      Uri(
-        Some(Scheme.http),
-        Some(Authority(host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)))).toString must_== ("http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]")
+      Uri(Some(Scheme.http), Some(Authority(host = ipv6"2001:db8:85a3:8d3:1319:8a2e:370:7344"))).toString must_== ("http://[2001:db8:85a3:8d3:1319:8a2e:370:7344]")
     }
 
     "not append a '/' unless it's in the path" in {

--- a/tests/src/test/scala/org/http4s/UriTemplateSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriTemplateSpec.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import org.http4s.Uri.{Authority, IPv6, RegName, Scheme, UserInfo}
+import org.http4s.Uri.{Authority, RegName, Scheme, UserInfo}
 import org.http4s.UriTemplate._
 
 class UriTemplateSpec extends Http4sSpec {
@@ -188,14 +188,14 @@ class UriTemplateSpec extends Http4sSpec {
       val fragment = List(FragmentElm(""))
       UriTemplate(query = Nil, fragment = fragment).toString must equalTo("/#")
     }
-    "render http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/foo?bar=baz" in {
+    "render http://[1ab:1ab:1ab:1ab:1ab:1ab:1ab:1ab]/foo?bar=baz" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
+      val host = ipv6"1ab:1ab:1ab:1ab:1ab:1ab:1ab:1ab"
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
       val query = List(ParamElm("bar", "baz"))
       UriTemplate(scheme, authority, path, query).toString must
-        equalTo("http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/foo?bar=baz")
+        equalTo("http://[1ab:1ab:1ab:1ab:1ab:1ab:1ab:1ab]/foo?bar=baz")
     }
     "render http://www.foo.com/foo?bar=baz" in {
       val scheme = Some(Scheme.http)
@@ -240,34 +240,34 @@ class UriTemplateSpec extends Http4sSpec {
       UriTemplate(scheme, authority, path, query).toString must
         equalTo("http://192.168.1.1:80/c?GB=object&Class=one")
     }
-    "render http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080" in {
+    "render http://[2001:db8:85a3:8d3:1319:8a2e:370:7344]:8080" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)
+      val host = ipv6"2001:db8:85a3:8d3:1319:8a2e:370:7344"
       val authority = Some(Authority(host = host, port = Some(8080)))
       UriTemplate(scheme, authority).toString must
-        equalTo("http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080")
+        equalTo("http://[2001:db8:85a3:8d3:1319:8a2e:370:7344]:8080")
     }
     "render http://[2001:db8::7]" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("2001:db8::7".ci)
+      val host = ipv6"2001:db8::7"
       val authority = Some(Authority(host = host))
       UriTemplate(scheme, authority).toString must
         equalTo("http://[2001:db8::7]")
     }
     "render http://[2001:db8::7]/c?GB=object&Class=one" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("2001:db8::7".ci)
+      val host = ipv6"2001:db8::7"
       val authority = Some(Authority(host = host))
       val path = List(PathElm("c"))
       val query = List(ParamElm("GB", "object"), ParamElm("Class", "one"))
       UriTemplate(scheme, authority, path, query).toString must
         equalTo("http://[2001:db8::7]/c?GB=object&Class=one")
     }
-    "render http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]" in {
+    "render http://[2001:db8:85a3:8d3:1319:8a2e:370:7344]" in {
       UriTemplate(
         Some(Scheme.http),
-        Some(Authority(host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)))).toString must
-        equalTo("http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]")
+        Some(Authority(host = ipv6"2001:db8:85a3:8d3:1319:8a2e:370:7344"))).toString must
+        equalTo("http://[2001:db8:85a3:8d3:1319:8a2e:370:7344]")
     }
     "render email address (not supported at the moment)" in {
       UriTemplate(Some(scheme"mailto"), path = List(PathElm("John.Doe@example.com"))).toString must
@@ -416,7 +416,7 @@ class UriTemplateSpec extends Http4sSpec {
     }
     "convert http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/{rel}/search{?term}{#section} to UriTemplate" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
+      val host = ipv6"01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab"
       val authority = Some(Authority(host = host))
       val path = List(VarExp("rel"), PathElm("search"))
       val query = List(ParamExp("term"))
@@ -426,7 +426,7 @@ class UriTemplateSpec extends Http4sSpec {
     }
     "convert http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]:8080/{rel}/search{?term}{#section} to UriTemplate" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
+      val host = ipv6"01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab"
       val authority = Some(Authority(host = host, port = Some(8080)))
       val path = List(VarExp("rel"), PathElm("search"))
       val query = List(ParamExp("term"))
@@ -436,7 +436,7 @@ class UriTemplateSpec extends Http4sSpec {
     }
     "convert http://[01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab]/foo?bar=baz Uri" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab".ci)
+      val host = ipv6"01ab:01ab:01ab:01ab:01ab:01ab:01ab:01ab"
       val authority = Some(Authority(host = host))
       val path = List(PathElm("foo"))
       val query = List(ParamElm("bar", List("baz")))
@@ -495,7 +495,7 @@ class UriTemplateSpec extends Http4sSpec {
     }
     "convert http://[2001:db8::7]/c?GB=object&Class=one to Uri" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("2001:db8::7".ci)
+      val host = ipv6"2001:db8::7"
       val authority = Some(Authority(host = host))
       val path = List(PathElm("c"))
       val query = List(ParamElm("GB", "object"), ParamElm("Class", "one"))
@@ -504,14 +504,14 @@ class UriTemplateSpec extends Http4sSpec {
     }
     "convert http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344] to Uri" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)
+      val host = ipv6"2001:0db8:85a3:08d3:1319:8a2e:0370:7344"
       val authority = Some(Authority(None, host, None))
       UriTemplate(scheme, authority).toUriIfPossible.get must
         equalTo(Uri(scheme, authority))
     }
     "convert http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080 to Uri" in {
       val scheme = Some(Scheme.http)
-      val host = IPv6("2001:0db8:85a3:08d3:1319:8a2e:0370:7344".ci)
+      val host = ipv6"2001:0db8:85a3:08d3:1319:8a2e:0370:7344"
       val authority = Some(Authority(None, host, Some(8080)))
       UriTemplate(scheme, authority).toUriIfPossible.get must
         equalTo(Uri(scheme, authority))

--- a/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -50,9 +50,10 @@ class UriParserSpec extends Http4sSpec {
       }
     }
 
-    "parse a short IPv6 address" in {
-      val s = "01ab::32ba:32ba"
-      Uri.requestTarget(s) must beRight(Uri(authority = Some(Authority(host = IPv6(s)))))
+    "parse a short IPv6 address in brackets" in {
+      val s = "[01ab::32ba:32ba]"
+      Uri.requestTarget(s) must beRight(
+        Uri(authority = Some(Authority(host = ipv6"01ab::32ba:32ba"))))
     }
 
     "handle port configurations" in {
@@ -95,7 +96,7 @@ class UriParserSpec extends Http4sSpec {
           "http://[2001:db8::7]/c?GB=object&Class=one",
           Uri(
             Some(Scheme.http),
-            Some(Authority(host = IPv6("2001:db8::7".ci))),
+            Some(Authority(host = ipv6"2001:db8::7")),
             "/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         ("mailto:John.Doe@example.com", Uri(Some(scheme"mailto"), path = "John.Doe@example.com"))
@@ -234,7 +235,7 @@ class UriParserSpec extends Http4sSpec {
           "http://[2001:db8::7]/c?GB=object&Class=one",
           Uri(
             Some(Scheme.http),
-            Some(Authority(host = IPv6("2001:db8::7".ci))),
+            Some(Authority(host = ipv6"2001:db8::7")),
             "/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         ("mailto:John.Doe@example.com", Uri(Some(scheme"mailto"), path = "John.Doe@example.com"))


### PR DESCRIPTION
* Deprecate `IPv6` in favor of `Ipv6Address`
* `Ipv6Address` is a case class of eight hextets
* Implements RFC5952 for normalized output
* Adds string interpolator
* Requires that ipv6 addresses be bracketed in authority form of request target