### PR TITLE
Add Mechanism To Create Validated Timeout Values

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -95,6 +95,21 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
       channelOptions = channelOptions
     ) {}
 
+  def withTimeouts(timeouts: Timeouts): BlazeClientBuilder[F] =
+    this
+      .withConnectTimeout(
+        timeouts.connectTimeout.value
+      )
+      .withIdleTimeout(
+        timeouts.idleTimeout.value
+      )
+      .withRequestTimeout(
+        timeouts.requestTimeout.value
+      )
+      .withResponseHeaderTimeout(
+        timeouts.responseHeaderTimeout.value
+      )
+
   def withResponseHeaderTimeout(responseHeaderTimeout: Duration): BlazeClientBuilder[F] =
     copy(responseHeaderTimeout = responseHeaderTimeout)
 

--- a/client/src/main/scala/org/http4s/client/Timeout.scala
+++ b/client/src/main/scala/org/http4s/client/Timeout.scala
@@ -1,0 +1,50 @@
+package org.http4s
+package client
+
+import cats._
+import scala.concurrent.duration._
+
+/** ADT for the timeout types which may be used by a http4s client.
+  *
+  * Not all clients support all timeout types.
+  *
+  * See [[Timeouts]] for a mechanism to construct timeout values which always
+  * line up to expected constraints, e.g. responseHeaderTimeout < idleTimeout.
+  */
+sealed trait Timeout extends Product with Serializable {
+  def value: Duration
+}
+
+object Timeout {
+
+  implicit val showInstance: Show[Timeout] =
+    Show.fromToString
+
+  final case class ConnectTimeout(override final val value: Duration) extends Timeout
+
+  object ConnectTimeout {
+    val Inf: ConnectTimeout = ConnectTimeout(Duration.Inf)
+    val default: ConnectTimeout = ConnectTimeout(10.seconds)
+  }
+
+  final case class IdleTimeout(override final val value: Duration) extends Timeout
+
+  object IdleTimeout {
+    val Inf: IdleTimeout = IdleTimeout(Duration.Inf)
+    val default: IdleTimeout = IdleTimeout(1.minute)
+  }
+
+  final case class RequestTimeout(override final val value: Duration) extends Timeout
+
+  object RequestTimeout {
+    val Inf: RequestTimeout = RequestTimeout(Duration.Inf)
+    val default: RequestTimeout = RequestTimeout(45.seconds)
+  }
+
+  final case class ResponseHeaderTimeout(override final val value: Duration) extends Timeout
+
+  object ResponseHeaderTimeout {
+    val Inf: ResponseHeaderTimeout = ResponseHeaderTimeout(Duration.Inf)
+    val default: ResponseHeaderTimeout = this.Inf
+  }
+}

