### PR TITLE
Server Throttle Middleware: Lower Constraint Add Translated Bucket

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/Throttle.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Throttle.scala
@@ -32,7 +32,7 @@ object Throttle {
 
   object TokenBucket {
 
-    private class Translated[F[_], G[_]](t: TokenBucket[F], fk: F ~> G) extends TokenBucket[G]{
+    private class Translated[F[_], G[_]](t: TokenBucket[F], fk: F ~> G) extends TokenBucket[G] {
       def takeToken: G[TokenAvailability] = fk(t.takeToken)
     }
 


### PR DESCRIPTION
- Sync is Stronger Constraint than what is required 
- Add ability to lift Bucket, since it will likely need to be lifted into the transformer due to how apply is written.