### PR TITLE
Release 0.21.0-RC4

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.21.0-SNAPSHOT"
+version in ThisBuild := "0.21.0-RC4"

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -8,6 +8,16 @@ Maintenance branches are merged before each new release. This change log is
 ordered chronologically, so each release contains all changes described below
 it.
 
+# v0.21.0-RC4 (2020-02-04)
+
+This release is binary incompatible with 0.21.0-RC2, but is source compatible.
+
+## Breaking changes
+
+### Binary
+
+* [#3145](https://github.com/http4s/http4s/pull/3145): Relax constraints from `Effect` to `Sync` in `resourceService`, `fileService`, and `webjarService`.
+
 # v0.21.0-RC3 (2020-02-03)
 
 This release is binary incompatible with 0.21.0-RC2, but should be source compatible, with deprecations.


### PR DESCRIPTION
Didn't get feedback on Gitter, so I'll throw it up here for discussion.

This gets #3145 out there for people to try before it's final.  The alternative is to sit on it and release it along with the bump to circe-0.13.0 in our own 0.21.0.