### PR TITLE
Fix client auth values in TomcatBuilder

### DIFF
--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -167,8 +167,14 @@ sealed class TomcatBuilder[F[_]] private (
           conn.setAttribute("keystoreFile", sslBits.keyStore.path)
           conn.setAttribute("keystorePass", sslBits.keyStore.password)
           conn.setAttribute("keyPass", sslBits.keyManagerPassword)
-
-          conn.setAttribute("clientAuth", sslBits.clientAuth)
+          conn.setAttribute(
+            "clientAuth",
+            sslBits.clientAuth match {
+              case SSLClientAuthMode.Required => "required"
+              case SSLClientAuthMode.Requested => "optional"
+              case SSLClientAuthMode.NotRequested => "none"
+            }
+          )
           conn.setAttribute("sslProtocol", sslBits.protocol)
 
           sslBits.trustStore.foreach { ts =>


### PR DESCRIPTION
We should be using [the values in `certificateVerification`](https://tomcat.apache.org/tomcat-9.0-doc/config/http.html#SSL_Support_-_SSLHostConfig).  This is already fixed in #3140, and there probably aren't many people who care, but it is a bug.