### PR TITLE
Weaken Http/HttpRoutes Constraint

### DIFF
--- a/core/src/main/scala/org/http4s/Http.scala
+++ b/core/src/main/scala/org/http4s/Http.scala
@@ -1,6 +1,6 @@
 package org.http4s
 
-import cats.Applicative
+import cats._
 import cats.data.Kleisli
 import cats.effect.Sync
 
@@ -16,8 +16,8 @@ object Http {
     * @param run the function to lift
     * @return an [[Http]] that suspends `run`.
     */
-  def apply[F[_], G[_]](run: Request[G] => F[Response[G]])(implicit F: Sync[F]): Http[F, G] =
-    Kleisli(req => F.suspend(run(req)))
+  def apply[F[_], G[_]](run: Request[G] => F[Response[G]])(implicit F: Defer[F]): Http[F, G] =
+    Kleisli(req => F.defer(run(req)))
 
   /** Lifts an effectful [[Response]] into an [[Http]] kleisli.
     *
@@ -51,6 +51,6 @@ object Http {
     * being applied to `fa`
     */
   def local[F[_], G[_]](f: Request[G] => Request[G])(fa: Http[F, G])(
-      implicit F: Sync[F]): Http[F, G] =
-    Kleisli(req => F.suspend(fa.run(f(req))))
+      implicit F: Defer[F]): Http[F, G] =
+    Kleisli(req => F.defer(fa.run(f(req))))
 }

--- a/core/src/main/scala/org/http4s/Http.scala
+++ b/core/src/main/scala/org/http4s/Http.scala
@@ -2,7 +2,6 @@ package org.http4s
 
 import cats._
 import cats.data.Kleisli
-import cats.effect.Sync
 
 /** Functions for creating [[Http]] kleislis. */
 object Http {

--- a/core/src/main/scala/org/http4s/HttpRoutes.scala
+++ b/core/src/main/scala/org/http4s/HttpRoutes.scala
@@ -53,7 +53,8 @@ object HttpRoutes {
     * partial function is suspended in `F` to permit more efficient combination
     * of routes via `SemigroupK`.
     *
-    * @tparam F the base effect of the [[HttpRoutes]]
+    * @tparam F the base effect of the [[HttpRoutes]] - Defer suspends evaluation
+    * of routes, so only 1 section of routes is checked at a time.
     * @param pf the partial function to lift
     * @return An [[HttpRoutes]] that returns some [[Response]] in an `OptionT[F, ?]`
     * wherever `pf` is defined, an `OptionT.none` wherever it is not


### PR DESCRIPTION
`Sync` is no longer required, we only need `Delay` for the ability to suspend the route analysis.