### PR TITLE
Skip some flaky tests

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -121,7 +121,7 @@ class BlazeClientSpec extends Http4sSpec {
             .unsafeRunTimed(timeout) must beSome(true)
         }
 
-        "behave and not deadlock on failures with parTraverse" in {
+        "behave and not deadlock on failures with parTraverse" in skipOnCi {
           mkClient(3)
             .use { client =>
               val failedHosts = addresses.map { address =>

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -160,7 +160,7 @@ class BlazeClientSpec extends Http4sSpec {
             .unsafeRunTimed(timeout) must beSome(true)
         }
 
-        "behave and not deadlock on failures with parSequence" in {
+        "behave and not deadlock on failures with parSequence" in skipOnCi {
           mkClient(3)
             .use { client =>
               val failedHosts = addresses.map { address =>

--- a/client/src/test/scala/org/http4s/client/PoolManagerSpec.scala
+++ b/client/src/test/scala/org/http4s/client/PoolManagerSpec.scala
@@ -73,7 +73,7 @@ class PoolManagerSpec(name: String) extends Http4sSpec {
     }
 
     // this is a regression test for https://github.com/http4s/http4s/issues/2962
-    "fail expired connections and then wake up a non-expired waiting connection on release" in {
+    "fail expired connections and then wake up a non-expired waiting connection on release" in skipOnCi {
       val timeout = 50.milliseconds
       (for {
         pool <- mkPool(maxTotal = 1, maxWaitQueueLimit = 3, requestTimeout = timeout)


### PR DESCRIPTION
We're not fixing them, and we're not touching blaze internals much, and these spurious failures are frustrating other work.  This is regrettable, but the status quo is worse.