### PR TITLE
Update to jawn-fs2-1.0.0

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -219,7 +219,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % "2.2.2"
   lazy val fs2ReactiveStreams               = "co.fs2"                 %% "fs2-reactive-streams"      % fs2Io.revision
   lazy val javaxServletApi                  = "javax.servlet"          %  "javax.servlet-api"         % "3.1.0"
-  lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "1.0.0-RC2"
+  lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % "1.0.0"
   lazy val jawnJson4s                       = "org.typelevel"          %% "jawn-json4s"               % "1.0.0"
   lazy val jawnPlay                         = "org.typelevel"          %% "jawn-play"                 % "1.0.0"
   lazy val jettyClient                      = "org.eclipse.jetty"      %  "jetty-client"              % "9.4.26.v20200117"


### PR DESCRIPTION
The only change in jawn-fs2 is to bump from fs2-2.2.1 to fs2-2.2.2, which http4s already depends on.  This gets us off an RC that we neglected to finalize before http4s-0.21.0.

Thanks to @travisbrown for calling it out on Gitter.
