### PR TITLE
Add Trailer Headers to Ember

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -179,6 +179,11 @@ lazy val emberCore = libraryProject("ember-core")
     description := "Base library for ember http4s clients and servers",
     libraryDependencies ++= Seq(log4catsCore, log4catsTesting % Test),
     mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.ChunkedEncoding.decode"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.ChunkedEncoding.decode"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Shared.chunk2ByteVector"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.http4s.ember.core.Parser#Request.parser"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.http4s.ember.core.Parser#Response.parser"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.ember.core.Parser#Response.parser"),
     )
   )
@@ -196,7 +201,6 @@ lazy val emberClient = libraryProject("ember-client")
     description := "ember implementation for http4s clients",
     libraryDependencies ++= Seq(keypool, log4catsSlf4j),
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.ember.core.Parser#Response.parser"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.ember.client.internal.ClientHelpers.request"),
     )
   )

--- a/ember-core/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
@@ -10,10 +10,13 @@
 
 package org.http4s.ember.core
 
-import cats.ApplicativeError
+import cats._
+import cats.effect.concurrent.Deferred
 import fs2._
 import scodec.bits.ByteVector
 import Shared._
+import org.http4s.Headers
+import _root_.io.chrisdavenport.log4cats.Logger
 
 import scala.util.control.NonFatal
 
