### PR TITLE
Fix Method.fromString

### DIFF
--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -83,7 +83,8 @@ private[http4s] object Rfc2616BasicRules {
   def token(in: ParserInput): ParseResult[String] =
     new Rfc2616BasicRules {
       override def input: ParserInput = in
-    }.Token
+      def Main = rule(Token ~ EOI)
+    }.Main
       .run()(Parser.DeliveryScheme.Either)
       .leftMap(e => ParseFailure("Invalid token", e.format(in)))
 

--- a/tests/src/test/scala/org/http4s/MethodSpec.scala
+++ b/tests/src/test/scala/org/http4s/MethodSpec.scala
@@ -6,11 +6,14 @@
 
 package org.http4s
 
-import cats.Hash
-import cats.kernel.laws.discipline._
 import java.util.Locale
+
+import cats.Hash
+import cats.implicits._
+import cats.kernel.laws.discipline._
 import org.http4s.parser.Rfc2616BasicRules
-import org.scalacheck.Prop.forAll
+import org.scalacheck.Gen
+import org.scalacheck.Prop.{forAll, forAllNoShrink}
 
 class MethodSpec extends Http4sSpec {
   import Method._
@@ -26,7 +29,30 @@ class MethodSpec extends Http4sSpec {
 
   "only tokens are valid methods" in {
     prop { (s: String) =>
+      // TODO: this check looks meaningless: `fromString` mostly relies on `Rfc2616BasicRules.token`
+      //       and the result is compared to `isToken` which calls to `Rfc2616BasicRules.token` as well.
       fromString(s).isRight must_== Rfc2616BasicRules.isToken(s)
+    }
+  }
+
+  "parse a whole input string" in { // see #3680
+    val genAlmostToken = {
+      val genNonToken =
+        Gen
+          .oneOf(
+            Gen.choose('\u0000', '\u001F'),
+            Gen.oneOf("()<>@,;:\\\"/[]?={} \t\u007F")
+          )
+          .map(_.toString)
+
+      for {
+        tokenHead <- genToken
+        nonToken <- genNonToken
+        tokenTail <- Gen.option(genToken).map(_.orEmpty)
+      } yield tokenHead + nonToken + tokenTail
+    }
+    forAllNoShrink(genAlmostToken) { almostToken =>
+      fromString(almostToken) must beLeft((_: ParseFailure).sanitized ==== "Invalid method")
     }
   }
 


### PR DESCRIPTION
Should resolve #3680
Fixes the `Rfc2616BasicRules.token` method which is used in `Method.fromString`.
The `Rfc2616BasicRules.isToken` method should also get fixed.