### PR TITLE
Connecting timeout

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -23,7 +23,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     val responseHeaderTimeout: Duration,
     val idleTimeout: Duration,
     val requestTimeout: Duration,
-    val connectingTimeout: Duration,
+    val connectTimeout: Duration,
     val userAgent: Option[`User-Agent`],
     val maxTotalConnections: Int,
     val maxWaitQueueLimit: Int,
@@ -49,7 +49,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
       responseHeaderTimeout: Duration = responseHeaderTimeout,
       idleTimeout: Duration = idleTimeout,
       requestTimeout: Duration = requestTimeout,
-      connectingTimeout: Duration = connectingTimeout,
+      connectTimeout: Duration = connectTimeout,
       userAgent: Option[`User-Agent`] = userAgent,
       maxTotalConnections: Int = maxTotalConnections,
       maxWaitQueueLimit: Int = maxWaitQueueLimit,
@@ -71,7 +71,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
       responseHeaderTimeout = responseHeaderTimeout,
       idleTimeout = idleTimeout,
       requestTimeout = requestTimeout,
-      connectingTimeout = connectingTimeout,
+      connectTimeout = connectTimeout,
       userAgent = userAgent,
       maxTotalConnections = maxTotalConnections,
       maxWaitQueueLimit = maxWaitQueueLimit,
@@ -102,8 +102,8 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   def withRequestTimeout(requestTimeout: Duration): BlazeClientBuilder[F] =
     copy(requestTimeout = requestTimeout)
 
-  def withConnectingTimeout(connectingTimeout: Duration): BlazeClientBuilder[F] =
-    copy(connectingTimeout = connectingTimeout)
+  def withConnectTimeout(connectTimeout: Duration): BlazeClientBuilder[F] =
+    copy(connectTimeout = connectTimeout)
 
   def withUserAgentOption(userAgent: Option[`User-Agent`]): BlazeClientBuilder[F] =
     copy(userAgent = userAgent)
@@ -214,7 +214,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
       parserMode = parserMode,
       userAgent = userAgent,
       channelOptions = channelOptions,
