### PR TITLE
Revert "Take `body: F[A]` as parameter instead of `G[A]`"

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -38,8 +38,19 @@ trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def apply(headers: Header*)(implicit F: Applicative[F]): F[Response[G]] =
     F.pure(Response[G](status, headers = Headers(`Content-Length`.zero :: headers.toList)))
 
-  def apply[A](body: F[A])(implicit F: Monad[F], w: EntityEncoder[G, A]): F[Response[G]] =
-    F.flatMap(body)(apply[A](_))
+  def apply[A](body: G[A])(implicit F: Monad[F], w: EntityEncoder[G, A]): F[Response[G]] = {
+    val entity = Entity(fs2.Stream.eval(body).flatMap(w.toEntity(_).body))
+    val headers = {
+      val h = w.headers
+      entity.length
+        .map { l =>
+          `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
+        }
+        .getOrElse(h)
+    }
+
+    F.pure(Response[G](status = status, headers = headers, body = entity.body))
+  }
 
   def apply[A](body: A, headers: Header*)(
       implicit F: Monad[F],


### PR DESCRIPTION
#2785 passed MiMa, but was not a compatible change.  We hoped it wouldn't break anything in practice, but it broke http4s-directives.