### PR TITLE
Prefer blackbox macros

### DIFF
--- a/core/src/main/scala/org/http4s/MediaType.scala
+++ b/core/src/main/scala/org/http4s/MediaType.scala
@@ -25,7 +25,7 @@ import org.http4s.internal.parboiled2.{Parser => PbParser, _}
 import org.http4s.parser.{Http4sParser, Rfc2616BasicRules}
 import org.http4s.util.{StringWriter, Writer}
 
-import scala.reflect.macros.whitebox
+import scala.reflect.macros.blackbox
 import scala.util.hashing.MurmurHash3
 
 sealed class MediaRange private[http4s] (
@@ -286,7 +286,7 @@ object MediaType extends MimeDB {
       }
     }
 
-  class Macros(val c: whitebox.Context) {
+  class Macros(val c: blackbox.Context) {
     import c.universe._
 
     def mediaTypeLiteral(s: c.Expr[String]): Tree =

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -4,7 +4,7 @@ import cats.{Order, Show}
 import org.http4s.internal.parboiled2.{Parser => PbParser}
 import org.http4s.parser.{AdditionalRules, Http4sParser}
 import org.http4s.util.Writer
-import scala.reflect.macros.whitebox
+import scala.reflect.macros.blackbox
 
 /**
   * A Quality Value.  Represented as thousandths for an exact representation rounded to three
@@ -97,7 +97,7 @@ object QValue {
   /** Exists to support compile-time verified literals. Do not call directly. */
   def ☠(thousandths: Int): QValue = new QValue(thousandths)
 
-  class Macros(val c: whitebox.Context) {
+  class Macros(val c: blackbox.Context) {
     import c.universe._
 
     def qValueLiteral(d: c.Expr[Double]): Tree =

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -14,7 +14,7 @@ import org.http4s.syntax.string._
 import org.http4s.util._
 import scala.collection.immutable
 import scala.math.Ordered
-import scala.reflect.macros.whitebox
+import scala.reflect.macros.blackbox
 
 /** Representation of the [[Request]] URI
   *
@@ -155,7 +155,7 @@ final case class Uri(
 }
 
 object Uri {
-  class Macros(val c: whitebox.Context) {
+  class Macros(val c: blackbox.Context) {
     import c.universe._
 
     def uriLiteral(s: c.Expr[String]): Tree =

--- a/testing/src/test/scala/org/http4s/illTyped.scala
+++ b/testing/src/test/scala/org/http4s/illTyped.scala
@@ -18,7 +18,7 @@
 package org.http4s
 
 import java.util.regex.Pattern
-import scala.reflect.macros.{ParseException, TypecheckException, whitebox}
+import scala.reflect.macros.{ParseException, TypecheckException, blackbox}
 
 /**
   * A utility which ensures that a code fragment does not typecheck.
@@ -30,7 +30,7 @@ object illTyped {
   def apply(code: String, expected: String): Unit = macro IllTypedMacros.applyImpl
 }
 
-class IllTypedMacros(val c: whitebox.Context) {
+class IllTypedMacros(val c: blackbox.Context) {
   import c.universe._
 
   def applyImplNoExp(code: Tree): Tree = applyImpl(code, null)


### PR DESCRIPTION
I noticed this while porting the macros to Dotty, and found [this comment](https://github.com/http4s/http4s/pull/2508#pullrequestreview-226336649):

> Also can't remember why these had to be whitebox instead of blackbox.

…but these definitely shouldn't need to be whitebox. Maybe there was an issue on 2.11? In any case tests pass with this change now.