### PR TITLE
WebjarService: Do not use OS-specific directory seperators

### DIFF
--- a/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -88,7 +88,7 @@ object WebjarService {
   /**
     * Returns an Option(WebjarAsset) for a Request, or None if it couldn't be mapped
     *
-    * @param subPath The request path without the prefix
+    * @param p The request path without the prefix
     * @return The WebjarAsset, or None if it couldn't be mapped
     */
   private def toWebjarAsset(p: Path): Option[WebjarAsset] = {
@@ -96,12 +96,24 @@ object WebjarService {
     if (count > 2) {
       val library = p.getName(0).toString
       val version = p.getName(1).toString
-      val asset = p.subpath(2, count)
-      Some(WebjarAsset(library, version, asset.toString))
+      val asset = asScalaIterator(p.subpath(2, count).iterator()).mkString("/")
+      Some(WebjarAsset(library, version, asset))
     } else {
       None
     }
   }
+
+  /** Creates a scala.Iterator from a java.util.Iterator.
+    *
+    * We're not using scala.jdk.CollectionConverters (which was added in 2.13)
+    * or scala.collection.convert.ImplicitConversion (which was deprecated in 2.13)
+    * to ease cross-building against multiple Scala versions.
+    */
+  private def asScalaIterator[A](underlying: java.util.Iterator[A]): Iterator[A] =
+    new Iterator[A] {
+      override def hasNext: Boolean = underlying.hasNext
+      override def next(): A = underlying.next()
+    }
 
   /**
     * Returns an asset that matched the request if it's found in the webjar path


### PR DESCRIPTION
`Path#toString` uses the OS-specific directory separator if a `Path`
contains of multiple components. On Windows this means that the
`WebjarAsset#asset` field might contain backslashes. The `assets` field
is then later used to load a resource which [fails because of the
backslashes](https://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html#getResources-java.lang.String-).

This change always uses `/` as directory separator for the assets path
so that loading them works on all operating systems again.

Closes: #3304