### PR TITLE
Drop Scala 2.13.0-M5 support in 0.20.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
 
 scala_version_211: &scala_version_211 2.11.12
 scala_version_212: &scala_version_212 2.12.8
-scala_version_213: &scala_version_213 2.13.0-M5
 
 java_8: &java_8 openjdk8
 java_11: &java_11 openjdk11
@@ -39,13 +38,6 @@ jobs:
     - <<: *tests
       scala: *scala_version_212
       jdk: *java_8
-    - <<: *tests
-      scala: *scala_version_213
-      jdk: *java_8
-      script:
-        - sbt ++$TRAVIS_SCALA_VERSION thirteen/test
-        - sbt ++$TRAVIS_SCALA_VERSION thirteen/mimaReportBinaryIssues
-        - sbt ++$TRAVIS_SCALA_VERSION thirteen/unusedCompileDependenciesTest
     - <<: *tests
       scala: *scala_version_212
       jdk: *java_11

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -102,12 +102,7 @@ object Http4sPlugin extends AutoPlugin {
       ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.client.blaze.Http1Support.this")
     ),
 
-    libraryDependencies += compilerPlugin(
-      CrossVersion.binaryScalaVersion(scalaVersion.value) match {
-        case "2.13.0-M5" => "org.spire-math" %% "kind-projector" % "0.9.9" cross CrossVersion.binary
-        case _ => "org.typelevel" %% "kind-projector" % "0.10.0"
-      }
-    ),
+    libraryDependencies += compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0"),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M4"),
 
     scalafmtVersion := "1.5.1",

--- a/website/src/hugo/content/versions.md
+++ b/website/src/hugo/content/versions.md
@@ -57,7 +57,7 @@ title: Versions
 	  <td class="text-center"><i class="fa fa-ban"></i></td>
 	  <td class="text-center"><i class="fa fa-check"></i></td>
 	  <td class="text-center"><i class="fa fa-check"></i></td>
-	  <td class="text-center">M5</td>
+	  <td class="text-center"><i class="fa fa-ban"></i></td>
 	  <td>1.x</td>
 	  <td>1.x</td>
 	  <td>1.8+</td>


### PR DESCRIPTION
Sonatype is routinely too slow to publish three crossbuilds within the 50 minute timeout, and this was just a preview release.  People who need Scala 2.13 are better off on http4s-0.21.