### PR TITLE
Implement withQueryParams and withMultiValueQueryParams

### DIFF
--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -143,7 +143,7 @@ trait QueryOps {
     * [[Query]]. If any of the given parameters' keys already exists, the
     * value(s) will be replaced. Parameters from the input map are added
     * left-to-right, so if a parameter with a given key is specified more than
-    * once, it will be self-overriding.
+    * once, it will be self-overwriting.
     */
   def withQueryParams[T: QueryParamEncoder, K: QueryParamKeyLike](params: Map[K, T]): Self =
     params.foldLeft(self) {
@@ -155,7 +155,7 @@ trait QueryOps {
     * [[Query]]. If any of the given parameters' keys already exists, the
     * value(s) will be replaced. Parameters from the input map are added
     * left-to-right, so if a parameter with a given key is specified more than
-    * once, it will be self-overriding.
+    * once, it will be self-overwriting.
     */
   def withMultiValueQueryParams[T: QueryParamEncoder, K: QueryParamKeyLike](
       params: Map[K, collection.Seq[T]]): Self =

--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -138,6 +138,31 @@ trait QueryOps {
       values: collection.Seq[T]): Self =
     _withQueryParam(QueryParamKeyLike[K].getKey(key), values.map(QueryParamEncoder[T].encode))
 
+  /**
+    * Creates maybe a new `Self` with all the specified parameters in the
+    * [[Query]]. If any of the given parameters' keys already exists, the
+    * value(s) will be replaced. Parameters from the input map are added
+    * left-to-right, so if a parameter with a given key is specified more than
+    * once, it will be self-overriding.
+    */
+  def withQueryParams[T: QueryParamEncoder, K: QueryParamKeyLike](params: Map[K, T]): Self =
+    params.foldLeft(self) {
+      case (s, (k, v)) => replaceQuery(Query.fromVector(s.withQueryParam(k, v).query.toVector))
+    }
+
+  /**
+    * Creates maybe a new `Self` with all the specified parameters in the
+    * [[Query]]. If any of the given parameters' keys already exists, the
+    * value(s) will be replaced. Parameters from the input map are added
+    * left-to-right, so if a parameter with a given key is specified more than
+    * once, it will be self-overriding.
+    */
+  def withMultiValueQueryParams[T: QueryParamEncoder, K: QueryParamKeyLike](
+      params: Map[K, collection.Seq[T]]): Self =
+    params.foldLeft(self) {
+      case (s, (k, v)) => replaceQuery(Query.fromVector(s.withQueryParam(k, v).query.toVector))
+    }
+
   private def _withQueryParam(
       name: QueryParameterKey,
       values: collection.Seq[QueryParameterValue]): Self = {


### PR DESCRIPTION
I could not find a more elegant way of returning `Self` (and folding on `self`) other than the proposed
```scala
replaceQuery(Query.fromVector(s.withQueryParam(k, v).query.toVector))
```
If anyone has input on this, let me know.