### PR TITLE
Implement WebSocket stream with a single send-receive pipe

### DIFF
--- a/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
@@ -12,11 +12,13 @@ import fs2.concurrent.{Queue, SignallingRef}
 import cats.effect.IO
 import cats.implicits._
 import java.util.concurrent.atomic.AtomicBoolean
+
 import org.http4s.Http4sSpec
 import org.http4s.blaze.pipeline.LeafBuilder
-import org.http4s.websocket.{WebSocket, WebSocketFrame}
+import org.http4s.websocket.{WebSocketFrame, WebSocketSeparatePipe}
 import org.http4s.websocket.WebSocketFrame._
 import org.http4s.blaze.pipeline.Command
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scodec.bits.ByteVector
@@ -64,7 +66,7 @@ class Http4sWSStageSpec extends Http4sSpec with CatsEffect {
         outQ <- Queue.unbounded[IO, WebSocketFrame]
         backendInQ <- Queue.unbounded[IO, WebSocketFrame]
         closeHook = new AtomicBoolean(false)
-        ws = WebSocket[IO](outQ.dequeue, backendInQ.enqueue, IO(closeHook.set(true)))
+        ws = WebSocketSeparatePipe[IO](outQ.dequeue, backendInQ.enqueue, IO(closeHook.set(true)))
         deadSignal <- SignallingRef[IO, Boolean](false)
         wsHead <- WSTestHead()
         head = LeafBuilder(new Http4sWSStage[IO](ws, closeHook, deadSignal)).base(wsHead)

--- a/core/src/main/scala/org/http4s/websocket/WebSocket.scala
+++ b/core/src/main/scala/org/http4s/websocket/WebSocket.scala
@@ -8,14 +8,17 @@ package org.http4s.websocket
 
 import fs2._
 
-private[http4s] final case class WebSocket[F[_]](
+private[http4s] sealed trait WebSocket[F[_]] {
+  def onClose: F[Unit]
+}
+
+private[http4s] final case class WebSocketSeparatePipe[F[_]](
     send: Stream[F, WebSocketFrame],
     receive: Pipe[F, WebSocketFrame, Unit],
     onClose: F[Unit]
-) {
-  @deprecated("Parameter has been renamed to `send`", "0.18.0-M7")
-  def read: Stream[F, WebSocketFrame] = send
+) extends WebSocket[F]
 
-  @deprecated("Parameter has been renamed to `receive`", "0.18.0-M7")
-  def write: Pipe[F, WebSocketFrame, Unit] = receive
-}
+private[http4s] final case class WebSocketCombinedPipe[F[_]](
+    receiveSend: Pipe[F, WebSocketFrame, WebSocketFrame],
+    onClose: F[Unit]
+) extends WebSocket[F]

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -7,9 +7,7 @@
 package com.example.http4s.blaze
 
 import cats.effect._
-import cats.implicits._
 import fs2._
-import fs2.concurrent.Queue
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.dsl.Http4sDsl
@@ -47,26 +45,7 @@ class BlazeWebSocketExampleApp[F[_]](implicit F: ConcurrentEffect[F], timer: Tim
             case Text(msg, _) => Text("You sent the server: " + msg)
             case _ => Text("Something new")
           }
-
-        /* Note that this use of a queue is not typical of http4s applications.
-         * This creates a single queue to connect the input and output activity
-         * on the WebSocket together. The queue is therefore not accessible outside
-         * of the scope of this single HTTP request to connect a WebSocket.
-         *
-       * While this meets the contract of the service to echo traffic back to
-         * its source, many applications will want to create the queue object at
-         * a higher level and pass it into the "routes" method or the containing
-         * class constructor in order to share the queue (or some other concurrency
-         * object) across multiple requests, or to scope it to the application itself
-         * instead of to a request.
-         */
-        Queue
-          .unbounded[F, WebSocketFrame]
-          .flatMap { q =>
-            val d = q.dequeue.through(echoReply)
-            val e = q.enqueue
-            WebSocketBuilder[F].build(d, e)
-          }
+        WebSocketBuilder[F].build(echoReply)
     }
 
   def stream: Stream[F, ExitCode] =

--- a/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -9,83 +9,128 @@ package org.http4s.server.websocket
 import cats.Applicative
 import cats.implicits._
 import fs2.{Pipe, Stream}
