### PR TITLE
Update streaming.md

### DIFF
--- a/docs/src/main/mdoc/streaming.md
+++ b/docs/src/main/mdoc/streaming.md
@@ -52,7 +52,7 @@ function, which takes a `Request[F]` and a `Response[F] => Stream[F, A]` and ret
 to consume a stream is just:
 
 ```scala
-client.stream(req).flatMap(_)
+client.stream(req).flatMap(_.body)
 ```
 
 That gives you a `Stream[F, Byte]`, but you probably want something other than a `Byte`.


### PR DESCRIPTION
`client.stream(req).flatMap(_)` returns a partially applied function. Changing `_` to `_.body` gives the `Stream[F, Byte]` that the docs describe.