### PR TITLE
Fixes Connection Reuse for Ember Client

### DIFF
--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -138,7 +138,7 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
                 timeout
               )(logger)
               .map(response =>
-              // TODO If Response Body has a take(1).compile.drain - would leave rest of bytes in root stream for next caller
+                // TODO If Response Body has a take(1).compile.drain - would leave rest of bytes in root stream for next caller
                 response.copy(body = response.body.onFinalizeCaseWeak {
                   case ExitCase.Completed =>
                     val requestClose = request.headers.get(Connection).exists(_.hasClose)
@@ -151,8 +151,7 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
                   case ExitCase.Canceled => Sync[F].unit
                   case ExitCase.Error(_) => Sync[F].unit
                 }))
-        } yield responseResource
-      )
+        } yield responseResource)
       new EmberClient[F](client, pool)
     }
 }

--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -56,13 +56,14 @@ private[ember] object Encoder {
         .append(req.httpVersion.renderString)
         .append(CRLF)
 
-      // Host From Uri Becomes Header
-      req.uri.authority.foreach { auth =>
-        stringBuilder
-          .append("Host: ")
-          .append(auth.renderString)
-          .append(CRLF)
-      }
+      // Host From Uri Becomes Header if not already present in headers
+      if (org.http4s.headers.Host.from(req.headers).isEmpty)
+        req.uri.authority.foreach { auth =>
+          stringBuilder
+            .append("Host: ")
+            .append(auth.renderString)
+            .append(CRLF)
+        }
 
       // Apply each header followed by a CRLF
       req.headers.foreach { h =>
@@ -71,6 +72,7 @@ private[ember] object Encoder {
           .append(CRLF)
         ()
       }
+
       // Final CRLF terminates headers and signals body to follow.
       stringBuilder.append(CRLF)
       stringBuilder.toString.getBytes(StandardCharsets.ISO_8859_1)


### PR DESCRIPTION
Fixes #3592 

First Error Discovered: When we are actually able to reuse a connection it was draining the root stream of extra bytes. As we had listed to take 2060 bytes, and then with the same reference try to pull 2060 more bytes as the effect was executed in the use block. This hung waiting for new bytes. (This signals to me that the user has a hold of the root connection not only a handle of 2060 bytes worth of it as pulling twice tries to take that twice, unsure if we should do something or how to do something that separates that logic). This means as well that a partially consumed stream will trigger the finalizers for reuse but the underlying stream will have however many bytes are uncomsumed present. We could add something that measures how much is read and then read that on shutdown, but then that introduces a race condition between release and an asynchronous effect. I feel that this default is reasonable for now, but we may want to revisit it in the future.

When introducing the host logic, we created a way to write the Host header twice, as if it was present in the headers and the uri it was written twice. This is now fixed to only render a Host header from a Uri if it is not present in headers. This is how its done in blaze but feels pretty inefficient compared to my other methods here. (We were previously ok due to how headers ++ operated)



