### PR TITLE
Bugfix in the baze-core/util/IdentityWriter causing upload failure

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -93,8 +93,7 @@ private[http4s] trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
                "Connection: keep-alive\r\n\r\n"
              else "\r\n")
 
-      // FIXME: This cast to int is bad, but needs refactoring of IdentityWriter to change
-      new IdentityWriter[F](h.length.toInt, this)
+      new IdentityWriter[F](h.length, this)
 
     case _ => // No Length designated for body or Transfer-Encoding included for HTTP 1.1
       if (minor == 0) { // we are replying to a HTTP 1.0 request see if the length is reasonable

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
@@ -21,9 +21,9 @@ private[http4s] class IdentityWriter[F[_]](size: Long, out: TailStage[ByteBuffer
 
   private var bodyBytesWritten = 0L
 
-  private def willOverflow(count: Long) =
-    if (size < 0) false
-    else count + bodyBytesWritten > size
+  private def willOverflow(count: Int) =
+    if (size < 0L) false
+    else count.toLong + bodyBytesWritten > size
 
   def writeHeaders(headerWriter: StringWriter): Future[Unit] = {
     headers = Http1Writer.headersToByteBuffer(headerWriter.result)

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
@@ -11,7 +11,7 @@ import org.http4s.util.StringWriter
 import org.log4s.getLogger
 import scala.concurrent.{ExecutionContext, Future}
 
-private[http4s] class IdentityWriter[F[_]](size: Int, out: TailStage[ByteBuffer])(
+private[http4s] class IdentityWriter[F[_]](size: Long, out: TailStage[ByteBuffer])(
     implicit protected val F: Effect[F],
     protected val ec: ExecutionContext)
     extends Http1Writer[F] {
@@ -19,9 +19,9 @@ private[http4s] class IdentityWriter[F[_]](size: Int, out: TailStage[ByteBuffer]
   private[this] val logger = getLogger
   private[this] var headers: ByteBuffer = null
 
-  private var bodyBytesWritten = 0
+  private var bodyBytesWritten = 0L
 
-  private def willOverflow(count: Int) =
+  private def willOverflow(count: Long) =
     if (size < 0) false
     else count + bodyBytesWritten > size
 
@@ -38,7 +38,7 @@ private[http4s] class IdentityWriter[F[_]](size: Int, out: TailStage[ByteBuffer]
 
       logger.warn(msg)
 
-      val reducedChunk = chunk.take(size - bodyBytesWritten)
+      val reducedChunk = chunk.take((size - bodyBytesWritten).toInt)
       writeBodyChunk(reducedChunk, flush = true) *> Future.failed(new IllegalArgumentException(msg))
     } else {
       val b = chunk.toByteBuffer


### PR DESCRIPTION
Bug causes failure of a chunked upload in case when Content-Length (Long) converted to Int32 overflows to a positive number.

Test case: chunked upload of file with a content length 4,294,967,300 bytes.
Result: `IllegalArgumentException("Will not write more bytes than what was indicated by the Content-Length header 4")`