### PR TITLE
#3665 Bug in CSRF error handler for `onFailure`

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -174,7 +174,7 @@ final class CSRF[F[_], G[_]] private[middleware] (
           newToken <- signToken[F](raw)
         } yield res.addCookie(createResponseCookie(newToken)))
           .recover {
-            case CSRFCheckFailed => Response[G](Status.Forbidden)
+            case CSRFCheckFailed => onFailure
           }
       case None =>
         if (createIfNotFound)
@@ -202,7 +202,7 @@ final class CSRF[F[_], G[_]] private[middleware] (
         newToken <- signToken[F](raw1) //Generate a new token to guard against BREACH.
       } yield response.addCookie(createResponseCookie(newToken)))
         .recover {
-          case CSRFCheckFailed => Response[G](Status.Forbidden)
+          case CSRFCheckFailed => onFailure
         }
 
   /** Check for CSRF validity for an unsafe action. */

--- a/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CSRFSpec.scala
@@ -9,13 +9,13 @@ package org.http4s.server.middleware
 import java.time.{Clock, Instant, ZoneId}
 import java.util.concurrent.atomic.AtomicLong
 
+import cats.arrow.FunctionK
 import cats.effect.IO
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.headers.Referer
+import org.http4s.server.middleware.CSRF.unlift
 import org.http4s.util.CaseInsensitiveString
-import CSRF.unlift
-import cats.arrow.FunctionK
 
 class CSRFSpec extends Http4sSpec {
 
@@ -68,6 +68,14 @@ class CSRFSpec extends Http4sSpec {
         .withCookieName(cookieName)
         .withCSRFCheck(CSRF.checkCSRFinHeaderAndForm[IO, IO](headerName.value, FunctionK.id))
         .build)
+    .unsafeRunSync()
+
+  val csrfCatchFailure: CSRF[IO, IO] = CSRF
+    .withGeneratedKey[IO, IO](defaultOriginCheck)
+    .map(_.withClock(testClock).withCookieName(cookieName).withOnFailure(
+      Response[IO](status = Status.SeeOther, headers = Headers(List(Header("Location", "/"))))
+        .removeCookie(cookieName)
+    ).build)
     .unsafeRunSync()
 
   ///
@@ -294,6 +302,92 @@ class CSRFSpec extends Http4sSpec {
 
       response.status must_== Status.Forbidden
       !response.cookies.exists(_.name == cookieName) must_== true
+    }
+
+    "catch a failure if defined explicitly" should {
+
+      "pass through and embed a new token for a safe, fresh request if set" in {
+        val response = csrfCatchFailure.validate()(dummyRoutes)(passThroughRequest).unsafeRunSync()
+
+        response.status must_== Status.Ok
+        response.cookies.exists(_.name == cookieName) must_== true
+      }
+
+      "fail a request with an invalid cookie, despite it being a safe method" in {
+        val response =
+          csrfCatchFailure
+            .validate()(dummyRoutes)(passThroughRequest.addCookie(RequestCookie(cookieName, "MOOSE")))
+            .unsafeRunSync()
+
+        response.status must_== Status.SeeOther
+        response.cookies.exists(_.name == cookieName) must_== true
+      }
+
+      "pass through and embed a slightly different token for a safe request" in {
+        val (oldToken, oldRaw, response, newToken, newRaw) =
+          (for {
+            oldToken <- csrfCatchFailure.generateToken[IO]
+            raw1 <- IO.fromEither(csrfCatchFailure.extractRaw(unlift(oldToken)))
+            response <-
+              csrfCatchFailure.validate()(dummyRoutes)(csrf.embedInRequestCookie(passThroughRequest, oldToken))
+            newCookie =
+            response.cookies
+              .find(_.name == cookieName)
+              .getOrElse(ResponseCookie("invalid", "Invalid2"))
+            raw2 <- IO.fromEither(csrfCatchFailure.extractRaw(newCookie.content))
+          } yield (oldToken, raw1, response, newCookie, raw2)).unsafeRunSync()
+
+        response.status must_== Status.Ok
+        oldToken must_!= newToken.content
+        oldRaw must_== newRaw
+      }
+
+      "fail and catch a request without any origin, even with a token" in {
+        val program: IO[Response[IO]] = for {
+          token <- csrfCatchFailure.generateToken[IO]
+          req = csrfCatchFailure.embedInRequestCookie(Request[IO](POST), token)
+          v <- csrfCatchFailure.checkCSRF(req, dummyRoutes.run(req))
+        } yield v
+
+        program.unsafeRunSync().status must_== Status.SeeOther
+      }
+
+      "not validate if token is missing in both" in {
+        csrfCatchFailure
+          .validate()(dummyRoutes)(dummyRequest)
+          .unsafeRunSync()
+          .status must_== Status.SeeOther
+      }
+
+      "fail a request with an incorrect origin and incorrect referrer, even with a token" in {
+        (for {
+          token <- csrfCatchFailure.generateToken[IO]
+          res <- csrfCatchFailure.validate()(dummyRoutes)(
+            Request[IO](POST)
+              .putHeaders(
+                Header(headerName.value, unlift(token)),
+                Header("Origin", "http://example.com"),
+                Referer(Uri.unsafeFromString("http://example.com/lol")))
+              .addCookie(cookieName, unlift(token))
+          )
+        } yield res).unsafeRunSync().status must_== Status.SeeOther
+      }
+
+      "return a fresh token for a failed CSRF check" in {
+        val response = (for {
+          token1 <- csrfCatchFailure.generateToken[IO]
+          token2 <- csrfCatchFailure.generateToken[IO]
+          res <- csrfCatchFailure.validate()(dummyRoutes)(
+            dummyRequest
+              .putHeaders(Header(headerName.value, unlift(token1)))
+              .addCookie(cookieName, unlift(token2))
+          )
+        } yield res).unsafeRunSync()
+
+
+        response.status must_== Status.SeeOther
+        response.cookies.exists(_.name == cookieName) must_== true
+      }
     }
   }
 }


### PR DESCRIPTION
- The `recover` cases in `validate` and `checkCSRFToken` use the defined `onFailure` response. This is by definition already `Response[G](Status.Forbidden)` and does not change the former behavior of the hard-coded responses.
- Add tests for a CSRF object that has a defined `onFailure` response.
- Fixes #3665 