### PR TITLE
Close urlConn in StaticFile.fromURL

### DIFF
--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -90,7 +90,7 @@ object StaticFile {
           Some(
             Response(
               headers = headers,
-              body = readInputStream[F](F.delay(url.openStream), DefaultBufferSize, blocker)
+              body = readInputStream[F](F.delay(urlConn.getInputStream), DefaultBufferSize, blocker)
             ))
         } else {
           urlConn.getInputStream.close()


### PR DESCRIPTION
The URLConnection in StaticFile.fromURL is never closed (when the resource is not expired).
This PR reuses the already opened URLConnection to read the response body which in effect causes fs2 to close the URLConnection once the body is fully read.
Or was the body intended to open a separate url connection? In that case the previous URLConnection should probably be closed before returning the response.