### PR TITLE
Compile without fatal warnings on 2.13.0

### DIFF
--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
@@ -10,8 +10,8 @@ import org.http4s.Uri.uri
 object PathInHttpRoutesSpec extends Http4sSpec {
 
   object List {
-    def unapplySeq(params: Map[String, Seq[String]]) = params.get("list")
-    def unapply(params: Map[String, Seq[String]]) = unapplySeq(params)
+    def unapplySeq(params: Map[String, collection.Seq[String]]) = params.get("list")
+    def unapply(params: Map[String, collection.Seq[String]]) = unapplySeq(params)
   }
 
   object I extends QueryParamDecoderMatcher[Int]("start")

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -57,15 +57,6 @@ object Http4sPlugin extends AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     scalaVersion := scala_213,
     crossScalaVersions := Seq(scala_213, scala_212),
-    // Getting some spurious unreachable code warnings in 2.13.0
-    scalacOptions -= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 13)) =>
-          "-Xfatal-warnings"
-        case _ =>
-          "I DON'T EXIST I'M WORKING AROUND NOT BEING ABLE TO CALL scalaVersion.value FROM ~="
-      }
-    },
 
     // https://github.com/tkawachi/sbt-doctest/issues/102
     Test / compile / scalacOptions -= "-Ywarn-unused:params",

--- a/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSpec.scala
+++ b/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSpec.scala
@@ -13,14 +13,11 @@ import org.specs2.concurrent.ExecutionEnv
 import scala.concurrent.duration._
 import scala.io.Source
 
-class TomcatServerSpec(implicit ee: ExecutionEnv) extends {
+class TomcatServerSpec(implicit ee: ExecutionEnv) extends Http4sSpec {
   // Prevents us from loading jar and war URLs, but lets us
   // run Tomcat twice in the same JVM.  This makes me grumpy.
-  //
-  // Needs to run before the server is initialized in the superclass.
-  // This also makes me grumpy.
-  val _ = TomcatURLStreamHandlerFactory.disable()
-} with Http4sSpec {
+  TomcatURLStreamHandlerFactory.disable()
+
   def builder = TomcatBuilder[IO]
 
   val serverR =


### PR DESCRIPTION
* Reimplement the case classiness of `Request` by hand to work around scala/bug#11457.
* Work around `Seq` aliasing in a spec
* Eliminate early initializer in TomcatSpec, which no longer appears to be necessary