### PR TITLE
Upgrade to Scala 2.13.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [adopt@1.8, adopt@1.11, adopt@1.14]
-        scala: [2.12.11, 2.13.2]
+        scala: [2.12.11, 2.13.3]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
     steps:

--- a/argonaut/src/main/scala/org/http4s/argonaut/Parser.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/Parser.scala
@@ -51,9 +51,13 @@ private[argonaut] object Parser extends SupportParser[Json] {
             if (key == null)
               key = s.toString
             else {
-              vs = vs + (key, jstring(s)); key = null
+              vs = vs.+(key, jstring(s))
+              key = null
             }
-          def add(v: Json): Unit = { vs = vs + (key, v); key = null }
+          def add(v: Json): Unit = {
+            vs = vs.+(key, v)
+            key = null
+          }
           def finish() = Json.jObject(vs)
           def isObj = true
         }

--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -23,18 +23,18 @@ class CirceJsonBench {
 
   @Benchmark
   def decode_byte_buffer(in: BenchState): Either[DecodeFailure, Json] =
-    jsonDecoderByteBuffer[IO].decode(in.req, strict = true).value.unsafeRunSync
+    jsonDecoderByteBuffer[IO].decode(in.req, strict = true).value.unsafeRunSync()
 
   @Benchmark
   def decode_incremental(in: BenchState): Either[DecodeFailure, Json] =
-    jsonDecoderIncremental[IO].decode(in.req, strict = true).value.unsafeRunSync
+    jsonDecoderIncremental[IO].decode(in.req, strict = true).value.unsafeRunSync()
 
   @Benchmark
   def decode_adaptive(in: BenchState): Either[DecodeFailure, Json] =
     jsonDecoderAdaptive[IO](in.cutoff, MediaType.application.json)
       .decode(in.req, strict = true)
       .value
-      .unsafeRunSync
+      .unsafeRunSync()
 }
 
 object CirceJsonBench {

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -159,7 +159,7 @@ object BlazeClient {
                   },
                   ec,
                   d)
