### PR TITLE
Fix Bug Where The Body Of The Request Is Not Sent In Async Client

### DIFF
--- a/client/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
+++ b/client/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
@@ -152,7 +152,7 @@ sealed abstract class JavaNetClientBuilder[F[_]] private (
   }
 
   private def writeBody(req: Request[F], conn: HttpURLConnection): F[Unit] =
-    if (req.isChunked) {
+    if (req.isChunked || req.contentLength.isEmpty) {
       F.delay(conn.setDoOutput(true)) *>
         F.delay(conn.setChunkedStreamingMode(4096)) *>
         req.body

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -13,6 +13,7 @@ import org.http4s.dsl.io._
 import org.http4s.multipart.{Multipart, Part}
 import org.specs2.specification.core.Fragments
 import scala.concurrent.duration._
+import java.nio.charset.StandardCharsets.UTF_8
 
 abstract class ClientRouteTestBattery(name: String) extends Http4sSpec with Http4sClientDsl[IO] {
   val timeout = 20.seconds
@@ -101,6 +102,18 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSpec with Http
           val req = POST(multipart, uri).map(_.withHeaders(multipart.headers))
           val body = client.expect[String](req)
           body must returnValue(containing("This is text."))
+        }
+
+        "Preserve send the body even if neither contentLength or isChunked are set." in {
+          val uri = Uri.fromString(s"http://${address.getHostName}:${address.getPort}/echo").yolo
+          val req: Request[IO] =
+            Request[IO](
+              method = POST,
+              uri = uri,
+              body = Stream.emits("This is normal.".getBytes(UTF_8))
+            )
+          val body = client.expect[String](req)
+          body must returnValue("This is normal.")
         }
       }
     }


### PR DESCRIPTION
The old code used the `EmptyBodyGenerator` in the event that the a request had `_.isChunked == false` and `_.contentLength.isEmpty`. This caused valid requests created in the following manner to not have their body's sent.

```scala
Request(method = POST, Stream.eval(IO.pure(1.toByte)))
```

This seems like a strange way to construct a `Request` value, and indeed it is, but since it is permissible by http4s it should be valid.

A further reason for this change is to create parity between the different client implementations. The test I added _passes_ for the other clients right now, it is only the async client which fails (before this change that is).

It should be noted that I am seeing this issue in the wild with a less contrived example. I have an http4s server using the async client to proxy requests. This uses the incoming `Request` to create the new out going `Request`. I believe that the requests themselves are invalid, that is they are missing a content-type header or a transfer encoding header, which should not be permitted by the RFC.

We could go a different route here, and categorically enforce that any `Request` value have either a `Content-Length` or a `Transfer-Encoding` header, but I was hesitant to do so because that significantly changes the design of `Message.scala` which derives many of its values from the `Headers`.

Note, this effectively reverts https://github.com/http4s/http4s/commit/13dc0e6bff0191c776ede21acd68d7434cc811ed

I'm a bit concerned that it will resurrect the issue described here, https://github.com/http4s/http4s/blob/9f7c6f5a5d3570c38aa4bc9b3b0fb518937d86ea/website/src/hugo/content/changelog.md#L1673.

Rather than the changes proposed in this PR, I'm totally open to some way of preventing the construction of invalid `Request` values. I think we'd be able to enforce being explicit about the content-length on creation and perhaps having the server reject requests which are missing these headers, but that seems like something which requires a much wider discussion.