### PR TITLE
Don't add ResponseHeaderTimeoutStage on infinite timeout

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/ResponseHeaderTimeoutStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/ResponseHeaderTimeoutStage.scala
@@ -52,7 +52,7 @@ final private[http4s] class ResponseHeaderTimeoutStage[A](
 
   override def stageStartup(): Unit = {
     super.stageStartup()
-    logger.debug(s"Starting response header timeout stage with timeout of ${timeout.toMillis} ms")
+    logger.debug(s"Starting response header timeout stage with timeout of ${timeout}")
   }
 
   def init(cb: Callback[TimeoutException]): Unit = {

--- a/blaze-core/src/main/scala/org/http4s/blazecore/ResponseHeaderTimeoutStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/ResponseHeaderTimeoutStage.scala
@@ -8,10 +8,10 @@ import org.http4s.blaze.util.{Cancelable, TickWheelExecutor}
 import org.log4s.getLogger
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 final private[http4s] class ResponseHeaderTimeoutStage[A](
-    timeout: Duration,
+    timeout: FiniteDuration,
     exec: TickWheelExecutor,
     ec: ExecutionContext)
     extends MidStage[A, A] { stage =>

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.typesafe.tools.mima.core._
 import org.http4s.build.Http4sPlugin._
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
@@ -192,6 +193,10 @@ lazy val blazeCore = libraryProject("blaze-core")
   .settings(
     description := "Base library for binding blaze to http4s clients and servers",
     libraryDependencies += blaze,
+    mimaBinaryIssueFilters ++= List(
+      // Private API
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.http4s.blazecore.ResponseHeaderTimeoutStage.this")
+    ),
   )
   .dependsOn(core, testing % "test->test")
 


### PR DESCRIPTION
Also fixes #2760 by restricting that to a `FiniteDuration`.  As a bonus, stop calling `.toMillis` to guard against regressions that are hard to test when we're not in debug logging.