### PR TITLE
Move Arbitrary[Chunk[Byte]] out of Http4sSpec

### DIFF
--- a/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
@@ -7,6 +7,7 @@ import fs2._
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.headers._
+import org.http4s.testing.fs2Arbitraries._
 import org.scalacheck._
 import org.specs2.matcher.MatchResult
 

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -19,7 +19,6 @@ import org.http4s.laws.discipline.ArbitraryInstances
 import org.http4s.testing._
 import org.http4s.util.threads.{newBlockingPool, newDaemonPool, threadFactory}
 import org.scalacheck._
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.util.{FreqMap, Pretty}
 import org.specs2.ScalaCheck
 import org.specs2.execute.{Result, Skipped}
@@ -60,16 +59,6 @@ trait Http4sSpec
   implicit class ParseResultSyntax[A](self: ParseResult[A]) {
     def yolo: A = self.valueOr(e => sys.error(e.toString))
   }
-
-  /** This isn't really ours to provide publicly in implicit scope */
-  implicit lazy val arbitraryByteChunk: Arbitrary[Chunk[Byte]] =
-    Arbitrary {
-      Gen
-        .containerOf[Array, Byte](arbitrary[Byte])
-        .map { b =>
-          Chunk.bytes(b)
-        }
-    }
 
   def writeToString[A](a: A)(implicit W: EntityEncoder[IO, A]): String =
     Stream

--- a/testing/src/test/scala/org/http4s/testing/fs2Arbitraries.scala
+++ b/testing/src/test/scala/org/http4s/testing/fs2Arbitraries.scala
@@ -1,0 +1,11 @@
+package org.http4s.testing
+
+import fs2.Chunk
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary.arbitrary
+
+/** Arbitraries for fs2 types that aren't ours to publish. */
+object fs2Arbitraries {
+  implicit val http4sArbitraryForFs2ChunkOfBytes: Arbitrary[Chunk[Byte]] =
+    Arbitrary(Gen.containerOf[Array, Byte](arbitrary[Byte]).map(Chunk.bytes))
+}

--- a/tests/src/test/scala/org/http4s/EntityCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityCodecSpec.scala
@@ -7,6 +7,7 @@ import cats.effect.laws.util.TestInstances._
 import cats.implicits._
 import fs2.Chunk
 import org.http4s.laws.discipline.EntityCodecTests
+import org.http4s.testing.fs2Arbitraries._
 
 class EntityCodecSpec extends Http4sSpec {
   implicit val testContext: TestContext = TestContext()


### PR DESCRIPTION
Part of an effort to slim down `Http4sSpec`. These don't need to be in scope everywhere, and we won't publish them because they're not our type.