-import org.http4s.websocket.{WebSocket, WebSocketContext, WebSocketFrame}
+import org.http4s.websocket.{
+  WebSocket,
+  WebSocketCombinedPipe,
+  WebSocketContext,
+  WebSocketFrame,
+  WebSocketSeparatePipe
+}
 import org.http4s.{Headers, Response, Status}
 
 /**
   * Build a response which will accept an HTTP websocket upgrade request and initiate a websocket connection using the
   * supplied exchange to process and respond to websocket messages.
-  * @param send     The send side of the Exchange represents the outgoing stream of messages that should be sent to the client
-  * @param receive  The receive side of the Exchange is a sink to which the framework will push the incoming websocket messages
-  *                 Once both streams have terminated, the server will initiate a close of the websocket connection.
-  *                 As defined in the websocket specification, this means the server
-  *                 will send a CloseFrame to the client and wait for a CloseFrame in response before closing the
-  *                 connection, this ensures that no messages are lost in flight. The server will shutdown the
-  *                 connection when it receives the `CloseFrame` message back from the client. The connection will also
-  *                 be closed if the client does not respond with a `CloseFrame` after some reasonable amount of
-  *                 time.
-  *                 Another way of closing the connection is by emitting a `CloseFrame` in the stream of messages
-  *                 heading to the client. This method allows one to attach a message to the `CloseFrame` as defined
-  *                 by the websocket protocol.
-  *                 Unfortunately the current implementation does not quite respect the description above, it violates
-  *                 the websocket protocol by terminating the connection immediately upon reception
-  *                 of a `CloseFrame`. This bug will be addressed soon in an upcoming release and this message will be
-  *                 removed.
-  *                 Currently, there is no way for the server to be notified when the connection is closed, neither in
-  *                 the case of a normal disconnection such as a Close handshake or due to a connection error. There
-  *                 are plans to address this limitation in the future.
   * @param headers Handshake response headers, such as such as:Sec-WebSocket-Protocol.
   * @param onNonWebSocketRequest The status code to return to a client making a non-websocket HTTP request to this route.
   *                              default: NotImplemented
   * @param onHandshakeFailure The status code to return when failing to handle a websocket HTTP request to this route.
   *                           default: BadRequest
   */
