### PR TITLE
Publishing http4s-scalafix-0.20.0

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -4,6 +4,10 @@ inThisBuild(
   List(
     organization := "org.http4s",
     version := outputVersion,
+    isSnapshot := {
+      if (outputVersion == "0.20.0") false
+      else isSnapshot.value
+    },
     homepage := Some(url("https://github.com/http4s/http4s")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
@@ -19,13 +23,20 @@ inThisBuild(
     scalacOptions ++= List(
       "-Yrangepos"
     ),
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value)
+        Some("snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    }
   )
 )
 
 skip in publish := true
 
 lazy val rules = project.settings(
-  moduleName := "scalafix",
+  moduleName := "http4s-scalafix",
   libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
 )
 

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -10,6 +10,7 @@ inThisBuild(
     },
     homepage := Some(url("https://github.com/http4s/http4s")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    scmInfo := Some(ScmInfo(url("https://github.com/http4s/http4s"), "git@github.com:http4s/http4s.git")),
     developers := List(
       Developer(
         "amarrella",

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,2 +1,5 @@
 resolvers += Resolver.sonatypeRepo("releases")
+
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.12")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")


### PR DESCRIPTION
Just enough extra *.sbt to backpublish the scalafix for 0.20.0, per #3502

If I understand our strategy correctly, we want to start publishing these with output version concurrent with http4s version, and should move scalacheck out of its isolated build and into a first-class module.

/cc @satorg 