### PR TITLE
Fix incorrect warning in blaze-client timeouts

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -214,7 +214,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     val inaccuracy = tick / timeout
     if (inaccuracy > warningThreshold) {
       logger.warn(
-        s"With current configuration $timeoutName ($timeout) may be up to ${inaccuracy * 100}% longer than configured. " +
+        s"With current configuration, $timeoutName ($timeout) may be up to ${inaccuracy * 100}% longer than configured. " +
           s"If timeout accuracy is important, consider using a scheduler with a shorter tick (currently $tick).")
     }
   }
@@ -234,8 +234,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     }
 
     if (requestTimeout.isFinite && requestTimeout >= idleTimeout) {
-      logger.warn(
-        s"responseHeaderTimeout ($responseHeaderTimeout) is >= idleTimeout ($idleTimeout). $advice")
+      logger.warn(s"requestTimeout ($requestTimeout) is >= idleTimeout ($idleTimeout). $advice")
     }
   }
 

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration._
 
 class ClientTimeoutSpec extends Http4sSpec {
 
-  val tickWheel = new TickWheelExecutor
+  val tickWheel = new TickWheelExecutor(tick = 50.millis)
 
   /** the map method allows to "post-process" the fragments after their creation */
   override def map(fs: => Fragments) = super.map(fs) ^ step(tickWheel.shutdown())


### PR DESCRIPTION
Throw in a grammar fix and some test warning mitigation while we're here.