### PR TITLE
Deprecate org.http4s.util.bug

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -15,6 +15,7 @@ import org.asynchttpclient.handler.StreamedAsyncHandler
 import org.asynchttpclient.request.body.generator.{BodyGenerator, ReactiveStreamsBodyGenerator}
 import org.asynchttpclient.{Request => AsyncRequest, Response => _, _}
 import org.http4s.internal.invokeCallback
+import org.http4s.internal.bug
 import org.http4s.util.threads._
 import org.log4s.getLogger
 import org.reactivestreams.Publisher
@@ -100,7 +101,7 @@ object AsyncHttpClient {
       }
 
       override def onBodyPartReceived(httpResponseBodyPart: HttpResponseBodyPart): State =
-        throw org.http4s.util.bug("Expected it to call onStream instead.")
+        throw bug("Expected it to call onStream instead.")
 
       override def onStatusReceived(status: HttpResponseStatus): State = {
         response = response.copy(status = getStatus(status))

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ReadBufferStage.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ReadBufferStage.scala
@@ -2,6 +2,7 @@ package org.http4s.client.blaze
 
 import org.http4s.blaze.pipeline.MidStage
 import org.http4s.blaze.util.Execution
+import org.http4s.internal.bug
 import scala.concurrent.Future
 
 /** Stage that buffers read requests in order to eagerly detect connection close events.
@@ -55,7 +56,7 @@ private[blaze] final class ReadBufferStage[T] extends MidStage[T, T] {
       buffered = channelRead()
     } else {
       val msg = "Tried to schedule a read when one is already pending"
-      val ex = org.http4s.util.bug(msg)
+      val ex = bug(msg)
       // This should never happen, but if it does, lets scream about it
       logger.error(ex)(msg)
       throw ex

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/WSFrameAggregator.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/WSFrameAggregator.scala
@@ -2,15 +2,15 @@ package org.http4s.server.blaze
 
 import org.http4s.blaze.pipeline.MidStage
 import org.http4s.blaze.util.Execution._
-import org.http4s.util
-import scala.concurrent.{Future, Promise}
-import scala.util.{Failure, Success}
 import java.net.ProtocolException
+import org.http4s.internal.bug
 import org.http4s.server.blaze.WSFrameAggregator.Accumulator
 import org.http4s.websocket.WebSocketFrame
 import org.http4s.websocket.WebSocketFrame._
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success}
 import scodec.bits.ByteVector
 
 private class WSFrameAggregator extends MidStage[WebSocketFrame, WebSocketFrame] {
@@ -100,7 +100,7 @@ private object WSFrameAggregator {
       if (queue.isEmpty) frame match {
         case _: Text | _: Binary => // nop
         case f =>
-          throw util.bug(s"Shouldn't get here. Wrong type: ${f.getClass.getName}")
+          throw bug(s"Shouldn't get here. Wrong type: ${f.getClass.getName}")
       }
       size += frame.length
       queue += frame
@@ -113,7 +113,7 @@ private object WSFrameAggregator {
         case _: Binary => false
         case f =>
           // shouldn't happen as it's guarded for in `append`
-          val e = util.bug(s"Shouldn't get here. Wrong type: ${f.getClass.getName}")
+          val e = bug(s"Shouldn't get here. Wrong type: ${f.getClass.getName}")
           throw e
       }
 

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -137,4 +137,8 @@ package object internal {
         F.delay { cf.cancel(true); () }
       })
     }
+
+  private[http4s] def bug(message: String): AssertionError =
+    new AssertionError(
+      s"This is a bug. Please report to https://github.com/http4s/http4s/issues: ${message}")
 }

--- a/core/src/main/scala/org/http4s/util/package.scala
+++ b/core/src/main/scala/org/http4s/util/package.scala
@@ -71,9 +71,8 @@ package object util {
   }
 
   /** Constructs an assertion error with a reference back to our issue tracker. Use only with head hung low. */
-  def bug(message: String): AssertionError =
-    new AssertionError(
-      s"This is a bug. Please report to https://github.com/http4s/http4s/issues: ${message}")
+  @deprecated("For internal use only. Will be removed from public API.", "0.20.22")
+  def bug(message: String): AssertionError = org.http4s.internal.bug(message)
 
   @deprecated("Moved to org.http4s.syntax.StringOps", "0.16")
   type CaseInsensitiveStringOps = org.http4s.syntax.StringOps

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -7,7 +7,7 @@ import fs2._
 import java.util.concurrent.atomic.AtomicReference
 import javax.servlet.{ReadListener, WriteListener}
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-import org.http4s.util.bug
+import org.http4s.internal.bug
 import org.http4s.util.execution.trampoline
 import org.log4s.getLogger
 import scala.annotation.tailrec


### PR DESCRIPTION
Should never have been part of the public API. Begin hiding it.