### PR TITLE
Change behaviour of Router to use segments

### DIFF
--- a/server/src/main/scala/org/http4s/server/ContextRouter.scala
+++ b/server/src/main/scala/org/http4s/server/ContextRouter.scala
@@ -1,0 +1,42 @@
+package org.http4s.server
+
+import org.http4s.{ContextRequest, ContextRoutes}
+import cats.data.Kleisli
+import cats.effect.Sync
+import cats.syntax.semigroupk._
+
+object ContextRouter {
+
+  /**
+    * Defines an [[ContextRoutes]] based on list of mappings.
+    * @see define
+    */
+  def apply[F[_]: Sync, A](mappings: (String, ContextRoutes[A, F])*): ContextRoutes[A, F] =
+    define(mappings: _*)(ContextRoutes.empty[A, F])
+
+  /**
+    * Defines an [[ContextRoutes]] based on list of mappings and
+    * a default Service to be used when none in the list match incoming requests.
+    *
+    * The mappings are processed in descending order (longest first) of prefix length.
+    */
+  def define[F[_]: Sync, A](
+      mappings: (String, ContextRoutes[A, F])*
+  )(default: ContextRoutes[A, F]): ContextRoutes[A, F] =
+    mappings.sortBy(_._1.length).foldLeft(default) {
+      case (acc, (prefix, routes)) =>
+        val segments = Router.toSegments(prefix)
+        if (segments.isEmpty) routes <+> acc
+        else
+          Kleisli { req =>
+            (
+              if (Router.toSegments(req.req.pathInfo).startsWith(segments))
+                routes
+                  .local[ContextRequest[F, A]](r =>
+                    ContextRequest(r.context, Router.translate(prefix)(r.req))) <+> acc
+              else
+                acc
+            )(req)
+          }
+    }
+}

--- a/server/src/test/scala/org/http4s/server/ContextRouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/ContextRouterSpec.scala
@@ -1,0 +1,98 @@
+package org.http4s
+package server
+
+import cats.data.{Kleisli, OptionT}
+import cats.effect._
+import org.http4s.dsl.io._
+import org.http4s.testing.Http4sLegacyMatchersIO
+
+class ContextRouterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
+  val numbers = ContextRoutes.of[Unit, IO] {
+    case GET -> Root / "1" as _ =>
+      Ok("one")
+  }
+  val numbers2 = ContextRoutes.of[Unit, IO] {
+    case GET -> Root / "1" as _ =>
+      Ok("two")
+  }
+
+  val letters = ContextRoutes.of[Unit, IO] {
+    case GET -> Root / "/b" as _ =>
+      Ok("bee")
+  }
+  val shadow = ContextRoutes.of[Unit, IO] {
+    case GET -> Root / "shadowed" as _ =>
+      Ok("visible")
+  }
+  val root = ContextRoutes.of[Unit, IO] {
+    case GET -> Root / "about" as _ =>
+      Ok("about")
+    case GET -> Root / "shadow" / "shadowed" as _ =>
+      Ok("invisible")
+  }
+
+  val notFound = ContextRoutes.of[Unit, IO] {
+    case _ as _ => NotFound("Custom NotFound")
+  }
+
+  def middleware(routes: ContextRoutes[Unit, IO]): ContextRoutes[Unit, IO] =
+    Kleisli((r: ContextRequest[IO, Unit]) =>
+      if (r.req.uri.query.containsQueryParam("block")) OptionT.liftF(Ok(r.req.uri.path))
+      else routes(r))
+
+  val service = ContextRouter[IO, Unit](
+    "/numbers" -> numbers,
+    "/numb" -> middleware(numbers2),
+    "/" -> root,
+    "/shadow" -> shadow,
+    "/letters" -> letters
+  )
+
+  "A router" should {
+    "translate mount prefixes" in {
+      service.orNotFound(ContextRequest((), Request[IO](GET, uri"/numbers/1"))) must returnBody(
+        "one")
+      service.orNotFound(ContextRequest((), Request[IO](GET, uri"/numb/1"))) must returnBody("two")
+      service.orNotFound(ContextRequest((), Request[IO](GET, uri"/numbe?block"))) must returnStatus(
+        NotFound)
+    }
+
+    "require the correct prefix" in {
+      val resp =
+        service.orNotFound(ContextRequest((), Request[IO](GET, uri"/letters/1"))).unsafeRunSync()
+      resp must not(haveBody("bee"))
+      resp must not(haveBody("one"))
+      resp must haveStatus(NotFound)
+    }
+
+    "support root mappings" in {
+      service.orNotFound(ContextRequest((), Request[IO](GET, uri"/about"))) must returnBody("about")
+    }
+
+    "match longer prefixes first" in {
+      service.orNotFound(ContextRequest((), Request[IO](GET, uri"/shadow/shadowed"))) must returnBody(
+        "visible")
+    }
+
+    "404 on unknown prefixes" in {
+      service.orNotFound(ContextRequest((), Request[IO](GET, uri"/symbols/~"))) must returnStatus(
+        NotFound)
+    }
+
+    "Allow passing through of routes with identical prefixes" in {
+      ContextRouter[IO, Unit]("" -> letters, "" -> numbers)
+        .orNotFound(ContextRequest((), Request[IO](GET, uri"/1"))) must returnBody("one")
+    }
+
+    "Serve custom NotFound responses" in {
+      ContextRouter[IO, Unit]("/foo" -> notFound).orNotFound(
+        ContextRequest((), Request[IO](uri = uri"/foo/bar"))) must returnBody("Custom NotFound")
+    }
+
+    "Return the fallthrough response if no route is found" in {
+      val router = ContextRouter[IO, Unit]("/foo" -> notFound)
+      router(ContextRequest((), Request[IO](uri = uri"/bar"))).value must returnValue(
+        Option.empty[Response[IO]])
+    }
+  }
+}

