### PR TITLE
Make RetryPolicy#isErrorOrRetriableStatus public, not private.

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -141,7 +141,7 @@ object RetryPolicy {
   def recklesslyRetriable[F[_]](result: Either[Throwable, Response[F]]): Boolean =
     isErrorOrRetriableStatus(result)
 
-  private def isErrorOrRetriableStatus[F[_]](result: Either[Throwable, Response[F]]): Boolean =
+  def isErrorOrRetriableStatus[F[_]](result: Either[Throwable, Response[F]]): Boolean =
     result match {
       case Right(resp) => RetriableStatuses(resp.status)
       case Left(WaitQueueTimeoutException) => false


### PR DESCRIPTION
I recently copied and pasted this function since I need to use it.

I propose exposing it to be `public` via this PR.