### PR TITLE
Use stable hostaddress in ConnectionFailure message

### DIFF
--- a/client/src/main/scala/org/http4s/client/ConnectionFailure.scala
+++ b/client/src/main/scala/org/http4s/client/ConnectionFailure.scala
@@ -12,7 +12,7 @@ class ConnectionFailure(
     val cause: Throwable)
     extends IOException(cause) {
   override def getMessage(): String =
-    s"Error connecting to $requestKey using address $upstream (unresolved: ${upstream.isUnresolved})"
+    s"Error connecting to $requestKey using address ${upstream.getHostString}:${upstream.getPort} (unresolved: ${upstream.isUnresolved})"
 }
 
 object ConnectionFailure {


### PR DESCRIPTION
Somewhere between jdk11 and jdk14 the toString for InetSocketAddress changed.