### PR TITLE
Asynchronous tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -592,9 +592,11 @@ lazy val commonSettings = Seq(
   ),
   libraryDependencies ++= Seq(
     catsEffectTestingSpecs2,
+    catsEffectTestingScalatest,
     catsLaws,
     catsKernelLaws,
     disciplineSpecs2,
+    disciplineScalatest,
     logbackClassic,
     scalacheck,
     specs2Core,

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -256,6 +256,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % "2.0.0"
   lazy val catsEffectLaws                   = "org.typelevel"          %% "cats-effect-laws"          % catsEffect.revision
   lazy val catsEffectTestingSpecs2          = "com.codecommit"         %% "cats-effect-testing-specs2" % "0.4.0"
+  lazy val catsEffectTestingScalatest       = "com.codecommit"         %% "cats-effect-testing-scalatest" % "0.4.0"
   lazy val catsKernelLaws                   = "org.typelevel"          %% "cats-kernel-laws"          % cats.revision
   lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % cats.revision
   lazy val circeGeneric                     = "io.circe"               %% "circe-generic"             % "0.13.0-RC1"
@@ -267,6 +268,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val dropwizardMetricsCore            = "io.dropwizard.metrics"  %  "metrics-core"              % "4.1.2"
   lazy val dropwizardMetricsJson            = "io.dropwizard.metrics"  %  "metrics-json"              % dropwizardMetricsCore.revision
   lazy val disciplineSpecs2                 = "org.typelevel"          %% "discipline-specs2"         % "1.0.0"
+  lazy val disciplineScalatest              = "org.typelevel"          %% "discipline-scalatest"      % "1.0.0"
   lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "2.2.1"
   lazy val fs2ReactiveStreams               = "co.fs2"                 %% "fs2-reactive-streams"      % fs2Io.revision
   lazy val javaxServletApi                  = "javax.servlet"          %  "javax.servlet-api"         % "3.1.0"

--- a/testing/src/test/scala/org/http4s/testing/CatsEquality.scala
+++ b/testing/src/test/scala/org/http4s/testing/CatsEquality.scala
@@ -1,0 +1,35 @@
+/* Derived from Cats:
+ * https://raw.githubusercontent.com/typelevel/cats/master/tests/src/test/scala/cats/tests/CatsEquality.scala
+ * License: https://raw.githubusercontent.com/typelevel/cats/master/LICENSE.txt
+ */
+package org.http4s.testing
+
+import cats.Eq
+import org.scalactic._
+import TripleEqualsSupport.AToBEquivalenceConstraint
+import TripleEqualsSupport.BToAEquivalenceConstraint
+
+// The code in this file was taken and only slightly modified from
+// https://github.com/bvenners/equality-integration-demo
+// Thanks for the great examples, Bill!
+
+final class CatsEquivalence[T](T: Eq[T]) extends Equivalence[T] {
+  def areEquivalent(a: T, b: T): Boolean = T.eqv(a, b)
+}
+
+trait LowPriorityStrictCatsConstraints extends TripleEquals {
+  implicit def lowPriorityCatsCanEqual[A, B](implicit B: Eq[B], ev: A <:< B): CanEqual[A, B] =
+    new AToBEquivalenceConstraint[A, B](new CatsEquivalence(B), ev)
+}
+
+trait StrictCatsEquality extends LowPriorityStrictCatsConstraints {
+  override def convertToEqualizer[T](left: T): Equalizer[T] = super.convertToEqualizer[T](left)
+  implicit override def convertToCheckingEqualizer[T](left: T): CheckingEqualizer[T] =
+    new CheckingEqualizer(left)
+  override def unconstrainedEquality[A, B](implicit equalityOfA: Equality[A]): CanEqual[A, B] =
+    super.unconstrainedEquality[A, B]
+  implicit def catsCanEqual[A, B](implicit A: Eq[A], ev: B <:< A): CanEqual[A, B] =
+    new BToAEquivalenceConstraint[A, B](new CatsEquivalence(A), ev)
+}
+
+object StrictCatsEquality extends StrictCatsEquality

--- a/testing/src/test/scala/org/http4s/testing/Http4sMatchersSpec.scala
+++ b/testing/src/test/scala/org/http4s/testing/Http4sMatchersSpec.scala
@@ -2,18 +2,19 @@ package org.http4s
 package testing
 
 import cats.effect.IO
+import cats.implicits._
 import org.http4s.headers._
+import org.http4s.testing.Http4sSyncSpec
 
-class ResponseGeneratorSpec extends Http4sSpec {
-  "haveHeaders" should {
+class Http4sMatchersSpec extends Http4sSyncSpec {
+  "haveHeaders" - {
     "work on value equality" in {
       val resp = Response[IO]().withEntity("test")
-      resp must
-        haveHeaders(
-          Headers.of(
-            `Content-Length`.unsafeFromLong(4L),
-            `Content-Type`(MediaType.text.`plain`, Charset.`UTF-8`)
-          ))
+      assert(
+        resp.headers === Headers.of(
+          `Content-Length`.unsafeFromLong(4L),
+          `Content-Type`(MediaType.text.`plain`, Charset.`UTF-8`)
+        ))
     }
   }
 }

--- a/testing/src/test/scala/org/http4s/testing/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/testing/Http4sSpec.scala
@@ -1,0 +1,16 @@
+package org.http4s.testing
+
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.Assertions
+import org.scalatest.freespec.AnyFreeSpec
+
+private[testing] trait Http4sSpec { self: Assertions =>
+  override def convertToEqualizer[T](left: T): Equalizer[T] = {
+    val _ = left
+    sys.error("Intentionally ambiguous implicit for Equalizer")
+  }
+}
+
+private[http4s] trait Http4sSyncSpec extends AnyFreeSpec with Http4sSpec
+
+private[http4s] trait Http4sAsyncSpec extends AsyncIOSpec with Http4sSpec


### PR DESCRIPTION
Specs2 has a blocking execution model. `IOMatchers` and `CatsIO` both call blocking methods under the covers.  I believe this blocking is likely a cause of the flakiness that plagues our Travis CI.

This introduces an `Http4sAsyncSpec`, built on cats-effect-testing-scalatest, itself built on Scalatest's asynchronous testing.  The underlying framework accepts a `Future[Assertion]`, and the intermediaries let us not think about `Future`.

This is a radical change, because it introduces another major testing framework unless and until we migrate all the tests.  Then again, testing `IO` is a large part of what we do, and our flaky tests are highly discouraging.

Discuss.