### PR TITLE
Client Request/Response Modifications

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,8 +195,10 @@ lazy val emberClient = libraryProject("ember-client")
     description := "ember implementation for http4s clients",
     libraryDependencies ++= Seq(keypool, log4catsSlf4j),
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.ember.core.Parser#Response.parser"),
+
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.client.internal.ClientHelpers.request"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.ember.client.internal.ClientHelpers.request"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.ember.core.Parser#Response.parser"),
     )
   )
   .dependsOn(emberCore % "compile;test->test", client % "compile;test->test")

--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -35,6 +35,35 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     val userAgent: Option[`User-Agent`]
 ) { self =>
 
+  @deprecated("Preserved for binary compatibility", "0.21.7")
+  private[EmberClientBuilder] def this(
+      blockerOpt: Option[Blocker],
+      tlsContextOpt: Option[TLSContext],
+      sgOpt: Option[SocketGroup],
+      maxTotal: Int,
+      maxPerKey: RequestKey => Int,
+      idleTimeInPool: Duration,
+      logger: Logger[F],
+      chunkSize: Int,
+      maxResponseHeaderSize: Int,
+      timeout: Duration,
+      additionalSocketOptions: List[SocketOptionMapping[_]]
+  ) =
+    this(
+      blockerOpt = blockerOpt,
+      tlsContextOpt = tlsContextOpt,
+      sgOpt = sgOpt,
+      maxTotal = maxTotal,
+      maxPerKey = maxPerKey,
+      idleTimeInPool = idleTimeInPool,
+      logger = logger,
+      chunkSize = chunkSize,
+      maxResponseHeaderSize = maxResponseHeaderSize,
+      timeout = timeout,
+      additionalSocketOptions = additionalSocketOptions,
+      userAgent = EmberClientBuilder.Defaults.userAgent
+    )
+
   private def copy(
       blockerOpt: Option[Blocker] = self.blockerOpt,
       tlsContextOpt: Option[TLSContext] = self.tlsContextOpt,

--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -13,12 +13,12 @@ import cats._
 import cats.implicits._
 import cats.effect._
 import scala.concurrent.duration._
-import org.http4s.headers.Connection
 import org.http4s.client._
 import fs2.io.tcp.SocketGroup
 import fs2.io.tcp.SocketOptionMapping
 import fs2.io.tls._
 import scala.concurrent.duration.Duration
+import org.http4s.headers.{AgentProduct, `User-Agent`}
 
 final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     private val blockerOpt: Option[Blocker],
@@ -31,7 +31,8 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     val chunkSize: Int,
     val maxResponseHeaderSize: Int,
     val timeout: Duration,
-    val additionalSocketOptions: List[SocketOptionMapping[_]]
+    val additionalSocketOptions: List[SocketOptionMapping[_]],
+    val userAgent: Option[`User-Agent`]
 ) { self =>
 
   private def copy(
@@ -45,7 +46,8 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       chunkSize: Int = self.chunkSize,
       maxResponseHeaderSize: Int = self.maxResponseHeaderSize,
       timeout: Duration = self.timeout,
-      additionalSocketOptions: List[SocketOptionMapping[_]] = self.additionalSocketOptions
+      additionalSocketOptions: List[SocketOptionMapping[_]] = self.additionalSocketOptions,
+      userAgent: Option[`User-Agent`] = self.userAgent
   ): EmberClientBuilder[F] =
     new EmberClientBuilder[F](
       blockerOpt = blockerOpt,
@@ -58,7 +60,8 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       chunkSize = chunkSize,
       maxResponseHeaderSize = maxResponseHeaderSize,
       timeout = timeout,
-      additionalSocketOptions = additionalSocketOptions
+      additionalSocketOptions = additionalSocketOptions,
+      userAgent = userAgent
     )
 
   def withTLSContext(tlsContext: TLSContext) =
@@ -81,6 +84,11 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
   def withTimeout(timeout: Duration) = copy(timeout = timeout)
   def withAdditionalSocketOptions(additionalSocketOptions: List[SocketOptionMapping[_]]) =
     copy(additionalSocketOptions = additionalSocketOptions)
+
+  def withUserAgent(userAgent: `User-Agent`) = 
+    copy(userAgent = userAgent.some)
+  def withoutUserAgent = 
+    copy(userAgent = None)
 
   def build: Resource[F, Client[F]] =
     for {
@@ -133,30 +141,19 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
               .request[F](
                 request,
                 managed.value._1,
+                managed.canBeReused,
                 chunkSize,
                 maxResponseHeaderSize,
-                timeout
+                timeout,
+                userAgent
               )(logger)
-              .map(response =>
-                // TODO If Response Body has a take(1).compile.drain - would leave rest of bytes in root stream for next caller
-                response.copy(body = response.body.onFinalizeCaseWeak {
-                  case ExitCase.Completed =>
-                    val requestClose = request.headers.get(Connection).exists(_.hasClose)
-                    val responseClose = response.isChunked || response.headers
-                      .get(Connection)
-                      .exists(_.hasClose)
-
-                    if (requestClose || responseClose) Sync[F].unit
-                    else managed.canBeReused.set(Reusable.Reuse)
-                  case ExitCase.Canceled => Sync[F].unit
-                  case ExitCase.Error(_) => Sync[F].unit
-                }))
         } yield responseResource)
       new EmberClient[F](client, pool)
     }
 }
 
 object EmberClientBuilder {
+
   def default[F[_]: Concurrent: Timer: ContextShift] =
     new EmberClientBuilder[F](
       blockerOpt = None,
@@ -169,7 +166,8 @@ object EmberClientBuilder {
       chunkSize = Defaults.chunkSize,
       maxResponseHeaderSize = Defaults.maxResponseHeaderSize,
       timeout = Defaults.timeout,
-      additionalSocketOptions = Defaults.additionalSocketOptions
+      additionalSocketOptions = Defaults.additionalSocketOptions,
+      userAgent = Defaults.userAgent
     )
 
   private object Defaults {
@@ -185,5 +183,6 @@ object EmberClientBuilder {
     val maxTotal = 100
     val idleTimeInPool = 30.seconds // 30 Seconds in Nanos
     val additionalSocketOptions = List.empty[SocketOptionMapping[_]]
+    val userAgent = Some(`User-Agent`(AgentProduct("http4s-ember", Some(org.http4s.BuildInfo.version))))
   }
 }

--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -85,9 +85,9 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
   def withAdditionalSocketOptions(additionalSocketOptions: List[SocketOptionMapping[_]]) =
     copy(additionalSocketOptions = additionalSocketOptions)
 
-  def withUserAgent(userAgent: `User-Agent`) = 
+  def withUserAgent(userAgent: `User-Agent`) =
     copy(userAgent = userAgent.some)
-  def withoutUserAgent = 
+  def withoutUserAgent =
     copy(userAgent = None)
 
   def build: Resource[F, Client[F]] =
@@ -183,6 +183,7 @@ object EmberClientBuilder {
     val maxTotal = 100
     val idleTimeInPool = 30.seconds // 30 Seconds in Nanos
     val additionalSocketOptions = List.empty[SocketOptionMapping[_]]
-    val userAgent = Some(`User-Agent`(AgentProduct("http4s-ember", Some(org.http4s.BuildInfo.version))))
+    val userAgent = Some(
+      `User-Agent`(AgentProduct("http4s-ember", Some(org.http4s.BuildInfo.version))))
   }
 }

--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -10,18 +10,23 @@ import org.http4s.ember.client._
 import fs2.concurrent._
 import fs2.io.tcp._
 import cats._
+import cats.data.NonEmptyList
 import cats.effect._
+import cats.effect.concurrent._
 import cats.implicits._
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
 import org.http4s._
+import org.http4s.implicits._
 import org.http4s.client.RequestKey
 import _root_.org.http4s.ember.core.{Encoder, Parser}
 import _root_.org.http4s.ember.core.Util.readWithTimeout
 import _root_.fs2.io.tcp.SocketGroup
 import _root_.fs2.io.tls._
 import _root_.io.chrisdavenport.log4cats.Logger
+import _root_.io.chrisdavenport.keypool.Reusable
 import javax.net.ssl.SNIHostName
+import org.http4s.headers.{Connection, Date, `User-Agent`}
 
 private[client] object ClientHelpers {
   def requestToSocketWithKey[F[_]: Concurrent: Timer: ContextShift](
@@ -68,32 +73,35 @@ private[client] object ClientHelpers {
   def request[F[_]: Concurrent: ContextShift: Timer](
       request: Request[F],
       requestKeySocket: RequestKeySocket[F],
+      reuseable: Ref[F, Reusable],
       chunkSize: Int,
       maxResponseHeaderSize: Int,
-      timeout: Duration
+      timeout: Duration,
+      userAgent: Option[`User-Agent`]
   )(logger: Logger[F]): Resource[F, Response[F]] = {
     val RT: Timer[Resource[F, *]] = Timer[F].mapK(Resource.liftK[F])
 
     def writeRequestToSocket(
+        req: Request[F],
         socket: Socket[F],
         timeout: Option[FiniteDuration]): Resource[F, Unit] =
       Encoder
-        .reqToBytes(request)
+        .reqToBytes(req)
         .through(socket.writes(timeout))
         .compile
         .resource
         .drain
 
-    def onNoTimeout(socket: Socket[F]): Resource[F, Response[F]] =
-      writeRequestToSocket(socket, None) >>
+    def onNoTimeout(req: Request[F], socket: Socket[F]): Resource[F, Response[F]] =
+      writeRequestToSocket(req, socket, None) >>
         Parser.Response.parser(maxResponseHeaderSize)(
           socket.reads(chunkSize, None)
         )(logger)
 
-    def onTimeout(socket: Socket[F], fin: FiniteDuration): Resource[F, Response[F]] =
+    def onTimeout(req: Request[F], socket: Socket[F], fin: FiniteDuration): Resource[F, Response[F]] =
       for {
         start <- RT.clock.realTime(MILLISECONDS)
-        _ <- writeRequestToSocket(socket, Option(fin))
+        _ <- writeRequestToSocket(req, socket, Option(fin))
         timeoutSignal <- Resource.liftF(SignallingRef[F, Boolean](true))
         sent <- RT.clock.realTime(MILLISECONDS)
         remains = fin - (sent - start).millis
@@ -102,11 +110,45 @@ private[client] object ClientHelpers {
         )(logger)
         _ <- Resource.liftF(timeoutSignal.set(false).void)
       } yield resp
-
-    timeout match {
-      case t: FiniteDuration => onTimeout(requestKeySocket.socket, t)
-      case _ => onNoTimeout(requestKeySocket.socket)
+ 
+    def writeRead(req: Request[F]) = timeout match {
+      case t: FiniteDuration => onTimeout(req, requestKeySocket.socket, t)
+      case _ => onNoTimeout(req, requestKeySocket.socket)
     }
+
+    for {
+      processedReq <-Resource.liftF(preprocessRequest(request, userAgent))
+      resp <- writeRead(processedReq)
+      processedResp <- postProcessResponse(processedReq, resp, reuseable)
+    } yield processedResp
+  }
+
+  private[internal] def preprocessRequest[F[_]: Monad: Clock](req: Request[F], userAgent: Option[`User-Agent`]): F[Request[F]] = {
+    val connection = req.headers.get(Connection)
+      .fold(Connection(NonEmptyList.of("keep-alive".ci)))(identity)
+    val userAgentHeader: Option[`User-Agent`] = req.headers.get(`User-Agent`).orElse(userAgent)
+    for {
+      date <- req.headers.get(Date).fold(HttpDate.current[F].map(Date(_)))(_.pure[F])
+    } yield req
+      .putHeaders(date, connection)
+      .putHeaders(userAgentHeader.toSeq:_*)
+  }
+
+  private[internal] def postProcessResponse[F[_]: Applicative](req: Request[F], resp: Response[F], canBeReused: Ref[F, Reusable]): Resource[F, Response[F]] = {
+    val newResp: Response[F] = resp.copy(
+      body = resp.body.onFinalizeCaseWeak {
+        case ExitCase.Completed =>
+          val requestClose = req.headers.get(Connection).exists(_.hasClose)
+          val responseClose = resp.headers.get(Connection).exists(_.hasClose)
+
+          if (requestClose || responseClose) Applicative[F].unit
+          else canBeReused.set(Reusable.Reuse)
+        case ExitCase.Canceled => Applicative[F].unit
+        case ExitCase.Error(_) => Applicative[F].unit
+      }
+    )
+
+    Resource.pure[F, Response[F]](newResp)
   }
 
   // https://github.com/http4s/http4s/blob/master/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala#L86

--- a/ember-client/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSpec.scala
+++ b/ember-client/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSpec.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.ember.client.internal
+
+import cats.implicits._
+import cats.data.NonEmptyList
+import cats.effect._
+import cats.effect.concurrent._
+import org.http4s._
+import org.http4s.implicits._
+import org.specs2.mutable.Specification
+import cats.effect.testing.specs2.CatsIO
+import org.http4s.headers.{Connection, Date, `User-Agent`}
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.headers.AgentProduct
+import io.chrisdavenport.keypool.Reusable
+
+class ClientHelpersSpec extends Specification with CatsIO {
+  "Request Preprocessing" should {
+    "add a date header if not present" in {
+      ClientHelpers.preprocessRequest(Request[IO](), None)
+        .map{req =>   
+          req.headers.get(Date) must beSome      
+        } 
+    }
+    "not add a date header if already present" in {
+      ClientHelpers.preprocessRequest(Request[IO](
+        headers = Headers.of(Date(HttpDate.Epoch))
+      ), None)
+        .map{req =>   
+          req.headers.get(Date) must beSome.like{
+            case d => d.date === HttpDate.Epoch
+          }  
+        } 
+    }
+    "add a connection keep-alive header if not present" in {
+      ClientHelpers.preprocessRequest(Request[IO](), None)
+        .map{req =>   
+          req.headers.get(Connection) must beSome.like{
+            c => c.hasKeepAlive must beTrue
+          }     
+        } 
+    }
+
+    "not add a connection header if already present" in {
+      ClientHelpers.preprocessRequest(
+        Request[IO](headers = Headers.of(Connection(NonEmptyList.of("close".ci)))), None
+      )
+        .map{req =>   
+          req.headers.get(Connection) must beSome.like{
+            c => c.hasKeepAlive must beFalse
+          }     
+        } 
+    }
+
+    "add default user-agent" in {
+      ClientHelpers.preprocessRequest(Request[IO](), EmberClientBuilder.default[IO].userAgent)
+      .map{req => 
+        req.headers.get(`User-Agent`) must beSome
+      }
+    }
+
+    "not change a present user-agent" in {
+      val name = "foo"
+      ClientHelpers.preprocessRequest(Request[IO](
+        headers = Headers.of(`User-Agent`(AgentProduct(name, None)))
+      ), 
+      EmberClientBuilder.default[IO].userAgent)
+      .map{req => 
+        req.headers.get(`User-Agent`) must beSome.like{
+          case e => e.product.name must_=== name
+        }
+      }
+    }
+  }
+
+  "Postprocess response" should {
+    "reuse when body is run" in {
+
+      for {
+        reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+
+        testResult <- ClientHelpers.postProcessResponse(
+          Request[IO](), 
+          Response[IO](),
+          reuse        
+        ).use{resp => 
+          resp.body.compile.drain >>
+          reuse.get.map{
+            case r => r must beEqualTo(Reusable.Reuse)
+          }
+        }
+      } yield testResult
+    }
+
+    "do not reuse when body is not run" in {
+      for {
+        reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+
+        testResult <- ClientHelpers.postProcessResponse(
+          Request[IO](), 
+          Response[IO](),
+          reuse        
+        ).use{_ => 
+          reuse.get.map{
+            case r => r must beEqualTo(Reusable.DontReuse)
+          }
+        }
+      } yield testResult
+    }
+
+    "do not reuse when connection close is set on request" in {
+      for {
+        reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+
+        testResult <- ClientHelpers.postProcessResponse(
+          Request[IO](headers = Headers.of(Connection(NonEmptyList.of("close".ci)))), 
+          Response[IO](),
+          reuse        
+        ).use{resp => 
+          resp.body.compile.drain >>
+          reuse.get.map{
+            case r => r must beEqualTo(Reusable.DontReuse)
+          }
+        }
+      } yield testResult
+    }
+
+    "do not reuse when connection close is set on response" in {
+      for {
+        reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+
+        testResult <- ClientHelpers.postProcessResponse(
+          Request[IO](), 
+          Response[IO](headers = Headers.of(Connection(NonEmptyList.of("close".ci)))),
+          reuse        
+        ).use{resp => 
+          resp.body.compile.drain >>
+          reuse.get.map{
+            case r => r must beEqualTo(Reusable.DontReuse)
+          }
+        }
+      } yield testResult
+    }
+  }
+}

--- a/ember-client/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSpec.scala
+++ b/ember-client/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSpec.scala
@@ -38,7 +38,7 @@ class ClientHelpersSpec extends Specification with CatsIO {
           None)
         .map { req =>
           req.headers.get(Date) must beSome.like {
-            case d => d.date === HttpDate.Epoch
+            case d: Date => d.date === HttpDate.Epoch
           }
         }
     }
@@ -46,8 +46,9 @@ class ClientHelpersSpec extends Specification with CatsIO {
       ClientHelpers
         .preprocessRequest(Request[IO](), None)
         .map { req =>
-          req.headers.get(Connection) must beSome.like { c =>
-            c.hasKeepAlive must beTrue
+          req.headers.get(Connection) must beSome.like {
+            case c: Connection =>
+              c.hasKeepAlive must beTrue
           }
         }
     }
@@ -59,8 +60,9 @@ class ClientHelpersSpec extends Specification with CatsIO {
           None
         )
         .map { req =>
-          req.headers.get(Connection) must beSome.like { c =>
-            c.hasKeepAlive must beFalse
+          req.headers.get(Connection) must beSome.like {
+            case c: Connection =>
+              c.hasKeepAlive must beFalse
           }
         }
     }

--- a/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -27,7 +27,8 @@ private[ember] object Parser {
         case None =>
           Pull.raiseError[F](
             EmberException.ParseError(
-              s"Incomplete Header received (sz = ${buff.size}): ${buff.decodeUtf8}"))
+              s"""Incomplete Header received (sz = ${buff.size}): utf8: ${buff.decodeUtf8} - b64: "${buff.toBase64}"""")
+            )
         case Some((chunk, tl)) =>
           val bv = chunk2ByteVector(chunk)
           val all = buff ++ bv

--- a/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -28,7 +28,7 @@ private[ember] object Parser {
           Pull.raiseError[F](
             EmberException.ParseError(
               s"""Incomplete Header received (sz = ${buff.size}): utf8: ${buff.decodeUtf8} - b64: "${buff.toBase64}"""")
-            )
+          )
         case Some((chunk, tl)) =>
           val bv = chunk2ByteVector(chunk)
           val all = buff ++ bv

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.3.13


### PR DESCRIPTION
- Connection Keep-Alive added if not present to request
- Date add if not present to request
- Default User-Agent added, and added to request if not present along with builder options
- Added Tests For the above and for response cancelation. We have an intriguing position that streams are scoped as closing before the last element. I wonder what else this could cause elsewhere as well.