### PR TITLE
Entity: added mediaType/charset fields

### DIFF
--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets
 
 import org.http4s.Status.Ok
 import org.http4s.argonaut._
-import org.http4s.headers.`Content-Type`
 import jawn.JawnDecodeSupportSpec
 import org.specs2.specification.core.Fragment
 
@@ -35,8 +34,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     val json = Json("test" -> jString("ArgonautSupport"))
 
     "have json content type" in {
-      jsonEncoder.headers.get(`Content-Type`) must_== Some(
-        `Content-Type`(MediaType.application.json))
+      jsonEncoder.toEntity(json).mediaType must_== Some(MediaType.application.json)
     }
 
     "write compact JSON" in {
@@ -60,8 +58,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
 
   "jsonEncoderOf" should {
     "have json content type" in {
-      jsonEncoderOf[IO, Foo].headers.get(`Content-Type`) must_== Some(
-        `Content-Type`(MediaType.application.json))
+      jsonEncoderOf[IO, Foo].toEntity(foo).mediaType must_== Some(MediaType.application.json)
     }
 
     "write compact JSON" in {

--- a/boopickle/src/main/scala/org/http4s/booPickle/BooPickleInstances.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/BooPickleInstances.scala
@@ -18,9 +18,9 @@ import scala.util.{Failure, Success}
   */
 trait BooPickleInstances {
 
-  private def booDecoderByteBuffer[F[_]: Sync, A](msg: Message[F])(
+  private def booDecoderByteBuffer[F[_]: Sync, A](e: Entity[F])(
       implicit pickler: Pickler[A]): DecodeResult[F, A] =
-    EntityDecoder.collectBinary(msg).subflatMap { chunk =>
+    EntityDecoder.collectBinary(e).subflatMap { chunk =>
       val bb = ByteBuffer.wrap(chunk.toArray)
       if (bb.hasRemaining) {
         Unpickle[A](pickler).tryFromBytes(bb) match {

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
@@ -7,7 +7,6 @@ import cats.implicits._
 import cats.Eq
 import cats.effect.laws.util.TestContext
 import cats.effect.laws.util.TestInstances._
-import org.http4s.headers.`Content-Type`
 import org.http4s.laws.discipline.EntityCodecTests
 import org.http4s.MediaType
 import org.scalacheck.Arbitrary
@@ -50,15 +49,14 @@ class BoopickleSpec extends Http4sSpec with BooPickleInstances {
 
   "boopickle encoder" should {
     "have octet-stream content type" in {
-      encoder.headers.get(`Content-Type`) must_== Some(
-        `Content-Type`(MediaType.application.`octet-stream`))
+      encoder.toEntity(Kiwi(1.0)).mediaType must_== Some(MediaType.application.`octet-stream`)
     }
   }
 
   "booEncoderOf" should {
-    "have octect-stream content type" in {
-      booEncoderOf[IO, Fruit].headers.get(`Content-Type`) must_== Some(
-        `Content-Type`(MediaType.application.`octet-stream`))
+    "have octet-stream content type" in {
+      booEncoderOf[IO, Fruit].toEntity(Kiwi(1.0)).mediaType must_== Some(
+        MediaType.application.`octet-stream`)
     }
   }
 

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -61,8 +61,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
     val json = Json.obj("test" -> Json.fromString("CirceSupport"))
 
     "have json content type" in {
-      jsonEncoder[IO].headers.get(`Content-Type`) must_== Some(
-        `Content-Type`(MediaType.application.json))
+      jsonEncoder[IO].toEntity(json).mediaType must_== Some(MediaType.application.json)
     }
 
     "write compact JSON" in {
@@ -86,8 +85,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] {
 
   "jsonEncoderOf" should {
     "have json content type" in {
-      jsonEncoderOf[IO, Foo].headers.get(`Content-Type`) must_== Some(
-        `Content-Type`(MediaType.application.json))
+      jsonEncoderOf[IO, Foo].toEntity(foo).mediaType must_== Some(MediaType.application.json)
     }
 
     "write compact JSON" in {

--- a/core/src/main/scala/org/http4s/Entity.scala
+++ b/core/src/main/scala/org/http4s/Entity.scala
@@ -9,15 +9,15 @@ final case class Entity[+F[_]](
     charset: Option[Charset] = None,
     length: Option[Long] = None
 ) {
-  length.foreach {
-    case l if l < 0 => Entity.logger.warn(s"Attempt to provide a negative content length of $l")
-    case _ => ()
-  }
-
   def headers: Headers = {
     var hdrs: List[Header] = Nil
     mediaType.foreach(mt => hdrs = `Content-Type`(mt, charset) :: hdrs)
-    length.foreach(l => hdrs = Header("Content-Length", l.toString) :: hdrs)
+    length.foreach {
+      case l if l < 0 =>
+        Entity.logger.warn(s"Attempt to provide a negative content length of $l")
+      case l =>
+        hdrs = Header("Content-Length", l.toString) :: hdrs
+    }
     Headers(hdrs)
   }
 }

--- a/core/src/main/scala/org/http4s/Entity.scala
+++ b/core/src/main/scala/org/http4s/Entity.scala
@@ -4,12 +4,12 @@ import org.http4s.headers.`Content-Type`
 import org.log4s.getLogger
 
 final case class Entity[+F[_]](
-  body: EntityBody[F],
-  mediaType: Option[MediaType] = None,
-  charset: Option[Charset] = None,
-  length: Option[Long] = None
+    body: EntityBody[F],
+    mediaType: Option[MediaType] = None,
+    charset: Option[Charset] = None,
+    length: Option[Long] = None
 ) {
-  length foreach {
+  length.foreach {
     case l if l < 0 => Entity.logger.warn(s"Attempt to provide a negative content length of $l")
     case _ => ()
   }

--- a/core/src/main/scala/org/http4s/Entity.scala
+++ b/core/src/main/scala/org/http4s/Entity.scala
@@ -25,20 +25,6 @@ final case class Entity[+F[_]](
 object Entity {
   private[http4s] val logger = getLogger
 
-  def fromMessage[F[_]](msg: Message[F]): Entity[F] = {
-    val (mediaType, charset) = headers.`Content-Type`.from(msg.headers) match {
-      case None => None -> None
-      case Some(ct) => Some(ct.mediaType) -> ct.charset
-    }
-
-    Entity(
-      body = msg.body,
-      mediaType = mediaType,
-      charset = charset,
-      length = headers.`Content-Length`.from(msg.headers).map(_.length)
-    )
-  }
-
   val empty: Entity[Nothing] = Entity[Nothing](
     body = EmptyBody,
     length = Some(0L)

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -26,7 +26,7 @@ trait EntityDecoder[F[_], T] { self =>
 
   /** Attempt to decode the body of the [[Message]] */
   final def decode(msg: Message[F], strict: Boolean): DecodeResult[F, T] =
-    decode(Entity.fromMessage(msg), strict)
+    decode(msg.toEntity, strict)
 
   /** The [[MediaRange]]s this [[EntityDecoder]] knows how to handle */
   def consumes: Set[MediaRange]

--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -35,8 +35,13 @@ trait EntityEncoder[F[_], A] { self =>
 
   /** Generate a new EntityEncoder that will contain the `Content-Type` header */
   def withContentType(tpe: `Content-Type`): EntityEncoder[F, A] = new EntityEncoder[F, A] {
-    override def toEntity(a: A): Entity[F] = self.toEntity(a)
-    override val headers: Headers = self.headers.put(tpe)
+    override def toEntity(a: A): Entity[F] =
+      self
+        .toEntity(a)
+        .copy(
+          mediaType = Some(tpe.mediaType)
+        )
+    override val headers: Headers = self.headers
   }
 }
 

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -60,17 +60,7 @@ sealed trait Message[F[_]] { self =>
     */
   def withEntity[T](b: T)(implicit w: EntityEncoder[F, T]): Self = {
     val entity = w.toEntity(b)
-    val hs = entity.length match {
-      case Some(l) =>
-        `Content-Length`
-          .fromLong(l)
-          .fold[Headers](_ => {
-            Message.logger.warn(s"Attempt to provide a negative content length of $l")
-            w.headers
-          }, cl => Headers(cl :: w.headers.toList))
-      case None => w.headers
-    }
-    change(body = entity.body, headers = headers ++ hs)
+    change(body = entity.body, headers = headers ++ entity.headers)
   }
 
   /** Sets the entity body without affecting headers such as `Transfer-Encoding`

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -204,6 +204,20 @@ sealed trait Message[F[_]] { self =>
   def as[A](implicit F: MonadError[F, Throwable], decoder: EntityDecoder[F, A]): F[A] =
     // n.b. this will be better with redeem in Cats-2.0
     attemptAs.leftWiden[Throwable].rethrowT
+
+  final def toEntity: Entity[F] = {
+    val (mediaType, charset) = contentType match {
+      case None => None -> None
+      case Some(ct) => Some(ct.mediaType) -> ct.charset
+    }
+
+    Entity(
+      body = body,
+      mediaType = mediaType,
+      charset = charset,
+      length = contentLength
+    )
+  }
 }
 
 object Message {

--- a/core/src/main/scala/org/http4s/headers/Content-Type.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Type.scala
@@ -13,7 +13,7 @@ object `Content-Type` extends HeaderKey.Internal[`Content-Type`] with HeaderKey.
     HttpHeaderParser.CONTENT_TYPE(s)
 }
 
-final case class `Content-Type` private (mediaType: MediaType, charset: Option[Charset])
+final case class `Content-Type`(mediaType: MediaType, charset: Option[Charset])
     extends Header.Parsed {
   override def key: `Content-Type`.type = `Content-Type`
   override def renderValue(writer: Writer): writer.type = charset match {

--- a/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -7,11 +7,11 @@ import cats.implicits._
 private[http4s] object MultipartDecoder {
 
   def decoder[F[_]: Sync]: EntityDecoder[F, Multipart[F]] =
-    EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
-      msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
+    EntityDecoder.decodeBy(MediaRange.`multipart/*`) { e =>
+      e.mediaType.flatMap(_.extensions.get("boundary")) match {
         case Some(boundary) =>
           DecodeResult {
-            msg.body
+            e.body
               .through(MultipartParser.parseToPartsStream[F](Boundary(boundary)))
               .compile
               .toVector
@@ -60,11 +60,11 @@ private[http4s] object MultipartDecoder {
       maxSizeBeforeWrite: Int = 52428800,
       maxParts: Int = 50,
       failOnLimit: Boolean = false): EntityDecoder[F, Multipart[F]] =
-    EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
-      msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
+    EntityDecoder.decodeBy(MediaRange.`multipart/*`) { e =>
+      e.mediaType.flatMap(_.extensions.get("boundary")) match {
         case Some(boundary) =>
           DecodeResult {
-            msg.body
+            e.body
               .through(
                 MultipartParser.parseToPartsStreamedFile[F](
                   Boundary(boundary),

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -4,18 +4,9 @@ package impl
 
 import cats.{Applicative, Monad}
 import org.http4s.headers._
-import ResponseGenerator.addEntityLength
 
 trait ResponseGenerator extends Any {
   def status: Status
-}
-
-private[impl] object ResponseGenerator {
-  def addEntityLength[G[_]](entity: Entity[G], headers: Headers): Headers =
-    entity.length match {
-      case Some(l) => `Content-Length`.fromLong(l).fold(_ => headers, c => headers.put(c))
-      case None => headers
-    }
 }
 
 /**
@@ -53,13 +44,14 @@ trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def apply[A](body: A, headers: Header*)(
       implicit F: Applicative[F],
       w: EntityEncoder[G, A]): F[Response[G]] = {
-    val h = w.headers ++ Headers(headers.toList)
     val entity = w.toEntity(body)
     F.pure(
       Response[G](
         status = status,
-        headers = entity.headers ++ addEntityLength(entity, h),
-        body = entity.body))
+        headers = w.headers ++ entity.headers ++ Headers(headers.toList),
+        body = entity.body
+      )
+    )
   }
 }
 
@@ -84,13 +76,14 @@ trait LocationResponseGenerator[F[_], G[_]] extends Any with EntityResponseGener
   def apply[A](location: Location, body: A, headers: Header*)(
       implicit F: Applicative[F],
       w: EntityEncoder[G, A]): F[Response[G]] = {
-    val h = w.headers ++ Headers(location +: headers.toList)
     val entity = w.toEntity(body)
     F.pure(
       Response[G](
         status = status,
-        headers = entity.headers ++ addEntityLength(entity, h),
-        body = entity.body))
+        headers = w.headers ++ entity.headers ++ Headers(location +: headers.toList),
+        body = entity.body
+      )
+    )
   }
 }
 
@@ -121,13 +114,14 @@ trait WwwAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGene
   def apply[A](authenticate: `WWW-Authenticate`, body: A, headers: Header*)(
       implicit F: Applicative[F],
       w: EntityEncoder[G, A]): F[Response[G]] = {
-    val h = w.headers ++ Headers(authenticate +: headers.toList)
     val entity = w.toEntity(body)
     F.pure(
       Response[G](
         status = status,
-        headers = entity.headers ++ addEntityLength(entity, h),
-        body = entity.body))
+        headers = w.headers ++ entity.headers ++ Headers(authenticate +: headers.toList),
+        body = entity.body
+      )
+    )
   }
 }
 
@@ -145,13 +139,14 @@ trait AllowResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def apply[A](allow: Allow, body: A, headers: Header*)(
       implicit F: Applicative[F],
       w: EntityEncoder[G, A]): F[Response[G]] = {
-    val h = w.headers ++ Headers(allow +: headers.toList)
     val entity = w.toEntity(body)
     F.pure(
       Response[G](
         status = status,
-        headers = entity.headers ++ addEntityLength(entity, h),
-        body = entity.body))
+        headers = w.headers ++ entity.headers ++ Headers(allow +: headers.toList),
+        body = entity.body
+      )
+    )
   }
 
 }
@@ -183,12 +178,13 @@ trait ProxyAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGe
   def apply[A](authenticate: `Proxy-Authenticate`, body: A, headers: Header*)(
       implicit F: Applicative[F],
       w: EntityEncoder[G, A]): F[Response[G]] = {
-    val h = w.headers ++ Headers(authenticate +: headers.toList)
     val entity = w.toEntity(body)
     F.pure(
       Response[G](
         status = status,
-        headers = entity.headers ++ addEntityLength(entity, h),
-        body = entity.body))
+        headers = w.headers ++ entity.headers ++ Headers(authenticate +: headers.toList),
+        body = entity.body
+      )
+    )
   }
 }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -55,7 +55,11 @@ trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers ++ Headers(headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(
+      Response[G](
+        status = status,
+        headers = entity.headers ++ addEntityLength(entity, h),
+        body = entity.body))
   }
 }
 
@@ -82,7 +86,11 @@ trait LocationResponseGenerator[F[_], G[_]] extends Any with EntityResponseGener
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers ++ Headers(location +: headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(
+      Response[G](
+        status = status,
+        headers = entity.headers ++ addEntityLength(entity, h),
+        body = entity.body))
   }
 }
 
@@ -115,7 +123,11 @@ trait WwwAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGene
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers ++ Headers(authenticate +: headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(
+      Response[G](
+        status = status,
+        headers = entity.headers ++ addEntityLength(entity, h),
+        body = entity.body))
   }
 }
 
@@ -135,7 +147,11 @@ trait AllowResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers ++ Headers(allow +: headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(
+      Response[G](
+        status = status,
+        headers = entity.headers ++ addEntityLength(entity, h),
+        body = entity.body))
   }
 
 }
@@ -169,6 +185,10 @@ trait ProxyAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGe
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers ++ Headers(authenticate +: headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(
+      Response[G](
+        status = status,
+        headers = entity.headers ++ addEntityLength(entity, h),
+        body = entity.body))
   }
 }

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -18,9 +18,9 @@ trait JawnInstances {
 
   // some decoders may reuse it and avoid extra content negotiation
   private[http4s] def jawnDecoderImpl[F[_]: Sync, J: RawFacade](
-      msg: Message[F]): DecodeResult[F, J] =
+      e: Entity[F]): DecodeResult[F, J] =
     DecodeResult {
-      msg.body.chunks
+      e.body.chunks
         .parseJson(AsyncParser.SingleValue)
         .map(Either.right)
         .handleErrorWith {

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -17,8 +17,7 @@ trait JawnInstances {
     JawnInstances.defaultJawnEmptyBodyMessage
 
   // some decoders may reuse it and avoid extra content negotiation
-  private[http4s] def jawnDecoderImpl[F[_]: Sync, J: RawFacade](
-      e: Entity[F]): DecodeResult[F, J] =
+  private[http4s] def jawnDecoderImpl[F[_]: Sync, J: RawFacade](e: Entity[F]): DecodeResult[F, J] =
     DecodeResult {
       e.body.chunks
         .parseJson(AsyncParser.SingleValue)

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -19,8 +19,7 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
     val json: JValue = JObject(JField("test", JString("json4s")))
 
     "have json content type" in {
-      jsonEncoder[IO, JValue].headers.get(`Content-Type`) must beSome(
-        `Content-Type`(MediaType.application.json))
+      jsonEncoder[IO, JValue].toEntity(JInt(0)).mediaType must beSome(MediaType.application.json)
     }
 
     "write compact JSON" in {
@@ -30,8 +29,8 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] { self: Json4sInstance
 
   "jsonEncoderOf" should {
     "have json content type" in {
-      jsonEncoderOf[IO, Option[Int]].headers.get(`Content-Type`) must beSome(
-        `Content-Type`(MediaType.application.json))
+      jsonEncoderOf[IO, Option[Int]].toEntity(None).mediaType must beSome(
+        MediaType.application.json)
     }
 
     "write compact JSON with a json4s writer" in {

--- a/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
+++ b/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
@@ -14,7 +14,10 @@ trait EntityCodecLaws[F[_], A] extends EntityEncoderLaws[F, A] {
   def entityCodecRoundTrip(a: A): IsEq[IO[Either[DecodeFailure, A]]] =
     (for {
       entity <- F.delay(encoder.toEntity(a))
-      message = Request(body = entity.body, headers = encoder.headers)
+      message = Request(
+        body = entity.body,
+        headers = encoder.headers ++ entity.headers
+      )
       a0 <- decoder.decode(message, strict = true).value
     } yield a0).toIO <-> IO.pure(Right(a))
 }

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -755,15 +755,13 @@ private[http4s] trait ArbitraryInstances {
       implicit
       F: Effect[F],
       g: Arbitrary[DecodeResult[F, A]]) =
-    Arbitrary(
-      for {
-        f <- Arbitrary.arbitrary[(Entity[F], Boolean) => DecodeResult[F, A]]
-        mrs <-Arbitrary.arbitrary[Set[MediaRange]]
-      } yield
-        new EntityDecoder[F, A] {
-          def decode(e: Entity[F], strict: Boolean): DecodeResult[F, A] = f(e, strict)
-          def consumes = mrs
-        })
+    Arbitrary(for {
+      f <- Arbitrary.arbitrary[(Entity[F], Boolean) => DecodeResult[F, A]]
+      mrs <- Arbitrary.arbitrary[Set[MediaRange]]
+    } yield new EntityDecoder[F, A] {
+      def decode(e: Entity[F], strict: Boolean): DecodeResult[F, A] = f(e, strict)
+      def consumes = mrs
+    })
 
   implicit def http4sTestingCogenForMessage[F[_]](implicit F: Effect[F]): Cogen[Message[F]] =
     Cogen[(Headers, EntityBody[F])].contramap(m => (m.headers, m.body))

--- a/play-json/src/test/scala/org/http4s/play/PlaySpec.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySpec.scala
@@ -4,7 +4,6 @@ package play.test // Get out of play package so we can import custom instances
 import _root_.play.api.libs.json._
 import cats.effect.IO
 import cats.effect.laws.util.TestContext
-import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSpec
 import org.http4s.play._
 
@@ -22,8 +21,7 @@ class PlaySpec extends JawnDecodeSupportSpec[JsValue] {
     val json: JsValue = Json.obj("test" -> JsString("PlaySupport"))
 
     "have json content type" in {
-      jsonEncoder.headers.get(`Content-Type`) must_== Some(
-        `Content-Type`(MediaType.application.json))
+      jsonEncoder.toEntity(json).mediaType must_== Some(MediaType.application.json)
     }
 
     "write JSON" in {
@@ -34,8 +32,7 @@ class PlaySpec extends JawnDecodeSupportSpec[JsValue] {
 
   "jsonEncoderOf" should {
     "have json content type" in {
-      jsonEncoderOf[IO, Foo].headers.get(`Content-Type`) must_== Some(
-        `Content-Type`(MediaType.application.json))
+      jsonEncoderOf[IO, Foo].toEntity(foo).mediaType must_== Some(MediaType.application.json)
     }
 
     "write compact JSON" in {

--- a/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSpec.scala
+++ b/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.IO
 import org.http4s.Status.Ok
 import _root_.scalatags.Text
 import cats.data.NonEmptyList
-import org.http4s.headers.`Content-Type`
 
 class ScalatagsSpec extends Http4sSpec {
 
@@ -28,8 +27,9 @@ class ScalatagsSpec extends Http4sSpec {
 
     "return Content-Type text/html with proper charset" in {
       testCharsets.forall { implicit cs =>
-        val headers = EntityEncoder[IO, Text.TypedTag[String]].headers
-        headers.get(`Content-Type`) must_== Some(`Content-Type`(MediaType.text.html, Some(cs)))
+        val e = EntityEncoder[IO, Text.TypedTag[String]].toEntity(testBody())
+        e.mediaType must_== Some(MediaType.text.html)
+        e.charset must_== Some(cs)
       }
     }
 

--- a/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -434,7 +434,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
       val resp = Response[IO](Ok)
         .withEntity(str.getBytes(Charset.`UTF-8`.nioCharset))
         .withContentType(`Content-Type`(MediaType.text.plain, Some(Charset.`UTF-8`)))
-      EntityDecoder.decodeString(Entity.fromMessage(resp))(implicitly, Charset.`US-ASCII`) must returnValue(
+      EntityDecoder.decodeString(resp.toEntity)(implicitly, Charset.`US-ASCII`) must returnValue(
         str
       )
     }
@@ -443,7 +443,7 @@ class EntityDecoderSpec extends Http4sSpec with PendingUntilFixed {
       val resp = Response[IO](Ok)
         .withEntity(str.getBytes(Charset.`UTF-8`.nioCharset))
         .withContentType(`Content-Type`(MediaType.text.plain, None))
-      EntityDecoder.decodeString(Entity.fromMessage(resp))(implicitly, Charset.`UTF-8`) must returnValue(
+      EntityDecoder.decodeString(resp.toEntity)(implicitly, Charset.`UTF-8`) must returnValue(
         str
       )
     }

--- a/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -90,9 +90,9 @@ class EntityEncoderSpec extends Http4sSpec {
     }
 
     "give the content type" in {
-      EntityEncoder[IO, String].contentType must beSome(
+      EntityEncoder[IO, String].toEntity("").mediaType must beSome(
         `Content-Type`(MediaType.text.plain, Charset.`UTF-8`))
-      EntityEncoder[IO, Array[Byte]].contentType must beSome(
+      EntityEncoder[IO, Array[Byte]].toEntity(Array.empty).mediaType must beSome(
         `Content-Type`(MediaType.application.`octet-stream`))
     }
 
@@ -101,9 +101,17 @@ class EntityEncoderSpec extends Http4sSpec {
       sealed case class ModelB(name: String, id: Long)
 
       implicit val w1: EntityEncoder[IO, ModelA] =
-        EntityEncoder.simple[IO, ModelA]()(_ => Chunk.bytes("A".getBytes))
+        EntityEncoder.simple[IO, ModelA]()(
+          MediaType.application.`octet-stream`,
+          None,
+          _ => Chunk.bytes("A".getBytes)
+        )
       implicit val w2: EntityEncoder[IO, ModelB] =
-        EntityEncoder.simple[IO, ModelB]()(_ => Chunk.bytes("B".getBytes))
+        EntityEncoder.simple[IO, ModelB]()(
+          MediaType.application.`octet-stream`,
+          None,
+          _ => Chunk.bytes("B".getBytes)
+        )
 
       EntityEncoder[IO, ModelA] must_== w1
       EntityEncoder[IO, ModelB] must_== w2

--- a/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -90,10 +90,12 @@ class EntityEncoderSpec extends Http4sSpec {
     }
 
     "give the content type" in {
-      EntityEncoder[IO, String].toEntity("").mediaType must beSome(
-        `Content-Type`(MediaType.text.plain, Charset.`UTF-8`))
+      val s = EntityEncoder[IO, String].toEntity("")
+      s.mediaType must beSome(MediaType.text.plain)
+      s.charset must beSome(Charset.`UTF-8`)
       EntityEncoder[IO, Array[Byte]].toEntity(Array.empty).mediaType must beSome(
-        `Content-Type`(MediaType.application.`octet-stream`))
+        MediaType.application.`octet-stream`
+      )
     }
 
     "work with local defined EntityEncoders" in {

--- a/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
+++ b/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
@@ -3,7 +3,6 @@ package twirl
 
 import cats.effect.IO
 import org.http4s.Status.Ok
-import org.http4s.headers.`Content-Type`
 import org.scalacheck.{Arbitrary, Gen}
 import play.twirl.api.{Html, JavaScript, Txt, Xml}
 
@@ -21,8 +20,9 @@ class TwirlSpec extends Http4sSpec {
 
   "HTML encoder" should {
     "return Content-Type text/html with proper charset" in prop { implicit cs: Charset =>
-      val headers = EntityEncoder[IO, Html].headers
-      headers.get(`Content-Type`) must beSome(`Content-Type`(MediaType.text.html, Some(cs)))
+      val e = EntityEncoder[IO, Html].toEntity(html.test())
+      e.mediaType must beSome(MediaType.text.html)
+      e.charset must beSome(cs)
     }
 
     "render the body" in prop { implicit cs: Charset =>
@@ -35,9 +35,9 @@ class TwirlSpec extends Http4sSpec {
   "JS encoder" should {
     "return Content-Type application/javascript with proper charset" in prop {
       implicit cs: Charset =>
-        val headers = EntityEncoder[IO, JavaScript].headers
-        headers.get(`Content-Type`) must beSome(
-          `Content-Type`(MediaType.application.javascript, Some(cs)))
+        val e = EntityEncoder[IO, JavaScript].toEntity(js.test())
+        e.mediaType must beSome(MediaType.application.javascript)
+        e.charset must beSome(cs)
     }
 
     "render the body" in prop { implicit cs: Charset =>
@@ -49,8 +49,9 @@ class TwirlSpec extends Http4sSpec {
 
   "Text encoder" should {
     "return Content-Type text/plain with proper charset" in prop { implicit cs: Charset =>
-      val headers = EntityEncoder[IO, Txt].headers
-      headers.get(`Content-Type`) must beSome(`Content-Type`(MediaType.text.plain, Some(cs)))
+      val e = EntityEncoder[IO, Txt].toEntity(txt.test())
+      e.mediaType must beSome(MediaType.text.plain)
+      e.charset must beSome(cs)
     }
 
     "render the body" in prop { implicit cs: Charset =>
@@ -62,8 +63,9 @@ class TwirlSpec extends Http4sSpec {
 
   "XML encoder" should {
     "return Content-Type application/xml with proper charset" in prop { implicit cs: Charset =>
-      val headers = EntityEncoder[IO, Xml].headers
-      headers.get(`Content-Type`) must beSome(`Content-Type`(MediaType.application.xml, Some(cs)))
+      val e = EntityEncoder[IO, Xml].toEntity(_root_.xml.test())
+      e.mediaType must beSome(MediaType.application.xml)
+      e.charset must beSome(cs)
     }
 
     "render the body" in prop { implicit cs: Charset =>


### PR DESCRIPTION
### The problem:
`EntityDecoder` interface is not consistent with `EntityEncoder`.

`EntityEncoder` returns an `Entity`, while `EntityDecoder` only accepts a `Message[F]`.

This is problematic because it is not possible to decode arbitrary `EntityBody` using `EntityDecoder` even if you know its Media Type.

Also it is not possible to return different media types from one `EntityEncoder`.

### Proposal:
Interface of `Entity` is changed - this change adds (optional) `mediaType` and `charset` fields, so now it is possible to specify what is inside the body.

`EntityDecoder` now accepts an `Entity` - however, there is overload for `decode` method that accepts a `Message`.

`EntityEncoder` doesn't have `contentType` and `charset` methods anymore - instead it returns an `Entity` with appropriate `mediaType` and `charset`.

**P.S.** Tests are not compiling now; I want to know what do you guys think about this change and then I'll fix it.