### PR TITLE
Fix flaky decode

### DIFF
--- a/tests/src/test/scala/org/http4s/util/DecodeSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/DecodeSpec.scala
@@ -55,5 +55,11 @@ class DecodeSpec extends Http4sSpec {
         decoded must_== expected
       }
     }
+
+    "drop Byte Order Mark" in {
+      val source = Stream.emits(Seq(0xef.toByte, 0xbb.toByte, 0xbf.toByte))
+      val decoded = decode(Charset.`UTF-8`)(source).toList.combineAll
+      decoded must_== ""
+    }
   }
 }


### PR DESCRIPTION
Fixes #2956

Test was failing when the generated string contained UTF-8 BOM character (that's why the minimum example looked like an empty String).

Last year fs2 started ignoring UTF-8 BOM characters:
https://github.com/functional-streams-for-scala/fs2/issues/1484

So flakiness of this test is a successful discovery of the difference between the behavior of fs2 and http4s decoders.

Following the example of fs2, I made changes to the `decode` function dropping BOM characters and added an example test to verify that.