### PR TITLE
Add Armeria as a backend server

### DIFF
--- a/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaHttp4sHandler.scala
+++ b/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaHttp4sHandler.scala
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+package server
+package armeria
+
+import cats.effect.{Async, ConcurrentEffect, IO}
+import cats.implicits._
+import com.linecorp.armeria.common.{HttpData, HttpHeaderNames, HttpRequest, HttpResponse, ResponseHeaders}
+import com.linecorp.armeria.common.util.Version
+import com.linecorp.armeria.server.{HttpService, ServiceRequestContext}
+import io.chrisdavenport.vault._
+import fs2._
+import fs2.interop.reactivestreams._
+import java.net.InetSocketAddress
+import java.util.concurrent.CompletableFuture
+import org.http4s.internal.CollectionCompat.CollectionConverters._
+import org.http4s.internal.unsafeRunAsync
+import org.http4s.server.armeria.ArmeriaHttp4sHandler.defaultVault
+import scala.concurrent.ExecutionContext
+import scodec.bits.ByteVector
+
+/** An [[HttpService]] that handles the specified [[HttpApp]] under the specified `prefix`. */
+private[armeria] class ArmeriaHttp4sHandler[F[_]](
+  prefix: String,
+  service: HttpApp[F],
+  serviceErrorHandler: ServiceErrorHandler[F]
+)(implicit F: ConcurrentEffect[F])
+    extends HttpService {
+
+  // micro-optimization: unwrap the service and call its .run directly
+  private val serviceFn: Request[F] => F[Response[F]] = service.run
+
+  override def serve(ctx: ServiceRequestContext, req: HttpRequest): HttpResponse = {
+    implicit val ec = ExecutionContext.fromExecutor(ctx.eventLoop())
+    val future = new CompletableFuture[HttpResponse]()
+    unsafeRunAsync(toRequest(ctx, req).fold(onParseFailure, handleRequest(_, ctx))) {
+      case Right(res) =>
+        IO.pure(discardReturn(future.complete(res)))
+      case Left(ex) =>
+        IO.pure(discardReturn(future.completeExceptionally(ex)))
+    }
+    HttpResponse.from(future)
+  }
+
+  private def handleRequest(request: Request[F], ctx: ServiceRequestContext)(implicit ec: ExecutionContext): F[HttpResponse] =
+    raceTimeout(ctx)
+      .apply(request)
+      .recoverWith(serviceErrorHandler(request))
+      .map(toHttpResponse)
+
+  /** Cancels a [[Request]] when the request has been timed out.
+    * A work around for handling [[IO.never]].
+    */
+  private[this] def raceTimeout(ctx: ServiceRequestContext)(implicit ec: ExecutionContext): Request[F] => F[Response[F]] =
+    if (ctx.requestTimeoutMillis == 0) {
+      serviceFn
+    } else {
+      val timeoutResponse: F[Response[F]] = F.async[Response[F]] { cb =>
+        discardReturn {
+          ctx.log().whenComplete().thenRun(() => cb(Right(Response.timeout[F])))
+        }
+      }
+      // Use explicit an execution context to serve the service in Armeria's event loop
+      req => F.race(Async.shift(ec) *> serviceFn(req), timeoutResponse).map(_.merge)
+    }
+
+  private def onParseFailure(parseFailure: ParseFailure): F[HttpResponse] = {
+    val response = Response[F](Status.BadRequest).withEntity(parseFailure.sanitized)
+    F.pure(toHttpResponse(response))
+  }
+
+  /** Converts http4s' [[Response]] to Armeria's [[HttpResponse]]. */
+  private def toHttpResponse(response: Response[F]): HttpResponse = {
+    val headers = Stream(toResponseHeaders(response.headers, response.status.some))
+    val body: Stream[F, HttpData] = response.body.chunks.map(chunk => {
+      val byteChunk = chunk.toBytes
+      HttpData.copyOf(chunk.toBytes.values, byteChunk.offset, byteChunk.length)
+    })
+    val trailers = Stream
+      .eval(response.trailerHeaders)
+      .flatMap { trailers =>
+        if (trailers.isEmpty)
+          Stream.empty
+        else
+          Stream(toResponseHeaders(trailers, None))
+      }
+
+    HttpResponse.of((headers ++ body ++ trailers).toUnicastPublisher())
+  }
+
+  /** Converts Armeria's [[HttpRequest]] to http4s' [[Request]]. */
+  private def toRequest(ctx: ServiceRequestContext, req: HttpRequest): ParseResult[Request[F]] = {
+    val path = req.path()
+    for {
+      method <- Method.fromString(req.method().name())
+      uri <- Uri.requestTarget(path)
+    } yield Request(
+      method = method,
+      uri = uri,
+      httpVersion =
+        if (ctx.sessionProtocol().isMultiplex) {
+          HttpVersion.`HTTP/2.0`
+        } else {
+          if (req.headers().get(HttpHeaderNames.HOST) != null) {
+            HttpVersion.`HTTP/1.1`
+          } else {
+            HttpVersion.`HTTP/1.0`
+          }
+        },
+      headers = toHeaders(req),
+      body = toBody(req),
+      attributes = requestAttributes(ctx, uri)
+    )
+  }
+
+  /** Converts http4s' [[Headers]] to Armeria's [[ResponseHeaders]]. */
+  private def toResponseHeaders(headers: Headers, status: Option[Status]): ResponseHeaders = {
+    val builder = status
+      .map(s => ResponseHeaders.builder(s.code))
+      .getOrElse(ResponseHeaders.builder())
+
+    for (header <- headers.toList)
+      builder.add(header.name.toString, header.value)
+
+    builder.build()
+  }
+
+  /** Converts Armeria's [[HttpRequest]] to htt4s' [[Headers]]. */
+  private def toHeaders(req: HttpRequest): Headers =
+    Headers(
+      req
+        .headers()
+        .asScala
+        .map(entry => Header(entry.getKey.toString(), entry.getValue))
+        .toList
+    )
+
+  /** Converts a HTTP payload to [[EntityBody]]. */
+  private def toBody(req: HttpRequest): EntityBody[F] =
+    req
+      .toStream[F]
+      .filter(_.isInstanceOf[HttpData])
+      .flatMap(data => Stream.chunk(Chunk.bytes(data.asInstanceOf[HttpData].array())))
+
+  private def requestAttributes(ctx: ServiceRequestContext, uri: Uri): Vault = {
+    val secure = ctx.sessionProtocol().isTls
+    defaultVault
+       .insert(Request.Keys.PathInfoCaret, uri.path.indexOfString(prefix).getOrElse(-1))
+       .insert(ServiceRequestContextKeys.RequestContext, ctx)
+      .insert(
+        Request.Keys.ConnectionInfo,
+        Request.Connection(
+          local = ctx.localAddress[InetSocketAddress],
+          remote = ctx.remoteAddress[InetSocketAddress],
+          secure = secure)
+      )
+      .insert(
+        ServerRequestKeys.SecureSession,
+        Option.when[SecureSession](secure) {
+          val sslSession = ctx.sslSession()
+          val cipherSuite = sslSession.getCipherSuite
+          SecureSession(
+            ByteVector(sslSession.getId).toHex,
+            cipherSuite,
+            SSLContextFactory.deduceKeyLength(cipherSuite),
+            SSLContextFactory.getCertChain(sslSession)
+          )
+        }
+      )
+  }
+
+  /** Discards the returned value from the specified `f` and return [[Unit]].
+    * A work around for "discarded non-Unit value" error on Java [[Void]] type.
+    */
+  @inline
+  private def discardReturn(f: => Any): Unit = {
+    val _ = f
+  }
+}
+
+private[armeria] object ArmeriaHttp4sHandler {
+  def apply[F[_]: ConcurrentEffect](prefix: String, service: HttpApp[F]): ArmeriaHttp4sHandler[F] =
+    new ArmeriaHttp4sHandler(prefix, service, DefaultServiceErrorHandler)
+
+  private val serverSoftware: ServerSoftware =
+    ServerSoftware("armeria", Some(Version.get("armeria").artifactVersion()))
+
+  private val defaultVault: Vault = Vault.empty.insert(Request.Keys.ServerSoftware, serverSoftware)
+}
+
+object ServiceRequestContextKeys {
+  val RequestContext: Key[ServiceRequestContext] =
+    Key.newKey[IO, ServiceRequestContext].unsafeRunSync
+}

