### PR TITLE
Add HttpRoutes.strict

### DIFF
--- a/core/src/main/scala/org/http4s/ContextRoutes.scala
+++ b/core/src/main/scala/org/http4s/ContextRoutes.scala
@@ -33,6 +33,19 @@ object ContextRoutes {
       FA: Applicative[F]): ContextRoutes[T, F] =
     Kleisli(req => OptionT(F.defer(pf.lift(req).sequence)))
 
+  /** Lifts a partial function into an [[ContextRoutes]].  The application of the
+    * partial function is not suspended in `F`, unlike [[of]]. This allows for less
+    * constraints when not combining many routes.
+    *
+    * @tparam F the base effect of the [[ContextRoutes]]
+    * @param pf the partial function to lift
+    * @return A [[ContextRoutes]] that returns some [[Response]] in an `OptionT[F, ?]`
+    * wherever `pf` is defined, an `OptionT.none` wherever it is not
+    */
+  def strict[T, F[_]: Applicative](
+      pf: PartialFunction[ContextRequest[F, T], F[Response[F]]]): ContextRoutes[T, F] =
+    Kleisli(req => OptionT(pf.lift(req).sequence))
+
   /**
     * The empty service (all requests fallthrough).
     *

--- a/core/src/main/scala/org/http4s/HttpRoutes.scala
+++ b/core/src/main/scala/org/http4s/HttpRoutes.scala
@@ -62,18 +62,16 @@ object HttpRoutes {
   def of[F[_]: Defer: Applicative](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] =
     Kleisli(req => OptionT(Defer[F].defer(pf.lift(req).sequence)))
 
-
   /** Lifts a partial function into an [[HttpRoutes]].  The application of the
     * partial function is not suspended in `F`, unlike [[of]]. This allows for less
     * constraints when not combining many routes.
     *
-    * @tparam F the base effect of the [[HttpRoutes]] - Defer suspends evaluation
-    * of routes, so only 1 section of routes is checked at a time.
+    * @tparam F the base effect of the [[HttpRoutes]]
     * @param pf the partial function to lift
     * @return An [[HttpRoutes]] that returns some [[Response]] in an `OptionT[F, ?]`
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
-  def simple[F[_]: Applicative](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] = 
+  def strict[F[_]: Applicative](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] =
     Kleisli(req => OptionT(pf.lift(req).sequence))
 
   /** An empty set of routes.  Always responds with `OptionT.none`.

--- a/core/src/main/scala/org/http4s/HttpRoutes.scala
+++ b/core/src/main/scala/org/http4s/HttpRoutes.scala
@@ -62,6 +62,20 @@ object HttpRoutes {
   def of[F[_]: Defer: Applicative](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] =
     Kleisli(req => OptionT(Defer[F].defer(pf.lift(req).sequence)))
 
+
+  /** Lifts a partial function into an [[HttpRoutes]].  The application of the
+    * partial function is not suspended in `F`, unlike [[of]]. This allows for less
+    * constraints when not combining many routes.
+    *
+    * @tparam F the base effect of the [[HttpRoutes]] - Defer suspends evaluation
+    * of routes, so only 1 section of routes is checked at a time.
+    * @param pf the partial function to lift
+    * @return An [[HttpRoutes]] that returns some [[Response]] in an `OptionT[F, ?]`
+    * wherever `pf` is defined, an `OptionT.none` wherever it is not
+    */
+  def simple[F[_]: Applicative](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] = 
+    Kleisli(req => OptionT(pf.lift(req).sequence))
+
   /** An empty set of routes.  Always responds with `OptionT.none`.
     *
     * @tparam F the base effect of the [[HttpRoutes]]

--- a/tests/src/test/scala/org/http4s/HttpRoutesSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpRoutesSpec.scala
@@ -3,9 +3,9 @@ package org.http4s
 import cats.Id
 
 class HttpRoutesSpec extends Http4sSpec {
-  "HttpRoutes.simple" should {
+  "HttpRoutes.strict" should {
     "work for type without defer" in {
-      val route = HttpRoutes.simple[Id] {
+      val route = HttpRoutes.strict[Id] {
         case _ => Response[Id](Status.Ok)
       }
       val req = Request[Id](Method.GET)

--- a/tests/src/test/scala/org/http4s/HttpRoutesSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpRoutesSpec.scala
@@ -1,0 +1,15 @@
+package org.http4s
+
+import cats.Id
+
+class HttpRoutesSpec extends Http4sSpec {
+  "HttpRoutes.simple" should {
+    "work for type without defer" in {
+      val route = HttpRoutes.simple[Id]{
+        case _ => Response[Id](Status.Ok)
+      }
+      val req = Request[Id](Method.GET)
+      route.run(req).map(_.status).value must_=== Some(Status.Ok)
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/HttpRoutesSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpRoutesSpec.scala
@@ -5,7 +5,7 @@ import cats.Id
 class HttpRoutesSpec extends Http4sSpec {
   "HttpRoutes.simple" should {
     "work for type without defer" in {
-      val route = HttpRoutes.simple[Id]{
+      val route = HttpRoutes.simple[Id] {
         case _ => Response[Id](Status.Ok)
       }
       val req = Request[Id](Method.GET)


### PR DESCRIPTION
If users don't care about efficient route composition under a large number of routes, this exposes the ability of `of` as a partial function but only requires applicative and not `of`. 

Open to different naming semantics. This change doesn't effect existing api and can be a patch if we don't want it in final, but I don't see why that's necessary for a convenience method like this.