### PR TITLE
Restore binary compatibility of http4s-jetty

### DIFF
--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -46,6 +46,32 @@ sealed class JettyBuilder[F[_]] private (
 
   private[this] val logger = getLogger
 
+  @deprecated("Retained for binary compatibility", "0.20.23")
+  private[JettyBuilder] def this(
+      socketAddress: InetSocketAddress,
+      threadPool: ThreadPool,
+      idleTimeout: Duration,
+      asyncTimeout: Duration,
+      shutdownTimeout: Duration,
+      servletIo: ServletIo[F],
+      sslBits: Option[SSLConfig],
+      mounts: Vector[Mount[F]],
+      serviceErrorHandler: ServiceErrorHandler[F],
+      banner: immutable.Seq[String]
+  )(implicit F: ConcurrentEffect[F]) = this(
+    socketAddress = socketAddress,
+    threadPool = threadPool,
+    idleTimeout = idleTimeout,
+    asyncTimeout = asyncTimeout,
+    shutdownTimeout = shutdownTimeout,
+    servletIo = servletIo,
+    sslBits = sslBits,
+    mounts = mounts,
+    serviceErrorHandler = serviceErrorHandler,
+    supportHttp2 = false,
+    banner = banner
+  )
+
   private def copy(
       socketAddress: InetSocketAddress = socketAddress,
       threadPool: ThreadPool = threadPool,

--- a/website/src/hugo/content/changelog.md
+++ b/website/src/hugo/content/changelog.md
@@ -8,10 +8,23 @@ Maintenance branches are merged before each new release. This change log is
 ordered chronologically, so each release contains all changes described below
 it.
 
-# v0.20.22 (2020-04-27)
+# v0.20.23 (2020-04-28)
 
-This release is fully backward compatible with 0.20.21.  
-It is the final planned release in the 0.20.x series.
+This release restores backward compatibility with the 0.20 series.
+This is the final planned release in the 0.20 series.
+
+## Compatibility
+
+* [#3362](https://github.com/http4s/http4s/pull/3362): Restores binary compatibility in http4s-jetty back to 0.20.21.
+
+# v0.20.22 (2020-04-28)
+
+This release is backward compatible with 0.20, except for http4s-jetty.
+This incompatibility will be corrected in 0.20.23.
+
+## Breaking changes
+
+* [#3333](https://github.com/http4s/http4s/pull/3333): Add Http2c support to jetty-server. This accidentally broke binary compatibility, and will be patched in v0.20.23.
 
 ## Bugfixes
 
@@ -20,7 +33,6 @@ It is the final planned release in the 0.20.x series.
 
 ## Enhancements
 
-* [#3333](https://github.com/http4s/http4s/pull/3333): Add Http2c support to jetty-server
 * [#3327](https://github.com/http4s/http4s/pull/3327): Add `httpRoutes` and `httpApp` convenience constructors to `Date` middleware
 * [#3381](https://github.com/http4s/http4s/pull/3327): Add `httpRoutes` and `httpApp` convenience constructors to `CORS` middleware
 * [#3298](https://github.com/http4s/http4s/pull/3298): In `Logger` client and server middlewares, detect any media types ending in `+json` as non-binary


### PR DESCRIPTION
It was just a private constructor.  Probably could have gotten away with a MiMa exception, but those have burned us in the past.

We should tag v0.20.23 off this.

We still need to understand why CI didn't catch this.