### PR TITLE
Remove http4sJvmTarget setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -581,21 +581,8 @@ def exampleProject(name: String) =
     .dependsOn(examples)
 
 lazy val commonSettings = Seq(
-  http4sJvmTarget := scalaVersion.map {
-    VersionNumber(_).numbers match {
-      case Seq(2, 10, _*) => "1.7"
-      case _ => "1.8"
-    }
-  }.value,
-  Compile / scalacOptions ++= Seq(
-    s"-target:jvm-${http4sJvmTarget.value}"
-  ),
   Compile / doc / scalacOptions += "-no-link-warnings",
   javacOptions ++= Seq(
-    "-source",
-    http4sJvmTarget.value,
-    "-target",
-    http4sJvmTarget.value,
     "-Xlint:deprecation",
     "-Xlint:unchecked"
   ),

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -18,7 +18,6 @@ object Http4sPlugin extends AutoPlugin {
     val isCi = settingKey[Boolean]("true if this build is running on CI")
     val http4sMimaVersion = settingKey[Option[String]]("Version to target for MiMa compatibility")
     val http4sApiVersion = taskKey[(Int, Int)]("API version of http4s")
-    val http4sJvmTarget = taskKey[String]("JVM target")
     val http4sBuildData = taskKey[Unit]("Export build metadata for Hugo")
   }
   import autoImport._


### PR DESCRIPTION
We've not needed this since Scala 2.10.