### PR TITLE
Remove unused EntityEncoder argument

### DIFF
--- a/play-json/src/main/scala/org/http4s/play/PlayEntityEncoder.scala
+++ b/play-json/src/main/scala/org/http4s/play/PlayEntityEncoder.scala
@@ -8,7 +8,7 @@ import org.http4s.EntityEncoder
   */
 trait PlayEntityEncoder {
   implicit def playEntityEncoder[F[_], A: Writes]: EntityEncoder[F, A] =
-    jsonEncoderOf(EntityEncoder.stringEncoder[F], implicitly)
+    jsonEncoderOf[F, A]
 }
 
 object PlayEntityEncoder extends PlayEntityEncoder

--- a/play-json/src/main/scala/org/http4s/play/PlayInstances.scala
+++ b/play-json/src/main/scala/org/http4s/play/PlayInstances.scala
@@ -31,7 +31,7 @@ trait PlayInstances {
   implicit def jsonDecoder[F[_]: Sync]: EntityDecoder[F, JsValue] =
     jawn.jawnDecoder[F, JsValue]
 
-  def jsonEncoderOf[F[_]: EntityEncoder[?[_], String], A: Writes]: EntityEncoder[F, A] =
+  def jsonEncoderOf[F[_], A: Writes]: EntityEncoder[F, A] =
     jsonEncoder[F].contramap[A](Json.toJson(_))
 
   implicit def jsonEncoder[F[_]]: EntityEncoder[F, JsValue] =


### PR DESCRIPTION
This is a minor follow-up to #3253 that couldn't be included there because it breaks bincompat. The issue is that the `EntityEncoder` constraint here is unnecessary, but the compiler didn't warn because of the kind-projector syntax. This PR just removes the unnecessary parameter.

This change will have to wait for 0.22.x because it breaks bincompat, but it's source-compatible for normal usage.