### PR TITLE
Fixes failing local unit tests

### DIFF
--- a/client/src/test/scala/org/http4s/client/JettyScaffold.scala
+++ b/client/src/test/scala/org/http4s/client/JettyScaffold.scala
@@ -66,7 +66,7 @@ class JettyScaffold private (num: Int, secure: Boolean) {
       server.start()
 
       val address = new InetSocketAddress(
-        InetAddress.getLocalHost(),
+        InetAddress.getLoopbackAddress,
         server.getConnectors.head.asInstanceOf[ServerConnector].getLocalPort)
 
       (address, server)

--- a/client/src/test/scala/org/http4s/client/JettyScaffold.scala
+++ b/client/src/test/scala/org/http4s/client/JettyScaffold.scala
@@ -66,7 +66,7 @@ class JettyScaffold private (num: Int, secure: Boolean) {
       server.start()
 
       val address = new InetSocketAddress(
-        InetAddress.getLoopbackAddress,
+        InetAddress.getLocalHost.getCanonicalHostName,
         server.getConnectors.head.asInstanceOf[ServerConnector].getLocalPort)
 
       (address, server)


### PR DESCRIPTION
On some personal computers (namely on MacBooks) the following unit tests:
* org.http4s.client.jetty.JettyClientSpec
* org.http4s.client.okhttp.OkHttpClientSpec

may fail with the following errors correspondingly:
```
[error]  java.net.UnknownHostException: john-doe-macbookpro (SocketAddressResolver.java:170)
[error] org.eclipse.jetty.util.SocketAddressResolver$Async.lambda$resolve$1(SocketAddressResolver.java:170)
[error] org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
[error] org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
``` 
and
```
[error]  java.net.UnknownHostException: john-doe-macbookpro (Dns.kt:49)
[error] okhttp3.Dns$Companion$DnsSystem.lookup(Dns.kt:49)
[error] okhttp3.internal.connection.RouteSelector.resetNextInetSocketAddress(RouteSelector.kt:160)
```
It looks like the root cause is in [this](https://github.com/http4s/http4s/blob/v0.21.3/client/src/test/scala/org/http4s/client/JettyScaffold.scala#L69) line:
```scala
      val address = new InetSocketAddress(
        InetAddress.getLocalHost(),
        server.getConnectors.head.asInstanceOf[ServerConnector].getLocalPort)
```
The problem is that on some machines `InetAddress.getLocalHost` return a result with a weird host name like `john-doe-macbookpro` (the same as `hostname` util does). Such host names cannot be further resolved which leads to the test failures.

This PR suggests to replace the `InetAddress.getLocalHost` method call with `InetAddress.getLoopbackAddress`. It should work fine for unit tests executed on local machines, although it hasn't been tried on any CI/CD yet.

If for some reason `getLoopbackAddress` won't work as expected in all possible scenarios, it can be changed to any of the following alternatives:
* InetAddress.getLocalHost.getHostAddress
* InetAddress.getLocalHost.getCanonicalHostName
* InetAddress.getByAddress(InetAddress.getLocalHost.getAddress)

All these alternatives enforce using IP address part of the `InetAddress.getLocalHost` result.

