### PR TITLE
Deprecate org.http4s.util.hashLower

### DIFF
--- a/core/src/main/scala/org/http4s/TransferCoding.scala
+++ b/core/src/main/scala/org/http4s/TransferCoding.scala
@@ -12,6 +12,7 @@ package org.http4s
 
 import cats.data.NonEmptyList
 import cats.{Order, Show}
+import org.http4s.internal.hashLower
 import org.http4s.internal.parboiled2.{Parser => PbParser}
 import org.http4s.parser.{Http4sParser, Rfc2616BasicRules}
 import org.http4s.util._

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -16,7 +16,7 @@ import java.net.{Inet4Address, Inet6Address, InetAddress}
 import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{Charset => JCharset}
 import java.nio.charset.StandardCharsets
-import org.http4s.internal.bug
+import org.http4s.internal.{bug, hashLower}
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
 import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit, HexDigit}
 import org.http4s.parser._

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -186,4 +186,21 @@ package object internal {
   private[http4s] def bug(message: String): AssertionError =
     new AssertionError(
       s"This is a bug. Please report to https://github.com/http4s/http4s/issues: ${message}")
+
+  // TODO Remove in 1.0. We can do better with MurmurHash3.
+  private[http4s] def hashLower(s: String): Int = {
+    var h = 0
+    var i = 0
+    val len = s.length
+    while (i < len) {
+      // Strings are equal igoring case if either their uppercase or lowercase
+      // forms are equal. Equality of one does not imply the other, so we need
+      // to go in both directions. A character is not guaranteed to make this
+      // round trip, but it doesn't matter as long as all equal characters
+      // hash the same.
+      h = h * 31 + Character.toLowerCase(Character.toUpperCase(s.charAt(i)))
+      i += 1
+    }
+    h
+  }
 }

--- a/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
+++ b/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
@@ -7,6 +7,7 @@
 package org.http4s.util
 
 import cats.{Monoid, Order, Show}
+import org.http4s.internal.hashLower
 
 /**
   * A String wrapper such that two strings `x` and `y` are equal if

--- a/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
+++ b/core/src/main/scala/org/http4s/util/CaseInsensitiveString.scala
@@ -7,7 +7,7 @@
 package org.http4s.util
 
 import cats.{Monoid, Order, Show}
-import org.http4s.internal.hashLower
+import org.http4s.internal.{hashLower => ciHash}
 
 /**
   * A String wrapper such that two strings `x` and `y` are equal if
@@ -25,7 +25,7 @@ sealed class CaseInsensitiveString private (val value: String)
   private[this] var hash = 0
   override def hashCode(): Int = {
     if (hash == 0)
-      hash = hashLower(value)
+      hash = ciHash(value)
     hash
   }
 

--- a/core/src/main/scala/org/http4s/util/package.scala
+++ b/core/src/main/scala/org/http4s/util/package.scala
@@ -93,6 +93,7 @@ package object util {
   /* This is nearly identical to the hashCode of java.lang.String, but converting
    * to lower case on the fly to avoid copying `value`'s character storage.
    */
+  @deprecated("Not a good hash. Prefer org.typelevel.ci.CIString.", "0.21.5")
   def hashLower(s: String): Int = {
     var h = 0
     var i = 0


### PR DESCRIPTION
1. This is not a great hash. We've done much better in typelevel/case-insensitive#19.
2. It shouldn't be public API anyway.

In a followup, we should fix `Scheme` and `TransferCoding` to just use a `CIString`.