### PR TITLE
Minor patches to logger 

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -52,17 +52,14 @@ object Logger {
     val bodyStream = if (logBody && isText) {
       message.bodyAsText(charset.getOrElse(Charset.`UTF-8`))
     } else if (logBody) {
-      message
-        .body
+      message.body
         .map(b => java.lang.Integer.toHexString(b & 0xff))
     } else {
       Stream.empty.covary[F]
     }
 
     val bodyText = if (logBody) {
-      bodyStream
-        .compile
-        .string
+      bodyStream.compile.string
         .map(text => s"""body="$text"""")
     } else {
       F.pure("")

--- a/client/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -68,12 +68,10 @@ object Logger {
       F.pure("")
     }
 
-    if (!logBody && !logHeaders) F.unit
-    else {
-      bodyText
-        .map(body => s"$prelude $headers $body")
-        .flatMap(log)
-        .void
-    }
+    def spaced(x: String): String = if (x.isEmpty) x else s" $x"
+
+    bodyText
+      .map(body => s"$prelude${spaced(headers)}${spaced(body)}")
+      .flatMap(log)
   }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -78,17 +78,14 @@ object Logger {
     val bodyStream = if (logBody && isText) {
       message.bodyAsText(charset.getOrElse(Charset.`UTF-8`))
     } else if (logBody) {
-      message
-        .body
+      message.body
         .map(b => java.lang.Integer.toHexString(b & 0xff))
     } else {
       Stream.empty.covary[F]
     }
 
     val bodyText = if (logBody) {
-      bodyStream
-        .compile
-        .string
+      bodyStream.compile.string
         .map(text => s"""body="$text"""")
     } else {
       F.pure("")

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -94,15 +94,10 @@ object Logger {
       F.pure("")
     }
 
-    def msg(body: String) =
-      (logHeaders, logBody) match {
-        case (false, false) => prelude
-        case _ => s"$prelude $headers $body"
-      }
+    def spaced(x: String): String = if (x.isEmpty) x else s" $x"
 
     bodyText
-      .map(msg)
+      .map(body => s"$prelude${spaced(headers)}${spaced(body)}")
       .flatMap(log)
-      .void
   }
 }


### PR DESCRIPTION
1. concat the message body more efficiently (using `StringBuilder`)
2. client.middleware.Logger: log the `prelude` if `logBody` and `logHeaders` are false