### PR TITLE
Ember Parsing in N of prelude + header bytes

### DIFF
--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -136,7 +136,7 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
                 chunkSize,
                 maxResponseHeaderSize,
                 timeout
-              )(logger)
+              )
               .map(response =>
                 // TODO If Response Body has a take(1).compile.drain - would leave rest of bytes in root stream for next caller
                 response.copy(body = response.body.onFinalizeCaseWeak {

--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -20,7 +20,6 @@ import _root_.org.http4s.ember.core.{Encoder, Parser}
 import _root_.org.http4s.ember.core.Util.readWithTimeout
 import _root_.fs2.io.tcp.SocketGroup
 import _root_.fs2.io.tls._
-import _root_.io.chrisdavenport.log4cats.Logger
 import javax.net.ssl.SNIHostName
 
 private[client] object ClientHelpers {
@@ -71,7 +70,7 @@ private[client] object ClientHelpers {
       chunkSize: Int,
       maxResponseHeaderSize: Int,
       timeout: Duration
-  )(logger: Logger[F]): Resource[F, Response[F]] = {
+  ): Resource[F, Response[F]] = {
     val RT: Timer[Resource[F, *]] = Timer[F].mapK(Resource.liftK[F])
 
     def writeRequestToSocket(
@@ -88,7 +87,7 @@ private[client] object ClientHelpers {
       writeRequestToSocket(socket, None) >>
         Parser.Response.parser(maxResponseHeaderSize)(
           socket.reads(chunkSize, None)
-        )(logger)
+        )
 
     def onTimeout(socket: Socket[F], fin: FiniteDuration): Resource[F, Response[F]] =
       for {
@@ -99,7 +98,7 @@ private[client] object ClientHelpers {
         remains = fin - (sent - start).millis
         resp <- Parser.Response.parser[F](maxResponseHeaderSize)(
           readWithTimeout(socket, start, remains, timeoutSignal.get, chunkSize)
-        )(logger)
+        )
         _ <- Resource.liftF(timeoutSignal.set(false).void)
       } yield resp
 

--- a/ember-core/src/main/scala/org/http4s/ember/core/Util.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Util.scala
@@ -50,7 +50,7 @@ private[ember] object Util {
       else
         for {
           start <- Stream.eval(C.realTime(MILLISECONDS))
-          read <- Stream.eval(socket.read(chunkSize, Some(remains)))
+          read <- Stream.eval(socket.read(chunkSize, Some(remains))) //  Each Read Yields
           end <- Stream.eval(C.realTime(MILLISECONDS))
           out <- read.fold[Stream[F, Byte]](
             Stream.empty

--- a/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
@@ -11,56 +11,56 @@ import org.specs2.ScalaCheck
 import cats.implicits._
 import cats.effect.IO
 import org.http4s._
-import _root_.io.chrisdavenport.log4cats.testing.TestingLogger
+// import _root_.io.chrisdavenport.log4cats.testing.TestingLogger
 import org.http4s.laws.discipline.ArbitraryInstances._
 
 class TraversalSpec extends Specification with ScalaCheck {
   "Request Encoder/Parser" should {
     "preserve headers" >> prop { (req: Request[IO]) =>
-      val logger = TestingLogger.impl[IO]()
+      // val logger = TestingLogger.impl[IO]()
       val end = Parser.Request
         .parser[IO](Int.MaxValue)(
           Encoder.reqToBytes[IO](req)
-        )(logger)
+        ) //(logger)
         .unsafeRunSync()
 
       end.headers.toList must containTheSameElementsAs(req.headers.toList)
     }.pendingUntilFixed
 
     "preserve method with known uri" >> prop { (req: Request[IO]) =>
-      val logger = TestingLogger.impl[IO]()
+      // val logger = TestingLogger.impl[IO]()
       val newReq = req
         .withUri(Uri.unsafeFromString("http://www.google.com"))
 
       val end = Parser.Request
         .parser[IO](Int.MaxValue)(
           Encoder.reqToBytes[IO](newReq)
-        )(logger)
+        ) //(logger)
         .unsafeRunSync()
 
       end.method must_=== req.method
     }
 
     "preserve uri.scheme" >> prop { (req: Request[IO]) =>
-      val logger = TestingLogger.impl[IO]()
+      // val logger = TestingLogger.impl[IO]()
       val end = Parser.Request
         .parser[IO](Int.MaxValue)(
           Encoder.reqToBytes[IO](req)
-        )(logger)
+        ) //(logger)
         .unsafeRunSync()
 
       end.uri.scheme must_=== req.uri.scheme
     }.pendingUntilFixed
 
     "preserve body with a known uri" >> prop { (req: Request[IO], s: String) =>
-      val logger = TestingLogger.impl[IO]()
+      // val logger = TestingLogger.impl[IO]()
       val newReq = req
         .withUri(Uri.unsafeFromString("http://www.google.com"))
         .withEntity(s)
       val end = Parser.Request
         .parser[IO](Int.MaxValue)(
           Encoder.reqToBytes[IO](newReq)
-        )(logger)
+        ) //(logger)
         .unsafeRunSync()
 
       end.body.through(fs2.text.utf8Decode).compile.foldMonoid.unsafeRunSync() must_=== s

--- a/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
@@ -24,7 +24,7 @@ class TraversalSpec extends Specification with ScalaCheck {
         )(logger)
         .unsafeRunSync()
 
-      end.headers must_=== req.headers
+      end.headers.toList must containTheSameElementsAs(req.headers.toList)
     }.pendingUntilFixed
 
     "preserve method with known uri" >> prop { (req: Request[IO]) =>

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -32,6 +32,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     val receiveBufferSize: Int,
     val maxHeaderSize: Int,
     val requestHeaderReceiveTimeout: Duration,
+    val idleTimeout: Duration,
     val additionalSocketOptions: List[SocketOptionMapping[_]],
     private val logger: Logger[F]
 ) { self =>
@@ -49,6 +50,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       receiveBufferSize: Int = self.receiveBufferSize,
       maxHeaderSize: Int = self.maxHeaderSize,
       requestHeaderReceiveTimeout: Duration = self.requestHeaderReceiveTimeout,
+      idleTimeout: Duration = self.idleTimeout,
       additionalSocketOptions: List[SocketOptionMapping[_]] = self.additionalSocketOptions,
       logger: Logger[F] = self.logger
   ): EmberServerBuilder[F] =
@@ -65,6 +67,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       receiveBufferSize = receiveBufferSize,
       maxHeaderSize = maxHeaderSize,
       requestHeaderReceiveTimeout = requestHeaderReceiveTimeout,
+      idleTimeout = idleTimeout,
       additionalSocketOptions = additionalSocketOptions,
       logger = logger
     )
@@ -83,6 +86,9 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
 
   def withBlocker(blocker: Blocker) =
     copy(blockerOpt = blocker.pure[Option])
+
+  def withIdleTimeout(idleTimeout: Duration) =
+    copy(idleTimeout = idleTimeout)
 
   def withOnError(onError: Throwable => Response[F]) = copy(onError = onError)
   def withOnWriteFailure(onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit]) =
@@ -114,6 +120,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
             receiveBufferSize,
             maxHeaderSize,
             requestHeaderReceiveTimeout,
+            idleTimeout,
             additionalSocketOptions,
             logger
           )
@@ -143,6 +150,7 @@ object EmberServerBuilder {
       receiveBufferSize = Defaults.receiveBufferSize,
       maxHeaderSize = Defaults.maxHeaderSize,
       requestHeaderReceiveTimeout = Defaults.requestHeaderReceiveTimeout,
+      idleTimeout = Defaults.idleTimeout,
       additionalSocketOptions = Defaults.additionalSocketOptions,
       logger = Slf4jLogger.getLogger[F]
     )
@@ -163,6 +171,7 @@ object EmberServerBuilder {
     val receiveBufferSize: Int = 256 * 1024
     val maxHeaderSize: Int = 10 * 1024
     val requestHeaderReceiveTimeout: Duration = 5.seconds
+    val idleTimeout: Duration = 60.seconds
     val additionalSocketOptions = List.empty[SocketOptionMapping[_]]
   }
 }

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -18,6 +18,8 @@ import org.http4s.server.Server
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
 import _root_.io.chrisdavenport.log4cats.Logger
+import _root_.io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.http4s.ember.server.internal.ServerHelpers
 
 final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     val host: String,
@@ -107,7 +109,7 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       bindAddress <- Resource.liftF(Sync[F].delay(new InetSocketAddress(host, port)))
       shutdownSignal <- Resource.liftF(SignallingRef[F, Boolean](false))
       _ <- Concurrent[F].background(
-        org.http4s.ember.server.internal.ServerHelpers
+        ServerHelpers
           .server(
             bindAddress,
             httpApp,
@@ -133,7 +135,6 @@ final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       def isSecure: Boolean = tlsInfoOpt.isDefined
     }
 }
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 object EmberServerBuilder {
   def default[F[_]: Concurrent: Timer: ContextShift]: EmberServerBuilder[F] =

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -23,6 +23,13 @@ import _root_.io.chrisdavenport.log4cats.Logger
 import cats.data.NonEmptyList
 
 private[server] object ServerHelpers {
+
+  private val closeCi = "close".ci
+
+  private val connectionCi = "connection".ci
+  private val close = Connection(NonEmptyList.of(closeCi))
+  private val keepAlive = Connection(NonEmptyList.one("keep-alive".ci))
+
   def server[F[_]: Concurrent: ContextShift](
       bindAddress: InetSocketAddress,
       httpApp: HttpApp[F],
@@ -57,13 +64,14 @@ private[server] object ServerHelpers {
         case (fin: FiniteDuration, _, false) => (true, fin)
         case _ => (false, 0.millis)
       }
+
       SignallingRef[F, Boolean](initial).flatMap { timeoutSignal =>
         C.realTime(MILLISECONDS)
           .flatMap(now =>
             Parser.Request
               .parser(maxHeaderSize)(
                 readWithTimeout[F](socket, now, readDuration, timeoutSignal.get, receiveBufferSize)
-              )(logger)
+              )
               .flatMap { req =>
                 timeoutSignal.set(false).as(req)
               })
@@ -99,17 +107,18 @@ private[server] object ServerHelpers {
         }
 
     def postProcessResponse(req: Request[F], resp: Response[F]): F[Response[F]] = {
-      val reqHasClose = req.headers.get(Connection).exists(_.hasClose)
-      val respConnection = resp.headers.get(Connection)
+      val reqHasClose = req.headers.exists {
+        // We know this is raw because we have not parsed any headers in the underlying alg.
+        // If Headers are being parsed into processed for in ParseHeaders this is incorrect.
+        case Header.Raw(name, values) => name == connectionCi && values.contains(closeCi.value)
+        case _ => false
+      }
       val connection: Connection =
-        if (reqHasClose) Connection(NonEmptyList.of("close".ci))
-        else
-          respConnection.fold(
-            Connection(NonEmptyList.one("keep-alive".ci))
-          )(identity)
+        if (reqHasClose) close
+        else keepAlive
       for {
-        date <- resp.headers.get(Date).fold(HttpDate.current[F].map(Date(_)))(_.pure[F])
-      } yield resp.putHeaders(connection, date)
+        date <- HttpDate.current[F].map(Date(_))
+      } yield resp.withHeaders(Headers.of(date, connection) ++ resp.headers)
     }
 
     def withUpgradedSocket(socket: Socket[F]): Stream[F, Nothing] =

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -15,9 +15,12 @@ import cats.implicits._
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
 import org.http4s._
+import org.http4s.implicits._
+import org.http4s.headers.{Connection, Date}
 import _root_.org.http4s.ember.core.{Encoder, Parser}
 import _root_.org.http4s.ember.core.Util.readWithTimeout
 import _root_.io.chrisdavenport.log4cats.Logger
+import cats.data.NonEmptyList
 
 private[server] object ServerHelpers {
   def server[F[_]: Concurrent: ContextShift](
@@ -35,6 +38,7 @@ private[server] object ServerHelpers {
       receiveBufferSize: Int = 256 * 1024,
       maxHeaderSize: Int = 10 * 1024,
       requestHeaderReceiveTimeout: Duration = 5.seconds,
+      idleTimeout: Duration = 60.seconds,
       additionalSocketOptions: List[SocketOptionMapping[_]] = List.empty,
       logger: Logger[F]
   )(implicit C: Clock[F]): Stream[F, Nothing] = {
@@ -45,10 +49,12 @@ private[server] object ServerHelpers {
     def socketReadRequest(
         socket: Socket[F],
         requestHeaderReceiveTimeout: Duration,
-        receiveBufferSize: Int
+        receiveBufferSize: Int,
+        isReused: Boolean
     ): F[Request[F]] = {
-      val (initial, readDuration) = requestHeaderReceiveTimeout match {
-        case fin: FiniteDuration => (true, fin)
+      val (initial, readDuration) = (requestHeaderReceiveTimeout, idleTimeout, isReused) match {
+        case (fin: FiniteDuration, idle: FiniteDuration, true) => (true, idle + fin)
+        case (fin: FiniteDuration, _, false) => (true, fin)
         case _ => (false, 0.millis)
       }
       SignallingRef[F, Boolean](initial).flatMap { timeoutSignal =>
@@ -74,9 +80,9 @@ private[server] object ServerHelpers {
             .widen[Socket[F]]
       }
 
-    def runApp(socket: Socket[F]): F[(Request[F], Response[F])] =
+    def runApp(socket: Socket[F], isReused: Boolean): F[(Request[F], Response[F])] =
       for {
-        req <- socketReadRequest(socket, requestHeaderReceiveTimeout, receiveBufferSize)
+        req <- socketReadRequest(socket, requestHeaderReceiveTimeout, receiveBufferSize, isReused)
         resp <- httpApp.run(req).handleError(onError)
       } yield (req, resp)
 
@@ -92,6 +98,20 @@ private[server] object ServerHelpers {
           case Right(()) => Sync[F].pure(())
         }
 
+    def postProcessResponse(req: Request[F], resp: Response[F]): F[Response[F]] = {
+      val reqHasClose = req.headers.get(Connection).exists(_.hasClose)
+      val respConnection = resp.headers.get(Connection)
+      val connection: Connection =
+        if (reqHasClose) Connection(NonEmptyList.of("close".ci))
+        else
+          respConnection.fold(
+            Connection(NonEmptyList.one("keep-alive".ci))
+          )(identity)
+      for {
+        date <- resp.headers.get(Date).fold(HttpDate.current[F].map(Date(_)))(_.pure[F])
+      } yield resp.putHeaders(connection, date)
+    }
+
     Stream
       .eval(termSignal)
       .flatMap(terminationSignal =>
@@ -101,12 +121,28 @@ private[server] object ServerHelpers {
               for {
                 socket <- connect.flatMap(upgradeSocket(_, tlsInfoOpt))
                 out <- Resource.liftF(
-                  Stream
-                    .eval(runApp(socket).attempt)
+                  (Stream(false) ++ Stream(true).repeat)
+                    .flatMap { isReused =>
+                      Stream
+                        .eval(
+                          runApp(socket, isReused).flatMap {
+                            case (req, resp) =>
+                              postProcessResponse(req, resp)
+                                .map(resp => (req, resp))
+                          }.attempt
+                        )
+                    }
                     .evalTap {
                       case Right((request, response)) => send(socket)(Some(request), response)
                       case Left(err) => send(socket)(None, onError(err))
                     }
+                    .takeWhile {
+                      case Left(_) => false
+                      case Right((req, resp)) =>
+                        req.headers.get(Connection).exists(_.hasClose) ||
+                          resp.headers.get(Connection).exists(_.hasClose)
+                    }
+                    .evalTap(_ => ContextShift[F].shift) // Yield After Each Req/Resp Pair
                     .compile
                     .drain // In the above Stream is how we reuse connections
                 )

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -82,11 +82,8 @@ private[server] object ServerHelpers {
 
     def runApp(socket: Socket[F], isReused: Boolean): F[(Request[F], Response[F])] =
       for {
-        id <- Sync[F].delay(java.util.UUID.randomUUID())
-        _ <- logger.info(s"Starting HttpApp Processing- isReused: $isReused - $id")
         req <- socketReadRequest(socket, requestHeaderReceiveTimeout, receiveBufferSize, isReused)
         resp <- httpApp.run(req).handleError(onError)
-        _ <- logger.info(s"Finished HttpApp Processing - $id")
       } yield (req, resp)
 
     def send(socket: Socket[F])(request: Option[Request[F]], resp: Response[F]): F[Unit] =


### PR DESCRIPTION
Built on top of #3603 

This is optimized for the ideal and most probable case. Prelude and Headers are present in the first chunk of the request. It then get progressively worse from there as we concatenate arrays so we can continue in linear time. There may be a way to drop off what we have done so far, or two algorithms depending on state. Ideally then this operates in n iterations equal to exactly the number of bytes that form the prelude and headers for both requests and responses.

We generate special case information for chunked and content length, as profiling shows that going and looking for those headers afterwards becomes the most expensive operations, primarily because being rule following and checking all our parsers is slow. Presently Uri parsing is like 50% of the parsing algorithm cpu time used.

Each algorithm has throwable a variable. We exit the loop if we encounter throwables. There's no recovery on an error. 

