### PR TITLE
Relaxing constraints on Router.apply

### DIFF
--- a/server/src/main/scala/org/http4s/server/Router.scala
+++ b/server/src/main/scala/org/http4s/server/Router.scala
@@ -1,9 +1,8 @@
 package org.http4s
 package server
 
-import cats.Functor
+import cats._
 import cats.data.Kleisli
-import cats.effect.Sync
 import cats.syntax.semigroupk._
 
 object Router {
@@ -12,7 +11,7 @@ object Router {
     * Defines an [[HttpRoutes]] based on list of mappings.
     * @see define
     */
-  def apply[F[_]: Sync](mappings: (String, HttpRoutes[F])*): HttpRoutes[F] =
+  def apply[F[_]: Monad](mappings: (String, HttpRoutes[F])*): HttpRoutes[F] =
     define(mappings: _*)(HttpRoutes.empty[F])
 
   /**
@@ -21,7 +20,7 @@ object Router {
     *
     * The mappings are processed in descending order (longest first) of prefix length.
     */
-  def define[F[_]: Sync](mappings: (String, HttpRoutes[F])*)(
+  def define[F[_]: Monad](mappings: (String, HttpRoutes[F])*)(
       default: HttpRoutes[F]): HttpRoutes[F] =
     mappings.sortBy(_._1.length).foldLeft(default) {
       case (acc, (prefix, routes)) =>


### PR DESCRIPTION
`Monad` is needed for `<+>`, otherwise it could work with only `Applicative`.