### PR TITLE
Upgrade to tomcat-9.0.35

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -216,7 +216,7 @@ object Http4sPlugin extends AutoPlugin {
     val scalaXml = "1.3.0"
     val servlet = "3.1.0"
     val specs2 = "4.9.3"
-    val tomcat = "9.0.34"
+    val tomcat = "9.0.35"
     val treehugger = "0.4.4"
     val twirl = "1.4.2"
     val vault = "2.0.0"

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -182,11 +182,11 @@ sealed class TomcatBuilder[F[_]] private (
       val conn = tomcat.getConnector()
       sslConfig.configureConnector(conn)
 
-      conn.setAttribute("address", socketAddress.getHostString)
+      conn.setProperty("address", socketAddress.getHostString)
       conn.setPort(socketAddress.getPort)
-      conn.setAttribute(
+      conn.setProperty(
         "connection_pool_timeout",
-        if (idleTimeout.isFinite) idleTimeout.toSeconds.toInt else 0)
+        (if (idleTimeout.isFinite) idleTimeout.toSeconds.toInt else 0).toString)
 
       externalExecutor.foreach { ee =>
         conn.getProtocolHandler match {
@@ -260,13 +260,13 @@ object TomcatBuilder {
     def configureConnector(conn: Connector) = {
       conn.setSecure(true)
       conn.setScheme("https")
-      conn.setAttribute("SSLEnabled", true)
+      conn.setProperty("SSLEnabled", "true")
 
       // TODO These configuration properties are all deprecated
-      conn.setAttribute("keystoreFile", keyStore.path)
-      conn.setAttribute("keystorePass", keyStore.password)
-      conn.setAttribute("keyPass", keyManagerPassword)
-      conn.setAttribute(
+      conn.setProperty("keystoreFile", keyStore.path)
+      conn.setProperty("keystorePass", keyStore.password)
+      conn.setProperty("keyPass", keyManagerPassword)
+      conn.setProperty(
         "clientAuth",
         clientAuth match {
           case SSLClientAuthMode.Required => "required"
@@ -274,10 +274,10 @@ object TomcatBuilder {
           case SSLClientAuthMode.NotRequested => "none"
         }
       )
-      conn.setAttribute("sslProtocol", protocol)
+      conn.setProperty("sslProtocol", protocol)
       trustStore.foreach { ts =>
-        conn.setAttribute("truststoreFile", ts.path)
-        conn.setAttribute("truststorePass", ts.password)
+        conn.setProperty("truststoreFile", ts.path)
+        conn.setProperty("truststorePass", ts.password)
       }
     }
     def isSecure = true


### PR DESCRIPTION
There are a bunch of deprecated attributes not yet migrated. This just takes care of migrating the object values so we can keep current without abandoning fatal warnings.

Supersedes #3413.