### PR TITLE
Drop deprecated methods from

### DIFF
--- a/core/src/main/scala/org/http4s/util/threads.scala
+++ b/core/src/main/scala/org/http4s/util/threads.scala
@@ -44,18 +44,6 @@ object threads {
       }
     }
 
-  @deprecated("Use newDaemonPool instead", "0.15.7")
-  private[http4s] def newDefaultFixedThreadPool(
-      n: Int,
-      threadFactory: ThreadFactory): ExecutorService =
-    new ThreadPoolExecutor(
-      n,
-      n,
-      0L,
-      TimeUnit.MILLISECONDS,
-      new LinkedBlockingQueue[Runnable],
-      threadFactory)
-
   private[http4s] def newDaemonPool(
       name: String,
       min: Int = 4,

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -224,10 +224,6 @@ private[http4s] trait ArbitraryInstances {
       1 -> const(CharsetRange.`*`)
     )
 
-  @deprecated("Use genCharsetRangeNoQuality. This one may cause deadlocks.", "0.15.7")
-  val charsetRangesNoQuality: Gen[CharsetRange] =
-    genCharsetRangeNoQuality
-
   implicit val http4sTestingArbitraryForAcceptCharset: Arbitrary[`Accept-Charset`] =
     Arbitrary {
       for {


### PR DESCRIPTION
- The method `newDefaultFixedThreadPool` was deprecated years ago,
  and it was also marked as internal to http4s.

- The method `charsetRangesNoQuality` is part of the laws tests,
  has a default mapping, and has been deprecated for a while.