### PR TITLE
implementing QueryParamEncoder[LocalDate] and QueryParamDecoder[LocalDate]

### DIFF
--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
@@ -56,7 +56,6 @@ class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient") with
           .setMaxConnections(customMaxConnections)
           .setRequestTimeout(customRequestTimeout)
       }
-
       customConfig.getMaxConnectionsPerHost shouldEqual customMaxConnectionsPerHost
       customConfig.getMaxConnections shouldEqual customMaxConnections
       customConfig.getRequestTimeout shouldEqual customRequestTimeout

--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
@@ -56,6 +56,7 @@ class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient") with
           .setMaxConnections(customMaxConnections)
           .setRequestTimeout(customRequestTimeout)
       }
+
       customConfig.getMaxConnectionsPerHost shouldEqual customMaxConnectionsPerHost
       customConfig.getMaxConnections shouldEqual customMaxConnections
       customConfig.getRequestTimeout shouldEqual customRequestTimeout

--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -9,7 +9,7 @@ package org.http4s
 import cats.{Contravariant, Functor, MonoidK, Show}
 import cats.data.{Validated, ValidatedNel}
 import cats.implicits._
-import java.time.Instant
+import java.time.{Instant, LocalDate}
 import java.time.format.{DateTimeFormatter, DateTimeParseException}
 import java.time.temporal.TemporalAccessor
 
@@ -66,6 +66,14 @@ object QueryParamCodec {
     QueryParamCodec
       .from[Instant](instantQueryParamDecoder(formatter), instantQueryParamEncoder(formatter))
   }
+
+  def localDateQueryParamCodec(formatter: DateTimeFormatter): QueryParamCodec[LocalDate] = {
+    import QueryParamDecoder.localDateQueryParamDecoder
+    import QueryParamEncoder.localDateQueryParamEncoder
+
+    QueryParamCodec
+      .from[LocalDate](localDateQueryParamDecoder(formatter), localDateQueryParamEncoder(formatter))
+  }
 }
 
 /**
@@ -100,6 +108,11 @@ object QueryParamEncoder {
   def instantQueryParamEncoder(formatter: DateTimeFormatter): QueryParamEncoder[Instant] =
     QueryParamEncoder[String].contramap[Instant] { (i: Instant) =>
       formatter.format(i)
+    }
+
+  def localDateQueryParamEncoder(formatter: DateTimeFormatter): QueryParamEncoder[LocalDate] =
+    QueryParamEncoder[String].contramap[LocalDate] { (ld: LocalDate) =>
+      formatter.format(ld)
     }
 
   @deprecated("Use QueryParamEncoder[U].contramap(f)", "0.16")
@@ -195,6 +208,18 @@ object QueryParamDecoder {
           }
           .toValidatedNel
     }
+
+  def localDateQueryParamDecoder(formatter: DateTimeFormatter): QueryParamDecoder[LocalDate] =
+    (value: QueryParameterValue) =>
+      Validated
+        .catchOnly[DateTimeParseException] {
+          val x: TemporalAccessor = formatter.parse(value.value)
+          LocalDate.from(x)
+        }
+        .leftMap { e =>
+          ParseFailure(s"Failed to decode value: ${value.value} as LocalDate", e.getMessage)
+        }
+        .toValidatedNel
 
   /** QueryParamDecoder is a covariant functor. */
   implicit val FunctorQueryParamDecoder: Functor[QueryParamDecoder] =

--- a/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
@@ -11,7 +11,8 @@ import cats.data._
 import cats.implicits._
 import cats.laws.discipline.{arbitrary => _, _}
 import java.time.format.DateTimeFormatter
-import java.time.Instant
+import java.time.{Instant, LocalDate}
+
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop._
@@ -25,6 +26,7 @@ class QueryParamCodecSpec extends Http4sSpec with QueryParamCodecInstances {
   checkAll("Long QueryParamCodec", QueryParamCodecLaws[Long])
   checkAll("String QueryParamCodec", QueryParamCodecLaws[String])
   checkAll("Instant QueryParamCodec", QueryParamCodecLaws[Instant])
+  checkAll("LocalDate QueryParamCodec", QueryParamCodecLaws[LocalDate])
 
   // Law checks for instances.
   checkAll(
@@ -63,6 +65,8 @@ trait QueryParamCodecInstances { this: Http4sSpec =>
 
   implicit val eqInstant: Eq[Instant] = Eq.fromUniversalEquals[Instant]
 
+  implicit val eqLocalDate: Eq[LocalDate] = Eq.fromUniversalEquals[LocalDate]
+
   implicit def ArbQueryParamDecoder[A: Arbitrary]: Arbitrary[QueryParamDecoder[A]] =
     Arbitrary(arbitrary[String => A].map(QueryParamDecoder[String].map))
 
@@ -75,9 +79,18 @@ trait QueryParamCodecInstances { this: Http4sSpec =>
   implicit val instantQueryParamCodec: QueryParamCodec[Instant] =
     QueryParamCodec.instantQueryParamCodec(DateTimeFormatter.ISO_INSTANT)
 
+  implicit val localDateQueryParamCodec: QueryParamCodec[LocalDate] =
+    QueryParamCodec.localDateQueryParamCodec(DateTimeFormatter.ISO_LOCAL_DATE)
+
   implicit val ArbitraryInstant: Arbitrary[Instant] =
     Arbitrary(
       Gen
         .choose[Long](Instant.MIN.getEpochSecond, Instant.MAX.getEpochSecond)
         .map(Instant.ofEpochSecond))
+
+  implicit val ArbitraryLocalDate: Arbitrary[LocalDate] =
+    Arbitrary(
+      Gen
+        .choose[Long](LocalDate.MIN.toEpochDay, LocalDate.MAX.toEpochDay)
+        .map(LocalDate.ofEpochDay))
 }


### PR DESCRIPTION
Was looking through some issues when I found this conversation

> @LukaJCB - #2724 added support for `Instant`. What other types would you find useful - `ZonedDateTime` and `LocalDate`?

in #2670. I added support for `LocalDate`. I have something in my fork for `ZonedDateTime`, but maybe that'll come later since I'm having trouble testing it correctly.

I hope this is a useful contribution!
