### PR TITLE
Avoid incorrectly responding with an empty body in AHC client

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -88,8 +88,9 @@ object AsyncHttpClient {
           subscriber <- StreamSubscriber[F, HttpResponseBodyPart]
 
           subscribeF = F.delay(publisher.subscribe(subscriber))
+
           bodyDisposal <- Ref.of[F, F[Unit]] {
-            subscriber.stream(subscribeF).take(0).compile.drain
+            subscriber.stream(subscribeF).pull.uncons.void.stream.compile.drain
           }
 
           body = subscriber

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -128,9 +128,7 @@ object AsyncHttpClient {
 
       override def onCompleted(): Unit =
         onStreamCalled.get
-          .ifM(
-            F.unit,
-            F.delay(invokeCallback(logger)(cb(Right(response -> dispose)))))
+          .ifM(F.unit, F.delay(invokeCallback(logger)(cb(Right(response -> dispose)))))
           .runAsync(_ => IO.unit)
           .unsafeRunSync()
     }


### PR DESCRIPTION
1. Guards the callback invocation in `onCompleted` so that it is only called if `onStream` wasn't called.
2. Fixes `bodyDisposal` to actually sequence the stream finalizer via `.pull.uncons.void`. `take(0)` turns out to [be a noop](https://github.com/functional-streams-for-scala/fs2/blob/v1.0.0/core/shared/src/main/scala/fs2/Stream.scala#L3446), so the previous version wasn't finalizing.

Fixes #3293 