### PR TITLE
Fix dotty runtime error

### DIFF
--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -75,7 +75,7 @@ class FollowRedirectSpec
       ) = {
         val u = uri("http://localhost") / status.code.toString
         val req: Request[IO] = method match {
-          case _: Method.IsPermitsBody if body.nonEmpty =>
+          case (POST | PUT) if body.nonEmpty =>
             val bodyBytes = body.getBytes.toList
             Request[IO](
               method,

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -75,7 +75,7 @@ class FollowRedirectSpec
       ) = {
         val u = uri("http://localhost") / status.code.toString
         val req: Request[IO] = method match {
-          case _: Method.PermitsBody if body.nonEmpty =>
+          case _: Method.IsPermitsBody if body.nonEmpty =>
             val bodyBytes = body.getBytes.toList
             Request[IO](
               method,

--- a/core/src/main/scala/org/http4s/Method.scala
+++ b/core/src/main/scala/org/http4s/Method.scala
@@ -44,8 +44,8 @@ object Method {
   }
 
   // Type tags for a method allowing a body or not
-  sealed trait PermitsBody
-  sealed trait NoBody
+  sealed trait PermitsBody { _: Method => }
+  sealed trait NoBody { _: Method => }
 
   def fromString(s: String): ParseResult[Method] =
     allByKey.getOrElse(

--- a/core/src/main/scala/org/http4s/Method.scala
+++ b/core/src/main/scala/org/http4s/Method.scala
@@ -44,8 +44,8 @@ object Method {
   }
 
   // Type tags for a method allowing a body or not
-  sealed trait PermitsBody extends Method
-  sealed trait NoBody extends Method
+  sealed trait PermitsBody
+  sealed trait NoBody
 
   def fromString(s: String): ParseResult[Method] =
     allByKey.getOrElse(

--- a/core/src/main/scala/org/http4s/Method.scala
+++ b/core/src/main/scala/org/http4s/Method.scala
@@ -46,6 +46,7 @@ object Method {
   // Type tags for a method allowing a body or not
   sealed trait PermitsBody { _: Method => }
   sealed trait NoBody { _: Method => }
+  sealed trait IsPermitsBody extends Method with PermitsBody
 
   def fromString(s: String): ParseResult[Method] =
     allByKey.getOrElse(

--- a/core/src/main/scala/org/http4s/Method.scala
+++ b/core/src/main/scala/org/http4s/Method.scala
@@ -46,7 +46,6 @@ object Method {
   // Type tags for a method allowing a body or not
   sealed trait PermitsBody { _: Method => }
   sealed trait NoBody { _: Method => }
-  sealed trait IsPermitsBody extends Method with PermitsBody
 
   def fromString(s: String): ParseResult[Method] =
     allByKey.getOrElse(


### PR DESCRIPTION
## reproduce
in [`http4s-finagle`](https://github.com/http4s/http4s-finagle)
```
sbt "++ 0.24.0-RC1 test"
```
will get runtime exception
```
May 14, 2020 1:21:20 PM com.twitter.util.RootMonitor$$anonfun$2 applyOrElse
SEVERE: Fatal exception propagated to the root monitor!
java.lang.AbstractMethodError: Method org/http4s/dsl/io$.org$http4s$dsl$impl$Methods$_setter_$GET_$eq(Lorg/http4s/Method$Semantics$Safe;)V is abstract
	at org.http4s.dsl.io$.org$http4s$dsl$impl$Methods$_setter_$GET_$eq(io.scala)
	at org.http4s.dsl.impl.Methods.$init$(Methods.scala:12)
	at org.http4s.dsl.io$.<clinit>(io.scala:11)
```
## fix
publishLocal and rerun `sbt "++ 0.24.0-RC1 test"` in `http4s-finagle`
dotty runtime is not binary compat to initialize `PermitsBody` because it extends an abstract class
well I found it is unnecessary to extends though because all methods are `new Method` extended these two trait, kind of duplicated