### PR TITLE
Raise throwables into body if streaming has begun

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -22,18 +22,14 @@ import org.asynchttpclient.handler.StreamedAsyncHandler
 import org.asynchttpclient.request.body.generator.{BodyGenerator, ReactiveStreamsBodyGenerator}
 import org.asynchttpclient.{Request => AsyncRequest, Response => _, _}
 import org.http4s.internal.CollectionCompat.CollectionConverters._
-import org.http4s.internal.invokeCallback
 import org.http4s.internal.bug
 import org.http4s.internal.threads._
-import org.log4s.getLogger
 import org.reactivestreams.Publisher
 import _root_.io.netty.handler.codec.http.cookie.Cookie
 import org.asynchttpclient.uri.Uri
 import org.asynchttpclient.cookie.CookieStore
 
 object AsyncHttpClient {
-  private[this] val logger = getLogger
-
   val defaultConfig = new DefaultAsyncHttpClientConfig.Builder()
     .setMaxConnectionsPerHost(200)
     .setMaxConnections(400)
@@ -89,6 +85,7 @@ object AsyncHttpClient {
       var response: Response[F] = Response()
       val dispose = F.delay { state = State.ABORT }
       val onStreamCalled = Ref.unsafe[F, Boolean](false)
+      val deferredThrowable = Deferred.unsafe[F, Throwable]
 
       override def onStream(publisher: Publisher[HttpResponseBodyPart]): State = {
         val eff = for {
@@ -106,6 +103,7 @@ object AsyncHttpClient {
             subscriber
               .stream(bodyDisposal.set(F.unit) >> subscribeF)
               .flatMap(part => chunk(Chunk.bytes(part.getBodyPartBytes)))
+              .mergeHaltBoth(Stream.eval(deferredThrowable.get.flatMap(F.raiseError[Byte])))
 
           responseWithBody = response.copy(body = body)
 
@@ -132,7 +130,12 @@ object AsyncHttpClient {
       }
 
       override def onThrowable(throwable: Throwable): Unit =
-        invokeCallback(logger)(cb(Left(throwable)))
+        onStreamCalled.get
+          .ifM(
+            ifTrue = deferredThrowable.complete(throwable),
+            ifFalse = invokeCallbackF(cb(Left(throwable))))
+          .runAsync(_ => IO.unit)
+          .unsafeRunSync()
 
       override def onCompleted(): Unit =
         onStreamCalled.get


### PR DESCRIPTION
async-http-client can call `onThrowable` after we've returned a response from `onStream`.  We need a way to surface those to the client. We can't fail the response effect after we've already returned a response with a streaming body, but we can raise an error into that streaming body.

I haven't figured out a performant unit test, but my adaptation of @denisovlev's report is [here](https://gist.github.com/rossabaker/0934df905f2a11d3b658a9df66a0b6eb).

Fixes #3509.