### PR TITLE
Fix Compilation Errors With New `sbt-pgp` Plugin Version

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -2,9 +2,9 @@ package org.http4s.build
 
 import com.timushev.sbt.updates.UpdatesPlugin.autoImport._ // autoImport vs. UpdateKeys necessary here for implicit
 import com.typesafe.sbt.SbtGit.git
-import com.typesafe.sbt.SbtPgp.autoImport._
 import com.typesafe.sbt.git.JGit
-import com.typesafe.sbt.pgp.PgpKeys.publishSigned
+import com.jsuereth.sbtpgp.PgpKeys.publishSigned
+import com.jsuereth.sbtpgp.SbtPgp.autoImport._
 import com.typesafe.tools.mima.core.{DirectMissingMethodProblem, ProblemFilters}
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
@@ -179,7 +179,6 @@ object Http4sPlugin extends AutoPlugin {
   )
 
   val signingSettings = Seq(
-    useGpg := false,
     usePgpKeyHex("42FAD8A85B13261D"),
     pgpPublicRing := baseDirectory.value / "project" / ".gnupg" / "pubring.gpg",
     pgpSecretRing := baseDirectory.value / "project" / ".gnupg" / "secring.gpg",

--- a/project/PrivateProjectPlugin.scala
+++ b/project/PrivateProjectPlugin.scala
@@ -1,6 +1,6 @@
 package org.http4s.build
 
-import com.typesafe.sbt.pgp.PgpKeys.{publishLocalSigned, publishSigned}
+import com.jsuereth.sbtpgp.PgpKeys.{publishLocalSigned, publishSigned}
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 import explicitdeps.ExplicitDepsPlugin.autoImport._

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.eed3si9n"               %  "sbt-unidoc"                % "0.4.
 addSbtPlugin("com.github.cb372"           %  "sbt-explicit-dependencies" % "0.2.11")
 addSbtPlugin("com.github.gseitz"          %  "sbt-release"               % "1.0.11")
 addSbtPlugin("com.github.tkawachi"        %  "sbt-doctest"               % "0.9.5")
-addSbtPlugin("com.jsuereth"               %  "sbt-pgp"                   % "1.1.2")
+addSbtPlugin("com.jsuereth"               %  "sbt-pgp"                   % "2.0.0")
 addSbtPlugin("com.timushev.sbt"           %  "sbt-updates"               % "0.5.0")
 addSbtPlugin("com.typesafe"               %  "sbt-mima-plugin"           % "0.6.1")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-ghpages"               % "0.6.3")


### PR DESCRIPTION
WARNING: This does more than just fix the compilation errors, it also has at least one non-trivial consequence. As of [SBT 2.0.0][sbt-bc-deprecation] Bouncy Castle based PGP is deprecated. Thus this commit removes `useGpg := false`. I believe this means that `gpg` _must_ be on the `PATH` in order for `sbt-pgp` to provide PGP based operations.

[sbt-bc-deprecation]: https://github.com/sbt/sbt-pgp/blob/90465fcde014eb0688f0086fdec56db60ebfbfd6/sbt-pgp/src/main/scala/com/jsuereth/sbtpgp/SbtPgp.scala#L21 "SbtPgp.scala"

This should replace: https://github.com/http4s/http4s/pull/2870