### PR TITLE
Http4s 3095 Pretty-print an org.http4s.Request as a curl command

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -267,6 +267,21 @@ final class Request[F[_]](
 
   def queryString: String = uri.query.renderString
 
+  def asCurl: String = {
+    val elements = List(
+      s"-X ${method.name}",
+      s"'${uri.renderString}'",
+      headers
+        .redactSensitive()
+        .toList
+        .map { header =>
+          s"-H '${header.toString}'"
+        }
+        .mkString(" ")
+    )
+    s"curl ${elements.filter(_.nonEmpty).mkString(" ")}"
+  }
+
   /**
     * Representation of the query string as a map
     *

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -267,10 +267,12 @@ final class Request[F[_]](
 
   def queryString: String = uri.query.renderString
 
-  /**
-    * creates a cURL-command from the request, supported parameters are
-    * -X to specify the HTTP-method
-    * -H for headers, redacts sensitive information such as Authorization- or Cookie-Headers
+  /** cURL representation of the request.
+    *
+    * Supported Parameters are:
+    *
+    * -X,
+    * -H (redacts sensitive information such as Authorization- or Cookie-Headers)
     */
   def asCurl: String = {
     val elements = List(

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -282,6 +282,7 @@ final class Request[F[_]](
   def asCurl(
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)
       : String = {
+
     /**
       * escapes characters that are used in the curl-command, such as '
       */

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -279,7 +279,7 @@ final class Request[F[_]](
     /**
       * escapes characters that are used in the curl-command, such as '
       */
-    def escapeQuotationMarks(s: String) = s.replaceAll("'", "'\\''")
+    def escapeQuotationMarks(s: String) = s.replaceAll("'", """'\\''""")
 
     val elements = List(
       s"-X ${method.name}",

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -267,6 +267,11 @@ final class Request[F[_]](
 
   def queryString: String = uri.query.renderString
 
+  /**
+    * creates a cURL-command from the request, supported parameters are
+    * -X to specify the HTTP-method
+    * -H for headers, redacts sensitive information such as Authorization- or Cookie-Headers
+    */
   def asCurl: String = {
     val elements = List(
       s"-X ${method.name}",

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -283,7 +283,7 @@ final class Request[F[_]](
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)
       : String = {
 
-    /**
+    /*
       * escapes characters that are used in the curl-command, such as '
       */
     def escapeQuotationMarks(s: String) = s.replaceAll("'", """'\\''""")

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -269,18 +269,18 @@ final class Request[F[_]](
 
   /** cURL representation of the request.
     *
-    * Supported Parameters are:
+    * Supported cURL-Parameters are: -X, -H
     *
-    * -X,
-    * -H (redacts sensitive information such as Authorization- or Cookie-Headers)
+    * @param redactHeaders to determine whether sensitive information inheaders should be redacted, true per default
     */
-  def asCurl: String = {
+  def asCurl(redactHeaders: Boolean = true): String = {
+    val filteredHeaders =
+      if (redactHeaders) headers.redactSensitive(Headers.SensitiveHeaders.contains)
+      else headers
     val elements = List(
       s"-X ${method.name}",
       s"'${uri.renderString}'",
-      headers
-        .redactSensitive()
-        .toList
+      filteredHeaders.toList
         .map { header =>
           s"-H '${header.toString}'"
         }

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -284,8 +284,8 @@ final class Request[F[_]](
       : String = {
 
     /*
-      * escapes characters that are used in the curl-command, such as '
-      */
+     * escapes characters that are used in the curl-command, such as '
+     */
     def escapeQuotationMarks(s: String) = s.replaceAll("'", """'\\''""")
 
     val elements = List(

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -195,7 +195,9 @@ class MessageSpec extends Http4sSpec {
 
       "build cURL representation but redact sensitive information" in {
         request
-          .withHeaders(Header("Cookie", "k3=v3; k4=v4"), Authorization(BasicCredentials("user", "pass")))
+          .withHeaders(
+            Header("Cookie", "k3=v3; k4=v4"),
+            Authorization(BasicCredentials("user", "pass")))
           .asCurl mustEqual "curl -X GET 'http://localhost:1234/foo' -H 'Cookie: <REDACTED>' -H 'Authorization: <REDACTED>'"
       }
     }

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -207,7 +207,13 @@ class MessageSpec extends Http4sSpec {
             Header("Cookie", "k3=v3; k4=v4"),
             Header("k5", "v5"),
             Authorization(BasicCredentials("user", "pass")))
-          .asCurl(redactHeaders = false) mustEqual "curl -X GET 'http://localhost:1234/foo' -H 'Cookie: k3=v3; k4=v4' -H 'k5: v5' -H 'Authorization: Basic dXNlcjpwYXNz'"
+          .asCurl(_ => false) mustEqual "curl -X GET 'http://localhost:1234/foo' -H 'Cookie: k3=v3; k4=v4' -H 'k5: v5' -H 'Authorization: Basic dXNlcjpwYXNz'"
+      }
+
+      "escape quotation marks in header" in {
+        request
+          .withHeaders(Header("k6", "'v6'"), Header("'k7'", "v7"))
+          .asCurl() mustEqual "curl -X GET 'http://localhost:1234/foo' -H 'k6: '''v6'''' -H ''''k7''': v7'"
       }
     }
   }

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -213,7 +213,7 @@ class MessageSpec extends Http4sSpec {
       "escape quotation marks in header" in {
         request
           .withHeaders(Header("k6", "'v6'"), Header("'k7'", "v7"))
-          .asCurl() mustEqual "curl -X GET 'http://localhost:1234/foo' -H 'k6: '''v6'''' -H ''''k7''': v7'"
+          .asCurl() mustEqual s"""curl -X GET 'http://localhost:1234/foo' -H 'k6: '\\''v6'\\''' -H ''\\''k7'\\'': v7'"""
       }
     }
   }

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -183,17 +183,17 @@ class MessageSpec extends Http4sSpec {
       )
       val request = Request[IO](Method.GET, uri)
 
-      "build cURL command with scheme and authority" in {
+      "build cURL representation with scheme and authority" in {
         request.asCurl mustEqual "curl -X GET 'http://localhost:1234/foo'"
       }
 
-      "build cURL command with headers and redact sensitive information" in {
+      "build cURL representation with headers" in {
         request
           .withHeaders(Header("k1", "v1"), Header("k2", "v2"))
           .asCurl mustEqual "curl -X GET 'http://localhost:1234/foo' -H 'k1: v1' -H 'k2: v2'"
       }
 
-      "build cURL command but redact sensitive information" in {
+      "build cURL representation but redact sensitive information" in {
         request
           .withHeaders(Header("Cookie", "k3=v3; k4=v4"), Authorization(BasicCredentials("user", "pass")))
           .asCurl mustEqual "curl -X GET 'http://localhost:1234/foo' -H 'Cookie: <REDACTED>' -H 'Authorization: <REDACTED>'"


### PR DESCRIPTION
Initial Implementation for the curl-representation of the request.
Maybe  --data-body for POST-Requests should be included still.  What do you think?

Also I kept it that stringified version of the Request probably should redact sensitive information (Authorization- and Cookie-Headers). Is that fine?