### PR TITLE
Change Uri.Path to be own type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ project/metals.sbt
 project/travis-deploy-key
 project/.gnupg
 !project/.gnupg/secret.tar.enc
+out

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -328,7 +328,7 @@ private final class Http1Connection[F[_]](
         validateRequest(req.withHttpVersion(HttpVersion.`HTTP/1.0`))
       else
         Left(new IllegalArgumentException("Host header required for HTTP/1.1 request"))
-    else if (req.uri.path == "") Right(req.withUri(req.uri.copy(path = "/")))
+    else if (req.uri.path == Uri.Path.empty) Right(req.withUri(req.uri.copy(path = Uri.Path.Root)))
     else Right(req) // All appears to be well
   }
 

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -431,14 +431,14 @@ class Http1ServerStageSpec extends Http4sSpec with AfterAll {
 
       val routes = HttpRoutes
         .of[IO] {
-          case req if req.pathInfo == "/foo" =>
+          case req if req.pathInfo == path"/foo" =>
             for {
               _ <- req.body.compile.drain
               hs <- req.trailerHeaders
               resp <- Ok(hs.toList.mkString)
             } yield resp
 
-          case req if req.pathInfo == "/bar" =>
+          case req if req.pathInfo == path"/bar" =>
             for {
               // Don't run the body
               hs <- req.trailerHeaders

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
@@ -107,23 +107,23 @@ object ServerTestRoutes extends Http4sDsl[IO] {
   def apply()(implicit cs: ContextShift[IO]) =
     HttpRoutes
       .of[IO] {
-        case req if req.method == Method.GET && req.pathInfo == "/get" =>
+        case req if req.method == Method.GET && req.pathInfo == path"/get" =>
           Ok("get")
 
-        case req if req.method == Method.GET && req.pathInfo == "/chunked" =>
+        case req if req.method == Method.GET && req.pathInfo == path"/chunked" =>
           Ok(eval(IO.shift *> IO("chu")) ++ eval(IO.shift *> IO("nk")))
 
-        case req if req.method == Method.POST && req.pathInfo == "/post" =>
+        case req if req.method == Method.POST && req.pathInfo == path"/post" =>
           Ok("post")
 
-        case req if req.method == Method.GET && req.pathInfo == "/twocodings" =>
+        case req if req.method == Method.GET && req.pathInfo == path"/twocodings" =>
           Ok("Foo", `Transfer-Encoding`(TransferCoding.chunked))
 
-        case req if req.method == Method.POST && req.pathInfo == "/echo" =>
+        case req if req.method == Method.POST && req.pathInfo == path"/echo" =>
           Ok(emit("post") ++ req.bodyAsText)
 
         // Kind of cheating, as the real NotModified response should have a Date header representing the current? time?
-        case req if req.method == Method.GET && req.pathInfo == "/notmodified" =>
+        case req if req.method == Method.GET && req.pathInfo == path"/notmodified" =>
           NotModified()
       }
       .orNotFound

--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -103,7 +103,7 @@ object JsonDebugErrorHandler {
                   )
                   .dropNullValues)
               .asJson,
-            "path" -> req.uri.path.asJson,
+            "path" -> req.uri.path.renderString.asJson,
             "query" -> req.uri.query.multiParams.asJson
           )
           .dropNullValues,
@@ -118,7 +118,7 @@ object JsonDebugErrorHandler {
             )
           }
           .asJson,
-        "path_info" -> req.pathInfo.asJson,
+        "path_info" -> req.pathInfo.renderString.asJson,
         "remote_address" -> req.remoteAddr.asJson,
         "http_version" -> req.httpVersion.toString().asJson
       )

--- a/client/src/main/scala/org/http4s/client/middleware/CookieJar.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/CookieJar.scala
@@ -206,7 +206,7 @@ object CookieJar {
       r.uri.host.forall { authority =>
         authority.renderString.contains(s)
       })
