### PR TITLE
Run scalafmt as intended

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           key: sbt-${{ hashFiles('**/build.sbt') }}
       - name: Check formatting
         if: startsWith(matrix.scala, '2.12.') && (matrix.java == 'adopt@1.8')
-        run: sbt ++$SCALA_VERSION test:scalafmt::test
+        run: sbt ++$SCALA_VERSION scalafmtAll
       - name: Compile
         run: sbt ++$SCALA_VERSION test:compile
       - name: Check compatibility


### PR DESCRIPTION
I think we broke this backporting to an older version of scalafmt on 0.20.x, and then merging back.