### PR TITLE
Remove Scalafix from mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,6 @@ pull_request_rules:
       - status-success=Scala 2.13.2, Java adopt@1.8
       - status-success=Scala 2.12.11, Java adopt@1.11
       - status-success=Scala 2.13.2, Java adopt@1.11
-      - status-success=Scalafix
       - status-success=Project Site
       - status-success=Doc Site
     actions:


### PR DESCRIPTION
Mergify is looking for the result of the Scalafix job, but there no longer is a distinct Scalafix job.