### PR TITLE
docs(v0.21/service): add info about the usage of -Ypartial-unification

### DIFF
--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -23,7 +23,8 @@ libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-blaze-client" % http4sVersion
 )
 
-scalacOptions ++= Seq("-Ypartial-unification")
+// Uncomment if you're using Scala 2.12.x
+// scalacOptions ++= Seq("-Ypartial-unification")
 ```
 
 This tutorial is compiled as part of the build using [tut].  Each page


### PR DESCRIPTION
Here: https://http4s.org/v0.21/service/, the example `build.sbt` file includes the following line:
```scala
scalacOptions ++= Seq("-Ypartial-unification")
```
I added the information that this option should be used only with Scala 2.12.x.