### PR TITLE
Parse raw headers only if its name matches

### DIFF
--- a/core/src/main/scala/org/http4s/HeaderKey.scala
+++ b/core/src/main/scala/org/http4s/HeaderKey.scala
@@ -91,7 +91,7 @@ object HeaderKey {
       header match {
         case h if runtimeClass.isInstance(h) =>
           Some(header.asInstanceOf[HeaderT])
-        case Header.Raw(name, _) if name == header.name && runtimeClass.isInstance(header.parsed) =>
+        case Header.Raw(_, _) if name == header.name && runtimeClass.isInstance(header.parsed) =>
           Some(header.parsed.asInstanceOf[HeaderT])
         case _ =>
           None


### PR DESCRIPTION
Otherwise the header we're matching against will be parsed even if its name doesn't match.