--- a/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaHttp4sHandler.scala
+++ b/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaHttp4sHandler.scala
@@ -161,15 +161,17 @@ private[armeria] class ArmeriaHttp4sHandler[F[_]](
       )
       .insert(
         ServerRequestKeys.SecureSession,
-        Option.when[SecureSession](secure) {
+        if (secure) {
           val sslSession = ctx.sslSession()
           val cipherSuite = sslSession.getCipherSuite
-          SecureSession(
+          Some(SecureSession(
             ByteVector(sslSession.getId).toHex,
             cipherSuite,
             SSLContextFactory.deduceKeyLength(cipherSuite),
             SSLContextFactory.getCertChain(sslSession)
-          )
+          ))
+        } else {
+          None
         }
       )
   }

--- a/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaServerBuilder.scala
+++ b/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaServerBuilder.scala
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+package server
+package armeria
+
+import cats.effect.{ConcurrentEffect, Resource}
+import com.linecorp.armeria.common.util.Version
+import com.linecorp.armeria.common.{HttpRequest, HttpResponse, SessionProtocol}
+import com.linecorp.armeria.server.{HttpService, ServerListenerAdapter, ServiceRequestContext, Server => ArmeriaServer, ServerBuilder => ArmeriaBuilder}
+import io.micrometer.core.instrument.MeterRegistry
+import io.netty.channel.ChannelOption
+import io.netty.handler.ssl.SslContextBuilder
+import java.io.{File, InputStream}
+import java.net.InetSocketAddress
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import org.http4s.server._
+import org.http4s.syntax.all._
+import java.util.function.{Function => JFunction}
+import javax.net.ssl.KeyManagerFactory
+import org.http4s.server.defaults.{IdleTimeout, ResponseTimeout, ShutdownTimeout}
+import org.log4s.{Logger, getLogger}
+import scala.concurrent.duration.Duration
+
+sealed class ArmeriaServerBuilder[F[_]] private (
+  armeriaServerBuilder: ArmeriaBuilder,
+  socketAddress: InetSocketAddress,
+  serviceErrorHandler: ServiceErrorHandler[F],
+  banner: Seq[String]
+)(implicit protected val F: ConcurrentEffect[F]) extends ServerBuilder[F] {
+  override type Self = ArmeriaServerBuilder[F]
+
+  private[this] val logger: Logger = getLogger
+
+  type DecoratorFunction = (HttpService, ServiceRequestContext, HttpRequest) => HttpResponse
+
+  override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
+    copy(socketAddress = socketAddress)
+
+  override def withServiceErrorHandler(serviceErrorHandler: ServiceErrorHandler[F]): Self =
+    copy(serviceErrorHandler = serviceErrorHandler)
+
+  override def resource: Resource[F, Server] =
+    Resource(F.delay {
+      val armeriaServer = armeriaServerBuilder
+        .http(socketAddress)
+        .build()
+
+      armeriaServer.addListener(new ServerListenerAdapter {
+        override def serverStarting(server: ArmeriaServer): Unit = {
+          banner.foreach(logger.info(_))
+
+          val armeriaVersion = Version.get("armeria").artifactVersion()
+
+          logger.info(s"http4s v${BuildInfo.version} on Armeria v${armeriaVersion} started")
+        }
+      })
+      armeriaServer.start().join()
+
+      val server = new Server {
+        lazy val address: InetSocketAddress = {
+          val host = socketAddress.getHostString
+          val port = armeriaServer.activeLocalPort()
+          new InetSocketAddress(host, port)
+        }
+
+        override def isSecure: Boolean = armeriaServer.activePort(SessionProtocol.HTTPS) != null
+      }
+
+      server -> shutdown(armeriaServer)
+    })
+
+  /** Binds the specified `service` at the specified path pattern.
+    * See [[https://armeria.dev/docs/server-basics#path-patterns]] for detailed information of path pattens.
+    */
+  def withHttpService(
+    pathPattern: String,
+    service: (ServiceRequestContext, HttpRequest) => HttpResponse): Self = {
+    armeriaServerBuilder.service(
+      pathPattern,
+      new HttpService {
+        override def serve(ctx: ServiceRequestContext, req: HttpRequest): HttpResponse =
+          service(ctx, req)
+      })
+    this
+  }
+
+  /** Binds the specified [[HttpService]] at the specified path pattern.
+    * See [[https://armeria.dev/docs/server-basics#path-patterns]] for detailed information of path pattens.
+    */
+  def withHttpService(pathPattern: String, service: HttpService): Self = {
+    armeriaServerBuilder.service(pathPattern, service)
+    this
+  }
+
+  /** Binds the specified [[HttpRoutes]] under the specified prefix. */
+  def withHttpRoutes(prefix: String, service: HttpRoutes[F]): Self =
+    withHttpApp(prefix, service.orNotFound)
+
+  /** Binds the specified [[HttpApp]] under the specified prefix. */
+  def withHttpApp(prefix: String, service: HttpApp[F]): Self = {
+    armeriaServerBuilder.serviceUnder(prefix, ArmeriaHttp4sHandler(prefix, service))
+    this
+  }
+
+  /** Decorates all HTTP services with the specified [[DecoratorFunction]]. */
+  def withDecorator(decorator: DecoratorFunction): Self = {
+    armeriaServerBuilder.decorator((delegate, ctx, req) => decorator(delegate, ctx, req))
+    this
+  }
+
+  /** Decorates all HTTP services with the specified `decorator`. */
+  def withDecorator(decorator: JFunction[_ >: HttpService, _ <: HttpService]): Self = {
+    armeriaServerBuilder.decorator(decorator)
+    this
+  }
+
+  /** Decorates HTTP services under the specified directory with the specified [[DecoratorFunction]]. */
+  def withDecoratorUnder(prefix: String, decorator: DecoratorFunction): Self = {
+    armeriaServerBuilder.decoratorUnder(prefix, (delegate, ctx, req) => decorator(delegate, ctx, req))
+    this
+  }
+
+  /** Decorates HTTP services under the specified directory with the specified `decorator`. */
+  def withDecoratorUnder(
+    prefix: String,
+    decorator: JFunction[_ >: HttpService, _ <: HttpService]): Self = {
+    armeriaServerBuilder.decoratorUnder(prefix, decorator)
+    this
+  }
+
+  /** Configures the Armeria server using the specified [[ArmeriaBuilder]]. */
+  def withArmeriaBuilder(customizer: ArmeriaBuilder => Unit): Self = {
+    customizer(armeriaServerBuilder)
+    this
+  }
+
+  /** Sets the idle timeout of a connection in milliseconds for keep-alive.
+    *
+    * @param idleTimeout the timeout. [[Duration.Zero]] disables the timeout.
+    */
+  def withIdleTimeout(idleTimeout: Duration): Self = {
+    armeriaServerBuilder.idleTimeoutMillis(idleTimeout.toMillis)
+    this
+  }
+
+  /** Sets the timeout of a request.
+    *
+    * @param requestTimeout the timeout. [[Duration.Zero]] disables the timeout.
+    */
+  def withRequestTimeout(requestTimeout: Duration): Self = {
+    armeriaServerBuilder.requestTimeoutMillis(requestTimeout.toMillis)
+    this
+  }
+
+  /** Adds an HTTP port that listens on all available network interfaces.
+    *
+    * @param port the HTTP port number.
+    * @see [[ArmeriaBuilder#http(java.net.InetSocketAddress)]]
+    */
+  def withHttp(port: Int): Self = {
+    armeriaServerBuilder.http(port)
+    this
+  }
+
+  /** Adds an HTTPS port that listens on all available network interfaces.
+    *
+    * @param port the HTTPS port number.
+    * @see [[ArmeriaBuilder#https(java.net.InetSocketAddress)]]
+    */
+  def withHttps(port: Int): Self = {
+    armeriaServerBuilder.https(port)
+    this
+  }
+
+  /** Sets the [[ChannelOption]] of the server socket bound by [[ArmeriaServer]].
+    * Note that the previously added option will be overridden if the same option is set again.
+    *
+    * @see [[https://armeria.dev/docs/advanced-production-checklist Production checklist]]
+    */
+  def withChannelOption[T](option: ChannelOption[T], value: T): Self = {
+    armeriaServerBuilder.channelOption(option, value)
+    this
+  }
+
+  /** Sets the [[ChannelOption]] of sockets accepted by [[ArmeriaServer]].
+    * Note that the previously added option will be overridden if the same option is set again.
+    *
+    * @see [[https://armeria.dev/docs/advanced-production-checklist Production checklist]]
+    */
+  def withChildChannelOption[T](option: ChannelOption[T], value: T): Self = {
+    armeriaServerBuilder.childChannelOption(option, value)
+    this
+  }
+
+  def withTls(keyCertChainFile: File, keyFile: File, keyPassword: Option[String]): Self = {
+    armeriaServerBuilder.tls(keyCertChainFile, keyFile, keyPassword.orNull)
+    this
+  }
+
+  /** Configures SSL or TLS of this [[ArmeriaServer]] with the specified `keyCertChainInputStream`,
+    * `keyInputStream` and `keyPassword`.
+    *
+    * @see [[withTlsCustomizer(scala.Function1)]]
+    */
+  def withTls(keyCertChainInputStream: InputStream, keyInputStream: InputStream, keyPassword: Option[String])
+  : Self = {
+    armeriaServerBuilder.tls(keyCertChainInputStream, keyInputStream, keyPassword.orNull)
+    this
+  }
+
+  /** Configures SSL or TLS of this [[ArmeriaServer]] with the specified cleartext [[PrivateKey]] and
+    * [[X509Certificate]] chain.
+    *
+    * @see [[withTlsCustomizer(scala.Function1)]]
+    */
+  def withTls(key: PrivateKey, keyCertChain: X509Certificate*): Self = {
+    armeriaServerBuilder.tls(key, keyCertChain: _*)
+    this
+  }
+
+  /** Configures SSL or TLS of this [[ArmeriaServer]] with the specified [[KeyManagerFactory]].
+    *
+    * @see [[withTlsCustomizer(scala.Function1)]]
+    */
+  def withTls(keyManagerFactory: KeyManagerFactory): Self = {
+    armeriaServerBuilder.tls(keyManagerFactory)
+    this
+  }
+
+  /** Configures SSL or TLS of the [[ArmeriaServer]] with an auto-generated self-signed certificate.
+    * <strong>Note:</strong> You should never use this in production but only for a testing purpose.
+    *
+    * @see [[withTlsCustomizer(scala.Function1)]]
+    */
+  def withTlsSelfSigned: Self = {
+    armeriaServerBuilder.tlsSelfSigned
+    this
+  }
+
+  /** Adds the specified `tlsCustomizer` which can arbitrarily configure the [[SslContextBuilder]] that will be
+    * applied to the SSL session.
+    */
+  def withTlsCustomizer(tlsCustomizer: SslContextBuilder => Unit): Self = {
+    armeriaServerBuilder.tlsCustomizer(ctxBuilder => tlsCustomizer(ctxBuilder))
+    this
+  }
+
+  /** Sets the [[MeterRegistry]] that collects various stats. */
+  def meterRegistry(meterRegistry: MeterRegistry): Self = {
+    armeriaServerBuilder.meterRegistry(meterRegistry)
+    this
+  }
+
+  private def shutdown(armeriaServer: ArmeriaServer) =
+    F.async[Unit] { cb =>
+      val _ = armeriaServer
+        .stop()
+        .whenComplete { (_, cause) =>
+          if (cause == null)
+            cb(Right(()))
+          else
+            cb(Left(cause))
+        }
+    }
+
+  override def withBanner(banner: Seq[String]): Self = copy(banner = banner)
+
+  private def copy(
+      armeriaServerBuilder: ArmeriaBuilder = armeriaServerBuilder,
+      socketAddress: InetSocketAddress = socketAddress,
+      serviceErrorHandler: ServiceErrorHandler[F] = serviceErrorHandler,
+      banner: Seq[String] = banner
+  ): Self =
+    new ArmeriaServerBuilder(armeriaServerBuilder, socketAddress, serviceErrorHandler, banner)
+}
+
+object ArmeriaServerBuilder {
+  def apply[F[_] : ConcurrentEffect]: ArmeriaServerBuilder[F] = {
+    val defaultServerBuilder =
+      ArmeriaServer.builder()
+                   .idleTimeoutMillis(IdleTimeout.toMillis)
+                   .requestTimeoutMillis(ResponseTimeout.toMillis)
+                   .gracefulShutdownTimeoutMillis(ShutdownTimeout.toMillis, ShutdownTimeout.toMillis)
+    new ArmeriaServerBuilder(
+      armeriaServerBuilder = defaultServerBuilder,
+      socketAddress = defaults.SocketAddress,
+      serviceErrorHandler = DefaultServiceErrorHandler,
+      banner = defaults.Banner)
+  }
+}

