### PR TITLE
[WIP] Model Access-Control-Allow-Methods 

### DIFF
--- a/core/src/main/scala/org/http4s/WildcardOrMethods.scala
+++ b/core/src/main/scala/org/http4s/WildcardOrMethods.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+
+import org.http4s.util.{Renderable, Writer}
+import cats.data.NonEmptyList
+import cats.syntax.foldable._
+
+sealed trait WildcardOrMethods extends Renderable
+
+final case class Wildcard() extends WildcardOrMethods {
+
+  override def render(writer: Writer): writer.type = {
+    writer << '*'
+    writer
+  }
+}
+
+final case class Methods(methods: NonEmptyList[Method]) extends WildcardOrMethods {
+  override def render(writer: Writer): writer.type = {
+    writer.append(methods.mkString_(","))
+    writer
+  }
+}

--- a/core/src/main/scala/org/http4s/headers/Access-Control-Allow-Methods.scala
+++ b/core/src/main/scala/org/http4s/headers/Access-Control-Allow-Methods.scala
@@ -9,24 +9,24 @@ package headers
 
 import org.http4s.util.Writer
 import org.http4s.parser.HttpHeaderParser
+import cats.data.NonEmptyList
 
 object `Access-Control-Allow-Methods`
     extends HeaderKey.Internal[`Access-Control-Allow-Methods`]
     with HeaderKey.Singleton {
 
-  def apply(methods: Method*): `Access-Control-Allow-Methods` =
-    `Access-Control-Allow-Methods`(methods.toSet)
+  val `*` = `Access-Control-Allow-Methods`(Wildcard())
+
+  def apply(first: Method, rest: Method*): `Access-Control-Allow-Methods` =
+    `Access-Control-Allow-Methods`(Methods(NonEmptyList.of(first, rest: _*)))
 
   override def parse(s: String): ParseResult[`Access-Control-Allow-Methods`] =
     HttpHeaderParser.ACCESS_CONTROL_ALLOW_METHODS(s)
 }
 
-final case class `Access-Control-Allow-Methods`(methods: Set[Method]) extends Header.Parsed {
+final case class `Access-Control-Allow-Methods`(wildCardOrMethods: WildcardOrMethods)
+    extends Header.Parsed {
   override def key: `Access-Control-Allow-Methods`.type = `Access-Control-Allow-Methods`
 
-  override def value: String =
-    if (methods.isEmpty) "*"
-    else methods.mkString(",")
-
-  override def renderValue(writer: Writer): writer.type = writer.append(value)
+  override def renderValue(writer: Writer): writer.type = wildCardOrMethods.render(writer)
 }

--- a/core/src/main/scala/org/http4s/headers/Access-Control-Allow-Methods.scala
+++ b/core/src/main/scala/org/http4s/headers/Access-Control-Allow-Methods.scala
@@ -7,4 +7,26 @@
 package org.http4s
 package headers
 
-object `Access-Control-Allow-Methods` extends HeaderKey.Default
+import org.http4s.util.Writer
+import org.http4s.parser.HttpHeaderParser
+
+object `Access-Control-Allow-Methods`
+    extends HeaderKey.Internal[`Access-Control-Allow-Methods`]
+    with HeaderKey.Singleton {
+
+  def apply(methods: Method*): `Access-Control-Allow-Methods` =
+    `Access-Control-Allow-Methods`(methods.toSet)
+
+  override def parse(s: String): ParseResult[`Access-Control-Allow-Methods`] =
+    HttpHeaderParser.ACCESS_CONTROL_ALLOW_METHODS(s)
+}
+
+final case class `Access-Control-Allow-Methods`(methods: Set[Method]) extends Header.Parsed {
+  override def key: `Access-Control-Allow-Methods`.type = `Access-Control-Allow-Methods`
+
+  override def value: String =
+    if (methods.isEmpty) "*"
+    else methods.mkString(",")
+
+  override def renderValue(writer: Writer): writer.type = writer.append(value)
+}

--- a/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
+++ b/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
@@ -112,6 +112,7 @@ object HttpHeaderParser
     addParser_(CIString("ACCEPT-LANGUAGE"), `ACCEPT_LANGUAGE`)
     addParser_(CIString("ACCEPT-RANGES"), `ACCEPT_RANGES`)
     addParser_(CIString("ACCESS-CONTROL-ALLOW-CREDENTIALS"), `ACCESS_CONTROL_ALLOW_CREDENTIALS`)
+    addParser_(CIString("ACCESS-CONTROL-ALLOW-METHODS"), `ACCESS_CONTROL_ALLOW_METHODS`)
     addParser_(CIString("AGE"), `AGE`)
     addParser_(CIString("ALLOW"), `ALLOW`)
     addParser_(CIString("AUTHORIZATION"), `AUTHORIZATION`)

--- a/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
+++ b/core/src/main/scala/org/http4s/parser/SimpleHeaders.scala
@@ -51,6 +51,21 @@ private[parser] trait SimpleHeaders {
         }
     }.parse
 
