### PR TITLE
Update Jawn and Circe

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/Parser.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/Parser.scala
@@ -12,23 +12,23 @@ import scala.collection.mutable
 /* Temporary parser until jawn-argonaut supports 6.2.x. */
 private[argonaut] object Parser extends SupportParser[Json] {
   implicit val facade: Facade[Json] =
-    new Facade[Json] {
-      override def jnull() = Json.jNull
-      override def jfalse() = Json.jFalse
-      override def jtrue() = Json.jTrue
+    new Facade.NoIndexFacade[Json] {
+      override def jnull: Json = Json.jNull
+      override def jfalse: Json = Json.jFalse
+      override def jtrue: Json = Json.jTrue
       override def jnum(s: CharSequence, decIndex: Int, expIndex: Int): Json =
         Json.jNumber(JsonNumber.unsafeDecimal(s.toString))
       override def jstring(s: CharSequence): Json = Json.jString(s.toString)
 
-      def singleContext() = new FContext[Json] {
+      def singleContext(): FContext[Json] = new FContext.NoIndexFContext[Json] {
         var value: Json = null
         def add(s: CharSequence): Unit = { value = jstring(s); () }
         def add(v: Json): Unit = { value = v; () }
-        def finish: Json = value
+        def finish(): Json = value
         def isObj: Boolean = false
       }
 
-      def arrayContext() = new FContext[Json] {
+      def arrayContext(): FContext[Json] = new FContext.NoIndexFContext[Json] {
         val vs = mutable.ListBuffer.empty[Json]
         def add(s: CharSequence): Unit = { vs += jstring(s); () }
         def add(v: Json): Unit = { vs += v; () }
@@ -36,7 +36,7 @@ private[argonaut] object Parser extends SupportParser[Json] {
         def isObj: Boolean = false
       }
 
-      def objectContext() = new FContext[Json] {
+      def objectContext(): FContext[Json] = new FContext.NoIndexFContext[Json] {
         var key: String = null
         var vs = JsonObject.empty
         def add(s: CharSequence): Unit =

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSpec.scala
@@ -87,7 +87,7 @@ class ArgonautSpec extends JawnDecodeSupportSpec[Json] with Argonauts {
     "handle the optionality of jNumber" in {
       // TODO Urgh.  We need to make testing these smoother.
       // https://github.com/http4s/http4s/issues/157
-      def getBody(body: EntityBody[IO]): IO[Array[Byte]] = body.compile.to[Array]
+      def getBody(body: EntityBody[IO]): IO[Array[Byte]] = body.compile.to(Array)
       val req = Request[IO]().withEntity(jNumberOrNull(157))
       req
         .decode { json: Json =>

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -110,8 +110,8 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSpec with Http
     val hs = rec.headers.toList
     for {
       _ <- IO(rec.status must be_==(expected.status))
-      body <- rec.body.compile.to[Array]
-      expBody <- expected.body.compile.to[Array]
+      body <- rec.body.compile.to(Array)
+      expBody <- expected.body.compile.to(Array)
       _ <- IO(body must_== expBody)
       _ <- IO(expected.headers.foreach { h =>
         h must beOneOf(hs: _*); ()

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/client/StreamClient.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/client/StreamClient.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import io.circe.Json
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.{Request, Uri}
-import org.typelevel.jawn.RawFacade
+import org.typelevel.jawn.Facade
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object StreamClient extends IOApp {
@@ -15,7 +15,7 @@ object StreamClient extends IOApp {
 }
 
 class HttpClient[F[_]](implicit F: ConcurrentEffect[F], S: StreamUtils[F]) {
-  implicit val jsonFacade: RawFacade[Json] =
+  implicit val jsonFacade: Facade[Json] =
     new io.circe.jawn.CirceSupportParser(None, false).facade
 
   def run: F[Unit] =

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -4,11 +4,11 @@ package jawn
 import cats.effect._
 import cats.implicits._
 import fs2.Stream
-import org.typelevel.jawn.{AsyncParser, ParseException, RawFacade}
+import org.typelevel.jawn.{AsyncParser, ParseException, Facade}
 import jawnfs2._
 
 trait JawnInstances {
-  def jawnDecoder[F[_]: Sync, J: RawFacade]: EntityDecoder[F, J] =
+  def jawnDecoder[F[_]: Sync, J: Facade]: EntityDecoder[F, J] =
     EntityDecoder.decodeBy(MediaType.application.json)(jawnDecoderImpl[F, J])
 
   protected def jawnParseExceptionMessage: ParseException => DecodeFailure =
@@ -17,7 +17,7 @@ trait JawnInstances {
     JawnInstances.defaultJawnEmptyBodyMessage
 
   // some decoders may reuse it and avoid extra content negotiation
-  private[http4s] def jawnDecoderImpl[F[_]: Sync, J: RawFacade](m: Media[F]): DecodeResult[F, J] =
+  private[http4s] def jawnDecoderImpl[F[_]: Sync, J: Facade](m: Media[F]): DecodeResult[F, J] =
     DecodeResult {
       m.body.chunks
         .parseJson(AsyncParser.SingleValue)

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -4,7 +4,7 @@ package jawn
 import cats.effect._
 import cats.implicits._
 import fs2.Stream
-import org.typelevel.jawn.{AsyncParser, ParseException, Facade}
+import org.typelevel.jawn.{AsyncParser, Facade, ParseException}
 import jawnfs2._
 
 trait JawnInstances {

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -258,7 +258,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val catsEffectTestingSpecs2          = "com.codecommit"         %% "cats-effect-testing-specs2" % "0.4.0"
   lazy val catsKernelLaws                   = "org.typelevel"          %% "cats-kernel-laws"          % cats.revision
   lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % cats.revision
-  lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % "0.13.0-M2"
+  lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % "0.13.0-RC1"
   lazy val circeJawn                        = "io.circe"               %% "circe-jawn"                % circeGeneric.revision
   lazy val circeLiteral                     = "io.circe"               %% "circe-literal"             % circeGeneric.revision
   lazy val circeParser                      = "io.circe"               %% "circe-parser"              % circeGeneric.revision

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -268,7 +268,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val dropwizardMetricsJson            = "io.dropwizard.metrics"  %  "metrics-json"              % dropwizardMetricsCore.revision
   lazy val disciplineSpecs2                 = "org.typelevel"          %% "discipline-specs2"         % "1.0.0"
   lazy val fs2Crypto                        = "com.spinoco"            %% "fs2-crypto"                % "0.5.0-M1"
-  lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "2.1.0"
+  lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "2.2.0"
   lazy val fs2ReactiveStreams               = "co.fs2"                 %% "fs2-reactive-streams"      % fs2Io.revision
   lazy val javaxServletApi                  = "javax.servlet"          %  "javax.servlet-api"         % "3.1.0"
   lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "1.0.0-RC1"

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -271,9 +271,9 @@ object Http4sPlugin extends AutoPlugin {
   lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "2.1.0"
   lazy val fs2ReactiveStreams               = "co.fs2"                 %% "fs2-reactive-streams"      % fs2Io.revision
   lazy val javaxServletApi                  = "javax.servlet"          %  "javax.servlet-api"         % "3.1.0"
-  lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "0.16.0-SNAPSHOT"
-  lazy val jawnJson4s                       = "org.typelevel"          %% "jawn-json4s"               % "1.0.0-RC3"
-  lazy val jawnPlay                         = "org.typelevel"          %% "jawn-play"                 % "1.0.0-RC3"
+  lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "1.0.0-RC1"
+  lazy val jawnJson4s                       = "org.typelevel"          %% "jawn-json4s"               % "1.0.0"
+  lazy val jawnPlay                         = "org.typelevel"          %% "jawn-play"                 % "1.0.0"
   lazy val jettyClient                      = "org.eclipse.jetty"      %  "jetty-client"              % "9.4.25.v20191220"
   lazy val jettyRunner                      = "org.eclipse.jetty"      %  "jetty-runner"              % jettyServer.revision
   lazy val jettyServer                      = "org.eclipse.jetty"      %  "jetty-server"              % "9.4.25.v20191220"

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -258,7 +258,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val catsEffectTestingSpecs2          = "com.codecommit"         %% "cats-effect-testing-specs2" % "0.4.0"
   lazy val catsKernelLaws                   = "org.typelevel"          %% "cats-kernel-laws"          % cats.revision
   lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % cats.revision
-  lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % "0.12.3"
+  lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % "0.13.0-M2"
   lazy val circeJawn                        = "io.circe"               %% "circe-jawn"                % circeGeneric.revision
   lazy val circeLiteral                     = "io.circe"               %% "circe-literal"             % circeGeneric.revision
   lazy val circeParser                      = "io.circe"               %% "circe-parser"              % circeGeneric.revision
@@ -271,9 +271,9 @@ object Http4sPlugin extends AutoPlugin {
   lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "2.1.0"
   lazy val fs2ReactiveStreams               = "co.fs2"                 %% "fs2-reactive-streams"      % fs2Io.revision
   lazy val javaxServletApi                  = "javax.servlet"          %  "javax.servlet-api"         % "3.1.0"
-  lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "0.15.0"
-  lazy val jawnJson4s                       = "org.typelevel"          %% "jawn-json4s"               % "0.14.3"
-  lazy val jawnPlay                         = "org.typelevel"          %% "jawn-play"                 % "0.14.3"
+  lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "0.16.0-SNAPSHOT"
+  lazy val jawnJson4s                       = "org.typelevel"          %% "jawn-json4s"               % "1.0.0-RC3"
+  lazy val jawnPlay                         = "org.typelevel"          %% "jawn-play"                 % "1.0.0-RC3"
   lazy val jettyClient                      = "org.eclipse.jetty"      %  "jetty-client"              % "9.4.25.v20191220"
   lazy val jettyRunner                      = "org.eclipse.jetty"      %  "jetty-runner"              % jettyServer.revision
   lazy val jettyServer                      = "org.eclipse.jetty"      %  "jetty-server"              % "9.4.25.v20191220"

--- a/server/src/test/scala/org/http4s/server/staticcontent/StaticContentShared.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/StaticContentShared.scala
@@ -55,7 +55,7 @@ private[staticcontent] trait StaticContentShared { this: Http4sSpec =>
 
   def runReq(req: Request[IO]): (Chunk[Byte], Response[IO]) = {
     val resp = routes.orNotFound(req).unsafeRunSync
-    val chunk = Chunk.bytes(resp.body.compile.to[Array].unsafeRunSync)
+    val chunk = Chunk.bytes(resp.body.compile.to(Array).unsafeRunSync)
     (chunk, resp)
   }
 }

--- a/tests/src/test/scala/org/http4s/StaticFileSpec.scala
+++ b/tests/src/test/scala/org/http4s/StaticFileSpec.scala
@@ -261,7 +261,7 @@ class StaticFileSpec extends Http4sSpec {
       // saves chunks, which are mutated by naive usage of readInputStream.
       // This ensures that we're making a defensive copy of the bytes for
       // things like CachingChunkWriter that buffer the chunks.
-      new String(s.compile.to[Array].unsafeRunSync(), "utf-8") must_== expected
+      new String(s.compile.to(Array).unsafeRunSync(), "utf-8") must_== expected
     }
 
     "Set content-length header from a URL" in {


### PR DESCRIPTION
We're working on finalizing Jawn 1.0.0 and this is a WIP PR that updates to the latest Jawn RC and Circe milestones. It also depends on [this unpublished PR](https://github.com/http4s/jawn-fs2/pull/86).

This probably shouldn't be merged until we release Jawn 1.0.0 (which is likely to happen in the next week), but I needed to update http4s for some local testing and thought I should go ahead and open this.