### PR TITLE
Fix UserInfoSpec (#2767)

### DIFF
--- a/tests/src/test/scala/org/http4s/UserInfoSpec.scala
+++ b/tests/src/test/scala/org/http4s/UserInfoSpec.scala
@@ -95,4 +95,11 @@ class UserInfoSpec extends Http4sSpec {
       HttpCodec[UserInfo].parse(renderString(userInfo)) must_== Right(userInfo)
     }
   }
+
+  "bug2767" should {
+    "reject userinfos with invalid characters" in {
+      val s = "@"
+      UserInfo.fromString(s) must beLeft
+    }
+  }
 }

--- a/tests/src/test/scala/org/http4s/UserInfoSpec.scala
+++ b/tests/src/test/scala/org/http4s/UserInfoSpec.scala
@@ -74,7 +74,7 @@ class UserInfoSpec extends Http4sSpec {
 
     "reject userinfos with invalid characters" in prop { s: String =>
       !s.forall(CharPredicate.Alpha ++ UrlCodingUtils.Unreserved ++ ":") ==>
-        (Uri.fromString(s) must beLeft)
+        (UserInfo.fromString(s) must beLeft)
     }
   }
 


### PR DESCRIPTION
I *believe* that what's the test intended.

Now it does work with "@" as a parameter - not sure if it's worth adding another test to make it explicit though