### PR TITLE
commenting out QueryParamCodecSpec.ZonedDateTime tests

### DIFF
--- a/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
@@ -107,11 +107,7 @@ trait QueryParamCodecInstances { this: Http4sSpec =>
     val zoneIds: Seq[String] = ZoneId.getAvailableZoneIds.asScala.toSeq
     Arbitrary(
       for {
-        secSinceEpoch <-
-          Gen
-            .choose[Long](
-              Instant.now.minusSeconds(5000).getEpochSecond,
-              Instant.now.minusSeconds(1000).getEpochSecond)
+        secSinceEpoch <- Gen.choose[Long](Instant.EPOCH.getEpochSecond, Instant.now.getEpochSecond)
         zoneId <- Gen.oneOf(zoneIds)
       } yield ZonedDateTime.ofInstant(Instant.ofEpochSecond(secSinceEpoch), ZoneId.of(zoneId))
     )

--- a/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
@@ -29,7 +29,8 @@ class QueryParamCodecSpec extends Http4sSpec with QueryParamCodecInstances {
   checkAll("String QueryParamCodec", QueryParamCodecLaws[String])
   checkAll("Instant QueryParamCodec", QueryParamCodecLaws[Instant])
   checkAll("LocalDate QueryParamCodec", QueryParamCodecLaws[LocalDate])
-  checkAll("ZonedDateTime QueryParamCodec", QueryParamCodecLaws[ZonedDateTime])
+  // The following test fails on CI/CD, adds more trouble than it might be worth
+  // checkAll("ZonedDateTime QueryParamCodec", QueryParamCodecLaws[ZonedDateTime])
 
   // Law checks for instances.
   checkAll(
@@ -106,7 +107,11 @@ trait QueryParamCodecInstances { this: Http4sSpec =>
     val zoneIds: Seq[String] = ZoneId.getAvailableZoneIds.asScala.toSeq
     Arbitrary(
       for {
-        secSinceEpoch <- Gen.choose[Long](Instant.EPOCH.getEpochSecond, Instant.now.getEpochSecond)
+        secSinceEpoch <-
+          Gen
+            .choose[Long](
+              Instant.now.minusSeconds(5000).getEpochSecond,
+              Instant.now.minusSeconds(1000).getEpochSecond)
         zoneId <- Gen.oneOf(zoneIds)
       } yield ZonedDateTime.ofInstant(Instant.ofEpochSecond(secSinceEpoch), ZoneId.of(zoneId))
     )

--- a/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
@@ -30,6 +30,7 @@ class QueryParamCodecSpec extends Http4sSpec with QueryParamCodecInstances {
   checkAll("Instant QueryParamCodec", QueryParamCodecLaws[Instant])
   checkAll("LocalDate QueryParamCodec", QueryParamCodecLaws[LocalDate])
   // The following test fails on CI/CD, adds more trouble than it might be worth
+  // Original issue: https://github.com/http4s/http4s/issues/3664
   // checkAll("ZonedDateTime QueryParamCodec", QueryParamCodecLaws[ZonedDateTime])
 
   // Law checks for instances.


### PR DESCRIPTION
Resolves #3664 

@hamnis disabling the `ZonedDateTime` tests as discussed.

Ideally I would have liked to tag the test with a ScalaTest `ignore`, but there appears to be no way of doing so. Perhaps I'm wrong.