### PR TITLE
Release v0.20.22, mark 0.20.x EOL

### DIFF
--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -8,7 +8,7 @@ Maintenance branches are merged before each new release. This change log is
 ordered chronologically, so each release contains all changes described below
 it.
 
-# v0.20.22 (unreleased)
+# v0.20.22 (2020-04-27)
 
 This release is fully backward compatible with 0.20.21.  
 It is the final planned release in the 0.20.x series.

--- a/website/src/hugo/content/versions.md
+++ b/website/src/hugo/content/versions.md
@@ -41,8 +41,8 @@ title: Versions
   </thead>
   <tbody>
 	<tr>
-	  <td><a href="/v0.21">0.21.0-SNAPSHOT</a></td>
-	  <td class="text-center"><span class="badge badge-danger">Snapshots</span></td>
+	  <td><a href="/v0.21">{{% latestInSeries "0.20" %}}</a></td>
+	  <td class="text-center"><span class="badge badge-success">Stable</span></td>
 	  <td class="text-center"><i class="fa fa-ban"></i></td>
 	  <td class="text-center"><i class="fa fa-check"></i></td>
 	  <td class="text-center"><i class="fa fa-check"></i></td>
@@ -53,7 +53,7 @@ title: Versions
 	</tr>
 	<tr>
 	  <td><a href="/v0.20">{{% latestInSeries "0.20" %}}</a></td>
-	  <td class="text-center"><span class="badge badge-success">Stable</span></td>
+	  <td class="text-center"><span class="badge badge-secondary">EOL</span></td>
 	  <td class="text-center"><i class="fa fa-ban"></i></td>
 	  <td class="text-center"><i class="fa fa-check"></i></td>
 	  <td class="text-center"><i class="fa fa-check"></i></td>

--- a/website/src/hugo/themes/http4s.org/layouts/partials/nav-docs.html
+++ b/website/src/hugo/themes/http4s.org/layouts/partials/nav-docs.html
@@ -1,8 +1,8 @@
 <div class="dropdown-menu" aria-labelledby="doc-menu-item">
   <a class="dropdown-item" href="/v1.0/">v1.0 (development)</a>
   <a class="dropdown-item" href="/v0.21/">v0.21 (stable)</a>
-  <a class="dropdown-item" href="/v0.20/">v0.20 (stable)</a>
-  <a class="dropdown-item" href="/v0.18/">v0.18 (stable)</a>
+  <a class="dropdown-item" href="/v0.20/">v0.20 (EOL)</a>
+  <a class="dropdown-item" href="/v0.18/">v0.18 (EOL)</a>
   <a class="dropdown-item" href="/v0.17/">v0.17 (EOL)</a>
   <a class="dropdown-item" href="/v0.16/">v0.16 (EOL)</a>
   <a class="dropdown-item" href="/versions/">Help me choose...</a>


### PR DESCRIPTION
It's time to consider EOL for series/0.20.  We haven't been backporting to this branch as aggressively as 0.21, which has been out since the beginning of February.  I'll look for low-hanging fruit, but it's a drag maintaining three branches, so I'd like to be done with it soon.

This PR has the mechanics for it.