### PR TITLE
Assign an initial version to the scalafix subproject

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,7 +1,9 @@
 lazy val V = _root_.scalafix.sbt.BuildInfo
+lazy val outputVersion = "0.20.0"
 inThisBuild(
   List(
     organization := "org.http4s",
+    version := outputVersion,
     homepage := Some(url("https://github.com/http4s/http4s")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
@@ -30,9 +32,9 @@ lazy val rules = project.settings(
 lazy val input = project.settings(
   skip in publish := true,
   libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-blaze-client" % "0.18.21",
-  "org.http4s" %% "http4s-blaze-server" % "0.18.21",
-  "org.http4s" %% "http4s-dsl" % "0.18.21"
+    "org.http4s" %% "http4s-blaze-client" % "0.18.21",
+    "org.http4s" %% "http4s-blaze-server" % "0.18.21",
+    "org.http4s" %% "http4s-dsl" % "0.18.21"
   )
 )
 
@@ -40,16 +42,16 @@ lazy val output = project.settings(
   skip in publish := true,
   skip in compile := true,
   libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-blaze-client" % "0.20.0-M5",
-  "org.http4s" %% "http4s-blaze-server" % "0.20.0-M5",
-  "org.http4s" %% "http4s-dsl" % "0.20.0-M5"
+    "org.http4s" %% "http4s-blaze-client" % outputVersion,
+    "org.http4s" %% "http4s-blaze-server" % outputVersion,
+    "org.http4s" %% "http4s-dsl" % outputVersion
   )
 )
 
 lazy val tests = project
   .settings(
     skip in publish := true,
-    libraryDependencies +="ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
     Compile / compile :=
       (Compile / compile).dependsOn(input / Compile / compile).value,
     scalafixTestkitOutputSourceDirectories :=


### PR DESCRIPTION
Allows the **scalafix** rules get published and then references from other projects.

**Note**: this also changes the **http4s** output version from "0.20.0-M5" to the final "0.20.0"
since there's no reason to reference a milestone version anymore.

This change is inspired by this conversation: #3372,
and ideally should be merged _before_ the former PR.