-    val pathApplies = c.path.forall(s => r.uri.path.contains(s))
+    val pathApplies = c.path.forall(s => r.uri.path.renderString.contains(s))
 
     val secureSatisfied =
       if (c.secure)

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -27,15 +27,15 @@ class ClientSyntaxSpec
     with Http4sLegacyMatchersIO {
   val app = HttpRoutes
     .of[IO] {
-      case r if r.method == GET && r.pathInfo == "/" =>
+      case r if r.method == GET && r.pathInfo == path"/" =>
         Response[IO](Ok).withEntity("hello").pure[IO]
-      case r if r.method == PUT && r.pathInfo == "/put" =>
+      case r if r.method == PUT && r.pathInfo == path"/put" =>
         Response[IO](Created).withEntity(r.body).pure[IO]
-      case r if r.method == GET && r.pathInfo == "/echoheaders" =>
+      case r if r.method == GET && r.pathInfo == path"/echoheaders" =>
         r.headers.get(Accept).fold(IO.pure(Response[IO](BadRequest))) { m =>
           Response[IO](Ok).withEntity(m.toString).pure[IO]
         }
-      case r if r.pathInfo == "/status/500" =>
+      case r if r.pathInfo == path"/status/500" =>
         Response[IO](InternalServerError).withEntity("Oops").pure[IO]
     }
     .orNotFound

--- a/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
@@ -19,6 +19,13 @@ object LiteralSyntaxMacros {
       Uri.fromString(_).isRight,
       s => c.universe.reify(Uri.unsafeFromString(s.splice)))
 
+  def pathInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Path] =
+    singlePartInterpolator(c)(
+      args,
+      "Uri.Path",
+      _ => true,
+      s => c.universe.reify(Uri.Path.fromString(s.splice)))
+
   def schemeInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Scheme] =
     singlePartInterpolator(c)(
       args,

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -209,7 +209,7 @@ object Message {
   */
 final class Request[F[_]](
     val method: Method = Method.GET,
-    val uri: Uri = Uri(path = "/"),
+    val uri: Uri = Uri(path = Uri.Path.Root),
     val httpVersion: HttpVersion = HttpVersion.`HTTP/1.1`,
     val headers: Headers = Headers.empty,
     val body: EntityBody[F] = EmptyBody,
@@ -271,11 +271,14 @@ final class Request[F[_]](
     uri.path.splitAt(caret)
 
   private def caret =
-    attributes.lookup(Request.Keys.PathInfoCaret).getOrElse(0)
+    attributes.lookup(Request.Keys.PathInfoCaret).getOrElse(-1)
 
+  @deprecated(message = "Use {withPathInfo(Uri.Path)} instead", since = "1.0.0-M1")
   def withPathInfo(pi: String): Self =
+    withPathInfo(Uri.Path.fromString(pi))
+  def withPathInfo(pi: Uri.Path): Self =
     // Don't use withUri, which clears the caret
-    copy(uri = uri.withPath(scriptName + pi))
+    copy(uri = uri.withPath(scriptName.concat(pi)))
 
   def pathTranslated: Option[File] = attributes.lookup(Keys.PathTranslated)
 
@@ -467,7 +470,7 @@ final class Request[F[_]](
 object Request {
   def apply[F[_]](
       method: Method = Method.GET,
-      uri: Uri = Uri(path = "/"),
+      uri: Uri = Uri(path = Uri.Path.Root),
       httpVersion: HttpVersion = HttpVersion.`HTTP/1.1`,
       headers: Headers = Headers.empty,
       body: EntityBody[F] = EmptyBody,

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -17,10 +17,12 @@ import java.net.{Inet4Address, Inet6Address, InetAddress}
 import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{Charset => JCharset, StandardCharsets}
 import org.http4s.internal.{bug, hashLower}
+import cats.kernel.Semigroup
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
 import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit, HexDigit}
 import org.http4s.parser._
 import org.http4s.util._
+
 import scala.collection.immutable
 import scala.math.Ordered
 import scala.reflect.macros.blackbox
@@ -33,26 +35,27 @@ import scala.reflect.macros.blackbox
   * @param query      optional Query. url-encoded.
   * @param fragment   optional Uri Fragment. url-encoded.
   */
-// TODO fix Location header, add unit tests
 final case class Uri(
     scheme: Option[Uri.Scheme] = None,
     authority: Option[Uri.Authority] = None,
-    path: Uri.Path = "",
+    path: Uri.Path = Uri.Path.empty,
     query: Query = Query.empty,
     fragment: Option[Uri.Fragment] = None)
     extends QueryOps
     with Renderable {
-  import Uri._
 
   /**
     * Adds the path exactly as described. Any path element must be urlencoded ahead of time.
     * @param path the path string to replace
     */
-  def withPath(path: Path): Uri = copy(path = path)
+  @deprecated("Use {withPath(Uri.Path)} instead", "1.0.0-M1")
+  def withPath(path: String): Uri = copy(path = Uri.Path.fromString(path))
 
-  def withFragment(fragment: Fragment): Uri = copy(fragment = Option(fragment))
+  def withPath(path: Uri.Path): Uri = copy(path = path)
 
-  def withoutFragment: Uri = copy(fragment = Option.empty[Fragment])
+  def withFragment(fragment: Uri.Fragment): Uri = copy(fragment = Option(fragment))
+
+  def withoutFragment: Uri = copy(fragment = Option.empty[Uri.Fragment])
 
   /**
     * Urlencodes and adds a path segment to the Uri
@@ -60,12 +63,12 @@ final case class Uri(
     * @param newSegment the segment to add.
     * @return a new uri with the segment added to the path
     */
-  def addSegment(newSegment: Path): Uri = copy(path = toSegment(path, newSegment))
+  def addSegment(newSegment: String): Uri = copy(path = toSegment(path, newSegment))
 
   /**
     * This is an alias to [[addSegment(Path)]]
     */
-  def /(newSegment: Path): Uri = addSegment(newSegment)
+  def /(newSegment: String): Uri = addSegment(newSegment)
 
   /**
     * Splits the path segments and adds each of them to the path url-encoded.
@@ -73,12 +76,12 @@ final case class Uri(
     * @param morePath the path to add
     * @return a new uri with the segments added to the path
     */
-  def addPath(morePath: Path): Uri =
+  def addPath(morePath: String): Uri =
     copy(path = morePath.split("/").foldLeft(path)((p, segment) => toSegment(p, segment)))
 
-  def host: Option[Host] = authority.map(_.host)
+  def host: Option[Uri.Host] = authority.map(_.host)
   def port: Option[Int] = authority.flatMap(_.port)
-  def userInfo: Option[UserInfo] = authority.flatMap(_.userInfo)
+  def userInfo: Option[Uri.UserInfo] = authority.flatMap(_.userInfo)
 
   def resolve(relative: Uri): Uri = Uri.resolve(this, relative)
 
@@ -117,7 +120,7 @@ final case class Uri(
     super.renderString
 
   override def render(writer: Writer): writer.type = {
-    def renderScheme(s: Scheme): writer.type =
+    def renderScheme(s: Uri.Scheme): writer.type =
       writer << s << ':'
 
     this match {
@@ -134,7 +137,7 @@ final case class Uri(
     }
 
     this match {
-      case Uri(_, Some(_), p, _, _) if p.nonEmpty && !p.startsWith("/") =>
+      case Uri(_, Some(_), p, _, _) if p.nonEmpty && !p.absolute =>
         writer << "/" << p
       case Uri(_, _, p, _, _) =>
         writer << p
@@ -142,7 +145,7 @@ final case class Uri(
 
     if (query.nonEmpty) writer << '?' << query
     fragment.foreach { f =>
-      writer << '#' << encode(f, spaceIsPlus = false)
+      writer << '#' << Uri.encode(f, spaceIsPlus = false)
     }
     writer
   }
@@ -154,13 +157,8 @@ final case class Uri(
 
   override protected def replaceQuery(query: Query): Self = copy(query = query)
 
-  private def toSegment(path: Path, newSegment: Path): Path = {
-    val encoded = pathEncode(newSegment)
-    val newPath =
-      if (path.isEmpty || path.last != '/') s"$path/$encoded"
-      else s"$path$encoded"
-    newPath
-  }
+  private def toSegment(path: Uri.Path, newSegment: String): Uri.Path =
+    path / Uri.Path.Segment(newSegment)
 }
 
 object Uri {
@@ -273,7 +271,6 @@ object Uri {
       }
   }
 
-  type Path = String
   type Fragment = String
 
   final case class Authority(
@@ -289,6 +286,151 @@ object Uri {
         case Authority(_, h, _) => writer << h
         case _ => writer
       }
+  }
+
+  final class Path private (
+      val segments: Vector[Path.Segment],
+      val absolute: Boolean,
+      val endsWithSlash: Boolean)
+      extends Renderable {
+
+    def isEmpty: Boolean = segments.isEmpty
+    def nonEmpty: Boolean = segments.nonEmpty
+
+    override def equals(obj: Any): Boolean =
+      obj match {
+        case p: Path => doEquals(p)
+        case _ => false
+      }
+
+    private def doEquals(path: Path): Boolean =
+      this.segments == path.segments && path.absolute == this.absolute && path.endsWithSlash == this.endsWithSlash
+
+    override def hashCode(): Int = {
+      var hash = segments.hashCode()
+      hash += 31 * java.lang.Boolean.hashCode(absolute)
+      hash += 31 * java.lang.Boolean.hashCode(endsWithSlash)
+      hash
+    }
+
+    def render(writer: Writer): writer.type = {
+      val start = if (absolute) "/" else ""
+      writer << start << segments.iterator.mkString("/")
+      if (endsWithSlash) writer << "/" else writer
+    }
+
+    override val renderString: String = super.renderString
+    override def toString: String = renderString
+
+    def /(segment: Path.Segment): Path = addSegment(segment)
+    def addSegment(segment: Path.Segment): Path =
+      addSegments(List(segment))
+    def addSegments(value: Seq[Path.Segment]): Path =
+      Path(this.segments ++ value, absolute = absolute || this.segments.isEmpty)
+
+    def normalize: Path = Path(segments.filterNot(_.isEmpty))
+
+    /* Merge paths per RFC 3986 5.2.3 */
+    def merge(path: Path): Path = {
+      val merge = if (isEmpty) segments else segments.init
+      Path(merge ++ path.segments, absolute = absolute, endsWithSlash = path.endsWithSlash)
+    }
+
+    def concat(path: Path): Path =
+      Path(segments ++ path.segments, absolute = absolute, endsWithSlash = path.endsWithSlash)
+
+    def startsWith(path: Path): Boolean = segments.startsWith(path.segments)
+
+    def startsWithString(path: String): Boolean = startsWith(Path.fromString(path))
+
+    def indexOf(path: Path): Option[Int] =
+      if (path.isEmpty) None else Some(segments.indexOfSlice(path.segments)).filterNot(_ == -1)
+
+    def indexOfString(path: String): Option[Int] = indexOf(Path.fromString(path))
+
+    def splitAt(idx: Int): (Path, Path) =
+      if (idx < 0) (if (absolute) Path.Root else Path.empty, this)
+      else {
+        val (start, end) = segments.splitAt(idx + 1)
+        Path(start, absolute = absolute) -> Path(end, true, endsWithSlash = endsWithSlash)
+      }
+    private def copy(
+        segments: Vector[Path.Segment] = segments,
+        absolute: Boolean = absolute,
+        endsWithSlash: Boolean = endsWithSlash) =
+      new Path(segments, absolute, endsWithSlash)
+
+    def dropEndsWithSlash = copy(endsWithSlash = false)
+    def addEndsWithSlash = copy(endsWithSlash = true)
+
+    def toAbsolute = copy(absolute = true)
+    def toRelative = copy(absolute = false)
+  }
+
+  object Path {
+    val empty = Path(Vector.empty)
+    val Root = Path(Vector.empty, absolute = true)
+
+    final class Segment private (val encoded: String) {
+      def isEmpty = encoded.isEmpty
+
+      override def equals(obj: Any): Boolean =
+        obj match {
+          case s: Segment => s.encoded == encoded
+        }
+
+      override def hashCode(): Int = encoded.hashCode
+
+      def decoded(
+          charset: JCharset = StandardCharsets.UTF_8,
+          plusIsSpace: Boolean = false,
+          toSkip: Char => Boolean = Function.const(false)): String =
+        Uri.decode(encoded, charset, plusIsSpace, toSkip)
+
+      override val toString: String = encoded
+    }
+
+    object Segment extends (String => Segment) {
+      def apply(value: String): Segment = new Segment(pathEncode(value))
+      def encoded(value: String): Segment = new Segment(value)
+    }
+
+    /**
+      * This constructor allows you to construct the path directly.
+      * Each path segment needs to be encoded for it to be used here.
+      *
+      * @param segments the segments that this path consists of. MUST be Urlencoded.
+      * @param absolute if the path is absolute. I.E starts with a "/"
+      * @param endsWithSlash if the path is a "directory", ends with a "/"
+      * @return a Uri.Path that can be used in Uri, or by itself.
+      */
+    def apply(
+        segments: Vector[Segment],
+        absolute: Boolean = false,
+        endsWithSlash: Boolean = false): Path =
+      new Path(segments, absolute, endsWithSlash)
+
+    def unapply(path: Path): Some[(Vector[Segment], Boolean, Boolean)] =
+      Some((path.segments, path.absolute, path.endsWithSlash))
+
+    def fromString(fromPath: String): Path =
+      fromPath match {
+        case "" => empty
+        case "/" => Root
+        case pth =>
+          val absolute = pth.startsWith("/")
+          val relative = if (absolute) pth.substring(1) else pth
+          Path(
+            segments = relative
+              .split("/")
+              .foldLeft(Vector.empty[Segment])((path, segment) => path :+ Segment.encoded(segment)),
+            absolute = absolute,
+            endsWithSlash = relative.endsWith("/")
+          )
+      }
+
+    implicit val eq: Eq[Path] = Eq.fromUniversalEquals[Path]
+    implicit val semigroup: Semigroup[Path] = (a: Path, b: Path) => a.concat(b)
   }
 
   /** The userinfo subcomponent may consist of a user name and,
@@ -663,19 +805,14 @@ object Uri {
     * Resolve a relative Uri reference, per RFC 3986 sec 5.2
     */
   def resolve(base: Uri, reference: Uri): Uri = {
-
-    /* Merge paths per RFC 3986 5.2.3 */
-    def merge(base: Path, reference: Path): Path =
-      base.substring(0, base.lastIndexOf('/') + 1) + reference
-
     val target = (base, reference) match {
       case (_, Uri(Some(_), _, _, _, _)) => reference
       case (Uri(s, _, _, _, _), Uri(_, a @ Some(_), p, q, f)) => Uri(s, a, p, q, f)
-      case (Uri(s, a, p, q, _), Uri(_, _, "", Query.empty, f)) => Uri(s, a, p, q, f)
-      case (Uri(s, a, p, _, _), Uri(_, _, "", q, f)) => Uri(s, a, p, q, f)
+      case (Uri(s, a, p, q, _), Uri(_, _, pa, Query.empty, f)) if pa.isEmpty => Uri(s, a, p, q, f)
+      case (Uri(s, a, p, _, _), Uri(_, _, pa, q, f)) if pa.isEmpty => Uri(s, a, p, q, f)
       case (Uri(s, a, bp, _, _), Uri(_, _, p, q, f)) =>
-        if (p.headOption.fold(false)(_ == '/')) Uri(s, a, p, q, f)
-        else Uri(s, a, merge(bp, p), q, f)
+        if (p.absolute) Uri(s, a, p, q, f)
+        else Uri(s, a, bp.merge(p), q, f)
     }
 
     target.withPath(removeDotSegments(target.path))
@@ -686,13 +823,13 @@ object Uri {
     * Adapted from"
     * https://github.com/Norconex/commons-lang/blob/c83fdeac7a60ac99c8602e0b47056ad77b08f570/norconex-commons-lang/src/main/java/com/norconex/commons/lang/url/URLNormalizer.java#L429
     */
-  def removeDotSegments(path: String): String = {
+  def removeDotSegments(path: Uri.Path): Uri.Path = {
     // (Bulleted comments are from RFC3986, section-5.2.4)
 
     // 1.  The input buffer is initialized with the now-appended path
     //     components and the output buffer is initialized to the empty
     //     string.
-    val in = new StringBuilder(path)
+    val in = new StringBuilder(path.renderString)
     val out = new StringBuilder
 
     // 2.  While the input buffer is not empty, loop as follows:
@@ -750,7 +887,7 @@ object Uri {
 
     // 3.  Finally, the output buffer is returned as the result of
     //     remove_dot_segments.
-    out.toString
+    Uri.Path.fromString(out.toString)
   }
 
   // Helper functions for removeDotSegments

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -401,12 +401,18 @@ object UriTemplate {
       case UriTemplate(s, a, Nil, q, Nil) => Uri(s, a, query = buildQuery(q))
       case UriTemplate(s, a, Nil, q, f) =>
         Uri(s, a, query = buildQuery(q), fragment = Some(renderFragmentIdentifier(f)))
-      case UriTemplate(s, a, p, Nil, Nil) => Uri(s, a, renderPath(p))
-      case UriTemplate(s, a, p, q, Nil) => Uri(s, a, renderPath(p), buildQuery(q))
+      case UriTemplate(s, a, p, Nil, Nil) => Uri(s, a, Uri.Path.fromString(renderPath(p)))
+      case UriTemplate(s, a, p, q, Nil) =>
+        Uri(s, a, Uri.Path.fromString(renderPath(p)), buildQuery(q))
       case UriTemplate(s, a, p, Nil, f) =>
-        Uri(s, a, renderPath(p), fragment = Some(renderFragmentIdentifier(f)))
+        Uri(s, a, Uri.Path.fromString(renderPath(p)), fragment = Some(renderFragmentIdentifier(f)))
       case UriTemplate(s, a, p, q, f) =>
-        Uri(s, a, renderPath(p), buildQuery(q), Some(renderFragmentIdentifier(f)))
+        Uri(
+          s,
+          a,
+          Uri.Path.fromString(renderPath(p)),
+          buildQuery(q),
+          Some(renderFragmentIdentifier(f)))
     }
 
   sealed trait PathDef

--- a/core/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -8,7 +8,7 @@ package org.http4s.metrics
 
 import cats.Foldable
 import cats.implicits._
-import org.http4s.{Method, Request, Status, Uri}
+import org.http4s.{Method, Request, Status}
 
 /**
   * Describes an algebra capable of writing metrics to a metrics registry
@@ -106,7 +106,7 @@ object MetricsOps {
     val initial: String = request.method.name
 
     val pathList: List[String] =
-      requestToPathList(request)
+      request.pathInfo.segments.map(_.decoded()).toList
 
     val minusExcluded: List[String] = pathList.map { value: String =>
       if (exclude(value)) excludedValue else value
@@ -122,25 +122,6 @@ object MetricsOps {
 
     Some(result)
   }
-
-  // The following was copied from
-  // https://github.com/http4s/http4s/blob/v0.20.17/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala#L56-L64,
-  // and then modified.
-  private def requestToPathList[F[_]](request: Request[F]): List[String] = {
-    val str: String = request.pathInfo
-
-    if (str == "" || str == "/")
-      Nil
-    else {
-      val segments = str.split("/", -1)
-      // .head is safe because split always returns non-empty array
-      val segments0 = if (segments.head == "") segments.drop(1) else segments
-      val reversed: List[String] =
-        segments0.foldLeft[List[String]](Nil)((path, seg) => Uri.decode(seg) :: path)
-      reversed.reverse
-    }
-  }
-
 }
 
 /** Describes the type of abnormal termination*/

--- a/core/src/main/scala/org/http4s/parser/RequestUriParser.scala
+++ b/core/src/main/scala/org/http4s/parser/RequestUriParser.scala
@@ -27,7 +27,10 @@ private[http4s] class RequestUriParser(val input: ParserInput, val charset: Char
       PathAbsolute ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) ~> {
         (path, query, fragment) =>
           val q = query.map(Q.fromString).getOrElse(Q.empty)
-          org.http4s.Uri(path = path, query = q, fragment = fragment)
+          org.http4s.Uri(
+            path = org.http4s.Uri.Path.fromString(path),
+            query = q,
+            fragment = fragment)
       }
     }
 
@@ -36,6 +39,7 @@ private[http4s] class RequestUriParser(val input: ParserInput, val charset: Char
       "*" ~ push(
         org.http4s.Uri(
           authority = Some(org.http4s.Uri.Authority(host = org.http4s.Uri.RegName("*"))),
-          path = ""))
+          path = org.http4s.Uri.Path.empty))
     }
+  // scalastyle:on public.methods.have.type
 }

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -33,7 +33,12 @@ private[http4s] trait Rfc3986Parser
       scheme ~ ":" ~ HierPart ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) ~> {
         (scheme, auth, path, query, fragment) =>
           org.http4s
-            .Uri(Some(scheme), auth, path, query.map(Q.fromString).getOrElse(Q.empty), fragment)
+            .Uri(
+              Some(scheme),
+              auth,
+              org.http4s.Uri.Path.fromString(path),
+              query.map(Q.fromString).getOrElse(Q.empty),
+              fragment)
       }
     }
 
@@ -41,15 +46,19 @@ private[http4s] trait Rfc3986Parser
     rule {
       RelativePart ~ optional("?" ~ Query) ~ optional("#" ~ Fragment) ~> {
         (auth, path, query, fragment) =>
-          org.http4s.Uri(None, auth, path, query.map(Q.fromString).getOrElse(Q.empty), fragment)
+          org.http4s.Uri(
+            None,
+            auth,
+            org.http4s.Uri.Path.fromString(path),
+            query.map(Q.fromString).getOrElse(Q.empty),
+            fragment)
       }
     }
 
-  def HierPart: Rule2[Option[org.http4s.Uri.Authority], org.http4s.Uri.Path] =
+  def HierPart: Rule2[Option[org.http4s.Uri.Authority], String] =
     rule {
-      "//" ~ Authority ~ PathAbempty ~> {
-        (auth: org.http4s.Uri.Authority, path: org.http4s.Uri.Path) =>
-          Some(auth) :: path :: HNil
+      "//" ~ Authority ~ PathAbempty ~> { (auth: org.http4s.Uri.Authority, path: String) =>
+        Some(auth) :: path :: HNil
       } |
         PathAbsolute ~> (None :: _ :: HNil) |
         PathRootless ~> (None :: _ :: HNil) |
@@ -58,11 +67,10 @@ private[http4s] trait Rfc3986Parser
         }
     }
 
-  def RelativePart: Rule2[Option[org.http4s.Uri.Authority], org.http4s.Uri.Path] =
+  def RelativePart: Rule2[Option[org.http4s.Uri.Authority], String] =
     rule {
-      "//" ~ Authority ~ PathAbempty ~> {
-        (auth: org.http4s.Uri.Authority, path: org.http4s.Uri.Path) =>
-          Some(auth) :: path :: HNil
+      "//" ~ Authority ~ PathAbempty ~> { (auth: org.http4s.Uri.Authority, path: String) =>
+        Some(auth) :: path :: HNil
       } |
         PathAbsolute ~> (None :: _ :: HNil) |
         PathNoscheme ~> (None :: _ :: HNil) |
@@ -101,9 +109,9 @@ private[http4s] trait Rfc3986Parser
 
   def RegName: Rule0 = rule {zeroOrMore(Unreserved | PctEncoded | SubDelims)}
 
-  def Path: Rule1[String] = rule {
+  def Path: Rule1[org.http4s.Uri.Path] = rule {
     (PathAbempty | PathAbsolute | PathNoscheme | PathRootless | PathEmpty) ~> { (s: String) =>
-      decode(s)
+      org.http4s.Uri.Path.fromString(decode(s))
     }
   }
 

--- a/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
@@ -14,6 +14,7 @@ trait LiteralsSyntax {
 
 class LiteralsOps(val sc: StringContext) extends AnyVal {
   def uri(args: Any*): Uri = macro LiteralSyntaxMacros.uriInterpolator
+  def path(args: Any*): Uri.Path = macro LiteralSyntaxMacros.pathInterpolator
   def scheme(args: Any*): Uri.Scheme = macro LiteralSyntaxMacros.schemeInterpolator
   def ipv4(args: Any*): Uri.Ipv4Address = macro LiteralSyntaxMacros.ipv4AddressInterpolator
   def ipv6(args: Any*): Uri.Ipv6Address = macro LiteralSyntaxMacros.ipv6AddressInterpolator

--- a/core/src/main/scala/org/http4s/syntax/StringSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/StringSyntax.scala
@@ -17,6 +17,5 @@ trait StringSyntax {
 
 @deprecated("Use CIString.apply instead", "1.0.0-M1")
 final class StringOps(val self: String) extends AnyVal {
-  def ci: CIString =
-    CIString(self)
+  def ci: CIString = CIString(self)
 }

--- a/docs/src/main/mdoc/client.md
+++ b/docs/src/main/mdoc/client.md
@@ -192,7 +192,7 @@ You can also build up a URI incrementally, e.g.:
 
 ```scala mdoc:nest
 val baseUri = uri"http://foo.com"
-val withPath = baseUri.withPath("/bar/baz")
+val withPath = baseUri.withPath(path"/bar/baz")
 val withQuery = withPath.withQueryParam("hello", "world")
 ```
 

--- a/docs/src/main/mdoc/uri.md
+++ b/docs/src/main/mdoc/uri.md
@@ -30,7 +30,7 @@ or you could use the URLTemplates.
 Use the methods on the [uri class].
 
 ```scala mdoc
-val docs = uri.withPath("/docs/0.15")
+val docs = uri.withPath(path"/docs/0.15")
 val docs2 = uri / "docs" / "0.15"
 assert(docs == docs2)
 ```

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -56,14 +56,13 @@ object Path {
     * }}}
     */
   def apply(str: String): Path =
-    if (str == "" || str == "/")
-      Root
-    else {
-      val segments = str.split("/", -1)
-      // .head is safe because split always returns non-empty array
-      val segments0 = if (segments.head == "") segments.drop(1) else segments
-      segments0.foldLeft(Root: Path)((path, seg) => path / Uri.decode(seg))
-    }
+    apply(Uri.Path.fromString(str))
+
+  def apply(path: Uri.Path): Path =
+    if (path.isEmpty) Root
+    else
+      (if (path.endsWithSlash) path.segments :+ Uri.Path.Segment("") else path.segments)
+        .foldLeft(Root: Path)((path, seg) => path / seg.decoded())
 
   def apply(first: String, rest: String*): Path =
     rest.foldLeft(Root / first)(_ / _)

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
@@ -10,7 +10,6 @@ package dsl
 import cats.data.Validated._
 import cats.effect.IO
 import cats.implicits._
-import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.http4s.testing.Http4sLegacyMatchersIO
 
@@ -88,33 +87,33 @@ object PathInHttpRoutesSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
   "Path DSL within HttpService" should {
     "GET /" in {
-      val response = serve(Request(GET, Uri(path = "/")))
+      val response = serve(Request(GET, Uri(path = Uri.Path.Root)))
       response.status must_== (Ok)
       response.as[String] must returnValue("(empty)")
     }
     "GET /{id}" in {
-      val response = serve(Request(GET, Uri(path = "/12345")))
+      val response = serve(Request(GET, uri"/12345"))
       response.status must_== (Ok)
       response.as[String] must returnValue("id: 12345")
     }
     "GET /?{start}" in {
-      val response = serve(Request(GET, uri("/?start=1")))
+      val response = serve(Request(GET, uri"/?start=1"))
       response.status must_== (Ok)
       response.as[String] must returnValue("start: 1")
     }
     "GET /?{start,limit}" in {
-      val response = serve(Request(GET, uri("/?start=1&limit=2")))
+      val response = serve(Request(GET, uri"/?start=1&limit=2"))
       response.status must_== (Ok)
       response.as[String] must returnValue("start: 1, limit: 2")
     }
     "GET /calc" in {
-      val response = serve(Request(GET, Uri(path = "/calc")))
+      val response = serve(Request(GET, uri"/calc"))
       response.status must_== (NotFound)
       response.as[String] must returnValue("404 Not Found: /calc")
     }
     "GET /calc?decimal=1.3" in {
       val response =
-        serve(Request(GET, Uri(path = "/calc", query = Query.fromString("decimal=1.3"))))
+        serve(Request(GET, Uri(path = path"/calc", query = Query.fromString("decimal=1.3"))))
       response.status must_== (Ok)
       response.as[String] must returnValue(s"result: 0.65")
     }
@@ -122,89 +121,94 @@ object PathInHttpRoutesSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val response = serve(
         Request(
           GET,
-          Uri(path = "/items", query = Query.fromString("list=1&list=2&list=3&list=4&list=5"))))
+          Uri(path = path"/items", query = Query.fromString("list=1&list=2&list=3&list=4&list=5"))))
       response.status must_== (Ok)
       response.as[String] must returnValue(s"items: 1,2,3,4,5")
     }
     "GET /search" in {
-      val response = serve(Request(GET, Uri(path = "/search")))
+      val response = serve(Request(GET, uri"/search"))
       response.status must_== (NotFound)
       response.as[String] must returnValue("404 Not Found: /search")
     }
     "GET /search?term" in {
-      val response = serve(Request(GET, Uri(path = "/search", query = Query.fromString("term"))))
+      val response =
+        serve(Request(GET, Uri(path = path"/search", query = Query.fromString("term"))))
       response.status must_== (NotFound)
       response.as[String] must returnValue("404 Not Found: /search")
     }
     "GET /search?term=" in {
-      val response = serve(Request(GET, Uri(path = "/search", query = Query.fromString("term="))))
+      val response =
+        serve(Request(GET, Uri(path = path"/search", query = Query.fromString("term="))))
       response.status must_== (Ok)
       response.as[String] must returnValue("term: ")
     }
     "GET /search?term= http4s  " in {
       val response =
-        serve(Request(GET, Uri(path = "/search", query = Query.fromString("term=%20http4s%20%20"))))
+        serve(
+          Request(GET, Uri(path = path"/search", query = Query.fromString("term=%20http4s%20%20"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("term:  http4s  ")
     }
     "GET /search?term=http4s" in {
       val response =
-        serve(Request(GET, Uri(path = "/search", query = Query.fromString("term=http4s"))))
+        serve(Request(GET, Uri(path = path"/search", query = Query.fromString("term=http4s"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("term: http4s")
     }
     "optional parameter present" in {
-      val response = serve(Request(GET, Uri(path = "/app", query = Query.fromString("counter=3"))))
+      val response =
+        serve(Request(GET, Uri(path = path"/app", query = Query.fromString("counter=3"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("counter: Some(3)")
     }
     "optional parameter absent" in {
-      val response = serve(Request(GET, Uri(path = "/app", query = Query.fromString("other=john"))))
+      val response =
+        serve(Request(GET, Uri(path = path"/app", query = Query.fromString("other=john"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("counter: None")
     }
     "optional parameter present with incorrect format" in {
       val response =
-        serve(Request(GET, Uri(path = "/app", query = Query.fromString("counter=john"))))
+        serve(Request(GET, Uri(path = path"/app", query = Query.fromString("counter=john"))))
       response.status must_== (NotFound)
     }
     "validating parameter present" in {
       val response =
-        serve(Request(GET, Uri(path = "/valid", query = Query.fromString("counter=3"))))
+        serve(Request(GET, Uri(path = path"/valid", query = Query.fromString("counter=3"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("counter: 3")
     }
     "validating parameter absent" in {
       val response =
-        serve(Request(GET, Uri(path = "/valid", query = Query.fromString("notthis=3"))))
+        serve(Request(GET, Uri(path = path"/valid", query = Query.fromString("notthis=3"))))
       response.status must_== (NotFound)
     }
     "validating parameter present with incorrect format" in {
       val response =
-        serve(Request(GET, Uri(path = "/valid", query = Query.fromString("counter=foo"))))
+        serve(Request(GET, Uri(path = path"/valid", query = Query.fromString("counter=foo"))))
       response.status must_== (BadRequest)
       response.as[String] must returnValue("Query decoding Int failed")
     }
     "optional validating parameter present" in {
       val response =
-        serve(Request(GET, Uri(path = "/optvalid", query = Query.fromString("counter=3"))))
+        serve(Request(GET, Uri(path = path"/optvalid", query = Query.fromString("counter=3"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("counter: 3")
     }
     "optional validating parameter absent" in {
       val response =
-        serve(Request(GET, Uri(path = "/optvalid", query = Query.fromString("notthis=3"))))
+        serve(Request(GET, Uri(path = path"/optvalid", query = Query.fromString("notthis=3"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("no counter")
     }
     "optional validating parameter present with incorrect format" in {
       val response =
-        serve(Request(GET, Uri(path = "/optvalid", query = Query.fromString("counter=foo"))))
+        serve(Request(GET, Uri(path = path"/optvalid", query = Query.fromString("counter=foo"))))
       response.status must_== (BadRequest)
       response.as[String] must returnValue("Query decoding Int failed")
     }
     "optional multi parameter with no parameters" in {
-      val response = serve(Request(GET, Uri(path = "/multiopt")))
+      val response = serve(Request(GET, uri"/multiopt"))
       response.status must_== (Ok)
       response.as[String] must returnValue("absent")
     }
@@ -212,33 +216,39 @@ object PathInHttpRoutesSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val response = serve(
         Request(
           GET,
-          Uri(path = "/multiopt", query = Query.fromString("counter=1&counter=2&counter=3"))))
+          Uri(path = path"/multiopt", query = Query.fromString("counter=1&counter=2&counter=3"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("3: 1,2,3")
     }
     "optional multi parameter with one parameter" in {
       val response =
-        serve(Request(GET, Uri(path = "/multiopt", query = Query.fromString("counter=3"))))
+        serve(Request(GET, Uri(path = path"/multiopt", query = Query.fromString("counter=3"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("1: 3")
     }
     "optional multi parameter with incorrect format" in {
       val response =
-        serve(Request(GET, Uri(path = "/multiopt", query = Query.fromString("counter=foo"))))
+        serve(Request(GET, Uri(path = path"/multiopt", query = Query.fromString("counter=foo"))))
       response.status must_== (BadRequest)
     }
     "optional multi parameter with one incorrect parameter" in {
       val response = serve(
-        Request(GET, Uri(path = "/multiopt", query = Query.fromString("counter=foo&counter=1"))))
+        Request(
+          GET,
+          Uri(path = path"/multiopt", query = Query.fromString("counter=foo&counter=1"))))
       response.status must_== (BadRequest)
 
       val response2 = serve(
-        Request(GET, Uri(path = "/multiopt", query = Query.fromString("counter=1&counter=foo"))))
+        Request(
+          GET,
+          Uri(path = path"/multiopt", query = Query.fromString("counter=1&counter=foo"))))
       response2.status must_== (BadRequest)
     }
     "optional multi parameter with two incorrect parameters must return both" in {
       val response = serve(
-        Request(GET, Uri(path = "/multiopt", query = Query.fromString("counter=foo&counter=bar"))))
+        Request(
+          GET,
+          Uri(path = path"/multiopt", query = Query.fromString("counter=foo&counter=bar"))))
       response.status must_== (BadRequest)
       response.as[String].map(_.split("\n").toList) must returnValue(
         scala.List(
@@ -248,19 +258,19 @@ object PathInHttpRoutesSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     }
     "optional flag parameter when present" in {
       val response =
-        serve(Request(GET, Uri(path = "/flagparam", query = Query.fromString("flag"))))
+        serve(Request(GET, Uri(path = path"/flagparam", query = Query.fromString("flag"))))
       response.status must_== Ok
       response.as[String] must returnValue("flag present")
     }
     "optional flag parameter when present with a value" in {
       val response =
-        serve(Request(GET, Uri(path = "/flagparam", query = Query.fromString("flag=1"))))
+        serve(Request(GET, Uri(path = path"/flagparam", query = Query.fromString("flag=1"))))
       response.status must_== (Ok)
       response.as[String] must returnValue("flag present")
     }
     "optional flag parameter when not present" in {
       val response =
-        serve(Request(GET, Uri(path = "/flagparam", query = Query.fromString(""))))
+        serve(Request(GET, Uri(path = path"/flagparam", query = Query.fromString(""))))
       response.status must_== (Ok)
       response.as[String] must returnValue("flag not present")
     }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
@@ -27,7 +27,7 @@ object ClientMultipartPostExample extends IOApp with Http4sClientDsl[IO] {
     val url = Uri(
       scheme = Some(Scheme.http),
       authority = Some(Authority(host = RegName("ptsv2.com"))),
-      path = "/t/http4s/post")
+      path = Uri.Path.fromString("/t/http4s/post"))
 
     val multipart = Multipart[IO](
       Vector(

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
@@ -15,6 +15,7 @@ import org.http4s.circe._
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.{Header, Request, Uri}
+import org.http4s.syntax.literals._
 
 // See: https://developer.github.com/apps/building-oauth-apps/authorization-options-for-oauth-apps/#web-application-flow
 class GitHubService[F[_]: Sync](client: Client[F]) extends Http4sClientDsl[F] {
@@ -29,7 +30,7 @@ class GitHubService[F[_]: Sync](client: Client[F]) extends Http4sClientDsl[F] {
   val authorize: Stream[F, Byte] = {
     val uri = Uri
       .uri("https://github.com")
-      .withPath("/login/oauth/authorize")
+      .withPath(path"/login/oauth/authorize")
       .withQueryParam("client_id", ClientId)
       .withQueryParam("redirect_uri", RedirectUri)
       .withQueryParam("scopes", "public_repo")
@@ -39,9 +40,8 @@ class GitHubService[F[_]: Sync](client: Client[F]) extends Http4sClientDsl[F] {
   }
 
   def accessToken(code: String, state: String): F[String] = {
-    val uri = Uri
-      .uri("https://github.com")
-      .withPath("/login/oauth/access_token")
+    val uri = uri"https://github.com"
+      .withPath(path"/login/oauth/access_token")
       .withQueryParam("client_id", ClientId)
       .withQueryParam("client_secret", ClientSecret)
       .withQueryParam("code", code)
@@ -54,7 +54,7 @@ class GitHubService[F[_]: Sync](client: Client[F]) extends Http4sClientDsl[F] {
   }
 
   def userData(accessToken: String): F[String] = {
-    val request = Request[F](uri = Uri.uri("https://api.github.com/user"))
+    val request = Request[F](uri = uri"https://api.github.com/user")
       .putHeaders(Header("Authorization", s"token $accessToken"))
 
     client.expect[String](request)

--- a/server/src/main/scala/org/http4s/server/ContextRouter.scala
+++ b/server/src/main/scala/org/http4s/server/ContextRouter.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.server
 
-import org.http4s.{ContextRequest, ContextRoutes}
+import org.http4s.{ContextRequest, ContextRoutes, Uri}
 import cats.data.Kleisli
 import cats.effect.Sync
 import cats.syntax.semigroupk._
@@ -31,15 +31,15 @@ object ContextRouter {
   )(default: ContextRoutes[A, F]): ContextRoutes[A, F] =
     mappings.sortBy(_._1.length).foldLeft(default) {
       case (acc, (prefix, routes)) =>
-        val segments = Router.toSegments(prefix)
-        if (segments.isEmpty) routes <+> acc
+        val prefixSegments = Uri.Path.fromString(prefix)
+        if (prefixSegments.isEmpty) routes <+> acc
         else
           Kleisli { req =>
             (
-              if (Router.toSegments(req.req.pathInfo).startsWith(segments))
+              if (req.req.pathInfo.startsWith(prefixSegments))
                 routes
                   .local[ContextRequest[F, A]](r =>
-                    ContextRequest(r.context, Router.translate(prefix)(r.req))) <+> acc
+                    ContextRequest(r.context, Router.translate(prefixSegments)(r.req))) <+> acc
               else
                 acc
             )(req)

--- a/server/src/main/scala/org/http4s/server/Server.scala
+++ b/server/src/main/scala/org/http4s/server/Server.scala
@@ -33,6 +33,6 @@ abstract class Server {
           },
           port = Some(address.getPort)
         )),
-      path = "/"
+      path = Uri.Path.Root
     )
 }

--- a/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
@@ -27,10 +27,10 @@ object AutoSlash {
       http(req) <+> {
         val pathInfo = req.pathInfo
 
-        if (pathInfo.isEmpty || pathInfo.charAt(pathInfo.length - 1) != '/')
+        if (pathInfo.isEmpty)
           F.empty
         else
-          http.apply(req.withPathInfo(pathInfo.substring(0, pathInfo.length - 1)))
+          http.apply(req.withPathInfo(pathInfo.dropEndsWithSlash))
       }
     }
   }

--- a/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
@@ -25,10 +25,9 @@ object PushSupport {
     def push(url: String, cascade: Boolean = true)(implicit req: Request[F]): Response[F] = {
       val newUrl = {
         val script = req.scriptName
-        if (script.length > 0) {
+        if (script.nonEmpty) {
           val sb = new StringBuilder()
-          sb.append(script)
-          if (!url.startsWith("/")) sb.append('/')
+          sb.append(script.toAbsolute)
           sb.append(url).result()
         } else url
       }
@@ -54,7 +53,7 @@ object PushSupport {
     val emptyCollect: F[Vector[PushResponse[F]]] = F.pure(Vector.empty[PushResponse[F]])
 
     def fetchAndAdd(facc: F[Vector[PushResponse[F]]], v: PushLocation): F[Vector[PushResponse[F]]] =
-      routes(req.withPathInfo(v.location)).value.flatMap {
+      routes(req.withPathInfo(Uri.Path.fromString(v.location))).value.flatMap {
         case None => emptyCollect
         case Some(response) if !v.cascade =>
           facc.map(_ :+ PushResponse(v.location, response))

--- a/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -32,7 +32,7 @@ object FileService {
     * @param pathPrefix prefix of Uri from which content will be served
     * @param pathCollector function that performs the work of collecting the file or rendering the directory into a response.
     * @param bufferSize buffer size to use for internal read buffers
-    * @param blockingExecutionContext `ExecutionContext` to use for blocking I/O
+    * @param blocker to use for blocking I/O
     * @param cacheStrategy strategy to use for caching purposes. Default to no caching.
     */
   final case class Config[F[_]](
@@ -60,31 +60,29 @@ object FileService {
     object BadTraversal extends Exception with NoStackTrace
     Try(Paths.get(config.systemPath).toRealPath()) match {
       case Success(rootPath) =>
-        TranslateUri(config.pathPrefix)(Kleisli {
-          case request =>
-            def resolvedPath: OptionT[F, Path] =
-              request.pathInfo.split("/") match {
-                case Array() => OptionT.some(rootPath)
-                case Array(head, segments @ _*) if head.isEmpty =>
-                  OptionT
-                    .liftF(F.catchNonFatal {
-                      segments.foldLeft(rootPath) {
-                        case (_, "" | "." | "..") => throw BadTraversal
-                        case (path, segment) =>
-                          path.resolve(Uri.decode(segment, plusIsSpace = true))
-                      }
-                    })
-                case _ => OptionT.none
-              }
-            resolvedPath
-              .semiflatMap(path => F.delay(path.toRealPath(LinkOption.NOFOLLOW_LINKS)))
-              .collect { case path if path.startsWith(rootPath) => path.toFile }
-              .flatMap(f => config.pathCollector(f, config, request))
-              .semiflatMap(config.cacheStrategy.cache(request.pathInfo, _))
-              .recoverWith {
-                case _: NoSuchFileException => OptionT.none
-                case BadTraversal => OptionT.some(Response(Status.BadRequest))
-              }
+        TranslateUri(config.pathPrefix)(Kleisli { request =>
+          def resolvedPath: OptionT[F, Path] = {
+            val segments = request.pathInfo.segments.map(_.decoded(plusIsSpace = true))
+            if (request.pathInfo.isEmpty) OptionT.some(rootPath)
+            else
+              OptionT
+                .liftF(F.catchNonFatal {
+                  segments.foldLeft(rootPath) {
+                    case (_, "" | "." | "..") => throw BadTraversal
+                    case (path, segment) =>
+                      path.resolve(segment)
+                  }
+                })
+          }
+          resolvedPath
+            .semiflatMap(path => F.delay(path.toRealPath(LinkOption.NOFOLLOW_LINKS)))
+            .collect { case path if path.startsWith(rootPath) => path.toFile }
+            .flatMap(f => config.pathCollector(f, config, request))
+            .semiflatMap(config.cacheStrategy.cache(request.pathInfo.renderString, _))
+            .recoverWith {
+              case _: NoSuchFileException => OptionT.none
+              case BadTraversal => OptionT.some(Response(Status.BadRequest))
+            }
         })
 
       case Failure(_: NoSuchFileException) =>

--- a/server/src/test/scala/org/http4s/server/ContextRouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/ContextRouterSpec.scala
@@ -43,7 +43,8 @@ class ContextRouterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
   def middleware(routes: ContextRoutes[Unit, IO]): ContextRoutes[Unit, IO] =
     Kleisli((r: ContextRequest[IO, Unit]) =>
-      if (r.req.uri.query.containsQueryParam("block")) OptionT.liftF(Ok(r.req.uri.path))
+      if (r.req.uri.query.containsQueryParam("block"))
+        OptionT.liftF(Ok(r.req.uri.path.renderString))
       else routes(r))
 
   val service = ContextRouter[IO, Unit](

--- a/server/src/test/scala/org/http4s/server/HttpRoutesSpec.scala
+++ b/server/src/test/scala/org/http4s/server/HttpRoutesSpec.scala
@@ -9,26 +9,25 @@ package server
 
 import cats.effect._
 import cats.implicits._
-import org.http4s.Uri.uri
 import org.http4s.testing.Http4sLegacyMatchersIO
 
 class HttpRoutesSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   val routes1 = HttpRoutes.of[IO] {
-    case req if req.pathInfo == "/match" =>
+    case req if req.pathInfo == path"/match" =>
       Response[IO](Status.Ok).withEntity("match").pure[IO]
 
-    case req if req.pathInfo == "/conflict" =>
+    case req if req.pathInfo == path"/conflict" =>
       Response[IO](Status.Ok).withEntity("routes1conflict").pure[IO]
 
-    case req if req.pathInfo == "/notfound" =>
+    case req if req.pathInfo == path"/notfound" =>
       Response[IO](Status.NotFound).withEntity("notfound").pure[IO]
   }
 
   val routes2 = HttpRoutes.of[IO] {
-    case req if req.pathInfo == "/routes2" =>
+    case req if req.pathInfo == path"/routes2" =>
       Response[IO](Status.Ok).withEntity("routes2").pure[IO]
 
-    case req if req.pathInfo == "/conflict" =>
+    case req if req.pathInfo == path"/conflict" =>
       Response[IO](Status.Ok).withEntity("routes2conflict").pure[IO]
   }
 
@@ -36,23 +35,23 @@ class HttpRoutesSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
   "HttpRoutes" should {
     "Return a valid Response from the first service of an aggregate" in {
-      aggregate1.orNotFound(Request[IO](uri = uri("/match"))) must returnBody("match")
+      aggregate1.orNotFound(Request[IO](uri = uri"/match")) must returnBody("match")
     }
 
     "Return a custom NotFound from the first service of an aggregate" in {
-      aggregate1.orNotFound(Request[IO](uri = uri("/notfound"))) must returnBody("notfound")
+      aggregate1.orNotFound(Request[IO](uri = uri"/notfound")) must returnBody("notfound")
     }
 
     "Accept the first matching route in the case of overlapping paths" in {
-      aggregate1.orNotFound(Request[IO](uri = uri("/conflict"))) must returnBody("routes1conflict")
+      aggregate1.orNotFound(Request[IO](uri = uri"/conflict")) must returnBody("routes1conflict")
     }
 
     "Fall through the first service that doesn't match to a second matching service" in {
-      aggregate1.orNotFound(Request[IO](uri = uri("/routes2"))) must returnBody("routes2")
+      aggregate1.orNotFound(Request[IO](uri = uri"/routes2")) must returnBody("routes2")
     }
 
     "Properly fall through two aggregated service if no path matches" in {
-      aggregate1.apply(Request[IO](uri = uri("/wontMatch"))).value must returnValue(
+      aggregate1.apply(Request[IO](uri = uri"/wontMatch")).value must returnValue(
         Option.empty[Response[IO]])
     }
   }

--- a/server/src/test/scala/org/http4s/server/MockRoute.scala
+++ b/server/src/test/scala/org/http4s/server/MockRoute.scala
@@ -11,27 +11,28 @@ import cats.effect._
 import cats.implicits._
 import org.http4s.Status.{Accepted, Ok}
 import org.http4s.server.middleware.PushSupport._
+import org.http4s.syntax.literals._
 
 object MockRoute {
   def route(): HttpRoutes[IO] =
     HttpRoutes.of {
-      case req if req.uri.path === "/ping" =>
+      case req if req.uri.path === path"/ping" =>
         Response[IO](Ok).withEntity("pong").pure[IO]
 
-      case req if req.method === Method.POST && req.uri.path === "/echo" =>
+      case req if req.method === Method.POST && req.uri.path === path"/echo" =>
         IO.pure(Response[IO](body = req.body))
 
-      case req if req.uri.path === "/withslash" =>
+      case req if req.uri.path === path"/withslash" =>
         IO.pure(Response(Ok))
 
-      case req if req.uri.path === "/withslash/" =>
+      case req if req.uri.path === path"/withslash/" =>
         IO.pure(Response(Accepted))
 
-      case req if req.uri.path === "/fail" =>
+      case req if req.uri.path === path"/fail" =>
         sys.error("Problem!")
 
       /** For testing the PushSupport middleware */
-      case req if req.uri.path === "/push" =>
+      case req if req.uri.path === path"/push" =>
         Response[IO](Ok).withEntity("Hello").push("/ping")(req).pure[IO]
     }
 }

--- a/server/src/test/scala/org/http4s/server/RouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSpec.scala
@@ -43,7 +43,8 @@ class RouterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
   def middleware(routes: HttpRoutes[IO]): HttpRoutes[IO] =
     Kleisli((r: Request[IO]) =>
-      if (r.uri.query.containsQueryParam("block")) OptionT.liftF(Ok(r.uri.path)) else routes(r))
+      if (r.uri.query.containsQueryParam("block")) OptionT.liftF(Ok(r.uri.path.renderString))
+      else routes(r))
 
   val service = Router[IO](
     "/numbers" -> numbers,

--- a/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CORSSpec.scala
@@ -16,8 +16,8 @@ import org.http4s.testing.Http4sLegacyMatchersIO
 
 class CORSSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   val routes = HttpRoutes.of[IO] {
-    case req if req.pathInfo == "/foo" => Response[IO](Ok).withEntity("foo").pure[IO]
-    case req if req.pathInfo == "/bar" => Response[IO](Unauthorized).withEntity("bar").pure[IO]
+    case req if req.pathInfo == path"/foo" => Response[IO](Ok).withEntity("foo").pure[IO]
+    case req if req.pathInfo == path"/bar" => Response[IO](Unauthorized).withEntity("bar").pure[IO]
   }
 
   val cors1 = CORS(routes)
@@ -38,7 +38,7 @@ class CORSSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     hs.get(hk).fold(false)(_.value === expected)
 
   def buildRequest(path: String, method: Method = GET) =
-    Request[IO](uri = Uri(path = path), method = method).withHeaders(
+    Request[IO](uri = Uri(path = Uri.Path.fromString(path)), method = method).withHeaders(
       Header("Origin", "http://allowed.com"),
       Header("Access-Control-Request-Method", "GET"))
 

--- a/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSpec.scala
@@ -15,13 +15,12 @@ import fs2.Stream._
 import java.nio.charset.StandardCharsets
 import org.http4s.Method._
 import org.http4s.Status._
-import org.http4s.Uri.uri
 import org.http4s.server.middleware.EntityLimiter.EntityTooLarge
 import org.http4s.testing.Http4sLegacyMatchersIO
 
 class EntityLimiterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   val routes = HttpRoutes.of[IO] {
-    case r if r.uri.path == "/echo" => r.decode[String](Response[IO](Ok).withEntity(_).pure[IO])
+    case r if r.pathInfo == path"/echo" => r.decode[String](Response[IO](Ok).withEntity(_).pure[IO])
   }
 
   val b = chunk(Chunk.bytes("hello".getBytes(StandardCharsets.UTF_8)))
@@ -29,14 +28,14 @@ class EntityLimiterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   "EntityLimiter" should {
     "Allow reasonable entities" in {
       EntityLimiter(routes, 100)
-        .apply(Request[IO](POST, uri("/echo"), body = b))
+        .apply(Request[IO](POST, uri"/echo", body = b))
         .map(_ => -1)
         .value must returnValue(Some(-1))
     }
 
     "Limit the maximum size of an EntityBody" in {
       EntityLimiter(routes, 3)
-        .apply(Request[IO](POST, uri("/echo"), body = b))
+        .apply(Request[IO](POST, uri"/echo", body = b))
         .map(_ => -1L)
         .value
         .handleError { case EntityTooLarge(i) => Some(i) } must returnValue(Some(3))
@@ -44,17 +43,17 @@ class EntityLimiterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
     "Chain correctly with other HttpRoutes" in {
       val routes2 = HttpRoutes.of[IO] {
-        case r if r.uri.path == "/echo2" =>
+        case r if r.pathInfo == path"/echo2" =>
           r.decode[String](Response[IO](Ok).withEntity(_).pure[IO])
       }
 
       val st = EntityLimiter(routes, 3) <+> routes2
 
-      st.apply(Request[IO](POST, uri("/echo2"), body = b))
+      st.apply(Request[IO](POST, uri"/echo2", body = b))
         .map(_ => -1)
         .value must returnValue(Some(-1))
 
-      st.apply(Request[IO](POST, uri("/echo"), body = b))
+      st.apply(Request[IO](POST, uri"/echo", body = b))
         .map(_ => -1L)
         .value
         .handleError { case EntityTooLarge(i) => Some(i) } must returnValue(Some(3L))

--- a/server/src/test/scala/org/http4s/server/middleware/HttpsRedirectSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpsRedirectSpec.scala
@@ -22,7 +22,7 @@ class HttpsRedirectSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   }
 
   val reqHeaders = Headers.of(Header("X-Forwarded-Proto", "http"), Header("Host", "example.com"))
-  val req = Request[IO](method = GET, uri = Uri(path = "/"), headers = reqHeaders)
+  val req = Request[IO](method = GET, uri = Uri(path = Uri.Path.Root), headers = reqHeaders)
 
   "HttpsRedirect" should {
     "redirect to https when 'X-Forwarded-Proto' is http" in {
@@ -30,7 +30,11 @@ class HttpsRedirectSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val resp = app(req).unsafeRunSync
       val expectedAuthority = Authority(host = RegName("example.com"))
       val expectedLocation =
-        Location(Uri(path = "/", scheme = Some(Scheme.https), authority = Some(expectedAuthority)))
+        Location(
+          Uri(
+            path = Uri.Path.Root,
+            scheme = Some(Scheme.https),
+            authority = Some(expectedAuthority)))
       val expectedHeaders = Headers(expectedLocation :: `Content-Type`(MediaType.text.xml) :: Nil)
       resp.status must_== Status.MovedPermanently
       resp.headers must_== expectedHeaders
@@ -38,7 +42,7 @@ class HttpsRedirectSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
     "not redirect otherwise" in {
       val app = HttpsRedirect(innerRoutes).orNotFound
-      val noHeadersReq = Request[IO](method = GET, uri = Uri(path = "/"))
+      val noHeadersReq = Request[IO](method = GET, uri = Uri(path = Uri.Path.Root))
       val resp = app(noHeadersReq).unsafeRunSync
       resp.status must_== Status.Ok
       resp.as[String] must returnValue("pong")

--- a/server/src/test/scala/org/http4s/server/middleware/TranslateUriSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/TranslateUriSpec.scala
@@ -18,7 +18,7 @@ class TranslateUriSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       Ok("foo")
 
     case r @ _ -> Root / "checkattr" =>
-      val s = r.scriptName + " " + r.pathInfo
+      val s = r.scriptName.renderString + " " + r.pathInfo.renderString
       Ok(s)
   }
 
@@ -27,28 +27,28 @@ class TranslateUriSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
   "UriTranslation" should {
     "match a matching request" in {
-      val req = Request[IO](uri = Uri(path = "/http4s/foo"))
+      val req = Request[IO](uri = uri"/http4s/foo")
       trans1(req) must returnStatus(Ok)
       trans2(req) must returnStatus(Ok)
       routes.orNotFound(req) must returnStatus(NotFound)
     }
 
     "not match a request missing the prefix" in {
-      val req = Request[IO](uri = Uri(path = "/foo"))
+      val req = Request[IO](uri = uri"/foo")
       trans1(req) must returnStatus(NotFound)
       trans2(req) must returnStatus(NotFound)
       routes.orNotFound(req) must returnStatus(Ok)
     }
 
     "not match a request with a different prefix" in {
-      val req = Request[IO](uri = Uri(path = "/http5s/foo"))
+      val req = Request[IO](uri = uri"/http5s/foo")
       trans1(req) must returnStatus(NotFound)
       trans2(req) must returnStatus(NotFound)
       routes.orNotFound(req) must returnStatus(NotFound)
     }
 
     "split the Uri into scriptName and pathInfo" in {
-      val req = Request[IO](uri = Uri(path = "/http4s/checkattr"))
+      val req = Request[IO](uri = uri"/http4s/checkattr")
       val resp = trans1(req).unsafeRunSync()
       resp.status must be(Ok)
       resp must haveBody("/http4s /checkattr")
@@ -58,7 +58,7 @@ class TranslateUriSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val emptyPrefix = TranslateUri("")(routes)
       val slashPrefix = TranslateUri("/")(routes)
 
-      val req = Request[IO](uri = Uri(path = "/foo"))
+      val req = Request[IO](uri = uri"/foo")
       emptyPrefix.orNotFound(req) must returnStatus(Ok)
       slashPrefix.orNotFound(req) must returnStatus(Ok)
     }

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -53,7 +53,7 @@ class AuthenticationSpec extends Http4sSpec {
 
   "Failure to authenticate" should {
     "not run unauthorized routes" in {
-      val req = Request[IO](uri = Uri(path = "/launch-the-nukes"))
+      val req = Request[IO](uri = uri"/launch-the-nukes")
       var isNuked = false
       val authedValidateNukeService = basicAuthMiddleware(nukeService {
         isNuked = true
@@ -68,7 +68,7 @@ class AuthenticationSpec extends Http4sSpec {
     val basicAuthedService = basicAuthMiddleware(service)
 
     "Respond to a request without authentication with 401" in {
-      val req = Request[IO](uri = Uri(path = "/"))
+      val req = Request[IO](uri = uri"/")
       val res = basicAuthedService.orNotFound(req).unsafeRunSync
 
       res.status must_=== Unauthorized
@@ -78,7 +78,7 @@ class AuthenticationSpec extends Http4sSpec {
 
     "Respond to a request with unknown username with 401" in {
       val req = Request[IO](
-        uri = Uri(path = "/"),
+        uri = uri"/",
         headers = Headers.of(Authorization(BasicCredentials("Wrong User", password))))
       val res = basicAuthedService.orNotFound(req).unsafeRunSync
 
@@ -89,7 +89,7 @@ class AuthenticationSpec extends Http4sSpec {
 
     "Respond to a request with wrong password with 401" in {
       val req = Request[IO](
-        uri = Uri(path = "/"),
+        uri = uri"/",
         headers = Headers.of(Authorization(BasicCredentials(username, "Wrong Password"))))
       val res = basicAuthedService.orNotFound(req).unsafeRunSync
 
@@ -100,7 +100,7 @@ class AuthenticationSpec extends Http4sSpec {
 
     "Respond to a request with correct credentials" in {
       val req = Request[IO](
-        uri = Uri(path = "/"),
+        uri = uri"/",
         headers = Headers.of(Authorization(BasicCredentials(username, password))))
       val res = basicAuthedService.orNotFound(req).unsafeRunSync
 
@@ -118,7 +118,7 @@ class AuthenticationSpec extends Http4sSpec {
 
     "Respond to a request without authentication with 401" in {
       val authedService = digestAuthMiddleware(service)
-      val req = Request[IO](uri = Uri(path = "/"))
+      val req = Request[IO](uri = uri"/")
       val res = authedService.orNotFound(req).unsafeRunSync
 
       res.status must_=== Unauthorized
@@ -136,7 +136,7 @@ class AuthenticationSpec extends Http4sSpec {
     // Send a request without authorization, receive challenge.
     def doDigestAuth1(digest: HttpApp[IO]) = {
       // Get auth data
-      val req = Request[IO](uri = Uri(path = "/"))
+      val req = Request[IO](uri = uri"/")
       val res = digest(req).unsafeRunSync
 
       res.status must_=== Unauthorized
@@ -171,7 +171,7 @@ class AuthenticationSpec extends Http4sSpec {
       )
       val header = Authorization(Credentials.AuthParams(CIString("Digest"), params))
 
-      val req2 = Request[IO](uri = Uri(path = "/"), headers = Headers.of(header))
+      val req2 = Request[IO](uri = uri"/", headers = Headers.of(header))
       val res2 = digest(req2).unsafeRunSync
 
       if (withReplay) {
@@ -272,7 +272,7 @@ class AuthenticationSpec extends Http4sSpec {
         val invalidParams = params.toList.take(i) ++ params.toList.drop(i + 1)
         val header = Authorization(
           Credentials.AuthParams(CIString("Digest"), invalidParams.head, invalidParams.tail: _*))
-        val req = Request[IO](uri = Uri(path = "/"), headers = Headers.of(header))
+        val req = Request[IO](uri = uri"/", headers = Headers.of(header))
         val res = digestAuthService.orNotFound(req).unsafeRunSync
 
         res.status

--- a/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceFilterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceFilterSpec.scala
@@ -23,7 +23,7 @@ object WebjarServiceFilterSpec extends Http4sSpec with StaticContentShared {
 
   "The WebjarService" should {
     "Return a 200 Ok file" in {
-      val req = Request[IO](GET, Uri(path = "/test-lib/1.0.0/testresource.txt"))
+      val req = Request[IO](GET, uri"/test-lib/1.0.0/testresource.txt")
       val rb = runReq(req)
 
       rb._1 must_== testWebjarResource
@@ -31,7 +31,7 @@ object WebjarServiceFilterSpec extends Http4sSpec with StaticContentShared {
     }
 
     "Not find filtered asset" in {
-      val req = Request[IO](GET, Uri(path = "/test-lib/1.0.0/sub/testresource.txt"))
+      val req = Request[IO](GET, uri"/test-lib/1.0.0/sub/testresource.txt")
       val rb = runReq(req)
 
       rb._2.status must_== Status.NotFound

--- a/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSpec.scala
@@ -11,7 +11,6 @@ package staticcontent
 import cats.effect.IO
 import java.nio.file.Paths
 import org.http4s.Method.{GET, POST}
-import org.http4s.Uri.uri
 import org.http4s.server.staticcontent.WebjarService.Config
 import org.http4s.testing.Http4sLegacyMatchersIO
 
@@ -23,7 +22,7 @@ object WebjarServiceSpec extends Http4sSpec with StaticContentShared with Http4s
 
   "The WebjarService" should {
     "Return a 200 Ok file" in {
-      val req = Request[IO](GET, Uri(path = "/test-lib/1.0.0/testresource.txt"))
+      val req = Request[IO](GET, uri"/test-lib/1.0.0/testresource.txt")
       val rb = runReq(req)
 
       rb._1 must_== testWebjarResource
@@ -31,7 +30,7 @@ object WebjarServiceSpec extends Http4sSpec with StaticContentShared with Http4s
     }
 
     "Return a 200 Ok file in a subdirectory" in {
-      val req = Request[IO](GET, Uri(path = "/test-lib/1.0.0/sub/testresource.txt"))
+      val req = Request[IO](GET, uri"/test-lib/1.0.0/sub/testresource.txt")
       val rb = runReq(req)
 
       rb._1 must_== testWebjarSubResource
@@ -39,7 +38,7 @@ object WebjarServiceSpec extends Http4sSpec with StaticContentShared with Http4s
     }
 
     "Decodes path segments" in {
-      val req = Request[IO](uri = uri("/deep+purple/machine+head/space+truckin%27.txt"))
+      val req = Request[IO](uri = uri"/deep+purple/machine+head/space+truckin%27.txt")
       routes.orNotFound(req) must returnStatus(Status.Ok)
     }
 
@@ -74,27 +73,27 @@ object WebjarServiceSpec extends Http4sSpec with StaticContentShared with Http4s
     }
 
     "Not find missing file" in {
-      val req = Request[IO](uri = uri("/test-lib/1.0.0/doesnotexist.txt"))
+      val req = Request[IO](uri = uri"/test-lib/1.0.0/doesnotexist.txt")
       routes.apply(req).value must returnValue(Option.empty[Response[IO]])
     }
 
     "Not find missing library" in {
-      val req = Request[IO](uri = uri("/1.0.0/doesnotexist.txt"))
+      val req = Request[IO](uri = uri"/1.0.0/doesnotexist.txt")
       routes.apply(req).value must returnValue(Option.empty[Response[IO]])
     }
 
     "Return bad request on missing version" in {
-      val req = Request[IO](uri = uri("/test-lib//doesnotexist.txt"))
+      val req = Request[IO](uri = uri"/test-lib//doesnotexist.txt")
       routes.orNotFound(req) must returnStatus(Status.BadRequest)
     }
 
     "Not find blank asset" in {
-      val req = Request[IO](uri = uri("/test-lib/1.0.0/"))
+      val req = Request[IO](uri = uri"/test-lib/1.0.0/")
       routes.apply(req).value must returnValue(Option.empty[Response[IO]])
     }
 
     "Not match a request with POST" in {
-      val req = Request[IO](POST, Uri(path = "/test-lib/1.0.0/testresource.txt"))
+      val req = Request[IO](POST, uri"/test-lib/1.0.0/testresource.txt")
       routes.apply(req).value must returnValue(Option.empty[Response[IO]])
     }
   }

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -89,7 +89,7 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
       headers = toHeaders(req),
       body = servletIo.reader(req),
       attributes = Vault.empty
-        .insert(Request.Keys.PathInfoCaret, req.getContextPath.length + req.getServletPath.length)
+        .insert(Request.Keys.PathInfoCaret, getPathInfoIndex(req, uri))
         .insert(
           Request.Keys.ConnectionInfo,
           Request.Connection(
@@ -127,6 +127,16 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
             .mapN(SecureSession.apply)
         )
     )
+
+  private def getPathInfoIndex(req: HttpServletRequest, uri: Uri) = {
+    val pathInfo =
+      Uri.Path
+        .fromString(req.getContextPath)
+        .concat(Uri.Path.fromString(req.getServletPath))
+    uri.path
+      .indexOf(pathInfo)
+      .getOrElse(-1)
+  }
 
   protected def toHeaders(req: HttpServletRequest): Headers = {
     val headers = for {

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -13,7 +13,6 @@ import java.net.{InetAddress, InetSocketAddress}
 import org.http4s.headers.{Authorization, `Content-Type`, `X-Forwarded-For`}
 import org.http4s.testing.Http4sLegacyMatchersIO
 import _root_.io.chrisdavenport.vault._
-import org.http4s.Uri.{Authority, Scheme}
 import org.typelevel.ci.CIString
 
 class MessageSpec extends Http4sSpec with Http4sLegacyMatchersIO {
@@ -102,34 +101,34 @@ class MessageSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     }
 
     "Request.with..." should {
-      val path1 = "/path1"
-      val path2 = "/somethingelse"
-      val attributes = Vault.empty.insert(Request.Keys.PathInfoCaret, 3)
+      val path1 = uri"/path1"
+      val path2 = path"/somethingelse"
+      val attributes = Vault.empty.insert(Request.Keys.PathInfoCaret, 0)
 
       "reset pathInfo if uri is changed" in {
-        val originalReq = Request(uri = Uri(path = path1), attributes = attributes)
-        val updatedReq = originalReq.withUri(uri = Uri(path = path2))
+        val originalReq = Request(uri = path1, attributes = attributes)
+        val updatedReq = originalReq.withUri(uri = Uri().withPath(path2))
 
-        updatedReq.scriptName mustEqual ""
+        updatedReq.scriptName mustEqual Uri.Path.Root
         updatedReq.pathInfo mustEqual path2
       }
 
       "not modify pathInfo if uri is unchanged" in {
-        val originalReq = Request(uri = Uri(path = path1), attributes = attributes)
+        val originalReq = Request(uri = path1, attributes = attributes)
         val updatedReq = originalReq.withMethod(method = Method.DELETE)
 
-        originalReq.pathInfo mustEqual updatedReq.pathInfo
         originalReq.scriptName mustEqual updatedReq.scriptName
+        originalReq.pathInfo mustEqual updatedReq.pathInfo
       }
 
       "preserve caret in withPathInfo" in {
         val originalReq = Request(
-          uri = Uri(path = "/foo/bar"),
-          attributes = Vault.empty.insert(Request.Keys.PathInfoCaret, 4))
-        val updatedReq = originalReq.withPathInfo("/quux")
+          uri = uri"/foo/bar",
+          attributes = Vault.empty.insert(Request.Keys.PathInfoCaret, 0))
+        val updatedReq = originalReq.withPathInfo(path"/quux")
 
-        updatedReq.scriptName mustEqual "/foo"
-        updatedReq.pathInfo mustEqual "/quux"
+        updatedReq.scriptName mustEqual path"/foo"
+        updatedReq.pathInfo mustEqual path"/quux"
       }
     }
 
@@ -197,12 +196,7 @@ class MessageSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     }
 
     "asCurl" should {
-      val port = 1234
-      val uri = Uri(
-        path = "/foo",
-        scheme = Some(Scheme.http),
-        authority = Some(Authority(port = Some(port)))
-      )
+      val uri = uri"http://localhost:1234/foo"
       val request = Request[IO](Method.GET, uri)
 
       "build cURL representation with scheme and authority" in {

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -11,8 +11,9 @@
 package org.http4s
 
 import cats.implicits._
-import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.{EqTests, SemigroupTests}
 import java.nio.file.Paths
+
 import org.http4s.internal.parboiled2.CharPredicate
 import org.http4s.Uri._
 import org.scalacheck.Gen
@@ -172,15 +173,14 @@ http://example.org/a file
 
   "Uri copy" should {
     "support updating the schema" in {
-      uri("http://example.com/").copy(scheme = Scheme.https.some) must_== uri(
-        "https://example.com/")
+      uri"http://example.com/".copy(scheme = Scheme.https.some) must_== uri("https://example.com/")
       // Must add the authority to set the scheme and host
-      uri("/route/").copy(
+      uri"/route/".copy(
         scheme = Scheme.https.some,
         authority = Some(Authority(None, RegName("example.com")))) must_== uri(
         "https://example.com/route/")
       // You can add a port too
-      uri("/route/").copy(
+      uri"/route/".copy(
         scheme = Scheme.https.some,
         authority = Some(Authority(None, RegName("example.com"), Some(8443)))) must_== uri(
         "https://example.com:8443/route/")
@@ -194,7 +194,7 @@ http://example.org/a file
 
     "withPath without slash adds a / on render" in {
       val uri = getUri("http://localhost/foo/bar/baz")
-      uri.withPath("bar").toString must_=== "http://localhost/bar"
+      uri.withPath(path"bar").toString must_=== "http://localhost/bar"
     }
 
     "render a IPv6 address, should be wrapped in brackets" in {
@@ -209,7 +209,7 @@ http://example.org/a file
         Uri(
           Some(Scheme.http),
           Some(Authority(host = Ipv6Address.unsafeFromString(s))),
-          "/foo",
+          Uri.Path.fromString("/foo"),
           Query.fromPairs("bar" -> "baz")).toString must_==
           (s"http://[$s]/foo?bar=baz")
       }
@@ -219,7 +219,7 @@ http://example.org/a file
       Uri(
         Some(Scheme.http),
         Some(Authority(host = RegName(CIString("www.foo.com")))),
-        "/foo",
+        Uri.Path.fromString("/foo"),
         Query.fromPairs("bar" -> "baz")).toString must_== ("http://www.foo.com/foo?bar=baz")
     }
 
@@ -244,7 +244,7 @@ http://example.org/a file
       Uri(
         Some(Scheme.http),
         Some(Authority(host = ipv4"192.168.1.1", port = Some(80))),
-        "/c",
+        Uri.Path.fromString("/c"),
         Query.fromPairs(
           "GB" -> "object",
           "Class" -> "one")).toString must_== ("http://192.168.1.1:80/c?GB=object&Class=one")
@@ -269,7 +269,7 @@ http://example.org/a file
       Uri(
         Some(Scheme.http),
         Some(Authority(host = ipv6"2001:db8::7")),
-        "/c",
+        Uri.Path.fromString("/c"),
         Query.fromPairs(
           "GB" -> "object",
           "Class" -> "one")).toString must_== ("http://[2001:db8::7]/c?GB=object&Class=one")
@@ -300,7 +300,9 @@ http://example.org/a file
     "render email address" in {
       Uri(
         Some(scheme"mailto"),
-        path = "John.Doe@example.com").toString must_== ("mailto:John.Doe@example.com")
+        path =
+          Uri.Path.fromString(
+            "John.Doe@example.com")).toString must_== ("mailto:John.Doe@example.com")
     }
 
     "render an URL with username and password" in {
@@ -311,9 +313,10 @@ http://example.org/a file
             Some(UserInfo("username", Some("password"))),
             RegName("some.example.com"),
             None)),
-        "/",
+        Uri.Path.fromString("/"),
         Query.empty,
-        None).toString must_== ("http://username:password@some.example.com/")
+        None
+      ).toString must_== ("http://username:password@some.example.com/")
     }
 
     "render an URL with username and password, path and params" in {
@@ -324,48 +327,56 @@ http://example.org/a file
             Some(UserInfo("username", Some("password"))),
             RegName("some.example.com"),
             None)),
-        "/some/path",
+        Uri.Path.fromString("/some/path"),
         Query.fromString("param1=5&param-without-value"),
         None
       ).toString must_== ("http://username:password@some.example.com/some/path?param1=5&param-without-value")
     }
 
     "render relative URI with empty query string" in {
-      Uri(path = "/", query = Query.fromString(""), fragment = None).toString must_== ("/?")
+      Uri(
+        path = Uri.Path.fromString("/"),
+        query = Query.fromString(""),
+        fragment = None).toString must_== ("/?")
     }
 
     "render relative URI with empty query string and fragment" in {
-      Uri(path = "/", query = Query.fromString(""), fragment = Some("")).toString must_== ("/?#")
+      Uri(
+        path = Uri.Path.Root,
+        query = Query.fromString(""),
+        fragment = Some("")).toString must_== ("/?#")
     }
 
     "render relative URI with empty fragment" in {
-      Uri(path = "/", query = Query.empty, fragment = Some("")).toString must_== ("/#")
+      Uri(path = Uri.Path.Root, query = Query.empty, fragment = Some("")).toString must_== ("/#")
     }
 
     "render relative path with fragment" in {
-      Uri(path = "/foo/bar", fragment = Some("an-anchor")).toString must_== ("/foo/bar#an-anchor")
+      Uri(
+        path = Uri.Path.fromString("/foo/bar"),
+        fragment = Some("an-anchor")).toString must_== ("/foo/bar#an-anchor")
     }
 
     "render relative path with parameters" in {
       Uri(
-        path = "/foo/bar",
+        path = Uri.Path.fromString("/foo/bar"),
         query =
           Query.fromString("foo=bar&ding=dong")).toString must_== ("/foo/bar?foo=bar&ding=dong")
     }
 
     "render relative path with parameters and fragment" in {
       Uri(
-        path = "/foo/bar",
+        path = Uri.Path.fromString("/foo/bar"),
         query = Query.fromString("foo=bar&ding=dong"),
         fragment = Some("an_anchor")).toString must_== ("/foo/bar?foo=bar&ding=dong#an_anchor")
     }
 
     "render relative path without parameters" in {
-      Uri(path = "/foo/bar").toString must_== ("/foo/bar")
+      Uri(path = Uri.Path.fromString("/foo/bar")).toString must_== ("/foo/bar")
     }
 
     "render relative root path without parameters" in {
-      Uri(path = "/").toString must_== ("/")
+      Uri(path = Uri.Path.fromString("/")).toString must_== ("/")
     }
 
     "render a query string with a single param" in {
@@ -385,17 +396,7 @@ http://example.org/a file
        * - http://en.wikipedia.org/wiki/Uniform_Resource_Identifier
        *
        * URI.fromString fails for:
-       * - "http://en.wikipedia.org/wiki/URI#Examples_of_URI_references",
-       * - "file:///C:/Users/Benutzer/Desktop/Uniform%20Resource%20Identifier.html",
-       * - "file:///etc/fstab",
-       * - "relative/path/to/resource.txt",
        * - "//example.org/scheme-relative/URI/with/absolute/path/to/resource.txt",
-       * - "../../../resource.txt",
-       * - "./resource.txt#frag01",
-       * - "resource.txt",
-       * - "#frag01",
-       * - ""
-       *
        */
       val examples = Seq(
         "http://de.wikipedia.org/wiki/Uniform_Resource_Identifier",
@@ -413,7 +414,16 @@ http://example.org/a file
         "git://github.com/rails/rails.git",
         "crid://broadcaster.com/movies/BestActionMovieEver",
         "http://example.org/absolute/URI/with/absolute/path/to/resource.txt",
-        "/relative/URI/with/absolute/path/to/resource.txt"
+        "/relative/URI/with/absolute/path/to/resource.txt",
+        "http://en.wikipedia.org/wiki/URI#Examples_of_URI_references",
+        "file:///C:/Users/Benutzer/Desktop/Uniform%20Resource%20Identifier.html",
+        "file:///etc/fstab",
+        "relative/path/to/resource.txt",
+        "../../../resource.txt",
+        "./resource.txt#frag01",
+        "resource.txt",
+        "#frag01",
+        ""
       )
       foreach(examples) { e =>
         Uri.fromString(e).map(_.toString) must beRight(e)
@@ -817,17 +827,17 @@ http://example.org/a file
 
   "Uri.withFragment convenience method" should {
     "set a Fragment" in {
-      val u = Uri(path = "/")
+      val u = Uri(path = Uri.Path.Root)
       val updated = u.withFragment("nonsense")
       updated.renderString must_== "/#nonsense"
     }
     "set a new Fragment" in {
-      val u = Uri(path = "/", fragment = Some("adjakda"))
+      val u = Uri(path = Uri.Path.Root, fragment = Some("adjakda"))
       val updated = u.withFragment("nonsense")
       updated.renderString must_== "/#nonsense"
     }
     "set no Fragment on a null String" in {
-      val u = Uri(path = "/", fragment = Some("adjakda"))
+      val u = Uri(path = Uri.Path.Root, fragment = Some("adjakda"))
       val evilString: String = null
       val updated = u.withFragment(evilString)
       updated.renderString must_== "/"
@@ -836,7 +846,7 @@ http://example.org/a file
 
   "Uri.withoutFragment convenience method" should {
     "unset a Fragment" in {
-      val u = Uri(path = "/", fragment = Some("nonsense"))
+      val u = Uri(path = Uri.Path.Root, fragment = Some("nonsense"))
       val updated = u.withoutFragment
       updated.renderString must_== "/"
     }
@@ -844,11 +854,11 @@ http://example.org/a file
 
   "Uri.renderString" should {
     "Encode special chars in the query" in {
-      val u = Uri(path = "/").withQueryParam("foo", " !$&'()*+,;=:/?@~")
+      val u = Uri(path = Uri.Path.Root).withQueryParam("foo", " !$&'()*+,;=:/?@~")
       u.renderString must_== "/?foo=%20%21%24%26%27%28%29%2A%2B%2C%3B%3D%3A/?%40~"
     }
     "Encode special chars in the fragment" in {
-      val u = Uri(path = "/", fragment = Some(" !$&'()*+,;=:/?@~"))
+      val u = Uri(path = Uri.Path.Root, fragment = Some(" !$&'()*+,;=:/?@~"))
       u.renderString must_== "/#%20!$&'()*+,;=:/?@~"
     }
   }
@@ -857,14 +867,14 @@ http://example.org/a file
     val base = getUri("http://a/b/c/d;p?q")
 
     "correctly remove ./.. sequences" >> {
-      implicit class checkDotSequences(path: String) {
-        def removingDotsShould_==(expected: String) =
+      implicit class checkDotSequences(path: Uri.Path) {
+        def removingDotsShould_==(expected: Uri.Path) =
           s"$path -> $expected" in { removeDotSegments(path) must_== expected }
       }
 
       // from RFC 3986 sec 5.2.4
-      "mid/content=5/../6".removingDotsShould_==("mid/6")
-      "/a/b/c/./../../g".removingDotsShould_==("/a/g")
+      path"mid/content=5/../6".removingDotsShould_==(path"mid/6")
+      path"/a/b/c/./../../g".removingDotsShould_==(path"/a/g")
     }
 
     implicit class check(relative: String) {
@@ -939,7 +949,7 @@ http://example.org/a file
 
     "correctly remove dot segments in other examples" >> prop { (input: String) =>
       val prefix = "/this/isa/prefix/"
-      val processed = Uri.removeDotSegments(input)
+      val processed = Uri.removeDotSegments(Uri.Path.fromString(input)).renderString
       val path = Paths.get(prefix, processed).normalize
       path.startsWith(Paths.get(prefix)) must beTrue
       processed must not contain "./"
@@ -957,7 +967,7 @@ http://example.org/a file
 
   "Uri.equals" should {
     "be false between an empty path and a trailing slash after an authority" in {
-      uri("http://example.com") must_!= uri("http://example.com/")
+      getUri("http://example.com") must_!= getUri("http://example.com/")
     }
   }
 
@@ -969,24 +979,25 @@ http://example.org/a file
 
   "/" should {
     "encode space as %20" in {
-      uri("http://example.com/") / " " must_== uri("http://example.com/%20")
+      getUri("http://example.com/") / " " must_== getUri("http://example.com/%20")
     }
 
     "encode generic delimiters that aren't pchars" in {
       // ":" and "@" are valid pchars
-      uri("http://example.com") / ":/?#[]@" must_== uri("http://example.com/:%2F%3F%23%5B%5D@")
+      getUri("http://example.com") / ":/?#[]@" must_== getUri(
+        "http://example.com/:%2F%3F%23%5B%5D@")
     }
 
     "encode percent sequences" in {
-      uri("http://example.com") / "%2F" must_== uri("http://example.com/%252F")
+      getUri("http://example.com") / "%2F" must_== getUri("http://example.com/%252F")
     }
 
     "not encode sub-delims" in {
-      uri("http://example.com") / "!$&'()*+,;=" must_== uri("http://example.com/!$&'()*+,;=")
+      getUri("http://example.com") / "!$&'()*+,;=" must_== getUri("http://example.com/!$&'()*+,;=")
     }
 
     "UTF-8 encode characters" in {
-      uri("http://example.com/") / "ö" must_== uri("http://example.com/%C3%B6")
+      getUri("http://example.com/") / "ö" must_== getUri("http://example.com/%C3%B6")
     }
 
     "not make bad URIs" >> forAll { (s: String) =>
@@ -1079,4 +1090,22 @@ http://example.org/a file
       decode(encode("%2f", toSkip = CharPredicate("%")), toSkip = CharPredicate("/")) must_== "%2f"
     }
   }
+
+  "Uri.Path" should {
+    "check that we store the encoded path from parsed" in {
+      val uriReference = uri"https://example.com/auth0%7Cdsfhsklh46ksx/we-have-a%2Ftest"
+      uriReference.path.segments must_== List("auth0%7Cdsfhsklh46ksx", "we-have-a%2Ftest").map(
+        Uri.Path.Segment.encoded)
+    }
+    "check that we store the encoded " in {
+      val uriReference = uri"https://example.com/test" / "auth0|dsfhsklh46ksx" / "we-have-a/test"
+      uriReference.path.segments must_== List("test", "auth0%7Cdsfhsklh46ksx", "we-have-a%2Ftest")
+        .map(Uri.Path.Segment.encoded)
+    }
+    "instances" in {
+      checkAll("Uri.Path", SemigroupTests[Uri.Path].semigroup)
+      checkAll("Uri.Path", EqTests[Uri.Path].eqv)
+    }
+  }
+
 }

--- a/tests/src/test/scala/org/http4s/UriTemplateSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriTemplateSpec.scala
@@ -307,11 +307,10 @@ class UriTemplateSpec extends Http4sSpec {
   "UriTemplate.toUriIfPossible" should {
     "convert / to Uri" in {
       UriTemplate().toUriIfPossible.get must equalTo(Uri())
-      UriTemplate(path = Nil).toUriIfPossible.get must equalTo(Uri(path = ""))
+      UriTemplate(path = Nil).toUriIfPossible.get must equalTo(Uri(path = Uri.Path.empty))
     }
     "convert /test to Uri" in {
-      UriTemplate(path = List(PathElm("test"))).toUriIfPossible.get must equalTo(
-        Uri(path = "/test"))
+      UriTemplate(path = List(PathElm("test"))).toUriIfPossible.get must equalTo(uri"/test")
     }
     "convert {path} to UriTemplate" in {
       val tpl = UriTemplate(path = List(VarExp("path")))
@@ -323,7 +322,7 @@ class UriTemplateSpec extends Http4sSpec {
     }
     "convert {+path} to Uri" in {
       val tpl = UriTemplate(path = List(ReservedExp("path"))).expandPath("path", List("foo", "bar"))
-      tpl.toUriIfPossible.get must equalTo(Uri(path = "/foo/bar"))
+      tpl.toUriIfPossible.get must equalTo(uri"/foo/bar")
     }
     "convert /some/test/{rel} to UriTemplate" in {
       val tpl = UriTemplate(path = List(PathElm("some"), PathElm("test"), VarExp("rel")))
@@ -341,11 +340,11 @@ class UriTemplateSpec extends Http4sSpec {
     }
     "convert ?switch to Uri" in {
       UriTemplate(query = List(ParamElm("switch"))).toUriIfPossible.get must
-        equalTo(Uri(path = "", query = Query.fromString("switch")))
+        equalTo(Uri(path = Uri.Path.empty, query = Query.fromString("switch")))
     }
     "convert ?switch=foo&switch=bar to Uri" in {
       UriTemplate(query = List(ParamElm("switch", List("foo", "bar")))).toUriIfPossible.get must
-        equalTo(Uri(path = "", query = Query.fromString("switch=foo&switch=bar")))
+        equalTo(Uri(path = Uri.Path.empty, query = Query.fromString("switch=foo&switch=bar")))
     }
     "convert /{?id} to UriTemplate" in {
       val tpl = UriTemplate(query = List(ParamExp("id")))
@@ -451,7 +450,7 @@ class UriTemplateSpec extends Http4sSpec {
       val path = List(PathElm("foo"))
       val query = List(ParamElm("bar", List("baz")))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/foo", Query.fromString("bar=baz")))
+        equalTo(Uri(scheme, authority, path"/foo", Query.fromString("bar=baz")))
     }
     "convert http://www.foo.com/foo?bar=baz to Uri" in {
       val scheme = Some(Scheme.http)
@@ -460,7 +459,7 @@ class UriTemplateSpec extends Http4sSpec {
       val path = List(PathElm("foo"))
       val query = List(ParamElm("bar", "baz"))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/foo", Query.fromString("bar=baz")))
+        equalTo(Uri(scheme, authority, path"/foo", Query.fromString("bar=baz")))
     }
     "convert http://www.foo.com:80 to Uri" in {
       val scheme = Some(Scheme.http)
@@ -468,7 +467,7 @@ class UriTemplateSpec extends Http4sSpec {
       val authority = Some(Authority(host = host, port = Some(80)))
       val path = Nil
       UriTemplate(scheme, authority, path).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, ""))
+        equalTo(Uri(scheme, authority, Uri.Path.empty))
     }
     "convert http://www.foo.com to Uri" in {
       val scheme = Some(Scheme.http)
@@ -492,9 +491,9 @@ class UriTemplateSpec extends Http4sSpec {
       val authority = Some(Authority(host = host, port = Some(8080)))
       val query = List(ParamElm("", Nil))
       UriTemplate(scheme, authority, Nil, query).toUriIfPossible.get must equalTo(
-        Uri(scheme, authority, "", Query.fromString("")))
+        Uri(scheme, authority, Uri.Path.empty, Query.fromString("")))
       UriTemplate(scheme, authority, Nil, Nil).toUriIfPossible.get must equalTo(
-        Uri(scheme, authority, "", Query.empty))
+        Uri(scheme, authority, Uri.Path.empty, Query.empty))
     }
     "convert http://192.168.1.1:80/c?GB=object&Class=one to Uri" in {
       val scheme = Some(Scheme.http)
@@ -503,7 +502,7 @@ class UriTemplateSpec extends Http4sSpec {
       val path = List(PathElm("c"))
       val query = List(ParamElm("GB", "object"), ParamElm("Class", "one"))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/c", Query.fromString("GB=object&Class=one")))
+        equalTo(Uri(scheme, authority, path"/c", Query.fromString("GB=object&Class=one")))
     }
     "convert http://[2001:db8::7]/c?GB=object&Class=one to Uri" in {
       val scheme = Some(Scheme.http)
@@ -512,7 +511,7 @@ class UriTemplateSpec extends Http4sSpec {
       val path = List(PathElm("c"))
       val query = List(ParamElm("GB", "object"), ParamElm("Class", "one"))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
-        equalTo(Uri(scheme, authority, "/c", Query.fromString("GB=object&Class=one")))
+        equalTo(Uri(scheme, authority, path"/c", Query.fromString("GB=object&Class=one")))
     }
     "convert http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344] to Uri" in {
       val scheme = Some(Scheme.http)
@@ -543,7 +542,11 @@ class UriTemplateSpec extends Http4sSpec {
       val query = List(ParamElm("param1", "5"), ParamElm("param-without-value"))
       UriTemplate(scheme, authority, path, query).toUriIfPossible.get must
         equalTo(
-          Uri(scheme, authority, "/some/path", Query.fromString("param1=5&param-without-value")))
+          Uri(
+            scheme,
+            authority,
+            path"/some/path",
+            Query.fromString("param1=5&param-without-value")))
     }
     "convert http://username:password@some.example.com/some/path?param1=5&param-without-value#sec-1.2 to Uri" in {
       val scheme = Some(Scheme.http)
@@ -557,7 +560,7 @@ class UriTemplateSpec extends Http4sSpec {
           Uri(
             scheme,
             authority,
-            "/some/path",
+            path"/some/path",
             Query.fromString("param1=5&param-without-value"),
             Some("sec-1.2")))
     }

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -13,17 +13,14 @@ import cats.implicits._
 import fs2._
 import java.io.File
 import org.http4s.headers._
-import org.http4s.Uri._
+import org.http4s.syntax.literals._
 import org.http4s.EntityEncoder._
 import org.specs2.mutable.Specification
 
 class MultipartSpec extends Specification {
   implicit val contextShift: ContextShift[IO] = IO.contextShift(Http4sSpec.TestExecutionContext)
 
-  val url = Uri(
-    scheme = Some(Scheme.https),
-    authority = Some(Authority(host = RegName("example.com"))),
-    path = "/path/to/some/where")
+  val url = uri"https://example.com/path/to/some/where"
 
   implicit def partIOEq: Eq[Part[IO]] =
     Eq.instance[Part[IO]] {

--- a/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -92,7 +92,7 @@ class UriParserSpec extends Http4sSpec {
           Uri(
             Some(Scheme.http),
             Some(Authority(host = RegName(CIString("www.foo.com")))),
-            "/foo",
+            path"/foo",
             Query.fromPairs("bar" -> "baz"))),
         ("http://192.168.1.1", Uri(Some(Scheme.http), Some(Authority(host = ipv4"192.168.1.1")))),
         (
@@ -100,16 +100,18 @@ class UriParserSpec extends Http4sSpec {
           Uri(
             Some(Scheme.http),
             Some(Authority(host = ipv4"192.168.1.1", port = Some(80))),
-            "/c",
+            path"/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         (
           "http://[2001:db8::7]/c?GB=object&Class=one",
           Uri(
             Some(Scheme.http),
             Some(Authority(host = ipv6"2001:db8::7")),
-            "/c",
+            path"/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
-        ("mailto:John.Doe@example.com", Uri(Some(scheme"mailto"), path = "John.Doe@example.com"))
+        (
+          "mailto:John.Doe@example.com",
+          Uri(Some(scheme"mailto"), path = Uri.Path.fromString("John.Doe@example.com")))
       )
 
       check(absoluteUris)
@@ -117,11 +119,11 @@ class UriParserSpec extends Http4sSpec {
 
     "parse relative URIs" in {
       val relativeUris: Seq[(String, Uri)] = Seq(
-        ("/foo/bar", Uri(path = "/foo/bar")),
+        ("/foo/bar", Uri(path = path"/foo/bar")),
         (
           "/foo/bar?foo=bar&ding=dong",
-          Uri(path = "/foo/bar", query = Query.fromPairs("foo" -> "bar", "ding" -> "dong"))),
-        ("/", Uri(path = "/"))
+          Uri(path = path"/foo/bar", query = Query.fromPairs("foo" -> "bar", "ding" -> "dong"))),
+        ("/", Uri(path = Uri.Path.Root))
       )
 
       check(relativeUris)
@@ -133,7 +135,7 @@ class UriParserSpec extends Http4sSpec {
         Uri(
           Some(Scheme.http),
           Some(Authority(host = RegName(CIString("foo.bar")))),
-          "/foo",
+          path"/foo",
           Query.empty,
           Some("Examples")))
     }
@@ -144,37 +146,40 @@ class UriParserSpec extends Http4sSpec {
         Uri(
           Some(Scheme.http),
           Some(Authority(host = RegName(CIString("foo.bar")))),
-          "/foo",
+          path"/foo",
           Query.fromPairs("bar" -> "baz"),
           Some("Example-Fragment")))
     }
 
     "parse relative URI with empty query string" in {
       val u = Uri.requestTarget("/foo/bar?")
-      u must beRight(Uri(path = "/foo/bar", query = Query("" -> None)))
+      u must beRight(Uri(path = path"/foo/bar", query = Query("" -> None)))
     }
 
     "parse relative URI with empty query string followed by empty fragment" in {
       val u = Uri.requestTarget("/foo/bar?#")
-      u must beRight(Uri(path = "/foo/bar", query = Query("" -> None), fragment = Some("")))
+      u must beRight(Uri(path = path"/foo/bar", query = Query("" -> None), fragment = Some("")))
     }
 
     "parse relative URI with empty query string followed by fragment" in {
       val u = Uri.requestTarget("/foo/bar?#Example_of_Fragment")
       u must beRight(
-        Uri(path = "/foo/bar", query = Query("" -> None), fragment = Some("Example_of_Fragment")))
+        Uri(
+          path = path"/foo/bar",
+          query = Query("" -> None),
+          fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with fragment" in {
       val u = Uri.requestTarget("/foo/bar#Examples_of_Fragment")
-      u must beRight(Uri(path = "/foo/bar", fragment = Some("Examples_of_Fragment")))
+      u must beRight(Uri(path = path"/foo/bar", fragment = Some("Examples_of_Fragment")))
     }
 
     "parse relative URI with single parameter without a value followed by a fragment" in {
       val u = Uri.requestTarget("/foo/bar?bar#Example_of_Fragment")
       u must beRight(
         Uri(
-          path = "/foo/bar",
+          path = path"/foo/bar",
           query = Query("bar" -> None),
           fragment = Some("Example_of_Fragment")))
     }
@@ -183,14 +188,14 @@ class UriParserSpec extends Http4sSpec {
       val u = Uri.requestTarget("/foo/bar?bar=baz#Example_of_Fragment")
       u must beRight(
         Uri(
-          path = "/foo/bar",
+          path = path"/foo/bar",
           query = Query.fromPairs("bar" -> "baz"),
           fragment = Some("Example_of_Fragment")))
     }
 
     "parse relative URI with slash and fragment" in {
       val u = Uri.requestTarget("/#Example_Fragment")
-      u must beRight(Uri(path = "/", fragment = Some("Example_Fragment")))
+      u must beRight(Uri(path = Uri.Path.Root, fragment = Some("Example_Fragment")))
     }
 
     {
@@ -231,7 +236,7 @@ class UriParserSpec extends Http4sSpec {
           Uri(
             Some(Scheme.http),
             Some(Authority(host = RegName(CIString("www.foo.com")))),
-            "/foo",
+            path"/foo",
             Query.fromPairs("bar" -> "baz"))),
         ("http://192.168.1.1", Uri(Some(Scheme.http), Some(Authority(host = ipv4"192.168.1.1")))),
         (
@@ -239,16 +244,18 @@ class UriParserSpec extends Http4sSpec {
           Uri(
             Some(Scheme.http),
             Some(Authority(host = ipv4"192.168.1.1", port = Some(80))),
-            "/c",
+            path"/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         (
           "http://[2001:db8::7]/c?GB=object&Class=one",
           Uri(
             Some(Scheme.http),
             Some(Authority(host = ipv6"2001:db8::7")),
-            "/c",
+            path"/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
-        ("mailto:John.Doe@example.com", Uri(Some(scheme"mailto"), path = "John.Doe@example.com"))
+        (
+          "mailto:John.Doe@example.com",
+          Uri(Some(scheme"mailto"), path = Uri.Path.fromString("John.Doe@example.com")))
       )
 
       check(absoluteUris)
@@ -257,37 +264,37 @@ class UriParserSpec extends Http4sSpec {
     "parse a path-noscheme uri" in {
       Uri.fromString("q") must beRight.like {
         case u =>
-          u must_== Uri(path = "q")
+          u must_== Uri(path = path"q")
       }
       Uri.fromString("a/b") must beRight.like {
         case u =>
-          u must_== Uri(path = "a/b")
+          u must_== Uri(path = path"a/b")
       }
     }
 
     "parse a path-noscheme uri with query" in {
       Uri.fromString("a/b?foo") must beRight.like {
         case u =>
-          u must_== Uri(path = "a/b", query = Query(("foo", None)))
+          u must_== Uri(path = path"a/b", query = Query(("foo", None)))
       }
     }
 
     "parse a path-absolute uri" in {
       Uri.fromString("/a/b") must beRight.like {
         case u =>
-          u must_== Uri(path = "/a/b")
+          u must_== Uri(path = path"/a/b")
       }
     }
     "parse a path-absolute uri with query" in {
       Uri.fromString("/a/b?foo") must beRight.like {
         case u =>
-          u must_== Uri(path = "/a/b", query = Query(("foo", None)))
+          u must_== Uri(path = path"/a/b", query = Query(("foo", None)))
       }
     }
     "parse a path-absolute uri with query and fragment" in {
       Uri.fromString("/a/b?foo#bar") must beRight.like {
         case u =>
-          u must_== Uri(path = "/a/b", query = Query(("foo", None)), fragment = Some("bar"))
+          u must_== Uri(path = path"/a/b", query = Query(("foo", None)), fragment = Some("bar"))
       }
     }
   }


### PR DESCRIPTION
This changes Uri.Path to be an actual class to encapsulate Path segments.
We have two boolean flags here. These can be removed by transforming
the `Path` type to an own `ADT` hierarchy.

The main motivation for this change is to represent paths as something more than a String.

I have used `scala.collection.immutable.Vector` instead of `List` as `Vector` allows O(1)
appends.

This change is binary incompatible.

Typeclasses:
* Eq
* Semigroup
* Adding a monoid is possible, but there are two zero cases. Changing the Path type to an ADT will resolve that.

We have a few convenince functions here:

* startWith to be able to use in the Routers
* indexOf and splitAt to allow us to replace the caret stuff.
* normalize: drops empty segments
* toAbsolute and toRelative
* merge: using RFC3986 rules
* concat

Unrelated, add `out` to .gitignore to be able to use bloop from intellij

Representing Encoded Strings as just Strings are not really useful, so we have added a Segment class to have encoded values in.

* Use uri and path string interpolation in tests

Request changes:
* scriptName and pathInfo changed to be Uri.Path