### PR TITLE
Fixed connection release when body isn't run, as well as thread affinity

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -3,6 +3,7 @@ package client
 package asynchttpclient
 
 import cats.effect._
+import cats.effect.concurrent._
 import cats.implicits._
 import cats.effect.implicits._
 import fs2.Stream._
@@ -80,22 +81,24 @@ object AsyncHttpClient {
       val dispose = F.delay { state = State.ABORT }
 
       override def onStream(publisher: Publisher[HttpResponseBodyPart]): State = {
-        // backpressure is handled by requests to the reactive streams subscription
-        StreamSubscriber[F, HttpResponseBodyPart]
-          .map { subscriber =>
-            val body = subscriber.stream.flatMap(part => chunk(Chunk.bytes(part.getBodyPartBytes)))
-            response = response.copy(body = body)
-            // Run this before we return the response, lest we violate
-            // Rule 3.16 of the reactive streams spec.
-            publisher.subscribe(subscriber)
-            // We have a fully formed response now.  Complete the
-            // callback, rather than waiting for onComplete, or else we'll
-            // buffer the entire response before we return it for
-            // streaming consumption.
-            invokeCallback(logger)(cb(Right(response -> dispose)))
+        val eff = for {
+          subscriber <- StreamSubscriber[F, HttpResponseBodyPart]
+
+          subscribeF = F.delay(publisher.subscribe(subscriber))
+          bodyDisposal <- Ref.of[F, F[Unit]] {
+            subscribeF >> subscriber.stream.take(0).compile.drain
           }
-          .runAsync(_ => IO.unit)
-          .unsafeRunSync()
+
+          body = Stream.eval(F.uncancelable(bodyDisposal.set(F.unit) >> subscribeF)) >>
+            subscriber.stream.flatMap(part => chunk(Chunk.bytes(part.getBodyPartBytes)))
+
+          responseWithBody = response.copy(body = body)
+
+          _ <- F.delay(cb(Right(responseWithBody -> (dispose >> bodyDisposal.get.flatten))))
+        } yield ()
+
+        eff.runAsync(_ => IO.unit).unsafeRunSync()
+
         state
       }
 
@@ -115,9 +118,9 @@ object AsyncHttpClient {
       override def onThrowable(throwable: Throwable): Unit =
         invokeCallback(logger)(cb(Left(throwable)))
 
-      override def onCompleted(): Unit = {
-        // Don't close here.  onStream may still be being called.
-      }
+      // it's okay to invoke this repeatedly since repeated async callbacks are dropped by law
+      override def onCompleted(): Unit =
+        invokeCallback(logger)(cb(Right(response -> dispose)))
     }
 
   private def toAsyncRequest[F[_]: ConcurrentEffect](request: Request[F]): AsyncRequest = {


### PR DESCRIPTION
This PR fixes three issues in the async-http-client implementation:

- When the `body` of the response was never sequenced, the upstream connection would never be closed and would ultimately end up stuck in TCP `CLOSE_WAIT`
- The fiber continuation of the `Response` was run on an AHC thread, rather than on the pool governed by the relevant `ContextShift`. In order to avoid breaking bincompat, this was fixed by forking a fiber to run the `async` callback
- Under certain circumstances, when the `body` of an HTTP was empty, the prior implementation could deadlock. This is fixed by adding a callback to `onComplete`. Note that, by law, Cats Effect `async` callbacks ignore repeated invocations, so it's safe to put this here without a latch to guard it.

It's worth noting that there is still a known issue with this fix: namely, if you start running the `body` stream and then the controlling fiber is almost immediately `cancel`ed, then the connection can leak. This can happen because we cannot uninterruptibly call `subscribe` *and* start the stream (which would register the finalizer that runs `cancel`). The only way to fix this is to change fs2-reactive-streams' `.stream` function to take an `F[Unit]` representing the subscription effect, which it would then sequence and manage itself in a properly bracketed fashion.

This case is very unlikely, and at least things are better than they were.