### PR TITLE
Multipart decoding using EntityDecoder

### DIFF
--- a/boopickle/src/main/scala/org/http4s/booPickle/BooPickleInstances.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/BooPickleInstances.scala
@@ -18,9 +18,9 @@ import scala.util.{Failure, Success}
   */
 trait BooPickleInstances {
 
-  private def booDecoderByteBuffer[F[_]: Sync, A](msg: Message[F])(
+  private def booDecoderByteBuffer[F[_]: Sync, A](m: Media[F])(
       implicit pickler: Pickler[A]): DecodeResult[F, A] =
-    EntityDecoder.collectBinary(msg).subflatMap { chunk =>
+    EntityDecoder.collectBinary(m).subflatMap { chunk =>
       val bb = ByteBuffer.wrap(chunk.toArray)
       if (bb.hasRemaining) {
         Unpickle[A](pickler).tryFromBytes(bb) match {

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -34,8 +34,8 @@ trait CirceInstances extends JawnInstances {
   def jsonDecoderByteBuffer[F[_]: Sync]: EntityDecoder[F, Json] =
     EntityDecoder.decodeBy(MediaType.application.json)(jsonDecoderByteBufferImpl[F])
 
-  private def jsonDecoderByteBufferImpl[F[_]: Sync](msg: Message[F]): DecodeResult[F, Json] =
-    EntityDecoder.collectBinary(msg).subflatMap { chunk =>
+  private def jsonDecoderByteBufferImpl[F[_]: Sync](m: Media[F]): DecodeResult[F, Json] =
+    EntityDecoder.collectBinary(m).subflatMap { chunk =>
       val bb = ByteBuffer.wrap(chunk.toArray)
       if (bb.hasRemaining)
         parseByteBuffer(bb).leftMap(circeParseExceptionMessage)

--- a/core/src/main/scala/org/http4s/Media.scala
+++ b/core/src/main/scala/org/http4s/Media.scala
@@ -1,5 +1,7 @@
 package org.http4s
 
+import cats.MonadError
+import cats.implicits._
 import fs2.Stream
 import fs2.text.utf8Decode
 import org.http4s.headers._
@@ -26,6 +28,29 @@ trait Media[F[_]] {
 
   final def charset: Option[Charset] =
     contentType.flatMap(_.charset)
+
+  // Decoding methods
+
+  /** Decode the [[Media]] to the specified type
+    *
+    * @param decoder [[EntityDecoder]] used to decode the [[Media]]
+    * @tparam T type of the result
+    * @return the effect which will generate the `DecodeResult[T]`
+    */
+  final def attemptAs[T](implicit decoder: EntityDecoder[F, T]): DecodeResult[F, T] =
+    decoder.decode(this, strict = false)
+
+  /** Decode the [[Media]] to the specified type
+    *
+    * If no valid [[Status]] has been described, allow Ok
+    *
+    * @param decoder [[EntityDecoder]] used to decode the [[Media]]
+    * @tparam A type of the result
+    * @return the effect which will generate the A
+    */
+  final def as[A](implicit F: MonadError[F, Throwable], decoder: EntityDecoder[F, A]): F[A] =
+    // n.b. this will be better with redeem in Cats-2.0
+    attemptAs.leftWiden[Throwable].rethrowT
 }
 
 object Media {

--- a/core/src/main/scala/org/http4s/Media.scala
+++ b/core/src/main/scala/org/http4s/Media.scala
@@ -1,0 +1,37 @@
+package org.http4s
+
+import fs2.Stream
+import fs2.text.utf8Decode
+import org.http4s.headers._
+import org.http4s.util.decode
+
+trait Media[F[_]] {
+  def body: EntityBody[F]
+  def headers: Headers
+
+  final def bodyAsText(implicit defaultCharset: Charset = DefaultCharset): Stream[F, String] =
+    charset.getOrElse(defaultCharset) match {
+      case Charset.`UTF-8` =>
+        // suspect this one is more efficient, though this is superstition
+        body.through(utf8Decode)
+      case cs =>
+        body.through(decode(cs))
+    }
+
+  final def contentType: Option[`Content-Type`] =
+    headers.get(`Content-Type`)
+
+  final def contentLength: Option[Long] =
+    headers.get(`Content-Length`).map(_.length)
+
+  final def charset: Option[Charset] =
+    contentType.flatMap(_.charset)
+}
+
+object Media {
+  def apply[F[_]](b: EntityBody[F], h: Headers): Media[F] = new Media[F] {
+    def body = b
+
+    def headers: Headers = h
+  }
+}

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats.{Applicative, Functor, Monad, MonadError, ~>}
+import cats.{Applicative, Functor, Monad, ~>}
 import cats.data.NonEmptyList
 import cats.implicits._
 import cats.effect.IO
@@ -168,29 +168,6 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     */
   def withoutAttribute(key: Key[_]): Self =
     change(attributes = attributes.delete(key))
-
-  // Decoding methods
-
-  /** Decode the [[Message]] to the specified type
-    *
-    * @param decoder [[EntityDecoder]] used to decode the [[Message]]
-    * @tparam T type of the result
-    * @return the effect which will generate the `DecodeResult[T]`
-    */
-  def attemptAs[T](implicit decoder: EntityDecoder[F, T]): DecodeResult[F, T] =
-    decoder.decode(this, strict = false)
-
-  /** Decode the [[Message]] to the specified type
-    *
-    * If no valid [[Status]] has been described, allow Ok
-    *
-    * @param decoder [[EntityDecoder]] used to decode the [[Message]]
-    * @tparam A type of the result
-    * @return the effect which will generate the A
-    */
-  def as[A](implicit F: MonadError[F, Throwable], decoder: EntityDecoder[F, A]): F[A] =
-    // n.b. this will be better with redeem in Cats-2.0
-    attemptAs.leftWiden[Throwable].rethrowT
 }
 
 object Message {

--- a/core/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/src/main/scala/org/http4s/multipart/Part.scala
@@ -10,7 +10,7 @@ import java.io.{File, InputStream}
 import java.net.URL
 import org.http4s.headers.`Content-Disposition`
 
-final case class Part[F[_]](headers: Headers, body: Stream[F, Byte]) {
+final case class Part[F[_]](headers: Headers, body: Stream[F, Byte]) extends Media[F] {
   def name: Option[String] = headers.get(`Content-Disposition`).flatMap(_.parameters.get("name"))
   def filename: Option[String] =
     headers.get(`Content-Disposition`).flatMap(_.parameters.get("filename"))

--- a/docs/src/main/tut/entity.md
+++ b/docs/src/main/tut/entity.md
@@ -57,14 +57,14 @@ case class Video(body: String) extends Resp
 
 ```tut:book
 val response = Ok("").map(_.withContentType(`Content-Type`(MediaType.audio.ogg)))
-val audioDec = EntityDecoder.decodeBy(MediaType.audio.ogg) { msg: Message[IO] =>
+val audioDec = EntityDecoder.decodeBy(MediaType.audio.ogg) { m: Media[IO] =>
   EitherT {
-    msg.as[String].map(s => Audio(s).asRight[DecodeFailure])
+    m.as[String].map(s => Audio(s).asRight[DecodeFailure])
   }
 }
-val videoDec = EntityDecoder.decodeBy(MediaType.video.ogg) { msg: Message[IO] =>
+val videoDec = EntityDecoder.decodeBy(MediaType.video.ogg) { m: Media[IO] =>
   EitherT {
-    msg.as[String].map(s => Video(s).asRight[DecodeFailure])
+    m.as[String].map(s => Video(s).asRight[DecodeFailure])
   }
 }
 implicit val bothDec = audioDec.widen[Resp] orElse videoDec.widen[Resp]

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -17,10 +17,9 @@ trait JawnInstances {
     JawnInstances.defaultJawnEmptyBodyMessage
 
   // some decoders may reuse it and avoid extra content negotiation
-  private[http4s] def jawnDecoderImpl[F[_]: Sync, J: RawFacade](
-      msg: Message[F]): DecodeResult[F, J] =
+  private[http4s] def jawnDecoderImpl[F[_]: Sync, J: RawFacade](m: Media[F]): DecodeResult[F, J] =
     DecodeResult {
-      msg.body.chunks
+      m.body.chunks
         .parseJson(AsyncParser.SingleValue)
         .map(Either.right)
         .handleErrorWith {

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -756,12 +756,15 @@ private[http4s] trait ArbitraryInstances {
       F: Effect[F],
       g: Arbitrary[DecodeResult[F, A]]) =
     Arbitrary(for {
-      f <- getArbitrary[(Message[F], Boolean) => DecodeResult[F, A]]
+      f <- getArbitrary[(Media[F], Boolean) => DecodeResult[F, A]]
       mrs <- getArbitrary[Set[MediaRange]]
     } yield new EntityDecoder[F, A] {
-      def decode(msg: Message[F], strict: Boolean): DecodeResult[F, A] = f(msg, strict)
+      def decode(m: Media[F], strict: Boolean): DecodeResult[F, A] = f(m, strict)
       def consumes = mrs
     })
+
+  implicit def http4sTestingCogenForMedia[F[_]](implicit F: Effect[F]): Cogen[Media[F]] =
+    Cogen[(Headers, EntityBody[F])].contramap(m => (m.headers, m.body))
 
   implicit def http4sTestingCogenForMessage[F[_]](implicit F: Effect[F]): Cogen[Message[F]] =
     Cogen[(Headers, EntityBody[F])].contramap(m => (m.headers, m.body))


### PR DESCRIPTION
This PR is an attempt to improve **multipart** decoding by allowing to use `EntityDecoder` on a `Part[F]`:

1) It introduces new interface `Media[F]` which is implemented by `Message[F]` and `Part[F]`;
2) `EntityDecoder.decode` now accepts a `Media[F]` instead of `Message[F]`.