### PR TITLE
More useful defaults for JettyClient

### DIFF
--- a/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
@@ -9,6 +9,7 @@ import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.api.{Request => JettyRequest}
 import org.eclipse.jetty.http.{HttpVersion => JHttpVersion}
 import org.log4s.{Logger, getLogger}
+import org.eclipse.jetty.util.ssl.SslContextFactory
 
 object JettyClient {
 
@@ -49,8 +50,9 @@ object JettyClient {
     Stream.resource(resource(client))
 
   def defaultHttpClient(): HttpClient = {
-    val c = new HttpClient()
+    val c = new HttpClient(new SslContextFactory.Client)
     c.setFollowRedirects(false)
+    c.setDefaultRequestContentType(null)
     c
   }
 


### PR DESCRIPTION
This PR changes default JettyClient:

1. Enabled SSL support
2. Disabled default Content-Type. It's inconvenient to have **application/octet-stream** by default even if the body is empty. [See also](https://github.com/eclipse/jetty.project/issues/2117).