### PR TITLE
Use Sum Type instead of Option[SSLContext] for BlazeClientBuilder#apply

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -138,7 +138,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
   /** Use the provided `SSLContext` when making secure calls */
   def withSslContext(sslContext: SSLContext): BlazeClientBuilder[F] =
-    withSslContextOption(Some(sslContext))
+    copy(sslContext = SSLContextOption.Provided(sslContext))
 
   /** Use an `SSLContext` obtained by `SSLContext.getDefault()` when making secure calls.
     *
@@ -153,7 +153,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
   /** Disable secure calls */
   def withoutSslContext: BlazeClientBuilder[F] =
-    copy(sslContext = None)
+    copy(sslContext = SSLContextOption.NoSSL)
 
   def withCheckEndpointAuthentication(checkEndpointIdentification: Boolean): BlazeClientBuilder[F] =
     copy(checkEndpointIdentification = checkEndpointIdentification)

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -278,15 +278,16 @@ object BlazeClientBuilder {
 
   sealed trait SSLContextOption
   object SSLContextOption {
-    case object NoSSL                                 extends SSLContextOption
-    case object TryDefaultSSLContextOrNone            extends SSLContextOption
+    case object NoSSL extends SSLContextOption
+    case object TryDefaultSSLContextOrNone extends SSLContextOption
     final case class Provided(SSLContext: SSLContext) extends SSLContextOption
 
-    def toMaybeSSLContext(sco: SSLContextOption): Option[SSLContext] = sco match {
-      case SSLContextOption.NoSSL => None
-      case SSLContextOption.TryDefaultSSLContextOrNone =>tryDefaultSslContext
-      case SSLContextOption.Provided(context) => Some(context)
-    }
+    def toMaybeSSLContext(sco: SSLContextOption): Option[SSLContext] =
+      sco match {
+        case SSLContextOption.NoSSL => None
+        case SSLContextOption.TryDefaultSSLContextOrNone => tryDefaultSslContext
+        case SSLContextOption.Provided(context) => Some(context)
+      }
   }
 
   import SSLContextOption.{TryDefaultSSLContextOrNone, toMaybeSSLContext}

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -295,14 +295,9 @@ object BlazeClientBuilder {
   /** Creates a BlazeClientBuilder
     *
     * @param executionContext the ExecutionContext for blaze's internal Futures
-    * @param sslContextOption indicates how to resolve SSLContext. The sum type offers three options:
-    *                         NoSSL                = do not use SSL/HTTPS
-    *                         TryDefaultSSLContext = `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
-    *                         Provided             = use the explicitly passed SSLContext
     */
   def apply[F[_]: ConcurrentEffect](
-      executionContext: ExecutionContext,
-      sslContextOption: SSLContextOption = TryDefaultSSLContext): BlazeClientBuilder[F] =
+      executionContext: ExecutionContext): BlazeClientBuilder[F] =
     new BlazeClientBuilder[F](
       responseHeaderTimeout = Duration.Inf,
       idleTimeout = 1.minute,
@@ -312,7 +307,7 @@ object BlazeClientBuilder {
       maxTotalConnections = 10,
       maxWaitQueueLimit = 256,
       maxConnectionsPerRequestKey = Function.const(256),
-      sslContext = toMaybeSSLContext(sslContextOption),
+      sslContext = toMaybeSSLContext(TryDefaultSSLContext),
       checkEndpointIdentification = true,
       maxResponseLineSize = 4096,
       maxHeaderLength = 40960,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -279,30 +279,30 @@ object BlazeClientBuilder {
   sealed trait SSLContextOption
   object SSLContextOption {
     case object NoSSL extends SSLContextOption
-    case object TryDefaultSSLContextOrNone extends SSLContextOption
+    case object TryDefaultSSLContext extends SSLContextOption
     final case class Provided(sslContext: SSLContext) extends SSLContextOption
 
     def toMaybeSSLContext(sco: SSLContextOption): Option[SSLContext] =
       sco match {
         case SSLContextOption.NoSSL => None
-        case SSLContextOption.TryDefaultSSLContextOrNone => tryDefaultSslContext
+        case SSLContextOption.TryDefaultSSLContext => tryDefaultSslContext
         case SSLContextOption.Provided(context) => Some(context)
       }
   }
 
-  import SSLContextOption.{TryDefaultSSLContextOrNone, toMaybeSSLContext}
+  import SSLContextOption.{TryDefaultSSLContext, toMaybeSSLContext}
 
   /** Creates a BlazeClientBuilder
     *
     * @param executionContext the ExecutionContext for blaze's internal Futures
     * @param sslContextOption indicates how to resolve SSLContext. The sum type offers three options:
-    *                         NoSSL                      = do not use SSL/HTTPS
-    *                         TryDefaultSSLContextOrNone = `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
-    *                         Provided                   = use the explicitly passed SSLContext
+    *                         NoSSL                = do not use SSL/HTTPS
+    *                         TryDefaultSSLContext = `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
+    *                         Provided             = use the explicitly passed SSLContext
     */
   def apply[F[_]: ConcurrentEffect](
       executionContext: ExecutionContext,
-      sslContextOption: SSLContextOption = TryDefaultSSLContextOrNone): BlazeClientBuilder[F] =
+      sslContextOption: SSLContextOption = TryDefaultSSLContext): BlazeClientBuilder[F] =
     new BlazeClientBuilder[F](
       responseHeaderTimeout = Duration.Inf,
       idleTimeout = 1.minute,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -148,9 +148,13 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     withSslContext(SSLContext.getDefault())
 
   /** Use some provided `SSLContext` when making secure calls, or disable secure calls with `None` */
-  @deprecated(message = "Use withDefaultSslContext, withSslContext or withoutSslContext to set the SSLContext", since = "1.0.0")
+  @deprecated(
+    message =
+      "Use withDefaultSslContext, withSslContext or withoutSslContext to set the SSLContext",
+    since = "1.0.0")
   def withSslContextOption(sslContext: Option[SSLContext]): BlazeClientBuilder[F] =
-    copy(sslContext = sslContext.fold[SSLContextOption](SSLContextOption.NoSSL)(SSLContextOption.Provided))
+    copy(sslContext =
+      sslContext.fold[SSLContextOption](SSLContextOption.NoSSL)(SSLContextOption.Provided))
 
   /** Disable secure calls */
   def withoutSslContext: BlazeClientBuilder[F] =
@@ -285,8 +289,8 @@ object BlazeClientBuilder {
     *  * TryDefaultSSLContext = `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
     *  * Provided             = use the explicitly passed SSLContext
     */
-  private [blaze] sealed trait SSLContextOption extends Product with Serializable
-  private [blaze] object SSLContextOption {
+  private[blaze] sealed trait SSLContextOption extends Product with Serializable
+  private[blaze] object SSLContextOption {
     case object NoSSL extends SSLContextOption
     case object TryDefaultSSLContext extends SSLContextOption
     final case class Provided(sslContext: SSLContext) extends SSLContextOption

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -276,7 +276,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
 object BlazeClientBuilder {
 
-  sealed trait SSLContextOption
+  sealed trait SSLContextOption extends Product with Serializable
   object SSLContextOption {
     case object NoSSL extends SSLContextOption
     case object TryDefaultSSLContext extends SSLContextOption

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -333,6 +333,18 @@ object BlazeClientBuilder {
       channelOptions = ChannelOptions(Vector.empty)
     ) {}
 
+  /** Creates a BlazeClientBuilder
+    *
+    * @param executionContext the ExecutionContext for blaze's internal Futures
+    * @param sslContext Some `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
+    */
+  @deprecated(message = "Use BlazeClientBuilder#apply(ExecutionContext).", since = "1.0.0")
+  def apply[F[_]: ConcurrentEffect](executionContext: ExecutionContext, sslContext: Option[SSLContext] = tryDefaultSslContext): BlazeClientBuilder[F] =
+    sslContext match {
+      case None => apply(executionContext).withoutSslContext
+      case Some(sslCtx) => apply(executionContext).withSslContext(sslCtx)
+    }
+
   private def tryDefaultSslContext: Option[SSLContext] =
     try Some(SSLContext.getDefault())
     catch {

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -283,25 +283,6 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
 object BlazeClientBuilder {
 
-  /**
-    * Indicates how to resolve SSLContext.
-    *  * NoSSL                = do not use SSL/HTTPS
-    *  * TryDefaultSSLContext = `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
-    *  * Provided             = use the explicitly passed SSLContext
-    */
-  private[blaze] sealed trait SSLContextOption extends Product with Serializable
-  private[blaze] object SSLContextOption {
-    case object NoSSL extends SSLContextOption
-    case object TryDefaultSSLContext extends SSLContextOption
-    final case class Provided(sslContext: SSLContext) extends SSLContextOption
-
-    def toMaybeSSLContext(sco: SSLContextOption): Option[SSLContext] =
-      sco match {
-        case SSLContextOption.NoSSL => None
-        case SSLContextOption.TryDefaultSSLContext => tryDefaultSslContext
-        case SSLContextOption.Provided(context) => Some(context)
-      }
-  }
 
   import SSLContextOption.TryDefaultSSLContext
 
@@ -345,11 +326,5 @@ object BlazeClientBuilder {
     sslContext match {
       case None => apply(executionContext).withoutSslContext
       case Some(sslCtx) => apply(executionContext).withSslContext(sslCtx)
-    }
-
-  private def tryDefaultSslContext: Option[SSLContext] =
-    try Some(SSLContext.getDefault())
-    catch {
-      case NonFatal(_) => None
     }
 }

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -147,10 +147,6 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   def withDefaultSslContext: BlazeClientBuilder[F] =
     withSslContext(SSLContext.getDefault())
 
-  /** Use some provided `SSLContext` when making secure calls, or disable secure calls with `None` */
-  def withSslContextOption(sslContext: Option[SSLContext]): BlazeClientBuilder[F] =
-    copy(sslContext = sslContext)
-
   /** Disable secure calls */
   def withoutSslContext: BlazeClientBuilder[F] =
     copy(sslContext = SSLContextOption.NoSSL)

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -296,7 +296,7 @@ object BlazeClientBuilder {
       }
   }
 
-  import SSLContextOption.{TryDefaultSSLContext, toMaybeSSLContext}
+  import SSLContextOption.TryDefaultSSLContext
 
   /** Creates a BlazeClientBuilder
     *

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -24,7 +24,6 @@ import org.log4s.getLogger
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.control.NonFatal
 
 /**
   * @param sslContext Some custom `SSLContext`, or `None` if the

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -285,8 +285,8 @@ object BlazeClientBuilder {
     *  * TryDefaultSSLContext = `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
     *  * Provided             = use the explicitly passed SSLContext
     */
-  sealed trait SSLContextOption extends Product with Serializable
-  object SSLContextOption {
+  private [blaze] sealed trait SSLContextOption extends Product with Serializable
+  private [blaze] object SSLContextOption {
     case object NoSSL extends SSLContextOption
     case object TryDefaultSSLContext extends SSLContextOption
     final case class Provided(sslContext: SSLContext) extends SSLContextOption

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -276,6 +276,12 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
 object BlazeClientBuilder {
 
+  /**
+    * Indicates how to resolve SSLContext.
+    *  * NoSSL                = do not use SSL/HTTPS
+    *  * TryDefaultSSLContext = `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
+    *  * Provided             = use the explicitly passed SSLContext
+    */
   sealed trait SSLContextOption extends Product with Serializable
   object SSLContextOption {
     case object NoSSL extends SSLContextOption

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -310,7 +310,7 @@ object BlazeClientBuilder {
       maxTotalConnections = 10,
       maxWaitQueueLimit = 256,
       maxConnectionsPerRequestKey = Function.const(256),
-      sslContext = toMaybeSSLContext(TryDefaultSSLContext),
+      sslContext = TryDefaultSSLContext,
       checkEndpointIdentification = true,
       maxResponseLineSize = 4096,
       maxHeaderLength = 40960,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -302,8 +302,7 @@ object BlazeClientBuilder {
     *
     * @param executionContext the ExecutionContext for blaze's internal Futures
     */
-  def apply[F[_]: ConcurrentEffect](
-      executionContext: ExecutionContext): BlazeClientBuilder[F] =
+  def apply[F[_]: ConcurrentEffect](executionContext: ExecutionContext): BlazeClientBuilder[F] =
     new BlazeClientBuilder[F](
       responseHeaderTimeout = Duration.Inf,
       idleTimeout = 1.minute,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -280,7 +280,7 @@ object BlazeClientBuilder {
   object SSLContextOption {
     case object NoSSL extends SSLContextOption
     case object TryDefaultSSLContextOrNone extends SSLContextOption
-    final case class Provided(SSLContext: SSLContext) extends SSLContextOption
+    final case class Provided(sslContext: SSLContext) extends SSLContextOption
 
     def toMaybeSSLContext(sco: SSLContextOption): Option[SSLContext] =
       sco match {

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -147,6 +147,10 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   def withDefaultSslContext: BlazeClientBuilder[F] =
     withSslContext(SSLContext.getDefault())
 
+  /** Use some provided `SSLContext` when making secure calls, or disable secure calls with `None` */
+  def withSslContextOption(sslContext: Option[SSLContext]): BlazeClientBuilder[F] =
+    copy(sslContext = sslContext)
+
   /** Disable secure calls */
   def withoutSslContext: BlazeClientBuilder[F] =
     copy(sslContext = SSLContextOption.NoSSL)

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -57,6 +57,8 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
   final protected val logger = getLogger(this.getClass)
 
+  import BlazeClientBuilder.SSLContextOption
+
   private def copy(
       responseHeaderTimeout: Duration = responseHeaderTimeout,
       idleTimeout: Duration = idleTimeout,
@@ -66,7 +68,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
       maxTotalConnections: Int = maxTotalConnections,
       maxWaitQueueLimit: Int = maxWaitQueueLimit,
       maxConnectionsPerRequestKey: RequestKey => Int = maxConnectionsPerRequestKey,
-      sslContext: Option[SSLContext] = sslContext,
+      sslContext: SSLContextOption = sslContext,
       checkEndpointIdentification: Boolean = checkEndpointIdentification,
       maxResponseLineSize: Int = maxResponseLineSize,
       maxHeaderLength: Int = maxHeaderLength,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -148,8 +148,9 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     withSslContext(SSLContext.getDefault())
 
   /** Use some provided `SSLContext` when making secure calls, or disable secure calls with `None` */
+  @deprecated(message = "Use withDefaultSslContext, withSslContext or withoutSslContext to set the SSLContext", since = "1.0.0")
   def withSslContextOption(sslContext: Option[SSLContext]): BlazeClientBuilder[F] =
-    copy(sslContext = sslContext)
+    copy(sslContext = sslContext.fold[SSLContextOption](SSLContextOption.NoSSL)(SSLContextOption.Provided))
 
   /** Disable secure calls */
   def withoutSslContext: BlazeClientBuilder[F] =

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -276,6 +276,18 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
 object BlazeClientBuilder {
 
+  sealed trait SSLContextOption
+  object SSLContextOption {
+    case object NoSSL                                 extends SSLContextOption
+    case object TryDefaultSSLContextOrNone            extends SSLContextOption
+    final case class Provided(SSLContext: SSLContext) extends SSLContextOption
+
+    def toMaybeSSLContext(sco: SSLContextOption): Option[SSLContext] = sco match {
+      case SSLContextOption.NoSSL => None
+      case SSLContextOption.TryDefaultSSLContextOrNone =>tryDefaultSslContext
+      case SSLContextOption.Provided(context) => Some(context)
+    }
+  }
   /** Creates a BlazeClientBuilder
     *
     * @param executionContext the ExecutionContext for blaze's internal Futures

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -38,7 +38,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     val maxTotalConnections: Int,
     val maxWaitQueueLimit: Int,
     val maxConnectionsPerRequestKey: RequestKey => Int,
-    val sslContext: Option[SSLContext],
+    val sslContext: BlazeClientBuilder.SSLContextOption,
     val checkEndpointIdentification: Boolean,
     val maxResponseLineSize: Int,
     val maxHeaderLength: Int,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -339,7 +339,9 @@ object BlazeClientBuilder {
     * @param sslContext Some `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
     */
   @deprecated(message = "Use BlazeClientBuilder#apply(ExecutionContext).", since = "1.0.0")
-  def apply[F[_]: ConcurrentEffect](executionContext: ExecutionContext, sslContext: Option[SSLContext] = tryDefaultSslContext): BlazeClientBuilder[F] =
+  def apply[F[_]: ConcurrentEffect](
+      executionContext: ExecutionContext,
+      sslContext: Option[SSLContext] = tryDefaultSslContext): BlazeClientBuilder[F] =
     sslContext match {
       case None => apply(executionContext).withoutSslContext
       case Some(sslCtx) => apply(executionContext).withSslContext(sslCtx)

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -17,6 +17,7 @@ import org.http4s.blaze.channel.ChannelOptions
 import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.blazecore.{BlazeBackendBuilder, tickWheelResource}
 import org.http4s.headers.`User-Agent`
+import org.http4s.internal.SSLContextOption
 import org.http4s.ProductId
 import org.http4s.internal.BackendBuilder
 import org.log4s.getLogger
@@ -38,7 +39,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     val maxTotalConnections: Int,
     val maxWaitQueueLimit: Int,
     val maxConnectionsPerRequestKey: RequestKey => Int,
-    val sslContext: BlazeClientBuilder.SSLContextOption,
+    val sslContext: SSLContextOption,
     val checkEndpointIdentification: Boolean,
     val maxResponseLineSize: Int,
     val maxHeaderLength: Int,
@@ -56,8 +57,6 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   type Self = BlazeClientBuilder[F]
 
   final protected val logger = getLogger(this.getClass)
-
-  import BlazeClientBuilder.SSLContextOption
 
   private def copy(
       responseHeaderTimeout: Duration = responseHeaderTimeout,
@@ -283,9 +282,6 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
 
 object BlazeClientBuilder {
 
-
-  import SSLContextOption.TryDefaultSSLContext
-
   /** Creates a BlazeClientBuilder
     *
     * @param executionContext the ExecutionContext for blaze's internal Futures
@@ -300,7 +296,7 @@ object BlazeClientBuilder {
       maxTotalConnections = 10,
       maxWaitQueueLimit = 256,
       maxConnectionsPerRequestKey = Function.const(256),
-      sslContext = TryDefaultSSLContext,
+      sslContext = SSLContextOption.TryDefaultSSLContext,
       checkEndpointIdentification = true,
       maxResponseLineSize = 4096,
       maxHeaderLength = 40960,
@@ -322,7 +318,8 @@ object BlazeClientBuilder {
   @deprecated(message = "Use BlazeClientBuilder#apply(ExecutionContext).", since = "1.0.0")
   def apply[F[_]: ConcurrentEffect](
       executionContext: ExecutionContext,
-      sslContext: Option[SSLContext] = tryDefaultSslContext): BlazeClientBuilder[F] =
+      sslContext: Option[SSLContext] = SSLContextOption.tryDefaultSslContext)
+      : BlazeClientBuilder[F] =
     sslContext match {
       case None => apply(executionContext).withoutSslContext
       case Some(sslCtx) => apply(executionContext).withSslContext(sslCtx)

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -11,7 +11,7 @@ package blaze
 import cats.effect._
 import fs2.Stream
 import org.http4s.blaze.channel.ChannelOptions
-import org.http4s.client.blaze.BlazeClientBuilder.SSLContextOption
+import org.http4s.internal.SSLContextOption
 
 import scala.concurrent.duration.Duration
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -11,6 +11,7 @@ package blaze
 import cats.effect._
 import fs2.Stream
 import org.http4s.blaze.channel.ChannelOptions
+import org.http4s.client.blaze.BlazeClientBuilder.SSLContextOption
 
 import scala.concurrent.duration.Duration
 
@@ -25,7 +26,7 @@ object Http1Client {
   private def resource[F[_]](config: BlazeClientConfig)(implicit
       F: ConcurrentEffect[F]): Resource[F, Client[F]] = {
     val http1: ConnectionBuilder[F, BlazeConnection[F]] = new Http1Support(
-      sslContextOption = config.sslContext,
+      sslContextOption = config.sslContext.fold[SSLContextOption](SSLContextOption.NoSSL)(SSLContextOption.Provided),
       bufferSize = config.bufferSize,
       asynchronousChannelGroup = config.group,
       executionContext = config.executionContext,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -26,7 +26,8 @@ object Http1Client {
   private def resource[F[_]](config: BlazeClientConfig)(implicit
       F: ConcurrentEffect[F]): Resource[F, Client[F]] = {
     val http1: ConnectionBuilder[F, BlazeConnection[F]] = new Http1Support(
-      sslContextOption = config.sslContext.fold[SSLContextOption](SSLContextOption.NoSSL)(SSLContextOption.Provided),
+      sslContextOption =
+        config.sslContext.fold[SSLContextOption](SSLContextOption.NoSSL)(SSLContextOption.Provided),
       bufferSize = config.bufferSize,
       asynchronousChannelGroup = config.group,
       executionContext = config.executionContext,

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -19,7 +19,7 @@ import org.http4s.blaze.channel.nio2.ClientChannelFactory
 import org.http4s.blaze.pipeline.stages.SSLStage
 import org.http4s.blaze.pipeline.{Command, LeafBuilder}
 import org.http4s.blaze.util.TickWheelExecutor
-import org.http4s.client.blaze.BlazeClientBuilder.SSLContextOption
+import org.http4s.internal.SSLContextOption
 import org.http4s.headers.`User-Agent`
 import org.http4s.blazecore.util.fromFutureNoShift
 import scala.concurrent.duration.Duration

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -19,6 +19,7 @@ import org.http4s.blaze.channel.nio2.ClientChannelFactory
 import org.http4s.blaze.pipeline.stages.SSLStage
 import org.http4s.blaze.pipeline.{Command, LeafBuilder}
 import org.http4s.blaze.util.TickWheelExecutor
+import org.http4s.client.blaze.BlazeClientBuilder.SSLContextOption
 import org.http4s.headers.`User-Agent`
 import org.http4s.blazecore.util.fromFutureNoShift
 import scala.concurrent.duration.Duration
@@ -28,7 +29,7 @@ import scala.util.{Failure, Success}
 /** Provides basic HTTP1 pipeline building
   */
 final private class Http1Support[F[_]](
-    sslContextOption: Option[SSLContext],
+    sslContextOption: SSLContextOption,
     bufferSize: Int,
     asynchronousChannelGroup: Option[AsynchronousChannelGroup],
     executionContext: ExecutionContext,
@@ -94,7 +95,11 @@ final private class Http1Support[F[_]](
     val builder = LeafBuilder(t).prepend(new ReadBufferStage[ByteBuffer])
     requestKey match {
       case RequestKey(Uri.Scheme.https, auth) =>
-        sslContextOption match {
+
+        val maybeSSLContext: Option[SSLContext] =
+          SSLContextOption.toMaybeSSLContext(sslContextOption)
+
+        maybeSSLContext match {
           case Some(sslContext) =>
             val eng = sslContext.createSSLEngine(auth.host.value, auth.port.getOrElse(443))
             eng.setUseClientMode(true)

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -95,7 +95,6 @@ final private class Http1Support[F[_]](
     val builder = LeafBuilder(t).prepend(new ReadBufferStage[ByteBuffer])
     requestKey match {
       case RequestKey(Uri.Scheme.https, auth) =>
-
         val maybeSSLContext: Option[SSLContext] =
           SSLContextOption.toMaybeSSLContext(sslContextOption)
 

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -51,13 +51,11 @@ class BlazeClientSpec extends Http4sSpec with Http4sLegacyMatchersIO {
         .withChunkBufferMaxSize(chunkBufferMaxSize)
         .withScheduler(scheduler = tickWheel)
 
-
     val builderWithMaybeSSLContext: BlazeClientBuilder[IO] =
-      sslContextOption.fold[BlazeClientBuilder[IO]](builder.withoutSslContext)(builder.withSslContext)
+      sslContextOption.fold[BlazeClientBuilder[IO]](builder.withoutSslContext)(
+        builder.withSslContext)
 
-
-    builderWithMaybeSSLContext
-      .resource
+    builderWithMaybeSSLContext.resource
   }
 
   private def testServlet =

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -40,17 +40,25 @@ class BlazeClientSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       requestTimeout: Duration = 45.seconds,
       chunkBufferMaxSize: Int = 1024,
       sslContextOption: Option[SSLContext] = Some(bits.TrustingSslContext)
-  ) =
-    BlazeClientBuilder[IO](testExecutionContext)
-      .withSslContextOption(sslContextOption)
-      .withCheckEndpointAuthentication(false)
-      .withResponseHeaderTimeout(responseHeaderTimeout)
-      .withRequestTimeout(requestTimeout)
-      .withMaxTotalConnections(maxTotalConnections)
-      .withMaxConnectionsPerRequestKey(Function.const(maxConnectionsPerRequestKey))
-      .withChunkBufferMaxSize(chunkBufferMaxSize)
-      .withScheduler(scheduler = tickWheel)
+  ) = {
+    val builder: BlazeClientBuilder[IO] =
+      BlazeClientBuilder[IO](testExecutionContext)
+        .withCheckEndpointAuthentication(false)
+        .withResponseHeaderTimeout(responseHeaderTimeout)
+        .withRequestTimeout(requestTimeout)
+        .withMaxTotalConnections(maxTotalConnections)
+        .withMaxConnectionsPerRequestKey(Function.const(maxConnectionsPerRequestKey))
+        .withChunkBufferMaxSize(chunkBufferMaxSize)
+        .withScheduler(scheduler = tickWheel)
+
+
+    val builderWithMaybeSSLContext: BlazeClientBuilder[IO] =
+      sslContextOption.fold[BlazeClientBuilder[IO]](builder.withoutSslContext)(builder.withSslContext)
+
+
+    builderWithMaybeSSLContext
       .resource
+  }
 
   private def testServlet =
     new HttpServlet {

--- a/core/src/main/scala/org/http4s/internal/SSLContextOption.scala
+++ b/core/src/main/scala/org/http4s/internal/SSLContextOption.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.internal
+
+import javax.net.ssl.SSLContext
+import scala.util.control.NonFatal
+
+/**
+  * Indicates how to resolve SSLContext.
+  *  * NoSSL                = do not use SSL/HTTPS
+  *  * TryDefaultSSLContext = `SSLContext.getDefault()`, or `None` on systems where the default is unavailable
+  *  * Provided             = use the explicitly passed SSLContext
+  */
+private[http4s] sealed trait SSLContextOption extends Product with Serializable
+private[http4s] object SSLContextOption {
+  case object NoSSL extends SSLContextOption
+  case object TryDefaultSSLContext extends SSLContextOption
+  final case class Provided(sslContext: SSLContext) extends SSLContextOption
+
+  def toMaybeSSLContext(sco: SSLContextOption): Option[SSLContext] =
+    sco match {
+      case SSLContextOption.NoSSL => None
+      case SSLContextOption.TryDefaultSSLContext => tryDefaultSslContext
+      case SSLContextOption.Provided(context) => Some(context)
+    }
+
+  def tryDefaultSslContext: Option[SSLContext] =
+    try Some(SSLContext.getDefault())
+    catch {
+      case NonFatal(_) => None
+    }
+}


### PR DESCRIPTION
Follows up on https://github.com/http4s/http4s/issues/2431#issuecomment-627474729.

Ross suggested using a sum type in https://github.com/http4s/http4s/issues/2431#issuecomment-496961469. Today, my teammates got confused at the `Option[SSLContext]`'s behavior when upgrading from 0.20.x -> 0.21.4 in `http4s`. 

Those two served as motivations to open this PR.

Hi @rossabaker - please take a look. Thanks!