### PR TITLE
Add Functions to org.http4s.[client|server].middleware.{Logger, RequestLogger, ResponseLogger} for Logging Payloads Explicitly

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -9,6 +9,7 @@ package client
 package middleware
 
 import cats.effect._
+import fs2.Stream
 import org.http4s.util.CaseInsensitiveString
 
 /**
@@ -23,6 +24,18 @@ object Logger {
   )(client: Client[F]): Client[F] =
     ResponseLogger.apply(logHeaders, logBody, redactHeadersWhen, logAction)(
       RequestLogger.apply(logHeaders, logBody, redactHeadersWhen, logAction)(
+        client
+      )
+    )
+
+  def logBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(client: Client[F]): Client[F] =
+    ResponseLogger.logBodyText(logHeaders, logBody, redactHeadersWhen, logAction)(
+      RequestLogger.logBodyText(logHeaders, logBody, redactHeadersWhen, logAction)(
         client
       )
     )

--- a/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -32,8 +32,8 @@ object RequestLogger {
   private def impl[F[_]: Concurrent](
       logHeaders: Boolean,
       logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-      logAction: Option[String => F[Unit]] = None
+      redactHeadersWhen: CaseInsensitiveString => Boolean,
+      logAction: Option[String => F[Unit]]
   )(client: Client[F]): Client[F] = {
     val log = logAction.getOrElse { (s: String) =>
       Sync[F].delay(logger.info(s))

--- a/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -29,7 +29,7 @@ object RequestLogger {
   )(client: Client[F]): Client[F] =
     impl[F](logHeaders, Left(logBody), redactHeadersWhen, logAction)(client)
 
-  def impl[F[_]: Concurrent](
+  private def impl[F[_]: Concurrent](
       logHeaders: Boolean,
       logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,

--- a/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -29,6 +29,14 @@ object RequestLogger {
   )(client: Client[F]): Client[F] =
     impl[F](logHeaders, Left(logBody), redactHeadersWhen, logAction)(client)
 
+  def logBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(client: Client[F]): Client[F] =
+    impl[F](logHeaders, Right(logBody), redactHeadersWhen, logAction)(client)
+
   private def impl[F[_]: Concurrent](
       logHeaders: Boolean,
       logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],

--- a/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -26,40 +26,8 @@ object RequestLogger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: Option[String => F[Unit]] = None
-  )(client: Client[F]): Client[F] = {
-    val log = logAction.getOrElse { (s: String) =>
-      Sync[F].delay(logger.info(s))
-    }
-    Client { req =>
-      if (!logBody)
-        Resource.liftF(Logger
-          .logMessage[F, Request[F]](req)(logHeaders, logBody, redactHeadersWhen)(log(_))) *> client
-          .run(req)
-      else
-        Resource.suspend {
-          Ref[F].of(Vector.empty[Chunk[Byte]]).map { vec =>
-            val newBody = Stream
-              .eval(vec.get)
-              .flatMap(v => Stream.emits(v).covary[F])
-              .flatMap(c => Stream.chunk(c).covary[F])
-
-            val changedRequest = req.withBodyStream(
-              req.body
-              // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
-                .observe(_.chunks.flatMap(s => Stream.eval_(vec.update(_ :+ s))))
-                .onFinalizeWeak(
-                  Logger.logMessage[F, Request[F]](req.withBodyStream(newBody))(
-                    logHeaders,
-                    logBody,
-                    redactHeadersWhen)(log(_))
-                )
-            )
-
-            client.run(changedRequest)
-          }
-        }
-    }
-  }
+  )(client: Client[F]): Client[F] =
+    impl[F](logHeaders, Left(logBody), redactHeadersWhen, logAction)(client)
 
   def impl[F[_]: Concurrent](
       logHeaders: Boolean,

--- a/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -26,16 +26,34 @@ object ResponseLogger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: Option[String => F[Unit]] = None
+  private def impl[F[_]](
+      logHeaders: Boolean,
+      logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean,
+      logAction: Option[String => F[Unit]]
   )(client: Client[F])(implicit F: Concurrent[F]): Client[F] = {
     val log = logAction.getOrElse { (s: String) =>
       Sync[F].delay(logger.info(s))
     }
+
+    def logMessage(resp: Response[F]): F[Unit] =
+      logBodyText match {
+        case Left(bool) =>
+          Logger.logMessage[F, Response[F]](resp)(logHeaders, bool, redactHeadersWhen)(log(_))
+        case Right(f) =>
+          org.http4s.internal.Logger
+            .logMessageWithBodyText[F, Response[F]](resp)(logHeaders, f, redactHeadersWhen)(log(_))
+      }
+
+    val logBody: Boolean = logBodyText match {
+      case Left(bool) => bool
+      case Right(_) => true
+    }
+
     Client { req =>
       client.run(req).flatMap { response =>
         if (!logBody)
-          Resource.liftF(
-            Logger.logMessage[F, Response[F]](response)(logHeaders, logBody, redactHeadersWhen)(
-              log(_)) *> F.delay(response))
+          Resource.liftF(logMessage(response) *> F.delay(response))
         else
           Resource.suspend {
             Ref[F].of(Vector.empty[Chunk[Byte]]).map { vec =>
@@ -49,13 +67,7 @@ object ResponseLogger {
                   .eval(vec.get)
                   .flatMap(v => Stream.emits(v).covary[F])
                   .flatMap(c => Stream.chunk(c).covary[F])
-
-                Logger
-                  .logMessage[F, Response[F]](response.withBodyStream(newBody))(
-                    logHeaders,
-                    logBody,
-                    redactHeadersWhen)(log(_))
-                  .attempt
+                logMessage(response.withBodyStream(newBody)).attempt
                   .flatMap {
                     case Left(t) => F.delay(logger.error(t)("Error logging response body"))
                     case Right(()) => F.unit

--- a/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -29,6 +29,14 @@ object ResponseLogger {
   )(client: Client[F])(implicit F: Concurrent[F]): Client[F] =
     impl[F](logHeaders, Left(logBody), redactHeadersWhen, logAction)(client)
 
+  def logBodyText[F[_]](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(client: Client[F])(implicit F: Concurrent[F]): Client[F] =
+    impl[F](logHeaders, Right(logBody), redactHeadersWhen, logAction)(client)
+
   private def impl[F[_]](
       logHeaders: Boolean,
       logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],

--- a/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -26,6 +26,9 @@ object ResponseLogger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: Option[String => F[Unit]] = None
+  )(client: Client[F])(implicit F: Concurrent[F]): Client[F] =
+    impl[F](logHeaders, Left(logBody), redactHeadersWhen, logAction)(client)
+
   private def impl[F[_]](
       logHeaders: Boolean,
       logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],
@@ -78,4 +81,5 @@ object ResponseLogger {
       }
     }
   }
+
 }

--- a/core/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/src/main/scala/org/http4s/internal/Logger.scala
@@ -19,10 +19,48 @@ object Logger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
       log: String => F[Unit])(implicit F: Sync[F]): F[Unit] = {
-    val logBodyText: Option[String => F[String]] =
-      if (logBody) Some(F.pure) else None
+    val charset = message.charset
+    val isBinary = message.contentType.exists(_.mediaType.binary)
+    val isJson = message.contentType.exists(mT =>
+      mT.mediaType == MediaType.application.json || mT.mediaType.subType.endsWith("+json"))
 
-    logMessageWithBodyText[F, A](message)(logHeaders, logBodyText, redactHeadersWhen)(log)
+    val isText = !isBinary || isJson
+
+    def prelude =
+      message match {
+        case Request(method, uri, httpVersion, _, _, _) =>
+          s"$httpVersion $method $uri"
+
+        case Response(status, httpVersion, _, _, _) =>
+          s"$httpVersion $status"
+      }
+
+    val headers =
+      if (logHeaders)
+        message.headers.redactSensitive(redactHeadersWhen).toList.mkString("Headers(", ", ", ")")
+      else ""
+
+    val bodyStream =
+      if (logBody && isText)
+        message.bodyAsText(charset.getOrElse(Charset.`UTF-8`))
+      else if (logBody)
+        message.body
+          .map(b => java.lang.Integer.toHexString(b & 0xff))
+      else
+        Stream.empty.covary[F]
+
+    val bodyText =
+      if (logBody)
+        bodyStream.compile.string
+          .map(text => s"""body="$text"""")
+      else
+        F.pure("")
+
+    def spaced(x: String): String = if (x.isEmpty) x else s" $x"
+
+    bodyText
+      .map(body => s"$prelude${spaced(headers)}${spaced(body)}")
+      .flatMap(log)
   }
 
   def logMessageWithBodyText[F[_], A <: Message[F]](message: A)(

--- a/core/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/src/main/scala/org/http4s/internal/Logger.scala
@@ -19,6 +19,11 @@ object Logger {
       logBody: Boolean,
       redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains)(
       log: String => F[Unit])(implicit F: Sync[F]): F[Unit] = {
+    val logBodyText: Option[String => F[String]] =
+      if (logBody) Some(F.pure) else None
+
+    logMessageWithBodyText[F, A](message)(logHeaders, logBodyText, redactHeadersWhen)(log)
+  }
 
   def logMessageWithBodyText[F[_], A <: Message[F]](message: A)(
       logHeaders: Boolean,

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -14,6 +14,7 @@ import cats.implicits._
 import cats.data.OptionT
 import cats.effect.{Bracket, Concurrent, Sync}
 import cats.effect.Sync._
+import fs2.Stream
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger
 
@@ -38,6 +39,21 @@ object Logger {
     )
   }
 
+  def logBodyText[G[_], F[_]](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      fk: F ~> G,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(http: Http[G, F])(implicit G: Bracket[G, Throwable], F: Concurrent[F]): Http[G, F] = {
+    val log: String => F[Unit] = logAction.getOrElse { s =>
+      Sync[F].delay(logger.info(s))
+    }
+    ResponseLogger.impl(logHeaders, Right(logBody), fk, redactHeadersWhen, log.pure[Option])(
+      RequestLogger.impl(logHeaders, Right(logBody), fk, redactHeadersWhen, log.pure[Option])(http)
+    )
+  }
+
   def httpApp[F[_]: Concurrent](
       logHeaders: Boolean,
       logBody: Boolean,
@@ -46,6 +62,14 @@ object Logger {
   )(httpApp: HttpApp[F]): HttpApp[F] =
     apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
+  def httpAppLogBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpApp: HttpApp[F]): HttpApp[F] =
+    logBodyText(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
+
   def httpRoutes[F[_]: Concurrent](
       logHeaders: Boolean,
       logBody: Boolean,
@@ -53,6 +77,14 @@ object Logger {
       logAction: Option[String => F[Unit]] = None
   )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
     apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
+
+  def httpRoutesLogBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+    logBodyText(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
   def logMessage[F[_], A <: Message[F]](message: A)(
       logHeaders: Boolean,

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -54,37 +54,43 @@ object Logger {
     )
   }
 
-  def httpApp[F[_]: Concurrent](
-      logHeaders: Boolean,
-      logBody: Boolean,
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-      logAction: Option[String => F[Unit]] = None
-  )(httpApp: HttpApp[F]): HttpApp[F] =
-    apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
+  object httpApp {
+    def apply[F[_]: Concurrent](
+        logHeaders: Boolean,
+        logBody: Boolean,
+        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+        logAction: Option[String => F[Unit]] = None
+    )(httpApp: HttpApp[F]): HttpApp[F] =
+      Logger.apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
-  def httpAppLogBodyText[F[_]: Concurrent](
-      logHeaders: Boolean,
-      logBody: Stream[F, Byte] => Option[F[String]],
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-      logAction: Option[String => F[Unit]] = None
-  )(httpApp: HttpApp[F]): HttpApp[F] =
-    logBodyText(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
+    def logBodyText[F[_]: Concurrent](
+        logHeaders: Boolean,
+        logBody: Stream[F, Byte] => Option[F[String]],
+        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+        logAction: Option[String => F[Unit]] = None
+    )(httpApp: HttpApp[F]): HttpApp[F] =
+      Logger.logBodyText(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(
+        httpApp)
+  }
 
-  def httpRoutes[F[_]: Concurrent](
-      logHeaders: Boolean,
-      logBody: Boolean,
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-      logAction: Option[String => F[Unit]] = None
-  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-    apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
+  object httpRoutes {
+    def apply[F[_]: Concurrent](
+        logHeaders: Boolean,
+        logBody: Boolean,
+        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+        logAction: Option[String => F[Unit]] = None
+    )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+      Logger.apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
-  def httpRoutesLogBodyText[F[_]: Concurrent](
-      logHeaders: Boolean,
-      logBody: Stream[F, Byte] => Option[F[String]],
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-      logAction: Option[String => F[Unit]] = None
-  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-    logBodyText(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
+    def logBodyText[F[_]: Concurrent](
+        logHeaders: Boolean,
+        logBody: Stream[F, Byte] => Option[F[String]],
+        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+        logAction: Option[String => F[Unit]] = None
+    )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+      Logger.logBodyText(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(
+        httpRoutes)
+  }
 
   def logMessage[F[_], A <: Message[F]](message: A)(
       logHeaders: Boolean,

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -54,43 +54,37 @@ object Logger {
     )
   }
 
-  object httpApp {
-    def apply[F[_]: Concurrent](
-        logHeaders: Boolean,
-        logBody: Boolean,
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None
-    )(httpApp: HttpApp[F]): HttpApp[F] =
-      Logger.apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
+  def httpApp[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpApp: HttpApp[F]): HttpApp[F] =
+    apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
-    def logBodyText[F[_]: Concurrent](
-        logHeaders: Boolean,
-        logBody: Stream[F, Byte] => Option[F[String]],
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None
-    )(httpApp: HttpApp[F]): HttpApp[F] =
-      Logger.logBodyText(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(
-        httpApp)
-  }
+  def httpAppLogBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpApp: HttpApp[F]): HttpApp[F] =
+    logBodyText(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
-  object httpRoutes {
-    def apply[F[_]: Concurrent](
-        logHeaders: Boolean,
-        logBody: Boolean,
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None
-    )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-      Logger.apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
+  def httpRoutes[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+    apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
-    def logBodyText[F[_]: Concurrent](
-        logHeaders: Boolean,
-        logBody: Stream[F, Byte] => Option[F[String]],
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None
-    )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-      Logger.logBodyText(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(
-        httpRoutes)
-  }
+  def httpRoutesLogBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+    logBodyText(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
   def logMessage[F[_], A <: Message[F]](message: A)(
       logHeaders: Boolean,

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -83,6 +83,73 @@ object RequestLogger {
     }
   }
 
+  private def impl[G[_], F[_]](
+      logHeaders: Boolean,
+      logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],
+      fk: F ~> G,
+      redactHeadersWhen: CaseInsensitiveString => Boolean,
+      logAction: Option[String => F[Unit]]
+  )(http: Http[G, F])(implicit
+      F: Concurrent[F],
+      G: Bracket[G, Throwable]
+  ): Http[G, F] = {
+    val log = logAction.fold { (s: String) =>
+      Sync[F].delay(logger.info(s))
+    }(identity)
+
+    def logMessage(r: Request[F]): F[Unit] =
+      logBodyText match {
+        case Left(bool) =>
+          Logger.logMessage[F, Request[F]](r)(logHeaders, bool, redactHeadersWhen)(log(_))
+        case Right(f) =>
+          org.http4s.internal.Logger
+            .logMessageWithBodyText[F, Request[F]](r)(logHeaders, f, redactHeadersWhen)(log(_))
+      }
+
+    val logBody: Boolean = logBodyText match {
+      case Left(bool) => bool
+      case Right(_) => true
+    }
+
+    Kleisli { req =>
+      if (!logBody) {
+        def logAct = logMessage(req)
+        // This construction will log on Any Error/Cancellation
+        // The Completed Case is Unit, as we rely on the semantics of G
+        // As None Is Successful, but we oly want to log on Some
+        http(req)
+          .guaranteeCase {
+            case ExitCase.Canceled => fk(logAct)
+            case ExitCase.Error(_) => fk(logAct)
+            case ExitCase.Completed => G.unit
+          } <* fk(logAct)
+      } else
+        fk(Ref[F].of(Vector.empty[Chunk[Byte]]))
+          .flatMap { vec =>
+            val newBody = Stream
+              .eval(vec.get)
+              .flatMap(v => Stream.emits(v).covary[F])
+              .flatMap(c => Stream.chunk(c).covary[F])
+
+            val changedRequest = req.withBodyStream(
+              req.body
+              // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+                .observe(_.chunks.flatMap(c => Stream.eval_(vec.update(_ :+ c))))
+            )
+            def logRequest: F[Unit] =
+              logMessage(req.withBodyStream(newBody))
+            val response: G[Response[F]] =
+              http(changedRequest)
+                .guaranteeCase {
+                  case ExitCase.Completed => G.unit
+                  case _ => fk(logRequest)
+                }
+                .map(resp => resp.withBodyStream(resp.body.onFinalizeWeak(logRequest)))
+            response
+          }
+    }
+  }
+
   def httpApp[F[_]: Concurrent](
       logHeaders: Boolean,
       logBody: Boolean,

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -38,7 +38,7 @@ object RequestLogger {
   ): Http[G, F] =
     impl[G, F](logHeaders, Left(logBody), fk, redactHeadersWhen, logAction)(http)
 
-  private def impl[G[_], F[_]](
+  private[server] def impl[G[_], F[_]](
       logHeaders: Boolean,
       logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],
       fk: F ~> G,

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -128,4 +128,17 @@ object RequestLogger {
       logAction: Option[String => F[Unit]] = None
   )(httpApp: HttpApp[F]): HttpApp[F] =
     impl[F, F](logHeaders, Right(logBody), FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
+
+  def httpRoutesLogBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+    impl[OptionT[F, *], F](
+      logHeaders,
+      Right(logBody),
+      OptionT.liftK[F],
+      redactHeadersWhen,
+      logAction)(httpRoutes)
 }

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -105,48 +105,40 @@ object RequestLogger {
     }
   }
 
-  object httpApp {
-    def apply[F[_]: Concurrent](
-        logHeaders: Boolean,
-        logBody: Boolean,
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None
-    )(httpApp: HttpApp[F]): HttpApp[F] =
-      RequestLogger.apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(
-        httpApp)
+  def httpApp[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpApp: HttpApp[F]): HttpApp[F] =
+    apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
-    def logBodyText[F[_]: Concurrent](
-        logHeaders: Boolean,
-        logBody: Stream[F, Byte] => Option[F[String]],
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None
-    )(httpApp: HttpApp[F]): HttpApp[F] =
-      RequestLogger
-        .impl[F, F](logHeaders, Right(logBody), FunctionK.id[F], redactHeadersWhen, logAction)(
-          httpApp)
-  }
+  def httpRoutes[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+    apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
-  object httpRoutes {
-    def apply[F[_]: Concurrent](
-        logHeaders: Boolean,
-        logBody: Boolean,
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None
-    )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-      RequestLogger.apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(
-        httpRoutes)
+  def httpAppLogBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpApp: HttpApp[F]): HttpApp[F] =
+    impl[F, F](logHeaders, Right(logBody), FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
-    def logBodyText[F[_]: Concurrent](
-        logHeaders: Boolean,
-        logBody: Stream[F, Byte] => Option[F[String]],
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None
-    )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-      RequestLogger.impl[OptionT[F, *], F](
-        logHeaders,
-        Right(logBody),
-        OptionT.liftK[F],
-        redactHeadersWhen,
-        logAction)(httpRoutes)
-  }
+  def httpRoutesLogBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+    impl[OptionT[F, *], F](
+      logHeaders,
+      Right(logBody),
+      OptionT.liftK[F],
+      redactHeadersWhen,
+      logAction)(httpRoutes)
 }

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -120,4 +120,12 @@ object RequestLogger {
       logAction: Option[String => F[Unit]] = None
   )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
     apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
+
+  def httpAppLogBodyText[F[_]: Concurrent](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None
+  )(httpApp: HttpApp[F]): HttpApp[F] =
+    impl[F, F](logHeaders, Right(logBody), FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 }

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -118,4 +118,17 @@ object ResponseLogger {
       logAction: Option[String => F[Unit]] = None)(
       httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
     apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
+
+  def httpRoutesLogBodyText[F[_]: Concurrent, A](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None)(
+      httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
+    impl[OptionT[F, *], F, A](
+      logHeaders,
+      Right(logBody),
+      OptionT.liftK[F],
+      redactHeadersWhen,
+      logAction)(httpRoutes)
 }

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -94,41 +94,53 @@ object ResponseLogger {
     }
   }
 
-  def httpApp[F[_]: Concurrent, A](
-      logHeaders: Boolean,
-      logBody: Boolean,
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-      logAction: Option[String => F[Unit]] = None)(
-      httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
-    apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
+  object httpApp {
+    def apply[F[_]: Concurrent, A](
+        logHeaders: Boolean,
+        logBody: Boolean,
+        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+        logAction: Option[String => F[Unit]] = None)(
+        httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
+      ResponseLogger.apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(
+        httpApp)
 
-  def httpAppLogBodyText[F[_]: Concurrent, A](
-      logHeaders: Boolean,
-      logBody: Stream[F, Byte] => Option[F[String]],
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-      logAction: Option[String => F[Unit]] = None)(
-      httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
-    impl[F, F, A](logHeaders, Right(logBody), FunctionK.id[F], redactHeadersWhen, logAction)(
-      httpApp)
+    def logBodyText[F[_]: Concurrent, A](
+        logHeaders: Boolean,
+        logBody: Stream[F, Byte] => Option[F[String]],
+        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+        logAction: Option[String => F[Unit]] = None)(
+        httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
+      ResponseLogger.impl[F, F, A](
+        logHeaders,
+        Right(logBody),
+        FunctionK.id[F],
+        redactHeadersWhen,
+        logAction)(httpApp)
+  }
 
-  def httpRoutes[F[_]: Concurrent, A](
-      logHeaders: Boolean,
-      logBody: Boolean,
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-      logAction: Option[String => F[Unit]] = None)(
-      httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
-    apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
+  object httpRoutes {
+    def apply[F[_]: Concurrent, A](
+        logHeaders: Boolean,
+        logBody: Boolean,
+        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+        logAction: Option[String => F[Unit]] = None)(
+        httpRoutes: Kleisli[OptionT[F, *], A, Response[F]])
+        : Kleisli[OptionT[F, *], A, Response[F]] =
+      ResponseLogger.apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(
+        httpRoutes)
 
-  def httpRoutesLogBodyText[F[_]: Concurrent, A](
-      logHeaders: Boolean,
-      logBody: Stream[F, Byte] => Option[F[String]],
-      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-      logAction: Option[String => F[Unit]] = None)(
-      httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
-    impl[OptionT[F, *], F, A](
-      logHeaders,
-      Right(logBody),
-      OptionT.liftK[F],
-      redactHeadersWhen,
-      logAction)(httpRoutes)
+    def logBodyText[F[_]: Concurrent, A](
+        logHeaders: Boolean,
+        logBody: Stream[F, Byte] => Option[F[String]],
+        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+        logAction: Option[String => F[Unit]] = None)(
+        httpRoutes: Kleisli[OptionT[F, *], A, Response[F]])
+        : Kleisli[OptionT[F, *], A, Response[F]] =
+      impl[OptionT[F, *], F, A](
+        logHeaders,
+        Right(logBody),
+        OptionT.liftK[F],
+        redactHeadersWhen,
+        logAction)(httpRoutes)
+  }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -102,6 +102,15 @@ object ResponseLogger {
       httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
     apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
+  def httpAppLogBodyText[F[_]: Concurrent, A](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None)(
+      httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
+    impl[F, F, A](logHeaders, Right(logBody), FunctionK.id[F], redactHeadersWhen, logAction)(
+      httpApp)
+
   def httpRoutes[F[_]: Concurrent, A](
       logHeaders: Boolean,
       logBody: Boolean,

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -36,7 +36,7 @@ object ResponseLogger {
       F: Concurrent[F]): Kleisli[G, A, Response[F]] =
     impl[G, F, A](logHeaders, Left(logBody), fk, redactHeadersWhen, logAction)(http)
 
-  private def impl[G[_], F[_], A](
+  private[server] def impl[G[_], F[_], A](
       logHeaders: Boolean,
       logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],
       fk: F ~> G,

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -94,53 +94,41 @@ object ResponseLogger {
     }
   }
 
-  object httpApp {
-    def apply[F[_]: Concurrent, A](
-        logHeaders: Boolean,
-        logBody: Boolean,
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None)(
-        httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
-      ResponseLogger.apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(
-        httpApp)
+  def httpApp[F[_]: Concurrent, A](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None)(
+      httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
+    apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
-    def logBodyText[F[_]: Concurrent, A](
-        logHeaders: Boolean,
-        logBody: Stream[F, Byte] => Option[F[String]],
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None)(
-        httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
-      ResponseLogger.impl[F, F, A](
-        logHeaders,
-        Right(logBody),
-        FunctionK.id[F],
-        redactHeadersWhen,
-        logAction)(httpApp)
-  }
+  def httpAppLogBodyText[F[_]: Concurrent, A](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None)(
+      httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
+    impl[F, F, A](logHeaders, Right(logBody), FunctionK.id[F], redactHeadersWhen, logAction)(
+      httpApp)
 
-  object httpRoutes {
-    def apply[F[_]: Concurrent, A](
-        logHeaders: Boolean,
-        logBody: Boolean,
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None)(
-        httpRoutes: Kleisli[OptionT[F, *], A, Response[F]])
-        : Kleisli[OptionT[F, *], A, Response[F]] =
-      ResponseLogger.apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(
-        httpRoutes)
+  def httpRoutes[F[_]: Concurrent, A](
+      logHeaders: Boolean,
+      logBody: Boolean,
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None)(
+      httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
+    apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
-    def logBodyText[F[_]: Concurrent, A](
-        logHeaders: Boolean,
-        logBody: Stream[F, Byte] => Option[F[String]],
-        redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
-        logAction: Option[String => F[Unit]] = None)(
-        httpRoutes: Kleisli[OptionT[F, *], A, Response[F]])
-        : Kleisli[OptionT[F, *], A, Response[F]] =
-      impl[OptionT[F, *], F, A](
-        logHeaders,
-        Right(logBody),
-        OptionT.liftK[F],
-        redactHeadersWhen,
-        logAction)(httpRoutes)
-  }
+  def httpRoutesLogBodyText[F[_]: Concurrent, A](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CaseInsensitiveString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None)(
+      httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
+    impl[OptionT[F, *], F, A](
+      logHeaders,
+      Right(logBody),
+      OptionT.liftK[F],
+      redactHeadersWhen,
+      logAction)(httpRoutes)
 }


### PR DESCRIPTION
Adds functions to `org.http4s.client.middleware.{Logger, RequestLogger, ResponseLogger}` and `org.http4s.client.middleware.{Logger, RequestLogger, ResponseLogger}` for specifying how to explicitly log the HTTP Request/Response payload.

My end goal is to be able to use these `Logger`'s in order to log a sanitized/redacted JSON payload on my server and client(s). So, in short, I'll be going from `Stream[F, Byte] => Stream[F, Json] => Stream[F, Json] => F[String]` or something like that where the second `Stream[F, Json]` indicates that it's sanitized.

Note that I'll be using https://github.com/circe/circe/blob/v0.14.0-M1/modules/extras/src/main/scala/io/circe/extras.scala#L7-L51 in order to sanitize the JSON.

Hi @hamnis and @rossabaker - can you please review? This one is in a follow-up to https://github.com/http4s/http4s/pull/3486. 

Thanks!