### PR TITLE
Remove 2.13.0-M5 from crossScalaVersions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,14 +68,11 @@ lazy val thirteen = project
     }: _*
   )
 
-val scala_213 = "2.13.0-M5"
 val scala_212 = "2.12.8"
 val scala_211 = "2.11.12"
 
-
-
 lazy val crossScalaAll = Seq(
-  crossScalaVersions := Seq(scala_213, scala_212, scala_211)
+  crossScalaVersions := Seq(scala_212, scala_211)
 )
 lazy val crossScalaNo213 = Seq(
   crossScalaVersions := Seq(scala_212, scala_211)


### PR DESCRIPTION
It's already removed from Travis.

When merging this to master, we'll need to be careful to keep 2.13.0.