### PR TITLE
Media: small change to remove note.

### DIFF
--- a/core/src/main/scala/org/http4s/Media.scala
+++ b/core/src/main/scala/org/http4s/Media.scala
@@ -1,7 +1,6 @@
 package org.http4s
 
 import cats.MonadError
-import cats.implicits._
 import fs2.Stream
 import fs2.text.utf8Decode
 import org.http4s.headers._
@@ -50,8 +49,7 @@ trait Media[F[_]] {
     * @return the effect which will generate the A
     */
   final def as[A](implicit F: MonadError[F, Throwable], decoder: EntityDecoder[F, A]): F[A] =
-    // n.b. this will be better with redeem in Cats-2.0
-    attemptAs.leftWiden[Throwable].rethrowT
+    F.rethrow(attemptAs.value)
 }
 
 object Media {


### PR DESCRIPTION
The note referred to `redeem` but I am not sure how this corresponds to `redeem`. By directly using method in `F` (expanding `rethrowT`) we no longer need syntax or the `leftWiden`.