### PR TITLE
Allow 'Allow' header to specify empty list of methods

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Allow.scala
+++ b/core/src/main/scala/org/http4s/headers/Allow.scala
@@ -1,19 +1,18 @@
 package org.http4s
 package headers
 
-import cats.data.NonEmptyList
 import org.http4s.parser.HttpHeaderParser
 import org.http4s.util.Writer
 
 object Allow extends HeaderKey.Internal[Allow] with HeaderKey.Singleton {
-  def apply(m: Method, ms: Method*): Allow = Allow(NonEmptyList.of(m, ms: _*))
+  def apply(ms: Method*): Allow = Allow(ms.toSet)
 
   override def parse(s: String): ParseResult[Allow] =
     HttpHeaderParser.ALLOW(s)
 }
 
-final case class Allow(methods: NonEmptyList[Method]) extends Header.Parsed {
+final case class Allow(methods: Set[Method]) extends Header.Parsed {
   override def key: Allow.type = Allow
   override def renderValue(writer: Writer): writer.type =
-    writer.addStringNel(methods.map(_.name), ", ")
+    writer.addSet[Method](methods, sep = ", ")
 }

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -34,13 +34,13 @@ private[parser] trait SimpleHeaders {
   def ALLOW(value: String): ParseResult[Allow] =
     new Http4sHeaderParser[Allow](value) {
       def entry = rule {
-        oneOrMore(Token).separatedBy(ListSep) ~ EOL ~> { ts: Seq[String] =>
+        zeroOrMore(Token).separatedBy(ListSep) ~ EOL ~> { ts: Seq[String] =>
           val ms = ts.map(
             Method
               .fromString(_)
               .toOption
               .getOrElse(sys.error("Impossible. Please file a bug report.")))
-          Allow(NonEmptyList.of(ms.head, ms.tail: _*))
+          Allow(ms.toSet)
         }
       }
     }.parse

--- a/core/src/main/scala/org/http4s/util/Renderable.scala
+++ b/core/src/main/scala/org/http4s/util/Renderable.scala
@@ -141,15 +141,15 @@ trait Writer {
     append(end)
   }
 
-  def addSeq[T: Renderer](
-      s: collection.Seq[T],
+  def addSet[T: Renderer](
+      s: collection.Set[T],
       sep: String = "",
       start: String = "",
       end: String = ""): this.type = {
     append(start)
     if (s.nonEmpty) {
       append(s.head)
-      s.tail.foreach(s => append(s).append(sep))
+      s.tail.foreach(s => append(sep).append(s))
     }
     append(end)
   }

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -370,8 +370,8 @@ private[http4s] trait ArbitraryInstances {
   implicit val http4sTestingArbitraryForAllow: Arbitrary[Allow] =
     Arbitrary {
       for {
-        methods <- nonEmptyContainerOf[Set, Method](getArbitrary[Method]).map(_.toList)
-      } yield Allow(methods.head, methods.tail: _*)
+        methods <- containerOf[Set, Method](getArbitrary[Method])
+      } yield Allow(methods)
     }
 
   implicit val http4sTestingArbitraryForContentLength: Arbitrary[`Content-Length`] =


### PR DESCRIPTION
[RFC7231 section-7.4.1](https://tools.ietf.org/html/rfc7231#section-7.4.1):

> An empty Allow field value indicates that the resource allows no methods, which might occur in a 405 response if the resource has been temporarily disabled by configuration