### PR TITLE
Introduce Query.blank, make it behave in withQueryParams

### DIFF
--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -128,7 +128,11 @@ final class Query private (val pairs: Vector[KeyValue]) extends QueryOps with Re
 object Query {
   type KeyValue = (String, Option[String])
 
+  /** Represents the absence of a query string. */
   val empty: Query = new Query(Vector.empty)
+
+  /** Represents a query string with no keys or values: `?` */
+  val blank = new Query(Vector("" -> None))
 
   /*
    * "The characters slash ("/") and question mark ("?") may represent data

--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -171,7 +171,8 @@ trait QueryOps {
   private def _withQueryParam(
       name: QueryParameterKey,
       values: collection.Seq[QueryParameterValue]): Self = {
-    val baseQuery = query.toVector.filter(_._1 != name.value)
+    val q = if (query == Query.blank) Query.empty else query
+    val baseQuery = q.toVector.filter(_._1 != name.value)
     val vec =
       if (values.isEmpty) baseQuery :+ (name.value -> None)
       else

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -810,6 +810,13 @@ http://example.org/a file
       val u = Uri(query = Query.fromString("param=value"))
       u =? ps must be_==(u =? ps)
     }
+    "discard the blank value in withQueryParam" in {
+      uri"/test?".withQueryParam("k", "v") must be_==(uri"/test?k=v")
+    }
+    "discard the blank value in withOptionQueryParam" in {
+      uri"/test?".withOptionQueryParam("k", Some("v")) must be_==(uri"/test?k=v")
+    }
+
   }
 
   "Uri.withFragment convenience method" should {


### PR DESCRIPTION
If a Uri has a trailing `?`, calling `withQueryParams` on it should not preserve the empty parameter.  We unfortunately already defined `Query.empty` to be the _absence_ of a query string, so we need a new name.  We probably should have made that an `Option`, which is something we can consider in 1.0.

I believe this will fix #3519.