### PR TITLE
Backport #3550: Empty bodies in client.GZip

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/GZip.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/GZip.scala
@@ -10,8 +10,7 @@ package middleware
 
 import cats.effect.Bracket
 import com.github.ghik.silencer.silent
-import fs2.{Pipe, Stream}
-import java.io.EOFException
+import fs2.{Pipe, Pull, Stream}
 import org.http4s.headers.{`Accept-Encoding`, `Content-Encoding`}
 
 /**
@@ -28,7 +27,7 @@ object GZip {
       val responseResource = client.run(reqWithEncoding)
 
       responseResource.map { actualResponse =>
-        decompress(bufferSize, canEntityBodyBeEmpty(req.method), actualResponse)
+        decompress(bufferSize, actualResponse)
       }
     }
 
@@ -41,38 +40,38 @@ object GZip {
           req.headers ++ Headers.of(Header(`Accept-Encoding`.name.value, supportedCompressions)))
     }
 
-  private def canEntityBodyBeEmpty(requestMethod: Method): Boolean =
-    requestMethod == Method.HEAD
-
   @silent("deprecated")
-  private def decompress[F[_]](
-      bufferSize: Int,
-      entityBodyCanBeEmpty: Boolean,
-      response: Response[F])(implicit F: Bracket[F, Throwable]): Response[F] =
+  private def decompress[F[_]](bufferSize: Int, response: Response[F])(implicit
+      F: Bracket[F, Throwable]): Response[F] =
     response.headers.get(`Content-Encoding`) match {
       case Some(header)
           if header.contentCoding == ContentCoding.gzip || header.contentCoding == ContentCoding.`x-gzip` =>
         val gunzip: Pipe[F, Byte, Byte] =
           _.through(fs2.compress.gunzip(bufferSize))
-
-        response.withBodyStream(response.body.through(decompressWith(gunzip, entityBodyCanBeEmpty)))
+        response.withBodyStream(response.body.through(decompressWith(gunzip)))
 
       case Some(header) if header.contentCoding == ContentCoding.deflate =>
         val deflate: Pipe[F, Byte, Byte] = fs2.compress.deflate(bufferSize)
-
-        response.withBodyStream(
-          response.body.through(decompressWith(deflate, entityBodyCanBeEmpty)))
+        response.withBodyStream(response.body.through(decompressWith(deflate)))
 
       case _ =>
         response
     }
 
-  private def decompressWith[F[_]](
-      decompressor: Pipe[F, Byte, Byte],
-      entityBodyCanBeEmpty: Boolean)(implicit F: Bracket[F, Throwable]): Pipe[F, Byte, Byte] =
-    _.through(decompressor)
+  private def decompressWith[F[_]](decompressor: Pipe[F, Byte, Byte])(implicit
+      F: Bracket[F, Throwable]): Pipe[F, Byte, Byte] =
+    _.pull.peek1
+      .flatMap {
+        case None => Pull.raiseError(EmptyBodyException)
+        case Some((_, fullStream)) => Pull.output1(fullStream)
+      }
+      .stream
+      .flatten
+      .through(decompressor)
       .handleErrorWith {
-        case _: EOFException if entityBodyCanBeEmpty => Stream.empty
+        case EmptyBodyException => Stream.empty
         case error => Stream.raiseError(error)
       }
+
+  private object EmptyBodyException extends Throwable
 }

--- a/client/src/main/scala/org/http4s/client/middleware/GZip.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/GZip.scala
@@ -12,6 +12,7 @@ import cats.effect.Bracket
 import com.github.ghik.silencer.silent
 import fs2.{Pipe, Pull, Stream}
 import org.http4s.headers.{`Accept-Encoding`, `Content-Encoding`}
+import scala.util.control.NoStackTrace
 
 /**
   * Client middleware for enabling gzip.
@@ -73,5 +74,5 @@ object GZip {
         case error => Stream.raiseError(error)
       }
 
-  private object EmptyBodyException extends Throwable
+  private object EmptyBodyException extends Throwable with NoStackTrace
 }

--- a/client/src/test/scala/org/http4s/client/middleware/GZipSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/GZipSpec.scala
@@ -34,7 +34,7 @@ class GZipSpec extends Http4sSpec {
       body.unsafeRunSync() must_== "Dummy response"
     }
 
-    "handle correctly the response of a HEAD request" in {
+    "not decompress when the response body is empty" in {
       val request = Request[IO](method = Method.HEAD, uri = Uri.unsafeFromString("/gziptest"))
       val response = gzipClient.run(request).use[IO, String] { response =>
         response.status must_== Status.Ok


### PR DESCRIPTION
This is a backport of #3550 to the 0.21 line.  It restores the deprecated `fs2.compress` calls for binary compatibility, because `Bracket` is the only constraint we have.  When we merge this back to master, we should keep the version from #3550.

Also add a `NoStackTrace` to the internal exception.  It should never be thrown outside the private method, and it's not an error condition.  We're using an untyped exception for control flow here, which is uncomfortable, but it's a highly localized implementation detail with a test.

I think this elides the concern from my bad merge of #3476, but I wanted to get eyes on it.

/cc @nelusnegur 