### PR TITLE
ResponseCookie parsing improvements (0.20.x)

### DIFF
--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -91,6 +91,11 @@ final case class RequestCookie(name: String, content: String) extends Renderable
   }
 }
 
+/**
+  * @param extension The extension attributes of the cookie.  If there is more
+  * than one, they are joined by semi-colon, which must not appear in an
+  * attribute value.
+  */
 final case class ResponseCookie(
     name: String,
     content: String,

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -97,7 +97,9 @@ private[parser] trait CookieHeader {
       }
     }
 
-    def DomainName: Rule1[String] = rule { capture(oneOrMore(DomainNamePart).separatedBy('.')) }
+    def DomainName: Rule1[String] = rule {
+      capture(optional('.') ~ oneOrMore(DomainNamePart).separatedBy('.'))
+    }
 
     def DomainNamePart: Rule0 = rule { AlphaNum ~ zeroOrMore(AlphaNum | ch('-')) }
 

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -87,7 +87,11 @@ private[parser] trait CookieHeader {
           cookie.copy(httpOnly = true)
         } |
         StringValue ~> { (cookie: ResponseCookie, stringValue: String) =>
-          cookie.copy(extension = Some(stringValue))
+          val ext0 = cookie.extension match {
+            case Some(extension) => s"${extension}; $stringValue"
+            case None => stringValue
+          }
+          cookie.copy(extension = Some(ext0))
         }
     }
 

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -67,23 +67,23 @@ private[parser] trait CookieHeader {
     }
 
     def CookieAttrs: Rule[ResponseCookie :: HNil, ResponseCookie :: HNil] = rule {
-      "Expires=" ~ HttpDate ~> { (cookie: ResponseCookie, dateTime: HttpDate) =>
+      ignoreCase("expires=") ~ HttpDate ~> { (cookie: ResponseCookie, dateTime: HttpDate) =>
         cookie.copy(expires = Some(dateTime))
       } |
-        "Max-Age=" ~ NonNegativeLong ~> { (cookie: ResponseCookie, seconds: Long) =>
+        ignoreCase("max-age=") ~ NonNegativeLong ~> { (cookie: ResponseCookie, seconds: Long) =>
           cookie.copy(maxAge = Some(seconds))
         } |
-        "Domain=" ~ DomainName ~> { (cookie: ResponseCookie, domainName: String) =>
+        ignoreCase("domain=") ~ DomainName ~> { (cookie: ResponseCookie, domainName: String) =>
           cookie.copy(domain = Some(domainName))
         } |
-        "Path=" ~ StringValue ~> { (cookie: ResponseCookie, pathValue: String) =>
+        ignoreCase("path=") ~ StringValue ~> { (cookie: ResponseCookie, pathValue: String) =>
           cookie.copy(path = Some(pathValue))
         } |
         // TODO: Capture so we can create the rule, but there must be a better way
-        "Secure" ~ MATCH ~> { (cookie: ResponseCookie) =>
+        ignoreCase("secure") ~ MATCH ~> { (cookie: ResponseCookie) =>
           cookie.copy(secure = true)
         } |
-        "HttpOnly" ~ MATCH ~> { (cookie: ResponseCookie) =>
+        ignoreCase("httponly") ~ MATCH ~> { (cookie: ResponseCookie) =>
           cookie.copy(httpOnly = true)
         } |
         StringValue ~> { (cookie: ResponseCookie, stringValue: String) =>

--- a/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
@@ -8,19 +8,30 @@ class SetCookieHeaderSpec extends Specification with HeaderParserHelper[`Set-Coo
   def hparse(value: String): ParseResult[`Set-Cookie`] = HttpHeaderParser.SET_COOKIE(value)
 
   "Set-Cookie parser" should {
-    val cookiestr = "myname=\"foo\"; Domain=value; Max-Age=1; Path=value; Secure;HttpOnly"
 
     "parse a set cookie" in {
+      val cookiestr = "myname=\"foo\"; Domain=example.com; Max-Age=1; Path=value; Secure;HttpOnly"
       val c = parse(cookiestr).cookie
       c.name must be_==("myname")
+      c.domain must beSome("example.com")
       c.content must be_==("foo")
       c.maxAge must be_==(Some(1))
       c.path must be_==(Some("value"))
       c.secure must be_==(true)
       c.httpOnly must be_==(true)
-
     }
 
+    "parse with a domain with a leading dot" in {
+      val cookiestr = "myname=\"foo\"; Domain=.example.com"
+      val c = parse(cookiestr).cookie
+      c.domain must beSome(".example.com")
+    }
+
+    "parse with a domain with a leading dot" in {
+      val cookiestr = "myname=\"foo\"; Domain=.example.com"
+      val c = parse(cookiestr).cookie
+      c.domain must beSome(".example.com")
+    }
   }
 }
 

--- a/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
@@ -32,6 +32,25 @@ class SetCookieHeaderSpec extends Specification with HeaderParserHelper[`Set-Coo
       val c = parse(cookiestr).cookie
       c.domain must beSome(".example.com")
     }
+
+    "parse with an extension" in {
+      val cookiestr = "myname=\"foo\"; http4s=fun"
+      val c = parse(cookiestr).cookie
+      c.extension must beSome("http4s=fun")
+    }
+
+    "parse with two extensions" in {
+      val cookiestr = "myname=\"foo\"; http4s=fun; rfc6265=not-fun"
+      val c = parse(cookiestr).cookie
+      c.extension must beSome("http4s=fun; rfc6265=not-fun")
+    }
+
+    "parse with an two extensions around a common attribute" in {
+      val cookiestr = "myname=\"foo\"; http4s=fun; Domain=example.com; rfc6265=not-fun"
+      val c = parse(cookiestr).cookie
+      c.domain must beSome("example.com")
+      c.extension must beSome("http4s=fun; rfc6265=not-fun")
+    }
   }
 }
 

--- a/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
@@ -21,6 +21,18 @@ class SetCookieHeaderSpec extends Specification with HeaderParserHelper[`Set-Coo
       c.httpOnly must be_==(true)
     }
 
+    "parse a set cookie with lowercase attributes" in {
+      val cookiestr = "myname=\"foo\"; domain=example.com; max-age=1; path=value; secure; httponly"
+      val c = parse(cookiestr).cookie
+      c.name must be_==("myname")
+      c.domain must beSome("example.com")
+      c.content must be_==("foo")
+      c.maxAge must be_==(Some(1))
+      c.path must be_==(Some("value"))
+      c.secure must be_==(true)
+      c.httpOnly must be_==(true)
+    }
+
     "parse with a domain with a leading dot" in {
       val cookiestr = "myname=\"foo\"; Domain=.example.com"
       val c = parse(cookiestr).cookie


### PR DESCRIPTION
Addresses #3178 in a binary compatible way.

* Supports leading dot in domain.  We punt on modeling it as a domain as opposed to a raw String.
* Supports multiple extension attributes
* Supports case-insensitive parsing of cookie attributes
* Does not preserve non-extension attributes with the same name