### PR TITLE
Fix 'unused' warnings in scalafix-input module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -614,6 +614,7 @@ lazy val scalafixInput = project
     // TODO: I think these are false positives
     unusedCompileDependenciesFilter -= moduleFilter(organization = "org.http4s"),
     scalacOptions -= "-Xfatal-warnings",
+    scalacOptions ~= { _.filterNot(_.startsWith("-Wunused:")) }
   )
   // Syntax matters as much as semantics here.
   .disablePlugins(HeaderPlugin, ScalafmtPlugin)


### PR DESCRIPTION
Resolves #3613

Suppresses all "unused-whatever" warnings in the `scalafixInput` module.
Sometimes `scalafixInput` have to contain unused stuff (imports, parameters, etc) just to let the `scalafixOutput` module be semantically correct and thus compile successfully.