### PR TITLE
Added executionContext as implicit parameter to BlazeBuilder.apply

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -165,7 +165,7 @@ class BlazeBuilder[F[_]](
   def resource: Resource[F, Server] = {
     val httpApp = Router(serviceMounts.map(mount => mount.prefix -> mount.service): _*).orNotFound
     var b = BlazeServerBuilder
-      .apply(F, timer, executionContext)
+      .apply[F]
       .bindSocketAddress(socketAddress)
       .withIdleTimeout(idleTimeout)
       .withNio2(isNio2)
@@ -223,13 +223,10 @@ class BlazeBuilder[F[_]](
 
 @deprecated("Use BlazeServerBuilder instead", "0.20.0-RC1")
 object BlazeBuilder {
-  def apply[F[_]](
-      implicit F: ConcurrentEffect[F],
-      timer: Timer[F],
-      executionContext: ExecutionContext): BlazeBuilder[F] =
+  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F]): BlazeBuilder[F] =
     new BlazeBuilder(
       socketAddress = ServerBuilder.DefaultSocketAddress,
-      executionContext = executionContext,
+      executionContext = ExecutionContext.global,
       idleTimeout = IdleTimeoutSupport.DefaultIdleTimeout,
       isNio2 = false,
       connectorPoolSize = channel.DefaultPoolSize,

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -164,7 +164,8 @@ class BlazeBuilder[F[_]](
 
   def resource: Resource[F, Server] = {
     val httpApp = Router(serviceMounts.map(mount => mount.prefix -> mount.service): _*).orNotFound
-    var b = BlazeServerBuilder.apply(F, timer, executionContext)
+    var b = BlazeServerBuilder
+      .apply(F, timer, executionContext)
       .bindSocketAddress(socketAddress)
       .withIdleTimeout(idleTimeout)
       .withNio2(isNio2)
@@ -222,7 +223,10 @@ class BlazeBuilder[F[_]](
 
 @deprecated("Use BlazeServerBuilder instead", "0.20.0-RC1")
 object BlazeBuilder {
-  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F], executionContext: ExecutionContext): BlazeBuilder[F] =
+  def apply[F[_]](
+      implicit F: ConcurrentEffect[F],
+      timer: Timer[F],
+      executionContext: ExecutionContext): BlazeBuilder[F] =
     new BlazeBuilder(
       socketAddress = ServerBuilder.DefaultSocketAddress,
       executionContext = executionContext,

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -164,9 +164,9 @@ class BlazeBuilder[F[_]](
 
   def resource: Resource[F, Server] = {
     val httpApp = Router(serviceMounts.map(mount => mount.prefix -> mount.service): _*).orNotFound
-    var b = BlazeServerBuilder
-      .apply[F]
+    var b = BlazeServerBuilder[F]
       .bindSocketAddress(socketAddress)
+      .withExecutionContext(executionContext)
       .withIdleTimeout(idleTimeout)
       .withNio2(isNio2)
       .withConnectorPoolSize(connectorPoolSize)

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeBuilder.scala
@@ -164,9 +164,8 @@ class BlazeBuilder[F[_]](
 
   def resource: Resource[F, Server] = {
     val httpApp = Router(serviceMounts.map(mount => mount.prefix -> mount.service): _*).orNotFound
-    var b = BlazeServerBuilder[F]
+    var b = BlazeServerBuilder.apply(F, timer, executionContext)
       .bindSocketAddress(socketAddress)
-      .withExecutionContext(executionContext)
       .withIdleTimeout(idleTimeout)
       .withNio2(isNio2)
       .withConnectorPoolSize(connectorPoolSize)
@@ -223,10 +222,10 @@ class BlazeBuilder[F[_]](
 
 @deprecated("Use BlazeServerBuilder instead", "0.20.0-RC1")
 object BlazeBuilder {
-  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F]): BlazeBuilder[F] =
+  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F], executionContext: ExecutionContext): BlazeBuilder[F] =
     new BlazeBuilder(
       socketAddress = ServerBuilder.DefaultSocketAddress,
-      executionContext = ExecutionContext.global,
+      executionContext = executionContext,
       idleTimeout = IdleTimeoutSupport.DefaultIdleTimeout,
       isNio2 = false,
       connectorPoolSize = channel.DefaultPoolSize,

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -380,10 +380,10 @@ class BlazeServerBuilder[F[_]](
 }
 
 object BlazeServerBuilder {
-  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F]): BlazeServerBuilder[F] =
+  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F], executionContext: ExecutionContext): BlazeServerBuilder[F] =
     new BlazeServerBuilder(
       socketAddress = defaults.SocketAddress,
-      executionContext = ExecutionContext.global,
+      executionContext = executionContext,
       responseHeaderTimeout = defaults.ResponseTimeout,
       idleTimeout = defaults.IdleTimeout,
       isNio2 = false,

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -188,6 +188,7 @@ class BlazeServerBuilder[F[_]](
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
     copy(socketAddress = socketAddress)
 
+  @deprecated("Use BlazeServerBuilder.apply with explicit executionContext instead", "0.20.22")
   def withExecutionContext(executionContext: ExecutionContext): BlazeServerBuilder[F] =
     copy(executionContext = executionContext)
 
@@ -380,10 +381,32 @@ class BlazeServerBuilder[F[_]](
 }
 
 object BlazeServerBuilder {
-  def apply[F[_]](
+  @deprecated("Use BlazeServerBuilder.apply with explicit executionContext instead", "0.20.22")
+  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F]): BlazeServerBuilder[F] =
+    new BlazeServerBuilder(
+      socketAddress = defaults.SocketAddress,
+      executionContext = ExecutionContext.global,
+      responseHeaderTimeout = defaults.ResponseTimeout,
+      idleTimeout = defaults.IdleTimeout,
+      isNio2 = false,
+      connectorPoolSize = DefaultPoolSize,
+      bufferSize = 64 * 1024,
+      selectorThreadFactory = defaultThreadSelectorFactory,
+      enableWebSockets = true,
+      sslConfig = new NoSsl[F](),
+      isHttp2Enabled = false,
+      maxRequestLineLen = 4 * 1024,
+      maxHeadersLen = 40 * 1024,
+      chunkBufferMaxSize = 1024 * 1024,
+      httpApp = defaultApp[F],
+      serviceErrorHandler = DefaultServiceErrorHandler[F],
+      banner = defaults.Banner,
+      channelOptions = ChannelOptions(Vector.empty)
+    )
+
+  def apply[F[_]](executionContext: ExecutionContext)(
       implicit F: ConcurrentEffect[F],
-      timer: Timer[F],
-      executionContext: ExecutionContext): BlazeServerBuilder[F] =
+      timer: Timer[F]): BlazeServerBuilder[F] =
     new BlazeServerBuilder(
       socketAddress = defaults.SocketAddress,
       executionContext = executionContext,

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -188,7 +188,6 @@ class BlazeServerBuilder[F[_]](
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
     copy(socketAddress = socketAddress)
 
-  @deprecated("Use BlazeServerBuilder.apply with explicit executionContext instead", "0.20.22")
   def withExecutionContext(executionContext: ExecutionContext): BlazeServerBuilder[F] =
     copy(executionContext = executionContext)
 

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -380,7 +380,10 @@ class BlazeServerBuilder[F[_]](
 }
 
 object BlazeServerBuilder {
-  def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F], executionContext: ExecutionContext): BlazeServerBuilder[F] =
+  def apply[F[_]](
+      implicit F: ConcurrentEffect[F],
+      timer: Timer[F],
+      executionContext: ExecutionContext): BlazeServerBuilder[F] =
     new BlazeServerBuilder(
       socketAddress = defaults.SocketAddress,
       executionContext = executionContext,

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
@@ -12,6 +12,7 @@ import org.http4s.{Http4sSpec, HttpApp}
 import scala.concurrent.duration._
 import scala.io.Source
 import scala.util.Try
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
   * Test cases for mTLS support in blaze server
@@ -27,9 +28,8 @@ class BlazeServerMtlsSpec extends Http4sSpec {
   }
 
   def builder: BlazeServerBuilder[IO] =
-    BlazeServerBuilder[IO]
+    BlazeServerBuilder[IO](global)
       .withResponseHeaderTimeout(1.second)
-      .withExecutionContext(testExecutionContext)
 
   val service: HttpApp[IO] = HttpApp {
     case req @ GET -> Root / "dummy" =>

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
@@ -12,7 +12,7 @@ import org.http4s.{Http4sSpec, HttpApp}
 import scala.concurrent.duration._
 import scala.io.Source
 import scala.util.Try
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.global
 
 /**
   * Test cases for mTLS support in blaze server

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 import scala.io.Source
 import org.specs2.execute.Result
 import org.http4s.multipart.Multipart
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.global
 
 class BlazeServerSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   def builder =

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
@@ -13,12 +13,12 @@ import scala.concurrent.duration._
 import scala.io.Source
 import org.specs2.execute.Result
 import org.http4s.multipart.Multipart
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class BlazeServerSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   def builder =
-    BlazeServerBuilder[IO]
+    BlazeServerBuilder[IO](global)
       .withResponseHeaderTimeout(1.second)
-      .withExecutionContext(testExecutionContext)
 
   val service: HttpApp[IO] = HttpApp {
     case GET -> Root / "thread" / "routing" =>

--- a/docs/src/main/tut/client.md
+++ b/docs/src/main/tut/client.md
@@ -47,12 +47,14 @@ implicit val timer: Timer[IO] = IO.timer(global)
 Finish setting up our server:
 
 ```tut:book
+import scala.concurrent.ExecutionContext.global
+
 val app = HttpRoutes.of[IO] {
   case GET -> Root / "hello" / name =>
     Ok(s"Hello, $name.")
 }.orNotFound
 
-val server = BlazeServerBuilder[IO].bindHttp(8080, "localhost").withHttpApp(app).resource
+val server = BlazeServerBuilder[IO](global).bindHttp(8080, "localhost").withHttpApp(app).resource
 ```
 
 We'll start the server in the background.  The `IO.never` keeps it

--- a/docs/src/main/tut/json.md
+++ b/docs/src/main/tut/json.md
@@ -274,7 +274,9 @@ implicit val cs: ContextShift[IO] = IO.contextShift(global)
 implicit val timer: Timer[IO] = IO.timer(global)
 
 import org.http4s.server.blaze._
-val server = BlazeServerBuilder[IO].bindHttp(8080).withHttpApp(jsonApp).resource
+import scala.concurrent.ExecutionContext.global
+
+val server = BlazeServerBuilder[IO](global).bindHttp(8080).withHttpApp(jsonApp).resource
 val fiber = server.use(_ => IO.never).start.unsafeRunSync()
 ```
 

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -181,6 +181,7 @@ import org.http4s.syntax._
 import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.http4s.server.blaze._
+import scala.concurrent.ExecutionContext.global
 ```
 
 ```tut:silent
@@ -192,7 +193,7 @@ object Main extends IOApp {
   }.orNotFound
 
   def run(args: List[String]): IO[ExitCode] =
-    BlazeServerBuilder[IO]
+    BlazeServerBuilder[IO](global)
       .bindHttp(8080, "localhost")
       .withHttpApp(helloWorldService)
       .serve
@@ -205,10 +206,12 @@ object Main extends IOApp {
 You may also create the server within an `IOApp` using resource:
 
 ```tut:silent
+import scala.concurrent.ExecutionContext.global
+
 object MainWithResource extends IOApp {
 
   def run(args: List[String]): IO[ExitCode] =
-    BlazeServerBuilder[IO]
+    BlazeServerBuilder[IO](global)
       .bindHttp(8080, "localhost")
       .withHttpApp(Main.helloWorldService)
       .resource

--- a/docs/src/main/tut/service.md
+++ b/docs/src/main/tut/service.md
@@ -127,12 +127,13 @@ import cats.implicits._
 import org.http4s.server.blaze._
 import org.http4s.implicits._
 import org.http4s.server.Router
+import scala.concurrent.ExecutionContext.global
 ```
 
 ```tut:book
 val services = tweetService <+> helloWorldService
 val httpApp = Router("/" -> helloWorldService, "/api" -> services).orNotFound
-val serverBuilder = BlazeServerBuilder[IO].bindHttp(8080, "localhost").withHttpApp(httpApp)
+val serverBuilder = BlazeServerBuilder[IO](global).bindHttp(8080, "localhost").withHttpApp(httpApp)
 ```
 
 The `bindHttp` call isn't strictly necessary as the server will be set to run

--- a/docs/src/main/tut/static.md
+++ b/docs/src/main/tut/static.md
@@ -25,6 +25,7 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.Server
 import org.http4s.server.staticcontent._
 import org.http4s.syntax.kleisli._
+import scala.concurrent.ExecutionContext.global
 
 object SimpleHttpServer extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
@@ -33,7 +34,7 @@ object SimpleHttpServer extends IOApp {
   val app: Resource[IO, Server] =
     for {
       blocker <- Blocker[IO]
-      server <- BlazeServerBuilder[IO]
+      server <- BlazeServerBuilder[IO](global)
         .bindHttp(8080)
         .withHttpApp(fileService[IO](FileService.Config(".", blocker)).orNotFound)
         .resource

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -7,7 +7,7 @@ import org.http4s.HttpApp
 import org.http4s.server.{Router, Server}
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.global
 
 object BlazeExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -24,7 +24,7 @@ object BlazeExampleApp {
     for {
       blocker <- Blocker[F]
       app = httpApp[F](blocker)
-      server <- BlazeServerBuilder[F]
+      server <- BlazeServerBuilder[F](global)
         .bindHttp(8080)
         .withHttpApp(app)
         .resource

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -7,6 +7,7 @@ import org.http4s.HttpApp
 import org.http4s.server.{Router, Server}
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object BlazeExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -31,7 +31,7 @@ object BlazeMetricsExampleApp {
     for {
       blocker <- Blocker[F]
       app = httpApp[F](blocker)
-      server <- BlazeServerBuilder[F]
+      server <- BlazeServerBuilder[F](global)
         .bindHttp(8080)
         .withHttpApp(app)
         .resource

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -10,6 +10,7 @@ import org.http4s.metrics.dropwizard._
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.Metrics
 import org.http4s.server.{HttpMiddleware, Router, Server}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class BlazeMetricsExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -10,7 +10,7 @@ import org.http4s.metrics.dropwizard._
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.Metrics
 import org.http4s.server.{HttpMiddleware, Router, Server}
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.global
 
 class BlazeMetricsExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
@@ -5,6 +5,7 @@ import cats.effect._
 import cats.implicits._
 import org.http4s.server.Server
 import org.http4s.server.blaze.BlazeServerBuilder
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object BlazeSslExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
@@ -18,7 +18,7 @@ object BlazeSslExampleApp {
 
   def builder[F[_]: ConcurrentEffect: ContextShift: Timer]: F[BlazeServerBuilder[F]] =
     context.map { sslContext =>
-      BlazeServerBuilder[F]
+      BlazeServerBuilder[F](global)
         .bindHttp(8443)
         .withSslContext(sslContext)
     }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
@@ -5,7 +5,7 @@ import cats.effect._
 import cats.implicits._
 import org.http4s.server.Server
 import org.http4s.server.blaze.BlazeServerBuilder
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.global
 
 object BlazeSslExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
@@ -5,6 +5,7 @@ import cats.effect._
 import cats.implicits._
 import fs2._
 import org.http4s.server.blaze.BlazeServerBuilder
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object BlazeSslExampleWithRedirect extends IOApp {
   import BlazeSslExampleWithRedirectApp._

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
@@ -20,7 +20,7 @@ object BlazeSslExampleWithRedirect extends IOApp {
 
 object BlazeSslExampleWithRedirectApp {
   def redirectStream[F[_]: ConcurrentEffect: Timer]: Stream[F, ExitCode] =
-    BlazeServerBuilder[F]
+    BlazeServerBuilder[F](global)
       .bindHttp(8080)
       .withHttpApp(ssl.redirectApp(8443))
       .serve

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExampleWithRedirect.scala
@@ -5,7 +5,7 @@ import cats.effect._
 import cats.implicits._
 import fs2._
 import org.http4s.server.blaze.BlazeServerBuilder
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.global
 
 object BlazeSslExampleWithRedirect extends IOApp {
   import BlazeSslExampleWithRedirectApp._

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -12,6 +12,7 @@ import org.http4s.server.websocket._
 import org.http4s.websocket.WebSocketFrame
 import org.http4s.websocket.WebSocketFrame._
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object BlazeWebSocketExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -12,7 +12,7 @@ import org.http4s.server.websocket._
 import org.http4s.websocket.WebSocketFrame
 import org.http4s.websocket.WebSocketFrame._
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.global
 
 object BlazeWebSocketExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -63,7 +63,7 @@ class BlazeWebSocketExampleApp[F[_]](implicit F: ConcurrentEffect[F], timer: Tim
   }
 
   def stream: Stream[F, ExitCode] =
-    BlazeServerBuilder[F]
+    BlazeServerBuilder[F](global)
       .bindHttp(8080)
       .withHttpApp(routes.orNotFound)
       .serve

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/Server.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/Server.scala
@@ -29,7 +29,7 @@ object HttpServer {
       blocker <- Stream.resource(Blocker[F])
       client <- BlazeClientBuilder[F](global).stream
       ctx <- Stream(new Module[F](client, blocker))
-      exitCode <- BlazeServerBuilder[F]
+      exitCode <- BlazeServerBuilder[F](global)
         .bindHttp(8080)
         .withHttpApp(httpApp(ctx))
         .serve

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/Server.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/Server.scala
@@ -8,7 +8,7 @@ import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.global
 
 object Server extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/docker/src/main/scala/com/example/http4s/Example.scala
+++ b/examples/docker/src/main/scala/com/example/http4s/Example.scala
@@ -17,7 +17,7 @@ object Main extends IOApp {
 
 object ExampleApp {
   def serverStream[F[_]: ConcurrentEffect: Timer]: Stream[F, ExitCode] =
-    BlazeServerBuilder[F]
+    BlazeServerBuilder[F](global)
       .bindHttp(port = 8080, host = "0.0.0.0")
       .withHttpApp(ExampleRoutes[F]().routes.orNotFound)
       .serve

--- a/examples/docker/src/main/scala/com/example/http4s/Example.scala
+++ b/examples/docker/src/main/scala/com/example/http4s/Example.scala
@@ -8,6 +8,8 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.syntax.kleisli._
 import org.http4s.server.blaze.BlazeServerBuilder
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object Main extends IOApp {
   def run(args: List[String]): IO[ExitCode] =
     ExampleApp.serverStream[IO].compile.drain.as(ExitCode.Success)

--- a/examples/docker/src/main/scala/com/example/http4s/Example.scala
+++ b/examples/docker/src/main/scala/com/example/http4s/Example.scala
@@ -7,8 +7,7 @@ import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.syntax.kleisli._
 import org.http4s.server.blaze.BlazeServerBuilder
-
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.global
 
 object Main extends IOApp {
   def run(args: List[String]): IO[ExitCode] =


### PR DESCRIPTION
Right now the BlazeBuilder.apply is using global as ExecutionContext by default.
In my opinion, is better to pass executionContext as an implicit parameter.
Please note that the official documentation is not totally clear about that, and from my point of view running an http4s server with global as the execution context in production is not correct.