-final case class WebSocketBuilder[F[_]](
-    send: Stream[F, WebSocketFrame],
-    receive: Pipe[F, WebSocketFrame, Unit],
+final case class WebSocketBuilder[F[_]: Applicative](
     headers: Headers,
     onNonWebSocketRequest: F[Response[F]],
-    onHandshakeFailure: F[Response[F]])
-object WebSocketBuilder {
-  class Builder[F[_]: Applicative] {
-    def build(
-        send: Stream[F, WebSocketFrame],
-        receive: Pipe[F, WebSocketFrame, Unit],
-        headers: Headers = Headers.empty,
-        onNonWebSocketRequest: F[Response[F]] =
-          Response[F](Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F],
-        onHandshakeFailure: F[Response[F]] = Response[F](Status.BadRequest)
-          .withEntity("WebSocket handshake failed.")
-          .pure[F],
-        onClose: F[Unit] = Applicative[F].unit,
-        filterPingPongs: Boolean = true): F[Response[F]] = {
+    onHandshakeFailure: F[Response[F]],
+    onClose: F[Unit],
+    filterPingPongs: Boolean
+) {
 
-      val finalReceive: Pipe[F, WebSocketFrame, Unit] =
-        if (filterPingPongs)
-          _.filterNot(isPingPong).through(receive)
-        else receive
-
-      WebSocketBuilder(
-        send,
-        finalReceive,
-        headers,
-        onNonWebSocketRequest,
-        onHandshakeFailure).onNonWebSocketRequest
-        .map(
-          _.withAttribute(
-            websocketKey[F],
-            WebSocketContext(WebSocket(send, finalReceive, onClose), headers, onHandshakeFailure))
+  private def buildResponse(webSocket: WebSocket[F]): F[Response[F]] =
+    onNonWebSocketRequest
+      .map(
+        _.withAttribute(
+          websocketKey[F],
+          WebSocketContext(
+            webSocket,
+            headers,
+            onHandshakeFailure
+          )
         )
-    }
+      )
+
+  /**
+    * @param sendReceive The send-receive stream represents transforming of incoming messages to outgoing for a single websocket
+    *                    Once the stream have terminated, the server will initiate a close of the websocket connection.
+    *                    As defined in the websocket specification, this means the server
+    *                    will send a CloseFrame to the client and wait for a CloseFrame in response before closing the
+    *                    connection, this ensures that no messages are lost in flight. The server will shutdown the
+    *                    connection when it receives the `CloseFrame` message back from the client. The connection will also
+    *                    be closed if the client does not respond with a `CloseFrame` after some reasonable amount of
+    *                    time.
+    *                    Another way of closing the connection is by emitting a `CloseFrame` in the stream of messages
+    *                    heading to the client. This method allows one to attach a message to the `CloseFrame` as defined
+    *                    by the websocket protocol.
+    *                    Unfortunately the current implementation does not quite respect the description above, it violates
+    *                    the websocket protocol by terminating the connection immediately upon reception
+    *                    of a `CloseFrame`. This bug will be addressed soon in an upcoming release and this message will be
+    *                    removed.
+    *                    Currently, there is no way for the server to be notified when the connection is closed, neither in
+    *                    the case of a normal disconnection such as a Close handshake or due to a connection error. There
+    *                    are plans to address this limitation in the future.
+    * @return
+    */
+  def build(sendReceive: Pipe[F, WebSocketFrame, WebSocketFrame]): F[Response[F]] = {
+
+    val finalSendReceive: Pipe[F, WebSocketFrame, WebSocketFrame] =
+      if (filterPingPongs)
+        sendReceive.compose(inputStream => inputStream.filterNot(isPingPong))
+      else
+        sendReceive
+
+    buildResponse(WebSocketCombinedPipe(finalSendReceive, onClose))
   }
 
-  def apply[F[_]: Applicative]: Builder[F] = new Builder[F]
+  /**
+    * @param send     The send side of the Exchange represents the outgoing stream of messages that should be sent to the client
+    * @param receive  The receive side of the Exchange is a sink to which the framework will push the incoming websocket messages
+    *                 Once both streams have terminated, the server will initiate a close of the websocket connection.
+    *                 As defined in the websocket specification, this means the server
+    *                 will send a CloseFrame to the client and wait for a CloseFrame in response before closing the
+    *                 connection, this ensures that no messages are lost in flight. The server will shutdown the
+    *                 connection when it receives the `CloseFrame` message back from the client. The connection will also
+    *                 be closed if the client does not respond with a `CloseFrame` after some reasonable amount of
+    *                 time.
+    *                 Another way of closing the connection is by emitting a `CloseFrame` in the stream of messages
+    *                 heading to the client. This method allows one to attach a message to the `CloseFrame` as defined
+    *                 by the websocket protocol.
+    *                 Unfortunately the current implementation does not quite respect the description above, it violates
+    *                 the websocket protocol by terminating the connection immediately upon reception
+    *                 of a `CloseFrame`. This bug will be addressed soon in an upcoming release and this message will be
+    *                 removed.
+    *                 Currently, there is no way for the server to be notified when the connection is closed, neither in
+    *                 the case of a normal disconnection such as a Close handshake or due to a connection error. There
+    *                 are plans to address this limitation in the future.
+    * @return
+    */
+  def build(
+      send: Stream[F, WebSocketFrame],
+      receive: Pipe[F, WebSocketFrame, Unit]): F[Response[F]] = {
 
-  private def isPingPong(frame: WebSocketFrame) =
-    frame match {
-      case _: WebSocketFrame.Ping => true
-      case _: WebSocketFrame.Pong => true
-      case _ => false
-    }
+    val finalReceive: Pipe[F, WebSocketFrame, Unit] =
+      if (filterPingPongs)
+        _.filterNot(isPingPong).through(receive)
+      else
+        receive
 
+    buildResponse(WebSocketSeparatePipe(send, finalReceive, onClose))
+  }
+
+  private val isPingPong: WebSocketFrame => Boolean = {
+    case _: WebSocketFrame.Ping => true
+    case _: WebSocketFrame.Pong => true
+    case _ => false
+  }
+}
+
+object WebSocketBuilder {
+  def apply[F[_]: Applicative]: WebSocketBuilder[F] =
+    new WebSocketBuilder[F](
+      headers = Headers.empty,
+      onNonWebSocketRequest =
+        Response[F](Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F],
+      onHandshakeFailure =
+        Response[F](Status.BadRequest).withEntity("WebSocket handshake failed.").pure[F],
+      onClose = Applicative[F].unit,
+      filterPingPongs = true
+    )
 }


### PR DESCRIPTION
This kind of API is much more easy to use and it is kinda superset of old API - as you see I can implement old API via new, but it's very hard to do new API with an old one.
Related to http4s/http4s#1863