### PR TITLE
[#3315] Record duration up until error instead of hard coded 1 when using Metrics middleware

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -33,7 +33,9 @@ object Metrics {
     * @param client the [[Client]] to gather metrics from
     * @return the metrics middleware wrapping the [[Client]]
     */
-  def apply[F[_]](ops: MetricsOps[F], classifierF: Request[F] => Option[String] = _ => None)(
+  def apply[F[_]](
+      ops: MetricsOps[F],
+      classifierF: Request[F] => Option[String] = (_: Request[F]) => None)(
       client: Client[F])(implicit F: Sync[F], clock: Clock[F]): Client[F] =
     Client(withMetrics(client, ops, classifierF))
 

--- a/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -33,10 +33,8 @@ object Metrics {
     * @param client the [[Client]] to gather metrics from
     * @return the metrics middleware wrapping the [[Client]]
     */
-  def apply[F[_]](ops: MetricsOps[F], classifierF: Request[F] => Option[String] = {
-    (_: Request[F]) =>
-      None
-  })(client: Client[F])(implicit F: Sync[F], clock: Clock[F]): Client[F] =
+  def apply[F[_]](ops: MetricsOps[F], classifierF: Request[F] => Option[String] = _ => None)(
+      client: Client[F])(implicit F: Sync[F], clock: Clock[F]): Client[F] =
     Client(withMetrics(client, ops, classifierF))
 
   private def withMetrics[F[_]](
@@ -47,35 +45,52 @@ object Metrics {
     for {
       statusRef <- Resource.liftF(Ref.of[F, Option[Status]](None))
       start <- Resource.liftF(clock.monotonic(TimeUnit.NANOSECONDS))
-      resp <- (for {
-        _ <- Resource.make(ops.increaseActiveRequests(classifierF(req)))(_ =>
-          ops.decreaseActiveRequests(classifierF(req)))
-        _ <- Resource.make(F.unit) { _ =>
-          clock
-            .monotonic(TimeUnit.NANOSECONDS)
-            .flatMap(now =>
-              statusRef.get.flatMap(oStatus =>
-                oStatus.traverse_(status =>
-                  ops.recordTotalTime(req.method, status, now - start, classifierF(req)))))
-        }
-        resp <- client.run(req)
-        _ <- Resource.liftF(statusRef.set(Some(resp.status)))
-        end <- Resource.liftF(clock.monotonic(TimeUnit.NANOSECONDS))
-        _ <- Resource.liftF(ops.recordHeadersTime(req.method, end - start, classifierF(req)))
-      } yield resp).handleErrorWith { e: Throwable =>
-        Resource.liftF[F, Response[F]](
-          clock
-            .monotonic(TimeUnit.NANOSECONDS)
-            .flatMap(now =>
-              registerError(now - start, ops, classifierF(req))(e) *> F.raiseError[Response[F]](e)))
-      }
+      resp <- executeRequestAndRecordMetrics(
+        client,
+        ops,
+        classifierF,
+        req,
+        statusRef,
+        start
+      )
     } yield resp
 
-  private def registerError[F[_]](duration: Long, ops: MetricsOps[F], classifier: Option[String])(
-      e: Throwable): F[Unit] =
-    if (e.isInstanceOf[TimeoutException]) {
-      ops.recordAbnormalTermination(duration, Timeout, classifier)
-    } else {
-      ops.recordAbnormalTermination(duration, Error, classifier)
+  private def executeRequestAndRecordMetrics[F[_]](
+      client: Client[F],
+      ops: MetricsOps[F],
+      classifierF: Request[F] => Option[String],
+      req: Request[F],
+      statusRef: Ref[F, Option[Status]],
+      start: Long
+  )(implicit F: Sync[F], clock: Clock[F]): Resource[F, Response[F]] =
+    (for {
+      _ <- Resource.make(ops.increaseActiveRequests(classifierF(req)))(_ =>
+        ops.decreaseActiveRequests(classifierF(req)))
+      _ <- Resource.make(F.unit) { _ =>
+        clock
+          .monotonic(TimeUnit.NANOSECONDS)
+          .flatMap(now =>
+            statusRef.get.flatMap(oStatus =>
+              oStatus.traverse_(status =>
+                ops.recordTotalTime(req.method, status, now - start, classifierF(req)))))
+      }
+      resp <- client.run(req)
+      _ <- Resource.liftF(statusRef.set(Some(resp.status)))
+      end <- Resource.liftF(clock.monotonic(TimeUnit.NANOSECONDS))
+      _ <- Resource.liftF(ops.recordHeadersTime(req.method, end - start, classifierF(req)))
+    } yield resp).handleErrorWith { e: Throwable =>
+      Resource.liftF(registerError(start, ops, classifierF(req))(e) *> F.raiseError[Response[F]](e))
     }
+
+  private def registerError[F[_]](start: Long, ops: MetricsOps[F], classifier: Option[String])(
+      e: Throwable)(implicit F: Sync[F], clock: Clock[F]): F[Unit] =
+    clock
+      .monotonic(TimeUnit.NANOSECONDS)
+      .flatMap { now =>
+        if (e.isInstanceOf[TimeoutException]) {
+          ops.recordAbnormalTermination(now - start, Timeout, classifier)
+        } else {
+          ops.recordAbnormalTermination(now - start, Error, classifier)
+        }
+      }
 }


### PR DESCRIPTION
This fixes #3315.