### PR TITLE
Fix the crash of the GZip client middleware when processing a HEAD response

### DIFF
--- a/client/src/test/scala/org/http4s/client/middleware/GZipSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/GZipSpec.scala
@@ -26,7 +26,7 @@ class GZipSpec extends Http4sSpec {
     "return data correctly" in {
       val body = gzipClient.get(Uri.unsafeFromString("/gziptest")) { response =>
         response.status must_== Status.Ok
-        response.headers.get(`Content-Encoding`) must beNone
+        response.headers.get(`Content-Encoding`) must beSome(`Content-Encoding`(ContentCoding.gzip))
 
         response.as[String]
       }
@@ -38,7 +38,7 @@ class GZipSpec extends Http4sSpec {
       val request = Request[IO](method = Method.HEAD, uri = Uri.unsafeFromString("/gziptest"))
       val response = gzipClient.fetch[String](request) { response =>
         response.status must_== Status.Ok
-        response.headers.get(`Content-Encoding`) must beNone
+        response.headers.get(`Content-Encoding`) must beSome(`Content-Encoding`(ContentCoding.gzip))
 
         response.as[String]
       }


### PR DESCRIPTION
This PR attempts to solve the ["GZip client middleware crashes when processing an HTTP HEAD response"](https://github.com/http4s/http4s/issues/3452) issue. 

I couldn't reproduce the issue with a unit test in `client/middleware/GZipSpec.scala ` because it seems like when generating an `Ok()` or `NoContent()` response, the http4s server puts an empty string in the response body which GZip server middleware tries to compress, and then the GZip client middleware decompresses that empty string and the test passes. I used the Scala ammonite script specified in the issue description to test the issue.

Since there is no  way to check if a stream is empty unless it is consumed, the decompression is allowed to run on the response stream and then handle the reported errors. I checked what errors are reported by `fs2.compression.gunzip` and `fs2.compression.deflate` methods and found that only `fs2.compression.gunzip` reports an error [when the stream is empty (the mandatory gzip header is missing)](https://github.com/functional-streams-for-scala/fs2/blob/099a3a1a996eecb2a9827705ee4bdcc9ed887cda/core/jvm/src/main/scala/fs2/compression.scala#L727) by raising `EOFException`; the `deflate` method seems to handle normally an empty stream. So, to fix the issue, this PR tries to handle the `EOFException` and not crash if this error is expected when processing a response from a HEAD request, because the body is usually empty.