### PR TITLE
Deprecate org.http4s.util.threads

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -24,7 +24,7 @@ import org.asynchttpclient.{Request => AsyncRequest, Response => _, _}
 import org.http4s.internal.CollectionCompat.CollectionConverters._
 import org.http4s.internal.invokeCallback
 import org.http4s.internal.bug
-import org.http4s.util.threads._
+import org.http4s.internal.threads._
 import org.log4s.getLogger
 import org.reactivestreams.Publisher
 import _root_.io.netty.handler.codec.http.cookie.Cookie

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeHttp1ClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeHttp1ClientSpec.scala
@@ -9,7 +9,7 @@ package client
 package blaze
 
 import cats.effect.IO
-import org.http4s.util.threads.newDaemonPoolExecutionContext
+import org.http4s.internal.threads.newDaemonPoolExecutionContext
 
 class BlazeHttp1ClientSpec extends ClientRouteTestBattery("BlazeClient") {
   def clientResource =

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -35,10 +35,10 @@ import org.http4s.blaze.pipeline.LeafBuilder
 import org.http4s.blaze.pipeline.stages.SSLStage
 import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.blazecore.{BlazeBackendBuilder, tickWheelResource}
+import org.http4s.internal.threads.threadFactory
 import org.http4s.server.ServerRequestKeys
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import org.http4s.server.blaze.BlazeServerBuilder._
-import org.http4s.util.threads.threadFactory
 import org.log4s.getLogger
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}

--- a/core/src/main/scala/org/http4s/internal/threads.scala
+++ b/core/src/main/scala/org/http4s/internal/threads.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.internal
+
+import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicLong
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+private[http4s] object threads {
+  final case class ThreadPriority(toInt: Int)
+  case object ThreadPriority {
+    val Min = ThreadPriority(Thread.MIN_PRIORITY)
+    val Norm = ThreadPriority(Thread.NORM_PRIORITY)
+    val Max = ThreadPriority(Thread.MAX_PRIORITY)
+  }
+
+  def threadFactory(
+      name: Long => String = { l =>
+        s"http4s-$l"
+      },
+      daemon: Boolean = false,
+      priority: ThreadPriority = ThreadPriority.Norm,
+      uncaughtExceptionHandler: PartialFunction[(Thread, Throwable), Unit] = PartialFunction.empty,
+      backingThreadFactory: ThreadFactory = Executors.defaultThreadFactory
+  ): ThreadFactory =
+    new ThreadFactory {
+      val count = new AtomicLong(0)
+      override def newThread(r: Runnable): Thread = {
+        val thread = backingThreadFactory.newThread(r)
+        thread.setName(name(count.getAndIncrement))
+        thread.setDaemon(daemon)
+        thread.setPriority(priority.toInt)
+        thread.setUncaughtExceptionHandler(new UncaughtExceptionHandler {
+          override def uncaughtException(t: Thread, e: Throwable): Unit =
+            uncaughtExceptionHandler.orElse(fallthrough)((t, e))
+          val fallthrough: PartialFunction[(Thread, Throwable), Unit] = {
+            case (t: Thread, e: Throwable) =>
+              Option(t.getThreadGroup)
+                .getOrElse(Thread.getDefaultUncaughtExceptionHandler)
+                .uncaughtException(t, e)
+          }
+        })
+        thread
+      }
+    }
+
+  def newDaemonPool(
+      name: String,
+      min: Int = 4,
+      cpuFactor: Double = 3.0,
+      timeout: Boolean = false): ThreadPoolExecutor = {
+    val cpus = Runtime.getRuntime.availableProcessors
+    val exec = new ThreadPoolExecutor(
+      math.max(min, cpus),
+      math.max(min, (cpus * cpuFactor).ceil.toInt),
+      10L,
+      TimeUnit.SECONDS,
+      new LinkedBlockingQueue[Runnable],
+      threadFactory(i => s"$name-$i", daemon = true)
+    )
+    exec.allowCoreThreadTimeOut(timeout)
+    exec
+  }
+
+  def newDaemonPoolExecutionContext(
+      name: String,
+      min: Int = 4,
+      cpuFactor: Double = 3.0,
+      timeout: Boolean = false): ExecutionContext =
+    ExecutionContext.fromExecutorService(newDaemonPool(name, min, cpuFactor, timeout))
+
+  def newBlockingPool(name: String): ExecutorService = {
+    val CorePoolSize = 0
+    val MaxPoolSize = Int.MaxValue
+    val KeepAliveTime = 1.minute
+
+    new ThreadPoolExecutor(
+      CorePoolSize,
+      MaxPoolSize,
+      KeepAliveTime.toSeconds,
+      TimeUnit.SECONDS,
+      new SynchronousQueue[Runnable](false),
+      threadFactory(i => s"$name-$i", daemon = true)
+    )
+  }
+}