@@ -23,19 +26,20 @@ private[ember] object ChunkedEncoding {
     * decodes from the HTTP chunked encoding. After last chunk this terminates. Allows to specify max header size, after which this terminates
     * Please see https://en.wikipedia.org/wiki/Chunked_transfer_encoding for details
     */
-  def decode[F[_]](maxChunkHeaderSize: Int)(implicit
-      F: ApplicativeError[F, Throwable]): Pipe[F, Byte, Byte] = {
+  def decode[F[_]](maxChunkHeaderSize: Int, trailers: Deferred[F, Headers], logger: Logger[F])(
+      implicit F: MonadError[F, Throwable]): Pipe[F, Byte, Byte] = {
     // on left reading the header of chunk (acting as buffer)
     // on right reading the chunk itself, and storing remaining bytes of the chunk
     def go(expect: Either[ByteVector, Long], in: Stream[F, Byte]): Pull[F, Byte, Unit] =
       in.pull.uncons.flatMap {
         case None => Pull.done
         case Some((h, tl)) =>
-          val bv = chunk2ByteVector(h)
+          val bv = h.toByteVector
           expect match {
             case Left(header) =>
               val nh = header ++ bv
               val endOfheader = nh.indexOfSlice(`\r\n`)
+              // println(s"header: ${header.decodeAscii}, nh: ${nh.decodeAscii}, endOfHeader: $endOfheader")
               if (endOfheader == 0)
                 go(
                   expect,
@@ -52,18 +56,24 @@ private[ember] object ChunkedEncoding {
                     Pull.raiseError[F](
                       EmberException.ChunkedEncodingError(
                         s"Failed to parse chunked header : ${hdr.decodeUtf8}"))
-                  case Some(0) => Pull.done
+                  case Some(0) =>
+                    // Done With Message, Now Parse Trailers
+                    parseTrailers[F](logger)(tl).flatMap { hdrs =>
+                      Pull.eval(trailers.complete(hdrs)) >> Pull.done
+                    }
                   case Some(sz) => go(Right(sz), Stream.chunk(Chunk.ByteVectorChunk(rem)) ++ tl)
                 }
               }
 
             case Right(remains) =>
+              // println(s"Right  - Remains: ${remains}, bv: ${bv.decodeAscii}")
               if (remains == bv.size)
                 Pull.output(Chunk.ByteVectorChunk(bv)) >> go(Left(ByteVector.empty), tl)
               else if (remains > bv.size)
                 Pull.output(Chunk.ByteVectorChunk(bv)) >> go(Right(remains - bv.size), tl)
               else {
                 val (out, next) = bv.splitAt(remains.toLong)
+                // println(s"outputing chunk ${out.decodeAscii}")
                 Pull.output(Chunk.ByteVectorChunk(out)) >> go(
                   Left(ByteVector.empty),
                   Stream.chunk(Chunk.ByteVectorChunk(next)) ++ tl)
@@ -72,6 +82,31 @@ private[ember] object ChunkedEncoding {
       }
 
     go(Left(ByteVector.empty), _).stream
+  }
+
+  private def parseTrailers[F[_]: Monad](logger: Logger[F])(
+      s: Stream[F, Byte]): Pull[F, Nothing, Headers] = {
+    def lookForCRLFCRLF(acc: ByteVector, s: Stream[F, Byte]): Pull[F, Nothing, Headers] =
+      s.pull.uncons.flatMap {
+        case None =>
+          // Should Not Reach this, should be finding a final index
+          Pull.eval(logger.warn("Reached End of Trailers Without Receiving CRLF/CRLF")) >>
+            Pull.pure(Headers.empty)
+        case Some((chunk, tl)) =>
+          val next = acc ++ chunk.toByteVector
+          val idx = next.indexOfSlice(`\r\n\r\n`)
+          if (idx >= 0)
+            Pull.eval(Parser.generateHeaders(next.slice(0, idx))(Headers.empty)(logger))
+          else lookForCRLFCRLF(next, tl)
+
+      }
+    s.pull.uncons.flatMap {
+      case None => Pull.pure(Headers.empty)
+      case Some((chunk, tl)) =>
+        val bv = chunk.toByteVector
+        if (bv.startsWith(`\r\n`)) Pull.pure(Headers.empty)
+        else lookForCRLFCRLF(bv, tl)
+    }
   }
 
   private val lastChunk: Chunk[Byte] =
@@ -87,12 +122,13 @@ private[ember] object ChunkedEncoding {
         Chunk.ByteVectorChunk(
           ByteVector.view(bv.size.toHexString.toUpperCase.getBytes) ++ `\r\n` ++ bv ++ `\r\n`)
     _.mapChunks { ch =>
-      encodeChunk(chunk2ByteVector(ch))
+      encodeChunk(ch.toByteVector)
     } ++ Stream.chunk(lastChunk)
   }
 
   /** yields to size of header in case the chunked header was succesfully parsed, else yields to None */
   private def readChunkedHeader(hdr: ByteVector): Option[Long] =
+    // println(s"Reading Chunked Header ${hdr.decodeAscii}")
     hdr.decodeUtf8.toOption.flatMap { s =>
       val parts = s.split(';') // lets ignore any extensions
       if (parts.isEmpty) None

--- a/ember-core/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
@@ -39,7 +39,6 @@ private[ember] object ChunkedEncoding {
             case Left(header) =>
               val nh = header ++ bv
               val endOfheader = nh.indexOfSlice(`\r\n`)
-              // println(s"header: ${header.decodeAscii}, nh: ${nh.decodeAscii}, endOfHeader: $endOfheader")
               if (endOfheader == 0)
                 go(
                   expect,
@@ -66,14 +65,12 @@ private[ember] object ChunkedEncoding {
               }
 
             case Right(remains) =>
-              // println(s"Right  - Remains: ${remains}, bv: ${bv.decodeAscii}")
               if (remains == bv.size)
                 Pull.output(Chunk.ByteVectorChunk(bv)) >> go(Left(ByteVector.empty), tl)
               else if (remains > bv.size)
                 Pull.output(Chunk.ByteVectorChunk(bv)) >> go(Right(remains - bv.size), tl)
               else {
                 val (out, next) = bv.splitAt(remains.toLong)
-                // println(s"outputing chunk ${out.decodeAscii}")
                 Pull.output(Chunk.ByteVectorChunk(out)) >> go(
                   Left(ByteVector.empty),
                   Stream.chunk(Chunk.ByteVectorChunk(next)) ++ tl)
@@ -135,7 +132,6 @@ private[ember] object ChunkedEncoding {
 
   /** yields to size of header in case the chunked header was succesfully parsed, else yields to None */
   private def readChunkedHeader(hdr: ByteVector): Option[Long] =
-    // println(s"Reading Chunked Header ${hdr.decodeAscii}")
     hdr.decodeUtf8.toOption.flatMap { s =>
       val parts = s.split(';') // lets ignore any extensions
       if (parts.isEmpty) None

--- a/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -54,16 +54,13 @@ private[ember] object Parser {
 
   def generateHeaders[F[_]: Monad](byteVector: ByteVector)(acc: Headers)(
       logger: Logger[F]): F[Headers] = {
-    // println(headerO)
 
     def generateHeaderForLine(bv: ByteVector): Option[Header] =
       for {
         line <- bv.decodeAscii.toOption
-        // _ = println(s"Generate Headers - line: ${line}")
         idx <- Some(line.indexOf(':'))
         if idx >= 0
         header = Header(line.substring(0, idx), line.substring(idx + 1).trim)
-        // _ = println(s"generateHeaders - header: ${header}")
       } yield header
 
     splitHeader(byteVector)(logger).flatMap {

--- a/ember-core/src/main/scala/org/http4s/ember/core/Shared.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Shared.scala
@@ -6,7 +6,6 @@
 
 package org.http4s.ember.core
 
-import fs2._
 import scodec.bits.ByteVector
 
 private[core] object Shared {
@@ -14,12 +13,4 @@ private[core] object Shared {
   val `\r` : ByteVector = ByteVector('\r')
   val `\r\n` : ByteVector = ByteVector('\r', '\n')
   val `\r\n\r\n` = (`\r\n` ++ `\r\n`).compact
-
-  def chunk2ByteVector(chunk: Chunk[Byte]): ByteVector =
-    chunk match {
-      case bv: Chunk.ByteVectorChunk => bv.toByteVector
-      case other =>
-        val bs = other.toBytes
-        ByteVector(bs.values, bs.offset, bs.size)
-    }
 }

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParsingSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParsingSpec.scala
@@ -9,7 +9,6 @@ package org.http4s.ember.core
 import org.specs2.mutable.Specification
 import cats.effect._
 import org.http4s._
-import fs2.{Stream, text}
 import scodec.bits.ByteVector
 import io.chrisdavenport.log4cats.testing.TestingLogger
 import org.specs2.concurrent.ExecutionEnv
@@ -18,6 +17,7 @@ import cats.effect.concurrent._
 import cats.data.OptionT
 import cats.implicits._
 import fs2.Chunk.ByteVectorChunk
+import org.http4s.headers.Expires
 
 class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
   implicit val cs: ContextShift[IO] = IO.contextShift(ee.ec)
@@ -27,7 +27,7 @@ class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
     def httpifyString(s: String): String = s.replace("\n", "\r\n")
 
     // Only for Use with Text Requests
-    def parseRequestRig[F[_]: Sync](s: String): F[Request[F]] = {
+    def parseRequestRig[F[_]: Concurrent](s: String): F[Request[F]] = {
       val logger = TestingLogger.impl[F]()
       val byteStream: Stream[F, Byte] = Stream
         .emit(s)
@@ -38,7 +38,7 @@ class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
       Parser.Request.parser[F](Int.MaxValue)(byteStream)(logger)
     }
 
-    def parseResponseRig[F[_]: Sync](s: String): Resource[F, Response[F]] = {
+    def parseResponseRig[F[_]: Concurrent](s: String): Resource[F, Response[F]] = {
       val logger = TestingLogger.impl[F]()
       val byteStream: Stream[F, Byte] = Stream
         .emit(s)
@@ -165,6 +165,75 @@ class ParsingSpec(implicit ee: ExecutionEnv) extends Specification {
         .map {
 
           _.size must beGreaterThan(0)
+        }
+        .unsafeRunSync()
+    }
+
+    "parse a chunked simple" in {
+      val logger = TestingLogger.impl[IO]()
+      val defaultMaxHeaderLength = 4096
+      val respS =
+        Stream(
+          "HTTP/1.1 200 OK\r\n",
+          "Content-Type: text/plain\r\n",
+          "Transfer-Encoding: chunked\r\n\r\n",
+          // "Trailer: Expires\r\n\r\n",
+          "7\r\n",
+          "Mozilla\r\n",
+          "9\r\n",
+          "Developer\r\n",
+          "7\r\n",
+          "Network\r\n",
+          "0\r\n",
+          "\r\n"
+          // "Expires: Wed, 21 Oct 2015 07:28:00 GMT\r\n\r\n"
+        )
+      val byteStream: Stream[IO, Byte] = respS
+        .flatMap(s =>
+          Stream.chunk(Chunk.array(s.getBytes(java.nio.charset.StandardCharsets.US_ASCII))))
+
+      Parser.Response
+        .parser[IO](defaultMaxHeaderLength)(byteStream)(logger)
+        .use { resp =>
+          resp.body.through(text.utf8Decode).compile.string.map { body =>
+            body must beEqualTo("MozillaDeveloperNetwork")
+          }
+        }
+        .unsafeRunSync()
+    }
+
+    "parse a chunked with trailer headers" in {
+      val logger = TestingLogger.impl[IO]()
+      val defaultMaxHeaderLength = 4096
+      val respS =
+        Stream(
+          "HTTP/1.1 200 OK\r\n",
+          "Content-Type: text/plain\r\n",
+          "Transfer-Encoding: chunked\r\n",
+          "Trailer: Expires\r\n\r\n",
+          "7\r\n",
+          "Mozilla\r\n",
+          "9\r\n",
+          "Developer\r\n",
+          "7\r\n",
+          "Network\r\n",
+          "0\r\n",
+          "Expires: Wed, 21 Oct 2015 07:28:00 GMT\r\n",
+          "\r\n"
+        )
+      val byteStream: Stream[IO, Byte] = respS
+        .flatMap(s =>
+          Stream.chunk(Chunk.array(s.getBytes(java.nio.charset.StandardCharsets.US_ASCII))))
+
+      Parser.Response
+        .parser[IO](defaultMaxHeaderLength)(byteStream)(logger)
+        .use { resp =>
+          for {
+            body <- resp.body.through(text.utf8Decode).compile.string
+            trailers <- resp.trailerHeaders
+          } yield (body must beEqualTo("MozillaDeveloperNetwork")).and(
+            trailers.get(Expires) must beSome
+          )
         }
         .unsafeRunSync()
     }

--- a/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
@@ -13,8 +13,10 @@ import cats.effect.IO
 import org.http4s._
 import _root_.io.chrisdavenport.log4cats.testing.TestingLogger
 import org.http4s.laws.discipline.ArbitraryInstances._
+import scala.concurrent.ExecutionContext
 
 class TraversalSpec extends Specification with ScalaCheck {
+  implicit val CS = IO.contextShift(ExecutionContext.global)
   "Request Encoder/Parser" should {
     "preserve headers" >> prop { (req: Request[IO]) =>
       val logger = TestingLogger.impl[IO]()


### PR DESCRIPTION
Adds Trailer Headers to Ember - Previous to this we had been marking chunked streams not reuseable because it did not parse correctly. Specifically it was leaving bytes left in the root stream.

The old behavior stopped reading after it had parsed 0\r\n, however the termination for chunked is 
`0\r\n\r\n` OR `0\r\nheader:keyr\r\nheader:key\r\n\r\n`

Since we had previously pulled `0\r\n` that means we need to parse to either an immediate `\r\n`, or pull into a buffer until we reach `\r\n\r\n`.  The only thing I feel is missing is a termination condition if the bytevector for accumulation gets too large. Is there a reasonable default here?

That final `\r\n\r\n` or `\r\n` should signal the very last bytes and hence mean connections are truly ready for reuse.