### PR TITLE
Backports to 0.20

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -259,7 +259,7 @@ private[blaze] class Http1ServerStage[F[_]](
           closeOnFinish)
     }
 
-    unsafeRunAsync(bodyEncoder.write(rr, resp.body)) {
+    unsafeRunAsync(bodyEncoder.write(rr, resp.body).recover { case EOF => true }) {
       case Right(requireClose) =>
         if (closeOnFinish || requireClose) {
           logger.trace("Request/route requested closing connection.")
@@ -276,9 +276,6 @@ private[blaze] class Http1ServerStage[F[_]](
               case Failure(t) => fatalError(t, "Failure in body cleanup")
             }(trampoline)
           }
-
-      case Left(EOF) =>
-        IO(closeConnection())
 
       case Left(t) =>
         logger.error(t)("Error writing body")

--- a/core/src/main/scala/org/http4s/HttpRoutes.scala
+++ b/core/src/main/scala/org/http4s/HttpRoutes.scala
@@ -63,6 +63,18 @@ object HttpRoutes {
       implicit F: Sync[F]): HttpRoutes[F] =
     Kleisli(req => OptionT(F.suspend(pf.lift(req).sequence)))
 
+  /** Lifts a partial function into an [[HttpRoutes]].  The application of the
+    * partial function is not suspended in `F`, unlike [[of]]. This allows for less
+    * constraints when not combining many routes.
+    *
+    * @tparam F the base effect of the [[HttpRoutes]]
+    * @param pf the partial function to lift
+    * @return An [[HttpRoutes]] that returns some [[Response]] in an `OptionT[F, ?]`
+    * wherever `pf` is defined, an `OptionT.none` wherever it is not
+    */
+  def strict[F[_]: Applicative](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] =
+    Kleisli(req => OptionT(pf.lift(req).sequence))
+
   /** An empty set of routes.  Always responds with `OptionT.none`.
     *
     * @tparam F the base effect of the [[HttpRoutes]]

--- a/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
@@ -12,21 +12,21 @@ object LiteralSyntaxMacros {
       args,
       "Uri",
       Uri.fromString(_).isRight,
-      s => c.universe.reify(Uri.fromString(s.splice).right.get))
+      s => c.universe.reify(Uri.unsafeFromString(s.splice)))
 
   def mediaTypeInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[MediaType] =
     singlePartInterpolator(c)(
       args,
       "MediaType",
       MediaType.parse(_).isRight,
-      s => c.universe.reify(MediaType.parse(s.splice).right.get))
+      s => c.universe.reify(MediaType.unsafeParse(s.splice)))
 
   def qValueInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[QValue] =
     singlePartInterpolator(c)(
       args,
       "QValue",
       QValue.fromString(_).isRight,
-      s => c.universe.reify(QValue.fromString(s.splice).right.get))
+      s => c.universe.reify(QValue.unsafeFromString(s.splice)))
 
   private def singlePartInterpolator[A](c: blackbox.Context)(
       args: Seq[c.Expr[Any]],

--- a/core/src/main/scala/org/http4s/MediaType.scala
+++ b/core/src/main/scala/org/http4s/MediaType.scala
@@ -18,7 +18,7 @@
  */
 package org.http4s
 
-import cats.implicits._
+import cats.implicits.{catsSyntaxEither => _, _}
 import cats.{Eq, Order, Show}
 import org.http4s.headers.MediaRangeAndQValue
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
@@ -247,6 +247,14 @@ object MediaType extends MimeDB {
     new Http4sParser[MediaType](s, "Invalid Media Type") with MediaTypeParser {
       def main = MediaTypeFull
     }.parse
+
+  /** Parse a MediaType
+    *
+    * For totality, call [[#parse]]. For compile-time
+    * verification of literals, call [[#mediaType]].
+    */
+  def unsafeParse(s: String): MediaType =
+    parse(s).valueOr(throw _)
 
   private[http4s] trait MediaTypeParser extends MediaParser {
     def MediaTypeFull: Rule1[MediaType] = rule {

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -80,6 +80,9 @@ object QValue {
       case _: NumberFormatException => ParseResult.fail("Invalid q-value", s"${s} is not a number")
     }
 
+  def unsafeFromString(s: String): QValue =
+    fromString(s).valueOr(throw _)
+
   def parse(s: String): ParseResult[QValue] =
     new Http4sParser[QValue](s, "Invalid q-value") with QValueParser {
       def main = QualityValue

--- a/server/src/main/scala/org/http4s/server/middleware/Caching.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Caching.scala
@@ -26,23 +26,32 @@ object Caching {
     Kleisli { a: A =>
       for {
         resp <- http(a)
-        now <- HttpDate.current[G]
-      } yield {
-        val headers = List(
-          `Cache-Control`(
-            NonEmptyList.of[CacheDirective](
-              CacheDirective.`no-store`,
-              CacheDirective.`private`(),
-              CacheDirective.`no-cache`(),
-              CacheDirective.`max-age`(0.seconds)
-            )),
-          Header("Pragma", "no-cache"),
-          HDate(now),
-          Expires(HttpDate.Epoch) // Expire at the epoch for no time confusion
-        )
-        resp.putHeaders(headers: _*)
-      }
+        out <- `no-store-response`[G](resp)
+      } yield out
     }
+
+  /**
+    * Transform a Response so that it will not be cached.
+    */
+  def `no-store-response`[G[_]]: PartiallyAppliedNoStoreCache[G] =
+    new PartiallyAppliedNoStoreCache[G] {
+      def apply[F[_]](resp: Response[F])(implicit M: Monad[G], C: Clock[G]): G[Response[F]] =
+        HttpDate.current[G].map(now => resp.putHeaders(HDate(now) :: noStoreStaticHeaders: _*))
+    }
+
+  // These never change, so don't recreate them each time.
+  private val noStoreStaticHeaders = List(
+    `Cache-Control`(
+      NonEmptyList.of[CacheDirective](
+        CacheDirective.`no-store`,
+        CacheDirective.`private`(),
+        CacheDirective.`no-cache`(),
+        CacheDirective.`max-age`(0.seconds)
+      )
+    ),
+    Header("Pragma", "no-cache"),
+    Expires(HttpDate.Epoch) // Expire at the epoch for no time confusion
+  )
 
   /**
     * Helpers Contains the default arguments used to help construct
@@ -81,6 +90,15 @@ object Caching {
       http)
 
   /**
+    * Publicly Cache a Response for the given lifetime.
+    *
+    * Note: If set to Duration.Inf, lifetime falls back to
+    * 10 years for support of Http1 caches.
+   **/
+  def publicCacheResponse[G[_]](lifetime: Duration): PartiallyAppliedCache[G] =
+    cacheResponse(lifetime, Either.left(CacheDirective.public))
+
+  /**
     * Sets headers for response to be privately cached for the specified duration.
     *
     * Note: If set to Duration.Inf, lifetime falls back to
@@ -98,6 +116,18 @@ object Caching {
       http)
 
   /**
+    * Privately Caches A Response for the given lifetime.
+    *
+    * Note: If set to Duration.Inf, lifetime falls back to
+    * 10 years for support of Http1 caches.
+   **/
+  def privateCacheResponse[G[_]](
+      lifetime: Duration,
+      fieldNames: List[CaseInsensitiveString] = Nil
+  ): PartiallyAppliedCache[G] =
+    cacheResponse(lifetime, Either.right(CacheDirective.`private`(fieldNames)))
+
+  /**
     * Construct a Middleware that will apply the appropriate caching headers.
     *
     * Helper functions for methodToSetOn and statusToSetOn can be found in [[Helpers]].
@@ -111,37 +141,67 @@ object Caching {
       methodToSetOn: Method => Boolean,
       statusToSetOn: Status => Boolean,
       http: Http[G, F]
-  ): Http[G, F] = {
-    val actualLifetime = lifetime match {
-      case finite: FiniteDuration => finite
-      case _ => 315360000.seconds // 10 years
-      // Http1 caches do not respect max-age headers, so to work globally it is recommended
-      // to explicitly set an Expire which requires some time interval to work
-    }
+  ): Http[G, F] =
     Kleisli { req: Request[F] =>
       for {
         resp <- http(req)
         out <- if (methodToSetOn(req.method) && statusToSetOn(resp.status)) {
-          HttpDate.current[G].flatMap { now =>
-            HttpDate
-              .fromEpochSecond(now.epochSecond + actualLifetime.toSeconds)
-              .liftTo[G]
-              .map { expires =>
-                val headers = List(
-                  `Cache-Control`(
-                    NonEmptyList.of(
-                      isPublic.fold[CacheDirective](identity, identity),
-                      CacheDirective.`max-age`(actualLifetime)
-                    )),
-                  HDate(now),
-                  Expires(expires)
-                )
-                resp.putHeaders(headers: _*)
-              }
-          }
+          cacheResponse[G](lifetime, isPublic)(resp)
         } else resp.pure[G]
       } yield out
     }
+
+  // Here as an optimization so we don't recreate durations
+  // in cacheResponse #TeamStatic
+  private val tenYearDuration: FiniteDuration = 315360000.seconds
+
+  /**
+    *  Method in order to turn a generated Response into one that
+    * will be appropriately cached.
+    *
+    *  Note: If set to Duration.Inf, lifetime falls back to
+    * 10 years for support of Http1 caches.
+   **/
+  def cacheResponse[G[_]](
+      lifetime: Duration,
+      isPublic: Either[CacheDirective.public.type, CacheDirective.`private`]
+  ): PartiallyAppliedCache[G] = {
+    val actualLifetime = lifetime match {
+      case finite: FiniteDuration => finite
+      case _ => tenYearDuration
+      // Http1 caches do not respect max-age headers, so to work globally it is recommended
+      // to explicitly set an Expire which requires some time interval to work
+    }
+    new PartiallyAppliedCache[G] {
+      override def apply[F[_]](
+          resp: Response[F])(implicit M: MonadError[G, Throwable], C: Clock[G]): G[Response[F]] =
+        for {
+          now <- HttpDate.current[G]
+          expires <- HttpDate
+            .fromEpochSecond(now.epochSecond + actualLifetime.toSeconds)
+            .liftTo[G]
+        } yield {
+          val headers = List(
+            `Cache-Control`(
+              NonEmptyList.of(
+                isPublic.fold[CacheDirective](identity, identity),
+                CacheDirective.`max-age`(actualLifetime)
+              )),
+            HDate(now),
+            Expires(expires)
+          )
+          resp.putHeaders(headers: _*)
+        }
+
+    }
   }
 
+  trait PartiallyAppliedCache[G[_]] {
+    def apply[F[_]](
+        resp: Response[F])(implicit M: MonadError[G, Throwable], C: Clock[G]): G[Response[F]]
+  }
+
+  trait PartiallyAppliedNoStoreCache[G[_]] {
+    def apply[F[_]](resp: Response[F])(implicit M: Monad[G], C: Clock[G]): G[Response[F]]
+  }
 }

--- a/tests/src/test/scala/org/http4s/HttpRoutesSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpRoutesSpec.scala
@@ -1,0 +1,15 @@
+package org.http4s
+
+import cats.Id
+
+class HttpRoutesSpec extends Http4sSpec {
+  "HttpRoutes.strict" should {
+    "work for type without defer" in {
+      val route = HttpRoutes.strict[Id] {
+        case _ => Response[Id](Status.Ok)
+      }
+      val req = Request[Id](Method.GET)
+      route.run(req).map(_.status).value must_=== Some(Status.Ok)
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/util/DecodeSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/DecodeSpec.scala
@@ -56,5 +56,10 @@ class DecodeSpec extends Http4sSpec {
       }
     }
 
+    "drop Byte Order Mark" in {
+      val source = Stream.emits(Seq(0xef.toByte, 0xbb.toByte, 0xbf.toByte))
+      val decoded = decode(Charset.`UTF-8`)(source).toList.combineAll
+      decoded must_== ""
+    }
   }
 }


### PR DESCRIPTION
In preparation for EOL of 0.20, these issues were:
* Not binary breaking
* Not semantic changing
* Didn't give me a headache at 1:30am

Each can be reviewed as an independent commit.