--- a/server/src/test/scala/org/http4s/server/RouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSpec.scala
@@ -1,8 +1,8 @@
 package org.http4s
 package server
 
+import cats.data.{Kleisli, OptionT}
 import cats.effect._
-import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.http4s.testing.Http4sLegacyMatchersIO
 
@@ -11,6 +11,11 @@ class RouterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     case GET -> Root / "1" =>
       Ok("one")
   }
+  val numbers2 = HttpRoutes.of[IO] {
+    case GET -> Root / "1" =>
+      Ok("two")
+  }
+
   val letters = HttpRoutes.of[IO] {
     case GET -> Root / "/b" =>
       Ok("bee")
@@ -30,8 +35,13 @@ class RouterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     case _ => NotFound("Custom NotFound")
   }
 
+  def middleware(routes: HttpRoutes[IO]): HttpRoutes[IO] =
+    Kleisli((r: Request[IO]) =>
+      if (r.uri.query.containsQueryParam("block")) OptionT.liftF(Ok(r.uri.path)) else routes(r))
+
   val service = Router[IO](
     "/numbers" -> numbers,
+    "/numb" -> middleware(numbers2),
     "/" -> root,
     "/shadow" -> shadow,
     "/letters" -> letters
@@ -39,41 +49,43 @@ class RouterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
   "A router" should {
     "translate mount prefixes" in {
-      service.orNotFound(Request[IO](GET, uri("/numbers/1"))) must returnBody("one")
+      service.orNotFound(Request[IO](GET, uri"/numbers/1")) must returnBody("one")
+      service.orNotFound(Request[IO](GET, uri"/numb/1")) must returnBody("two")
+      service.orNotFound(Request[IO](GET, uri"/numbe?block")) must returnStatus(NotFound)
     }
 
     "require the correct prefix" in {
-      val resp = service.orNotFound(Request[IO](GET, uri("/letters/1"))).unsafeRunSync()
+      val resp = service.orNotFound(Request[IO](GET, uri"/letters/1")).unsafeRunSync()
       resp must not(haveBody("bee"))
       resp must not(haveBody("one"))
       resp must haveStatus(NotFound)
     }
 
     "support root mappings" in {
-      service.orNotFound(Request[IO](GET, uri("/about"))) must returnBody("about")
+      service.orNotFound(Request[IO](GET, uri"/about")) must returnBody("about")
     }
 
     "match longer prefixes first" in {
-      service.orNotFound(Request[IO](GET, uri("/shadow/shadowed"))) must returnBody("visible")
+      service.orNotFound(Request[IO](GET, uri"/shadow/shadowed")) must returnBody("visible")
     }
 
     "404 on unknown prefixes" in {
-      service.orNotFound(Request[IO](GET, uri("/symbols/~"))) must returnStatus(NotFound)
+      service.orNotFound(Request[IO](GET, uri"/symbols/~")) must returnStatus(NotFound)
     }
 
     "Allow passing through of routes with identical prefixes" in {
       Router[IO]("" -> letters, "" -> numbers)
-        .orNotFound(Request[IO](GET, uri("/1"))) must returnBody("one")
+        .orNotFound(Request[IO](GET, uri"/1")) must returnBody("one")
     }
 
     "Serve custom NotFound responses" in {
-      Router[IO]("/foo" -> notFound).orNotFound(Request[IO](uri = uri("/foo/bar"))) must returnBody(
+      Router[IO]("/foo" -> notFound).orNotFound(Request[IO](uri = uri"/foo/bar")) must returnBody(
         "Custom NotFound")
     }
 
     "Return the fallthrough response if no route is found" in {
       val router = Router[IO]("/foo" -> notFound)
-      router(Request[IO](uri = uri("/bar"))).value must returnValue(Option.empty[Response[IO]])
+      router(Request[IO](uri = uri"/bar")).value must returnValue(Option.empty[Response[IO]])
     }
   }
 }


### PR DESCRIPTION
This changes the router to use segment routing instead of string prefix matching.
The previous behaviour was unsafe and would match longer prefixes which may cause unexpected matches.

This will no longer fall-through on partial matches.

* Add ContextRouter with same routing logic