### PR TITLE
Enable Ember Server Connection Reuse

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,12 @@ lazy val emberCore = libraryProject("ember-core")
 lazy val emberServer = libraryProject("ember-server")
   .settings(
     description := "ember implementation for http4s servers",
-    libraryDependencies ++= Seq(log4catsSlf4j)
+    libraryDependencies ++= Seq(log4catsSlf4j),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.server.internal.ServerHelpers.server"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.ember.server.internal.ServerHelpers.server$default$12"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.ember.server.internal.ServerHelpers.server$default$12"),
+    )
   )
   .dependsOn(emberCore % "compile;test->test", server % "compile;test->test")
 

--- a/ember-core/src/main/scala/org/http4s/ember/core/Util.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Util.scala
@@ -50,7 +50,7 @@ private[ember] object Util {
       else
         for {
           start <- Stream.eval(C.realTime(MILLISECONDS))
-          read <- Stream.eval(socket.read(chunkSize, Some(remains)))
+          read <- Stream.eval(socket.read(chunkSize, Some(remains))) //  Each Read Yields
           end <- Stream.eval(C.realTime(MILLISECONDS))
           out <- read.fold[Stream[F, Byte]](
             Stream.empty

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -39,6 +39,40 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     private val logger: Logger[F]
 ) { self =>
 
+  @deprecated("Kept for binary compatibility", "0.21.7")
+  private[EmberServerBuilder] def this(
+      host: String,
+      port: Int,
+      httpApp: HttpApp[F],
+      blockerOpt: Option[Blocker],
+      tlsInfoOpt: Option[(TLSContext, TLSParameters)],
+      sgOpt: Option[SocketGroup],
+      onError: Throwable => Response[F],
+      onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit],
+      maxConcurrency: Int,
+      receiveBufferSize: Int,
+      maxHeaderSize: Int,
+      requestHeaderReceiveTimeout: Duration,
+      additionalSocketOptions: List[SocketOptionMapping[_]],
+      logger: Logger[F]) =
+    this(
+      host = host,
+      port = port,
+      httpApp = httpApp,
+      blockerOpt = blockerOpt,
+      tlsInfoOpt = tlsInfoOpt,
+      sgOpt = sgOpt,
+      onError = onError,
+      onWriteFailure = onWriteFailure,
+      maxConcurrency = maxConcurrency,
+      receiveBufferSize = receiveBufferSize,
+      maxHeaderSize = maxHeaderSize,
+      requestHeaderReceiveTimeout = requestHeaderReceiveTimeout,
+      idleTimeout = EmberServerBuilder.Defaults.idleTimeout,
+      additionalSocketOptions = additionalSocketOptions,
+      logger = logger
+    )
+
   private def copy(
       host: String = self.host,
       port: Int = self.port,

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -32,6 +32,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     val receiveBufferSize: Int,
     val maxHeaderSize: Int,
     val requestHeaderReceiveTimeout: Duration,
+    val idleTimeout: Duration,
     val additionalSocketOptions: List[SocketOptionMapping[_]],
     private val logger: Logger[F]
 ) { self =>
@@ -49,6 +50,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       receiveBufferSize: Int = self.receiveBufferSize,
       maxHeaderSize: Int = self.maxHeaderSize,
       requestHeaderReceiveTimeout: Duration = self.requestHeaderReceiveTimeout,
+      idleTimeout: Duration = self.idleTimeout,
       additionalSocketOptions: List[SocketOptionMapping[_]] = self.additionalSocketOptions,
       logger: Logger[F] = self.logger
   ): EmberServerBuilder[F] =
@@ -65,6 +67,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       receiveBufferSize = receiveBufferSize,
       maxHeaderSize = maxHeaderSize,
       requestHeaderReceiveTimeout = requestHeaderReceiveTimeout,
+      idleTimeout = idleTimeout,
       additionalSocketOptions = additionalSocketOptions,
       logger = logger
     )
@@ -83,6 +86,9 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
 
   def withBlocker(blocker: Blocker) =
     copy(blockerOpt = blocker.pure[Option])
+
+  def withIdleTimeout(idleTimeout: Duration) =
+    copy(idleTimeout = idleTimeout)
 
   def withOnError(onError: Throwable => Response[F]) = copy(onError = onError)
   def withOnWriteFailure(onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit]) =
@@ -114,6 +120,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
             receiveBufferSize,
             maxHeaderSize,
             requestHeaderReceiveTimeout,
+            idleTimeout,
             additionalSocketOptions,
             logger
           )