--- a/core/src/main/scala/org/http4s/util/threads.scala
+++ b/core/src/main/scala/org/http4s/util/threads.scala
@@ -6,12 +6,10 @@
 
 package org.http4s.util
 
-import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent._
-import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 
+@deprecated("Not related to HTTP. Will be removed from public API.", "0.21.5")
 object threads {
   final case class ThreadPriority(toInt: Int)
   case object ThreadPriority {
@@ -28,27 +26,15 @@ object threads {
       priority: ThreadPriority = ThreadPriority.Norm,
       uncaughtExceptionHandler: PartialFunction[(Thread, Throwable), Unit] = PartialFunction.empty,
       backingThreadFactory: ThreadFactory = Executors.defaultThreadFactory
-  ): ThreadFactory =
-    new ThreadFactory {
-      val count = new AtomicLong(0)
-      override def newThread(r: Runnable): Thread = {
-        val thread = backingThreadFactory.newThread(r)
-        thread.setName(name(count.getAndIncrement))
-        thread.setDaemon(daemon)
-        thread.setPriority(priority.toInt)
-        thread.setUncaughtExceptionHandler(new UncaughtExceptionHandler {
-          override def uncaughtException(t: Thread, e: Throwable): Unit =
-            uncaughtExceptionHandler.orElse(fallthrough)((t, e))
-          val fallthrough: PartialFunction[(Thread, Throwable), Unit] = {
-            case (t: Thread, e: Throwable) =>
-              Option(t.getThreadGroup)
-                .getOrElse(Thread.getDefaultUncaughtExceptionHandler)
-                .uncaughtException(t, e)
-          }
-        })
-        thread
-      }
-    }
+  ): ThreadFactory = {
+    val p = org.http4s.internal.threads.ThreadPriority(priority.toInt)
+    org.http4s.internal.threads.threadFactory(
+      name,
+      daemon,
+      p,
+      uncaughtExceptionHandler,
+      backingThreadFactory)
+  }
 
   @deprecated("Use newDaemonPool instead", "0.15.7")
   private[http4s] def newDefaultFixedThreadPool(
@@ -66,39 +52,16 @@ object threads {
       name: String,
       min: Int = 4,
       cpuFactor: Double = 3.0,
-      timeout: Boolean = false): ThreadPoolExecutor = {
-    val cpus = Runtime.getRuntime.availableProcessors
-    val exec = new ThreadPoolExecutor(
-      math.max(min, cpus),
-      math.max(min, (cpus * cpuFactor).ceil.toInt),
-      10L,
-      TimeUnit.SECONDS,
-      new LinkedBlockingQueue[Runnable],
-      threadFactory(i => s"$name-$i", daemon = true)
-    )
-    exec.allowCoreThreadTimeOut(timeout)
-    exec
-  }
+      timeout: Boolean = false): ThreadPoolExecutor =
+    org.http4s.internal.threads.newDaemonPool(name, min, cpuFactor, timeout)
 
   private[http4s] def newDaemonPoolExecutionContext(
       name: String,
       min: Int = 4,
       cpuFactor: Double = 3.0,
       timeout: Boolean = false): ExecutionContext =
-    ExecutionContext.fromExecutorService(newDaemonPool(name, min, cpuFactor, timeout))
+    org.http4s.internal.threads.newDaemonPoolExecutionContext(name, min, cpuFactor, timeout)
 
-  private[http4s] def newBlockingPool(name: String): ExecutorService = {
-    val CorePoolSize = 0
-    val MaxPoolSize = Int.MaxValue
-    val KeepAliveTime = 1.minute
-
-    new ThreadPoolExecutor(
-      CorePoolSize,
-      MaxPoolSize,
-      KeepAliveTime.toSeconds,
-      TimeUnit.SECONDS,
-      new SynchronousQueue[Runnable](false),
-      threadFactory(i => s"$name-$i", daemon = true)
-    )
-  }
+  private[http4s] def newBlockingPool(name: String): ExecutorService =
+    org.http4s.internal.threads.newBlockingPool(name)
 }

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -15,8 +15,8 @@ import cats.implicits._
 import fs2._
 import fs2.text._
 import java.util.concurrent.{ScheduledExecutorService, ScheduledThreadPoolExecutor, TimeUnit}
+import org.http4s.internal.threads.{newBlockingPool, newDaemonPool, threadFactory}
 import org.http4s.laws.discipline.ArbitraryInstances
-import org.http4s.util.threads.{newBlockingPool, newDaemonPool, threadFactory}
 import org.scalacheck._
 import org.scalacheck.util.{FreqMap, Pretty}
 import org.specs2.ScalaCheck


### PR DESCRIPTION
Another detestable PR in the name of binary compatibility.  Part of the process of moving our util package into proper public libraries, or tucking it away where we can change it at will.