### PR TITLE
Fix case sensitivity of SameSite

### DIFF
--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -78,7 +78,7 @@ private[parser] trait CookieHeader {
         ignoreCase("path=") ~ StringValue ~> { (cookie: ResponseCookie, pathValue: String) =>
           cookie.copy(path = Some(pathValue))
         } |
-        "SameSite=" ~ SameSite ~> { (cookie: ResponseCookie, sameSiteValue: SameSite) =>
+        ignoreCase("samesite=") ~ SameSite ~> { (cookie: ResponseCookie, sameSiteValue: SameSite) =>
           cookie.copy(sameSite = sameSiteValue)
         } |
         // TODO: Capture so we can create the rule, but there must be a better way
@@ -112,7 +112,7 @@ private[parser] trait CookieHeader {
     def StringValue: Rule1[String] = rule { capture(oneOrMore((!(CTL | ch(';'))) ~ Char)) }
 
     def SameSite: Rule1[SameSite] = rule {
-      "Strict" ~ push(Strict) | "Lax" ~ push(Lax) | "None" ~ push(None)
+      ignoreCase("strict") ~ push(Strict) | ignoreCase("lax") ~ push(Lax) | ignoreCase("none") ~ push(None)
     }
   }
   // scalastyle:on public.methods.have.type

--- a/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
@@ -30,13 +30,14 @@ class SetCookieHeaderSpec extends Specification with HeaderParserHelper[`Set-Coo
 
     "parse a set cookie with lowercase attributes" in {
       val cookiestr =
-        "myname=\"foo\"; domain=example.com; max-age=1; path=value; secure; httponly"
+        "myname=\"foo\"; domain=example.com; max-age=1; path=value; samesite=strict; secure; httponly"
       val c = parse(cookiestr).cookie
       c.name must be_==("myname")
       c.domain must beSome("example.com")
       c.content must be_==("foo")
       c.maxAge must be_==(Some(1))
       c.path must be_==(Some("value"))
+      c.sameSite must be_==(SameSite.Strict)
       c.secure must be_==(true)
       c.httpOnly must be_==(true)
     }


### PR DESCRIPTION
Like those in #3184, `SameSite` is [case insensitive](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#page-27).