### PR TITLE
Add org.http4s.internal.Logger#logMessageWithBodyText

### DIFF
--- a/core/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/src/main/scala/org/http4s/internal/Logger.scala
@@ -19,10 +19,48 @@ object Logger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
       log: String => F[Unit])(implicit F: Sync[F]): F[Unit] = {
-    val logBodyText: Option[String => F[String]] =
-      if (logBody) Some(F.pure) else None
+    val charset = message.charset
+    val isBinary = message.contentType.exists(_.mediaType.binary)
+    val isJson = message.contentType.exists(mT =>
+      mT.mediaType == MediaType.application.json || mT.mediaType.subType.endsWith("+json"))
 
-    logMessageWithBodyText[F, A](message)(logHeaders, logBodyText, redactHeadersWhen)(log)
+    val isText = !isBinary || isJson
+
+    def prelude =
+      message match {
+        case Request(method, uri, httpVersion, _, _, _) =>
+          s"$httpVersion $method $uri"
+
+        case Response(status, httpVersion, _, _, _) =>
+          s"$httpVersion $status"
+      }
+
+    val headers =
+      if (logHeaders)
+        message.headers.redactSensitive(redactHeadersWhen).toList.mkString("Headers(", ", ", ")")
+      else ""
+
+    val bodyStream =
+      if (logBody && isText)
+        message.bodyAsText(charset.getOrElse(Charset.`UTF-8`))
+      else if (logBody)
+        message.body
+          .map(b => java.lang.Integer.toHexString(b & 0xff))
+      else
+        Stream.empty.covary[F]
+
+    val bodyText =
+      if (logBody)
+        bodyStream.compile.string
+          .map(text => s"""body="$text"""")
+      else
+        F.pure("")
+
+    def spaced(x: String): String = if (x.isEmpty) x else s" $x"
+
+    bodyText
+      .map(body => s"$prelude${spaced(headers)}${spaced(body)}")
+      .flatMap(log)
   }
 
   def logMessageWithBodyText[F[_], A <: Message[F]](message: A)(

--- a/core/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/src/main/scala/org/http4s/internal/Logger.scala
@@ -19,6 +19,11 @@ object Logger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
       log: String => F[Unit])(implicit F: Sync[F]): F[Unit] = {
+    val logBodyText: Option[String => F[String]] =
+      if (logBody) Some(F.pure) else None
+
+    logMessageWithBodyText[F, A](message)(logHeaders, logBodyText, redactHeadersWhen)(log)
+  }
 
   def logMessageWithBodyText[F[_], A <: Message[F]](message: A)(
       logHeaders: Boolean,


### PR DESCRIPTION
My primary motivation of this PR is to, via this Logger for `client`, offer a function, Option[String => F[String]]. It supplies the option of further modifying the String body.

In my case, I'm interested to transform the String into Json, sanitize it, and then print out the sanitized JSON. By "sanitize," I mean to hide/obscure JSON keys' values that are sensitive.

I intend, in a follow-up PR, to make such a change for `org.http4s.server.middleware`'s `Request/ResponseLogger`.