### PR TITLE
Start publishing snapshots for v1.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,2 @@
+// Temporary hack to distinguish 0.21 snapshots from master
+dynverGitDescribeOutput in ThisBuild ~= { _.map(_.copy(ref = sbtdynver.GitRef("1.0.0-M0"))) }

--- a/website/src/hugo/content/versions.md
+++ b/website/src/hugo/content/versions.md
@@ -41,6 +41,17 @@ title: Versions
   </thead>
   <tbody>
 	<tr>
+	  <td><a href="/v1.0">{{% latestInSeries "1.0" %}}</a></td>
+	  <td class="text-center"><span class="badge badge-danger">Snapshots</span></td>
+	  <td class="text-center"><i class="fa fa-ban"></i></td>
+	  <td class="text-center"><i class="fa fa-ban"></i></td>
+	  <td class="text-center"><i class="fa fa-check"></i></td>
+	  <td class="text-center"><i class="fa fa-check"></i></td>
+	  <td>2.x</td>
+	  <td>2.x</td>
+	  <td>1.8+</td>
+	</tr>
+	<tr>
 	  <td><a href="/v0.21">{{% latestInSeries "0.21" %}}</a></td>
 	  <td class="text-center"><span class="badge badge-success">Stable</span></td>
 	  <td class="text-center"><i class="fa fa-ban"></i></td>


### PR DESCRIPTION
There is currently no distinction between 0.21 and (incompatible) 1.0 snapshots.  `version.sbt` is a hack that invents a pseudo-release for version derivation until the branch has a real release.

Adds another row to the versions table.

More interestingly, this is a public statement to the next breaking release being 1.0, not 0.22.  We can squeeze in an 0.22 if we must, but I'd rather we don't.