### PR TITLE
In jetty-server, warn on HTTP/2 support with SSLContextBits

### DIFF
--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -183,6 +183,7 @@ sealed class JettyBuilder[F[_]] private (
         httpsConnector(sslContextFactory)
 
       case Some(SSLContextBits(sslContext, clientAuth)) =>
+        if (supportHttp2) logger.warn("JettyBuilder does not support HTTP/2 with SSL at the moment")
         val sslContextFactory = new SslContextFactory.Server()
         sslContextFactory.setSslContext(sslContext)
         updateClientAuth(sslContextFactory, clientAuth)


### PR DESCRIPTION
Overlooked this case when I cherry-picked #3333.