### PR TITLE
GZip client middleware should not decompres empty response body

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/GZip.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/GZip.scala
@@ -9,8 +9,7 @@ package client
 package middleware
 
 import cats.effect.{Bracket, Sync}
-import fs2.{Pipe, Stream}
-import java.io.EOFException
+import fs2.{Pipe, Pull, Stream}
 import org.http4s.headers.{`Accept-Encoding`, `Content-Encoding`}
 
 /**
@@ -26,7 +25,7 @@ object GZip {
       val responseResource = client.run(reqWithEncoding)
 
       responseResource.map { actualResponse =>
-        decompress(bufferSize, canEntityBodyBeEmpty(req.method), actualResponse)
+        decompress(bufferSize, actualResponse)
       }
     }
 
@@ -39,37 +38,37 @@ object GZip {
           req.headers ++ Headers.of(Header(`Accept-Encoding`.name.toString, supportedCompressions)))
     }
 
-  private def canEntityBodyBeEmpty(requestMethod: Method): Boolean =
-    requestMethod == Method.HEAD
-
-  private def decompress[F[_]](
-      bufferSize: Int,
-      entityBodyCanBeEmpty: Boolean,
-      response: Response[F])(implicit F: Sync[F]): Response[F] =
+  private def decompress[F[_]](bufferSize: Int, response: Response[F])(implicit
+      F: Sync[F]): Response[F] =
     response.headers.get(`Content-Encoding`) match {
       case Some(header)
           if header.contentCoding == ContentCoding.gzip || header.contentCoding == ContentCoding.`x-gzip` =>
         val gunzip: Pipe[F, Byte, Byte] =
           _.through(fs2.compression.gunzip(bufferSize)).flatMap(_.content)
-
-        response.withBodyStream(response.body.through(decompressWith(gunzip, entityBodyCanBeEmpty)))
+        response.withBodyStream(response.body.through(decompressWith(gunzip)))
 
       case Some(header) if header.contentCoding == ContentCoding.deflate =>
         val deflate: Pipe[F, Byte, Byte] = fs2.compression.deflate(bufferSize)
-
-        response.withBodyStream(
-          response.body.through(decompressWith(deflate, entityBodyCanBeEmpty)))
+        response.withBodyStream(response.body.through(decompressWith(deflate)))
 
       case _ =>
         response
     }
 
-  private def decompressWith[F[_]](
-      decompressor: Pipe[F, Byte, Byte],
-      entityBodyCanBeEmpty: Boolean)(implicit F: Bracket[F, Throwable]): Pipe[F, Byte, Byte] =
-    _.through(decompressor)
+  private def decompressWith[F[_]](decompressor: Pipe[F, Byte, Byte])(implicit
+      F: Bracket[F, Throwable]): Pipe[F, Byte, Byte] =
+    _.pull.peek1
+      .flatMap {
+        case None => Pull.raiseError(EmptyBodyException)
+        case Some((_, fullStream)) => Pull.output1(fullStream)
+      }
+      .stream
+      .flatten
+      .through(decompressor)
       .handleErrorWith {
-        case _: EOFException if entityBodyCanBeEmpty => Stream.empty
+        case EmptyBodyException => Stream.empty
         case error => Stream.raiseError(error)
       }
+
+  private object EmptyBodyException extends Throwable
 }

--- a/client/src/test/scala/org/http4s/client/middleware/GZipSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/GZipSpec.scala
@@ -34,7 +34,7 @@ class GZipSpec extends Http4sSpec {
       body.unsafeRunSync() must_== "Dummy response"
     }
 
-    "handle correctly the response of a HEAD request" in {
+    "not decompress when the response body is empty" in {
       val request = Request[IO](method = Method.HEAD, uri = Uri.unsafeFromString("/gziptest"))
       val response = gzipClient.run(request).use[IO, String] { response =>
         response.status must_== Status.Ok


### PR DESCRIPTION
This PR generlizes the solution to the ["GZip client middleware crashes when processing an HTTP HEAD response"](https://github.com/http4s/http4s/issues/3452) issue as was suggested from the [prevoius PR](https://github.com/http4s/http4s/pull/3476), by not decompresing a response body regardless of the corresponding request method.

The GZip client middleware inspects the response stream whether it's empty, by trying to peek the first byte from it without consuming it. If there is at least on byte in the stream, then the stream is considered non empty and the decompression process is applied; otherwise it just returns an empty stream. 
I only was able to signal whether the stream is empty via the error channel, because the `fs2.compression.gunzip` method before proceeding with the decompression [creates a `java.util.zip.Inflater` and encloses it using a `Stream.bracket`](https://github.com/functional-streams-for-scala/fs2/blob/80b90a6536ffdbe6e9087ae77844586d9eaa3bee/core/jvm/src/main/scala/fs2/compression.scala#L709). If I run the decompression either inside the Pull (line 63) or outside (line 66), in the process of flattening the inner stream, it seems like it gets terminated and the `Inflater` is disposed before the decompression completes and it throws a `java.lang.NullPointerException: Inflater has been closed` exception.  