### PR TITLE
Add JsonDecoder Algebra

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -115,6 +115,12 @@ trait CirceInstances extends JawnInstances {
       Uri.fromString(str).leftMap(_ => "Uri")
     }
 
+  implicit class JsonDecoderSyntax[F[_]: JsonDecoder](private val req: Message[F])(
+      implicit F: JsonDecoder[F]) {
+    def asJson: F[Json] = F.asJson(req)
+    def asJsonDecode[A: Decoder]: F[A] = F.asJsonDecode(req)
+  }
+
   implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
     def decodeJson[A](implicit decoder: Decoder[A]): F[A] =
       self.as(implicitly, jsonOf[F, A])

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -115,8 +115,7 @@ trait CirceInstances extends JawnInstances {
       Uri.fromString(str).leftMap(_ => "Uri")
     }
 
-  implicit class JsonDecoderSyntax[F[_]](private val req: Message[F])(
-      implicit F: JsonDecoder[F]) {
+  implicit class JsonDecoderSyntax[F[_]](private val req: Message[F])(implicit F: JsonDecoder[F]) {
     def asJson: F[Json] = F.asJson(req)
     def asJsonDecode[A: Decoder]: F[A] = F.asJsonDecode(req)
   }

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -115,7 +115,7 @@ trait CirceInstances extends JawnInstances {
       Uri.fromString(str).leftMap(_ => "Uri")
     }
 
-  implicit class JsonDecoderSyntax[F[_]: JsonDecoder](private val req: Message[F])(
+  implicit class JsonDecoderSyntax[F[_]](private val req: Message[F])(
       implicit F: JsonDecoder[F]) {
     def asJson: F[Json] = F.asJson(req)
     def asJsonDecode[A: Decoder]: F[A] = F.asJsonDecode(req)

--- a/circe/src/main/scala/org/http4s/circe/JsonDecoder.scala
+++ b/circe/src/main/scala/org/http4s/circe/JsonDecoder.scala
@@ -1,0 +1,25 @@
+package org.http4s.circe
+
+import cats.effect.Sync
+import org.http4s._
+import io.circe._
+
+/**
+  * F-algebra for separating the Sync required for extracting
+  * the Json from the body. As such if F is Sync at some layer,
+  * then this can be used to extract without the lower layer
+  * needing to be aware of the strong constraint.
+ **/
+trait JsonDecoder[F[_]] {
+  def asJson(m: Message[F]): F[Json]
+  def asJsonDecode[A: Decoder](m: Message[F]): F[A]
+}
+
+object JsonDecoder {
+  def apply[F[_]](implicit ev: JsonDecoder[F]): JsonDecoder[F] = ev
+
+  implicit def impl[F[_]: Sync]: JsonDecoder[F] = new JsonDecoder[F] {
+    def asJson(m: Message[F]): F[Json] = m.as[Json]
+    def asJsonDecode[A: Decoder](m: Message[F]): F[A] = m.decodeJson
+  }
+}


### PR DESCRIPTION
Single Type Abstraction for separation of Sync and the locations using the `Json`, which is primarily businesss logic where we'd prefer to remove effects.