### PR TITLE
Fix conflicting circe on plugin path

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -6,7 +6,7 @@ scalacOptions := Seq(
 // our other sbt plugins.
 libraryDependencies ++= List(
   "com.eed3si9n" %% "treehugger" % "0.4.4",
-  "io.circe" %% "circe-generic" % "0.12.3",
+  "io.circe" %% "circe-generic" % "0.11.2",
   "org.http4s" %% "http4s-blaze-client" % "0.20.15",
   "org.http4s" %% "http4s-circe" % "0.20.15",
 )


### PR DESCRIPTION
http4s-0.20 is built on circe-0.11.  So is bloop, I think: this made it load for me on metals-0.7.6 with Emacs.