### PR TITLE
Models 'Forwarded' header

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Forwarded.scala
+++ b/core/src/main/scala/org/http4s/headers/Forwarded.scala
@@ -54,15 +54,12 @@ object Forwarded
         checkPortNum(num).toLeft(C(num))
 
       def unapply(port: Port): Option[Int] =
-        PartialFunction.condOpt(port) {
-          case C(num) => num
-        }
+        PartialFunction.condOpt(port) { case C(num) => num }
     }
 
     sealed trait Obfuscated extends Name with Port { _: Product =>
 
-      /**
-        * Obfuscated value must start with '_' (underscore) symbol.
+      /** Obfuscated value must start with '_' (underscore) symbol.
         */
       def value: String
     }
@@ -131,8 +128,7 @@ object Forwarded
     override def render(writer: Writer): writer.type = renderElement(writer, this)
   }
 
-  /**
-    * Enables the following construction syntax (while preserving type safety and consistency):
+  /** Enables the following construction syntax (while preserving type safety and consistency):
     * {{{
     *   Element
     *     .withBy(<by-node>)

--- a/core/src/main/scala/org/http4s/headers/Forwarded.scala
+++ b/core/src/main/scala/org/http4s/headers/Forwarded.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.headers
+
+import java.net.{Inet4Address, Inet6Address}
+
+import cats.data.NonEmptyList
+import cats.syntax.either._
+import org.http4s._
+import org.http4s.util.{Renderable, Writer}
+
+object Forwarded
+    extends HeaderKey.Internal[Forwarded]
+    with HeaderKey.Recurring
+    with ForwardedRenderers
+    with parser.ForwardedModelParsing {
+
+  final case class Node(nodeName: Node.Name, nodePort: Option[Node.Port] = None)
+
+  protected[http4s] val NodeNameIpv4 = Node.Name.Ipv4
+
+  object Node {
+    def apply(nodeName: Name, nodePort: Port): Node = apply(nodeName, Some(nodePort))
+
+    sealed trait Name { _: Product => }
+
+    object Name {
+      case class Ipv4(address: Uri.Ipv4Address) extends Name
+      case class Ipv6(address: Uri.Ipv6Address) extends Name
+      case object Unknown extends Name
+
+      def apply(address: Uri.Ipv4Address): Name = Name.Ipv4(address)
+      def apply(address: Inet4Address): Name = apply(Uri.Ipv4Address.fromInet4Address(address))
+      def apply(a: Byte, b: Byte, c: Byte, d: Byte): Name = apply(Uri.Ipv4Address(a, b, c, d))
+
+      def apply(address: Uri.Ipv6Address): Name = Name.Ipv6(address)
+      def apply(address: Inet6Address): Name = apply(Uri.Ipv6Address.fromInet6Address(address))
+      def apply(a: Short, b: Short, c: Short, d: Short, e: Short, f: Short, g: Short, h: Short)
+          : Name = apply(Uri.Ipv6Address(a, b, c, d, e, f, g, h))
+    }
+
+    sealed trait Port { _: Product => }
+
+    object Port {
+      private[this] final case class C(value: Int) extends Port {
+        override def productPrefix: String = "Port"
+      }
+
+      def fromInt(num: Int): ParseResult[Port] =
+        checkPortNum(num).toLeft(C(num))
+
+      def unapply(port: Port): Option[Int] =
+        PartialFunction.condOpt(port) {
+          case C(num) => num
+        }
+    }
+
+    sealed trait Obfuscated extends Name with Port { _: Product =>
+
+      /**
+        * Obfuscated value must start with '_' (underscore) symbol.
+        */
+      def value: String
+    }
+    object Obfuscated {
+      private[this] final case class C(value: String) extends Obfuscated {
+        override def productPrefix: String = "Obfuscated"
+      }
+
+      def fromString(s: String): ParseResult[Obfuscated] =
+        new ModelNodeObfuscatedParser(s).parse
+
+      def unapply(o: Obfuscated): Option[String] = Some(o.value)
+
+      // Referenced by model parsers.
+      private[http4s] def apply(s: String): Obfuscated = C(s)
+    }
+
+    def fromString(s: String): ParseResult[Node] = new ModelNodeParser(s).parse
+  }
+
+  sealed trait Host { _: Product =>
+    def host: Uri.Host
+    def port: Option[Int]
+  }
+
+  object Host {
+    private[this] final case class C(host: Uri.Host, port: Option[Int]) extends Host {
+      override def productPrefix: String = "Host"
+    }
+
+    def apply(uriHost: Uri.Host): Host = C(uriHost, None)
+
+    def from(uriHost: Uri.Host, port: Int): ParseResult[Host] =
+      checkPortNum(port).toLeft(C(uriHost, Some(port)))
+
+    def from(uriHost: Uri.Host, port: Option[Int]): ParseResult[Host] =
+      port.fold(apply(uriHost).asRight[ParseFailure])(from(uriHost, _))
+
+    def fromUri(uri: Uri): ParseResult[Host] =
+      uri.host.toRight(Failures.missingHost(uri)).flatMap(from(_, uri.port))
+
+    def fromString(s: String): ParseResult[Host] = new ModelHostParser(s).parse
+
+    def unapply(host: Host): Option[(Uri.Host, Option[Int])] = Some((host.host, host.port))
+  }
+
+  type Proto = Uri.Scheme
+  val Proto: Uri.Scheme.type = Uri.Scheme
+
+  sealed trait Element extends Renderable { _: Product =>
+    def `by`: Option[Node]
+    def `for`: Option[Node]
+    def `host`: Option[Host]
+    def `proto`: Option[Proto]
+
+    def withBy(value: Node): Element
+    def withFor(value: Node): Element
+    def withHost(value: Host): Element
+    def withProto(value: Proto): Element
+
+    def withoutBy: Element
+    def withoutFor: Element
+    def withoutHost: Element
+    def withoutProto: Element
+
+    override def render(writer: Writer): writer.type = renderElement(writer, this)
+  }
+
+  /**
+    * Enables the following construction syntax (while preserving type safety and consistency):
+    * {{{
+    *   Element
+    *     .withBy(<by-node>)
+    *     .withFor(<for-node>)
+    *     .withHost(<host>)
+    *     .withProto(<schema>)`
+    * }}}
+    */
+  object Element {
+    // Since at least one of the fields must be set to `Some`,
+    // the `Element` trait implementation is hidden.
+    private[this] final case class C(
+        `by`: Option[Node] = None,
+        `for`: Option[Node] = None,
+        `host`: Option[Host] = None,
+        `proto`: Option[Proto] = None)
+        extends Element {
+
+      def withBy(value: Node): Element = copy(`by` = Some(value))
+      def withFor(value: Node): Element = copy(`for` = Some(value))
+      def withHost(value: Host): Element = copy(`host` = Some(value))
+      def withProto(value: Proto): Element = copy(`proto` = Some(value))
+
+      def withoutBy: Element = copy(`by` = None)
+      def withoutFor: Element = copy(`for` = None)
+      def withoutHost: Element = copy(`host` = None)
+      def withoutProto: Element = copy(`proto` = None)
+
+      override def productPrefix: String = "Element"
+    }
+
+    def withBy(value: Node): Element = C(`by` = Some(value))
+    def withFor(value: Node): Element = C(`for` = Some(value))
+    def withHost(value: Host): Element = C(`host` = Some(value))
+    def withProto(value: Proto): Element = C(`proto` = Some(value))
+
+    def unapply(elem: Element): Option[(Option[Node], Option[Node], Option[Host], Option[Proto])] =
+      Some((elem.`by`, elem.`for`, elem.`host`, elem.`proto`))
+  }
+
+  final val PortMin = 0
+  final val PortMax = 65535
+
+  private def checkPortNum(portNum: Int): Option[ParseFailure] =
+    if ((portNum >= PortMin) && (portNum <= PortMax))
+      None
+    else
+      Some(Failures.invalidPortNum(portNum))
+
+  private object Failures {
+    def invalidPortNum(num: Int) =
+      ParseFailure("invalid port number", s"port $num is not in range $PortMin..$PortMax")
+    def missingHost(uri: Uri) =
+      ParseFailure("missing host", s"no host defined in the URI '$uri'")
+  }
+
+  override def parse(s: String): ParseResult[Forwarded] = parser.HttpHeaderParser.FORWARDED(s)
+}
+
+final case class Forwarded(values: NonEmptyList[Forwarded.Element])
+    extends Header.RecurringRenderable {
+
+  override type Value = Forwarded.Element
+  override def key: Forwarded.type = Forwarded
+
+  def apply(firstElem: Forwarded.Element, otherElems: Forwarded.Element*): Forwarded =
+    Forwarded(NonEmptyList.of(firstElem, otherElems: _*))
+}

