### PR TITLE
AHC: work around duplicate request-body-streamer

### DIFF
--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
@@ -6,4 +6,5 @@ import cats.effect.IO
 
 class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient") {
   def clientResource = AsyncHttpClient.resource[IO]()
+
 }

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -90,7 +90,8 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSpec with Http
 
         "POST bodies concurrently" in {
           // https://github.com/AsyncHttpClient/async-http-client/issues/1660
-          Stream(0 to 100)
+          Stream
+            .emits(0 to 100)
             .covary[IO]
             .parEvalMap(8) { _ =>
               val uri =


### PR DESCRIPTION
See https://github.com/AsyncHttpClient/async-http-client/issues/1660 for a deeper discussion.  This is terrible, but is something we can do without an AHC patch.