### PR TITLE
X-Request-ID Middleware

### DIFF
--- a/docs/src/main/mdoc/middleware.md
+++ b/docs/src/main/mdoc/middleware.md
@@ -241,9 +241,16 @@ val requestIdService = RequestId.httpRoutes(HttpRoutes.of[IO] {
 val responseIO = requestIdService.orNotFound(goodRequest)
 ```
 
+Note: `req.attributes.lookup(RequestId.requestIdAttrKey)` can also be used to lookup the request id
+extracted from the header, or the generated request id.
+
 ```scala mdoc
 // generated request id can be correlated with logs
-responseIO.unsafeRunSync().headers
+val resp = responseIO.unsafeRunSync()
+// X-Request-ID header added to response
+resp.headers
+// the request id is also available using attributes
+resp.attributes.lookup(RequestId.requestIdAttrKey)
 ```
 
 [service]: ../service

--- a/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
@@ -56,7 +56,6 @@ object RequestId {
       } yield response.putHeaders(header)
     }
 
-
   object httpApp {
     def apply[F[_]: Sync](httpApp: HttpApp[F]): HttpApp[F] =
       RequestId.apply(requestIdHeader)(httpApp)

--- a/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+package server
+package middleware
+
+import org.http4s.{Header, Http, Request, Response}
+import cats.data.Kleisli
+import cats.effect.Sync
+import cats.implicits._
+import org.typelevel.ci.CIString
+import java.util.UUID
+
+/** Propagate a `X-Request-Id` header to the response, generate a UUID
+  * when the `X-Request-Id` header is unset.
+  * https://devcenter.heroku.com/articles/http-request-id
+  */
+object RequestId {
+
+  def apply[G[_], F[_]](headerName: CIString = CIString("X-Request-ID"))(http: Http[G, F])(implicit
+      G: Sync[G]): Http[G, F] =
+    Kleisli[G, Request[F], Response[F]] { req =>
+      for {
+        header <- req.headers.get(headerName) match {
+          case None => G.delay[Header](Header.Raw(headerName, UUID.randomUUID().show))
+          case Some(header) => G.pure[Header](header)
+        }
+        response <- http(req.putHeaders(header))
+      } yield response.putHeaders(header)
+    }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
@@ -56,31 +56,36 @@ object RequestId {
       } yield response.putHeaders(header)
     }
 
-  def httpApp[F[_]: Sync](httpApp: HttpApp[F]): HttpApp[F] =
-    apply(requestIdHeader)(httpApp)
 
-  def httpApp[F[_]: Sync](
-      headerName: CIString
-  )(httpApp: HttpApp[F]): HttpApp[F] =
-    apply(headerName)(httpApp)
+  object httpApp {
+    def apply[F[_]: Sync](httpApp: HttpApp[F]): HttpApp[F] =
+      RequestId.apply(requestIdHeader)(httpApp)
 
-  def httpApp[F[_]: Sync](
-      headerName: CIString = requestIdHeader,
-      genReqId: F[UUID]
-  )(httpApp: HttpApp[F]): HttpApp[F] =
-    apply(FunctionK.id[F], headerName, genReqId)(httpApp)
+    def apply[F[_]: Sync](
+        headerName: CIString
+    )(httpApp: HttpApp[F]): HttpApp[F] =
+      RequestId.apply(headerName)(httpApp)
 
-  def httpRoutes[F[_]: Sync](httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-    apply(requestIdHeader)(httpRoutes)
+    def apply[F[_]: Sync](
+        headerName: CIString = requestIdHeader,
+        genReqId: F[UUID]
+    )(httpApp: HttpApp[F]): HttpApp[F] =
+      RequestId.apply(FunctionK.id[F], headerName, genReqId)(httpApp)
+  }
 
-  def httpRoutes[F[_]: Sync](
-      headerName: CIString
-  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-    apply(headerName)(httpRoutes)
+  object httpRoutes {
+    def apply[F[_]: Sync](httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+      RequestId.apply(requestIdHeader)(httpRoutes)
 
-  def httpRoutes[F[_]: Sync](
-      headerName: CIString = requestIdHeader,
-      genReqId: F[UUID]
-  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-    apply(OptionT.liftK[F], headerName, genReqId)(httpRoutes)
+    def apply[F[_]: Sync](
+        headerName: CIString
+    )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+      RequestId.apply(headerName)(httpRoutes)
+
+    def apply[F[_]: Sync](
+        headerName: CIString = requestIdHeader,
+        genReqId: F[UUID]
+    )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+      RequestId.apply(OptionT.liftK[F], headerName, genReqId)(httpRoutes)
+  }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/RequestIdSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/RequestIdSpec.scala
@@ -96,7 +96,7 @@ class RequestIdSpec extends Http4sSpec {
       val uuid = UUID.fromString("00000000-0000-0000-0000-000000000000")
       val req = Request[IO](uri = uri("/request"))
       val (reqReqId, respReqId) = RequestId
-        .httpRoutes(genReqId = Some(IO.pure(uuid)))(testService())
+        .httpRoutes(genReqId = IO.pure(uuid))(testService())
         .orNotFound(req)
         .flatMap { resp =>
           requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp))

--- a/server/src/test/scala/org/http4s/server/middleware/RequestIdSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/RequestIdSpec.scala
@@ -15,35 +15,46 @@ import org.typelevel.ci.CIString
 import java.util.UUID
 
 class RequestIdSpec extends Http4sSpec {
-  private def testService(headerKey: CIString = CIString("X-Request-ID")) = HttpRoutes.of[IO] {
-    case req @ GET -> Root / "request" =>
-      Ok(show"request-id: ${req.headers.get(headerKey).fold("None")(_.value)}")
-  }
+  private def testService(headerKey: CIString = CIString("X-Request-ID")) =
+    HttpRoutes.of[IO] {
+      case req @ GET -> Root / "request" =>
+        Ok(show"request-id: ${req.headers.get(headerKey).fold("None")(_.value)}")
+    }
 
   private def requestIdFromBody(resp: Response[IO]) =
     resp.as[String].map(_.stripPrefix("request-id: "))
 
-  private def requestIdFromHeaders(resp: Response[IO], headerKey: CIString = CIString("X-Request-ID")) =
+  private def requestIdFromHeaders(
+      resp: Response[IO],
+      headerKey: CIString = CIString("X-Request-ID")) =
     resp.headers.get(headerKey).fold("None")(_.value)
 
   "RequestId middleware" should {
     "propagate X-Request-ID header from request to response" in {
-      val req = Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123")))
-      val (reqReqId, respReqId) = RequestId.httpRoutes(testService()).orNotFound(req)
+      val req =
+        Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123")))
+      val (reqReqId, respReqId) = RequestId
+        .httpRoutes(testService())
+        .orNotFound(req)
         .flatMap { resp =>
           requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp))
-        }.unsafeRunSync()
+        }
+        .unsafeRunSync()
 
-      (reqReqId must_=== "123") and (respReqId must_=== "123")
+      (reqReqId must_=== "123").and(respReqId must_=== "123")
     }
     "generate X-Request-ID header when unset" in {
       val req = Request[IO](uri = uri("/request"))
-      val (reqReqId, respReqId) = RequestId.httpRoutes(testService()).orNotFound(req)
+      val (reqReqId, respReqId) = RequestId
+        .httpRoutes(testService())
+        .orNotFound(req)
         .flatMap { resp =>
           requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp))
-        }.unsafeRunSync()
+        }
+        .unsafeRunSync()
 
-      (reqReqId must_=== respReqId) and (Either.catchNonFatal(UUID.fromString(respReqId)) must(beRight))
+      (reqReqId must_=== respReqId).and(
+        Either.catchNonFatal(UUID.fromString(respReqId)) must (beRight))
     }
     "generate different request ids on subsequent requests" in {
       val req = Request[IO](uri = uri("/request"))
@@ -54,32 +65,45 @@ class RequestIdSpec extends Http4sSpec {
       (requestId1 must_!== requestId2)
     }
     "propagate custom request id header from request to response" in {
-      val req = Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123"), Header("X-Correlation-ID", "abc")))
-      val (reqReqId, respReqId) = RequestId.httpRoutes(CIString("X-Correlation-ID"))(testService(CIString("X-Correlation-ID"))).orNotFound(req)
+      val req = Request[IO](
+        uri = uri("/request"),
+        headers = Headers.of(Header("X-Request-ID", "123"), Header("X-Correlation-ID", "abc")))
+      val (reqReqId, respReqId) = RequestId
+        .httpRoutes(CIString("X-Correlation-ID"))(testService(CIString("X-Correlation-ID")))
+        .orNotFound(req)
         .flatMap { resp =>
           requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp, CIString("X-Correlation-ID")))
-        }.unsafeRunSync()
+        }
+        .unsafeRunSync()
 
-      (reqReqId must_=== "abc") and (respReqId must_=== "abc")
+      (reqReqId must_=== "abc").and(respReqId must_=== "abc")
     }
     "generate custom request id header when unset" in {
-      val req = Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123")))
-      val (reqReqId, respReqId) = RequestId.httpRoutes(CIString("X-Correlation-ID"))(testService(CIString("X-Correlation-ID"))).orNotFound(req)
+      val req =
+        Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123")))
+      val (reqReqId, respReqId) = RequestId
+        .httpRoutes(CIString("X-Correlation-ID"))(testService(CIString("X-Correlation-ID")))
+        .orNotFound(req)
         .flatMap { resp =>
           requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp, CIString("X-Correlation-ID")))
-        }.unsafeRunSync()
+        }
+        .unsafeRunSync()
 
-      (reqReqId must_=== respReqId) and (Either.catchNonFatal(UUID.fromString(respReqId)) must(beRight))
+      (reqReqId must_=== respReqId).and(
+        Either.catchNonFatal(UUID.fromString(respReqId)) must (beRight))
     }
     "generate X-Request-ID header when unset using supplied generator" in {
       val uuid = UUID.fromString("00000000-0000-0000-0000-000000000000")
       val req = Request[IO](uri = uri("/request"))
-      val (reqReqId, respReqId) = RequestId.httpRoutes(genReqId = Some(IO.pure(uuid)))(testService()).orNotFound(req)
+      val (reqReqId, respReqId) = RequestId
+        .httpRoutes(genReqId = Some(IO.pure(uuid)))(testService())
+        .orNotFound(req)
         .flatMap { resp =>
           requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp))
-        }.unsafeRunSync()
+        }
+        .unsafeRunSync()
 
-      (reqReqId must_=== uuid.show) and (respReqId must_=== uuid.show)
+      (reqReqId must_=== uuid.show).and(respReqId must_=== uuid.show)
     }
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/RequestIdSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/RequestIdSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.server.middleware
+
+import cats.effect._
+import cats.implicits._
+import org.http4s._
+import org.http4s.dsl.io._
+import org.http4s.Uri.uri
+import org.typelevel.ci.CIString
+import java.{util => ju}
+
+class RequestIdSpec extends Http4sSpec {
+  private def testService(headerKey: CIString = CIString("X-Request-ID")) = HttpRoutes.of[IO] {
+    case req @ GET -> Root / "request" =>
+      Ok(show"request-id: ${req.headers.get(headerKey).fold("None")(_.value)}")
+  }
+
+  private def requestIdFromBody(resp: Response[IO]) =
+    resp.as[String].map(_.stripPrefix("request-id: "))
+
+  private def requestIdFromHeaders(resp: Response[IO], headerKey: CIString = CIString("X-Request-ID")) =
+    resp.headers.get(headerKey).fold("None")(_.value)
+
+  "RequestId middleware" should {
+    "propagate X-Request-ID header from request to response" in {
+      val req = Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123")))
+      val (reqReqId, respReqId) = RequestId()(testService()).orNotFound(req)
+        .flatMap { resp =>
+          requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp))
+        }.unsafeRunSync()
+
+      (reqReqId must_=== "123") and (respReqId must_=== "123")
+    }
+    "generate X-Request-ID header when unset" in {
+      val req = Request[IO](uri = uri("/request"))
+      val (reqReqId, respReqId) = RequestId()(testService()).orNotFound(req)
+        .flatMap { resp =>
+          requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp))
+        }.unsafeRunSync()
+
+      (reqReqId must_=== respReqId) and (Either.catchNonFatal(ju.UUID.fromString(respReqId)) must(beRight))
+    }
+    "propagate custom request id header from request to response" in {
+      val req = Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123"), Header("X-Correlation-ID", "abc")))
+      val (reqReqId, respReqId) = RequestId(CIString("X-Correlation-ID"))(testService(CIString("X-Correlation-ID"))).orNotFound(req)
+        .flatMap { resp =>
+          requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp, CIString("X-Correlation-ID")))
+        }.unsafeRunSync()
+
+      (reqReqId must_=== "abc") and (respReqId must_=== "abc")
+    }
+    "generate custom request id header when unset" in {
+      val req = Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123")))
+      val (reqReqId, respReqId) = RequestId(CIString("X-Correlation-ID"))(testService(CIString("X-Correlation-ID"))).orNotFound(req)
+        .flatMap { resp =>
+          requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp, CIString("X-Correlation-ID")))
+        }.unsafeRunSync()
+
+      (reqReqId must_=== respReqId) and (Either.catchNonFatal(ju.UUID.fromString(respReqId)) must(beRight))
+    }
+  }
+}

--- a/server/src/test/scala/org/http4s/server/middleware/RequestIdSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/RequestIdSpec.scala
@@ -20,7 +20,8 @@ class RequestIdSpec extends Http4sSpec {
       case req @ GET -> Root / "request" =>
         Ok(show"request-id: ${req.headers.get(headerKey).fold("None")(_.value)}")
       case req @ GET -> Root / "attribute" =>
-        Ok(show"request-id: ${req.attributes.lookup(RequestId.requestIdAttrKey).getOrElse[String]("None")}")
+        Ok(
+          show"request-id: ${req.attributes.lookup(RequestId.requestIdAttrKey).getOrElse[String]("None")}")
     }
 
   private def requestIdFromBody(resp: Response[IO]) =
@@ -114,7 +115,8 @@ class RequestIdSpec extends Http4sSpec {
         .httpRoutes(testService())
         .orNotFound(req)
         .flatMap { resp =>
-          requestIdFromBody(resp).map(_ -> resp.attributes.lookup(RequestId.requestIdAttrKey).getOrElse("None"))
+          requestIdFromBody(resp).map(
+            _ -> resp.attributes.lookup(RequestId.requestIdAttrKey).getOrElse("None"))
         }
         .unsafeRunSync()
 


### PR DESCRIPTION
Implements https://github.com/http4s/http4s/issues/3485 .

## TODO

- [x] Update docs
- [x] Deal with `UUID.randomUUID()` blocking (option 2 of https://github.com/http4s/http4s/issues/3485#issuecomment-642243296)
- [x] Include the request id as attributes in both the request and response - suggested by @ChristopherDavenport 