### PR TITLE
Remove obsolete docs about Canceled

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
@@ -23,8 +23,6 @@ private[http4s] trait EntityBodyWriter[F[_]] {
   implicit protected def ec: ExecutionContext
 
   /** Write a Chunk to the wire.
-    * If a request is cancelled, or the stream is closed this method should
-    * return a failed Future with Cancelled as the exception
     *
     * @param chunk BodyChunk to write to wire
     * @return a future letting you know when its safe to continue
@@ -32,10 +30,7 @@ private[http4s] trait EntityBodyWriter[F[_]] {
   protected def writeBodyChunk(chunk: Chunk[Byte], flush: Boolean): Future[Unit]
 
   /** Write the ending chunk and, in chunked encoding, a trailer to the
-    * wire.  If a request is cancelled, or the stream is closed this
-    * method should return a failed Future with Cancelled as the
-    * exception, or a Future with a Boolean to indicate whether the
-    * connection is to be closed or not.
+    * wire.
     *
     * @param chunk BodyChunk to write to wire
     * @return a future letting you know when its safe to continue (if `false`) or
@@ -47,7 +42,6 @@ private[http4s] trait EntityBodyWriter[F[_]] {
   protected def exceptionFlush(): Future[Unit] = FutureUnit
 
   /** Creates an effect that writes the contents of the EntityBody to the output.
-    * Cancelled exceptions fall through to the effect cb
     * The writeBodyEnd triggers if there are no exceptions, and the result will
     * be the result of the writeEnd call.
     *


### PR DESCRIPTION
The initial intent was to fix some bad spellings, but I think these docs are obsolete: I don't know what "Cancellation" exception it's talking about.