### PR TITLE
Router should use correct prefix when routing

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -345,15 +345,22 @@ object Uri {
 
     def startsWithString(path: String): Boolean = startsWith(Path.fromString(path))
 
-    def indexOf(path: Path): Option[Int] =
-      if (path.isEmpty) None else Some(segments.indexOfSlice(path.segments)).filterNot(_ == -1)
+    @deprecated("Misnamed, use findSplit(prefix) instead", since = "1.0.0-M5")
+    def indexOf(prefix: Path): Option[Int] = findSplit(prefix)
 
-    def indexOfString(path: String): Option[Int] = indexOf(Path.fromString(path))
+    @deprecated("Misnamed, use findSplitOfString(prefix) instead", since = "1.0.0-M5")
+    def indexOfString(path: String): Option[Int] = findSplit(Path.fromString(path))
+
+    def findSplit(prefix: Path): Option[Int] =
+      if (prefix.isEmpty) None
+      else if (startsWith(prefix)) Some(prefix.segments.size)
+      else None
+    def findSplitOfString(path: String): Option[Int] = findSplit(Path.fromString(path))
 
     def splitAt(idx: Int): (Path, Path) =
       if (idx < 0) (if (absolute) Path.Root else Path.empty, this)
       else {
-        val (start, end) = segments.splitAt(idx + 1)
+        val (start, end) = segments.splitAt(idx)
         Path(start, absolute = absolute) -> Path(end, true, endsWithSlash = endsWithSlash)
       }
     private def copy(

--- a/server/src/main/scala/org/http4s/server/middleware/TranslateUri.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/TranslateUri.scala
@@ -22,7 +22,7 @@ object TranslateUri {
       val prefixAsPath = Uri.Path.fromString(prefix)
 
       Kleisli { (req: Request[G]) =>
-        val newCaret = req.pathInfo.indexOf(prefixAsPath)
+        val newCaret = req.pathInfo.findSplit(prefixAsPath)
         val shouldTranslate = req.pathInfo.startsWith(prefixAsPath)
         if (shouldTranslate) http(setCaret(req, newCaret))
         else F.empty

--- a/server/src/test/scala/org/http4s/server/RouterSpec.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSpec.scala
@@ -51,13 +51,23 @@ class RouterSpec extends Http4sSpec with Http4sLegacyMatchersIO {
     "/numb" -> middleware(numbers2),
     "/" -> root,
     "/shadow" -> shadow,
-    "/letters" -> letters
+    "/letters" -> letters,
+    "/numbers/v1" -> HttpRoutes.of[IO] {
+      case GET -> Root / "1" => Ok("Yeah")
+    },
+    "/numbers" -> Router[IO](
+      "/v2" -> HttpRoutes.of[IO] {
+        case GET -> Root / "1" => Ok("Indeed")
+      }
+    )
   )
 
   "A router" should {
     "translate mount prefixes" in {
       service.orNotFound(Request[IO](GET, uri"/numbers/1")) must returnBody("one")
       service.orNotFound(Request[IO](GET, uri"/numb/1")) must returnBody("two")
+      service.orNotFound(Request[IO](GET, uri"/numbers/v1/1")) must returnBody("Yeah")
+      service.orNotFound(Request[IO](GET, uri"/numbers/v2/1")) must returnBody("Indeed")
       service.orNotFound(Request[IO](GET, uri"/numbe?block")) must returnStatus(NotFound)
     }
 

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -133,7 +133,7 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
         .fromString(req.getContextPath)
         .concat(Uri.Path.fromString(req.getServletPath))
     uri.path
-      .indexOf(pathInfo)
+      .findSplit(pathInfo)
       .getOrElse(-1)
   }
 

--- a/tests/src/test/scala/org/http4s/MessageSpec.scala
+++ b/tests/src/test/scala/org/http4s/MessageSpec.scala
@@ -124,7 +124,7 @@ class MessageSpec extends Http4sSpec with Http4sLegacyMatchersIO {
       "preserve caret in withPathInfo" in {
         val originalReq = Request(
           uri = uri"/foo/bar",
-          attributes = Vault.empty.insert(Request.Keys.PathInfoCaret, 0))
+          attributes = Vault.empty.insert(Request.Keys.PathInfoCaret, 1))
         val updatedReq = originalReq.withPathInfo(path"/quux")
 
         updatedReq.scriptName mustEqual path"/foo"

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -1112,6 +1112,17 @@ http://example.org/a file
       checkAll("Uri.Path", SemigroupTests[Uri.Path].semigroup)
       checkAll("Uri.Path", EqTests[Uri.Path].eqv)
     }
+
+    "indexOf / Split" in {
+      val path1 = path"/foo/bar/baz"
+      val path2 = path"/foo"
+      val split = path1.findSplit(path2)
+      split must beSome(1)
+      val (pre, post) = path1.splitAt(split.getOrElse(0))
+      pre must_=== path2
+      post must_=== path"/bar/baz"
+      pre.concat(post) must_=== path1
+    }
   }
 
 }


### PR DESCRIPTION
Added deprecations to indexOf and indexOfString and added the implementation to findSplit and findSplitOfString

Fixes #3713 