### PR TITLE
Don't call .toString on ResponseLogger input

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -67,7 +67,7 @@ object ResponseLogger {
         }
         .guaranteeCase {
           case ExitCase.Error(t) => fk(log(s"service raised an error: ${t.getClass}"))
-          case ExitCase.Canceled => fk(log(s"service cancelled response for request [$req]"))
+          case ExitCase.Canceled => fk(log(s"service cancelled response for request"))
           case ExitCase.Completed => G.unit
         }
     }

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -67,7 +67,7 @@ object ResponseLogger {
         }
         .guaranteeCase {
           case ExitCase.Error(t) => fk(log(s"service raised an error: ${t.getClass}"))
-          case ExitCase.Canceled => fk(log(s"service cancelled response for request"))
+          case ExitCase.Canceled => fk(log(s"service canceled response for request"))
           case ExitCase.Completed => G.unit
         }
     }


### PR DESCRIPTION
We should not call toString on the input to `ResponseLogger`, because it will usually be a request, and we don't have the means to redact non-default sensitive information.

Fixes #3482