### PR TITLE
Remove version.sbt

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.21.0-SNAPSHOT"


### PR DESCRIPTION
This is preventing sbt-dynver (and therefore sbt-ci-release) from detecting the tag.

Published snapshots will now also have a qualifier.