### PR TITLE
Drop prometheus dependency on http4s-dsl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val prometheusMetrics = libraryProject("prometheus-metrics")
   )
   .dependsOn(
     core % "compile->compile",
-    theDsl % "compile->compile",
+    theDsl % "test->compile",
     testing % "test->test",
     server % "test->compile",
     client % "test->compile"

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
@@ -7,7 +7,6 @@ import io.prometheus.client.exporter.common.TextFormat
 import io.prometheus.client.hotspot._
 import java.io.StringWriter
 import org.http4s._
-import org.http4s.dsl.Http4sDsl
 
 /*
  * PrometheusExportService Contains an HttpService
@@ -39,14 +38,11 @@ object PrometheusExportService {
       }
       .map(Response[F](Status.Ok).withEntity(_))
 
-  def service[F[_]: Sync](collectorRegistry: CollectorRegistry): HttpRoutes[F] = {
-    object dsl extends Http4sDsl[F]
-    import dsl._
-
+  def service[F[_]: Sync](collectorRegistry: CollectorRegistry): HttpRoutes[F] =
     HttpRoutes.of[F] {
-      case GET -> Root / "metrics" => generateResponse(collectorRegistry)
+      case req if req.method == Method.GET && req.pathInfo == "/metrics" =>
+        generateResponse(collectorRegistry)
     }
-  }
 
   def addDefaults[F[_]: Sync](cr: CollectorRegistry): Resource[F, Unit] =
     for {


### PR DESCRIPTION
Discovered in #3167.  Prometheus shouldn't require DSL.