### PR TITLE
DRY (Don't Repeat Yourself) up Logger#logMessage

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -32,5 +32,6 @@ object Logger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
       log: String => F[Unit])(implicit F: Sync[F]): F[Unit] =
-    org.http4s.internal.Logger.logMessage[F, A](message)(logHeaders, logBody, redactHeadersWhen)(log)
+    org.http4s.internal.Logger
+      .logMessage[F, A](message)(logHeaders, logBody, redactHeadersWhen)(log)
 }

--- a/client/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -9,8 +9,6 @@ package client
 package middleware
 
 import cats.effect._
-import cats.implicits._
-import fs2._
 import org.http4s.util.CaseInsensitiveString
 
 /**
@@ -33,48 +31,6 @@ object Logger {
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
-      log: String => F[Unit])(implicit F: Sync[F]): F[Unit] = {
-    val charset = message.charset
-    val isBinary = message.contentType.exists(_.mediaType.binary)
-    val isJson = message.contentType.exists(mT =>
-      mT.mediaType == MediaType.application.json || mT.mediaType.subType.endsWith("+json"))
-
-    val isText = !isBinary || isJson
-
-    def prelude =
-      message match {
-        case Request(method, uri, httpVersion, _, _, _) =>
-          s"$httpVersion $method $uri"
-
-        case Response(status, httpVersion, _, _, _) =>
-          s"$httpVersion $status"
-      }
-
-    val headers =
-      if (logHeaders)
-        message.headers.redactSensitive(redactHeadersWhen).toList.mkString("Headers(", ", ", ")")
-      else ""
-
-    val bodyStream =
-      if (logBody && isText)
-        message.bodyAsText(charset.getOrElse(Charset.`UTF-8`))
-      else if (logBody)
-        message.body
-          .map(b => java.lang.Integer.toHexString(b & 0xff))
-      else
-        Stream.empty.covary[F]
-
-    val bodyText =
-      if (logBody)
-        bodyStream.compile.string
-          .map(text => s"""body="$text"""")
-      else
-        F.pure("")
-
-    def spaced(x: String): String = if (x.isEmpty) x else s" $x"
-
-    bodyText
-      .map(body => s"$prelude${spaced(headers)}${spaced(body)}")
-      .flatMap(log)
-  }
+      log: String => F[Unit])(implicit F: Sync[F]): F[Unit] =
+    org.http4s.internal.Logger.logMessage[F, A](message)(logHeaders, logBody, redactHeadersWhen)(log)
 }

--- a/core/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/src/main/scala/org/http4s/internal/Logger.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.internal
+
+import cats.effect.Sync
+import cats.implicits._
+import fs2.Stream
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.{Charset, Headers, MediaType, Message, Request, Response}
+
+object Logger {
+
+  def logMessage[F[_], A <: Message[F]](message: A)(
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
+      log: String => F[Unit])(implicit F: Sync[F]): F[Unit] = {
+    val charset = message.charset
+    val isBinary = message.contentType.exists(_.mediaType.binary)
+    val isJson = message.contentType.exists(mT =>
+      mT.mediaType == MediaType.application.json || mT.mediaType.subType.endsWith("+json"))
+
+    val isText = !isBinary || isJson
+
+    def prelude =
+      message match {
+        case Request(method, uri, httpVersion, _, _, _) =>
+          s"$httpVersion $method $uri"
+
+        case Response(status, httpVersion, _, _, _) =>
+          s"$httpVersion $status"
+      }
+
+    val headers =
+      if (logHeaders)
+        message.headers.redactSensitive(redactHeadersWhen).toList.mkString("Headers(", ", ", ")")
+      else ""
+
+    val bodyStream =
+      if (logBody && isText)
+        message.bodyAsText(charset.getOrElse(Charset.`UTF-8`))
+      else if (logBody)
+        message.body
+          .map(b => java.lang.Integer.toHexString(b & 0xff))
+      else
+        Stream.empty.covary[F]
+
+    val bodyText =
+      if (logBody)
+        bodyStream.compile.string
+          .map(text => s"""body="$text"""")
+      else
+        F.pure("")
+
+    def spaced(x: String): String = if (x.isEmpty) x else s" $x"
+
+    bodyText
+      .map(body => s"$prelude${spaced(headers)}${spaced(body)}")
+      .flatMap(log)
+  }
+
+}

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -59,5 +59,6 @@ object Logger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
       log: String => F[Unit])(implicit F: Sync[F]): F[Unit] =
-    org.http4s.internal.Logger.logMessage[F, A](message)(logHeaders, logBody, redactHeadersWhen)(log)
+    org.http4s.internal.Logger
+      .logMessage[F, A](message)(logHeaders, logBody, redactHeadersWhen)(log)
 }


### PR DESCRIPTION
Both [org.http4s.server.middleware.Logger#logMessage](https://github.com/http4s/http4s/blob/v0.21.4/server/src/main/scala/org/http4s/server/middleware/Logger.scala#L52-L98) and [org.http4s.client.middleware.Logger#logMessage](https://github.com/http4s/http4s/blob/v0.21.4/client/src/main/scala/org/http4s/client/middleware/Logger.scala#L26-L72) are the same.

As a result, I copied their same definition to `org.http4s.internal.Logger#logMessage`, and then referenced that definition from both call sites.

Could you please review this one, @rossabaker, @ChristopherDavenport and @bpholt? 

Side note - Brian, we sat next to each other at NEScala in Philly 1-2 years ago. I'm the guy from Banno/Jack Henry. I hope you're well! Also, I reached out to you, Brian, per https://github.com/http4s/http4s/commit/801b58ce8dd2d068c64008858b5b6325ba2e14fd.

Thanks