@@ -143,6 +150,7 @@ object EmberServerBuilder {
       receiveBufferSize = Defaults.receiveBufferSize,
       maxHeaderSize = Defaults.maxHeaderSize,
       requestHeaderReceiveTimeout = Defaults.requestHeaderReceiveTimeout,
+      idleTimeout = Defaults.idleTimeout,
       additionalSocketOptions = Defaults.additionalSocketOptions,
       logger = Slf4jLogger.getLogger[F]
     )
@@ -163,6 +171,7 @@ object EmberServerBuilder {
     val receiveBufferSize: Int = 256 * 1024
     val maxHeaderSize: Int = 10 * 1024
     val requestHeaderReceiveTimeout: Duration = 5.seconds
+    val idleTimeout: Duration = 60.seconds
     val additionalSocketOptions = List.empty[SocketOptionMapping[_]]
   }
 }

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -18,6 +18,8 @@ import org.http4s.server.Server
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
 import _root_.io.chrisdavenport.log4cats.Logger
+import _root_.io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.http4s.ember.server.internal.ServerHelpers
 
 final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     val host: String,
@@ -107,7 +109,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       bindAddress <- Resource.liftF(Sync[F].delay(new InetSocketAddress(host, port)))
       shutdownSignal <- Resource.liftF(SignallingRef[F, Boolean](false))
       _ <- Concurrent[F].background(
-        org.http4s.ember.server.internal.ServerHelpers
+        ServerHelpers
           .server(
             bindAddress,
             httpApp,
@@ -133,7 +135,6 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       def isSecure: Boolean = tlsInfoOpt.isDefined
     }
 }
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 object EmberServerBuilder {
   def default[F[_]: Concurrent: Timer: ContextShift]: EmberServerBuilder[F] =

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -15,9 +15,12 @@ import cats.implicits._
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
 import org.http4s._
+import org.http4s.implicits._
+import org.http4s.headers.{Connection, Date}
 import _root_.org.http4s.ember.core.{Encoder, Parser}
 import _root_.org.http4s.ember.core.Util.readWithTimeout
 import _root_.io.chrisdavenport.log4cats.Logger
+import cats.data.NonEmptyList
 
 private[server] object ServerHelpers {
   def server[F[_]: Concurrent: ContextShift](
@@ -35,6 +38,7 @@ private[server] object ServerHelpers {
       receiveBufferSize: Int = 256 * 1024,
       maxHeaderSize: Int = 10 * 1024,
       requestHeaderReceiveTimeout: Duration = 5.seconds,
+      idleTimeout: Duration = 60.seconds,
       additionalSocketOptions: List[SocketOptionMapping[_]] = List.empty,
       logger: Logger[F]
   )(implicit C: Clock[F]): Stream[F, Nothing] = {
@@ -45,10 +49,12 @@ private[server] object ServerHelpers {
     def socketReadRequest(
         socket: Socket[F],
         requestHeaderReceiveTimeout: Duration,
-        receiveBufferSize: Int
+        receiveBufferSize: Int,
+        isReused: Boolean
     ): F[Request[F]] = {
-      val (initial, readDuration) = requestHeaderReceiveTimeout match {
-        case fin: FiniteDuration => (true, fin)
+      val (initial, readDuration) = (requestHeaderReceiveTimeout, idleTimeout, isReused) match {
+        case (fin: FiniteDuration, idle: FiniteDuration, true) => (true, idle + fin)
+        case (fin: FiniteDuration, _, false) => (true, fin)
         case _ => (false, 0.millis)
       }
       SignallingRef[F, Boolean](initial).flatMap { timeoutSignal =>
@@ -74,9 +80,9 @@ private[server] object ServerHelpers {
             .widen[Socket[F]]
       }
 
-    def runApp(socket: Socket[F]): F[(Request[F], Response[F])] =
+    def runApp(socket: Socket[F], isReused: Boolean): F[(Request[F], Response[F])] =
       for {
-        req <- socketReadRequest(socket, requestHeaderReceiveTimeout, receiveBufferSize)
+        req <- socketReadRequest(socket, requestHeaderReceiveTimeout, receiveBufferSize, isReused)
         resp <- httpApp.run(req).handleError(onError)
       } yield (req, resp)
 
@@ -92,6 +98,20 @@ private[server] object ServerHelpers {
           case Right(()) => Sync[F].pure(())
         }
 
+    def postProcessResponse(req: Request[F], resp: Response[F]): F[Response[F]] = {
+      val reqHasClose = req.headers.get(Connection).exists(_.hasClose)
+      val respConnection = resp.headers.get(Connection)
+      val connection: Connection =
+        if (reqHasClose) Connection(NonEmptyList.of("close".ci))
+        else
+          respConnection.fold(
+            Connection(NonEmptyList.one("keep-alive".ci))
+          )(identity)
+      for {
+        date <- resp.headers.get(Date).fold(HttpDate.current[F].map(Date(_)))(_.pure[F])
+      } yield resp.putHeaders(connection, date)
+    }
+
     Stream
       .eval(termSignal)
       .flatMap(terminationSignal =>
@@ -101,12 +121,28 @@ private[server] object ServerHelpers {
               for {
                 socket <- connect.flatMap(upgradeSocket(_, tlsInfoOpt))
                 out <- Resource.liftF(
-                  Stream
-                    .eval(runApp(socket).attempt)
+                  (Stream(false) ++ Stream(true).repeat)
+                    .flatMap { isReused =>
+                      Stream
+                        .eval(
+                          runApp(socket, isReused).flatMap {
+                            case (req, resp) =>
+                              postProcessResponse(req, resp)
+                                .map(resp => (req, resp))
+                          }.attempt
+                        )
+                    }
                     .evalTap {
                       case Right((request, response)) => send(socket)(Some(request), response)
                       case Left(err) => send(socket)(None, onError(err))
                     }
+                    .takeWhile {
+                      case Left(_) => false
+                      case Right((req, resp)) =>
+                        req.headers.get(Connection).exists(_.hasClose) ||
+                          resp.headers.get(Connection).exists(_.hasClose)
+                    }
+                    .evalTap(_ => ContextShift[F].shift) // Yield After Each Req/Resp Pair
                     .compile
                     .drain // In the above Stream is how we reuse connections
                 )

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -82,11 +82,8 @@ private[server] object ServerHelpers {
 
     def runApp(socket: Socket[F], isReused: Boolean): F[(Request[F], Response[F])] =
       for {
-        id <- Sync[F].delay(java.util.UUID.randomUUID())
-        _ <- logger.info(s"Starting HttpApp Processing- isReused: $isReused - $id")
         req <- socketReadRequest(socket, requestHeaderReceiveTimeout, receiveBufferSize, isReused)
         resp <- httpApp.run(req).handleError(onError)
-        _ <- logger.info(s"Finished HttpApp Processing - $id")
       } yield (req, resp)
 
     def send(socket: Socket[F])(request: Option[Request[F]], resp: Response[F]): F[Unit] =


### PR DESCRIPTION
- Enables Server Connection Reuse For Ember
- Add Similar Processing as is done in Client, with implicit keep-alive and date.


Performance Locally

#### Blaze

```
hey -z 30s  http://localhost:8080/hello

Summary:
  Total:	30.0007 secs
  Slowest:	0.5015 secs
  Fastest:	0.0001 secs
  Average:	0.0015 secs
  Requests/sec:	75735.8589
  
  Total data:	68549378 bytes
  Size/request:	68 bytes

Response time histogram:
  0.000 [1]	|
  0.050 [999948]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.100 [1]	|
  0.151 [0]	|
  0.201 [0]	|
  0.251 [0]	|
  0.301 [0]	|
  0.351 [0]	|
  0.401 [0]	|
  0.451 [0]	|
  0.502 [50]	|


Latency distribution:
  10% in 0.0003 secs
  25% in 0.0004 secs
  50% in 0.0005 secs
  75% in 0.0007 secs
  90% in 0.0011 secs
  95% in 0.0014 secs
  99% in 0.0039 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0001 secs, 0.5015 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0030 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0051 secs
  resp wait:	0.0014 secs, 0.0001 secs, 0.4993 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0089 secs

Status code distribution:
  [200]	1000000 responses
```

#### Ember

```
hey -z 30s  http://localhost:8080/hello

Summary:
  Total:	30.0409 secs
  Slowest:	0.0541 secs
  Fastest:	0.0001 secs
  Average:	0.0024 secs
  Requests/sec:	20693.2210
  
  Total data:	18754221 bytes
  Size/request:	30 bytes

Response time histogram:
  0.000 [1]	|
  0.006 [593700]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.011 [73]	|
  0.016 [9]	|
  0.022 [6]	|
  0.027 [6]	|
  0.032 [8]	|
  0.038 [6]	|
  0.043 [1289]	|
  0.049 [26514]	|■■
  0.054 [32]	|


Latency distribution:
  10% in 0.0002 secs
  25% in 0.0002 secs
  50% in 0.0003 secs
  75% in 0.0006 secs
  90% in 0.0010 secs
  95% in 0.0018 secs
  99% in 0.0475 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0001 secs, 0.0541 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0007 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0030 secs
  resp wait:	0.0003 secs, 0.0001 secs, 0.0379 secs
  resp read:	0.0021 secs, 0.0000 secs, 0.0485 secs

Status code distribution:
  [200]	621644 responses
```

