### PR TITLE
Configure server TLS with fs2.io.tls.TLSParameters

### DIFF
--- a/core/src/main/scala/org/http4s/internal/BackendBuilder.scala
+++ b/core/src/main/scala/org/http4s/internal/BackendBuilder.scala
@@ -1,7 +1,7 @@
 package org.http4s.internal
 
 import cats.effect.{Bracket, Resource}
-import fs2.Stream
+import _root_.fs2.Stream
 
 private[http4s] trait BackendBuilder[F[_], A] {
   protected implicit def F: Bracket[F, Throwable]

--- a/core/src/main/scala/org/http4s/internal/ChunkWriter.scala
+++ b/core/src/main/scala/org/http4s/internal/ChunkWriter.scala
@@ -1,7 +1,7 @@
 package org.http4s.internal
 
 import java.nio.charset.{Charset, StandardCharsets}
-import fs2.Chunk
+import _root_.fs2.Chunk
 import org.http4s.util.Writer
 import scala.collection.mutable.Buffer
 

--- a/core/src/main/scala/org/http4s/internal/fs2.scala
+++ b/core/src/main/scala/org/http4s/internal/fs2.scala
@@ -1,0 +1,27 @@
+package org.http4s.internal
+
+import _root_.fs2.io.tls.TLSParameters
+import javax.net.ssl.SSLParameters
+import org.http4s.internal.CollectionCompat.CollectionConverters._
+
+private[http4s] object fs2 {
+  def toSSLParameters(tlsParameters: TLSParameters): SSLParameters = {
+    val p = new SSLParameters()
+    import tlsParameters._
+    algorithmConstraints.foreach(p.setAlgorithmConstraints)
+    // applicationProtocols.foreach(ap => p.setApplicationProtocols(ap.toArray))
+    cipherSuites.foreach(cs => p.setCipherSuites(cs.toArray))
+    // enableRetransmissions.foreach(p.setEnableRetransmissions)
+    endpointIdentificationAlgorithm.foreach(p.setEndpointIdentificationAlgorithm)
+    // maximumPacketSize.foreach(p.setMaximumPacketSize)
+    protocols.foreach(ps => p.setProtocols(ps.toArray))
+    serverNames.foreach(sn => p.setServerNames(sn.asJava))
+    sniMatchers.foreach(sm => p.setSNIMatchers(sm.asJava))
+    p.setUseCipherSuitesOrder(useCipherSuitesOrder)
+    if (needClientAuth)
+      p.setNeedClientAuth(needClientAuth)
+    else if (wantClientAuth)
+      p.setWantClientAuth(wantClientAuth)
+    p
+  }
+}

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
@@ -17,6 +17,9 @@ object BlazeSslExampleApp {
       .bindHttp(8443)
       .withSSL(ssl.storeInfo, ssl.keyManagerPassword)
 
+  def sslContext =
+    SSLContext
+
   def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server[F]] =
     for {
       blocker <- Blocker[F]

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -92,6 +92,11 @@ object Http4sPlugin extends AutoPlugin {
     addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
 
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.4.4" cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % "1.4.4" % Provided cross CrossVersion.full
+    ),
+
     http4sBuildData := {
       val dest = target.value / "hugo-data" / "build.toml"
       val (major, minor) = http4sApiVersion.value

--- a/server/src/main/scala/org/http4s/server/SSLClientAuthMode.scala
+++ b/server/src/main/scala/org/http4s/server/SSLClientAuthMode.scala
@@ -3,8 +3,10 @@ package org.http4s.server
 /**
   * Client Auth mode for mTLS
   */
+@deprecated("Use methods that take fs2.io.tls.TLSParameters instead", "0.21.0-RC3")
 sealed trait SSLClientAuthMode extends Product with Serializable
 
+@deprecated("Use methods that take fs2.io.tls.TLSParameters instead", "0.21.0-RC3")
 object SSLClientAuthMode {
   case object NotRequested extends SSLClientAuthMode
   case object Requested extends SSLClientAuthMode

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -90,8 +90,10 @@ object AsyncTimeoutSupport {
   val DefaultAsyncTimeout = defaults.ResponseTimeout
 }
 
-sealed trait SSLConfig
+@deprecated("Use javax.net.ssl.SSLContext and fs2.io.tls.TLSParameters instead", "0.21.0-RC3")
+trait SSLConfig
 
+@deprecated("Use javax.net.ssl.SSLContext and fs2.io.tls.TLSParameters instead", "0.21.0-RC3")
 final case class KeyStoreBits(
     keyStore: StoreInfo,
     keyManagerPassword: String,
@@ -100,9 +102,11 @@ final case class KeyStoreBits(
     clientAuth: SSLClientAuthMode)
     extends SSLConfig
 
+@deprecated("Use javax.net.ssl.SSLContext and fs2.io.tls.TLSParameters instead", "0.21.0-RC3")
 final case class SSLContextBits(sslContext: SSLContext, clientAuth: SSLClientAuthMode)
     extends SSLConfig
 
+@deprecated("Use javax.net.ssl.SSLContext instead", "0.21.0-RC3")
 object SSLKeyStoreSupport {
   final case class StoreInfo(path: String, password: String)
 }


### PR DESCRIPTION
* Deprecates `SSLConfig` in the server package.
* Deprecates `SSLAuthMode`, which is good, but not part of the otherwise superior `TLSParameters`.
* Adds a `withTLSParameters` method to the server builders to replace the auth mode and allow more configuration.

Fixes #2499.