### PR TITLE
Make QueryParam A SubClass Of QueryParamKeyLike

### DIFF
--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -28,8 +28,8 @@ trait QueryOps {
     _withQueryParam(QueryParam[T].key, Nil)
 
   /** alias for withQueryParam */
-  def +*?[T: QueryParam: QueryParamEncoder](value: T): Self =
-    _withQueryParam(QueryParam[T].key, QueryParamEncoder[T].encode(value) :: Nil)
+  def +*?[T: QueryParamKeyLike: QueryParamEncoder](value: T): Self =
+    _withQueryParam(QueryParamKeyLike[T].getKey(value), QueryParamEncoder[T].encode(value) :: Nil)
 
   /** alias for withQueryParam */
   def +*?[T: QueryParam: QueryParamEncoder](values: collection.Seq[T]): Self =

--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -20,9 +20,13 @@ final case class QueryParameterValue(value: String) extends AnyVal
 /**
   * type class defining the key of a query parameter
   * Usually used in conjunction with [[QueryParamEncoder]] and [[QueryParamDecoder]]
+  *
+  * Any [[QueryParam]] instance is also a valid [[QueryParamKeyLike]] instance
+  * where the same key is used for all values.
   */
-trait QueryParam[T] {
+trait QueryParam[T] extends QueryParamKeyLike[T] {
   def key: QueryParameterKey
+  override final def getKey(t: T): QueryParameterKey = key
 }
 
 object QueryParam {


### PR DESCRIPTION
Any `QueryParam` instance is also an instance of `QueryParamKeyLike`, this commit makes that relationship explicit. This solves, and prevents, a few edge cases in the DSL. For example, the following would yield a compilation error before this commit.

```scala
final case class Foo(value: String)

object Foo {
    implicit val queryParam: QueryParam[Foo] = QueryParam.fromKey("foo")
    implicit val queryParamEncoder: QueryParamEncoder[Foo] = QueryParamEncoder[String].contramap(_.value)

    val foo: Foo = Foo("bar")
    val baseUri: Uri = Uri()

    // Works
    val uri0: Uri = baseUri.+*?(foo)
    // Works
    val uri1: Uri = baseUri.withOptionQueryParam(Some(foo))

    // Fails
    val uri2: Uri = baseUri.withQueryParam(foo)
}
```

The reason the final case fails is that there is no `withQueryParam` which takes a `QueryParam` instance to determine the key. There is a `withQueryParam` which takes a `QueryParamKeyLike`. The reason that `+*?` works is that it is not truly an alias for `withQueryParam`, but rather it invokes the internal helper function `_withQueryParam`.

After this commit all three work just fine.

It should be noted that there are two other ways to solve this problem.

1. The most simple is just to add the missing instance of `+*?` which uses `QueryParam` to resolve the key. The disadvantages to this approach are,

* It would make missed cases in the DSL harder to see in the event of a future refactor.
* Since both `QueryParam` and `QueryParamKeyLike` are public symbols, it is possible for code using http4s to wish to depend on them to express a constraint for a query parameter key. If the two classes are kept separate then code wishing to be fully general will need to often write two methods, one using `QueryParam` and the other using `QueryParamKeyLike`.

2. Add an implicit to the companion object of `QueryParamKeyLike` to create an instance of that class for any implicit `QueryParam[T]` instance.

This approach seems somewhat functionally equivalent to me, though subjectively a bit more messy. That being said, I'm happy to refactor this commit if the maintainers feel it is somehow better.