### PR TITLE
Skip call a second host test on CI

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -304,7 +304,7 @@ class BlazeClientSpec extends Http4sSpec {
             .attempt must_== Some(Right(Status.Ok))
         }
 
-        "call a second host after reusing connections on a first" in {
+        "call a second host after reusing connections on a first" in skipOnCi {
           // https://github.com/http4s/http4s/pull/2546
           mkClient(maxConnectionsPerRequestKey = Int.MaxValue, maxTotalConnections = 5)
             .use { client =>


### PR DESCRIPTION
Regretfully. Is causing problems, for example on https://github.com/http4s/http4s/pull/3338/.