### PR TITLE
More Efficient Ember Encoding

### DIFF
--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -9,8 +9,6 @@ package org.http4s.ember.core
 import cats.effect._
 import fs2._
 import org.http4s._
-// import cats.implicits._
-// import Shared._
 import java.nio.charset.StandardCharsets
 
 private[ember] object Encoder {

--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -35,7 +35,7 @@ private[ember] object Encoder {
       }
       // Final CRLF terminates headers and signals body to follow.
       stringBuilder.append(CRLF)
-      stringBuilder.toString.getBytes(StandardCharsets.US_ASCII)
+      stringBuilder.toString.getBytes(StandardCharsets.ISO_8859_1)
     }
     val body = if (resp.isChunked) resp.body.through(ChunkedEncoding.encode[F]) else resp.body
 
@@ -73,7 +73,7 @@ private[ember] object Encoder {
       }
       // Final CRLF terminates headers and signals body to follow.
       stringBuilder.append(CRLF)
-      stringBuilder.toString.getBytes(StandardCharsets.US_ASCII)
+      stringBuilder.toString.getBytes(StandardCharsets.ISO_8859_1)
     }
     val body = if (req.isChunked) req.body.through(ChunkedEncoding.encode[F]) else req.body
 

--- a/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
@@ -21,7 +21,7 @@ class EncoderSpec extends Specification {
         .reqToBytes(req)
         .through(fs2.text.utf8Decode[F])
         .compile
-        .foldMonoid
+        .string
         .map(stripLines)
 
     // Only for Use with Text Requests
@@ -30,7 +30,7 @@ class EncoderSpec extends Specification {
         .respToBytes(resp)
         .through(fs2.text.utf8Decode[F])
         .compile
-        .foldMonoid
+        .string
         .map(stripLines)
   }
 
@@ -57,6 +57,21 @@ class EncoderSpec extends Specification {
       |
       |Hello World!""".stripMargin
 
+      Helpers.encodeRequestRig(req).unsafeRunSync must_=== expected
+    }
+
+    "encode headers correctly" in {
+      val req = Request[IO](
+        Method.GET,
+        Uri.unsafeFromString("http://www.google.com"),
+        headers = Headers.of(Header("foo", "bar"))
+      )
+      val expected =
+        """GET http://www.google.com HTTP/1.1
+        |Host: www.google.com
+        |foo: bar
+        |
+        |""".stripMargin
       Helpers.encodeRequestRig(req).unsafeRunSync must_=== expected
     }
   }


### PR DESCRIPTION
- It was previously UTF-8, we've switched to ASCII to match the [gist](https://gist.github.com/rossabaker/31ea688c2337c40a0a0a7070cc8b4e1d), is that the correct encoding?