--- a/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaServerBuilder.scala
+++ b/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaServerBuilder.scala
@@ -11,7 +11,13 @@ package armeria
 import cats.effect.{ConcurrentEffect, Resource}
 import com.linecorp.armeria.common.util.Version
 import com.linecorp.armeria.common.{HttpRequest, HttpResponse, SessionProtocol}
-import com.linecorp.armeria.server.{HttpService, ServerListenerAdapter, ServiceRequestContext, Server => ArmeriaServer, ServerBuilder => ArmeriaBuilder}
+import com.linecorp.armeria.server.{
+  HttpService,
+  ServerListenerAdapter,
+  ServiceRequestContext,
+  Server => ArmeriaServer,
+  ServerBuilder => ArmeriaBuilder
+}
 import io.micrometer.core.instrument.MeterRegistry
 import io.netty.channel.ChannelOption
 import io.netty.handler.ssl.SslContextBuilder
@@ -29,11 +35,12 @@ import scala.collection.immutable
 import scala.concurrent.duration.Duration
 
 sealed class ArmeriaServerBuilder[F[_]] private (
-  armeriaServerBuilder: ArmeriaBuilder,
-  socketAddress: InetSocketAddress,
-  serviceErrorHandler: ServiceErrorHandler[F],
-  banner: Seq[String]
-)(implicit protected val F: ConcurrentEffect[F]) extends ServerBuilder[F] {
+    armeriaServerBuilder: ArmeriaBuilder,
+    socketAddress: InetSocketAddress,
+    serviceErrorHandler: ServiceErrorHandler[F],
+    banner: Seq[String]
+)(implicit protected val F: ConcurrentEffect[F])
+    extends ServerBuilder[F] {
   override type Self = ArmeriaServerBuilder[F]
 
   private[this] val logger: Logger = getLogger
@@ -80,8 +87,8 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     * See [[https://armeria.dev/docs/server-basics#path-patterns]] for detailed information of path pattens.
     */
   def withHttpService(
-    pathPattern: String,
-    service: (ServiceRequestContext, HttpRequest) => HttpResponse): Self = {
+      pathPattern: String,
+      service: (ServiceRequestContext, HttpRequest) => HttpResponse): Self = {
     armeriaServerBuilder.service(
       pathPattern,
       new HttpService {
@@ -123,14 +130,16 @@ sealed class ArmeriaServerBuilder[F[_]] private (
 
   /** Decorates HTTP services under the specified directory with the specified [[DecoratorFunction]]. */
   def withDecoratorUnder(prefix: String, decorator: DecoratorFunction): Self = {
-    armeriaServerBuilder.decoratorUnder(prefix, (delegate, ctx, req) => decorator(delegate, ctx, req))
+    armeriaServerBuilder.decoratorUnder(
+      prefix,
+      (delegate, ctx, req) => decorator(delegate, ctx, req))
     this
   }
 
   /** Decorates HTTP services under the specified directory with the specified `decorator`. */
   def withDecoratorUnder(
-    prefix: String,
-    decorator: JFunction[_ >: HttpService, _ <: HttpService]): Self = {
+      prefix: String,
+      decorator: JFunction[_ >: HttpService, _ <: HttpService]): Self = {
     armeriaServerBuilder.decoratorUnder(prefix, decorator)
     this
   }
@@ -209,8 +218,10 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     *
     * @see [[withTlsCustomizer(scala.Function1)]]
     */
-  def withTls(keyCertChainInputStream: InputStream, keyInputStream: InputStream, keyPassword: Option[String])
-  : Self = {
+  def withTls(
+      keyCertChainInputStream: InputStream,
+      keyInputStream: InputStream,
+      keyPassword: Option[String]): Self = {
     armeriaServerBuilder.tls(keyCertChainInputStream, keyInputStream, keyPassword.orNull)
     this
   }
@@ -282,12 +293,13 @@ sealed class ArmeriaServerBuilder[F[_]] private (
 }
 
 object ArmeriaServerBuilder {
-  def apply[F[_] : ConcurrentEffect]: ArmeriaServerBuilder[F] = {
+  def apply[F[_]: ConcurrentEffect]: ArmeriaServerBuilder[F] = {
     val defaultServerBuilder =
-      ArmeriaServer.builder()
-                   .idleTimeoutMillis(IdleTimeout.toMillis)
-                   .requestTimeoutMillis(ResponseTimeout.toMillis)
-                   .gracefulShutdownTimeoutMillis(ShutdownTimeout.toMillis, ShutdownTimeout.toMillis)
+      ArmeriaServer
+        .builder()
+        .idleTimeoutMillis(IdleTimeout.toMillis)
+        .requestTimeoutMillis(ResponseTimeout.toMillis)
+        .gracefulShutdownTimeoutMillis(ShutdownTimeout.toMillis, ShutdownTimeout.toMillis)
     new ArmeriaServerBuilder(
       armeriaServerBuilder = defaultServerBuilder,
       socketAddress = defaults.SocketAddress,

--- a/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaServerBuilder.scala
+++ b/armeria-server/src/main/scala/org/http4s/server/armeria/ArmeriaServerBuilder.scala
@@ -25,6 +25,7 @@ import java.util.function.{Function => JFunction}
 import javax.net.ssl.KeyManagerFactory
 import org.http4s.server.defaults.{IdleTimeout, ResponseTimeout, ShutdownTimeout}
 import org.log4s.{Logger, getLogger}
+import scala.collection.immutable
 import scala.concurrent.duration.Duration
 
 sealed class ArmeriaServerBuilder[F[_]] private (
@@ -269,7 +270,7 @@ sealed class ArmeriaServerBuilder[F[_]] private (
         }
     }
 
-  override def withBanner(banner: Seq[String]): Self = copy(banner = banner)
+  override def withBanner(banner: immutable.Seq[String]): Self = copy(banner = banner)
 
   private def copy(
       armeriaServerBuilder: ArmeriaBuilder = armeriaServerBuilder,

--- a/armeria-server/src/main/scala/org/http4s/server/armeria/SSLContextFactory.scala
+++ b/armeria-server/src/main/scala/org/http4s/server/armeria/SSLContextFactory.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+package server
+package armeria
+
+import java.io.ByteArrayInputStream
+import java.security.cert.{CertificateFactory, X509Certificate}
+
+import javax.net.ssl.SSLSession
+
+import scala.util.Try
+
+/**
+  * Based on SSLContextFactory from jetty.
+  */
+private[armeria] object SSLContextFactory {
+
+  /**
+    * Return X509 certificates for the session.
+    *
+    * @param sslSession Session from which certificate to be read
+    * @return Empty array if no certificates can be read from {{{sslSession}}}
+    */
+  def getCertChain(sslSession: SSLSession): List[X509Certificate] =
+    Try {
+      val cf = CertificateFactory.getInstance("X.509")
+      sslSession.getPeerCertificates.map { certificate =>
+        val stream = new ByteArrayInputStream(certificate.getEncoded)
+        cf.generateCertificate(stream).asInstanceOf[X509Certificate]
+      }
+    }.toOption.getOrElse(Array.empty).toList
+
+  /**
+    * Given the name of a TLS/SSL cipher suite, return an int representing it effective stream
+    * cipher key strength. i.e. How much entropy material is in the key material being fed into the
+    * encryption routines.
+    *
+    * This is based on the information on effective key lengths in RFC 2246 - The TLS Protocol
+    * Version 1.0, Appendix C. CipherSuite definitions:
+    * <pre>
+    *                         Effective
+    *     Cipher       Type    Key Bits
+    *
+    *     NULL       * Stream     0
+    *     IDEA_CBC     Block    128
+    *     RC2_CBC_40 * Block     40
+    *     RC4_40     * Stream    40
+    *     RC4_128      Stream   128
+    *     DES40_CBC  * Block     40
+    *     DES_CBC      Block     56
+    *     3DES_EDE_CBC Block    168
+    * </pre>
+    *
+    * @param cipherSuite String name of the TLS cipher suite.
+    * @return int indicating the effective key entropy bit-length.
+    */
+  def deduceKeyLength(cipherSuite: String): Int =
+    if (cipherSuite == null) 0
+    else if (cipherSuite.contains("WITH_AES_256_")) 256
+    else if (cipherSuite.contains("WITH_RC4_128_")) 128
+    else if (cipherSuite.contains("WITH_AES_128_")) 128
+    else if (cipherSuite.contains("WITH_RC4_40_")) 40
+    else if (cipherSuite.contains("WITH_3DES_EDE_CBC_")) 168
+    else if (cipherSuite.contains("WITH_IDEA_CBC_")) 128
+    else if (cipherSuite.contains("WITH_RC2_CBC_40_")) 40
+    else if (cipherSuite.contains("WITH_DES40_CBC_")) 40
+    else if (cipherSuite.contains("WITH_DES_CBC_")) 56
+    else 0
+}

--- a/armeria-server/src/test/resources/logback-test.xml
+++ b/armeria-server/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<configuration>
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n${LOGBACK_EXCEPTION_PATTERN:-%throwable}</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="com.linecorp.armeria" level="DEBUG" />
+  <logger name="org.http4s.server.armeria" level="DEBUG" />
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/armeria-server/src/test/scala/org/http4s/server/armeria/ArmeriaServerBuilderSpec.scala
+++ b/armeria-server/src/test/scala/org/http4s/server/armeria/ArmeriaServerBuilderSpec.scala
@@ -52,14 +52,12 @@ class ArmeriaServerBuilderSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     .resource
 
   withResource(serverR) { server =>
-    // This should be in IO and shifted but I'm tired of fighting this.
     def get(path: String): String =
       Source
         .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
         .getLines
         .mkString
 
-    // This should be in IO and shifted but I'm tired of fighting this.
     def getStatus(path: String): IO[Status] = {
       val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
       for {
@@ -69,7 +67,6 @@ class ArmeriaServerBuilderSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       } yield status
     }
 
-    // This too
     def post(path: String, body: String): String = {
       val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
       val conn = url.openConnection().asInstanceOf[HttpURLConnection]
@@ -81,7 +78,6 @@ class ArmeriaServerBuilderSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
     }
 
-    // This too
     def postChunkedMultipart(path: String, boundary: String, body: String): IO[String] =
       IO {
         val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")

--- a/armeria-server/src/test/scala/org/http4s/server/armeria/ArmeriaServerBuilderSpec.scala
+++ b/armeria-server/src/test/scala/org/http4s/server/armeria/ArmeriaServerBuilderSpec.scala
@@ -52,7 +52,6 @@ class ArmeriaServerBuilderSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     .resource
 
   withResource(serverR) { server =>
-
     // This should be in IO and shifted but I'm tired of fighting this.
     def get(path: String): String =
       Source

--- a/armeria-server/src/test/scala/org/http4s/server/armeria/ArmeriaServerBuilderSpec.scala
+++ b/armeria-server/src/test/scala/org/http4s/server/armeria/ArmeriaServerBuilderSpec.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+package server
+package armeria
+
+import cats.implicits._
+import cats.effect.{IO, Resource}
+import com.linecorp.armeria.server.logging.{ContentPreviewingService, LoggingService}
+import java.net.{HttpURLConnection, URL}
+import java.nio.charset.StandardCharsets
+import org.http4s.Http4sSpec
+import org.http4s.dsl.io._
+import org.http4s.multipart.Multipart
+import org.http4s.testing.Http4sLegacyMatchersIO
+import org.specs2.execute.Result
+import scala.io.Source
+
+class ArmeriaServerBuilderSpec extends Http4sSpec with Http4sLegacyMatchersIO {
+
+  val service: HttpRoutes[IO] = HttpRoutes.of {
+    case GET -> Root / "thread" / "routing" =>
+      val thread = Thread.currentThread.getName
+      Ok(thread)
+
+    case GET -> Root / "thread" / "effect" =>
+      IO(Thread.currentThread.getName).flatMap(Ok(_))
+
+    case req @ POST -> Root / "echo" =>
+      Ok(req.body)
+
+    case _ -> Root / "never" =>
+      IO.never
+
+    case req @ POST -> Root / "issue2610" =>
+      req.decode[Multipart[IO]] { mp =>
+        Ok.apply(mp.parts.foldMap(_.body))
+      }
+
+    case _ => NotFound()
+  }
+
+  val serverR: Resource[IO, Server] = ArmeriaServerBuilder[IO]
+    .withDecorator(ContentPreviewingService.newDecorator(Int.MaxValue))
+    .withDecorator(LoggingService.newDecorator())
+    .bindAny()
+    .withHttpRoutes("/service", service)
+    .resource
+
+  withResource(serverR) { server =>
+
+    // This should be in IO and shifted but I'm tired of fighting this.
+    def get(path: String): String =
+      Source
+        .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
+        .getLines
+        .mkString
+
+    // This should be in IO and shifted but I'm tired of fighting this.
+    def getStatus(path: String): IO[Status] = {
+      val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
+      for {
+        conn <- IO(url.openConnection().asInstanceOf[HttpURLConnection])
+        _ = conn.setRequestMethod("GET")
+        status <- IO.fromEither(Status.fromInt(conn.getResponseCode()))
+      } yield status
+    }
+
+    // This too
+    def post(path: String, body: String): String = {
+      val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
+      val conn = url.openConnection().asInstanceOf[HttpURLConnection]
+      val bytes = body.getBytes(StandardCharsets.UTF_8)
+      conn.setRequestMethod("POST")
+      conn.setRequestProperty("Content-Length", bytes.size.toString)
+      conn.setDoOutput(true)
+      conn.getOutputStream.write(bytes)
+      Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+    }
+
+    // This too
+    def postChunkedMultipart(path: String, boundary: String, body: String): IO[String] =
+      IO {
+        val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
+        val conn = url.openConnection().asInstanceOf[HttpURLConnection]
+        val bytes = body.getBytes(StandardCharsets.UTF_8)
+        conn.setRequestMethod("POST")
+        conn.setChunkedStreamingMode(-1)
+        conn.setRequestProperty("Content-Type", s"""multipart/form-data; boundary="$boundary"""")
+        conn.setDoOutput(true)
+        conn.getOutputStream.write(bytes)
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines.mkString
+      }
+
+    "A server" should {
+      "route requests on the service executor" in {
+        // A event loop will serve the service to reduce an extra context switching
+        get("/service/thread/routing") must startWith("armeria-common-worker-nio")
+      }
+
+      "execute the service task on the service executor" in {
+        // A event loop will serve the service to reduce an extra context switching
+        get("/service/thread/effect") must startWith("armeria-common-worker-nio")
+      }
+
+      "be able to echo its input" in {
+        val input = """{ "Hello": "world" }"""
+        post("/service/echo", input) must startWith(input)
+      }
+
+      "return a 503 if the server doesn't respond" in {
+        getStatus("/service/never") must returnValue(Status.ServiceUnavailable)
+      }
+
+      "reliably handle multipart requests" in {
+        val body =
+          """|--aa
+             |Content-Disposition: form-data; name="a"
+             |Content-Length: 1
+             |
+             |a
+             |--aa--""".stripMargin.replace("\n", "\r\n")
+
+        Result.foreach(1 to 100) { _ =>
+          postChunkedMultipart(
+            "/service/issue2610",
+            "aa",
+            body
+          ) must returnValue("a")
+        }
+      }
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -282,6 +282,13 @@ lazy val tomcat = libraryProject("tomcat")
   )
   .dependsOn(servlet % "compile;test->test")
 
+lazy val armeriaServer = libraryProject("armeria-server")
+  .settings(
+    description := "Armeria implementation for http4s servers",
+    libraryDependencies ++= Seq(armeria, fs2ReactiveStreams)
+  )
+  .dependsOn(server % "compile;test->test")
+
 // `dsl` name conflicts with modern SBT
 lazy val theDsl = libraryProject("dsl")
   .settings(
@@ -489,6 +496,15 @@ lazy val examples = http4sProject("examples")
   )
   .dependsOn(server, dropwizardMetrics, theDsl, circe, scalaXml, twirl)
   .enablePlugins(SbtTwirl)
+
+lazy val examplesArmeria = exampleProject("examples-armeria")
+  .settings(Revolver.settings)
+  .settings(
+    description := "Example of http4s server on Armeria",
+    fork := true,
+    reStart / mainClass := Some("com.example.http4s.armeria.ArmeriaExample")
+  )
+  .dependsOn(armeriaServer)
 
 lazy val examplesBlaze = exampleProject("examples-blaze")
   .enablePlugins(AlpnBootPlugin)

--- a/examples/armeria/src/main/scala/com/example/http4s/armeria/ArmeriaExample.scala
+++ b/examples/armeria/src/main/scala/com/example/http4s/armeria/ArmeriaExample.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.example.http4s
+package armeria
+
+import cats.effect._
+import com.codahale.metrics.MetricRegistry
+import com.example.http4s.ExampleService
+import org.http4s.metrics.dropwizard.{Dropwizard, _}
+import org.http4s.server.armeria.ArmeriaServerBuilder
+import org.http4s.server.middleware.Metrics
+import org.http4s.server.{HttpMiddleware, Server}
+
+object ArmeriaExample extends IOApp {
+  override def run(args: List[String]): IO[ExitCode] =
+    ArmeriaExampleApp.resource[IO].use(_ => IO.never).as(ExitCode.Success)
+}
+
+object ArmeriaExampleApp {
+  def builder[F[_]: ConcurrentEffect: ContextShift: Timer](blocker: Blocker): ArmeriaServerBuilder[F] = {
+    val metricsRegistry: MetricRegistry = new MetricRegistry
+    val metrics: HttpMiddleware[F] = Metrics[F](Dropwizard(metricsRegistry, "server"))
+
+    ArmeriaServerBuilder[F]
+      .bindHttp(8080)
+      .withHttpRoutes("/http4s", metrics(ExampleService[F](blocker).routes))
+      .withHttpRoutes("/metrics", metricsService(metricsRegistry))
+      .withDecoratorUnder("/black-knight", new NoneShallPass(_))
+  }
+
+  def resource[F[_]: ConcurrentEffect: ContextShift: Timer]: Resource[F, Server] =
+    for {
+      blocker <- Blocker[F]
+      server <- builder[F](blocker).resource
+    } yield server
+}

--- a/examples/armeria/src/main/scala/com/example/http4s/armeria/NoneShallPass.scala
+++ b/examples/armeria/src/main/scala/com/example/http4s/armeria/NoneShallPass.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.example.http4s.armeria
+
+import com.linecorp.armeria.common.{HttpRequest, HttpResponse, HttpStatus}
+import com.linecorp.armeria.server.{HttpService, ServiceRequestContext, SimpleDecoratingHttpService}
+
+class NoneShallPass(delegate: HttpService) extends SimpleDecoratingHttpService(delegate) {
+
+  override def serve(ctx: ServiceRequestContext, req: HttpRequest): HttpResponse =
+    HttpResponse.of(HttpStatus.FORBIDDEN)
+}

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -201,6 +201,7 @@ object Http4sPlugin extends AutoPlugin {
     // reference of all the projects we depend on, and hopefully will reduce
     // error-prone merge conflicts in the dependencies below.
     val argonaut = "6.3.0"
+    val armeria = "0.99.8"
     val asyncHttpClient = "2.12.1"
     val blaze = "0.14.13"
     val boopickle = "1.3.3"
@@ -241,6 +242,7 @@ object Http4sPlugin extends AutoPlugin {
 
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % V.argonaut
   lazy val argonautJawn                     = "io.argonaut"            %% "argonaut-jawn"             % V.argonaut
+  lazy val armeria                          = "com.linecorp.armeria"   % "armeria"                    % V.armeria
   lazy val asyncHttpClient                  = "org.asynchttpclient"    %  "async-http-client"         % V.asyncHttpClient
   lazy val blaze                            = "org.http4s"             %% "blaze-http"                % V.blaze
   lazy val boopickle                        = "io.suzaku"              %% "boopickle"                 % V.boopickle


### PR DESCRIPTION
Hi all.
I'm one of the [Armeria](https://armeria.dev/) project maintainers, and also a big fan of http4s project.
Armeria is a Netty based asynchronous microservice framework that supports REST, gRPC, and Thrift.
Armeria is going to support other JVM languages. See https://github.com/line/armeria/issues/1078
I and our users want to use http4s with Armeria. 😀

By supporting Armeria as a backend server, http4s users can do:
- Run gRPC stub such as ScalaPB on the http4s server with sharing a single port.
- Supports various protocols H1, H1C, H2, H2C, HA Proxy, and so on. See https://armeria.dev/docs#features

If this PR is acceptable, I'm willing to add Armeria client integration too in the following PR.