--- a/core/src/main/scala/org/http4s/headers/Forwarded.scala
+++ b/core/src/main/scala/org/http4s/headers/Forwarded.scala
@@ -118,10 +118,10 @@ object Forwarded
   val Proto: Uri.Scheme.type = Uri.Scheme
 
   sealed trait Element extends Renderable { _: Product =>
-    def `by`: Option[Node]
-    def `for`: Option[Node]
-    def `host`: Option[Host]
-    def `proto`: Option[Proto]
+    def maybeBy: Option[Node]
+    def maybeFor: Option[Node]
+    def maybeHost: Option[Host]
+    def maybeProto: Option[Proto]
 
     def withBy(value: Node): Element
     def withFor(value: Node): Element
@@ -144,27 +144,27 @@ object Forwarded
     // Since at least one of the fields must be set to `Some`,
     // the `Element` trait implementation is hidden.
     private[this] final case class C(
-        `by`: Option[Node] = None,
-        `for`: Option[Node] = None,
-        `host`: Option[Host] = None,
-        `proto`: Option[Proto] = None)
+        maybeBy: Option[Node] = None,
+        maybeFor: Option[Node] = None,
+        maybeHost: Option[Host] = None,
+        maybeProto: Option[Proto] = None)
         extends Element {
 
-      def withBy(value: Node): Element = copy(`by` = Some(value))
-      def withFor(value: Node): Element = copy(`for` = Some(value))
-      def withHost(value: Host): Element = copy(`host` = Some(value))
-      def withProto(value: Proto): Element = copy(`proto` = Some(value))
+      def withBy(value: Node): Element = copy(maybeBy = Some(value))
+      def withFor(value: Node): Element = copy(maybeFor = Some(value))
+      def withHost(value: Host): Element = copy(maybeHost = Some(value))
+      def withProto(value: Proto): Element = copy(maybeProto = Some(value))
 
       override def productPrefix: String = "Element"
     }
 
-    def fromBy(value: Node): Element = C(`by` = Some(value))
-    def fromFor(value: Node): Element = C(`for` = Some(value))
-    def fromHost(value: Host): Element = C(`host` = Some(value))
-    def fromProto(value: Proto): Element = C(`proto` = Some(value))
+    def fromBy(value: Node): Element = C(maybeBy = Some(value))
+    def fromFor(value: Node): Element = C(maybeFor = Some(value))
+    def fromHost(value: Host): Element = C(maybeHost = Some(value))
+    def fromProto(value: Proto): Element = C(maybeProto = Some(value))
 
     def unapply(elem: Element): Option[(Option[Node], Option[Node], Option[Host], Option[Proto])] =
-      Some((elem.`by`, elem.`for`, elem.`host`, elem.`proto`))
+      Some((elem.maybeBy, elem.maybeFor, elem.maybeHost, elem.maybeProto))
   }
 
   final val PortMin = 0

--- a/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
+++ b/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.headers
+
+import java.nio.charset.StandardCharsets
+
+import cats.Eval
+import cats.syntax.flatMap._
+import org.http4s.Uri
+import org.http4s.parser.Rfc2616BasicRules
+import org.http4s.util.{Renderer, Writer}
+
+/**
+  * Renderers for the [[Forwarded]] header models.
+  */
+private[http4s] trait ForwardedRenderers {
+  import Forwarded._
+
+  implicit val http4sForwardedNodeNameRenderer: Renderer[Node.Name] =
+    new Renderer[Node.Name] {
+      override def render(writer: Writer, nodeName: Node.Name): writer.type =
+        nodeName match {
+          case Node.Name.Ipv4(ipv4addr) => writer << ipv4addr
+          case Node.Name.Ipv6(ipv6addr) => writer << '[' << ipv6addr << ']'
+          case Node.Name.Unknown => writer << "unknown"
+          case Node.Obfuscated(str) => writer << str
+        }
+    }
+
+  implicit val http4sForwardedNodePortRenderer: Renderer[Node.Port] = new Renderer[Node.Port] {
+    override def render(writer: Writer, nodePort: Node.Port): writer.type =
+      nodePort match {
+        case Node.Port(num) => writer << num
+        case Node.Obfuscated(str) => writer << str
+      }
+  }
+
+  implicit val http4sForwardedNodeRenderer: Renderer[Node] = new Renderer[Node] {
+    override def render(writer: Writer, node: Node): writer.type = {
+      writer << node.nodeName
+      node.nodePort.fold[writer.type](writer)(writer << ':' << _)
+    }
+  }
+
+  implicit val http4sForwardedHostRenderer: Renderer[Host] = new Renderer[Host] {
+    // See in `Rfc3986Parser`: `RegName` -> `SubDelims`
+    private val RegNameChars = Uri.Unreserved ++ "!$&'()*+,;="
+
+    override def render(writer: Writer, host: Host): writer.type = {
+      host.host match {
+        case Uri.RegName(name) =>
+          // TODO: A workaround for #1651, remove when the former issue gets fixed.
+          writer << Uri.encode(name.value, StandardCharsets.ISO_8859_1, toSkip = RegNameChars)
+        case other =>
+          writer << other
+      }
+      host.port.fold[writer.type](writer)(writer << ':' << _)
+    }
+  }
+
+  protected def renderElement(writer: Writer, elem: Element): writer.type = {
+
+    def renderParamEval[A: Renderer](name: String, maybeValue: Option[A]) =
+      maybeValue.map { value =>
+        // Do not write it immediately since we're going to interleave existing parameters with ';'
+        Eval.always[writer.type] { // NOTE: not clear why the explicit type is necessary here
+          writer << name << '='
+
+          val rendered = Renderer.renderString(value)
+          // TODO: Rfc2616BasicRules.isToken should be used instead, but as for now it works not as expected.
+          //       See: https://gitter.im/http4s/http4s-dev?at=5f55d832ec534f584fea2572
+          if (Rfc2616BasicRules.token(rendered).getOrElse(null) == rendered)
+            writer << rendered
+          else
+            writer <<# rendered // quote non-token values
+        }
+      }.toList
+
+    {
+      import elem._
+      renderParamEval("by", `by`) :::
+        renderParamEval("for", `for`) :::
+        renderParamEval("host", `host`) :::
+        renderParamEval("proto", `proto`)
+    }.reduceLeft { (leftParamEval, rightParamEval) =>
+      // Interleave every couple of parameters with ';'
+      leftParamEval >> Eval.always(writer << ';') >> rightParamEval
+    }.value // all actual rendering happens here
+  }
+}

