### PR TITLE
Interrupt Body of DefaultHead Middleware

### DIFF
--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
@@ -48,7 +48,7 @@ class DefaultHeadSpec extends Http4sSpec with CatsIO {
         cleanedUpRef <- Ref[IO].of(false)
         route = HttpRoutes.of[IO] {
           case GET -> _ =>
-            val body: EntityBody[IO] = Stream.empty.onFinalizeWeak(cleanedUpRef.set(true))
+            val body: EntityBody[IO] = Stream.never.onFinalizeWeak(cleanedUpRef.set(true))
             Ok(body)
         }
         app = DefaultHead(route).orNotFound

--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
@@ -48,7 +48,7 @@ class DefaultHeadSpec extends Http4sSpec with CatsIO {
         cleanedUpRef <- Ref[IO].of(false)
         route = HttpRoutes.of[IO] {
           case GET -> _ =>
-            val body: EntityBody[IO] = Stream.never.onFinalizeWeak(cleanedUpRef.set(true))
+            val body: EntityBody[IO] = Stream.never[IO].onFinalizeWeak(cleanedUpRef.set(true))
             Ok(body)
         }
         app = DefaultHead(route).orNotFound

--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSpec.scala
@@ -3,11 +3,16 @@ package server
 package middleware
 
 import cats.effect._
-import fs2.Stream._
+import cats.effect.concurrent.Ref
+import fs2.Stream
 import org.http4s.dsl.io._
 import org.http4s.Uri.uri
+import cats.effect.testing.specs2.CatsIO
 
-class DefaultHeadSpec extends Http4sSpec {
+class DefaultHeadSpec extends Http4sSpec with CatsIO {
+  override implicit val contextShift: ContextShift[IO] = Http4sSpec.TestContextShift
+  override implicit val timer: Timer[IO] = Http4sSpec.TestTimer
+
   val app = DefaultHead(HttpRoutes.of[IO] {
     case GET -> Root / "hello" =>
       Ok("hello")
@@ -39,14 +44,18 @@ class DefaultHeadSpec extends Http4sSpec {
     }
 
     "allow GET body to clean up on fallthrough" in {
-      var cleanedUp = false
-      val app = DefaultHead(HttpRoutes.of[IO] {
-        case GET -> _ =>
-          val body: EntityBody[IO] = eval_(IO({ cleanedUp = true }))
-          Ok(body)
-      }).orNotFound
-      app(Request[IO](Method.HEAD)).flatMap(_.as[String]).unsafeRunSync()
-      cleanedUp must beTrue
+      for {
+        cleanedUpRef <- Ref[IO].of(false)
+        route = HttpRoutes.of[IO] {
+          case GET -> _ =>
+            val body: EntityBody[IO] = Stream.empty.onFinalizeWeak(cleanedUpRef.set(true))
+            Ok(body)
+        }
+        app = DefaultHead(route).orNotFound
+        resp <- app(Request[IO](Method.HEAD))
+        _ <- resp.as[String]
+        cleanedUp <- cleanedUpRef.get
+      } yield cleanedUp must beTrue
     }
   }
 }


### PR DESCRIPTION
So if we are processing a GET as a HEAD, we know we do not care about the body, but we still want to ensure finalizers are run. To get the finalizers we must run the original stream, but we do not want to process all the bytes, in fact any of the bytes. 

To this end we immediately interrupt the stream and make sure that is empty. 

Requires the addition of a `Concurrent` restraint on the body, however I think that is worth it for the potentially gigabytes of processing this saves the server.