### PR TITLE
WIP - Classifier helper

### DIFF
--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/Prometheus.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/Prometheus.scala
@@ -199,10 +199,10 @@ object Prometheus {
     * [[org.http4s.client.middleware.Metrics#apply]].
     *
     * Let's say you want a classifier that excludes integers since your paths consist of:
-    *   * GET    /users/{integer}
-    *   * POST   /users
-    *   * PUT    /users/{integer}
-    *   * DELETE /users/{integer}
+    *   * GET    /users/{integer} = get_users_*
+    *   * POST   /users           = post_users
+    *   * PUT    /users/{integer} = put_users_*
+    *   * DELETE /users/{integer} = delete_users_*
     *
     * In such a case, we could use:
     *

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusSpec.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusSpec.scala
@@ -9,18 +9,17 @@ import Prometheus.classifierFMethodWithOptionallyExcludedPath
 class PrometheusSpec extends Http4sSpec {
 
   "classifierFMethodWithOptionallyExcludedPath" should {
-    "properly exclude UUIDs" in prop {
-      (method: Method, uuid: UUID) => {
+    "properly exclude UUIDs" in prop { (method: Method, uuid: UUID) =>
+      {
         val request: Request[IO] = Request[IO](
           method = method,
-          uri    = Uri.unsafeFromString(s"/users/$uuid/comments")
+          uri = Uri.unsafeFromString(s"/users/$uuid/comments")
         )
 
-        val excludeUUIDs: String => Boolean = {
-          str: String =>
-            Either
-              .catchOnly[IllegalArgumentException](UUID.fromString(str))
-              .isRight
+        val excludeUUIDs: String => Boolean = { str: String =>
+          Either
+            .catchOnly[IllegalArgumentException](UUID.fromString(str))
+            .isRight
         }
 
         val classifier: Request[IO] => Option[String] =
@@ -37,23 +36,22 @@ class PrometheusSpec extends Http4sSpec {
         result ==== expected
       }
     }
-    "return '$method' if the path is '/'" in prop {
-      method: Method =>
-        val request: Request[IO] = Request[IO](
-          method = method,
-          uri    = uri"""/"""
+    "return '$method' if the path is '/'" in prop { method: Method =>
+      val request: Request[IO] = Request[IO](
+        method = method,
+        uri = uri"""/"""
+      )
+
+      val classifier: Request[IO] => Option[String] =
+        classifierFMethodWithOptionallyExcludedPath(
+          _ => true
         )
 
-        val classifier: Request[IO] => Option[String] =
-          classifierFMethodWithOptionallyExcludedPath(
-            _ => true
-          )
+      val result: Option[String] =
+        classifier(request)
 
-        val result: Option[String] =
-          classifier(request)
-
-        result ==== Some(method.name.toLowerCase)
+      result ==== Some(method.name.toLowerCase)
     }
   }
-  
+
 }

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusSpec.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusSpec.scala
@@ -1,0 +1,59 @@
+package org.http4s.metrics.prometheus
+
+import cats.effect.IO
+import cats.implicits._
+import java.util.UUID
+import org.http4s._
+import Prometheus.classifierFMethodWithOptionallyExcludedPath
+
+class PrometheusSpec extends Http4sSpec {
+
+  "classifierFMethodWithOptionallyExcludedPath" should {
+    "properly exclude UUIDs" in prop {
+      (method: Method, uuid: UUID) => {
+        val request: Request[IO] = Request[IO](
+          method = method,
+          uri    = Uri.unsafeFromString(s"/users/$uuid/comments")
+        )
+
+        val excludeUUIDs: String => Boolean = {
+          str: String =>
+            Either
+              .catchOnly[IllegalArgumentException](UUID.fromString(str))
+              .isRight
+        }
+
+        val classifier: Request[IO] => Option[String] =
+          classifierFMethodWithOptionallyExcludedPath(
+            excludeUUIDs
+          )
+
+        val result: Option[String] =
+          classifier(request)
+
+        val expected: Option[String] =
+          Some(method.name.toLowerCase() + "_" + "users_*_comments")
+
+        result ==== expected
+      }
+    }
+    "return '$method' if the path is '/'" in prop {
+      method: Method =>
+        val request: Request[IO] = Request[IO](
+          method = method,
+          uri    = uri"""/"""
+        )
+
+        val classifier: Request[IO] => Option[String] =
+          classifierFMethodWithOptionallyExcludedPath(
+            _ => true
+          )
+
+        val result: Option[String] =
+          classifier(request)
+
+        result ==== Some(method.name.toLowerCase)
+    }
+  }
+  
+}

--- a/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
+++ b/testing/src/main/scala/org/http4s/testing/ArbitraryInstances.scala
@@ -11,7 +11,7 @@ import cats.implicits.{catsSyntaxEither => _, _}
 import fs2.{Pure, Stream}
 import java.nio.charset.{Charset => NioCharset}
 import java.time._
-import java.util.Locale
+import java.util.{Locale, UUID}
 import org.http4s.headers._
 import org.http4s.syntax.literals._
 import org.http4s.syntax.string._
@@ -861,6 +861,9 @@ trait ArbitraryInstances {
         body <- http4sTestingGenForPureByteStream
       } yield Response(status, httpVersion, headers, body)
     }
+
+  implicit val arbUUID: Arbitrary[UUID] =
+    Arbitrary(Gen.uuid)
 }
 
 object ArbitraryInstances extends ArbitraryInstances


### PR DESCRIPTION
Adds a function, `classifierFMethodWithOptionallyExcludedPath`, to `Prometheus`.

Given an exclude function, return a 'classifier' function, i.e. for application in
`[[org.http4s.client.middleware.Metrics#apply]]`.

Let's say you want a classifier that excludes integers since your paths consist of:
```
    * GET    /users/{integer}    = get_users_*
    * POST   /users                = post_users
    * PUT    /users/{integer}    = put_users_*
    * DELETE /users/{integer} = delete_users_*
```

In such a case, we could use:

```scala
   classifierFMethodWithOptionallyExcludedPath[F] { 
         str: String => scala.util.Try(str.toInt).isSuccess 
   }
```

This idea, namely adding a classifier with an `exclude: String => Boolean` was inspired by an internal library that @ChristopherDavenport wrote. 