### PR TITLE
Write ember-client request to socket before reading response

### DIFF
--- a/ember-core/src/test/scala/org/http4s/ember/core/ParsingSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParsingSpec.scala
@@ -1,13 +1,20 @@
 package org.http4s.ember.core
 
 import org.specs2.mutable.Specification
-import cats.effect.{IO, Sync}
+import cats.effect._
 import org.http4s._
-import fs2.Stream
+import fs2.{Stream, text}
 import io.chrisdavenport.log4cats.testing.TestingLogger
+import org.specs2.concurrent.ExecutionEnv
+import fs2._
+import cats.effect.concurrent._
+import cats.data.OptionT
+import cats.implicits._
 
-class ParsingSpec extends Specification {
-  private object Helpers {
+class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
+  implicit val cs: ContextShift[IO] = IO.contextShift(ee.ec)
+
+  object Helpers {
     def stripLines(s: String): String = s.replace("\r\n", "\n")
     def httpifyString(s: String): String = s.replace("\n", "\r\n")
 
@@ -23,7 +30,7 @@ class ParsingSpec extends Specification {
       Parser.Request.parser[F](Int.MaxValue)(byteStream)(logger)
     }
 
-    def parseResponseRig[F[_]: Sync](s: String): F[Response[F]] = {
+    def parseResponseRig[F[_]: Sync](s: String): Resource[F, Response[F]] = {
       val logger = TestingLogger.impl[F]()
       val byteStream: Stream[F, Byte] = Stream
         .emit(s)
@@ -33,7 +40,38 @@ class ParsingSpec extends Specification {
 
       Parser.Response.parser[F](Int.MaxValue)(byteStream)(logger)
     }
+
+    def forceScopedParsing[F[_]: Sync](s: String): Stream[F, Byte] = {
+      val pivotPoint = s.trim().length - 1
+      val firstChunk = s.substring(0, pivotPoint).replace("\n", "\r\n")
+      val secondChunk = s.substring(pivotPoint, s.length).replace("\n", "\r\n")
+
+      sealed trait StreamState
+      case object FirstChunk extends StreamState
+      case object SecondChunk extends StreamState
+      case object Completed extends StreamState
+
+      def unfoldStream(closed: Ref[F, Boolean]): Stream[F, Byte] = {
+        val scope = Resource(((), closed.set(true)).pure[F])
+        val noneChunk = OptionT.none[F, (Chunk[Byte], StreamState)].value
+
+        Stream.resource(scope) >>
+          Stream.unfoldChunkEval[F, StreamState, Byte](FirstChunk) {
+            case FirstChunk =>
+              Option((Chunk.array(firstChunk.getBytes()), SecondChunk: StreamState)).pure[F]
+            case SecondChunk =>
+              closed.get.ifM(
+                noneChunk, // simulates stream closing before we've read the entire body
+                Option((Chunk.array(secondChunk.getBytes()), Completed: StreamState)).pure[F]
+              )
+            case Completed => noneChunk
+          }
+      }
+
+      Stream.eval(Ref.of[F, Boolean](false)) >>= unfoldStream
+    }
   }
+
   "Parser.Request.parser" should {
     "Parse a request with no body correctly" in {
       val raw =
@@ -76,5 +114,28 @@ class ParsingSpec extends Specification {
       result.headers must_=== expected.headers
       result.body.compile.toVector.unsafeRunSync must_=== expected.body.compile.toVector.unsafeRunSync
     }
+
+    "handle a response that requires multiple chunks to be read" in {
+      val logger = TestingLogger.impl[IO]()
+      val defaultMaxHeaderLength = 4096
+      val raw =
+        """HTTP/1.1 200 OK
+          |content-type: application/json
+          |Content-Length: 2
+          |
+          |{}
+          |""".stripMargin
+
+      (for {
+        parsed <- Parser.Response
+          .parser[IO](defaultMaxHeaderLength)(Helpers.forceScopedParsing[IO](raw))(logger)
+          .use { resp =>
+            resp.body.through(text.utf8Decode).compile.string
+          }
+      } yield {
+        parsed must_== "{}"
+      }).unsafeRunSync()
+    }
+
   }
 }


### PR DESCRIPTION
Fixes #3235.

Also fixes an [issue I mentioned in gitter](https://gitter.im/http4s/http4s-dev?at=5e58a30153fa513e285a69da) with response parsing, which can cause the response body stream to be closed prematurely.