-                F.delay(c.cancel)
+                F.delay(c.cancel())
               }
             ).flatMap[Resource[F, Response[F]]] {
               case Left((r, fiber)) => fiber.cancel.as(r)

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -160,7 +160,7 @@ class ClientTimeoutSpec extends Http4sSpec {
       // header is split into two chunks, we wait for 10x
       val c = mkClient(h, tail)(responseHeaderTimeout = 1250.millis)
 
-      c.fetchAs[String](FooRequest).unsafeRunSync must_== "done"
+      c.fetchAs[String](FooRequest).unsafeRunSync() must_== "done"
     }
 
     // Regression test for: https://github.com/http4s/http4s/issues/2386

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ReadBufferStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ReadBufferStageSpec.scala
@@ -99,7 +99,7 @@ class ReadBufferStageSpec extends Http4sSpec {
     var lastRead: Promise[Unit] = _
     val readCount = new AtomicInteger(0)
     override def readRequest(size: Int): Future[Unit] = {
-      lastRead = Promise[Unit]
+      lastRead = Promise[Unit]()
       readCount.incrementAndGet()
       lastRead.future
     }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
@@ -37,7 +37,7 @@ private[util] object ChunkWriter {
   def writeTrailer[F[_]](pipe: TailStage[ByteBuffer], trailer: F[Headers])(implicit
       F: Effect[F],
       ec: ExecutionContext): Future[Boolean] = {
-    val promise = Promise[Boolean]
+    val promise = Promise[Boolean]()
     val f = trailer.map { trailerHeaders =>
       if (trailerHeaders.nonEmpty) {
         val rr = new StringWriter(256)

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
@@ -17,7 +17,7 @@ import scala.concurrent._
 private[http4s] trait EntityBodyWriter[F[_]] {
   implicit protected def F: Effect[F]
 
-  protected val wroteHeader: Promise[Unit] = Promise[Unit]
+  protected val wroteHeader: Promise[Unit] = Promise[Unit]()
 
   /** The `ExecutionContext` on which to run computations, assumed to be stack safe. */
   implicit protected def ec: ExecutionContext

--- a/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Serializer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Serializer.scala
@@ -33,7 +33,7 @@ private trait WriteSerializer[I] extends TailStage[I] { self =>
   override def channelWrite(data: collection.Seq[I]): Future[Unit] =
     synchronized {
       if (serializerWritePromise == null) { // there is no queue!
-        serializerWritePromise = Promise[Unit]
+        serializerWritePromise = Promise[Unit]()
         val f = super.channelWrite(data)
         f.onComplete(checkQueue)(directec)
         f
@@ -75,7 +75,7 @@ private trait WriteSerializer[I] extends TailStage[I] { self =>
             }
 
             val p = serializerWritePromise
-            serializerWritePromise = Promise[Unit]
+            serializerWritePromise = Promise[Unit]()
 
             f.onComplete { t =>
               checkQueue(t)
@@ -93,7 +93,7 @@ trait ReadSerializer[I] extends TailStage[I] {
   ///  channel reading bits //////////////////////////////////////////////
 
   override def channelRead(size: Int = -1, timeout: Duration = Duration.Inf): Future[I] = {
-    val p = Promise[I]
+    val p = Promise[I]()
     val pending = serializerReadRef.getAndSet(p.future)
 
     if (pending == null) serializerDoRead(p, size, timeout) // no queue, just do a read

--- a/blaze-core/src/test/scala/org/http4s/blazecore/ResponseParser.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/ResponseParser.scala
@@ -46,7 +46,7 @@ class ResponseParser extends Http1ClientParser {
       new String(Chunk.concatBytes(bytes).toArray, StandardCharsets.ISO_8859_1)
     }
 
-    val headers = this.headers.result.map { case (k, v) => Header(k, v): Header }.toSet
+    val headers = this.headers.result().map { case (k, v) => Header(k, v): Header }.toSet
 
     val status = Status.fromIntAndReason(this.code, reason).valueOr(throw _)
 

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
@@ -242,7 +242,7 @@ class Http1WriterSpec extends Http4sSpec with CatsEffect {
       bracket(IO("foo"))(_ => IO.unit).flatMap { str =>
         val it = str.iterator
         emit {
-          if (it.hasNext) Some(it.next.toByte)
+          if (it.hasNext) Some(it.next().toByte)
           else None
         }
       }.unNoneTerminate

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -220,7 +220,7 @@ private[blaze] class Http1ServerStage[F[_]](
         Connection.from(req.headers).map(checkCloseConnection(_, rr))
       }
       .getOrElse(
-        parser.minorVersion == 0
+        parser.minorVersion() == 0
       ) // Finally, if nobody specifies, http 1.0 defaults to close
 
     // choose a body encoder. Will add a Transfer-Encoding header if necessary
@@ -235,7 +235,7 @@ private[blaze] class Http1ServerStage[F[_]](
 
         if (req.method == Method.HEAD)
           // write message body header for HEAD response
-          (parser.minorVersion, respTransferCoding, lengthHeader) match {
+          (parser.minorVersion(), respTransferCoding, lengthHeader) match {
             case (minor, Some(enc), _) if minor > 0 && enc.hasChunked =>
               rr << "Transfer-Encoding: chunked\r\n"
             case (_, _, Some(len)) => rr << len << "\r\n"
@@ -243,7 +243,7 @@ private[blaze] class Http1ServerStage[F[_]](
           }
 
         // add KeepAlive to Http 1.0 responses if the header isn't already present
-        rr << (if (!closeOnFinish && parser.minorVersion == 0 && respConn.isEmpty)
+        rr << (if (!closeOnFinish && parser.minorVersion() == 0 && respConn.isEmpty)
                  "Connection: keep-alive\r\n\r\n"
                else "\r\n")
 
@@ -255,7 +255,7 @@ private[blaze] class Http1ServerStage[F[_]](
           lengthHeader,
           resp.trailerHeaders,
           rr,
-          parser.minorVersion,
+          parser.minorVersion(),
           closeOnFinish)
     }
 

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/WSFrameAggregator.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/WSFrameAggregator.scala
@@ -25,7 +25,7 @@ private class WSFrameAggregator extends MidStage[WebSocketFrame, WebSocketFrame]
   private[this] val accumulator = new Accumulator
 
   def readRequest(size: Int): Future[WebSocketFrame] = {
-    val p = Promise[WebSocketFrame]
+    val p = Promise[WebSocketFrame]()
     channelRead(size).onComplete {
       case Success(f) => readLoop(f, p)
       case Failure(t) => p.failure(t)

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerMtlsSpec.scala
@@ -127,7 +127,7 @@ class BlazeServerMtlsSpec extends Http4sSpec with SilenceOutputStream {
         conn.setSSLSocketFactory(noAuthClientContext.getSocketFactory)
 
       Try {
-        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines().mkString
       }.recover {
         case ex: Throwable =>
           ex.getMessage
@@ -161,7 +161,7 @@ class BlazeServerMtlsSpec extends Http4sSpec with SilenceOutputStream {
         conn.setSSLSocketFactory(noAuthClientContext.getSocketFactory)
 
       Try {
-        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines().mkString
       }.recover {
         case ex: Throwable =>
           ex.getMessage

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
@@ -59,7 +59,7 @@ class BlazeServerSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     def get(path: String): String =
       Source
         .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-        .getLines
+        .getLines()
         .mkString
 
     // This should be in IO and shifted but I'm tired of fighting this.
@@ -81,7 +81,7 @@ class BlazeServerSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       conn.setRequestProperty("Content-Length", bytes.size.toString)
       conn.setDoOutput(true)
       conn.getOutputStream.write(bytes)
-      Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+      Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines().mkString
     }
 
     // This too
@@ -95,7 +95,7 @@ class BlazeServerSpec extends Http4sSpec with Http4sLegacyMatchersIO {
         conn.setRequestProperty("Content-Type", s"""multipart/form-data; boundary="$boundary"""")
         conn.setDoOutput(true)
         conn.getOutputStream.write(bytes)
-        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines().mkString
       }
 
     "A server" should {

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
@@ -72,7 +72,7 @@ class BoopickleSpec extends Http4sSpec with BooPickleInstances {
     "decode a class from a boopickle decoder" in {
       val result = booOf[IO, Fruit]
         .decode(Request[IO]().withEntity(Banana(10.0): Fruit), strict = true)
-      result.value.unsafeRunSync must_== Right(Banana(10.0))
+      result.value.unsafeRunSync() must_== Right(Banana(10.0))
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,8 @@ lazy val root = project.in(file("."))
 lazy val core = libraryProject("core")
   .enablePlugins(
     BuildInfoPlugin,
-    MimeLoaderPlugin
+    MimeLoaderPlugin,
+    SilencerPlugin
   )
   .settings(
     description := "Core http4s library for servers and clients",

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -194,7 +194,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
       // From ArgonautSpec, which tests similar things:
       // TODO Urgh.  We need to make testing these smoother.
       // https://github.com/http4s/http4s/issues/157
-      def getBody(body: EntityBody[IO]): Array[Byte] = body.compile.toVector.unsafeRunSync.toArray
+      def getBody(body: EntityBody[IO]): Array[Byte] = body.compile.toVector.unsafeRunSync().toArray
       val req = Request[IO]().withEntity(Json.fromDoubleOrNull(157))
       val body = req
         .decode { (json: Json) =>
@@ -202,7 +202,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
             .withEntity(json.asNumber.flatMap(_.toLong).getOrElse(0L).toString)
             .pure[IO]
         }
-        .unsafeRunSync
+        .unsafeRunSync()
         .body
       new String(getBody(body), StandardCharsets.UTF_8) must_== "157"
     }
@@ -214,7 +214,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
         .decode(
           Request[IO]().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42))),
           strict = true)
-      result.value.unsafeRunSync must_== Right(Foo(42))
+      result.value.unsafeRunSync() must_== Right(Foo(42))
     }
 
     // https://github.com/http4s/http4s/issues/514
@@ -225,7 +225,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
         val json = Json.obj("wort" -> Json.fromString(wort))
         val result =
           jsonOf[IO, Umlaut].decode(Request[IO]().withEntity(json), strict = true)
-        result.value.unsafeRunSync must_== Right(Umlaut(wort))
+        result.value.unsafeRunSync() must_== Right(Umlaut(wort))
       }
     }
 
@@ -233,7 +233,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
       val result = CirceInstancesWithCustomErrors
         .jsonOf[IO, Bar]
         .decode(Request[IO]().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
-      result.value.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
+      result.value.unsafeRunSync() must beLeft(InvalidMessageBodyFailure(
         "Custom Could not decode JSON: {\"bar1\":42}, errors: DecodingFailure at .a: Attempt to decode value on failed cursor"))
     }
   }
@@ -244,14 +244,14 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
         .decode(
           Request[IO]().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42))),
           strict = true)
-      result.value.unsafeRunSync must_== Right(Foo(42))
+      result.value.unsafeRunSync() must_== Right(Foo(42))
     }
 
     "return an InvalidMessageBodyFailure with a list of failures on invalid JSON messages" in {
       val json = Json.obj("a" -> Json.fromString("sup"), "b" -> Json.fromInt(42))
       val result = accumulatingJsonOf[IO, Bar]
         .decode(Request[IO]().withEntity(json), strict = true)
-      result.value.unsafeRunSync must beLike {
+      result.value.unsafeRunSync() must beLike {
         case Left(InvalidMessageBodyFailure(_, Some(DecodingFailures(NonEmptyList(_, _))))) => ok
       }
     }
@@ -260,7 +260,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
       val result = CirceInstancesWithCustomErrors
         .accumulatingJsonOf[IO, Bar]
         .decode(Request[IO]().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
-      result.value.unsafeRunSync must beLeft(InvalidMessageBodyFailure(
+      result.value.unsafeRunSync() must beLeft(InvalidMessageBodyFailure(
         "Custom Could not decode JSON: {\"bar1\":42}, errors: DecodingFailure at .a: Attempt to decode value on failed cursor, DecodingFailure at .b: Attempt to decode value on failed cursor"))
     }
   }
@@ -281,7 +281,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
 
     "fail on invalid json" in {
       val req = Request[IO]().withEntity(List(13, 14).asJson)
-      req.decodeJson[Foo].attempt.unsafeRunSync must beLeft
+      req.decodeJson[Foo].attempt.unsafeRunSync() must beLeft
     }
   }
 
@@ -290,7 +290,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
       import org.http4s.circe.CirceEntityDecoder._
       val request = Request[IO]().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42)))
       val result = request.attemptAs[Foo]
-      result.value.unsafeRunSync must_== Right(Foo(42))
+      result.value.unsafeRunSync() must_== Right(Foo(42))
     }
 
     "encode without defining EntityEncoder using default printer" in {
@@ -306,7 +306,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
         .withContentType(`Content-Type`(MediaType.application.json))
 
       val decoder = CirceInstances.builder.build.jsonOf[IO, Int]
-      val result = decoder.decode(req, true).value.unsafeRunSync
+      val result = decoder.decode(req, true).value.unsafeRunSync()
 
       result must beLeft.like {
         case _: MalformedMessageBodyFailure => ok
@@ -318,7 +318,7 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
         .withEntity(Json.obj())
 
       val decoder = CirceInstances.builder.build.jsonOf[IO, Int]
-      val result = decoder.decode(req, true).value.unsafeRunSync
+      val result = decoder.decode(req, true).value.unsafeRunSync()
 
       result must beLeft.like {
         case _: InvalidMessageBodyFailure => ok

--- a/circe/src/test/scala/org/http4s/circe/middleware/JsonDebugErrorHandlerSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/middleware/JsonDebugErrorHandlerSpec.scala
@@ -24,7 +24,7 @@ class JsonDebugErrorHandlerSpec extends Http4sSpec with SilenceOutputStream {
       JsonDebugErrorHandler(service)
         .run(req)
         .attempt
-        .unsafeRunSync must beRight
+        .unsafeRunSync() must beRight
     }
     "handle an message failure" in {
       val service: Kleisli[IO, Request[IO], Response[IO]] =
@@ -36,7 +36,7 @@ class JsonDebugErrorHandlerSpec extends Http4sSpec with SilenceOutputStream {
       JsonDebugErrorHandler(service)
         .run(req)
         .attempt
-        .unsafeRunSync must beRight
+        .unsafeRunSync() must beRight
     }
   }
 }

--- a/client/src/main/scala/org/http4s/client/dsl/io.scala
+++ b/client/src/main/scala/org/http4s/client/dsl/io.scala
@@ -25,8 +25,8 @@ import cats.effect.IO
   *
   *   val r: IO[String] = client(GET(uri("https://www.foo.bar/"))).as[String]
   *   val r2: DecodeResult[String] = client(GET(uri("https://www.foo.bar/"))).attemptAs[String] // implicitly resolve the decoder
-  *   val req1 = r.unsafeRunSync
-  *   val req2 = r.unsafeRunSync // Each invocation fetches a new Result based on the behavior of the Client
+  *   val req1 = r.unsafeRunSync()
+  *   val req2 = r.unsafeRunSync() // Each invocation fetches a new Result based on the behavior of the Client
   *
   * }}}
   */

--- a/client/src/main/scala/org/http4s/client/middleware/DestinationAttribute.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/DestinationAttribute.scala
@@ -28,7 +28,7 @@ object DestinationAttribute {
     */
   def getDestination[F[_]](): Request[F] => Option[String] = _.attributes.lookup(Destination)
 
-  val Destination = Key.newKey[IO, String].unsafeRunSync
+  val Destination = Key.newKey[IO, String].unsafeRunSync()
 
   val EmptyDestination = ""
 }

--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -151,7 +151,7 @@ object FollowRedirect {
         None
     }
 
-  private val redirectUrisKey = Key.newKey[IO, List[Uri]].unsafeRunSync
+  private val redirectUrisKey = Key.newKey[IO, List[Uri]].unsafeRunSync()
 
   /**
     * Get the redirection URIs for a `response`.

--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -156,6 +156,6 @@ object RetryPolicy {
   private def expBackoff(k: Int, maxInMillis: Long): FiniteDuration = {
     val millis = (pow(2.0, k.toDouble) - 1.0) * 1000.0
     val interval = min(millis, maxInMillis.toDouble)
-    FiniteDuration((random * interval).toLong, MILLISECONDS)
+    FiniteDuration((random() * interval).toLong, MILLISECONDS)
   }
 }

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -191,7 +191,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
 object Message {
   private[http4s] val logger = getLogger
   object Keys {
-    private[this] val trailerHeaders: Key[Any] = Key.newKey[IO, Any].unsafeRunSync
+    private[this] val trailerHeaders: Key[Any] = Key.newKey[IO, Any].unsafeRunSync()
     def TrailerHeaders[F[_]]: Key[F[Headers]] = trailerHeaders.asInstanceOf[Key[F[Headers]]]
   }
 }
@@ -502,10 +502,10 @@ object Request {
   final case class Connection(local: InetSocketAddress, remote: InetSocketAddress, secure: Boolean)
 
   object Keys {
-    val PathInfoCaret: Key[Int] = Key.newKey[IO, Int].unsafeRunSync
-    val PathTranslated: Key[File] = Key.newKey[IO, File].unsafeRunSync
-    val ConnectionInfo: Key[Connection] = Key.newKey[IO, Connection].unsafeRunSync
-    val ServerSoftware: Key[ServerSoftware] = Key.newKey[IO, ServerSoftware].unsafeRunSync
+    val PathInfoCaret: Key[Int] = Key.newKey[IO, Int].unsafeRunSync()
+    val PathTranslated: Key[File] = Key.newKey[IO, File].unsafeRunSync()
+    val ConnectionInfo: Key[Connection] = Key.newKey[IO, Connection].unsafeRunSync()
+    val ServerSoftware: Key[ServerSoftware] = Key.newKey[IO, ServerSoftware].unsafeRunSync()
   }
 }
 

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -216,5 +216,5 @@ object StaticFile {
       case i => MediaType.forExtension(name.substring(i + 1)).map(`Content-Type`(_))
     }
 
-  private[http4s] val staticFileKey = Key.newKey[IO, File].unsafeRunSync
+  private[http4s] val staticFileKey = Key.newKey[IO, File].unsafeRunSync()
 }

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -12,6 +12,7 @@ package org.http4s
 
 import cats.{Eq, Hash, Order, Show}
 import cats.syntax.either._
+import com.github.ghik.silencer.silent
 import java.net.{Inet4Address, Inet6Address, InetAddress}
 import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{Charset => JCharset}
@@ -251,6 +252,7 @@ object Uri {
     def unsafeFromString(s: String): Scheme =
       fromString(s).fold(throw _, identity)
 
+    @silent("deprecated")
     private[http4s] trait Parser { self: PbParser =>
       def scheme =
         rule {

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -32,7 +32,7 @@ package object internal {
   // have an ExecutionContext but not a Timer.
   private[http4s] def unsafeRunAsync[F[_], A](fa: F[A])(
       f: Either[Throwable, A] => IO[Unit])(implicit F: Effect[F], ec: ExecutionContext): Unit =
-    F.runAsync(Async.shift(ec) *> fa)(f).unsafeRunSync
+    F.runAsync(Async.shift(ec) *> fa)(f).unsafeRunSync()
 
   private[http4s] def loggingAsyncCallback[A](logger: Logger)(
       attempt: Either[Throwable, A]): IO[Unit] =

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -11,6 +11,7 @@
 package org.http4s
 package parser
 
+import com.github.ghik.silencer.silent
 import org.http4s.SameSite._
 import org.http4s.headers.`Set-Cookie`
 import org.http4s.internal.parboiled2._
@@ -111,6 +112,7 @@ private[parser] trait CookieHeader {
 
     def DomainNamePart: Rule0 = rule(AlphaNum ~ zeroOrMore(AlphaNum | ch('-')))
 
+    @silent("deprecated")
     def StringValue: Rule1[String] = rule(capture(oneOrMore((!(CTL | ch(';'))) ~ Char)))
 
     def SameSite: Rule1[SameSite] =

--- a/core/src/main/scala/org/http4s/parser/QueryParser.scala
+++ b/core/src/main/scala/org/http4s/parser/QueryParser.scala
@@ -32,7 +32,7 @@ private[http4s] class QueryParser(
     val acc: Builder[Query.KeyValue, Vector[Query.KeyValue]] = Vector.newBuilder
     decodeBuffer(input, (k, v) => acc += ((k, v)), flush) match {
       case Some(e) => ParseResult.fail("Decoding of url encoded data failed.", e)
-      case None => ParseResult.success(Query.fromVector(acc.result))
+      case None => ParseResult.success(Query.fromVector(acc.result()))
     }
   }
 

--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -11,6 +11,7 @@
 package org.http4s.parser
 
 import cats.implicits._
+import com.github.ghik.silencer.silent
 import org.http4s.{ParseFailure, ParseResult}
 import org.http4s.internal.parboiled2._
 
@@ -36,12 +37,14 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
 
   def LWS = rule(optional(CRLF) ~ oneOrMore(anyOf(" \t")))
 
+  @silent("deprecated")
   def Text = rule(!CTL ~ ANY | LWS)
 
   def Hex = rule("A" - "F" | "a" - "f" | Digit)
 
   def Separator = rule(anyOf("()<>@,;:\\\"/[]?={} \t"))
 
+  @silent("deprecated")
   def Token: Rule1[String] = rule(capture(oneOrMore(!CTL ~ !Separator ~ ANY)))
 
   // TODO What's the replacement for DROP?
@@ -51,6 +54,7 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
     ()
   }
 
+  @silent("deprecated")
   def CText = rule(!anyOf("()") ~ Text)
 
   // TODO This parser cannot handle strings terminating on \" which is a border case but still valid quoted pair
@@ -61,6 +65,7 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
       } ~ "\""
     }
 
+  @silent("deprecated")
   def QDText: Rule1[Char] = rule(!ch('"') ~ Text ~ LASTCHAR)
 
   def QuotedPair: Rule1[Char] = rule("\\" ~ Char ~ LASTCHAR)

--- a/docs/src/main/mdoc/client.md
+++ b/docs/src/main/mdoc/client.md
@@ -10,7 +10,7 @@ http4s to try our service.
 A recap of the dependencies for this example, in case you skipped the [service] example. Ensure you have the following dependencies in your build.sbt:
 
 ```scala
-scalaVersion := "2.13.2" // Also supports 2.11.x and 2.12.x
+scalaVersion := "2.13.3" // Also supports 2.11.x and 2.12.x
 
 val http4sVersion = "{{< version "http4s.doc" >}}"
 
@@ -157,7 +157,7 @@ the world" varies by context:
 
 ```scala mdoc:nest
 val greetingsStringEffect = greetingList.map(_.mkString("\n"))
-greetingsStringEffect.unsafeRunSync
+greetingsStringEffect.unsafeRunSync()
 ```
 
 ## Constructing a URI

--- a/docs/src/main/mdoc/cors.md
+++ b/docs/src/main/mdoc/cors.md
@@ -35,7 +35,7 @@ val service = HttpRoutes.of[IO] {
 
 val request = Request[IO](Method.GET, uri"/")
 
-service.orNotFound(request).unsafeRunSync
+service.orNotFound(request).unsafeRunSync()
 ```
 
 Now we can wrap the service in the `CORS` middleware.
@@ -47,7 +47,7 @@ import org.http4s.server.middleware._
 ```scala mdoc
 val corsService = CORS(service)
 
-corsService.orNotFound(request).unsafeRunSync
+corsService.orNotFound(request).unsafeRunSync()
 ```
 
 So far, there was no change. That's because an `Origin` header is required
@@ -57,7 +57,7 @@ in the requests and it must include a scheme. This, of course, is the responsibi
 val originHeader = Header("Origin", "https://somewhere.com")
 val corsRequest = request.putHeaders(originHeader)
 
-corsService.orNotFound(corsRequest).unsafeRunSync
+corsService.orNotFound(corsRequest).unsafeRunSync()
 ```
 
 Notice how the response has the CORS headers added. How easy was
@@ -95,9 +95,9 @@ val methodConfig = CORSConfig(
 
 val corsMethodSvc = CORS(service, methodConfig)
 
-corsMethodSvc.orNotFound(googleGet).unsafeRunSync
-corsMethodSvc.orNotFound(yahooPut).unsafeRunSync
-corsMethodSvc.orNotFound(duckPost).unsafeRunSync
+corsMethodSvc.orNotFound(googleGet).unsafeRunSync()
+corsMethodSvc.orNotFound(yahooPut).unsafeRunSync()
+corsMethodSvc.orNotFound(duckPost).unsafeRunSync()
 ```
 
 As you can see, the CORS headers were only added to the `GET` and `POST` requests.
@@ -113,9 +113,9 @@ val originConfig = CORSConfig(
 
 val corsOriginSvc = CORS(service, originConfig)
 
-corsOriginSvc.orNotFound(googleGet).unsafeRunSync
-corsOriginSvc.orNotFound(yahooPut).unsafeRunSync
-corsOriginSvc.orNotFound(duckPost).unsafeRunSync
+corsOriginSvc.orNotFound(googleGet).unsafeRunSync()
+corsOriginSvc.orNotFound(yahooPut).unsafeRunSync()
+corsOriginSvc.orNotFound(duckPost).unsafeRunSync()
 ```
 
 Again, the results are as expected. You can, of course, create a configuration that

--- a/docs/src/main/mdoc/csrf.md
+++ b/docs/src/main/mdoc/csrf.md
@@ -36,14 +36,14 @@ val service = HttpRoutes.of[IO] {
 
 val request = Request[IO](Method.GET, uri"/")
 
-service.orNotFound(request).unsafeRunSync
+service.orNotFound(request).unsafeRunSync()
 ```
 
 That didn't do all that much. Lets build out our CSRF Middleware by creating a `CSRFBuilder`
 
 ```scala mdoc:silent
 val cookieName = "csrf-token"
-val key  = CSRF.generateSigningKey[IO].unsafeRunSync
+val key  = CSRF.generateSigningKey[IO].unsafeRunSync()
 val defaultOriginCheck: Request[IO] => Boolean =
   CSRF.defaultOriginCheck[IO](_, "localhost", Uri.Scheme.http, None)
 val csrfBuilder = CSRF[IO,IO](key, defaultOriginCheck)

--- a/docs/src/main/mdoc/dsl.md
+++ b/docs/src/main/mdoc/dsl.md
@@ -85,7 +85,7 @@ run it.
 But here in the REPL, it's up to us to run it:
 
 ```scala mdoc
-val response = io.unsafeRunSync
+val response = io.unsafeRunSync()
 ```
 
 Cool.
@@ -103,7 +103,7 @@ applying a status code:
 
 ```scala mdoc
 val okIo = Ok()
-val ok = okIo.unsafeRunSync
+val ok = okIo.unsafeRunSync()
 ```
 
 This simple `Ok()` expression succinctly says what we mean in a
@@ -112,7 +112,7 @@ service:
 ```scala mdoc
 HttpRoutes.of[IO] {
   case _ => Ok()
-}.orNotFound.run(getRoot).unsafeRunSync
+}.orNotFound.run(getRoot).unsafeRunSync()
 ```
 
 This syntax works for other status codes as well.  In our example, we
@@ -122,7 +122,7 @@ response:
 ```scala mdoc
 HttpRoutes.of[IO] {
   case _ => NoContent()
-}.orNotFound.run(getRoot).unsafeRunSync
+}.orNotFound.run(getRoot).unsafeRunSync()
 ```
 
 ### Headers
@@ -130,7 +130,7 @@ HttpRoutes.of[IO] {
 http4s adds a minimum set of headers depending on the response, e.g:
 
 ```scala mdoc
-Ok("Ok response.").unsafeRunSync.headers
+Ok("Ok response.").unsafeRunSync().headers
 ```
 
 Extra headers can be added using `putHeaders`, for example to specify cache policies:
@@ -142,7 +142,7 @@ import cats.data.NonEmptyList
 ```
 
 ```scala mdoc
-Ok("Ok response.", `Cache-Control`(NonEmptyList(`no-cache`(), Nil))).unsafeRunSync.headers
+Ok("Ok response.", `Cache-Control`(NonEmptyList(`no-cache`(), Nil))).unsafeRunSync().headers
 ```
 
 http4s defines all the well known headers directly, but sometimes you need to
@@ -150,7 +150,7 @@ define custom headers, typically prefixed by an `X-`. In simple cases you can
 construct a `Header` instance by hand:
 
 ```scala mdoc
-Ok("Ok response.", Header("X-Auth-Token", "value")).unsafeRunSync.headers
+Ok("Ok response.", Header("X-Auth-Token", "value")).unsafeRunSync().headers
 ```
 
 ### Cookies
@@ -159,7 +159,7 @@ http4s has special support for Cookie headers using the `Cookie` type to add
 and invalidate cookies. Adding a cookie will generate the correct `Set-Cookie` header:
 
 ```scala mdoc
-Ok("Ok response.").map(_.addCookie(ResponseCookie("foo", "bar"))).unsafeRunSync.headers
+Ok("Ok response.").map(_.addCookie(ResponseCookie("foo", "bar"))).unsafeRunSync().headers
 ```
 
 `Cookie` can be further customized to set, e.g., expiration, the secure flag, httpOnly, flag, etc
@@ -171,14 +171,14 @@ val cookieResp = {
     now <- HttpDate.current[IO]
   } yield resp.addCookie(ResponseCookie("foo", "bar", expires = Some(now), httpOnly = true, secure = true))
 }
-cookieResp.unsafeRunSync.headers
+cookieResp.unsafeRunSync().headers
 ```
 
 To request a cookie to be removed on the client, you need to set the cookie value
 to empty. http4s can do that with `removeCookie`:
 
 ```scala mdoc
-Ok("Ok response.").map(_.removeCookie("foo")).unsafeRunSync.headers
+Ok("Ok response.").map(_.removeCookie("foo")).unsafeRunSync().headers
 ```
 
 ### Responding with a body
@@ -198,10 +198,10 @@ implicit `EntityEncoder` in scope.  http4s provides several out of the
 box:
 
 ```scala mdoc
-Ok("Received request.").unsafeRunSync
+Ok("Received request.").unsafeRunSync()
 
 import java.nio.charset.StandardCharsets.UTF_8
-Ok("binary".getBytes(UTF_8)).unsafeRunSync
+Ok("binary".getBytes(UTF_8)).unsafeRunSync()
 ```
 
 Per the HTTP specification, some status codes don't support a body.
@@ -238,7 +238,7 @@ val io = Ok(IO.fromFuture(IO(Future {
   println("I run when the future is constructed.")
   "Greetings from the future!"
 })))
-io.unsafeRunSync
+io.unsafeRunSync()
 ```
 
 As good functional programmers who like to delay our side effects, we
@@ -249,7 +249,7 @@ val io = Ok(IO {
   println("I run when the IO is run.")
   "Mission accomplished!"
 })
-io.unsafeRunSync
+io.unsafeRunSync()
 ```
 
 Note that in both cases, a `Content-Length` header is calculated.
@@ -281,7 +281,7 @@ We can see it for ourselves in the REPL:
 
 ```scala mdoc
 val dripOutIO = drip.through(fs2.text.lines).through(_.evalMap(s => {IO{println(s); s}})).compile.drain
-dripOutIO.unsafeRunSync
+dripOutIO.unsafeRunSync()
 ```
 
 When wrapped in a `Response[F]`, http4s will flush each chunk of a
@@ -414,7 +414,7 @@ val dailyWeatherService = HttpRoutes.of[IO] {
     Ok(getTemperatureForecast(localDate).map(s"The temperature on $localDate will be: " + _))
 }
 
-println(GET(uri"/weather/temperature/2016-11-05").flatMap(dailyWeatherService.orNotFound(_)).unsafeRunSync)
+println(GET(uri"/weather/temperature/2016-11-05").flatMap(dailyWeatherService.orNotFound(_)).unsafeRunSync())
 ```
 
 ### Handling query parameters

--- a/docs/src/main/mdoc/entity.md
+++ b/docs/src/main/mdoc/entity.md
@@ -68,7 +68,7 @@ val videoDec = EntityDecoder.decodeBy(MediaType.video.ogg) { (m: Media[IO]) =>
   }
 }
 implicit val bothDec = audioDec.widen[Resp] orElse videoDec.widen[Resp]
-println(response.flatMap(_.as[Resp]).unsafeRunSync)
+println(response.flatMap(_.as[Resp]).unsafeRunSync())
 ```
 
 ## Presupplied Encoders/Decoders

--- a/docs/src/main/mdoc/gzip.md
+++ b/docs/src/main/mdoc/gzip.md
@@ -37,8 +37,8 @@ val service = HttpRoutes.of[IO] {
 val request = Request[IO](Method.GET, uri"/")
 
 // Do not call 'unsafeRun' in your code - see note at bottom.
-val response = service.orNotFound(request).unsafeRunSync
-val body = response.as[String].unsafeRunSync
+val response = service.orNotFound(request).unsafeRunSync()
+val body = response.as[String].unsafeRunSync()
 body.length
 ```
 
@@ -49,8 +49,8 @@ import org.http4s.server.middleware._
 val zipService = GZip(service)
 
 // Do not call 'unsafeRun' in your code - see note at bottom.
-val response = zipService.orNotFound(request).unsafeRunSync
-val body = response.as[String].unsafeRunSync
+val response = zipService.orNotFound(request).unsafeRunSync()
+val body = response.as[String].unsafeRunSync()
 body.length
 ```
 
@@ -63,8 +63,8 @@ val acceptHeader = Header("Accept-Encoding", "gzip")
 val zipRequest = request.putHeaders(acceptHeader)
 
 // Do not call 'unsafeRun' in your code - see note at bottom.
-val response = zipService.orNotFound(zipRequest).unsafeRunSync
-val body = response.as[String].unsafeRunSync
+val response = zipService.orNotFound(zipRequest).unsafeRunSync()
+val body = response.as[String].unsafeRunSync()
 body.length
 ```
 

--- a/docs/src/main/mdoc/hsts.md
+++ b/docs/src/main/mdoc/hsts.md
@@ -37,7 +37,7 @@ val service = HttpRoutes.of[IO] {
 val request = Request[IO](Method.GET, uri"/")
 
 // Do not call 'unsafeRunSync' in your code
-val response = service.orNotFound(request).unsafeRunSync
+val response = service.orNotFound(request).unsafeRunSync()
 response.headers
 ```
 
@@ -51,7 +51,7 @@ import org.http4s.server.middleware._
 val hstsService = HSTS(service)
 
 // Do not call 'unsafeRunSync' in your code
-val response = hstsService.orNotFound(request).unsafeRunSync
+val response = hstsService.orNotFound(request).unsafeRunSync()
 response.headers
 ```
 
@@ -78,7 +78,7 @@ val hstsHeader = `Strict-Transport-Security`.unsafeFromDuration(30.days, include
 val hstsService = HSTS(service, hstsHeader)
 
 // Do not call 'unsafeRunSync' in your code
-val response = hstsService.orNotFound(request).unsafeRunSync
+val response = hstsService.orNotFound(request).unsafeRunSync()
 response.headers
 ```
 

--- a/docs/src/main/mdoc/json.md
+++ b/docs/src/main/mdoc/json.md
@@ -80,7 +80,7 @@ val greeting = hello("world")
 We now have a JSON value, but we don't have enough to render it:
 
 ```scala mdoc:fail
-Ok(greeting).unsafeRunSync
+Ok(greeting).unsafeRunSync()
 ```
 
 To encode a Scala value of type `A` into an entity, we need an
@@ -93,7 +93,7 @@ import org.http4s.circe._
 ```
 
 ```scala mdoc
-Ok(greeting).unsafeRunSync
+Ok(greeting).unsafeRunSync()
 ```
 
 The same `EntityEncoder[Json]` we use on server responses is also
@@ -104,7 +104,7 @@ import org.http4s.client.dsl.io._
 ```
 
 ```scala mdoc
-POST(json"""{"name": "Alice"}""", uri"/hello").unsafeRunSync
+POST(json"""{"name": "Alice"}""", uri"/hello").unsafeRunSync()
 ```
 
 ## Encoding case classes as JSON
@@ -160,8 +160,8 @@ Equipped with an `Encoder` and `.asJson`, we can send JSON in requests
 and responses for our case classes:
 
 ```scala mdoc
-Ok(Hello("Alice").asJson).unsafeRunSync
-POST(User("Bob").asJson, uri"/hello").unsafeRunSync
+Ok(Hello("Alice").asJson).unsafeRunSync()
+POST(User("Bob").asJson, uri"/hello").unsafeRunSync()
 ```
 
 If within some route we serve json only, we can use:
@@ -186,8 +186,8 @@ The `org.http4s.circe._` package provides an implicit
 response body to JSON using the [`as` syntax]:
 
 ```scala mdoc
-Ok("""{"name":"Alice"}""").flatMap(_.as[Json]).unsafeRunSync
-POST("""{"name":"Bob"}""", uri"/hello").flatMap(_.as[Json]).unsafeRunSync
+Ok("""{"name":"Alice"}""").flatMap(_.as[Json]).unsafeRunSync()
+POST("""{"name":"Bob"}""", uri"/hello").flatMap(_.as[Json]).unsafeRunSync()
 ```
 
 Like sending raw JSON, this is useful to a point, but we typically
@@ -203,9 +203,9 @@ an implicit `Decoder[A]` and makes a `EntityDecoder[A]`:
 
 ```scala mdoc
 implicit val userDecoder = jsonOf[IO, User]
-Ok("""{"name":"Alice"}""").flatMap(_.as[User]).unsafeRunSync
+Ok("""{"name":"Alice"}""").flatMap(_.as[User]).unsafeRunSync()
 
-POST("""{"name":"Bob"}""", uri"/hello").flatMap(_.as[User]).unsafeRunSync
+POST("""{"name":"Bob"}""", uri"/hello").flatMap(_.as[User]).unsafeRunSync()
 ```
 
 If we are always decoding from JSON to a typed model, we can use
@@ -300,7 +300,7 @@ Finally, we post `User("Alice")` to our Hello service and expect
 
 ```scala mdoc
 val helloAlice = helloClient("Alice")
-helloAlice.compile.last.unsafeRunSync
+helloAlice.compile.last.unsafeRunSync()
 ```
 
 Finally, shut down our example server.

--- a/docs/src/main/mdoc/middleware.md
+++ b/docs/src/main/mdoc/middleware.md
@@ -67,8 +67,8 @@ val service = HttpRoutes.of[IO] {
 val goodRequest = Request[IO](Method.GET, uri"/")
 val badRequest = Request[IO](Method.GET, uri"/bad")
 
-service.orNotFound(goodRequest).unsafeRunSync
-service.orNotFound(badRequest).unsafeRunSync
+service.orNotFound(goodRequest).unsafeRunSync()
+service.orNotFound(badRequest).unsafeRunSync()
 ```
 
 Now, we'll wrap the service in our middleware to create a new service, and try it out.
@@ -76,8 +76,8 @@ Now, we'll wrap the service in our middleware to create a new service, and try i
 ```scala mdoc
 val wrappedService = myMiddle(service, Header("SomeKey", "SomeValue"));
 
-wrappedService.orNotFound(goodRequest).unsafeRunSync
-wrappedService.orNotFound(badRequest).unsafeRunSync
+wrappedService.orNotFound(goodRequest).unsafeRunSync()
+wrappedService.orNotFound(badRequest).unsafeRunSync()
 ```
 
 Note that the successful response has your header added to it.
@@ -99,8 +99,8 @@ object MyMiddle {
 
 val newService = MyMiddle(service, Header("SomeKey", "SomeValue"))
 
-newService.orNotFound(goodRequest).unsafeRunSync
-newService.orNotFound(badRequest).unsafeRunSync
+newService.orNotFound(goodRequest).unsafeRunSync()
+newService.orNotFound(badRequest).unsafeRunSync()
 ```
 
 It is possible for the wrapped `Service` to have different `Request` and `Response`
@@ -129,8 +129,8 @@ val aggregateService = apiService <+> MyMiddle(service, Header("SomeKey", "SomeV
 
 val apiRequest = Request[IO](Method.GET, uri"/api")
 
-aggregateService.orNotFound(goodRequest).unsafeRunSync
-aggregateService.orNotFound(apiRequest).unsafeRunSync
+aggregateService.orNotFound(goodRequest).unsafeRunSync()
+aggregateService.orNotFound(apiRequest).unsafeRunSync()
 ```
 
 Note that `goodRequest` ran through the `MyMiddle` middleware and the `Result` had

--- a/docs/src/main/mdoc/service.md
+++ b/docs/src/main/mdoc/service.md
@@ -10,7 +10,7 @@ and calling it with http4s' client.
 Create a new directory, with the following build.sbt in the root:
 
 ```scala
-scalaVersion := "2.13.2" // Also supports 2.12.x
+scalaVersion := "2.13.3" // Also supports 2.12.x
 
 val http4sVersion = "{{< version "http4s.doc" >}}"
 

--- a/docs/src/main/mdoc/testing.md
+++ b/docs/src/main/mdoc/testing.md
@@ -53,11 +53,11 @@ def check[A](actual:        IO[Response[IO]],
             expectedBody:   Option[A])(
     implicit ev: EntityDecoder[IO, A]
 ): Boolean =  {
-   val actualResp         = actual.unsafeRunSync
+   val actualResp         = actual.unsafeRunSync()
    val statusCheck        = actualResp.status == expectedStatus 
    val bodyCheck          = expectedBody.fold[Boolean](
-       actualResp.body.compile.toVector.unsafeRunSync.isEmpty)( // Verify Response's body is empty.
-       expected => actualResp.as[A].unsafeRunSync == expected
+       actualResp.body.compile.toVector.unsafeRunSync().isEmpty)( // Verify Response's body is empty.
+       expected => actualResp.as[A].unsafeRunSync() == expected
    )
    statusCheck && bodyCheck   
 }

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSpec.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSpec.scala
@@ -23,7 +23,7 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
       val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
       val req = Request[IO](uri = uri("/ok"))
 
-      val resp = meteredRoutes.orNotFound(req).unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).unsafeRunSync()
 
       resp must haveStatus(Status.Ok)
       resp must haveBody("200 OK")
@@ -42,7 +42,7 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
 
       val req = Request[IO](uri = uri("/bad-request"))
 
-      val resp = meteredRoutes.orNotFound(req).unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).unsafeRunSync()
 
       resp must haveStatus(Status.BadRequest)
       resp must haveBody("400 Bad Request")
@@ -60,7 +60,7 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
       val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
       val req = Request[IO](uri = uri("/internal-server-error"))
 
-      val resp = meteredRoutes.orNotFound(req).unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).unsafeRunSync()
 
       resp must haveStatus(Status.InternalServerError)
       resp must haveBody("500 Internal Server Error")
@@ -78,7 +78,7 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
       val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
       val req = Request[IO](method = GET, uri = uri("/ok"))
 
-      val resp = meteredRoutes.orNotFound(req).unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).unsafeRunSync()
 
       resp must haveStatus(Status.Ok)
       resp must haveBody("200 OK")
@@ -96,7 +96,7 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
       val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
       val req = Request[IO](method = POST, uri = uri("/ok"))
 
-      val resp = meteredRoutes.orNotFound(req).unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).unsafeRunSync()
 
       resp must haveStatus(Status.Ok)
       resp must haveBody("200 OK")
@@ -114,7 +114,7 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
       val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
       val req = Request[IO](method = PUT, uri = uri("/ok"))
 
-      val resp = meteredRoutes.orNotFound(req).unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).unsafeRunSync()
 
       resp must haveStatus(Status.Ok)
       resp must haveBody("200 OK")
@@ -132,7 +132,7 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
       val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
       val req = Request[IO](method = DELETE, uri = uri("/ok"))
 
-      val resp = meteredRoutes.orNotFound(req).unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).unsafeRunSync()
 
       resp must haveStatus(Status.Ok)
       resp must haveBody("200 OK")
@@ -150,7 +150,7 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
       val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
       val req = Request[IO](method = GET, uri = uri("/error"))
 
-      val resp = meteredRoutes.orNotFound(req).attempt.unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).attempt.unsafeRunSync()
 
       resp must beLeft
       count(registry, Timer("server.default.errors")) must beEqualTo(1)
@@ -166,10 +166,10 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
       val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
       val req = Request[IO](method = GET, uri = uri("/abnormal-termination"))
 
-      val resp = meteredRoutes.orNotFound(req).unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).unsafeRunSync()
 
       resp must haveStatus(Status.Ok)
-      resp.body.attempt.compile.lastOrError.unsafeRunSync must beLeft
+      resp.body.attempt.compile.lastOrError.unsafeRunSync() must beLeft
       count(registry, Timer("server.default.abnormal-terminations")) must beEqualTo(1)
       count(registry, Counter("server.default.active-requests")) must beEqualTo(0)
       count(registry, Timer("server.default.requests.total")) must beEqualTo(1)
@@ -185,7 +185,7 @@ class DropwizardServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
         Metrics[IO](ops = Dropwizard(registry, "server"), classifierF = classifierFunc)(testRoutes)
       val req = Request[IO](uri = uri("/ok"))
 
-      val resp = meteredRoutes.orNotFound(req).unsafeRunSync
+      val resp = meteredRoutes.orNotFound(req).unsafeRunSync()
 
       resp must haveStatus(Status.Ok)
       resp must haveBody("200 OK")

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
@@ -84,7 +84,7 @@ object PathInHttpRoutesSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   }
 
   def serve(req: Request[IO]): Response[IO] =
-    app(req).unsafeRunSync
+    app(req).unsafeRunSync()
 
   "Path DSL within HttpService" should {
     "GET /" in {

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSpec.scala
@@ -17,7 +17,7 @@ import org.http4s.testing.Http4sLegacyMatchersIO
 class ResponseGeneratorSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   "Add the EntityEncoder headers along with a content-length header" in {
     val body = "foo"
-    val resultheaders = Ok(body)(Monad[IO], EntityEncoder.stringEncoder[IO]).unsafeRunSync.headers
+    val resultheaders = Ok(body)(Monad[IO], EntityEncoder.stringEncoder[IO]).unsafeRunSync().headers
     EntityEncoder.stringEncoder[IO].headers.foldLeft(ok) { (old, h) =>
       old.and(resultheaders.toList.exists(_ == h) must_=== true)
     }

--- a/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
@@ -43,7 +43,7 @@ class EncoderSpec extends Specification {
       |
       |""".stripMargin
 
-      Helpers.encodeRequestRig(req).unsafeRunSync must_=== expected
+      Helpers.encodeRequestRig(req).unsafeRunSync() must_=== expected
     }
 
     "encode a request with a body correctly" in {
@@ -57,7 +57,7 @@ class EncoderSpec extends Specification {
       |
       |Hello World!""".stripMargin
 
-      Helpers.encodeRequestRig(req).unsafeRunSync must_=== expected
+      Helpers.encodeRequestRig(req).unsafeRunSync() must_=== expected
     }
 
     "encode headers correctly" in {
@@ -72,7 +72,7 @@ class EncoderSpec extends Specification {
         |foo: bar
         |
         |""".stripMargin
-      Helpers.encodeRequestRig(req).unsafeRunSync must_=== expected
+      Helpers.encodeRequestRig(req).unsafeRunSync() must_=== expected
     }
   }
 
@@ -85,7 +85,7 @@ class EncoderSpec extends Specification {
       |
       |""".stripMargin
 
-      Helpers.encodeResponseRig(resp).unsafeRunSync must_=== expected
+      Helpers.encodeResponseRig(resp).unsafeRunSync() must_=== expected
     }
 
     "encode a response with a body correctly" in {
@@ -99,7 +99,7 @@ class EncoderSpec extends Specification {
       |
       |Not Found""".stripMargin
 
-      Helpers.encodeResponseRig(resp).unsafeRunSync must_=== expected
+      Helpers.encodeResponseRig(resp).unsafeRunSync() must_=== expected
     }
   }
 }

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParsingSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParsingSpec.scala
@@ -89,7 +89,7 @@ class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
       |""".stripMargin
       val expected = Request[IO](Method.GET, Uri.unsafeFromString("www.google.com"))
 
-      val result = Helpers.parseRequestRig[IO](raw).unsafeRunSync
+      val result = Helpers.parseRequestRig[IO](raw).unsafeRunSync()
 
       result.method must_=== expected.method
       result.uri.scheme must_=== expected.uri.scheme
@@ -98,7 +98,8 @@ class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
       // result.uri.query must_=== expected.uri.query
       result.uri.fragment must_=== expected.uri.fragment
       result.headers must_=== expected.headers
-      result.body.compile.toVector.unsafeRunSync must_=== expected.body.compile.toVector.unsafeRunSync
+      result.body.compile.toVector.unsafeRunSync() must_=== expected.body.compile.toVector
+        .unsafeRunSync()
     }
 
     "Parse a request with a body correctly" in {
@@ -111,7 +112,7 @@ class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
       val expected = Request[IO](Method.POST, Uri.unsafeFromString("/foo"))
         .withEntity("Entity Here")
 
-      val result = Helpers.parseRequestRig[IO](raw).unsafeRunSync
+      val result = Helpers.parseRequestRig[IO](raw).unsafeRunSync()
 
       result.method must_=== expected.method
       result.uri.scheme must_=== expected.uri.scheme
@@ -120,7 +121,8 @@ class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
       // result.uri.query must_=== expected.uri.query
       result.uri.fragment must_=== expected.uri.fragment
       result.headers must_=== expected.headers
-      result.body.compile.toVector.unsafeRunSync must_=== expected.body.compile.toVector.unsafeRunSync
+      result.body.compile.toVector.unsafeRunSync() must_=== expected.body.compile.toVector
+        .unsafeRunSync()
     }
 
     "handle a response that requires multiple chunks to be read" in {
@@ -164,7 +166,7 @@ class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
 
           _.size must beGreaterThan(0)
         }
-        .unsafeRunSync
+        .unsafeRunSync()
     }
   }
 

--- a/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
@@ -22,7 +22,7 @@ class TraversalSpec extends Specification with ScalaCheck {
         .parser[IO](Int.MaxValue)(
           Encoder.reqToBytes[IO](req)
         )(logger)
-        .unsafeRunSync
+        .unsafeRunSync()
 
       end.headers must_=== req.headers
     }.pendingUntilFixed
@@ -36,7 +36,7 @@ class TraversalSpec extends Specification with ScalaCheck {
         .parser[IO](Int.MaxValue)(
           Encoder.reqToBytes[IO](newReq)
         )(logger)
-        .unsafeRunSync
+        .unsafeRunSync()
 
       end.method must_=== req.method
     }
@@ -47,7 +47,7 @@ class TraversalSpec extends Specification with ScalaCheck {
         .parser[IO](Int.MaxValue)(
           Encoder.reqToBytes[IO](req)
         )(logger)
-        .unsafeRunSync
+        .unsafeRunSync()
 
       end.uri.scheme must_=== req.uri.scheme
     }.pendingUntilFixed
@@ -61,9 +61,9 @@ class TraversalSpec extends Specification with ScalaCheck {
         .parser[IO](Int.MaxValue)(
           Encoder.reqToBytes[IO](newReq)
         )(logger)
-        .unsafeRunSync
+        .unsafeRunSync()
 
-      end.body.through(fs2.text.utf8Decode).compile.foldMonoid.unsafeRunSync must_=== s
+      end.body.through(fs2.text.utf8Decode).compile.foldMonoid.unsafeRunSync() must_=== s
     }
   }
 }

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSpec.scala
@@ -15,7 +15,7 @@ trait JawnDecodeSupportSpec[J] extends Http4sSpec {
     "json decoder" should {
       "return right when the entity is valid" in {
         val resp = Response[IO](Status.Ok).withEntity("""{"valid": true}""")
-        decoder.decode(resp, strict = false).value.unsafeRunSync must beRight
+        decoder.decode(resp, strict = false).value.unsafeRunSync() must beRight
       }
 
       testErrors(decoder)(
@@ -42,12 +42,12 @@ trait JawnDecodeSupportSpec[J] extends Http4sSpec {
   ) = {
     "return a ParseFailure when the entity is invalid" in {
       val resp = Response[IO](Status.Ok).withEntity("""garbage""")
-      decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like(parseError)
+      decoder.decode(resp, strict = false).value.unsafeRunSync() must beLeft.like(parseError)
     }
 
     "return a ParseFailure when the entity is empty" in {
       val resp = Response[IO](Status.Ok).withEntity("")
-      decoder.decode(resp, strict = false).value.unsafeRunSync must beLeft.like(emptyBody)
+      decoder.decode(resp, strict = false).value.unsafeRunSync() must beLeft.like(emptyBody)
     }
   }
 }

--- a/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
+++ b/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
@@ -54,7 +54,7 @@ class JettyServerSpec(implicit ee: ExecutionEnv) extends Http4sSpec with Http4sL
         IO(
           Source
             .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-            .getLines
+            .getLines()
             .mkString))
 
     def post(path: String, body: String): IO[String] =
@@ -66,7 +66,7 @@ class JettyServerSpec(implicit ee: ExecutionEnv) extends Http4sSpec with Http4sL
         conn.setRequestProperty("Content-Length", bytes.size.toString)
         conn.setDoOutput(true)
         conn.getOutputStream.write(bytes)
-        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines().mkString
       })
 
     "A server" should {

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -51,13 +51,13 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] with Http4sLegacyMatch
     "decode JSON from an json4s reader" in {
       val result =
         jsonOf[IO, Int].decode(Request[IO]().withEntity("42"), strict = false)
-      result.value.unsafeRunSync must beRight(42)
+      result.value.unsafeRunSync() must beRight(42)
     }
 
     "handle reader failures" in {
       val result =
         jsonOf[IO, Int].decode(Request[IO]().withEntity(""""oops""""), strict = false)
-      result.value.unsafeRunSync must beLeft.like {
+      result.value.unsafeRunSync() must beLeft.like {
         case InvalidMessageBodyFailure("Could not map JSON", _) => ok
       }
     }
@@ -69,13 +69,13 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] with Http4sLegacyMatch
     "extract JSON from formats" in {
       val result = jsonExtract[IO, Foo]
         .decode(Request[IO]().withEntity(JObject("bar" -> JInt(42))), strict = false)
-      result.value.unsafeRunSync must beRight(Foo(42))
+      result.value.unsafeRunSync() must beRight(Foo(42))
     }
 
     "handle extract failures" in {
       val result = jsonExtract[IO, Foo]
         .decode(Request[IO]().withEntity(""""oops""""), strict = false)
-      result.value.unsafeRunSync must beLeft.like {
+      result.value.unsafeRunSync() must beLeft.like {
         case InvalidMessageBodyFailure("Could not extract JSON", _) => ok
       }
     }
@@ -102,7 +102,7 @@ trait Json4sSpec[J] extends JawnDecodeSupportSpec[JValue] with Http4sLegacyMatch
       val req = Request[IO]()
         .withEntity("not a number")
         .withContentType(`Content-Type`(MediaType.application.json))
-      req.decodeJson[Int].attempt.unsafeRunSync must beLeft
+      req.decodeJson[Int].attempt.unsafeRunSync() must beLeft
     }
   }
 }

--- a/play-json/src/test/scala/org/http4s/play/PlaySpec.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySpec.scala
@@ -53,7 +53,7 @@ class PlaySpec extends JawnDecodeSupportSpec[JsValue] with Http4sLegacyMatchersI
     "decode JSON from a Play decoder" in {
       val result = jsonOf[IO, Foo]
         .decode(Request[IO]().withEntity(Json.obj("bar" -> JsNumber(42)): JsValue), strict = true)
-      result.value.unsafeRunSync must_== Right(Foo(42))
+      result.value.unsafeRunSync() must_== Right(Foo(42))
     }
   }
 
@@ -74,7 +74,7 @@ class PlaySpec extends JawnDecodeSupportSpec[JsValue] with Http4sLegacyMatchersI
 
     "fail on invalid json" in {
       val req = Request[IO]().withEntity(Json.toJson(List(13, 14)))
-      req.decodeJson[Foo].attempt.unsafeRunSync must beLeft
+      req.decodeJson[Foo].attempt.unsafeRunSync() must beLeft
     }
   }
 
@@ -83,7 +83,7 @@ class PlaySpec extends JawnDecodeSupportSpec[JsValue] with Http4sLegacyMatchersI
       import org.http4s.play.PlayEntityDecoder._
       val request = Request[IO]().withEntity(Json.obj("bar" -> JsNumber(42)): JsValue)
       val result = request.as[Foo]
-      result.unsafeRunSync must_== Foo(42)
+      result.unsafeRunSync() must_== Foo(42)
     }
 
     "encode without defining EntityEncoder using default printer" in {

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -21,7 +21,7 @@ object Http4sPlugin extends AutoPlugin {
 
   override def requires = Http4sOrgPlugin
 
-  val scala_213 = "2.13.2"
+  val scala_213 = "2.13.3"
   val scala_212 = "2.12.11"
 
   override lazy val buildSettings = Seq(

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -13,4 +13,4 @@ libraryDependencies ++= List(
 
 // Hack around a binary conflict in scalameta's dependency on
 // fastparse as specified by sbt-doctest-0.9.5.
-libraryDependencies += "org.scalameta" %% "scalameta" % "4.3.7"
+libraryDependencies += "org.scalameta" %% "scalameta" % "4.3.19"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,13 +3,13 @@ libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 // https://github.com/coursier/coursier/issues/450
 classpathTypes += "maven-plugin"
 
-addSbtPlugin("ch.epfl.scala"              %  "sbt-scalafix"              % "0.9.17")
+addSbtPlugin("ch.epfl.scala"              %  "sbt-scalafix"              % "0.9.18-1")
 addSbtPlugin("com.earldouglas"            %  "xsbt-web-plugin"           % "4.1.0")
 addSbtPlugin("com.eed3si9n"               %  "sbt-buildinfo"             % "0.9.0")
 addSbtPlugin("com.eed3si9n"               %  "sbt-unidoc"                % "0.4.3")
 addSbtPlugin("com.geirsson"               %  "sbt-ci-release"            % "1.5.2")
 addSbtPlugin("com.github.tkawachi"        %  "sbt-doctest"               % "0.9.6")
-addSbtPlugin("org.http4s"                 %  "sbt-http4s-org"            % "0.1.0")
+addSbtPlugin("org.http4s"                 %  "sbt-http4s-org"            % "0.2.0")
 addSbtPlugin("com.timushev.sbt"           %  "sbt-updates"               % "0.5.0")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-ghpages"               % "0.6.3")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-site"                  % "1.4.0")
@@ -17,7 +17,7 @@ addSbtPlugin("com.typesafe.sbt"           %  "sbt-twirl"                 % "1.5.
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-native-packager"       % "1.6.1")
 addSbtPlugin("de.heikoseeberger"          %  "sbt-header"                % "5.6.0")
 addSbtPlugin("io.get-coursier"            %  "sbt-coursier"              % "1.0.3")
-addSbtPlugin("io.github.davidgregory084"  %  "sbt-tpolecat"              % "0.1.10")
+addSbtPlugin("io.github.davidgregory084"  %  "sbt-tpolecat"              % "0.1.13")
 addSbtPlugin("io.spray"                   %  "sbt-revolver"              % "0.9.1")
 addSbtPlugin("pl.project13.scala"         %  "sbt-jmh"                   % "0.3.7")
 addSbtPlugin("org.scalameta"              %  "sbt-mdoc"                  % "2.2.0")

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSpec.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSpec.scala
@@ -163,7 +163,7 @@ class PrometheusServerMetricsSpec extends Http4sSpec with Http4sLegacyMatchersIO
           resp <- routes.run(req)
         } yield {
           resp must haveStatus(Status.Ok)
-          resp.body.attempt.compile.lastOrError.unsafeRunSync must beLeft
+          resp.body.attempt.compile.lastOrError.unsafeRunSync() must beLeft
 
           count(registry, "abnormal_terminations", "server") must beEqualTo(1)
           count(registry, "active_requests", "server") must beEqualTo(0)

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -15,7 +15,7 @@ import org.http4s.Status.Ok
 import scala.xml.Elem
 
 class ScalaXmlSpec extends Http4sSpec {
-  def getBody(body: EntityBody[IO]): Array[Byte] = body.compile.toVector.unsafeRunSync.toArray
+  def getBody(body: EntityBody[IO]): Array[Byte] = body.compile.toVector.unsafeRunSync().toArray
 
   def strBody(body: String): EntityBody[IO] = Stream(body).through(utf8Encode)
 
@@ -38,7 +38,7 @@ class ScalaXmlSpec extends Http4sSpec {
         .parTraverse(_ =>
           server(Request(body = strBody(
             """<?xml version="1.0" encoding="UTF-8" standalone="yes"?><html><h1>h1</h1></html>"""))))
-        .unsafeRunSync
+        .unsafeRunSync()
       resp.forall(_.status must_== Ok)
       resp.forall(x => getBody(x.body) must_== "html".getBytes)
     }
@@ -46,7 +46,7 @@ class ScalaXmlSpec extends Http4sSpec {
     "return 400 on parse error" in {
       val body = strBody("This is not XML.")
       val tresp = server(Request[IO](body = body))
-      tresp.unsafeRunSync.status must_== Status.BadRequest
+      tresp.unsafeRunSync().status must_== Status.BadRequest
     }
   }
 

--- a/scalafix/tests/src/test/scala/fix/RuleSuite.scala
+++ b/scalafix/tests/src/test/scala/fix/RuleSuite.scala
@@ -6,8 +6,9 @@
 
 package fix
 
-import scalafix.testkit.SemanticRuleSuite
+import org.scalatest.FunSpecLike
+import scalafix.testkit.AbstractSemanticRuleSuite
 
-class RuleSuite extends SemanticRuleSuite() {
+class RuleSuite extends AbstractSemanticRuleSuite with FunSpecLike {
   runAllTests()
 }

--- a/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSpec.scala
+++ b/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSpec.scala
@@ -39,7 +39,7 @@ class ScalatagsSpec extends Http4sSpec {
 
     "render the body" in {
       val resp = Response[IO](Ok).withEntity(testBody())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync() must beRight(
         "<div><p>this is my testBody</p></div>")
     }
   }

--- a/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
@@ -64,7 +64,7 @@ object HttpMethodOverrider {
       HeaderOverrideStrategy(CaseInsensitiveString("X-HTTP-Method-Override")),
       Set(Method.POST))
 
-  val overriddenMethodAttrKey: Key[Method] = Key.newKey[IO, Method].unsafeRunSync
+  val overriddenMethodAttrKey: Key[Method] = Key.newKey[IO, Method].unsafeRunSync()
 
   /** Simple middleware for HTTP Method Override.
     *

--- a/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
@@ -98,11 +98,11 @@ object PushSupport {
   private[PushSupport] final case class PushLocation(location: String, cascade: Boolean)
   private[http4s] final case class PushResponse[F[_]](location: String, resp: Response[F])
 
-  private[PushSupport] val pushLocationKey = Key.newKey[IO, Vector[PushLocation]].unsafeRunSync
+  private[PushSupport] val pushLocationKey = Key.newKey[IO, Vector[PushLocation]].unsafeRunSync()
   private[http4s] def pushResponsesKey[F[_]]: Key[F[Vector[PushResponse[F]]]] =
     Keys.PushResponses.asInstanceOf[Key[F[Vector[PushResponse[F]]]]]
 
   private[this] object Keys {
-    val PushResponses: Key[Any] = Key.newKey[IO, Any].unsafeRunSync
+    val PushResponses: Key[Any] = Key.newKey[IO, Any].unsafeRunSync()
   }
 }

--- a/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
@@ -27,7 +27,7 @@ object RequestId {
 
   private[this] val requestIdHeader = CIString("X-Request-ID")
 
-  val requestIdAttrKey: Key[String] = Key.newKey[IO, String].unsafeRunSync
+  val requestIdAttrKey: Key[String] = Key.newKey[IO, String].unsafeRunSync()
 
   def apply[G[_], F[_]](http: Http[G, F])(implicit G: Sync[G]): Http[G, F] =
     apply(requestIdHeader)(http)

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -42,7 +42,7 @@ package object server {
 
   object ServerRequestKeys {
     val SecureSession: Key[Option[SecureSession]] =
-      Key.newKey[IO, Option[SecureSession]].unsafeRunSync
+      Key.newKey[IO, Option[SecureSession]].unsafeRunSync()
   }
 
   /**

--- a/server/src/main/scala/org/http4s/server/websocket/package.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/package.scala
@@ -13,7 +13,7 @@ import cats.effect._
 
 package object websocket {
   private[this] object Keys {
-    val WebSocket: Key[Any] = Key.newKey[IO, Any].unsafeRunSync
+    val WebSocket: Key[Any] = Key.newKey[IO, Any].unsafeRunSync()
   }
 
   def websocketKey[F[_]]: Key[WebSocketContext[F]] =

--- a/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSpec.scala
@@ -41,7 +41,7 @@ class ChunkAggregatorSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
     def checkAppResponse(app: HttpApp[IO])(
         responseCheck: Response[IO] => MatchResult[Any]): MatchResult[Any] =
-      ChunkAggregator.httpApp(app).run(Request()).unsafeRunSync must beLike {
+      ChunkAggregator.httpApp(app).run(Request()).unsafeRunSync() must beLike {
         case response =>
           response.status must_== Ok
           responseCheck(response)
@@ -49,7 +49,7 @@ class ChunkAggregatorSpec extends Http4sSpec with Http4sLegacyMatchersIO {
 
     def checkRoutesResponse(routes: HttpRoutes[IO])(
         responseCheck: Response[IO] => MatchResult[Any]): MatchResult[Any] =
-      ChunkAggregator.httpRoutes(routes).run(Request()).value.unsafeRunSync must beSome
+      ChunkAggregator.httpRoutes(routes).run(Request()).value.unsafeRunSync() must beSome
         .like {
           case response =>
             response.status must_== Ok

--- a/server/src/test/scala/org/http4s/server/middleware/HSTSSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HSTSSpec.scala
@@ -28,7 +28,7 @@ class HSTSSpec extends Http4sSpec {
         HSTS.httpRoutes.unsafeFromDuration(innerRoutes, 365.days).orNotFound,
         HSTS.httpApp.unsafeFromDuration(innerRoutes.orNotFound, 365.days)
       ).map { app =>
-        val resp = app(req).unsafeRunSync
+        val resp = app(req).unsafeRunSync()
         resp.status must_== Status.Ok
         resp.headers.get(`Strict-Transport-Security`) must beSome
       }
@@ -42,7 +42,7 @@ class HSTSSpec extends Http4sSpec {
         HSTS.httpRoutes(innerRoutes).orNotFound,
         HSTS.httpApp(innerRoutes.orNotFound)
       ).map { app =>
-        val resp = app(req).unsafeRunSync
+        val resp = app(req).unsafeRunSync()
         resp.status must_== Status.Ok
         resp.headers.get(`Strict-Transport-Security`) must beSome
       }
@@ -54,7 +54,7 @@ class HSTSSpec extends Http4sSpec {
         HSTS.httpRoutes(innerRoutes).orNotFound,
         HSTS.httpApp(innerRoutes.orNotFound)
       ).map { app =>
-        val resp = app(req).unsafeRunSync
+        val resp = app(req).unsafeRunSync()
         resp.status must_== Status.Ok
         resp.headers.get(`Strict-Transport-Security`) must beSome
       }

--- a/server/src/test/scala/org/http4s/server/middleware/HttpsRedirectSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpsRedirectSpec.scala
@@ -31,7 +31,7 @@ class HttpsRedirectSpec extends Http4sSpec with Http4sLegacyMatchersIO {
         HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
         HttpsRedirect.httpApp(innerRoutes.orNotFound)
       ).map { app =>
-        val resp = app(req).unsafeRunSync
+        val resp = app(req).unsafeRunSync()
         val expectedAuthority = Authority(host = RegName("example.com"))
         val expectedLocation =
           Location(
@@ -49,7 +49,7 @@ class HttpsRedirectSpec extends Http4sSpec with Http4sLegacyMatchersIO {
         HttpsRedirect.httpApp(innerRoutes.orNotFound)
       ).map { app =>
         val noHeadersReq = Request[IO](method = GET, uri = Uri(path = "/"))
-        val resp = app(noHeadersReq).unsafeRunSync
+        val resp = app(noHeadersReq).unsafeRunSync()
         resp.status must_== Status.Ok
         resp.as[String] must returnValue("pong")
       }

--- a/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSpec.scala
@@ -25,7 +25,9 @@ class StaticHeadersSpec extends Http4sSpec {
       val resp = StaticHeaders.`no-cache`(testService).orNotFound(req)
 
       val check =
-        resp.map(_.headers.toList.map(_.toString).contains("Cache-Control: no-cache")).unsafeRunSync
+        resp
+          .map(_.headers.toList.map(_.toString).contains("Cache-Control: no-cache"))
+          .unsafeRunSync()
       check must_=== true
     }
   }

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -57,7 +57,7 @@ class AuthenticationSpec extends Http4sSpec {
       val authedValidateNukeService = basicAuthMiddleware(nukeService {
         isNuked = true
       })
-      val res = authedValidateNukeService.orNotFound(req).unsafeRunSync
+      val res = authedValidateNukeService.orNotFound(req).unsafeRunSync()
       isNuked must_=== false
       res.status must_=== Unauthorized
     }
@@ -68,7 +68,7 @@ class AuthenticationSpec extends Http4sSpec {
 
     "Respond to a request without authentication with 401" in {
       val req = Request[IO](uri = Uri(path = "/"))
-      val res = basicAuthedService.orNotFound(req).unsafeRunSync
+      val res = basicAuthedService.orNotFound(req).unsafeRunSync()
 
       res.status must_=== Unauthorized
       res.headers.get(`WWW-Authenticate`).map(_.value) must beSome(
@@ -79,7 +79,7 @@ class AuthenticationSpec extends Http4sSpec {
       val req = Request[IO](
         uri = Uri(path = "/"),
         headers = Headers.of(Authorization(BasicCredentials("Wrong User", password))))
-      val res = basicAuthedService.orNotFound(req).unsafeRunSync
+      val res = basicAuthedService.orNotFound(req).unsafeRunSync()
 
       res.status must_=== Unauthorized
       res.headers.get(`WWW-Authenticate`).map(_.value) must beSome(
@@ -90,7 +90,7 @@ class AuthenticationSpec extends Http4sSpec {
       val req = Request[IO](
         uri = Uri(path = "/"),
         headers = Headers.of(Authorization(BasicCredentials(username, "Wrong Password"))))
-      val res = basicAuthedService.orNotFound(req).unsafeRunSync
+      val res = basicAuthedService.orNotFound(req).unsafeRunSync()
 
       res.status must_=== Unauthorized
       res.headers.get(`WWW-Authenticate`).map(_.value) must beSome(
@@ -101,7 +101,7 @@ class AuthenticationSpec extends Http4sSpec {
       val req = Request[IO](
         uri = Uri(path = "/"),
         headers = Headers.of(Authorization(BasicCredentials(username, password))))
-      val res = basicAuthedService.orNotFound(req).unsafeRunSync
+      val res = basicAuthedService.orNotFound(req).unsafeRunSync()
 
       res.status must_=== Ok
     }
@@ -118,7 +118,7 @@ class AuthenticationSpec extends Http4sSpec {
     "Respond to a request without authentication with 401" in {
       val authedService = digestAuthMiddleware(service)
       val req = Request[IO](uri = Uri(path = "/"))
-      val res = authedService.orNotFound(req).unsafeRunSync
+      val res = authedService.orNotFound(req).unsafeRunSync()
 
       res.status must_=== Unauthorized
       val opt = res.headers.get(`WWW-Authenticate`).map(_.value)
@@ -136,7 +136,7 @@ class AuthenticationSpec extends Http4sSpec {
     def doDigestAuth1(digest: HttpApp[IO]) = {
       // Get auth data
       val req = Request[IO](uri = Uri(path = "/"))
-      val res = digest(req).unsafeRunSync
+      val res = digest(req).unsafeRunSync()
 
       res.status must_=== Unauthorized
       val opt = res.headers.get(`WWW-Authenticate`).map(_.value)
@@ -171,10 +171,10 @@ class AuthenticationSpec extends Http4sSpec {
       val header = Authorization(Credentials.AuthParams("Digest".ci, params))
 
       val req2 = Request[IO](uri = Uri(path = "/"), headers = Headers.of(header))
-      val res2 = digest(req2).unsafeRunSync
+      val res2 = digest(req2).unsafeRunSync()
 
       if (withReplay) {
-        val res3 = digest(req2).unsafeRunSync
+        val res3 = digest(req2).unsafeRunSync()
         (res2, res3)
       } else
         (res2, null)
@@ -218,7 +218,7 @@ class AuthenticationSpec extends Http4sSpec {
             res.status mustNotEqual NotFound
           })
         .toList
-      results.parSequence.unsafeRunSync
+      results.parSequence.unsafeRunSync()
 
       ok
     }
@@ -235,7 +235,7 @@ class AuthenticationSpec extends Http4sSpec {
           })
         .toList
 
-      val res = results.parSequence.unsafeRunSync
+      val res = results.parSequence.unsafeRunSync()
       res.filter(s => s == Ok).size must_=== 1
       res.filter(s => s == Unauthorized).size must_=== n - 1
 
@@ -272,7 +272,7 @@ class AuthenticationSpec extends Http4sSpec {
         val header = Authorization(
           Credentials.AuthParams("Digest".ci, invalidParams.head, invalidParams.tail: _*))
         val req = Request[IO](uri = Uri(path = "/"), headers = Headers.of(header))
-        val res = digestAuthService.orNotFound(req).unsafeRunSync
+        val res = digestAuthService.orNotFound(req).unsafeRunSync()
 
         res.status
       }

--- a/server/src/test/scala/org/http4s/server/staticcontent/StaticContentShared.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/StaticContentShared.scala
@@ -60,8 +60,8 @@ private[staticcontent] trait StaticContentShared { this: Http4sSpec =>
   }
 
   def runReq(req: Request[IO]): (Chunk[Byte], Response[IO]) = {
-    val resp = routes.orNotFound(req).unsafeRunSync
-    val chunk = Chunk.bytes(resp.body.compile.to(Array).unsafeRunSync)
+    val resp = routes.orNotFound(req).unsafeRunSync()
+    val chunk = Chunk.bytes(resp.body.compile.to(Array).unsafeRunSync())
     (chunk, resp)
   }
 }

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -32,7 +32,7 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
   private[this] var serverSoftware: ServerSoftware = _
 
   object ServletRequestKeys {
-    val HttpSession: Key[Option[HttpSession]] = Key.newKey[IO, Option[HttpSession]].unsafeRunSync
+    val HttpSession: Key[Option[HttpSession]] = Key.newKey[IO, Option[HttpSession]].unsafeRunSync()
   }
 
   override def init(config: ServletConfig): Unit = {

--- a/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSpec.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSpec.scala
@@ -39,7 +39,7 @@ class BlockingHttp4sServletSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       testBlocker.delay[IO, String](
         Source
           .fromURL(new URL(s"http://127.0.0.1:$serverPort/$path"))
-          .getLines
+          .getLines()
           .mkString)
 
     def post(path: String, body: String): IO[String] =
@@ -51,7 +51,7 @@ class BlockingHttp4sServletSpec extends Http4sSpec with Http4sLegacyMatchersIO {
         conn.setRequestProperty("Content-Length", bytes.size.toString)
         conn.setDoOutput(true)
         conn.getOutputStream.write(bytes)
-        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines().mkString
       }
 
     "Http4sBlockingServlet" should {

--- a/testing/src/main/scala/org/http4s/testing/IOMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/IOMatchers.scala
@@ -20,7 +20,7 @@ trait IOMatchers extends RunTimedMatchers[IO] {
   protected implicit def F: Sync[IO] = IO.ioEffect
   protected def runWithTimeout[A](fa: IO[A], timeout: FiniteDuration): Option[A] =
     fa.unsafeRunTimed(timeout)
-  protected def runAwait[A](fa: IO[A]): A = fa.unsafeRunSync
+  protected def runAwait[A](fa: IO[A]): A = fa.unsafeRunSync()
 }
 
 @deprecated("Provided by specs2-cats in org.specs2.matcher.IOMatchers", "0.21.0-RC2")

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -66,7 +66,7 @@ trait Http4sSpec
       .compile
       .last
       .map(_.getOrElse(""))
-      .unsafeRunSync
+      .unsafeRunSync()
 
   def checkAll(name: String, props: Properties)(implicit
       p: Parameters,

--- a/testing/src/test/scala/org/http4s/illTyped.scala
+++ b/testing/src/test/scala/org/http4s/illTyped.scala
@@ -35,8 +35,8 @@ class IllTypedMacros(val c: whitebox.Context) {
     }
 
     try {
-      val dummy0 = TermName(c.freshName)
-      val dummy1 = TermName(c.freshName)
+      val dummy0 = TermName(c.freshName())
+      val dummy1 = TermName(c.freshName())
       c.typecheck(c.parse(s"object $dummy0 { val $dummy1 = { $codeStr } }"))
       c.error(c.enclosingPosition, "Type-checking succeeded unexpectedly.\n" + expMsg)
     } catch {

--- a/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -307,7 +307,7 @@ class EntityDecoderSpec extends Http4sSpec with Http4sLegacyMatchersIO with Pend
             cb(Right(s))
             IO.pure(Response())
           }
-          .unsafeRunSync
+          .unsafeRunSync()
         ()
       } must returnValue("hooray")
     }
@@ -382,7 +382,7 @@ class EntityDecoderSpec extends Http4sSpec with Http4sLegacyMatchersIO with Pend
           req.decodeWith(EntityDecoder.textFile(tmpFile, testBlocker), strict = false) { _ =>
             Response[IO](Ok).withEntity("Hello").pure[IO]
           }
-        }.unsafeRunSync
+        }.unsafeRunSync()
 
         readTextFile(tmpFile) must_== new String(binData)
         response.status must_== Status.Ok
@@ -401,7 +401,7 @@ class EntityDecoderSpec extends Http4sSpec with Http4sLegacyMatchersIO with Pend
             req.decodeWith(EntityDecoder.binFile(tmpFile, testBlocker), strict = false) { _ =>
               Response[IO](Ok).withEntity("Hello").pure[IO]
             }
-        }.unsafeRunSync
+        }.unsafeRunSync()
 
         response must beStatus(Status.Ok)
         getBody(response.body) must returnValue("Hello".getBytes)

--- a/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -24,7 +24,7 @@ class ServerSentEventSpec extends Http4sSpec {
       |data: +2
       |data: 10
       |""".stripMargin('|'))
-      stream.through(ServerSentEvent.decoder).compile.toVector.unsafeRunSync must_== Vector(
+      stream.through(ServerSentEvent.decoder).compile.toVector.unsafeRunSync() must_== Vector(
         ServerSentEvent(data = "YHOO\n+2\n10")
       )
     }
@@ -41,7 +41,7 @@ class ServerSentEventSpec extends Http4sSpec {
       |data:  third event
       |""".stripMargin('|'))
       //test stream\n\ndata: first event\nid: 1\n\ndata:second event\nid\n\ndata:  third event\n")
-      stream.through(ServerSentEvent.decoder).compile.toVector.unsafeRunSync must_== Vector(
+      stream.through(ServerSentEvent.decoder).compile.toVector.unsafeRunSync() must_== Vector(
         ServerSentEvent(data = "first event", id = Some(EventId("1"))),
         ServerSentEvent(data = "second event", id = Some(EventId.reset)),
         ServerSentEvent(data = " third event", id = None)
@@ -58,7 +58,7 @@ class ServerSentEventSpec extends Http4sSpec {
       |data:
       |""".stripMargin('|'))
       //test stream\n\ndata: first event\nid: 1\n\ndata:second event\nid\n\ndata:  third event\n")
-      stream.through(ServerSentEvent.decoder).compile.toVector.unsafeRunSync must_== Vector(
+      stream.through(ServerSentEvent.decoder).compile.toVector.unsafeRunSync() must_== Vector(
         ServerSentEvent(data = ""),
         ServerSentEvent(data = "\n"),
         ServerSentEvent(data = "")
@@ -72,7 +72,7 @@ class ServerSentEventSpec extends Http4sSpec {
       |data: test
       |""".stripMargin('|'))
       //test stream\n\ndata: first event\nid: 1\n\ndata:second event\nid\n\ndata:  third event\n")
-      stream.through(ServerSentEvent.decoder).compile.toVector.unsafeRunSync must_== Vector(
+      stream.through(ServerSentEvent.decoder).compile.toVector.unsafeRunSync() must_== Vector(
         ServerSentEvent(data = "test"),
         ServerSentEvent(data = "test")
       )
@@ -88,7 +88,7 @@ class ServerSentEventSpec extends Http4sSpec {
         .through(ServerSentEvent.decoder)
         .compile
         .toVector
-        .unsafeRunSync
+        .unsafeRunSync()
       roundTrip must_== sses
     }
 
@@ -102,7 +102,7 @@ class ServerSentEventSpec extends Http4sSpec {
         .through(ServerSentEvent.decoder)
         .compile
         .last
-        .unsafeRunSync must beSome(sse)
+        .unsafeRunSync() must beSome(sse)
     }
   }
 
@@ -120,7 +120,7 @@ class ServerSentEventSpec extends Http4sSpec {
         .through(ServerSentEvent.decoder)
         .compile
         .toVector
-        .unsafeRunSync must_== eventStream.compile.toVector.unsafeRunSync
+        .unsafeRunSync() must_== eventStream.compile.toVector.unsafeRunSync()
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/StaticFileSpec.scala
+++ b/tests/src/test/scala/org/http4s/StaticFileSpec.scala
@@ -21,7 +21,7 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   "StaticFile" should {
     "Determine the media-type based on the files extension" in {
       def check(f: File, tpe: Option[MediaType]): MatchResult[Any] = {
-        val r = StaticFile.fromFile[IO](f, testBlocker).value.unsafeRunSync
+        val r = StaticFile.fromFile[IO](f, testBlocker).value.unsafeRunSync()
 
         r must beSome[Response[IO]]
         r.flatMap(_.headers.get(`Content-Type`)) must_== tpe.map(t => `Content-Type`(t))
@@ -111,7 +111,7 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val response = StaticFile
         .fromFile[IO](emptyFile, testBlocker, Some(request))
         .value
-        .unsafeRunSync
+        .unsafeRunSync()
       response must beSome[Response[IO]]
       response.map(_.status) must beSome(NotModified)
     }
@@ -125,7 +125,7 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val response = StaticFile
         .fromFile[IO](emptyFile, testBlocker, Some(request))
         .value
-        .unsafeRunSync
+        .unsafeRunSync()
       response must beSome[Response[IO]]
       response.map(_.status) must beSome(NotModified)
     }
@@ -143,7 +143,7 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val response = StaticFile
         .fromFile[IO](emptyFile, testBlocker, Some(request))
         .value
-        .unsafeRunSync
+        .unsafeRunSync()
       response must beSome[Response[IO]]
       response.map(_.status) must beSome(NotModified)
     }
@@ -158,7 +158,7 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val response = StaticFile
         .fromFile[IO](emptyFile, testBlocker, Some(request))
         .value
-        .unsafeRunSync
+        .unsafeRunSync()
       response must beSome[Response[IO]]
       response.map(_.status) must beSome(Ok)
     }
@@ -177,7 +177,7 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val response = StaticFile
         .fromFile[IO](emptyFile, testBlocker, Some(request))
         .value
-        .unsafeRunSync
+        .unsafeRunSync()
       response must beSome[Response[IO]]
       response.map(_.status) must beSome(Ok)
     }
@@ -196,13 +196,13 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
               None,
               StaticFile.calcETag[IO])
             .value
-            .unsafeRunSync
+            .unsafeRunSync()
 
         r must beSome[Response[IO]]
         // Length is only 1 byte
         r.flatMap(_.headers.get(`Content-Length`).map(_.length)) must beSome(1)
         // get the Body to check the actual size
-        r.map(_.body.compile.toVector.unsafeRunSync.length) must beSome(1)
+        r.map(_.body.compile.toVector.unsafeRunSync().length) must beSome(1)
       }
 
       val tests = List(
@@ -234,13 +234,13 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
             None,
             StaticFile.calcETag[IO])
           .value
-          .unsafeRunSync
+          .unsafeRunSync()
 
         r must beSome[Response[IO]]
         // Length of the body must match
         r.flatMap(_.headers.get(`Content-Length`).map(_.length)) must beSome(fileSize - 1)
         // get the Body to check the actual size
-        val body = r.map(_.body.compile.toVector.unsafeRunSync)
+        val body = r.map(_.body.compile.toVector.unsafeRunSync())
         body.map(_.length) must beSome(fileSize - 1)
         // Verify the context
         body.map(bytes =>
@@ -258,7 +258,7 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val s = StaticFile
         .fromURL[IO](getClass.getResource("/lorem-ipsum.txt"), testBlocker)
         .value
-        .unsafeRunSync
+        .unsafeRunSync()
         .fold[EntityBody[IO]](sys.error("Couldn't find resource"))(_.body)
       // Expose problem with readInputStream recycling buffer.  chunks.compile.toVector
       // saves chunks, which are mutated by naive usage of readInputStream.
@@ -282,7 +282,7 @@ class StaticFileSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       val s = StaticFile
         .fromURL[IO](getClass.getResource("/foo"), testBlocker)
         .value
-        .unsafeRunSync
+        .unsafeRunSync()
       s must_== None
     }
   }

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -518,17 +518,17 @@ http://example.org/a file
     "work with empty keys" in {
       val u = Uri(query = Query.fromString("=value1&=value2&=&"))
       val i = u.params.iterator
-      i.next must be_==("" -> "value1")
-      i.next must throwA[NoSuchElementException]
+      i.next() must be_==("" -> "value1")
+      i.next() must throwA[NoSuchElementException]
     }
     "work on non-empty query string" in {
       val u = Uri(
         query =
           Query.fromString("param1=value1&param1=value2&param1=value3&param2=value4&param2=value5"))
       val i = u.params.iterator
-      i.next must be_==("param1" -> "value1")
-      i.next must be_==("param2" -> "value4")
-      i.next must throwA[NoSuchElementException]
+      i.next() must be_==("param1" -> "value1")
+      i.next() must be_==("param2" -> "value4")
+      i.next() must throwA[NoSuchElementException]
     }
   }
 
@@ -624,35 +624,35 @@ http://example.org/a file
 
   "Uri parameter convenience methods" should {
     "add a parameter if no query is available" in {
-      val u = Uri(query = Query.empty) +? ("param1", "value")
+      val u = Uri(query = Query.empty).+?("param1", "value")
       u must be_==(Uri(query = Query.fromString("param1=value")))
     }
     "add a parameter" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2", "value")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")).+?("param2", "value")
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2=value")))
     }
     "add a parameter with boolean value" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2", true)
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")).+?("param2", true)
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2=true")))
     }
     "add a parameter without a value" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")).+?("param2")
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
     }
     "add a parameter with many values" in {
-      val u = Uri() +? ("param1", Seq("value1", "value2"))
+      val u = Uri().+?("param1", Seq("value1", "value2"))
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2")))
     }
     "add a parameter with many long values" in {
-      val u = Uri() +? ("param1", Seq(1L, -1L))
+      val u = Uri().+?("param1", Seq(1L, -1L))
       u must be_==(Uri(query = Query.fromString(s"param1=1&param1=-1")))
     }
     "add a query parameter with a QueryParamEncoder" in {
-      val u = Uri() +? ("test", Ttl(2))
+      val u = Uri().+?("test", Ttl(2))
       u must be_==(Uri(query = Query.fromString(s"test=2")))
     }
     "add a query parameter with a QueryParamEncoder and an implicit key" in {
-      val u = Uri() +*? (Ttl(2))
+      val u = Uri().+*?(Ttl(2))
       u must be_==(Uri(query = Query.fromString(s"ttl=2")))
     }
     "add a QueryParam instance" in {
@@ -660,11 +660,11 @@ http://example.org/a file
       u must be_==(Uri(query = Query.fromString(s"ttl")))
     }
     "add an optional query parameter (Just)" in {
-      val u = Uri() +?? ("param1", Some(2))
+      val u = Uri().+??("param1", Some(2))
       u must be_==(Uri(query = Query.fromString(s"param1=2")))
     }
     "add an optional query parameter (Empty)" in {
-      val u = Uri() +?? ("param1", None: Option[Int])
+      val u = Uri().+??("param1", None: Option[Int])
       u must be_==(Uri(query = Query.empty))
     }
     "add multiple query parameters at once" in {
@@ -736,7 +736,7 @@ http://example.org/a file
       u must be_==(Uri())
     }
     "replace a parameter" in {
-      val u = Uri(query = Query.fromString("param1=value&param2=value")) +? ("param1", "newValue")
+      val u = Uri(query = Query.fromString("param1=value&param2=value")).+?("param1", "newValue")
       u.multiParams must be_==(
         Uri(query = Query.fromString("param1=newValue&param2=value")).multiParams)
     }
@@ -747,19 +747,18 @@ http://example.org/a file
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace the same parameter" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) +? ("param1", Seq(
-        "value1",
-        "value2"))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2"))
+        .+?("param1", Seq("value1", "value2"))
       u.multiParams must be_==(
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace the same parameter without a value" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) +? ("param2")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")).+?("param2")
       u.multiParams must be_==(
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace a parameter set" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param1", "value")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")).+?("param1", "value")
       u.multiParams must be_==(Uri(query = Query.fromString("param1=value")).multiParams)
     }
     "set a parameter with a value" in {

--- a/tests/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -94,13 +94,18 @@ class UrlFormSpec extends Http4sSpec {
 
     "withFormField is effectively equal to factory constructor that takes a Map" in {
       (
-        UrlForm.empty +? ("foo", 1) +? ("bar", Some(true)) ++? ("dummy", Chain("a", "b", "c")) ===
+        UrlForm.empty.+?("foo", 1).+?("bar", Some(true)).++?("dummy", Chain("a", "b", "c")) ===
           UrlForm(Map("foo" -> Chain("1"), "bar" -> Chain("true"), "dummy" -> Chain("a", "b", "c")))
       )
 
       (
-        UrlForm.empty +? ("foo", 1) +? ("bar", Option
-          .empty[Boolean]) ++? ("dummy", Chain("a", "b", "c")) ===
+        UrlForm.empty
+          .+?("foo", 1)
+          .+?(
+            "bar",
+            Option
+              .empty[Boolean])
+          .++?("dummy", Chain("a", "b", "c")) ===
           UrlForm(Map("foo" -> Chain("1"), "dummy" -> Chain("a", "b", "c")))
       )
     }

--- a/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSpec.scala
+++ b/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSpec.scala
@@ -62,7 +62,7 @@ class TomcatServerSpec(implicit ee: ExecutionEnv) extends Http4sSpec with Http4s
           IO(
             Source
               .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-              .getLines
+              .getLines()
               .mkString))
 
       def post(path: String, body: String): IO[String] =
@@ -74,7 +74,10 @@ class TomcatServerSpec(implicit ee: ExecutionEnv) extends Http4sSpec with Http4s
           conn.setRequestProperty("Content-Length", bytes.size.toString)
           conn.setDoOutput(true)
           conn.getOutputStream.write(bytes)
-          Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+          Source
+            .fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
+            .getLines()
+            .mkString
         })
 
       "A server" should {

--- a/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
+++ b/twirl/src/test/scala/org/http4s/twirl/TwirlSpec.scala
@@ -33,7 +33,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(html.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync() must beRight(
         "<h1>test html</h1>")
     }
   }
@@ -48,7 +48,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(js.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync() must beRight(
         """"test js"""")
     }
   }
@@ -61,7 +61,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(txt.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync() must beRight(
         """test text""")
     }
   }
@@ -74,7 +74,7 @@ class TwirlSpec extends Http4sSpec {
 
     "render the body" in prop { implicit cs: Charset =>
       val resp = Response[IO](Ok).withEntity(_root_.xml.test())
-      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync must beRight(
+      EntityDecoder.text[IO].decode(resp, strict = false).value.unsafeRunSync() must beRight(
         "<test>test xml</test>")
     }
   }


### PR DESCRIPTION
* Large changeset due to syntactic deprecations.
* We needed a new silencer, which we get from sbt-http4s-org.
* Silenced deprecation of parboiled's unary `!`.  Consider fixing that in parboiled.
* Shows that our query string operators are on shaky ground.
* We needed a new scalafix.