### PR TITLE
j.u.c.CompletionStage conversions

### DIFF
--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -1,9 +1,9 @@
 package org.http4s
 
-import java.util.concurrent.{CancellationException, CompletableFuture, CompletionException}
-import java.util.function.BiFunction
+import java.util.concurrent.{CancellationException, CompletionException, CompletionStage}
 
-import cats.effect.{Async, Concurrent, ConcurrentEffect, Effect, IO}
+import cats.effect.implicits._
+import cats.effect.{Async, ConcurrentEffect, ContextShift, Effect, IO}
 import cats.implicits._
 import org.http4s.util.execution.direct
 import org.log4s.Logger
@@ -124,19 +124,20 @@ package object internal {
     }
 
   // Adapted from https://github.com/typelevel/cats-effect/issues/160#issue-306054982
-  private[http4s] def fromCompletableFuture[F[_], A](fcf: F[CompletableFuture[A]])(
-      implicit F: Concurrent[F]): F[A] =
-    fcf.flatMap { cf =>
-      F.cancelable { cb =>
-        cf.handle[Unit](new BiFunction[A, Throwable, Unit] {
-          override def apply(result: A, err: Throwable): Unit = err match {
-            case null => cb(Right(result))
-            case _: CancellationException => ()
-            case ex: CompletionException if ex.getCause ne null => cb(Left(ex.getCause))
-            case ex => cb(Left(ex))
+  private[http4s] def fromCompletionStage[F[_], CF[x] <: CompletionStage[x], A](
+      fcs: F[CF[A]])(implicit F: Async[F], CS: ContextShift[F]): F[A] =
+    fcs.flatMap { cs =>
+      F.async[A] { cb =>
+          cs.handle[Unit] { (result, err) =>
+            err match {
+              case null => cb(Right(result))
+              case _: CancellationException => ()
+              case ex: CompletionException if ex.getCause ne null => cb(Left(ex.getCause))
+              case ex => cb(Left(ex))
+            }
           }
-        })
-        F.delay { cf.cancel(true); () }
-      }
+          ()
+        }
+        .guarantee(CS.shift)
     }
 }

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -145,8 +145,11 @@ package object internal {
       }
     }
 
-  private[http4s] def fromCompletionStage[F[_], CF[x] <: CompletionStage[x], A](
-      fcs: F[CF[A]])(implicit F: Async[F], CS: ContextShift[F]): F[A] =
+  private[http4s] def fromCompletionStage[F[_], CF[x] <: CompletionStage[x], A](fcs: F[CF[A]])(
+      implicit
+      // Concurrent is intentional, see https://github.com/http4s/http4s/pull/3255#discussion_r395719880
+      F: Concurrent[F],
+      CS: ContextShift[F]): F[A] =
     fcs.flatMap { cs =>
       F.async[A] { cb =>
           cs.handle[Unit] { (result, err) =>

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -18,7 +18,6 @@ import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success}
 
 package object internal {
-
   // Like fs2.async.unsafeRunAsync before 1.0.  Convenient for when we
   // have an ExecutionContext but not a Timer.
   private[http4s] def unsafeRunAsync[F[_], A](fa: F[A])(

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -129,7 +129,7 @@ package object internal {
     }
 
   // Adapted from https://github.com/typelevel/cats-effect/issues/160#issue-306054982
-  @deprecated("use `fromCompletionStage`")
+  @deprecated("Use `fromCompletionStage`", since = "0.21.2")
   private[http4s] def fromCompletableFuture[F[_], A](fcf: F[CompletableFuture[A]])(
       implicit F: Concurrent[F]): F[A] =
     fcf.flatMap { cf =>


### PR DESCRIPTION
 - Rename `fromCompletableFuture` to `fromCompletionStage`, as we don't want to `complete` or `get` the given future. I removed the call to `cancel` (therefore, we only need `Async[F]` now), as it can be seen as a special case of `completeExceptionally` and therefore does not really seem cancel anything (but I don't really know much about Java futures, so please correct me if I am wrong).
 - Guarantee a shift in `fromCompletionStage` (motivated by #3236)
 - Add `unsafeToCompletionStage` (used in http4s-jdk-http-client) while we are at it.

These changes are internal and `fromCompletableFuture` is only used in http4s-jdk-http-client, so this should be fine.