--- a/client/src/main/scala/org/http4s/client/Timeouts.scala
+++ b/client/src/main/scala/org/http4s/client/Timeouts.scala
@@ -1,0 +1,94 @@
+package org.http4s
+package client
+
+import cats._
+import cats.data._
+import cats.implicits._
+import org.http4s.client.Timeout._
+
+sealed trait Timeouts {
+  def connectTimeout: ConnectTimeout
+  def idleTimeout: IdleTimeout
+  def requestTimeout: RequestTimeout
+  def responseHeaderTimeout: ResponseHeaderTimeout
+}
+
+object Timeouts {
+
+  implicit val showInstance: Show[Timeouts] =
+    Show.fromToString[Timeouts]
+
+  sealed trait Error extends Product with Serializable {
+    def errorMessage: String
+  }
+
+  object Error {
+    final case class TimeoutOrderingError(a: Timeout, b: Timeout) extends Error {
+      override final lazy val errorMessage: String = {
+        s"${a.show} should be < ${b.show}"
+      }
+    }
+  }
+
+  private[this] final case class TimeoutsImpl(
+      override final val connectTimeout: ConnectTimeout,
+      override final val idleTimeout: IdleTimeout,
+      override final val requestTimeout: RequestTimeout,
+      override final val responseHeaderTimeout: ResponseHeaderTimeout
+  ) extends Timeouts {
+    override final lazy val toString: String =
+      s"Timeouts($connectTimeout, $idleTimeout, $requestTimeout, $responseHeaderTimeout)"
+  }
+
+  def unapply(
+      value: Timeouts): Some[(ConnectTimeout, IdleTimeout, RequestTimeout, ResponseHeaderTimeout)] =
+    Some(
+      (value.connectTimeout, value.idleTimeout, value.requestTimeout, value.responseHeaderTimeout))
+
+  /** Attempt to construct a [[Timeouts]] value validating that timeouts pass
+    * sanity checks, e.g. responseHeaderTimeout < idleTimeout.
+    */
+  def apply[F[_], G[_]](
+      connectTimeout: ConnectTimeout,
+      idleTimeout: IdleTimeout,
+      requestTimeout: RequestTimeout,
+      responseHeaderTimeout: ResponseHeaderTimeout
+  )(
+      implicit F: ApplicativeError[F, G[Error]],
+      G: Applicative[G]
+  ): F[Timeouts] = {
+    def checkTimeouts(a: Timeout, b: Timeout): F[Unit] =
+      if (a.value.isFinite && a.value >= b.value) {
+        F.raiseError[Unit](G.pure(Error.TimeoutOrderingError(a, b)))
+      } else {
+        F.unit
+      }
+
+    (
+      checkTimeouts(responseHeaderTimeout, requestTimeout),
+      checkTimeouts(responseHeaderTimeout, idleTimeout),
+      checkTimeouts(requestTimeout, idleTimeout)).mapN((_: Unit, _: Unit, _: Unit) =>
+      TimeoutsImpl(connectTimeout, idleTimeout, requestTimeout, responseHeaderTimeout))
+  }
+
+  /** As [[#apply]], but the result is always a [[ValidatedNec]] value. */
+  def validatedNec(
+      connectTimeout: ConnectTimeout,
+      idleTimeout: IdleTimeout,
+      requestTimeout: RequestTimeout,
+      responseHeaderTimeout: ResponseHeaderTimeout
+  ): ValidatedNec[Error, Timeouts] =
+    this.apply[ValidatedNec[Error, ?], NonEmptyChain](
+      connectTimeout,
+      idleTimeout,
+      requestTimeout,
+      responseHeaderTimeout)
+
+  val defaults: Timeouts =
+    TimeoutsImpl(
+      ConnectTimeout.default,
+      IdleTimeout.default,
+      RequestTimeout.default,
+      ResponseHeaderTimeout.default
+    )
+}

