### PR TITLE
Remove type parameter from `org.http4s.server.Server`

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -162,7 +162,7 @@ class BlazeBuilder[F[_]](
   def withBanner(banner: immutable.Seq[String]): Self =
     copy(banner = banner)
 
-  def resource: Resource[F, Server[F]] = {
+  def resource: Resource[F, Server] = {
     val httpApp = Router(serviceMounts.map(mount => mount.prefix -> mount.service): _*).orNotFound
     var b = BlazeServerBuilder[F]
       .bindSocketAddress(socketAddress)

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
@@ -63,7 +63,7 @@ class BlazeServerMtlsSpec extends Http4sSpec {
     case _ => NotFound()
   }
 
-  def serverR(sslParameters: SSLParameters): Resource[IO, Server[IO]] =
+  def serverR(sslParameters: SSLParameters): Resource[IO, Server] =
     builder
       .bindAny()
       .withSslContextAndParameters(sslContext, sslParameters)

--- a/docs/src/main/tut/static.md
+++ b/docs/src/main/tut/static.md
@@ -30,7 +30,7 @@ object SimpleHttpServer extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
     app.use(_ => IO.never).as(ExitCode.Success)
 
-  val app: Resource[IO, Server[IO]] =
+  val app: Resource[IO, Server] =
     for {
       blocker <- Blocker[IO]
       server <- BlazeServerBuilder[IO]

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -87,7 +87,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     copy(requestHeaderReceiveTimeout = requestHeaderReceiveTimeout)
   def withLogger(l: Logger[F]) = copy(logger = l)
 
-  def build: Resource[F, Server[F]] =
+  def build: Resource[F, Server] =
     for {
       blocker <- blockerOpt.fold(Blocker[F])(_.pure[Resource[F, *]])
       sg <- sgOpt.fold(SocketGroup[F](blocker))(_.pure[Resource[F, *]])
@@ -116,7 +116,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
               .drain
           )
           .as(
-            new Server[F] {
+            new Server {
               def address: InetSocketAddress = bindAddress
               def isSecure: Boolean = false
             }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -19,7 +19,7 @@ object BlazeExampleApp {
       "/http4s" -> ExampleService[F](blocker).routes
     ).orNotFound
 
-  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server[F]] =
+  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server] =
     for {
       blocker <- Blocker[F]
       app = httpApp[F](blocker)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -26,7 +26,7 @@ object BlazeMetricsExampleApp {
     ).orNotFound
   }
 
-  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server[F]] =
+  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server] =
     for {
       blocker <- Blocker[F]
       app = httpApp[F](blocker)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
@@ -22,7 +22,7 @@ object BlazeSslExampleApp {
         .withSslContext(sslContext)
     }
 
-  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server[F]] =
+  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server] =
     for {
       blocker <- Blocker[F]
       b <- Resource.liftF(builder[F])

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
@@ -26,7 +26,7 @@ object JettyExampleApp {
       .mountFilter(NoneShallPass, "/black-knight/*")
   }
 
-  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server[F]] =
+  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server] =
     for {
       blocker <- Blocker[F]
       server <- builder[F](blocker).resource

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettySslExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettySslExample.scala
@@ -23,7 +23,7 @@ object JettySslExampleApp {
         .withSslContext(sslCtx)
     }
 
-  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server[F]] =
+  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server] =
     for {
       blocker <- Blocker[F]
       b <- Resource.liftF(builder[F](blocker))

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
@@ -27,7 +27,7 @@ object TomcatExampleApp {
       .mountFilter(NoneShallPass, "/black-knight/*")
   }
 
-  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server[F]] =
+  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server] =
     for {
       blocker <- Blocker[F]
       server <- builder[F](blocker).resource

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatSslExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatSslExample.scala
@@ -18,7 +18,7 @@ object TomcatSslExampleApp {
       .bindHttp(8443)
       .withSSL(ssl.storeInfo, ssl.keyManagerPassword)
 
-  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server[F]] =
+  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server] =
     for {
       blocker <- Blocker[F]
       server <- builder[F](blocker).resource

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -172,7 +172,7 @@ sealed class JettyBuilder[F[_]] private (
         new ServerConnector(jetty)
     }
 
-  def resource: Resource[F, Server[F]] =
+  def resource: Resource[F, Server] =
     Resource(F.delay {
       val jetty = new JServer(threadPool)
 
@@ -203,7 +203,7 @@ sealed class JettyBuilder[F[_]] private (
 
       jetty.start()
 
-      val server = new Server[F] {
+      val server = new Server {
         lazy val address: InetSocketAddress = {
           val host = socketAddress.getHostString
           val port = jetty.getConnectors()(0).asInstanceOf[ServerConnector].getLocalPort

--- a/server/src/main/scala/org/http4s/server/Server.scala
+++ b/server/src/main/scala/org/http4s/server/Server.scala
@@ -4,7 +4,7 @@ package server
 import java.net.{Inet4Address, Inet6Address, InetSocketAddress}
 import org.log4s.getLogger
 
-abstract class Server[F[_]] {
+abstract class Server {
   private[this] val logger = getLogger
 
   def address: InetSocketAddress

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -12,7 +12,7 @@ import org.http4s.internal.BackendBuilder
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import scala.collection.immutable
 
-trait ServerBuilder[F[_]] extends BackendBuilder[F, Server[F]] {
+trait ServerBuilder[F[_]] extends BackendBuilder[F, Server] {
   type Self <: ServerBuilder[F]
 
   protected implicit def F: Concurrent[F]
@@ -36,7 +36,7 @@ trait ServerBuilder[F[_]] extends BackendBuilder[F, Server[F]] {
   /** Returns a Server resource.  The resource is not acquired until the
     * server is started and ready to accept requests.
     */
-  def resource: Resource[F, Server[F]]
+  def resource: Resource[F, Server]
 
   /**
     * Runs the server as a process that never emits.  Useful for a server

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -163,7 +163,7 @@ sealed class TomcatBuilder[F[_]] private (
   def withClassloader(classloader: ClassLoader): Self =
     copy(classloader = Some(classloader))
 
-  override def resource: Resource[F, Server[F]] =
+  override def resource: Resource[F, Server] =
     Resource(F.delay {
       val tomcat = new Tomcat
       val cl = classloader.getOrElse(getClass.getClassLoader)
@@ -197,7 +197,7 @@ sealed class TomcatBuilder[F[_]] private (
 
       tomcat.start()
 
-      val server = new Server[F] {
+      val server = new Server {
         lazy val address: InetSocketAddress = {
           val host = socketAddress.getHostString
           val port = tomcat.getConnector.getLocalPort


### PR DESCRIPTION
From `server/src/main/scala/org/http4s/server/Server.scala`:
```
abstract class Server[F[_]] {
  ...
}
```
As per [conversation](https://gitter.im/http4s/http4s-dev?at=5e7ffe79426d5b06bf92c340) with @rossabaker, this type parameter looks like a legacy and isn't actually used anymore.
