### PR TITLE
Use defaultHttpClient in JettyClient builder

### DIFF
--- a/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
@@ -45,11 +45,11 @@ object JettyClient {
     acquire.map((_, dispose))
   }
 
-  def resource[F[_]](client: HttpClient = new HttpClient())(implicit
+  def resource[F[_]](client: HttpClient = defaultHttpClient())(implicit
       F: ConcurrentEffect[F]): Resource[F, Client[F]] =
     Resource(allocate[F](client))
 
-  def stream[F[_]](client: HttpClient = new HttpClient())(implicit
+  def stream[F[_]](client: HttpClient = defaultHttpClient())(implicit
       F: ConcurrentEffect[F]): Stream[F, Client[F]] =
     Stream.resource(resource(client))
 


### PR DESCRIPTION
I believe this might have been an oversight, comparing with alternativ clients such as [AsyncHttpClient](https://github.com/http4s/http4s/blob/master/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala#L43). Please feel free to close this PR if the current implementation was chosen for compatibility reasons.