--- a/client/src/test/scala/org/http4s/client/TimeoutsSpec.scala
+++ b/client/src/test/scala/org/http4s/client/TimeoutsSpec.scala
@@ -1,0 +1,113 @@
+package org.http4s
+package client
+
+import cats.data._
+import org.http4s.client.Timeout._
+import scala.concurrent.duration._
+
+final class TimeoutsSpec extends Http4sSpec {
+  "Timeouts" should {
+    "fail validation if responseHeaderTimeout > requestTimeout" in {
+      val responseHeaderTimeout: ResponseHeaderTimeout = ResponseHeaderTimeout(2.minutes)
+      val requestTimeout: RequestTimeout = RequestTimeout(1.minutes)
+      Timeouts.validatedNec(
+        ConnectTimeout.Inf,
+        IdleTimeout.Inf,
+        requestTimeout,
+        responseHeaderTimeout
+      ) must_== Validated.invalidNec(
+        Timeouts.Error.TimeoutOrderingError(responseHeaderTimeout, requestTimeout))
+    }
+    "not fail validation if responseHeaderTimeout < requestTimeout" in {
+      val responseHeaderTimeout: ResponseHeaderTimeout = ResponseHeaderTimeout(1.minutes)
+      val requestTimeout: RequestTimeout = RequestTimeout(2.minutes)
+      Timeouts
+        .validatedNec(
+          ConnectTimeout.Inf,
+          IdleTimeout.Inf,
+          requestTimeout,
+          responseHeaderTimeout
+        )
+        .isValid
+    }
+    "fail validation if responseHeaderTimeout == requestTimeout" in {
+      val responseHeaderTimeout: ResponseHeaderTimeout = ResponseHeaderTimeout(1.minutes)
+      val requestTimeout: RequestTimeout = RequestTimeout(1.minutes)
+      Timeouts.validatedNec(
+        ConnectTimeout.Inf,
+        IdleTimeout.Inf,
+        requestTimeout,
+        responseHeaderTimeout
+      ) must_== Validated.invalidNec(
+        Timeouts.Error.TimeoutOrderingError(responseHeaderTimeout, requestTimeout))
+    }
+    "fail validation if responseHeaderTimeout > idleTimeout" in {
+      val responseHeaderTimeout: ResponseHeaderTimeout = ResponseHeaderTimeout(2.minutes)
+      val idleTimeout: IdleTimeout = IdleTimeout(1.minutes)
+      Timeouts.validatedNec(
+        ConnectTimeout.Inf,
+        idleTimeout,
+        RequestTimeout.Inf,
+        responseHeaderTimeout
+      ) must_== Validated.invalidNec(
+        Timeouts.Error.TimeoutOrderingError(responseHeaderTimeout, idleTimeout))
+    }
+    "not fail validation if responseHeaderTimeout < idleTimeout" in {
+      val responseHeaderTimeout: ResponseHeaderTimeout = ResponseHeaderTimeout(1.minutes)
+      val idleTimeout: IdleTimeout = IdleTimeout(2.minutes)
+      Timeouts
+        .validatedNec(
+          ConnectTimeout.Inf,
+          idleTimeout,
+          RequestTimeout.Inf,
+          responseHeaderTimeout
+        )
+        .isValid
+    }
+    "fail validation if responseHeaderTimeout == idleTimeout" in {
+      val responseHeaderTimeout: ResponseHeaderTimeout = ResponseHeaderTimeout(1.minutes)
+      val idleTimeout: IdleTimeout = IdleTimeout(1.minutes)
+      Timeouts.validatedNec(
+        ConnectTimeout.Inf,
+        idleTimeout,
+        RequestTimeout.Inf,
+        responseHeaderTimeout
+      ) must_== Validated.invalidNec(
+        Timeouts.Error.TimeoutOrderingError(responseHeaderTimeout, idleTimeout))
+    }
+    "fail validation if requestTimeout > idleTimeout" in {
+      val idleTimeout: IdleTimeout = IdleTimeout(1.minutes)
+      val requestTimeout: RequestTimeout = RequestTimeout(2.minutes)
+      Timeouts.validatedNec(
+        ConnectTimeout.Inf,
+        idleTimeout,
+        requestTimeout,
+        ResponseHeaderTimeout.Inf
+      ) must_== Validated.invalidNec(
+        Timeouts.Error.TimeoutOrderingError(requestTimeout, idleTimeout))
+    }
+    "not fail validation if requestTimeout < idleTimeout" in {
+      val idleTimeout: IdleTimeout = IdleTimeout(2.minutes)
+      val requestTimeout: RequestTimeout = RequestTimeout(1.minutes)
+      Timeouts
+        .validatedNec(
+          ConnectTimeout.Inf,
+          idleTimeout,
+          requestTimeout,
+          ResponseHeaderTimeout.Inf
+        )
+        .isValid
+    }
+    "fail validation if responseHeaderTimeout == idleTimeout" in {
+      val idleTimeout: IdleTimeout = IdleTimeout(1.minutes)
+      val requestTimeout: RequestTimeout = RequestTimeout(1.minutes)
+      Timeouts.validatedNec(
+        ConnectTimeout.Inf,
+        idleTimeout,
+        requestTimeout,
+        ResponseHeaderTimeout.Inf
+      ) must_== Validated.invalidNec(
+        Timeouts.Error.TimeoutOrderingError(requestTimeout, idleTimeout))
+    }
+  }
+}


### PR DESCRIPTION
The impetus for this commit is the `verifyTimeoutRelations` method in `BlazeClientBuilder`. That method provides a runtime check with a warn log that the timeout values for a client pass some sanity checks.

This commit adds a new ADT `Timeout` and a product of all timeout types `Timeouts`. The latter provides a mechanism to ensure that the timeout values constructed are always valid.