### PR TITLE
Start testing on JDK-1.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [adopt@1.8, adopt@1.11]
+        java: [adopt@1.8, adopt@1.11, adopt@1.14]
         scala: [2.11.12, 2.12.10]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v5
+      - uses: olafurpg/setup-scala@v7
         with:
           java-version: ${{ matrix.java }}
       - name: Cache Coursier


### PR DESCRIPTION
We might regret this, because we have some unstable tests, and it raises the things that can go wrong by 50%.  And it's not an LTS JDK, so I'd kind of like to allow failures and just let this be a canary, but I don't know how to do that in GitHub Actions.  But we should be proactively testing this somehow.