### PR TITLE
Delete version.sbt from 0.20

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.20.18-SNAPSHOT"


### PR DESCRIPTION
Automated release is going to demand this, as well.