### PR TITLE
Remove coursier plugin, it is now part of sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,6 @@ addSbtPlugin("com.typesafe.sbt"           %  "sbt-ghpages"               % "0.6.
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-site"                  % "1.4.0")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-twirl"                 % "1.5.0")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-native-packager"       % "1.6.1")
-addSbtPlugin("io.get-coursier"            %  "sbt-coursier"              % "1.0.3")
 addSbtPlugin("io.github.davidgregory084"  %  "sbt-tpolecat"              % "0.1.11")
 addSbtPlugin("io.spray"                   %  "sbt-revolver"              % "0.9.1")
 addSbtPlugin("org.scalameta"              %  "sbt-scalafmt"              % "2.3.2")


### PR DESCRIPTION
o we do not need this plugin anymore
o conflicts with coursier based sbt launcher