### PR TITLE
Preserve request caret in withPathInfo

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -300,10 +300,9 @@ sealed abstract case class Request[F[_]](
   private def caret =
     attributes.lookup(Request.Keys.PathInfoCaret).getOrElse(0)
 
-  def withPathInfo(pi: String): Self = {
+  def withPathInfo(pi: String): Self =
     // Don't use withUri, which clears the caret
     copy(uri = uri.withPath(scriptName + pi))
-  }
 
   def pathTranslated: Option[File] = attributes.lookup(Keys.PathTranslated)
 

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -300,12 +300,9 @@ sealed abstract case class Request[F[_]](
   private def caret =
     attributes.lookup(Request.Keys.PathInfoCaret).getOrElse(0)
 
-  private def withCaret(caret: Int) =
-    withAttribute(Request.Keys.PathInfoCaret, caret)
-
   def withPathInfo(pi: String): Self = {
-    val oldCaret = caret
-    withUri(uri.withPath(scriptName + pi)).withCaret(oldCaret)
+    // Don't use withUri, which clears the caret
+    copy(uri = uri.withPath(scriptName + pi))
   }
 
   def pathTranslated: Option[File] = attributes.lookup(Keys.PathTranslated)

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -294,13 +294,19 @@ sealed abstract case class Request[F[_]](
       attributes = attributes
     )
 
-  lazy val (scriptName, pathInfo) = {
-    val caret = attributes.lookup(Request.Keys.PathInfoCaret).getOrElse(0)
+  lazy val (scriptName, pathInfo) =
     uri.path.splitAt(caret)
-  }
 
-  def withPathInfo(pi: String): Self =
-    withUri(uri.withPath(scriptName + pi))
+  private def caret =
+    attributes.lookup(Request.Keys.PathInfoCaret).getOrElse(0)
+
+  private def withCaret(caret: Int) =
+    withAttribute(Request.Keys.PathInfoCaret, caret)
+
+  def withPathInfo(pi: String): Self = {
+    val oldCaret = caret
+    withUri(uri.withPath(scriptName + pi)).withCaret(oldCaret)
+  }
 
   def pathTranslated: Option[File] = attributes.lookup(Keys.PathTranslated)
 

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -98,7 +98,9 @@ class MessageSpec extends Http4sSpec {
       }
 
       "preserve caret in withPathInfo" in {
-        val originalReq = Request(uri = Uri(path = "/foo/bar"), attributes = Vault.empty.insert(Request.Keys.PathInfoCaret, 4))
+        val originalReq = Request(
+          uri = Uri(path = "/foo/bar"),
+          attributes = Vault.empty.insert(Request.Keys.PathInfoCaret, 4))
         val updatedReq = originalReq.withPathInfo("/quux")
 
         updatedReq.scriptName mustEqual "/foo"

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -96,6 +96,14 @@ class MessageSpec extends Http4sSpec {
         originalReq.pathInfo mustEqual updatedReq.pathInfo
         originalReq.scriptName mustEqual updatedReq.scriptName
       }
+
+      "preserve caret in withPathInfo" in {
+        val originalReq = Request(uri = Uri(path = "/foo/bar"), attributes = Vault.empty.insert(Request.Keys.PathInfoCaret, 4))
+        val updatedReq = originalReq.withPathInfo("/quux")
+
+        updatedReq.scriptName mustEqual "/foo"
+        updatedReq.pathInfo mustEqual "/quux"
+      }
     }
 
     "toString" should {


### PR DESCRIPTION
`Request#withPathInfo` should preserve the position of the caret, an internal attribute that splits the URI path into `scriptName` and `pathInfo`.

Fixes #2726.  See #1183, #1213 for more historical context.