-      connectingTimeout = connectingTimeout
+      connectTimeout = connectTimeout
     ).makeClient
     Resource.make(
       ConnectionManager.pool(
@@ -237,7 +237,7 @@ object BlazeClientBuilder {
       responseHeaderTimeout = 10.seconds,
       idleTimeout = 1.minute,
       requestTimeout = 1.minute,
-      connectingTimeout = 10.seconds,
+      connectTimeout = 10.seconds,
       userAgent = Some(`User-Agent`(AgentProduct("http4s-blaze", Some(BuildInfo.version)))),
       maxTotalConnections = 10,
       maxWaitQueueLimit = 256,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -32,7 +32,7 @@ object Http1Client {
       parserMode = if (config.lenientParser) ParserMode.Lenient else ParserMode.Strict,
       userAgent = config.userAgent,
       channelOptions = ChannelOptions(Vector.empty),
-      connectingTimeout = Duration.Inf
+      connectTimeout = Duration.Inf
     ).makeClient
 
     Resource

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -6,6 +6,8 @@ import cats.effect._
 import fs2.Stream
 import org.http4s.blaze.channel.ChannelOptions
 
+import scala.concurrent.duration.Duration
+
 /** Create a HTTP1 client which will attempt to recycle connections */
 @deprecated("Use BlazeClientBuilder", "0.19.0-M2")
 object Http1Client {
@@ -21,6 +23,7 @@ object Http1Client {
       bufferSize = config.bufferSize,
       asynchronousChannelGroup = config.group,
       executionContext = config.executionContext,
+      scheduler = bits.ClientTickWheel,
       checkEndpointIdentification = config.checkEndpointIdentification,
       maxResponseLineSize = config.maxResponseLineSize,
       maxHeaderLength = config.maxHeaderLength,
@@ -28,7 +31,8 @@ object Http1Client {
       chunkBufferMaxSize = config.chunkBufferMaxSize,
       parserMode = if (config.lenientParser) ParserMode.Lenient else ParserMode.Strict,
       userAgent = config.userAgent,
-      channelOptions = ChannelOptions(Vector.empty)
+      channelOptions = ChannelOptions(Vector.empty),
+      connectingTimeout = Duration.Inf
     ).makeClient
 
     Resource

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -36,7 +36,7 @@ final private class Http1Support[F[_]](
     parserMode: ParserMode,
     userAgent: Option[`User-Agent`],
     channelOptions: ChannelOptions,
-    connectTimeout: Duration,
+    connectTimeout: Duration
 )(implicit F: ConcurrentEffect[F]) {
 
   // SSLContext.getDefault is effectful and can fail - don't force it until we have to.

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -36,7 +36,7 @@ final private class Http1Support[F[_]](
     parserMode: ParserMode,
     userAgent: Option[`User-Agent`],
     channelOptions: ChannelOptions,
-    connectingTimeout: Duration,
+    connectTimeout: Duration,
 )(implicit F: ConcurrentEffect[F]) {
 
   // SSLContext.getDefault is effectful and can fail - don't force it until we have to.
@@ -46,7 +46,7 @@ final private class Http1Support[F[_]](
     asynchronousChannelGroup,
     channelOptions,
     scheduler,
-    connectingTimeout
+    connectTimeout
   )
 
 ////////////////////////////////////////////////////

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -2,20 +2,23 @@ package org.http4s
 package client
 package blaze
 
-import cats.effect._
-import cats.implicits._
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousChannelGroup
+
+import cats.effect._
+import cats.implicits._
 import javax.net.ssl.SSLContext
 import org.http4s.blaze.channel.ChannelOptions
 import org.http4s.blaze.channel.nio2.ClientChannelFactory
-import org.http4s.blaze.pipeline.{Command, LeafBuilder}
 import org.http4s.blaze.pipeline.stages.SSLStage
+import org.http4s.blaze.pipeline.{Command, LeafBuilder}
+import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.headers.`User-Agent`
 import org.http4s.internal.fromFuture
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
 
 /** Provides basic HTTP1 pipeline building
   */
@@ -24,6 +27,7 @@ final private class Http1Support[F[_]](
     bufferSize: Int,
     asynchronousChannelGroup: Option[AsynchronousChannelGroup],
     executionContext: ExecutionContext,
+    scheduler: TickWheelExecutor,
     checkEndpointIdentification: Boolean,
     maxResponseLineSize: Int,
     maxHeaderLength: Int,
@@ -31,13 +35,19 @@ final private class Http1Support[F[_]](
     chunkBufferMaxSize: Int,
     parserMode: ParserMode,
     userAgent: Option[`User-Agent`],
-    channelOptions: ChannelOptions
+    channelOptions: ChannelOptions,
+    connectingTimeout: Duration,
 )(implicit F: ConcurrentEffect[F]) {
 
   // SSLContext.getDefault is effectful and can fail - don't force it until we have to.
   private lazy val sslContext = sslContextOption.getOrElse(SSLContext.getDefault)
-  private val connectionManager =
-    new ClientChannelFactory(bufferSize, asynchronousChannelGroup, channelOptions)
+  private val connectionManager = new ClientChannelFactory(
+    bufferSize,
+    asynchronousChannelGroup,
+    channelOptions,
+    scheduler,
+    connectingTimeout
+  )
 
 ////////////////////////////////////////////////////
 
@@ -51,7 +61,7 @@ final private class Http1Support[F[_]](
       requestKey: RequestKey,
       addr: InetSocketAddress): Future[BlazeConnection[F]] =
     connectionManager
-      .connect(addr, bufferSize)
+      .connect(addr)
       .map { head =>
         val (builder, t) = buildStages(requestKey)
         builder.base(head)

--- a/client/src/main/scala/org/http4s/client/ConnectionManager.scala
+++ b/client/src/main/scala/org/http4s/client/ConnectionManager.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration.Duration
   */
 trait ConnectionManager[F[_], A <: Connection[F]] {
 
-  /** Bundle of the connection and wheither its new or not */
+  /** Bundle of the connection and whether its new or not */
   // Sealed, rather than final, because SI-4440.
   sealed case class NextConnection(connection: A, fresh: Boolean)
 

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -295,7 +295,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.13.v20181017"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.3"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.8.1"
-  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.7-SNAPSHOT"
+  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.7"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.1"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.6.1"
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.3.1"

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -295,7 +295,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val alpnBoot                         = "org.mortbay.jetty.alpn" %  "alpn-boot"                 % "8.1.13.v20181017"
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % "6.2.3"
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % "2.8.1"
-  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.6"
+  lazy val blaze                            = "org.http4s"             %% "blaze-http"                % "0.14.7-SNAPSHOT"
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % "1.3.1"
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % "1.6.1"
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "1.3.1"

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -7,6 +7,7 @@ import com.typesafe.sbt.SbtGit.git
 import com.typesafe.sbt.SbtPgp.autoImport._
 import com.typesafe.sbt.git.JGit
 import com.typesafe.sbt.pgp.PgpKeys.publishSigned
+import com.typesafe.tools.mima.core.{DirectMissingMethodProblem, ProblemFilters}
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 import java.lang.{Runtime => JRuntime}
@@ -96,6 +97,10 @@ object Http4sPlugin extends AutoPlugin {
     }.map {
       organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % _
     }).toSet,
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.client.blaze.BlazeClientBuilder.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.client.blaze.Http1Support.this")
+    ),
 
     libraryDependencies += compilerPlugin(
       CrossVersion.binaryScalaVersion(scalaVersion.value) match {


### PR DESCRIPTION
Follow-up to https://github.com/http4s/blaze/pull/308.

WIP: It won't compile until the aforementioned PR is merged and blaze 0.14.7 is released.

This PR:
- gives users ability to provide custom TickWheelExecutor in place of the one allocated by BlazeClientBuilder
- adds `connectingTimeout` for configuring the newly introduced `connectingTimeout` in blaze's `ClientChannelFactory`

Fixes: #2386, #2338, #2690