### PR TITLE
Add SBT Missing Link

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 // https://github.com/coursier/coursier/issues/450
 classpathTypes += "maven-plugin"
 
+addSbtPlugin("ch.epfl.scala"              %  "sbt-missinglink"           % "0.3.1")
 addSbtPlugin("com.earldouglas"            %  "xsbt-web-plugin"           % "4.2.0")
 addSbtPlugin("com.eed3si9n"               %  "sbt-buildinfo"             % "0.9.0")
 addSbtPlugin("com.eed3si9n"               %  "sbt-unidoc"                % "0.4.3")


### PR DESCRIPTION
SBT Missing Link is an sbt plugin, developed by the Scala Center, 
that statically analyses all library dependencies (and transitive)
looking for Binary compatibility problems. 
https://github.com/scalacenter/sbt-missinglink

Given that http4s core sits upon many Scala libraries as well as 
many Java libraries, getting a static analysis for this is needed