### PR TITLE
Make SameSite cookie attribute optional

### DIFF
--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -102,7 +102,7 @@ final case class ResponseCookie(
     maxAge: Option[Long] = None,
     domain: Option[String] = None,
     path: Option[String] = None,
-    sameSite: Option[SameSite] = Some(SameSite.Lax),
+    sameSite: Option[SameSite] = None,
     secure: Boolean = false,
     httpOnly: Boolean = false,
     extension: Option[String] = None

--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -102,7 +102,7 @@ final case class ResponseCookie(
     maxAge: Option[Long] = None,
     domain: Option[String] = None,
     path: Option[String] = None,
-    sameSite: SameSite = SameSite.Lax,
+    sameSite: Option[SameSite] = Some(SameSite.Lax),
     secure: Boolean = false,
     httpOnly: Boolean = false,
     extension: Option[String] = None
@@ -117,8 +117,8 @@ final case class ResponseCookie(
     maxAge.foreach(writer.append("; Max-Age=").append(_))
     domain.foreach(writer.append("; Domain=").append(_))
     path.foreach(writer.append("; Path=").append(_))
-    writer.append("; SameSite=").append(sameSite)
-    if (secure || sameSite == SameSite.None) writer.append("; Secure")
+    sameSite.foreach(writer.append("; SameSite=").append(_))
+    if (secure || sameSite.exists(_ == SameSite.None)) writer.append("; Secure")
     if (httpOnly) writer.append("; HttpOnly")
     extension.foreach(writer.append("; ").append(_))
     writer

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -79,7 +79,7 @@ private[parser] trait CookieHeader {
           cookie.copy(path = Some(pathValue))
         } |
         ignoreCase("samesite=") ~ SameSite ~> { (cookie: ResponseCookie, sameSiteValue: SameSite) =>
-          cookie.copy(sameSite = sameSiteValue)
+          cookie.copy(sameSite = Some(sameSiteValue))
         } |
         // TODO: Capture so we can create the rule, but there must be a better way
         ignoreCase("secure") ~ MATCH ~> { (cookie: ResponseCookie) =>

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -365,7 +365,7 @@ object CSRF {
       httpOnly: Boolean,
       domain: Option[String] = None,
       path: Option[String] = None,
-      sameSite: SameSite = SameSite.Lax,
+      sameSite: Option[SameSite] = Some(SameSite.Lax),
       extension: Option[String] = None
   )
 

--- a/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
@@ -17,15 +17,15 @@ class SetCookieHeaderSpec extends Specification with HeaderParserHelper[`Set-Coo
       c.content must be_==("foo")
       c.maxAge must be_==(Some(1))
       c.path must beSome("value")
-      c.sameSite must be_==(SameSite.Strict)
+      c.sameSite must be_==(Some(SameSite.Strict))
       c.secure must be_==(true)
       c.httpOnly must be_==(true)
     }
 
-    "default to SameSite=Lax" in {
+    "default to None" in {
       val cookiestr = "myname=\"foo\"; Domain=value; Max-Age=1; Path=value"
       val c = parse(cookiestr).cookie
-      c.sameSite must be_==(SameSite.Lax)
+      c.sameSite must be_==(None)
     }
 
     "parse a set cookie with lowercase attributes" in {
@@ -37,7 +37,7 @@ class SetCookieHeaderSpec extends Specification with HeaderParserHelper[`Set-Coo
       c.content must be_==("foo")
       c.maxAge must be_==(Some(1))
       c.path must be_==(Some("value"))
-      c.sameSite must be_==(SameSite.Strict)
+      c.sameSite must be_==(Some(SameSite.Strict))
       c.secure must be_==(true)
       c.httpOnly must be_==(true)
     }


### PR DESCRIPTION
I mentioned this in gitter and figured I'd open a PR with the change. To get the behavior of `SameSite=None` in all browsers, it's necessary to completely exclude the `SameSite` attribute for [certain clients that handle it incorrectly](https://www.chromium.org/updates/same-site/incompatible-clients). This updates the field to be optional to allow for this.