### PR TITLE
Covary `F` in Message types. 

### DIFF
--- a/core/src/main/scala/org/http4s/Media.scala
+++ b/core/src/main/scala/org/http4s/Media.scala
@@ -10,6 +10,7 @@ import org.http4s.util.decode
 trait Media[F[_]] {
   def body: EntityBody[F]
   def headers: Headers
+  def covary[F2[x] >: F[x]]: Media[F2]
 
   final def bodyAsText(implicit defaultCharset: Charset = DefaultCharset): Stream[F, String] =
     charset.getOrElse(defaultCharset) match {
@@ -58,5 +59,7 @@ object Media {
     def body = b
 
     def headers: Headers = h
+
+    override def covary[F2[x] >: F[x]]: Media[F2] = this.asInstanceOf[Media[F2]]
   }
 }

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -176,7 +176,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
   /**
     * Lifts this Message's body to the specified effect type.
     */
-  def covary[F2[x] >: F[x]]: SelfF[F2] = this.asInstanceOf[SelfF[F2]]
+  override def covary[F2[x] >: F[x]]: SelfF[F2] = this.asInstanceOf[SelfF[F2]]
 }
 
 object Message {

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -19,7 +19,8 @@ import scala.util.hashing.MurmurHash3
   * Represents a HTTP Message. The interesting subclasses are Request and Response.
   */
 sealed trait Message[F[_]] extends Media[F] { self =>
-  type Self <: Message[F] { type Self = self.Self }
+  type SelfF[F2[_]] <: Message[F2] { type SelfF[F3[_]] = self.SelfF[F3] }
+  type Self = SelfF[F]
 
   def httpVersion: HttpVersion
 
@@ -171,6 +172,11 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     */
   def withoutAttribute(key: Key[_]): Self =
     change(attributes = attributes.delete(key))
+
+  /**
+    * Lifts this Message's body to the specified effect type.
+    */
+  def covary[F2[x] >: F[x]]: SelfF[F2] = this.asInstanceOf[SelfF[F2]]
 }
 
 object Message {
@@ -205,7 +211,7 @@ final class Request[F[_]](
     with Serializable {
   import Request._
 
-  type Self = Request[F]
+  type SelfF[F0[_]] = Request[F0]
 
   private def copy(
       method: Method = this.method,
@@ -478,7 +484,7 @@ final case class Response[F[_]](
     body: EntityBody[F] = EmptyBody,
     attributes: Vault = Vault.empty)
     extends Message[F] {
-  type Self = Response[F]
+  type SelfF[F0[_]] = Response[F0]
 
   def mapK[G[_]](f: F ~> G): Response[G] = Response[G](
     status = status,

--- a/core/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/src/main/scala/org/http4s/multipart/Part.scala
@@ -14,6 +14,8 @@ final case class Part[F[_]](headers: Headers, body: Stream[F, Byte]) extends Med
   def name: Option[String] = headers.get(`Content-Disposition`).flatMap(_.parameters.get("name"))
   def filename: Option[String] =
     headers.get(`Content-Disposition`).flatMap(_.parameters.get("filename"))
+
+  override def covary[F2[x] >: F[x]]: Part[F2] = this.asInstanceOf[Part[F2]]
 }
 
 object Part {

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -223,7 +223,6 @@ class MessageSpec extends Http4sSpec {
       }
     }
 
-
     "covary" should {
       "disallow unrelated effects" in {
         illTyped("Response[Option]().covary[IO]")

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -171,6 +171,20 @@ class MessageSpec extends Http4sSpec {
         request.toString must_== ("Request(method=GET, uri=/, headers=Headers(Cookie: <REDACTED>))")
       }
     }
+
+    "covary" should {
+      "disallow unrelated effects" in {
+        illTyped("Request[Option]().covary[IO]")
+        true
+      }
+
+      "allow related effects" in {
+        trait F1[A]
+        trait F2[A] extends F1[A]
+        Request[F2]().covary[F1]
+        true
+      }
+    }
   }
 
   "Message" >> {
@@ -206,6 +220,21 @@ class MessageSpec extends Http4sSpec {
         resp.contentType must beSome(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`))
         resp.status must_=== Status.NotFound
         resp.body.through(fs2.text.utf8Decode).toList.mkString("") must_=== "Not found"
+      }
+    }
+
+
+    "covary" should {
+      "disallow unrelated effects" in {
+        illTyped("Response[Option]().covary[IO]")
+        true
+      }
+
+      "allow related effects" in {
+        trait F1[A]
+        trait F2[A] extends F1[A]
+        Response[F2]().covary[F1]
+        true
       }
     }
   }

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -183,4 +183,21 @@ I am a big moose
 
   multipartSpec("with default decoder")(implicitly)
   multipartSpec("with mixed decoder")(MultipartDecoder.mixedMultipart[IO](Http4sSpec.TestBlocker))
+
+  "Part" >> {
+    def testPart[F[_]] = Part[F](Headers.empty, EmptyBody)
+    "covary" should {
+      "disallow unrelated effects" in {
+        illTyped("testPart[Option].covary[IO]")
+        true
+      }
+
+      "allow related effects" in {
+        trait F1[A]
+        trait F2[A] extends F1[A]
+        testPart[F2].covary[F1]
+        true
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adding a `covary` function to `Message` and its subtypes that matches the `Stream.covary` function.

It's implemented as a type cast to avoid the costs of creating a new `Request` object for something that should be safe to do as a cast.

Alternative implementation without a type cast, (but including an extra allocation of `Request` is [here](https://github.com/zarthross/http4s/commit/290831ad41ccb6ef1777cecabb9e2a583f09a5b8)