### PR TITLE
Deprecate HttpDate.now

### DIFF
--- a/core/src/main/scala/org/http4s/HttpDate.scala
+++ b/core/src/main/scala/org/http4s/HttpDate.scala
@@ -57,6 +57,7 @@ object HttpDate {
     * 10000, this will throw an exception. The author intends to leave this
     * problem for future generations.
     */
+  @deprecated("0.21.0-M7", "Use HttpDate.current instead, this breaks referential transparency")
   def now: HttpDate =
     unsafeFromInstant(Instant.now)
 

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -163,7 +163,12 @@ Ok("Ok response.").map(_.addCookie(ResponseCookie("foo", "bar"))).unsafeRunSync.
 `Cookie` can be further customized to set, e.g., expiration, the secure flag, httpOnly, flag, etc
 
 ```tut
-Ok("Ok response.").map(_.addCookie(ResponseCookie("foo", "bar", expires = Some(HttpDate.now), httpOnly = true, secure = true))).unsafeRunSync.headers
+{
+  for {
+    resp <- Ok("Ok response.")
+    now <- HttpDate.current
+  } yield resp.addCookie(ResponseCookie("foo", "bar", expires = Some(HttpDate), httpOnly = true, secure = true))
+}.unsafeRunSync.headers
 ```
 
 To request a cookie to be removed on the client, you need to set the cookie value

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -38,6 +38,7 @@ We'll need the following imports to get started:
 ```tut:silent
 import cats.effect._
 import org.http4s._, org.http4s.dsl.io._, org.http4s.implicits._
+implicit val T : Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
 ```
 
 The central concept of http4s-dsl is pattern matching.  An
@@ -167,7 +168,7 @@ Ok("Ok response.").map(_.addCookie(ResponseCookie("foo", "bar"))).unsafeRunSync.
   for {
     resp <- Ok("Ok response.")
     now <- HttpDate.current
-  } yield resp.addCookie(ResponseCookie("foo", "bar", expires = Some(HttpDate), httpOnly = true, secure = true))
+  } yield resp.addCookie(ResponseCookie("foo", "bar", expires = Some(now), httpOnly = true, secure = true))
 }.unsafeRunSync.headers
 ```
 

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -38,7 +38,8 @@ We'll need the following imports to get started:
 ```tut:silent
 import cats.effect._
 import org.http4s._, org.http4s.dsl.io._, org.http4s.implicits._
-implicit val T : Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
+// Provided by `cats.effect.IOApp`
+implicit val timer : Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
 ```
 
 The central concept of http4s-dsl is pattern matching.  An
@@ -273,9 +274,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 ```
 
 ```tut:book
-// Provided by `cats.effect.IOApp`
-implicit val timer: Timer[IO] = IO.timer(global)
-
 val drip: Stream[IO, String] =
   Stream.awakeEvery[IO](100.millis).map(_.toString).take(10)
 ```

--- a/docs/src/main/tut/dsl.md
+++ b/docs/src/main/tut/dsl.md
@@ -164,12 +164,13 @@ Ok("Ok response.").map(_.addCookie(ResponseCookie("foo", "bar"))).unsafeRunSync.
 `Cookie` can be further customized to set, e.g., expiration, the secure flag, httpOnly, flag, etc
 
 ```tut
-{
+val cookieResp = {
   for {
     resp <- Ok("Ok response.")
-    now <- HttpDate.current
+    now <- HttpDate.current[IO]
   } yield resp.addCookie(ResponseCookie("foo", "bar", expires = Some(now), httpOnly = true, secure = true))
-}.unsafeRunSync.headers
+}
+cookieResp.unsafeRunSync.headers
 ```
 
 To request a cookie to be removed on the client, you need to set the cookie value

