### PR TITLE
Adding the ability to filter out status codes to not include in metrics.

### DIFF
--- a/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
+++ b/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
@@ -312,9 +312,8 @@ object PrometheusMetrics {
       prefix: String = "org_http4s_server",
       emptyResponseHandler: Option[Status] = Status.NotFound.some,
       errorResponseHandler: Throwable => Option[Status] = _ => Status.InternalServerError.some,
-      requestFiltering: RequestFiltering[F] = Function.const[FilteringRule, Request[F]](Record)(_:Request[F]),
-      responseFiltering: ResponseFiltering[F] =
-        Function.const[FilteringRule, Response[F]](Record)(_:Response[F])
+      requestFiltering: RequestFiltering[F] = (_: Request[F]) => Record,
+      responseFiltering: ResponseFiltering[F] = (_: Response[F]) => Record
   ): Kleisli[F, HttpService[F], HttpService[F]] = Kleisli { service: HttpService[F] =>
     Sync[F].delay {
       val serviceMetrics =

--- a/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
+++ b/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
@@ -303,9 +303,9 @@ object PrometheusMetrics {
   type ResponseFiltering[F[_]] = Response[F] => FilteringRule
 
   /**
-    * Same behavior as apply except lets you filter out http status codes from the response metrics.
+    * Same behavior as apply except lets you filter requests or responses out of metrics.
     * For example keeping http status 503 from being included in the 5xx response metrics.
-    * Note that by filtering out response metrics by status codes the response metrics will no longer match the request metrics one to one.
+    * Note that by filtering the response metrics will no longer match the request metrics one to one.
     */
   def withFiltering[F[_]: Sync](
       c: CollectorRegistry,

--- a/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
+++ b/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
@@ -237,6 +237,11 @@ object PrometheusMetrics {
   ): Kleisli[F, HttpService[F], HttpService[F]] =
     withFiltering(c, Set.empty, prefix, emptyResponseHandler, errorResponseHandler)
 
+  /**
+    * Same behavior as apply except lets you filter out http status codes from the response metrics.
+    * For example keeping http status 503 from being included in the 5xx response metrics.
+    * Note that by filtering out response metrics by status codes the response metrics will no longer match the request metrics one to one.
+    */
   def withFiltering[F[_]: Sync](
       c: CollectorRegistry,
       statusesToIgnore: Set[Status],

--- a/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
+++ b/prometheus-server-metrics/src/main/scala/org/http4s/server/prometheus/PrometheusMetrics.scala
@@ -312,9 +312,9 @@ object PrometheusMetrics {
       prefix: String = "org_http4s_server",
       emptyResponseHandler: Option[Status] = Status.NotFound.some,
       errorResponseHandler: Throwable => Option[Status] = _ => Status.InternalServerError.some,
-      requestFiltering: RequestFiltering[F] = Function.const[FilteringRule, Request[F]](Record)(_),
+      requestFiltering: RequestFiltering[F] = Function.const[FilteringRule, Request[F]](Record)(_:Request[F]),
       responseFiltering: ResponseFiltering[F] =
-        Function.const[FilteringRule, Response[F]](Record)(_)
+        Function.const[FilteringRule, Response[F]](Record)(_:Response[F])
   ): Kleisli[F, HttpService[F], HttpService[F]] = Kleisli { service: HttpService[F] =>
     Sync[F].delay {
       val serviceMetrics =


### PR DESCRIPTION
Adding the ability to filter out status codes to not include in metrics.
For example 503's are normal because of maintenance on a third party and we don't
want them combined in with 500s which indicate an actual issue which needs fixed.
Introducing a new function and altering private functions should be backwards compatible.
The exiting apply function delegates to the new filter function as to not duplicate any code.

My immediate need is on 0.18.x but I intend on making the equivalent changes on 0.20.x and master branches as well as we'll need those as well pretty soon.