### PR TITLE
Drop semicolon to be an allowed query-part separator by default

### DIFF
--- a/core/src/main/scala/org/http4s/parser/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/parser/QueryParser.scala
@@ -107,7 +107,7 @@ private[http4s] object QueryParser {
 
   def parseQueryString(queryString: String, codec: Codec = Codec.UTF8): ParseResult[Query] =
     if (queryString.isEmpty) Right(Query.empty)
-    else new QueryParser(codec, true).decode(CharBuffer.wrap(queryString), true)
+    else new QueryParser(codec, colonSeparators = false).decode(CharBuffer.wrap(queryString), true)
 
   private sealed trait State
   private case object KEY extends State

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -328,6 +328,11 @@ http://example.org/a file
       Uri(query = Query.fromString("param1=test")).toString must_== ("?param1=test")
     }
 
+    "parse and render a uri with semicolon-in-qp-correctly" in {
+      val uri = uri"http://domain.com/path?param1=asd;fgh"
+      uri.renderString must_== "http://domain.com/path?param1=asd%3Bfgh"
+    }
+
     "render a query string with multiple value in a param" in {
       Uri(query = Query.fromString("param1=3&param2=2&param2=foo")).toString must_== ("?param1=3&param2=2&param2=foo")
     }

--- a/tests/src/test/scala/org/http4s/parser/QueryParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/QueryParserSpec.scala
@@ -43,7 +43,8 @@ class QueryParserSpec extends Http4sSpec {
 //    }
 
     "Allow ';' seperators" in {
-      parseQueryString("a=b;c") must beRight(Query("a" -> Some("b"), "c" -> None))
+      new QueryParser(Codec.UTF8, colonSeparators = true)
+        .decode(CharBuffer.wrap("a=b;c"), true) must beRight(Query("a" -> Some("b"), "c" -> None))
     }
 
     "Allow PHP-style [] in keys" in {


### PR DESCRIPTION
We should instead parse the ; and emit it as percent-encoded.
HTML 4 added this as a recommentation to support CGI-BIN servers.
Most sane libraries now use & for query separators.

https://www.w3.org/TR/1999/REC-html401-19991224/appendix/notes.html#h-B.2.2

If you still need to parse query-parts with ";", the code is still
there but not enabled by default.

Fixes #3277