### PR TITLE
Recover EOF on bodyEncoder.write to close connection

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -257,7 +257,7 @@ private[blaze] class Http1ServerStage[F[_]](
           closeOnFinish)
     }
 
-    unsafeRunAsync(bodyEncoder.write(rr, resp.body)) {
+    unsafeRunAsync(bodyEncoder.write(rr, resp.body).recover { case EOF => true }) {
       case Right(requireClose) =>
         if (closeOnFinish || requireClose) {
           logger.trace("Request/route requested closing connection.")
@@ -274,9 +274,6 @@ private[blaze] class Http1ServerStage[F[_]](
               case Failure(t) => fatalError(t, "Failure in body cleanup")
             }(trampoline)
           }
-
-      case Left(EOF) =>
-        IO(closeConnection())
 
       case Left(t) =>
         logger.error(t)("Error writing body")


### PR DESCRIPTION
Recover EOF raised by the body encoder rather than catching it as an exception, which some implementations may wrap.  This better expresses intent and cleans up logs in such implementations.

/cc @jadlr 