--- a/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
+++ b/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
@@ -70,9 +70,7 @@ private[http4s] trait ForwardedRenderers {
           writer << name << '='
 
           val rendered = Renderer.renderString(value)
-          // TODO: Rfc2616BasicRules.isToken should be used instead, but as for now it works not as expected.
-          //       See: https://gitter.im/http4s/http4s-dev?at=5f55d832ec534f584fea2572
-          if (Rfc2616BasicRules.token(rendered).getOrElse(null) == rendered)
+          if (Rfc2616BasicRules.isToken(rendered))
             writer << rendered
           else
             writer <<# rendered // quote non-token values

--- a/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
+++ b/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
@@ -14,8 +14,7 @@ import org.http4s.Uri
 import org.http4s.parser.Rfc2616BasicRules
 import org.http4s.util.{Renderer, Writer}
 
-/**
-  * Renderers for the [[Forwarded]] header models.
+/** Renderers for the [[Forwarded]] header models.
   */
 private[http4s] trait ForwardedRenderers {
   import Forwarded._

--- a/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
+++ b/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
@@ -79,10 +79,10 @@ private[http4s] trait ForwardedRenderers {
 
     {
       import elem._
-      renderParamEval("by", `by`) :::
-        renderParamEval("for", `for`) :::
-        renderParamEval("host", `host`) :::
-        renderParamEval("proto", `proto`)
+      renderParamEval("by", maybeBy) :::
+        renderParamEval("for", maybeFor) :::
+        renderParamEval("host", maybeHost) :::
+        renderParamEval("proto", maybeProto)
     }.reduceLeft { (leftParamEval, rightParamEval) =>
       // Interleave every couple of parameters with ';'
       leftParamEval >> Eval.always(writer << ';') >> rightParamEval

--- a/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
@@ -31,10 +31,6 @@ private[parser] trait ForwardedHeader {
         }
       }
 
-    // TODO: remove this override once the original `ListSet` gets fixed.
-    //       See also #3657.
-    override def ListSep: Rule0 = rule(OptWS ~ ',' ~ OptWS)
-
     private type MaybeElement = Option[Forwarded.Element]
 
     private def ELEMENT: Rule1[Forwarded.Element] =

--- a/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.parser
+
+import java.nio.charset.{Charset, StandardCharsets}
+import java.util.Locale
+
+import org.http4s.headers.Forwarded
+import org.http4s.internal.bug
+import org.http4s.internal.parboiled2._
+import org.http4s.internal.parboiled2.support._
+import org.http4s.{ParseResult, Uri => UriModel}
+
+private[parser] trait ForwardedHeader {
+  def FORWARDED(value: String): ParseResult[Forwarded] = new Parser(value).parse
+
+  private class Parser(value: String)
+      extends Http4sHeaderParser[Forwarded](value)
+      with Rfc3986Parser {
+
+    override def charset: Charset = StandardCharsets.ISO_8859_1
+
+    override def entry: Rule1[Forwarded] =
+      rule {
+        oneOrMore(ELEMENT).separatedBy(ListSep) ~ EOL ~> { (elems: Seq[Forwarded.Element]) =>
+          Forwarded(elems.head, elems.tail: _*)
+        }
+      }
+
+    // TODO: remove this override once the original `ListSet` gets fixed.
+    //       See also #3657.
+    override def ListSep: Rule0 = rule(OptWS ~ ',' ~ OptWS)
+
+    private type MaybeElement = Option[Forwarded.Element]
+
+    private def ELEMENT: Rule1[Forwarded.Element] =
+      rule {
+        push(None) ~ oneOrMore(Param).separatedBy(';') ~> {
+          (_: MaybeElement).getOrElse(throw bug("empty value should not occur here"))
+        }
+      }
+
+    private type ParamRule = Rule[MaybeElement :: HNil, MaybeElement :: HNil]
+
+    private def Param: ParamRule =
+      rule {
+        Token ~> { token: String =>
+          token.toLowerCase(Locale.ROOT) match {
+            case "by" => CreateOrAssignParam_by
+            case "for" => CreateOrAssignParam_for
+            case "host" => CreateOrAssignParam_host
+            case "proto" => CreateOrAssignParam_proto
+            case other => failX(s"parameters: 'by', 'for', 'host' or 'proto', but got '$other'")
+          }
+        }
+      }
+
+    private def CreateOrAssignParam_by =
+      CreateOrAssignParam(
+        "by",
+        Forwarded.Node.fromString,
+        Forwarded.Element.withBy,
+        _.`by`,
+        _.withBy)
+
+    private def CreateOrAssignParam_for =
+      CreateOrAssignParam(
+        "for",
+        Forwarded.Node.fromString,
+        Forwarded.Element.withFor,
+        _.`for`,
+        _.withFor)
+
+    private def CreateOrAssignParam_host =
+      CreateOrAssignParam(
+        "host",
+        Forwarded.Host.fromString,
+        Forwarded.Element.withHost,
+        _.`host`,
+        _.withHost)
+
+    private def CreateOrAssignParam_proto =
+      CreateOrAssignParam(
+        "proto",
+        UriModel.Scheme.fromString,
+        Forwarded.Element.withProto,
+        _.`proto`,
+        _.withProto)
+
+    private def CreateOrAssignParam[A](
+        name: String,
+        parse: String => ParseResult[A],
+        create: A => Forwarded.Element,
+        access: Forwarded.Element => Option[A],
+        assign: Forwarded.Element => A => Forwarded.Element): ParamRule =
+      rule {
+        '=' ~ Value ~> { (maybeElem: MaybeElement, value: String) =>
+          parse(value) match {
+            case Left(failure) => failX(failure.sanitized)
+            case Right(value) =>
+              maybeElem match {
+                case None =>
+                  push(Some(create(value)))
+                case Some(elem) if access(elem).isEmpty =>
+                  push(Some(assign(elem).apply(value)))
+                case _ =>
+                  failX(s"'$name' must not occur more than once within a single element")
+              }
+          }
+        }
+      }
+  }
+}

--- a/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
@@ -63,7 +63,7 @@ private[parser] trait ForwardedHeader {
       CreateOrAssignParam(
         "by",
         Forwarded.Node.fromString,
-        Forwarded.Element.withBy,
+        Forwarded.Element.fromBy,
         _.`by`,
         _.withBy)
 
@@ -71,7 +71,7 @@ private[parser] trait ForwardedHeader {
       CreateOrAssignParam(
         "for",
         Forwarded.Node.fromString,
-        Forwarded.Element.withFor,
+        Forwarded.Element.fromFor,
         _.`for`,
         _.withFor)
 
@@ -79,7 +79,7 @@ private[parser] trait ForwardedHeader {
       CreateOrAssignParam(
         "host",
         Forwarded.Host.fromString,
-        Forwarded.Element.withHost,
+        Forwarded.Element.fromHost,
         _.`host`,
         _.withHost)
 
@@ -87,7 +87,7 @@ private[parser] trait ForwardedHeader {
       CreateOrAssignParam(
         "proto",
         UriModel.Scheme.fromString,
-        Forwarded.Element.withProto,
+        Forwarded.Element.fromProto,
         _.`proto`,
         _.withProto)
 

--- a/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
@@ -60,7 +60,7 @@ private[parser] trait ForwardedHeader {
         "by",
         Forwarded.Node.fromString,
         Forwarded.Element.fromBy,
-        _.`by`,
+        _.maybeBy,
         _.withBy)
 
     private def CreateOrAssignParam_for =
@@ -68,7 +68,7 @@ private[parser] trait ForwardedHeader {
         "for",
         Forwarded.Node.fromString,
         Forwarded.Element.fromFor,
-        _.`for`,
+        _.maybeFor,
         _.withFor)
 
     private def CreateOrAssignParam_host =
@@ -76,7 +76,7 @@ private[parser] trait ForwardedHeader {
         "host",
         Forwarded.Host.fromString,
         Forwarded.Element.fromHost,
-        _.`host`,
+        _.maybeHost,
         _.withHost)
 
     private def CreateOrAssignParam_proto =
@@ -84,7 +84,7 @@ private[parser] trait ForwardedHeader {
         "proto",
         UriModel.Scheme.fromString,
         Forwarded.Element.fromProto,
-        _.`proto`,
+        _.maybeProto,
         _.withProto)
 
     private def CreateOrAssignParam[A](

--- a/core/src/main/scala/org/http4s/parser/ForwardedModelParsing.scala
+++ b/core/src/main/scala/org/http4s/parser/ForwardedModelParsing.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.parser
+
+import java.nio.charset.{Charset, StandardCharsets}
+
+import org.http4s.headers.Forwarded
+import org.http4s.internal.parboiled2.CharPredicate.{AlphaNum, Digit}
+import org.http4s.internal.parboiled2._
+import org.http4s.{Uri => UriModel}
+
+import scala.util.Try
+
+private[http4s] trait ForwardedModelParsing { model: Forwarded.type =>
+
+  private[ForwardedModelParsing] sealed trait ModelParsers extends Rfc3986Parser { rfc =>
+
+    override final def charset: Charset = StandardCharsets.ISO_8859_1
+
+    protected final def ModelNode: Rule1[model.Node] =
+      rule {
+        (ModelNodeName ~ optional(':' ~ ModelNodePort)) ~> {
+          model.Node(_: model.Node.Name, _: Option[model.Node.Port])
+        }
+      }
+
+    protected final def ModelNodeName: Rule1[model.Node.Name] =
+      rule {
+        (rfc.ipv4Address ~> model.Node.Name.Ipv4) |
+          ('[' ~ rfc.ipv6Address ~ ']' ~> model.Node.Name.Ipv6) |
+          ("unknown" ~ push(model.Node.Name.Unknown)) |
+          ModelNodeObfuscated
+      }
+
+    protected final def ModelNodePort: Rule1[model.Node.Port] =
+      rule {
+        capture((1 to 5).times(Digit)) ~> {
+          modelNodePortFromString(_) match {
+            case Some(port) => push(port)
+            case None => failX(s"incorrect port number")
+          }
+        } | ModelNodeObfuscated
+      }
+
+    private def modelNodePortFromString(str: String): Option[model.Node.Port] =
+      Try(Integer.parseUnsignedInt(str)).toOption.flatMap(model.Node.Port.fromInt(_).toOption)
+
+    protected final def ModelNodeObfuscated: Rule1[model.Node.Obfuscated] =
+      rule {
+        capture('_' ~ oneOrMore(AlphaNum | '.' | '_' | '-')) ~> { model.Node.Obfuscated(_) }
+      }
+
+    protected final def ModelHost: Rule1[model.Host] =
+      rule {
+        rfc.Host ~ rfc.Port ~> { (uriHost: UriModel.Host, portNum: Option[Int]) =>
+          model.Host.from(uriHost, portNum) match {
+            case Left(failure) => failX(failure.message)
+            case Right(modelHost) => push(modelHost)
+          }
+        }
+      }
+  }
+
+  protected final class ModelNodeParser(s: String)
+      extends Http4sParser[model.Node](s, s"invalid node '$s'")
+      with ModelParsers {
+
+    override def main: Rule1[Node] = rule(ModelNode ~ EOI)
+  }
+
+  protected final class ModelNodeObfuscatedParser(s: String)
+      extends Http4sParser[model.Node.Obfuscated](s, s"invalid obfuscated value '$s'")
+      with ModelParsers {
+
+    override def main: Rule1[model.Node.Obfuscated] = rule(ModelNodeObfuscated ~ EOI)
+  }
+
+  protected final class ModelHostParser(s: String)
+      extends Http4sParser[model.Host](s, s"invalid host '$s'")
+      with ModelParsers {
+
+    override def main: Rule1[model.Host] = rule(ModelHost ~ EOI)
+  }
+}

--- a/core/src/main/scala/org/http4s/parser/ForwardedModelParsing.scala
+++ b/core/src/main/scala/org/http4s/parser/ForwardedModelParsing.scala
@@ -59,7 +59,7 @@ private[http4s] trait ForwardedModelParsing { model: Forwarded.type =>
     protected final def ModelHost: Rule1[model.Host] =
       rule {
         rfc.Host ~ rfc.Port ~> { (uriHost: UriModel.Host, portNum: Option[Int]) =>
-          model.Host.from(uriHost, portNum) match {
+          model.Host.fromHostAndMaybePort(uriHost, portNum) match {
             case Left(failure) => failX(failure.message)
             case Right(modelHost) => push(modelHost)
           }

--- a/core/src/main/scala/org/http4s/parser/ForwardedModelParsing.scala
+++ b/core/src/main/scala/org/http4s/parser/ForwardedModelParsing.scala
@@ -51,7 +51,9 @@ private[http4s] trait ForwardedModelParsing { model: Forwarded.type =>
 
     protected final def ModelNodeObfuscated: Rule1[model.Node.Obfuscated] =
       rule {
-        capture('_' ~ oneOrMore(AlphaNum | '.' | '_' | '-')) ~> { model.Node.Obfuscated(_) }
+        capture('_' ~ oneOrMore(AlphaNum | '.' | '_' | '-')) ~> { str =>
+          model.Node.Obfuscated(str)
+        }
       }
 
     protected final def ModelHost: Rule1[model.Host] =

--- a/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
+++ b/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
@@ -26,6 +26,7 @@ object HttpHeaderParser
     with CacheControlHeader
     with ContentTypeHeader
     with CookieHeader
+    with ForwardedHeader
     with LinkHeader
     with LocationHeader
     with OriginHeader
@@ -123,6 +124,7 @@ object HttpHeaderParser
     addParser_("DATE".ci, `DATE`)
     addParser_("ETAG".ci, `ETAG`)
     addParser_("EXPIRES".ci, `EXPIRES`)
+    addParser_("FORWARDED".ci, `FORWARDED`)
     addParser_("HOST".ci, `HOST`)
     addParser_("IF-MATCH".ci, `IF_MATCH`)
     addParser_("IF-MODIFIED-SINCE".ci, `IF_MODIFIED_SINCE`)

--- a/tests/src/test/scala/org/http4s/headers/ForwardedArbitraryInstances.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedArbitraryInstances.scala
@@ -34,8 +34,8 @@ private[http4s] trait ForwardedArbitraryInstances
   implicit val http4sTestingArbitraryForForwardedNodeName: Arbitrary[Node.Name] =
     Arbitrary(
       Gen.oneOf(
-        Arbitrary.arbitrary[Uri.Ipv4Address].map(Node.Name(_)),
-        Arbitrary.arbitrary[Uri.Ipv6Address].map(Node.Name(_)),
+        Arbitrary.arbitrary[Uri.Ipv4Address].map(Node.Name.Ipv4),
+        Arbitrary.arbitrary[Uri.Ipv6Address].map(Node.Name.Ipv6),
         Arbitrary.arbitrary[Node.Obfuscated],
         Gen.const(Node.Name.Unknown)
       ) :| "Node.Name")
@@ -73,7 +73,7 @@ private[http4s] trait ForwardedArbitraryInstances
         // TODO: consider implementing it in `Gen[Uri.Host]` directly.
         uriHost <- Gen.oneOf(uriHostGen, Gen.const(Uri.RegName("")))
         portNum <- Gen.option(portNumGen)
-      } yield Host.from(uriHost, portNum).yolo
+      } yield Host.fromHostAndMaybePort(uriHost, portNum).yolo
     } :| "Host")
   }
 

--- a/tests/src/test/scala/org/http4s/headers/ForwardedArbitraryInstances.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedArbitraryInstances.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.headers
+
+import java.nio.charset.StandardCharsets
+
+import cats.data.NonEmptyList
+import cats.syntax.all._
+import org.http4s.internal.bug
+import org.http4s.laws.discipline.ArbitraryInstances
+import org.http4s.{ParseResult, Uri}
+import org.scalacheck.{Arbitrary, Gen}
+
+private[http4s] trait ForwardedArbitraryInstances
+    extends ArbitraryInstances
+    with ForwardedAuxiliaryGenerators {
+  import Forwarded._
+
+  // TODO: copied from `ArbitraryInstances` since the original is private.
+  //       Consider re-using it somehow (discuss it).
+  private implicit class ParseResultSyntax[A](self: ParseResult[A]) {
+    def yolo: A = self.valueOr(e => throw bug(e.toString))
+  }
+
+  implicit val http4sTestingArbitraryForForwardedNodeObfuscated: Arbitrary[Node.Obfuscated] =
+    Arbitrary(
+      obfuscatedStringGen.map(Node.Obfuscated.fromString(_).yolo) :|
+        "Node.Obfuscated")
+
+  implicit val http4sTestingArbitraryForForwardedNodeName: Arbitrary[Node.Name] =
+    Arbitrary(
+      Gen.oneOf(
+        Arbitrary.arbitrary[Uri.Ipv4Address].map(Node.Name(_)),
+        Arbitrary.arbitrary[Uri.Ipv6Address].map(Node.Name(_)),
+        Arbitrary.arbitrary[Node.Obfuscated],
+        Gen.const(Node.Name.Unknown)
+      ) :| "Node.Name")
+
+  implicit val http4sTestingArbitraryForForwardedNodePort: Arbitrary[Node.Port] =
+    Arbitrary(
+      Gen.oneOf(
+        portNumGen.map(Node.Port.fromInt(_).yolo),
+        Arbitrary.arbitrary[Node.Obfuscated]
+      ) :| "Node.Port")
+
+  implicit val http4sTestingArbitraryForForwardedNode: Arbitrary[Node] =
+    Arbitrary({
+      for {
+        nodeName <- Arbitrary.arbitrary[Node.Name]
+        nodePort <- Gen.option(Arbitrary.arbitrary[Node.Port])
+      } yield Node(nodeName, nodePort)
+    } :| "Node")
+
+  implicit val http4sTestingArbitraryForForwardedHost: Arbitrary[Host] = {
+    val uriHostGen =
+      Arbitrary
+        .arbitrary[Uri.Host]
+        .map {
+          // Currently `Gen[Uri.Host]` generates pct-encoded `Uri.RegName`,
+          // while the latter is designed to keep not encoded strings (see `Rfc3986Parser#Host`).
+          // TODO: consider fixing `Gen[Uri.Host]`. See also #1651.
+          case Uri.RegName(n) => Uri.RegName(Uri.decode(n.value, StandardCharsets.ISO_8859_1))
+          case other => other
+        }
+
+    Arbitrary({
+      for {
+        // Increase frequency of empty host reg-names since it's a border case.
+        // TODO: consider implementing it in `Gen[Uri.Host]` directly.
+        uriHost <- Gen.oneOf(uriHostGen, Gen.const(Uri.RegName("")))
+        portNum <- Gen.option(portNumGen)
+      } yield Host.from(uriHost, portNum).yolo
+    } :| "Host")
+  }
+
+  implicit val http4sTestingArbitraryForForwardedElement: Arbitrary[Element] =
+    Arbitrary(
+      Gen
+        .atLeastOne(
+          Arbitrary.arbitrary[Node].map(Element.withFor),
+          Arbitrary.arbitrary[Node].map(Element.withBy),
+          Arbitrary.arbitrary[Host].map(Element.withHost),
+          Arbitrary.arbitrary[Proto].map(Element.withProto)
+        )
+        .map(_.reduceLeft[Element] {
+          case (elem @ Element(None, _, _, _), Element(Some(forItem), None, None, None)) =>
+            elem.withFor(forItem)
+          case (elem @ Element(_, None, _, _), Element(None, Some(byItem), None, None)) =>
+            elem.withBy(byItem)
+          case (elem @ Element(_, _, None, _), Element(None, None, Some(hostItem), None)) =>
+            elem.withHost(hostItem)
+          case (elem @ Element(_, _, _, None), Element(None, None, None, Some(protoItem))) =>
+            elem.withProto(protoItem)
+          case (elem1, elem2) => throw bug(s"illegal combination of elements: $elem1 and $elem2")
+        }) :|
+        "Element"
+    )
+
+  implicit val http4sTestingArbitraryForForwarded: Arbitrary[Forwarded] =
+    Arbitrary(
+      Gen
+        .nonEmptyListOf(Arbitrary.arbitrary[Element])
+        .map(elems => Forwarded(NonEmptyList(elems.head, elems.tail))) :|
+        "Forwarded"
+    )
+}

--- a/tests/src/test/scala/org/http4s/headers/ForwardedArbitraryInstances.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedArbitraryInstances.scala
@@ -81,10 +81,10 @@ private[http4s] trait ForwardedArbitraryInstances
     Arbitrary(
       Gen
         .atLeastOne(
-          Arbitrary.arbitrary[Node].map(Element.withFor),
-          Arbitrary.arbitrary[Node].map(Element.withBy),
-          Arbitrary.arbitrary[Host].map(Element.withHost),
-          Arbitrary.arbitrary[Proto].map(Element.withProto)
+          Arbitrary.arbitrary[Node].map(Element.fromFor),
+          Arbitrary.arbitrary[Node].map(Element.fromBy),
+          Arbitrary.arbitrary[Host].map(Element.fromHost),
+          Arbitrary.arbitrary[Proto].map(Element.fromProto)
         )
         .map(_.reduceLeft[Element] {
           case (elem @ Element(None, _, _, _), Element(Some(forItem), None, None, None)) =>

--- a/tests/src/test/scala/org/http4s/headers/ForwardedAuxiliaryGenerators.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedAuxiliaryGenerators.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.headers
+
+import org.scalacheck.Gen
+
+trait ForwardedAuxiliaryGenerators {
+  import Forwarded.{PortMax, PortMin}
+
+  val obfuscatedCharGen: Gen[Char] = Gen.oneOf(Gen.alphaNumChar, Gen.oneOf('.', '_', '-'))
+
+  val obfuscatedStringGen: Gen[String] =
+    Gen.nonEmptyListOf(obfuscatedCharGen).map('_' :: _).map(_.mkString)
+
+  val portNumGen: Gen[Int] = Gen.chooseNum(PortMin, PortMax)
+}

--- a/tests/src/test/scala/org/http4s/headers/ForwardedRenderersSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedRenderersSpec.scala
@@ -82,9 +82,7 @@ class ForwardedRenderersSpec
       val rendered = Renderer.renderString(elem)
       rendered must not be empty
 
-      Forwarded.parse(rendered) must beRight.like {
-        case Forwarded(NonEmptyList(`elem`, Nil)) => ok
-      }
+      Forwarded.parse(rendered) must beRight(Forwarded(NonEmptyList(elem, Nil)))
     }
   }
   "Forwarded" in {

--- a/tests/src/test/scala/org/http4s/headers/ForwardedRenderersSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedRenderersSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.headers
+
+import cats.data.NonEmptyList
+import org.http4s.Uri
+import org.http4s.util.Renderer
+import org.specs2.ScalaCheck
+import org.specs2.mutable.{Specification, Tables}
+
+class ForwardedRenderersSpec
+    extends Specification
+    with ScalaCheck
+    with Tables
+    with ForwardedArbitraryInstances {
+
+  "Renderer should render to a string that roundtrips back to the original value".p.tab
+
+  "Node.Name" in {
+    import Forwarded.Node
+
+    prop { (nodeName: Node.Name) =>
+      val rendered = Renderer.renderString(nodeName)
+      rendered must not be empty // just to check for something here
+
+      nodeName match {
+        case Node.Name.Ipv4(ipv4) =>
+          Uri.Ipv4Address.fromString(rendered) must beRight(ipv4)
+        case Node.Name.Ipv6(ipv6) =>
+          rendered must startWith("[")
+          rendered must endWith("]")
+          Uri.Ipv6Address.fromString(rendered.tail.init) must beRight(ipv6)
+        case Node.Name.Unknown =>
+          rendered ==== "unknown"
+        case obfName: Node.Obfuscated =>
+          Node.Obfuscated.fromString(rendered) must beRight(obfName)
+      }
+    }
+  }
+  "Node.Port" in {
+    import Forwarded.Node
+
+    prop { (nodePort: Node.Port) =>
+      val rendered = Renderer.renderString(nodePort)
+      rendered must not be empty
+
+      nodePort match {
+        case Node.Port(num) =>
+          Integer.parseUnsignedInt(rendered) ==== num
+        case obfPort: Node.Obfuscated =>
+          Node.Obfuscated.fromString(rendered) must beRight(obfPort)
+      }
+    }
+  }
+  "Node" in {
+    import Forwarded.Node
+
+    prop { (node: Node) =>
+      val rendered = Renderer.renderString(node)
+      rendered must not be empty
+
+      Node.fromString(rendered) must beRight(node)
+    }
+  }
+  "Host" in {
+    import Forwarded.Host
+
+    prop { (host: Host) =>
+      val rendered = Renderer.renderString(host)
+
+      Host.fromString(rendered) must beRight(host)
+    }
+  }
+  "Element" in {
+    import Forwarded.Element
+
+    prop { (elem: Element) =>
+      val rendered = Renderer.renderString(elem)
+      rendered must not be empty
+
+      Forwarded.parse(rendered) must beRight.like {
+        case Forwarded(NonEmptyList(`elem`, Nil)) => ok
+      }
+    }
+  }
+  "Forwarded" in {
+    val headerInit = Forwarded.name.value + ": "
+
+    prop { (fwd: Forwarded) =>
+      val rendered = Renderer.renderString(fwd)
+      rendered must startWith(headerInit)
+
+      Forwarded.parse(rendered.drop(headerInit.length)) must beRight(fwd)
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/headers/ForwardedSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedSpec.scala
@@ -33,8 +33,8 @@ class ForwardedSpec
     "fromString" should {
       "parse valid node definitions" in {
         "Node Name String" | "Parsed Node Name" |
-          "1.2.3.4" ! Name(1, 2, 3, 4) |
-          "[1:2:3::4:5:6]" ! Name(1, 2, 3, 0, 0, 4, 5, 6) |
+          "1.2.3.4" ! Name.ofIpv4Address(1, 2, 3, 4) |
+          "[1:2:3::4:5:6]" ! Name.ofIpv6Address(1, 2, 3, 0, 0, 4, 5, 6) |
           "_a.b1-r2a_" ! Obfuscated("_a.b1-r2a_") |
           "unknown" ! Name.Unknown |> { (nameStr, parsedName) =>
             Node.fromString(nameStr) must beRight(Node(parsedName))

--- a/tests/src/test/scala/org/http4s/headers/ForwardedSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedSpec.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.headers
+
+import java.nio.charset.StandardCharsets
+
+import cats.instances.string._
+import cats.syntax.option._
+import org.http4s.laws.discipline.ArbitraryInstances
+import org.http4s.{ParseFailure, Uri}
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2.ScalaCheck
+import org.specs2.execute.Result
+import org.specs2.mutable.{Specification, Tables}
+
+class ForwardedSpec
+    extends Specification
+    with Tables
+    with ScalaCheck
+    with ArbitraryInstances
+    with ForwardedAuxiliaryGenerators {
+
+  "Node" >> {
+    import Forwarded.Node
+    import Node.{Name, Obfuscated}
+
+    def Port(num: Int) = Node.Port.fromInt(num).toTry.get
+
+    "fromString" should {
+      "parse valid node definitions" in {
+        "Node Name String" | "Parsed Node Name" |
+          "1.2.3.4" ! Name(1, 2, 3, 4) |
+          "[1:2:3::4:5:6]" ! Name(1, 2, 3, 0, 0, 4, 5, 6) |
+          "_a.b1-r2a_" ! Obfuscated("_a.b1-r2a_") |
+          "unknown" ! Name.Unknown |> { (nameStr, parsedName) =>
+          Node.fromString(nameStr) must beRight(Node(parsedName))
+
+          "Node Port String" | "Parsed Node Port" |
+            "000" ! Port(0) |
+            "567" ! Port(567) |
+            "__k3a.d4ab5.r6a-" ! Obfuscated("__k3a.d4ab5.r6a-") |> { (portStr, parsedPort) =>
+            Node.fromString(s"$nameStr:$portStr") must beRight(Node(parsedName, parsedPort))
+          }
+        }
+      }
+      "fail to parse invalid node definitions" in {
+        val invalidNodes = Seq(
+          "1.2.3", // incorrect IPv4
+          "1.2.3.4.5", // incorrect IPv4
+          "1.2.3.4.", // dot after IPv4
+          "1.2.3.4 ", // whitespace after IPv4
+          "1:2:3::4:5:6", // IPv5 must be in brackets
+          "[1:2:3:4:5:6]", // incorrect IPv6
+          "[1:2:3::4:5:]", // incorrect IPv6
+          "[1:2:3::4:5:6] ", // whitespace after node name
+          "1.2.3.4:", // missed port
+          "1.2.3.4:a", // alpha char as a node port
+          "1.2.3.4:_", // illegal char as a node port
+          "1.2.3.4: ", // whitespace instead of a node port
+          "1.2.3.4: 567", // whitespace before the port num
+          "1.2.3.4:567 ", // whitespace after the port num
+          "unknownn", // unknown word 'unknownn'
+          "_foo~bar", // illegal char '~' in obfuscated name
+          "unknown:_foo~bar", // illegal char '~' in the obfuscated node port
+          "http4s.org", // reg-name is not allowed
+          ":567" // node name is missed
+        )
+
+        Result.foreach(invalidNodes) { nodeStr =>
+          Node.fromString(nodeStr) must beLeft {
+            (_: ParseFailure).sanitized must_=== s"invalid node '$nodeStr'"
+          }
+        }
+      }
+    }
+  }
+  "Node.Obfuscated" >> {
+    import Forwarded.Node.Obfuscated
+
+    "fromString" >> {
+      "parse valid obfuscated values" in {
+        prop { (obfStr: String) =>
+          Obfuscated.fromString(obfStr) must beRight {
+            (_: Obfuscated).value must_=== obfStr
+          }
+        }.setGen(obfuscatedStringGen)
+      }
+      "fail to parse obfuscated values that don't start with '_'" in {
+        val obfGen =
+          for {
+            firstCh <- obfuscatedCharGen if firstCh != '_'
+            otherChs <- Gen.nonEmptyListOf(obfuscatedCharGen)
+          } yield (firstCh :: otherChs).mkString
+
+        prop { (obfStr: String) =>
+          Obfuscated.fromString(obfStr) must beLeft {
+            (_: ParseFailure).sanitized must_=== s"invalid obfuscated value '$obfStr'"
+          }
+        }.setGen(obfGen)
+      }
+      "fail to parse obfuscated values that contain invalid symbols" in {
+        val obfGen =
+          for {
+            initChs <- Gen.listOf(obfuscatedCharGen)
+            badCh <- Gen.asciiChar if !(badCh.isLetterOrDigit || "._-".contains(badCh))
+            lastChs <- Gen.listOf(obfuscatedCharGen)
+          } yield ('_' :: initChs ::: badCh :: lastChs).mkString
+
+        prop { (obfStr: String) =>
+          Obfuscated.fromString(obfStr) must beLeft {
+            (_: ParseFailure).sanitized must_=== s"invalid obfuscated value '$obfStr'"
+          }
+        }.setGen(obfGen)
+      }
+    }
+  }
+  "Host" >> {
+    import Forwarded.Host
+
+    "fromUri" should {
+      "build `Host` from `Uri` if a host is defined or fail otherwise" in prop { (uri: Uri) =>
+        Host.fromUri(uri) must {
+          if (uri.host.isDefined)
+            beRight { (host: Host) =>
+              host.host must_=== uri.host.get
+              host.port must_=== uri.port
+            }
+          else
+            beLeft {
+              (_: ParseFailure).sanitized must_=== "missing host"
+            }
+        }
+      }
+      "fail to build `Host` if incorrect port number is specified in `Uri`" in {
+        val portRange = Forwarded.PortMin to Forwarded.PortMax
+        val badPortGen = Arbitrary.arbitrary[Int].filterNot(portRange.contains)
+
+        prop { (genUri: Uri, portNum: Int) =>
+          val newUri =
+            genUri.copy(authority = genUri.authority
+              .map(_.copy(port = Some(portNum)))
+              .orElse(Some(Uri.Authority(port = Some(portNum)))))
+
+          Host.fromUri(newUri) must beLeft {
+            (_: ParseFailure).sanitized must_=== "invalid port number"
+          }
+        }.setGen2(badPortGen)
+      }
+    }
+
+    "fromString" should {
+      "parse valid host definitions" in prop { (uriAuth: Uri.Authority) =>
+        val hostStr = uriAuth.host.renderString + uriAuth.port.map(":" + _).orEmpty
+
+        Host.fromString(hostStr) must beRight { (host: Host) =>
+          (host.host, uriAuth.host) must beLike {
+            case (Uri.RegName(actual), Uri.RegName(expected)) =>
+              actual.value must_===
+                // TODO: `Uri.decode` should not be necessary here. Remove when #1651 (or #2012) get fixed.
+                Uri.decode(expected.value, StandardCharsets.ISO_8859_1)
+            case _ => host.host must_=== uriAuth.host
+          }
+          host.port must_=== uriAuth.port
+        }
+      }
+      "fail to parse invalid host definitions" in {
+        val invalidHosts = Seq(
+          "aaa.bbb:12:34", // two colons
+          "aaa.bbb:65536", // port number exceeds the maximum
+          "aaa.bbb:a12", // port is not a number
+          " aaa.bbb:12", // whitespace
+          "aaa .bbb:12", // whitespace
+          "aaa. bbb:12", // whitespace
+          "aaa.bbb :12", // whitespace
+          "aaa.bbb: 12", // whitespace
+          "aaa.bbb:12 ", // whitespace
+          "aaa?bbb" // illegal symbol
+        )
+
+        Result.foreach(invalidHosts) { hostStr =>
+          Host.fromString(hostStr) must beLeft {
+            (_: ParseFailure).sanitized must_=== s"invalid host '$hostStr'"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/headers/ForwardedSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedSpec.scala
@@ -37,15 +37,15 @@ class ForwardedSpec
           "[1:2:3::4:5:6]" ! Name(1, 2, 3, 0, 0, 4, 5, 6) |
           "_a.b1-r2a_" ! Obfuscated("_a.b1-r2a_") |
           "unknown" ! Name.Unknown |> { (nameStr, parsedName) =>
-          Node.fromString(nameStr) must beRight(Node(parsedName))
+            Node.fromString(nameStr) must beRight(Node(parsedName))
 
-          "Node Port String" | "Parsed Node Port" |
-            "000" ! Port(0) |
-            "567" ! Port(567) |
-            "__k3a.d4ab5.r6a-" ! Obfuscated("__k3a.d4ab5.r6a-") |> { (portStr, parsedPort) =>
-            Node.fromString(s"$nameStr:$portStr") must beRight(Node(parsedName, parsedPort))
+            "Node Port String" | "Parsed Node Port" |
+              "000" ! Port(0) |
+              "567" ! Port(567) |
+              "__k3a.d4ab5.r6a-" ! Obfuscated("__k3a.d4ab5.r6a-") |> { (portStr, parsedPort) =>
+                Node.fromString(s"$nameStr:$portStr") must beRight(Node(parsedName, parsedPort))
+              }
           }
-        }
       }
       "fail to parse invalid node definitions" in {
         val invalidNodes = Seq(

--- a/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
@@ -131,8 +131,8 @@ object ForwardedHeaderSpec {
   implicit def convertUriToNode(uri: Uri): Node =
     Node(
       uri.host match {
-        case Some(ipv4: Uri.Ipv4Address) => Node.Name(ipv4)
-        case Some(ipv6: Uri.Ipv6Address) => Node.Name(ipv6)
+        case Some(ipv4: Uri.Ipv4Address) => Node.Name.Ipv4(ipv4)
+        case Some(ipv6: Uri.Ipv6Address) => Node.Name.Ipv6(ipv6)
         case Some(Uri.RegName(UnCIString("unknown"))) => Node.Name.Unknown
         case Some(Uri.RegName(UnCIString(ObfuscatedRe(obfuscatedName)))) =>
           Node.Obfuscated(obfuscatedName)

--- a/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
@@ -39,58 +39,58 @@ class ForwardedHeaderSpec extends Specification with Tables {
           "proto=http" ! Element.withProto(scheme"http") |
           "proto=\"https\"" ! Element.withProto(scheme"https") |
           "prOtO=gopher" ! Element.withProto(scheme"gopher") |> { (headerStr, parsedMod) =>
-          parse(headerStr) must beRight((_: Forwarded).values ==== NEL(parsedMod))
-        }
+            parse(headerStr) must beRight((_: Forwarded).values ==== NEL(parsedMod))
+          }
       }
       "single compound elements" in {
         "Header String" | "Parsed Model" |
           "by=_abra;for=_kadabra" !
-            Element.withBy(uri"//_abra").withFor(uri"//_kadabra") |
+          Element.withBy(uri"//_abra").withFor(uri"//_kadabra") |
           "by=_abra;for=_kadabra;host=http4s.org" !
-            Element.withBy(uri"//_abra").withFor(uri"//_kadabra").withHost(uri"//http4s.org") |
+          Element.withBy(uri"//_abra").withFor(uri"//_kadabra").withHost(uri"//http4s.org") |
           "by=_abra;for=_kadabra;host=\"http4s.org\";proto=http" !
-            Element
-              .withBy(uri"//_abra")
-              .withFor(uri"//_kadabra")
-              .withHost(uri"//http4s.org")
-              .withProto(scheme"http") |
+          Element
+            .withBy(uri"//_abra")
+            .withFor(uri"//_kadabra")
+            .withHost(uri"//http4s.org")
+            .withProto(scheme"http") |
           "for=_kadabra;by=_abra;proto=http;host=http4s.org" !
-            Element
-              .withBy(uri"//_abra")
-              .withFor(uri"//_kadabra")
-              .withHost(uri"//http4s.org")
-              .withProto(scheme"http") |
+          Element
+            .withBy(uri"//_abra")
+            .withFor(uri"//_kadabra")
+            .withHost(uri"//http4s.org")
+            .withProto(scheme"http") |
           "host=http4s.org;for=_kadabra;proto=http;by=_abra" !
-            Element
-              .withBy(uri"//_abra")
-              .withFor(uri"//_kadabra")
-              .withHost(uri"//http4s.org")
-              .withProto(scheme"http") |> { (headerStr, parsedMod) =>
-          parse(headerStr) must beRight((_: Forwarded).values ==== NEL(parsedMod))
-        }
+          Element
+            .withBy(uri"//_abra")
+            .withFor(uri"//_kadabra")
+            .withHost(uri"//http4s.org")
+            .withProto(scheme"http") |> { (headerStr, parsedMod) =>
+            parse(headerStr) must beRight((_: Forwarded).values ==== NEL(parsedMod))
+          }
       }
       "multi elements" in {
         "Header String" | "Parsed Model" |
           "by=_foo, for=_bar , host=foo.bar ,proto=foobar" !
-            NEL(
-              Element.withBy(uri"//_foo"),
-              Element.withFor(uri"//_bar"),
-              Element.withHost(uri"//foo.bar"),
-              Element.withProto(scheme"foobar")
-            ) |
+          NEL(
+            Element.withBy(uri"//_foo"),
+            Element.withFor(uri"//_bar"),
+            Element.withHost(uri"//foo.bar"),
+            Element.withProto(scheme"foobar")
+          ) |
           "by=_foo;for=_bar , host=foo.bar;proto=foobar" !
-            NEL(
-              Element.withBy(uri"//_foo").withFor(uri"//_bar"),
-              Element.withHost(uri"//foo.bar").withProto(scheme"foobar")
-            ) |
+          NEL(
+            Element.withBy(uri"//_foo").withFor(uri"//_bar"),
+            Element.withHost(uri"//foo.bar").withProto(scheme"foobar")
+          ) |
           "by=_foo ,for=_bar;host=foo.bar, proto=foobar" !
-            NEL(
-              Element.withBy(uri"//_foo"),
-              Element.withFor(uri"//_bar").withHost(uri"//foo.bar"),
-              Element.withProto(scheme"foobar")
-            ) |> { (headerStr, parsedMod) =>
-          parse(headerStr) must beRight((_: Forwarded).values ==== parsedMod)
-        }
+          NEL(
+            Element.withBy(uri"//_foo"),
+            Element.withFor(uri"//_bar").withHost(uri"//foo.bar"),
+            Element.withProto(scheme"foobar")
+          ) |> { (headerStr, parsedMod) =>
+            parse(headerStr) must beRight((_: Forwarded).values ==== parsedMod)
+          }
       }
     }
     "fail to parse" >> {
@@ -142,8 +142,8 @@ object ForwardedHeaderSpec {
       uri.port.flatMap(Node.Port.fromInt(_).toOption).orElse {
         // Convention: use the URI fragment to define an obfuscated port.
         uri.fragment.flatMap {
-          PartialFunction.condOpt(_) {
-            case ObfuscatedRe(obfuscatedPort) => Node.Obfuscated(obfuscatedPort)
+          PartialFunction.condOpt(_) { case ObfuscatedRe(obfuscatedPort) =>
+            Node.Obfuscated(obfuscatedPort)
           }
         }
       }

--- a/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
@@ -26,43 +26,43 @@ class ForwardedHeaderSpec extends Specification with Tables {
     "parse" >> {
       "single simple elements" in {
         "Header String" | "Parsed Model" |
-          "by=4.3.2.1" ! Element.withBy(uri"//4.3.2.1") |
-          "for=\"[1:2:0::0:3:4]:56\"" ! Element.withFor(uri"//[1:2::3:4]:56") |
-          "BY=\"_a.b-r.a_:_k.a-d._.b-r.a\"" ! Element.withBy(uri"//_a.b-r.a_#_k.a-d._.b-r.a") |
-          "for=unknown" ! Element.withFor(uri"//unknown") |
-          "by=\"unknown:451\"" ! Element.withBy(uri"//unknown:451") |
-          "For=\"unknown:__p.0_r.t-\"" ! Element.withFor(uri"//unknown#__p.0_r.t-") |
-          "host=http4s.org" ! Element.withHost(uri"//http4s.org") |
-          "hOSt=\"http4s.org:12345\"" ! Element.withHost(uri"//http4s.org:12345") |
-          "host=\"1.2.3.4:567\"" ! Element.withHost(uri"//1.2.3.4:567") |
-          "host=\"[8:7:6:5:4:3:2:1]\"" ! Element.withHost(uri"//[8:7:6:5:4:3:2:1]") |
-          "proto=http" ! Element.withProto(scheme"http") |
-          "proto=\"https\"" ! Element.withProto(scheme"https") |
-          "prOtO=gopher" ! Element.withProto(scheme"gopher") |> { (headerStr, parsedMod) =>
+          "by=4.3.2.1" ! Element.fromBy(uri"//4.3.2.1") |
+          "for=\"[1:2:0::0:3:4]:56\"" ! Element.fromFor(uri"//[1:2::3:4]:56") |
+          "BY=\"_a.b-r.a_:_k.a-d._.b-r.a\"" ! Element.fromBy(uri"//_a.b-r.a_#_k.a-d._.b-r.a") |
+          "for=unknown" ! Element.fromFor(uri"//unknown") |
+          "by=\"unknown:451\"" ! Element.fromBy(uri"//unknown:451") |
+          "For=\"unknown:__p.0_r.t-\"" ! Element.fromFor(uri"//unknown#__p.0_r.t-") |
+          "host=http4s.org" ! Element.fromHost(uri"//http4s.org") |
+          "hOSt=\"http4s.org:12345\"" ! Element.fromHost(uri"//http4s.org:12345") |
+          "host=\"1.2.3.4:567\"" ! Element.fromHost(uri"//1.2.3.4:567") |
+          "host=\"[8:7:6:5:4:3:2:1]\"" ! Element.fromHost(uri"//[8:7:6:5:4:3:2:1]") |
+          "proto=http" ! Element.fromProto(scheme"http") |
+          "proto=\"https\"" ! Element.fromProto(scheme"https") |
+          "prOtO=gopher" ! Element.fromProto(scheme"gopher") |> { (headerStr, parsedMod) =>
             parse(headerStr) must beRight((_: Forwarded).values ==== NEL(parsedMod))
           }
       }
       "single compound elements" in {
         "Header String" | "Parsed Model" |
           "by=_abra;for=_kadabra" !
-          Element.withBy(uri"//_abra").withFor(uri"//_kadabra") |
+          Element.fromBy(uri"//_abra").withFor(uri"//_kadabra") |
           "by=_abra;for=_kadabra;host=http4s.org" !
-          Element.withBy(uri"//_abra").withFor(uri"//_kadabra").withHost(uri"//http4s.org") |
+          Element.fromBy(uri"//_abra").withFor(uri"//_kadabra").withHost(uri"//http4s.org") |
           "by=_abra;for=_kadabra;host=\"http4s.org\";proto=http" !
           Element
-            .withBy(uri"//_abra")
+            .fromBy(uri"//_abra")
             .withFor(uri"//_kadabra")
             .withHost(uri"//http4s.org")
             .withProto(scheme"http") |
           "for=_kadabra;by=_abra;proto=http;host=http4s.org" !
           Element
-            .withBy(uri"//_abra")
+            .fromBy(uri"//_abra")
             .withFor(uri"//_kadabra")
             .withHost(uri"//http4s.org")
             .withProto(scheme"http") |
           "host=http4s.org;for=_kadabra;proto=http;by=_abra" !
           Element
-            .withBy(uri"//_abra")
+            .fromBy(uri"//_abra")
             .withFor(uri"//_kadabra")
             .withHost(uri"//http4s.org")
             .withProto(scheme"http") |> { (headerStr, parsedMod) =>
@@ -73,21 +73,21 @@ class ForwardedHeaderSpec extends Specification with Tables {
         "Header String" | "Parsed Model" |
           "by=_foo, for=_bar , host=foo.bar ,proto=foobar" !
           NEL(
-            Element.withBy(uri"//_foo"),
-            Element.withFor(uri"//_bar"),
-            Element.withHost(uri"//foo.bar"),
-            Element.withProto(scheme"foobar")
+            Element.fromBy(uri"//_foo"),
+            Element.fromFor(uri"//_bar"),
+            Element.fromHost(uri"//foo.bar"),
+            Element.fromProto(scheme"foobar")
           ) |
           "by=_foo;for=_bar , host=foo.bar;proto=foobar" !
           NEL(
-            Element.withBy(uri"//_foo").withFor(uri"//_bar"),
-            Element.withHost(uri"//foo.bar").withProto(scheme"foobar")
+            Element.fromBy(uri"//_foo").withFor(uri"//_bar"),
+            Element.fromHost(uri"//foo.bar").withProto(scheme"foobar")
           ) |
           "by=_foo ,for=_bar;host=foo.bar, proto=foobar" !
           NEL(
-            Element.withBy(uri"//_foo"),
-            Element.withFor(uri"//_bar").withHost(uri"//foo.bar"),
-            Element.withProto(scheme"foobar")
+            Element.fromBy(uri"//_foo"),
+            Element.fromFor(uri"//_bar").withHost(uri"//foo.bar"),
+            Element.fromProto(scheme"foobar")
           ) |> { (headerStr, parsedMod) =>
             parse(headerStr) must beRight((_: Forwarded).values ==== parsedMod)
           }

--- a/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.parser
+
+import cats.data.NonEmptyList
+import cats.syntax.either._
+import org.http4s.headers.Forwarded
+import org.http4s.internal.bug
+import org.http4s.syntax.literals._
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.{ParseFailure, Uri}
+import org.specs2.execute.Result
+import org.specs2.mutable.{Specification, Tables}
+
+class ForwardedHeaderSpec extends Specification with Tables {
+  import Forwarded.Element
+  import ForwardedHeaderSpec._
+
+  "FORWARDED" should {
+    def parse(input: String) = HttpHeaderParser.FORWARDED(input)
+
+    "parse" >> {
+      "single simple elements" in {
+        "Header String" | "Parsed Model" |
+          "by=4.3.2.1" ! Element.withBy(uri"//4.3.2.1") |
+          "for=\"[1:2:0::0:3:4]:56\"" ! Element.withFor(uri"//[1:2::3:4]:56") |
+          "BY=\"_a.b-r.a_:_k.a-d._.b-r.a\"" ! Element.withBy(uri"//_a.b-r.a_#_k.a-d._.b-r.a") |
+          "for=unknown" ! Element.withFor(uri"//unknown") |
+          "by=\"unknown:451\"" ! Element.withBy(uri"//unknown:451") |
+          "For=\"unknown:__p.0_r.t-\"" ! Element.withFor(uri"//unknown#__p.0_r.t-") |
+          "host=http4s.org" ! Element.withHost(uri"//http4s.org") |
+          "hOSt=\"http4s.org:12345\"" ! Element.withHost(uri"//http4s.org:12345") |
+          "host=\"1.2.3.4:567\"" ! Element.withHost(uri"//1.2.3.4:567") |
+          "host=\"[8:7:6:5:4:3:2:1]\"" ! Element.withHost(uri"//[8:7:6:5:4:3:2:1]") |
+          "proto=http" ! Element.withProto(scheme"http") |
+          "proto=\"https\"" ! Element.withProto(scheme"https") |
+          "prOtO=gopher" ! Element.withProto(scheme"gopher") |> { (headerStr, parsedMod) =>
+          parse(headerStr) must beRight((_: Forwarded).values ==== NEL(parsedMod))
+        }
+      }
+      "single compound elements" in {
+        "Header String" | "Parsed Model" |
+          "by=_abra;for=_kadabra" !
+            Element.withBy(uri"//_abra").withFor(uri"//_kadabra") |
+          "by=_abra;for=_kadabra;host=http4s.org" !
+            Element.withBy(uri"//_abra").withFor(uri"//_kadabra").withHost(uri"//http4s.org") |
+          "by=_abra;for=_kadabra;host=\"http4s.org\";proto=http" !
+            Element
+              .withBy(uri"//_abra")
+              .withFor(uri"//_kadabra")
+              .withHost(uri"//http4s.org")
+              .withProto(scheme"http") |
+          "for=_kadabra;by=_abra;proto=http;host=http4s.org" !
+            Element
+              .withBy(uri"//_abra")
+              .withFor(uri"//_kadabra")
+              .withHost(uri"//http4s.org")
+              .withProto(scheme"http") |
+          "host=http4s.org;for=_kadabra;proto=http;by=_abra" !
+            Element
+              .withBy(uri"//_abra")
+              .withFor(uri"//_kadabra")
+              .withHost(uri"//http4s.org")
+              .withProto(scheme"http") |> { (headerStr, parsedMod) =>
+          parse(headerStr) must beRight((_: Forwarded).values ==== NEL(parsedMod))
+        }
+      }
+      "multi elements" in {
+        "Header String" | "Parsed Model" |
+          "by=_foo, for=_bar , host=foo.bar ,proto=foobar" !
+            NEL(
+              Element.withBy(uri"//_foo"),
+              Element.withFor(uri"//_bar"),
+              Element.withHost(uri"//foo.bar"),
+              Element.withProto(scheme"foobar")
+            ) |
+          "by=_foo;for=_bar , host=foo.bar;proto=foobar" !
+            NEL(
+              Element.withBy(uri"//_foo").withFor(uri"//_bar"),
+              Element.withHost(uri"//foo.bar").withProto(scheme"foobar")
+            ) |
+          "by=_foo ,for=_bar;host=foo.bar, proto=foobar" !
+            NEL(
+              Element.withBy(uri"//_foo"),
+              Element.withFor(uri"//_bar").withHost(uri"//foo.bar"),
+              Element.withProto(scheme"foobar")
+            ) |> { (headerStr, parsedMod) =>
+          parse(headerStr) must beRight((_: Forwarded).values ==== parsedMod)
+        }
+      }
+    }
+    "fail to parse" >> {
+      "unknown parameter" in {
+        Result.foreach(
+          Seq(
+            "bye=1.2.3.4",
+            "four=_foobar",
+            "ghost=foo.bar",
+            "proot=http"
+          )) {
+          parse(_) must beLeft((_: ParseFailure).sanitized ==== "Invalid header")
+        }
+      }
+      "unquoted non-token" in {
+        Result.foreach(
+          Seq(
+            "by=[1:2:3::4:5:6]",
+            "for=_abra:_kadabra",
+            "host=foo.bar:123"
+          )) {
+          parse(_) must beLeft((_: ParseFailure).sanitized ==== "Invalid header")
+        }
+      }
+    }
+  }
+}
+
+object ForwardedHeaderSpec {
+  import Forwarded.{Host, Node}
+
+  private val ObfuscatedRe = """^(_[\p{Alnum}\.\_\-]+)$""".r
+
+  private object UnCIString {
+    def unapply(cistr: CaseInsensitiveString): Option[String] = Some(cistr.value)
+  }
+
+  implicit def convertUriToNode(uri: Uri): Node =
+    Node(
+      uri.host match {
+        case Some(ipv4: Uri.Ipv4Address) => Node.Name(ipv4)
+        case Some(ipv6: Uri.Ipv6Address) => Node.Name(ipv6)
+        case Some(Uri.RegName(UnCIString("unknown"))) => Node.Name.Unknown
+        case Some(Uri.RegName(UnCIString(ObfuscatedRe(obfuscatedName)))) =>
+          Node.Obfuscated(obfuscatedName)
+        case Some(other) => throw bug(s"not allowed as host for node: $other")
+        case _ => throw bug(s"no host in URI: $uri")
+      },
+      uri.port.flatMap(Node.Port.fromInt(_).toOption).orElse {
+        // Convention: use the URI fragment to define an obfuscated port.
+        uri.fragment.flatMap {
+          PartialFunction.condOpt(_) {
+            case ObfuscatedRe(obfuscatedPort) => Node.Obfuscated(obfuscatedPort)
+          }
+        }
+      }
+    )
+
+  implicit def convertUriToHost(uri: Uri): Host = Host.fromUri(uri).valueOr(throw _)
+
+  /** Just a shortcut for `NonEmptyList.of()` */
+  private def NEL[A](head: A, tail: A*) = NonEmptyList.of[A](head, tail: _*)
+}


### PR DESCRIPTION
Resolves #3471.

The `Forwarded` header model tries to be as type safe as possible and thus introduces a hierarchy of model classes for that.

In particular, `Element` enables the following syntax for building elements:
```scala
Element
  .fromFor(Node(...))
  .withBy(Node(...))
  .withHost(Host(...))
  .withProto(Proto(...))
```