### PR TITLE
Backport #2922: chunked upload of long Content-Lengths

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -93,8 +93,7 @@ trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
                "Connection: keep-alive\r\n\r\n"
              else "\r\n")
 
-      // FIXME: This cast to int is bad, but needs refactoring of IdentityWriter to change
-      new IdentityWriter[F](h.length.toInt, this)
+      new IdentityWriter[F](h.length, this)
 
     case _ => // No Length designated for body or Transfer-Encoding included for HTTP 1.1
       if (minor == 0) { // we are replying to a HTTP 1.0 request see if the length is reasonable

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
@@ -16,6 +16,12 @@ private[http4s] class IdentityWriter[F[_]](size: Long, out: TailStage[ByteBuffer
     protected val ec: ExecutionContext)
     extends Http1Writer[F] {
 
+  @deprecated("Kept for binary compatibility. To be removed in 0.21.", "0.20.13")
+  private[IdentityWriter] def this(size: Int, out: TailStage[ByteBuffer])(
+      implicit F: Effect[F],
+      ec: ExecutionContext) =
+    this(size.toLong, out)
+
   private[this] val logger = getLogger
   private[this] var headers: ByteBuffer = null
 

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -8,11 +8,13 @@ Maintenance branches are merged before each new release. This change log is
 ordered chronologically, so each release contains all changes described below
 it.
 
-# v0.20.12 (2019-10-31)
+# v0.20.13 (unreleased)
 
 ## Bug fixes
 
 * [#2922](https://github.com/http4s/http4s/pull/2922): Handle Content-Length longer that Int.MaxValue in chunked uploads
+
+# v0.20.12 (2019-10-31)
 
 ## Enhancements
 


### PR DESCRIPTION
This was advertised as fixed in 0.20.12, but I messed up.  Want to get this released ASAP in 0.20.13.