### PR TITLE
Clarify Method imports for client DSL in docs

### DIFF
--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -298,7 +298,7 @@ can build up a request object and pass that to `expect`:
 import org.http4s.client.dsl.io._
 import org.http4s.headers._
 import org.http4s.MediaType
-import org.http4s.Methods._
+import org.http4s.Method._
 ```
 
 ```tut:book

--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -298,6 +298,7 @@ can build up a request object and pass that to `expect`:
 import org.http4s.client.dsl.io._
 import org.http4s.headers._
 import org.http4s.MediaType
+import org.http4s.Methods._
 ```
 
 ```tut:book

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -309,6 +309,8 @@ HttpRoutes.of[IO] {
 }
 ```
 
+Methods such as `GET` are typically found in `org.http4s.Methods`, but are imported automatically as part of the DSL. 
+
 ### Path info
 
 Path matching is done on the request's `pathInfo`.  Path info is the

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -309,7 +309,7 @@ HttpRoutes.of[IO] {
 }
 ```
 
-Methods such as `GET` are typically found in `org.http4s.Methods`, but are imported automatically as part of the DSL. 
+Methods such as `GET` are typically found in `org.http4s.Method`, but are imported automatically as part of the DSL. 
 
 ### Path info
 

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -286,7 +286,7 @@ Now let's make a client for the service above:
 import org.http4s.client._
 import org.http4s.client.dsl.io._
 import org.http4s.client.blaze._
-import org.http4s.Methods._
+import org.http4s.Method._
 import cats.effect.IO
 import io.circe.generic.auto._
 import fs2.Stream

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -286,6 +286,7 @@ Now let's make a client for the service above:
 import org.http4s.client._
 import org.http4s.client.dsl.io._
 import org.http4s.client.blaze._
+import org.http4s.Methods._
 import cats.effect.IO
 import io.circe.generic.auto._
 import fs2.Stream


### PR DESCRIPTION
Clarifies the documentation to specify that `org.http4s.Methods._` is imported into scope with the default routing DSL, and that the client DSL needs an extra import in order for some of the examples to compile.

Changes could/should also be made for the current 0.20.x documentation, if it all looks good I'll write this up for that as well.