### PR TITLE
Remove unused compile dep filter on scala-reflect

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -107,11 +107,6 @@ object Http4sPlugin extends AutoPlugin {
     },
 
     dependencyUpdatesFilter -= moduleFilter(organization = "javax.servlet"), // servlet-4.0 is not yet supported by jetty-9 or tomcat-9, so don't accidentally depend on its new features
-    unusedCompileDependenciesFilter -= moduleFilter(
-      organization = "org.scala-lang",
-      name = "scala-reflect",
-      revision = "2.12.*",
-    ), // false positive on 2.12.10
 
     ivyConfigurations += CompileTime,
     unmanagedClasspath in Compile ++= update.value.select(configurationFilter("CompileTime")),


### PR DESCRIPTION
This doesn't fail anymore, so decruft.