### PR TITLE
Make requests to mock client cancelable

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -218,7 +218,8 @@ object Client {
             }
           val req0 =
             addHostHeaderIfUriIsAbsolute(req.withBodyStream(go(req.body).stream))
-          Resource.liftF(app(req0))
+          Resource
+            .liftF(app(req0))
             .flatTap(_ => Resource.make(F.unit)(_ => disposed.set(true)))
             .map(resp => resp.copy(body = go(resp.body).stream))
         }

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -218,8 +218,8 @@ object Client {
             }
           val req0 =
             addHostHeaderIfUriIsAbsolute(req.withBodyStream(go(req.body).stream))
-          Resource
-            .make(app(req0))(_ => disposed.set(true))
+          Resource.liftF(app(req0))
+            .flatTap(_ => Resource.make(F.unit)(_ => disposed.set(true)))
             .map(resp => resp.copy(body = go(resp.body).stream))
         }
       }

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -7,6 +7,8 @@
 package org.http4s
 package client
 
+import scala.concurrent.duration._
+import cats.effect.concurrent.Deferred
 import cats.effect._
 import cats.implicits._
 import java.io.IOException
@@ -70,6 +72,26 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
       hostClient
         .expect[String](Request[IO](GET, Uri.uri("https://http4s.org/")))
         .unsafeRunSync() must_== "http4s.org"
+    }
+
+    "allow request to be canceled" in {
+
+      Deferred[IO, Unit].flatMap { cancelSignal =>
+        val routes = HttpRoutes.of[IO] {
+          case _ => cancelSignal.complete(()) >> IO.never
+        }
+
+        val cancelClient = Client.fromHttpApp(routes.orNotFound)
+
+        Deferred[IO, ExitCase[Throwable]].flatTap { exitCase =>
+          cancelClient
+            .expect[String](Request[IO](GET, Uri.uri("https://http4s.org/")))
+            .guaranteeCase(exitCase.complete)
+            .start
+            .flatTap(fiber => cancelSignal.get >> fiber.cancel) // don't cancel until the returned resource is in use
+        }.flatMap(_.get)
+      }.unsafeRunTimed(2.seconds) must_== Some(ExitCase.Canceled)
+
     }
   }
 }


### PR DESCRIPTION
Changes `Client.fromHttpApp` to run the app in `Resource.liftF` rather than `Resource.make`, to preserve cancelability.