### PR TITLE
Refactor Tomcat SSL config, deprecate abandoned ServerBuilder

### DIFF
--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -65,6 +65,9 @@ sealed class JettyBuilder[F[_]] private (
       serviceErrorHandler,
       banner)
 
+  @deprecated(
+    "Build an `SSLContext` from the first four parameters and use `withSslContext` (note lowercase). To also request client certificates, use `withSslContextAndParameters, calling either `.setWantClientAuth(true)` or `setNeedClientAuth(true)` on the `SSLParameters`.",
+    "0.21.0-RC3")
   def withSSL(
       keyStore: StoreInfo,
       keyManagerPassword: String,

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -90,8 +90,10 @@ object AsyncTimeoutSupport {
   val DefaultAsyncTimeout = defaults.ResponseTimeout
 }
 
+@deprecated("No longer used", "0.21.0-RC3")
 sealed trait SSLConfig
 
+@deprecated("No longer used", "0.21.0-RC3")
 final case class KeyStoreBits(
     keyStore: StoreInfo,
     keyManagerPassword: String,
@@ -100,6 +102,7 @@ final case class KeyStoreBits(
     clientAuth: SSLClientAuthMode)
     extends SSLConfig
 
+@deprecated("No longer used", "0.21.0-RC3")
 final case class SSLContextBits(sslContext: SSLContext, clientAuth: SSLClientAuthMode)
     extends SSLConfig
 


### PR DESCRIPTION
* Refactors the Tomcat SSL configuration
* Lets us deprecate types from the `ServerBuilder` not in the public API
* Deprecated `JettyBuider.withSSL`, like Blaze's.  Tomcat doesn't currently have an alternative.
* Tomcat still falls short of the other four backends in being able to use `SSLParameters` or fs2's `TLSParameters`. :shrug: