### PR TITLE
Close urlConn in StaticFile.fromURL

### DIFF
--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -19,6 +19,7 @@ import java.net.URL
 import org.http4s.Status.NotModified
 import org.http4s.headers._
 import org.log4s.getLogger
+import scala.util.Try
 
 object StaticFile {
   private[this] val logger = getLogger
@@ -88,7 +89,7 @@ object StaticFile {
           val headers = Headers(lenHeader :: lastModHeader ::: contentType)
 
           blocker
-            .delay(url.openStream)
+            .delay(urlConn.getInputStream)
             .redeem(
               recover = {
                 case _: FileNotFoundException => None
@@ -104,7 +105,7 @@ object StaticFile {
             )
         } else
           blocker
-            .delay(urlConn.getInputStream.close)
+            .delay(Try(urlConn.getInputStream.close()))
             .as(Some(Response(NotModified)))
       }
     })

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -19,7 +19,6 @@ import java.net.URL
 import org.http4s.Status.NotModified
 import org.http4s.headers._
 import org.log4s.getLogger
-import scala.util.Try
 
 object StaticFile {
   private[this] val logger = getLogger
@@ -105,7 +104,8 @@ object StaticFile {
             )
         } else
           blocker
-            .delay(Try(urlConn.getInputStream.close()))
+            .delay(urlConn.getInputStream.close())
+            .handleError(_ => ())
             .as(Some(Response(NotModified)))
       }
     })


### PR DESCRIPTION
Previous discussion in #3584

The URLConnection in StaticFile.fromURL is never closed (if the resource is not expired).
This PR reuses the already opened URLConnection to read the response body which in effect causes fs2 to close the URLConnection once the body is fully read.

This PR also wraps `urlConn.getInputStream.close()` in a `Try` because it should just be a last attempt to close the resource and should return NotModified in case of errors.

Because of the discussion in #3594 I opened this against series/0.21