--- a/server/src/test/scala/org/http4s/server/middleware/DateSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DateSpec.scala
@@ -25,10 +25,11 @@ class DateSpec extends Http4sSpec with CatsIO {
     "always be very shortly before the current time httpRoutes" >> {
       for {
         out <- testService(req).value
+        now <- HttpDate.current[IO]
       } yield {
         out.flatMap(_.headers.get(HDate)) must beSome.like {
           case date =>
-            val diff = HttpDate.now.epochSecond - date.date.epochSecond
+            val diff = now.epochSecond - date.date.epochSecond
             diff must be_<=(2L)
         }
       }
@@ -37,10 +38,11 @@ class DateSpec extends Http4sSpec with CatsIO {
     "always be very shortly before the current time httpApp" >> {
       for {
         out <- testApp(req)
+        now <- HttpDate.current[IO]
       } yield {
         out.headers.get(HDate) must beSome.like {
           case date =>
-            val diff = HttpDate.now.epochSecond - date.date.epochSecond
+            val diff = now.epochSecond - date.date.epochSecond
             diff must be_<=(2L)
         }
       }
@@ -59,10 +61,11 @@ class DateSpec extends Http4sSpec with CatsIO {
 
       for {
         out <- test(req)
+        nowD <- HttpDate.current[IO]
       } yield {
         out.headers.get(HDate) must beSome.like {
           case date =>
-            val now = HttpDate.now.epochSecond
+            val now = nowD.epochSecond
             val diff = now - date.date.epochSecond
             now must_=== diff
         }

--- a/tests/src/test/scala/org/http4s/HeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeaderSpec.scala
@@ -29,7 +29,7 @@ class HeaderSpec extends Http4sSpec {
       h1 == h2 should beTrue
       h2 == h1 should beTrue
 
-      val h3 = Date(HttpDate.now).toRaw.parsed
+      val h3 = Date(HttpDate.Epoch).toRaw.parsed
       val h4 = h3.toRaw
 
       h3 == h4 should beTrue

--- a/tests/src/test/scala/org/http4s/HttpDateSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpDateSpec.scala
@@ -6,9 +6,10 @@ import cats.effect.testing.specs2.CatsIO
 class HttpDateSpec extends Http4sSpec with CatsIO {
   override val timer: Timer[IO] = Http4sSpec.TestTimer
   "HttpDate" should {
-    "current should be extremely close to now" >> {
+    "current should be extremely close to Instant.now" >> {
       HttpDate.current[IO].map { current =>
-        val diff = HttpDate.now.epochSecond - current.epochSecond
+        val diff = HttpDate.unsafeFromInstant(java.time.Instant.now).epochSecond - current
+          .epochSecond
         (diff must be_===(0L)).or(be_===(1L))
       }
     }

--- a/tests/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/tests/src/test/scala/org/http4s/ResponderSpec.scala
@@ -52,7 +52,7 @@ class ResponderSpec extends Specification {
         resp.putHeaders(Connection("close".ci), `Content-Length`.unsafeFromLong(10), Host("foo"))
       (wHeader.headers.toList must have).length(3)
 
-      val newHeaders = wHeader.withHeaders(Date(HttpDate.now))
+      val newHeaders = wHeader.withHeaders(Date(HttpDate.Epoch))
       (newHeaders.headers.toList must have).length(1)
       newHeaders.headers.get(Connection) must beNone
     }
@@ -62,7 +62,7 @@ class ResponderSpec extends Specification {
         resp.putHeaders(Connection("close".ci), `Content-Length`.unsafeFromLong(10), Host("foo"))
       (wHeader.headers.toList must have).length(3)
 
-      val newHeaders = wHeader.withHeaders(Headers.of(Date(HttpDate.now)))
+      val newHeaders = wHeader.withHeaders(Headers.of(Date(HttpDate.Epoch)))
       (newHeaders.headers.toList must have).length(1)
       newHeaders.headers.get(Connection) must beNone
     }

--- a/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -37,7 +37,7 @@ class SimpleHeadersSpec extends Http4sSpec {
     }
 
     "parse Date" in { // mills are lost, get rid of them
-      val header = Date(HttpDate.now).toRaw.parsed
+      val header = Date(HttpDate.Epoch).toRaw.parsed
       HttpHeaderParser.parseHeader(header.toRaw) must beRight(header)
 
       val bad = Header(header.name.toString, "foo")
@@ -56,7 +56,7 @@ class SimpleHeadersSpec extends Http4sSpec {
     }
 
     "parse Last-Modified" in {
-      val header = `Last-Modified`(HttpDate.now).toRaw.parsed
+      val header = `Last-Modified`(HttpDate.Epoch).toRaw.parsed
       HttpHeaderParser.parseHeader(header.toRaw) must beRight(header)
 
       val bad = Header(header.name.toString, "foo")
@@ -64,7 +64,7 @@ class SimpleHeadersSpec extends Http4sSpec {
     }
 
     "parse If-Modified-Since" in {
-      val header = `If-Modified-Since`(HttpDate.now).toRaw.parsed
+      val header = `If-Modified-Since`(HttpDate.Epoch).toRaw.parsed
       HttpHeaderParser.parseHeader(header.toRaw) must beRight(header)
 
       val bad = Header(header.name.toString, "foo")


### PR DESCRIPTION
Following Feedback from after #3051 was merged, deprecate `HttpDate.now` and instruct to use `current` instead.