### PR TITLE
Make Link implement Extractable

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Link.scala
+++ b/core/src/main/scala/org/http4s/headers/Link.scala
@@ -4,7 +4,7 @@ package headers
 import org.http4s.parser.HttpHeaderParser
 import org.http4s.util.Writer
 
-object Link extends HeaderKey.Internal[Link] {
+object Link extends HeaderKey.Internal[Link] with HeaderKey.Singleton {
   override def parse(s: String): ParseResult[Link] =
     HttpHeaderParser.LINK(s)
 }

--- a/tests/src/test/scala/org/http4s/headers/LinkSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/LinkSpec.scala
@@ -28,4 +28,11 @@ class LinkSpec extends HeaderLaws {
         "Link: </feed>; rel=alternate; title=main; type=text/*"
     }
   }
+
+  "get" should {
+    "return extracted link header" in {
+      val headers = Headers.of(Header("Link", """<https://example.com>; rel="preconnect""""))
+      headers.get(Link) must beSome(Link(Uri.uri("https://example.com"), Some("preconnect")))
+    }
+  }
 }


### PR DESCRIPTION
Make `Link` implement `Extractable` interface so that it can be extracted with `org.http4s.Headers#get(key: HeaderKey.Extractable)`.

As discussed on gitter:
* here https://gitter.im/http4s/http4s?at=5d5406367d56bc6080507e4f
* and here: https://gitter.im/http4s/http4s?at=5d5437574e17537f522f119d

Based on these references I could find:
* there shouldn't be multiple Link headers: [https://tools.ietf.org/html/rfc8288#section-3]()

> The Link header field provides a means for serialising one or more
   links into HTTP headers.

That's why it implements `HeaderKey.Singleton`, not `HeaderKey.Recurring`.
* there could be more than one link in a Link header (which is not currently implemented): [https://tools.ietf.org/html/rfc8288#appendix-B.2]()
> This algorithm parses zero or more comma-separated link-values from a
   Link header field.  Given a string field_value, assuming ASCII
   encoding, it returns a list of link objects.