+  def ACCESS_CONTROL_ALLOW_METHODS(value: String): ParseResult[`Access-Control-Allow-Methods`] =
+    new Http4sHeaderParser[`Access-Control-Allow-Methods`](value) {
+      def entry =
+        rule {
+          oneOrMore(Token).separatedBy(ListSep) ~ EOL ~> { (ts: Seq[String]) =>
+            val ms = ts.map(
+              Method
+                .fromString(_)
+                .toOption
+                .getOrElse(sys.error("Impossible. Please file a bug report.")))
+            `Access-Control-Allow-Methods`(ms.toSet)
+          }
+        }
+    }.parse
+
   def ALLOW(value: String): ParseResult[Allow] =
     new Http4sHeaderParser[Allow](value) {
       def entry =

--- a/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -217,5 +217,23 @@ class SimpleHeadersSpec extends Http4sSpec {
       val bad2 = Header("x-forwarded-for", "256.56.56.56")
       HttpHeaderParser.parseHeader(bad2) must beLeft
     }
+
+    "parse Access-Control-Allow-Methods" in {
+      val headers = Seq(
+        `Access-Control-Allow-Methods`(Method.GET, Method.POST),
+        `Access-Control-Allow-Methods`(Method.GET)
+      )
+      foreach(headers) { header =>
+        HttpHeaderParser.parseHeader(header.toRaw) must beRight(header)
+      }
+
+      //Access-Control-Allow-Methods should not be empty
+      val bad = Header("Access-Control-Allow-Methods", "")
+      HttpHeaderParser.parseHeader(bad) must beLeft
+
+      //FIXME: Invalid Method Name should return a Left Value
+      // val bad3 = Header("Access-Control-Allow-Methods", "invalid, GET")
+      // HttpHeaderParser.parseHeader(bad3) must beLeft
+    }
   }
 }

--- a/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -221,11 +221,16 @@ class SimpleHeadersSpec extends Http4sSpec {
     "parse Access-Control-Allow-Methods" in {
       val headers = Seq(
         `Access-Control-Allow-Methods`(Method.GET, Method.POST),
-        `Access-Control-Allow-Methods`(Method.GET)
+        `Access-Control-Allow-Methods`(Method.GET),
+        `Access-Control-Allow-Methods`.`*`
       )
       foreach(headers) { header =>
         HttpHeaderParser.parseHeader(header.toRaw) must beRight(header)
       }
+
+      //Wildcard
+      val w = Header("Access-Control-Allow-Methods", "GET, POST, *")
+      HttpHeaderParser.parseHeader(w) must beRight(`Access-Control-Allow-Methods`.`*`)
 
       //Access-Control-Allow-Methods should not be empty
       val bad = Header("Access-Control-Allow-Methods", "")


### PR DESCRIPTION
This PR aims to model `Access-Control-Allow-Methods` a header from #2011 

RFC for Access-Control-Allow-Methods can be found here - https://fetch.spec.whatwg.org/#http-access-control-allow-headers

Below are the assumptions, would request someone to please validate it

- [x] An empty `Access-Control-Allow-Methods` cannot exists

- [x] `Access-Control-Allow-Methods` cannot have an invalid method name, i.e `Access-Control-Allow-Methods: GET, xyz` is an invalid header value

- [ ] `Access-Control-Allow-Methods` can have a wildcard `*` at any place. i.e `Access-Control-Allow-Methods: GET, POST, *` is a valid header value.

Currently the PR does not solve for invalid header names.

