### PR TITLE
Add Client#fetchOrError to Explicitly Account for Errors 

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -49,7 +49,7 @@ trait Client[F[_]] {
     * @return The result of applying f to the response to req, while handling any raised errors
     */
   def fetchOrError[A](req: Request[F])(f: Response[F] => F[A])(handle: Throwable => F[A])(
-    implicit ev: MonadError[F, Throwable]
+      implicit ev: MonadError[F, Throwable]
   ): F[A]
 
   /**

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -48,7 +48,7 @@ trait Client[F[_]] {
     * @param handle A function that maps a Throwable to an F[A]
     * @return The result of applying f to the response to req, while handling any raised errors
     */
-  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(handle: Throwable => F[A])(
+  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(handle: PartialFunction[Throwable, F[A]])(
       implicit ev: MonadError[F, Throwable]
   ): F[A]
 

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -48,7 +48,8 @@ trait Client[F[_]] {
     * @param handle A function that maps a Throwable to an F[A]
     * @return The result of applying f to the response to req, while handling any raised errors
     */
-  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(handle: PartialFunction[Throwable, F[A]])(
+  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(
+      handle: PartialFunction[Throwable, F[A]])(
       implicit ev: MonadError[F, Throwable]
   ): F[A]
 

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -48,7 +48,7 @@ trait Client[F[_]] {
     * @param handle A function that maps a Throwable to an F[A]
     * @return The result of applying f to the response to req, while handling any raised errors
     */
-  def fetchOrError[A](req: Request[F])(f: Response[F] => F[A])(handle: Throwable => F[A])(
+  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(handle: Throwable => F[A])(
       implicit ev: MonadError[F, Throwable]
   ): F[A]
 

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -41,7 +41,7 @@ trait Client[F[_]] {
   /** Submits a request, and provides a callback to process the response.
     * Note that all errors, e.g. decoding a payload, client times out, etc.
     *
-    * @param req An effect of the request to submit
+    * @param req The request to submit
     * @param f A callback for the response to req.  The underlying HTTP connection
     *          is disposed when the returned task completes.  Attempts to read the
     *          response body afterward will result in an error.

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -50,7 +50,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
   ): F[A] =
     run(req)
       .use(f)
-      .handleErrorWith(handle)
+      .recoverWith(handle)
 
   /**
     * Returns this client as a [[Kleisli]].  All connections created by this

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -46,7 +46,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     * @return The result of applying f to the response to req, while handling any raised errors
     */
   def fetchOrError[A](req: Request[F])(f: Response[F] => F[A])(handle: Throwable => F[A])(
-    implicit ev: MonadError[F, Throwable]
+      implicit ev: MonadError[F, Throwable]
   ): F[A] =
     run(req)
       .use(f)

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -45,7 +45,8 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     * @param handle A function that maps a Throwable to an F[A]
     * @return The result of applying f to the response to req, while handling any raised errors
     */
-  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(handle: PartialFunction[Throwable, F[A]])(
+  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(
+      handle: PartialFunction[Throwable, F[A]])(
       implicit ev: MonadError[F, Throwable]
   ): F[A] =
     run(req)

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -45,7 +45,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     * @param handle A function that maps a Throwable to an F[A]
     * @return The result of applying f to the response to req, while handling any raised errors
     */
-  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(handle: Throwable => F[A])(
+  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(handle: PartialFunction[Throwable, F[A]])(
       implicit ev: MonadError[F, Throwable]
   ): F[A] =
     run(req)

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -45,7 +45,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     * @param handle A function that maps a Throwable to an F[A]
     * @return The result of applying f to the response to req, while handling any raised errors
     */
-  def fetchOrError[A](req: Request[F])(f: Response[F] => F[A])(handle: Throwable => F[A])(
+  def fetchAndRecoverWith[A](req: Request[F])(f: Response[F] => F[A])(handle: Throwable => F[A])(
       implicit ev: MonadError[F, Throwable]
   ): F[A] =
     run(req)

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -84,7 +84,6 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
       val result: IO[Int] = c.fetchAndRecoverWith[Int](Request[IO]())(_ => IO.pure(42)) {
         case e if e.getClass.getCanonicalName == "java.util.concurrent.TimeoutException" =>
           IO.pure(100)
-        case e => IO.raiseError(e)
       }
       result.unsafeRunSync ==== 100
     }
@@ -92,7 +91,6 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
       val c: Client[IO] = testClient(IO.pure(Response[IO]().withEntity[String]("foobar")))
       val result: IO[Elem] = c.fetchAndRecoverWith[Elem](Request[IO]()) { _.as[Elem] } {
         case MalformedMessageBodyFailure(_, _) => IO.pure(<oops></oops>)
-        case e => IO.raiseError(e)
       }
       result.unsafeRunSync ==== <oops></oops>
     }

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -81,7 +81,7 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
   "Client#fetchOrError" should {
     "return handle Throwable if error is raised due to HTTP Response's raised error" in {
       val c: Client[IO] = testClient(IO.raiseError(new TimeoutException("BOOM!")))
-      val result: IO[Int] = c.fetchOrError[Int](Request[IO]())(_ => IO.pure(42)) {
+      val result: IO[Int] = c.fetchAndRecoverWith[Int](Request[IO]())(_ => IO.pure(42)) {
         case e if e.getClass.getCanonicalName == "java.util.concurrent.TimeoutException" =>
           IO.pure(100)
         case e => IO.raiseError(e)
@@ -90,7 +90,7 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
     }
     "return handle Throwable if error is raised due to decoding failure" in {
       val c: Client[IO] = testClient(IO.pure(Response[IO]().withEntity[String]("foobar")))
-      val result: IO[Elem] = c.fetchOrError[Elem](Request[IO]()) { _.as[Elem] } {
+      val result: IO[Elem] = c.fetchAndRecoverWith[Elem](Request[IO]()) { _.as[Elem] } {
         case MalformedMessageBodyFailure(_, _) => IO.pure(<oops></oops>)
         case e => IO.raiseError(e)
       }

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -94,5 +94,12 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
       }
       result.unsafeRunSync ==== <oops></oops>
     }
+    "raise a TimeoutException if it's not handled." in {
+      val c: Client[IO] = testClient(IO.raiseError(new TimeoutException("BOOM!")))
+      val result: IO[Int] = c.fetchAndRecoverWith[Int](Request[IO]())(_ => IO.pure(42)) {
+        case MalformedMessageBodyFailure(_, _) => IO.pure(42)
+      }
+      result.unsafeRunSync should throwA[TimeoutException]
+    }
   }
 }

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -81,15 +81,16 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
   "Client#fetchOrError" should {
     "return handle Throwable if error is raised due to HTTP Response's raised error" in {
       val c: Client[IO] = testClient(IO.raiseError(new TimeoutException("BOOM!")))
-      val result: IO[Int] = c.fetchOrError[Int](Request[IO]())(_ => IO.pure(42)){
-        case e if e.getClass.getCanonicalName == "java.util.concurrent.TimeoutException" => IO.pure(100)
+      val result: IO[Int] = c.fetchOrError[Int](Request[IO]())(_ => IO.pure(42)) {
+        case e if e.getClass.getCanonicalName == "java.util.concurrent.TimeoutException" =>
+          IO.pure(100)
         case e => IO.raiseError(e)
       }
       result.unsafeRunSync ==== 100
     }
     "return handle Throwable if error is raised due to decoding failure" in {
       val c: Client[IO] = testClient(IO.pure(Response[IO]().withEntity[String]("foobar")))
-      val result: IO[Elem] = c.fetchOrError[Elem](Request[IO]()){ _.as[Elem] } {
+      val result: IO[Elem] = c.fetchOrError[Elem](Request[IO]()) { _.as[Elem] } {
         case MalformedMessageBodyFailure(_, _) => IO.pure(<oops></oops>)
         case e => IO.raiseError(e)
       }

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -79,7 +79,7 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
   import scala.xml.Elem
 
   "Client#fetchOrError" should {
-    "return handle Throwable if error is raised due to HTTP Response's raised error" in {
+    "handle Throwable due to raised error in Client" in {
       val c: Client[IO] = testClient(IO.raiseError(new TimeoutException("BOOM!")))
       val result: IO[Int] = c.fetchAndRecoverWith[Int](Request[IO]())(_ => IO.pure(42)) {
         case e if e.getClass.getCanonicalName == "java.util.concurrent.TimeoutException" =>
@@ -87,7 +87,7 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
       }
       result.unsafeRunSync ==== 100
     }
-    "return handle Throwable if error is raised due to decoding failure" in {
+    "handle Throwable due to raised error on decoding HTTP Response" in {
       val c: Client[IO] = testClient(IO.pure(Response[IO]().withEntity[String]("foobar")))
       val result: IO[Elem] = c.fetchAndRecoverWith[Elem](Request[IO]()) { _.as[Elem] } {
         case MalformedMessageBodyFailure(_, _) => IO.pure(<oops></oops>)

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -13,6 +13,7 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
   val app = HttpApp[IO] {
     case r => Response[IO](Ok).withEntity(r.body).pure[IO]
   }
+
   val client: Client[IO] = Client.fromHttpApp(app)
 
   "mock client" should {
@@ -64,6 +65,35 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
       hostClient
         .expect[String](Request[IO](GET, Uri.uri("https://http4s.org/")))
         .unsafeRunSync() must_== "http4s.org"
+    }
+  }
+
+  def testApp(resp: IO[Response[IO]]) = HttpApp[IO] {
+    case _ => resp
+  }
+
+  def testClient(resp: IO[Response[IO]]): Client[IO] = Client.fromHttpApp(testApp(resp))
+
+  import java.util.concurrent.TimeoutException
+  import org.http4s.scalaxml.xml
+  import scala.xml.Elem
+
+  "Client#fetchOrError" should {
+    "return handle Throwable if error is raised due to HTTP Response's raised error" in {
+      val c: Client[IO] = testClient(IO.raiseError(new TimeoutException("BOOM!")))
+      val result: IO[Int] = c.fetchOrError[Int](Request[IO]())(_ => IO.pure(42)){
+        case e if e.getClass.getCanonicalName == "java.util.concurrent.TimeoutException" => IO.pure(100)
+        case e => IO.raiseError(e)
+      }
+      result.unsafeRunSync ==== 100
+    }
+    "return handle Throwable if error is raised due to decoding failure" in {
+      val c: Client[IO] = testClient(IO.pure(Response[IO]().withEntity[String]("foobar")))
+      val result: IO[Elem] = c.fetchOrError[Elem](Request[IO]()){ _.as[Elem] } {
+        case MalformedMessageBodyFailure(_, _) => IO.pure(<oops></oops>)
+        case e => IO.raiseError(e)
+      }
+      result.unsafeRunSync ==== <oops></oops>
     }
   }
 }


### PR DESCRIPTION
Typically I code an algebra and HTTP interpreter in the following way: https://github.com/kevinmeredith/testing-http4s-example/blob/master/src/main/scala/net/User.scala.

I frequently use `adaptError` to handle raised errors, namely:

* client timed out
* failed to decode HTTP Response's body as `A`

As a result, I commonly resort to `adaptError` as in https://github.com/kevinmeredith/testing-http4s-example/blob/master/src/main/scala/net/User.scala#L45-L61.

```scala
    override def get(id: UUID): F[Option[ApplicationUser]] = {
      
      val uri: Uri = base / "users" / id.toString
      
      val req: Request[F] = Request[F](method = Method.GET, uri = uri)
      
      val response: F[Option[ApplicationUser]] = 
        httpClient.fetch[Option[ApplicationUser]](req) {
          case Status.Ok(body)    => body.as[ApplicationUser].map(Some(_))
          case Status.NotFound(_) => F.pure(None)
          case unexpectedStatus   => F.raiseError(UserError(uri, id, UnexpectedStatus(unexpectedStatus.status)))
        }

      MonadError[F, Throwable].adaptError(response) {
        case ue @ UserError(_,_,_) => ue
        case t                     => UserError(uri, id, t)
      }
```

I would find it useful to have such a method available in `org.http4s.Client`. Please let me know what you think of this method.
