### PR TITLE
Fixes QueryParamCodecSpec flakiness

### DIFF
--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -72,6 +72,7 @@ trait Http4sSpec
       p: Parameters,
       f: FreqMap[Set[Any]] => Pretty): Fragments = {
     addFragment(ff.text(s"$name  ${props.name} must satisfy"))
+    addBreak
     addFragments(Fragments.foreach(props.properties.toList) {
       case (name, prop) =>
         Fragments(name in check(prop, p, f))


### PR DESCRIPTION
Should resolve #3664

The root cause of the issue is a bug in Java 1.8 which fails parsing of zoned dates/times with "GMT0" zone id.
Please find more details on this here: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8138664

The suggested fix simply suppresses generation of `ZonedDateTime` instances with "GMT0" in `QueryParamCodecSpec` if the test runs on Java 1.8.

It doesn't fix the corresponding `QueryParamCodec` itself – I'm not sure if it would be a correct approach to try mitigating Java bugs on this level.

Also it slightly improves output for this test as well as other tests based on `Http4sSpec`.