### PR TITLE
Fix Cogen[ContentCoding]

### DIFF
--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -264,7 +264,7 @@ private[http4s] trait ArbitraryInstances {
     }
 
   implicit val http4sTestingCogenForContentCoding: Cogen[ContentCoding] =
-    Cogen[String].contramap(_.coding)
+    Cogen[String].contramap(_.coding.map(_.toUpper.toLower))
 
   // MediaRange exepects the quoted pair without quotes
   val http4sGenUnquotedPair = genQuotedPair.map { c =>

--- a/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
@@ -11,6 +11,9 @@ import cats.kernel.laws.discipline.OrderTests
 import org.http4s.laws.discipline.HttpCodecTests
 import org.http4s.util.Renderer
 
+import org.specs2.scalacheck.Parameters
+import org.scalacheck.rng.Seed
+
 class ContentCodingSpec extends Http4sSpec {
   "equals" should {
     "be consistent with equalsIgnoreCase of the codings and quality" in prop {
@@ -85,4 +88,9 @@ class ContentCodingSpec extends Http4sSpec {
 
   checkAll("Order[ContentCoding]", OrderTests[ContentCoding].order)
   checkAll("HttpCodec[ContentCoding]", HttpCodecTests[ContentCoding].httpCodec)
+
+  checkAll("Order[ContentCoding] for #3328", OrderTests[ContentCoding].order)(
+    Parameters(
+      seed = Seed.fromBase64("2kpw5tJ8tADijqPv2GG3pUWPhjzpJUnaypQufFSWHBB=").toOption,
+      minTestsOk = 1))
 }


### PR DESCRIPTION
I'm sorry. I led @ashwinbhaskar down a wrong path.

Cats' `OrderLaws` [inherit]((https://github.com/typelevel/cats/blob/fd586f0b010deef4fdcd8d4b94c560d72396dc24/kernel-laws/shared/src/main/scala/cats/kernel/laws/PartialOrderLaws.scala#L15-L16)) this:

```scala
  def antisymmetry(x: A, y: A): IsEq[Boolean] =
    (!(E.lteqv(x, y) && E.lteqv(y, x)) || E.eqv(x, y)) <-> true
```

And they also [inherit](https://github.com/typelevel/cats/blob/master/kernel-laws/shared/src/main/scala/cats/kernel/laws/EqLaws.scala#L15-L16) this:

```scala
  def antiSymmetryEq(x: A, y: A, f: A => A): IsEq[Boolean] =
    (!E.eqv(x, y) || E.eqv(f(x), f(y))) <-> true
```

I thought we were failing on the former, but it's actually the latter being checked.  The `ARG_2` in the failure is the `f`:

```
2020-04-13T03:25:16.4858291Z [error] x order.antisymmetry (41 ms)
2020-04-13T03:25:16.4858573Z [error]  Falsified after 0 passed tests.
2020-04-13T03:25:16.4858823Z [error]  > Labels of failing property:Expected: true
2020-04-13T03:25:16.4859069Z [error]  Received: false> ARG_0: ContentCoding(t, QValue(0.0))
2020-04-13T03:25:16.4859312Z [error]  > ARG_1: ContentCoding(t, QValue(0.0))
2020-04-13T03:25:16.4859557Z [error]  > ARG_2: org.scalacheck.GenArities$$Lambda$20955/1421781070@14088a8f
```

Since the `toString` of that Lambda is useless, I created my own copy of the laws so I could inspect the failure.  I also fixed the `.toString` on `ContentCoding` so we can distinguish the initial arguments.  And look at this:

```
x -> ContentCoding(t, QValue(0.0))
y -> ContentCoding(T, QValue(0.0))
f(x) -> ContentCoding(identity, QValue(1.0))
f(y) -> ContentCoding(*, QValue(0.0))
```

The law says that if `x == y`, then `f(x) == f(y)`.  Our `f` violates that because we have a bad `Cogen` instance.  We have a bad `Cogen` instance because we modeled this one as a `String` instead of a `CIString`.

This fixes #3328 in a binary compatible way, and we need to fix the model in 1.0.