### PR TITLE
Make Http1Stage private[http4s]

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -18,7 +18,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 /** Utility bits for dealing with the HTTP 1.x protocol */
-trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
+private[http4s] trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
 
   /** ExecutionContext to be used for all Future continuations
     * '''WARNING:''' The ExecutionContext should trampoline or risk possibly unhandled stack overflows */


### PR DESCRIPTION
This is an implementation detail and we can't fix it in 0.20 without breaking binary compatibility.