### PR TITLE
  Wrap uninformative Java exceptions in ConnectionFailure

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -2,12 +2,11 @@ package org.http4s
 package client
 package blaze
 
+import cats.effect._
+import cats.implicits._
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousChannelGroup
-
-import cats.effect._
-import cats.implicits._
 import javax.net.ssl.SSLContext
 import org.http4s.blaze.channel.ChannelOptions
 import org.http4s.blaze.channel.nio2.ClientChannelFactory
@@ -16,9 +15,9 @@ import org.http4s.blaze.pipeline.{Command, LeafBuilder}
 import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.headers.`User-Agent`
 import org.http4s.internal.fromFuture
-
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 /** Provides basic HTTP1 pipeline building
   */
@@ -60,17 +59,19 @@ final private class Http1Support[F[_]](
       addr: InetSocketAddress): Future[BlazeConnection[F]] =
     connectionManager
       .connect(addr)
-      .flatMap { head =>
-        buildStages(requestKey) match {
-          case Right((builder, t)) =>
-            Future.successful {
-              builder.base(head)
-              head.inboundCommand(Command.Connected)
-              t
-            }
-          case Left(e) =>
-            Future.failed(e)
-        }
+      .transformWith {
+        case Success(head) =>
+          buildStages(requestKey) match {
+            case Right((builder, t)) =>
+              Future.successful {
+                builder.base(head)
+                head.inboundCommand(Command.Connected)
+                t
+              }
+            case Left(e) =>
+              Future.failed(e)
+          }
+        case Failure(e) => Future.failed(new ConnectionFailure(requestKey, e))
       }(executionContext)
 
   private def buildStages(requestKey: RequestKey)

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -3,6 +3,7 @@ package blaze
 
 import cats.effect._
 import cats.effect.concurrent.{Deferred, Ref}
+import cats.effect.testing.specs2.CatsIO
 import cats.implicits._
 import fs2.Stream
 import java.util.concurrent.TimeoutException
@@ -11,13 +12,16 @@ import javax.servlet.ServletOutputStream
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import org.http4s._
 import org.http4s.blaze.util.TickWheelExecutor
+import org.http4s.client.ConnectionFailure
 import org.http4s.client.testroutes.GetRoutes
 import org.specs2.specification.core.Fragments
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Random
 
-class BlazeClientSpec extends Http4sSpec {
+class BlazeClientSpec extends Http4sSpec with CatsIO {
+  override val timer: Timer[IO] = Http4sSpec.TestTimer
+  override implicit val contextShift: ContextShift[IO] = Http4sSpec.TestContextShift
 
   val tickWheel = new TickWheelExecutor(tick = 50.millis)
 
@@ -335,6 +339,20 @@ class BlazeClientSpec extends Http4sSpec {
             }
             .unsafeRunTimed(5.seconds)
             .attempt must_== Some(Right("simple path"))
+        }
+
+        "raise a ConnectionFailure when a host can't be resolved" in {
+          mkClient(1)
+            .use { client =>
+              client.status(Request[IO](uri = uri"http://example.invalid/"))
+            }
+            .attempt
+            .map {
+              _ must beLike {
+                case Left(e: ConnectionFailure) =>
+                  e.getMessage must_== "Error connecting to http://example.invalid"
+              }
+            }
         }
       }
     }

--- a/client/src/main/scala/org/http4s/client/ConnectionFailure.scala
+++ b/client/src/main/scala/org/http4s/client/ConnectionFailure.scala
@@ -1,0 +1,11 @@
+package org.http4s.client
+
+import java.io.IOException
+
+/** Indicates a failure to establish a client connection, preserving the request key
+  * that we tried to connect to.
+  */
+class ConnectionFailure(requestKey: RequestKey, cause: Throwable) extends IOException(cause) {
+  override def getMessage(): String =
+    s"Error connecting to $requestKey"
+}

--- a/client/src/main/scala/org/http4s/client/RequestKey.scala
+++ b/client/src/main/scala/org/http4s/client/RequestKey.scala
@@ -4,7 +4,9 @@ package client
 import org.http4s.Uri.{Authority, Scheme}
 
 /** Represents a key for requests that can conceivably share a [[Connection]]. */
-final case class RequestKey(scheme: Scheme, authority: Authority)
+final case class RequestKey(scheme: Scheme, authority: Authority) {
+  override def toString = s"${scheme.value}://${authority}"
+}
 
 object RequestKey {
   def fromRequest[F[_]](request: Request[F]): RequestKey = {


### PR DESCRIPTION
See http4s/blaze#373.

Java's `UnresolvableAddressException` does not carry any information about the host that failed to resolve.  If a client fails to connect, we should provide context on which host we failed to connect to.  We do so by introducing a wrapper exception, `ConnectionFailure`, in the client package.

Other clients should probably use this if they can.   Fixed for blaze, as it was reported on blaze.