### PR TITLE
Refactor query param infix operators to avoid 2.13 error

### DIFF
--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -47,7 +47,7 @@ trait QueryOps {
   def ++?[K: QueryParamKeyLike, T: QueryParamEncoder](param: (K, collection.Seq[T])): Self =
     _withQueryParam(
       QueryParamKeyLike[K].getKey(param._1),
-      param._2.map((t: T) => QueryParamEncoder[T].encode(t)))
+      param._2.map(QueryParamEncoder[T].encode))
 
   /** alias for withOptionQueryParam */
   def +??[K: QueryParamKeyLike, T: QueryParamEncoder](param: (K, Option[T])): Self =

--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -36,20 +36,24 @@ trait QueryOps {
     _withQueryParam(QueryParam[T].key, values.map(QueryParamEncoder[T].encode))
 
   /** alias for withQueryParam */
-  def +?[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, value: T): Self =
-    ++?(name, value :: Nil)
+  def +?[K: QueryParamKeyLike, T: QueryParamEncoder](param: (K, T)): Self =
+    ++?((param._1, param._2 :: Nil))
 
   /** alias for withQueryParam */
   def +?[K: QueryParamKeyLike](name: K): Self =
     _withQueryParam(QueryParamKeyLike[K].getKey(name), Nil)
 
   /** alias for withQueryParam */
-  def ++?[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, values: collection.Seq[T]): Self =
-    _withQueryParam(QueryParamKeyLike[K].getKey(name), values.map(QueryParamEncoder[T].encode))
+  def ++?[K: QueryParamKeyLike, T: QueryParamEncoder](param: (K, collection.Seq[T])): Self =
+    _withQueryParam(
+      QueryParamKeyLike[K].getKey(param._1),
+      param._2.map((t: T) => QueryParamEncoder[T].encode(t)))
 
   /** alias for withOptionQueryParam */
-  def +??[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, value: Option[T]): Self =
-    _withOptionQueryParam(QueryParamKeyLike[K].getKey(name), value.map(QueryParamEncoder[T].encode))
+  def +??[K: QueryParamKeyLike, T: QueryParamEncoder](param: (K, Option[T])): Self =
+    _withOptionQueryParam(
+      QueryParamKeyLike[K].getKey(param._1),
+      param._2.map(QueryParamEncoder[T].encode))
 
   /** alias for withOptionQueryParam */
   def +??[T: QueryParam: QueryParamEncoder](value: Option[T]): Self =

--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -37,14 +37,14 @@ trait QueryOps {
 
   /** alias for withQueryParam */
   def +?[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, value: T): Self =
-    +?(name, value :: Nil)
+    ++?(name, value :: Nil)
 
   /** alias for withQueryParam */
   def +?[K: QueryParamKeyLike](name: K): Self =
     _withQueryParam(QueryParamKeyLike[K].getKey(name), Nil)
 
   /** alias for withQueryParam */
-  def +?[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, values: collection.Seq[T]): Self =
+  def ++?[K: QueryParamKeyLike, T: QueryParamEncoder](name: K, values: collection.Seq[T]): Self =
     _withQueryParam(QueryParamKeyLike[K].getKey(name), values.map(QueryParamEncoder[T].encode))
 
   /** alias for withOptionQueryParam */

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -634,31 +634,31 @@ http://example.org/a file
 
   "Uri parameter convenience methods" should {
     "add a parameter if no query is available" in {
-      val u = Uri(query = Query.empty).+?("param1", "value")
+      val u = Uri(query = Query.empty) +? ("param1", "value")
       u must be_==(Uri(query = Query.fromString("param1=value")))
     }
     "add a parameter" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")).+?("param2", "value")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2", "value")
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2=value")))
     }
     "add a parameter with boolean value" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")).+?("param2", true)
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2", true)
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2=true")))
     }
     "add a parameter without a value" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")).+?("param2")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? "param2"
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
     }
     "add a parameter with many values" in {
-      val u = Uri().+?("param1", Seq("value1", "value2"))
+      val u = Uri() +? ("param1", Seq("value1", "value2"))
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2")))
     }
     "add a parameter with many long values" in {
-      val u = Uri().+?("param1", Seq(1L, -1L))
+      val u = Uri() +? ("param1", Seq(1L, -1L))
       u must be_==(Uri(query = Query.fromString(s"param1=1&param1=-1")))
     }
     "add a query parameter with a QueryParamEncoder" in {
-      val u = Uri().+?("test", Ttl(2))
+      val u = Uri() +? ("test", Ttl(2))
       u must be_==(Uri(query = Query.fromString(s"test=2")))
     }
     "add a query parameter with a QueryParamEncoder and an implicit key" in {
@@ -670,11 +670,11 @@ http://example.org/a file
       u must be_==(Uri(query = Query.fromString(s"ttl")))
     }
     "add an optional query parameter (Just)" in {
-      val u = Uri().+??("param1", Some(2))
+      val u = Uri() +?? ("param1", Some(2))
       u must be_==(Uri(query = Query.fromString(s"param1=2")))
     }
     "add an optional query parameter (Empty)" in {
-      val u = Uri().+??("param1", None: Option[Int])
+      val u = Uri() +?? ("param1", None: Option[Int])
       u must be_==(Uri(query = Query.empty))
     }
     "add multiple query parameters at once" in {
@@ -746,7 +746,7 @@ http://example.org/a file
       u must be_==(Uri())
     }
     "replace a parameter" in {
-      val u = Uri(query = Query.fromString("param1=value&param2=value")).+?("param1", "newValue")
+      val u = Uri(query = Query.fromString("param1=value&param2=value")) +? ("param1", "newValue")
       u.multiParams must be_==(
         Uri(query = Query.fromString("param1=newValue&param2=value")).multiParams)
     }
@@ -757,18 +757,18 @@ http://example.org/a file
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace the same parameter" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2"))
-        .+?("param1", Seq("value1", "value2"))
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) +?
+        ("param1", Seq("value1", "value2"))
       u.multiParams must be_==(
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace the same parameter without a value" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")).+?("param2")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) +? "param2"
       u.multiParams must be_==(
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace a parameter set" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")).+?("param1", "value")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param1", "value")
       u.multiParams must be_==(Uri(query = Query.fromString("param1=value")).multiParams)
     }
     "set a parameter with a value" in {

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -634,15 +634,15 @@ http://example.org/a file
 
   "Uri parameter convenience methods" should {
     "add a parameter if no query is available" in {
-      val u = Uri(query = Query.empty) +? ("param1", "value")
+      val u = Uri(query = Query.empty) +? ("param1" -> "value")
       u must be_==(Uri(query = Query.fromString("param1=value")))
     }
     "add a parameter" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2", "value")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2" -> "value")
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2=value")))
     }
     "add a parameter with boolean value" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2", true)
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param2" -> true)
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2=true")))
     }
     "add a parameter without a value" in {
@@ -650,15 +650,15 @@ http://example.org/a file
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
     }
     "add a parameter with many values" in {
-      val u = Uri() ++? ("param1", Seq("value1", "value2"))
+      val u = Uri() ++? ("param1" -> Seq("value1", "value2"))
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2")))
     }
     "add a parameter with many long values" in {
-      val u = Uri() ++? ("param1", Seq(1L, -1L))
+      val u = Uri() ++? ("param1" -> Seq(1L, -1L))
       u must be_==(Uri(query = Query.fromString(s"param1=1&param1=-1")))
     }
     "add a query parameter with a QueryParamEncoder" in {
-      val u = Uri() +? ("test", Ttl(2))
+      val u = Uri() +? ("test" -> Ttl(2))
       u must be_==(Uri(query = Query.fromString(s"test=2")))
     }
     "add a query parameter with a QueryParamEncoder and an implicit key" in {
@@ -670,11 +670,11 @@ http://example.org/a file
       u must be_==(Uri(query = Query.fromString(s"ttl")))
     }
     "add an optional query parameter (Just)" in {
-      val u = Uri() +?? ("param1", Some(2))
+      val u = Uri() +?? ("param1" -> Some(2))
       u must be_==(Uri(query = Query.fromString(s"param1=2")))
     }
     "add an optional query parameter (Empty)" in {
-      val u = Uri() +?? ("param1", None: Option[Int])
+      val u = Uri() +?? ("param1" -> Option.empty[Int])
       u must be_==(Uri(query = Query.empty))
     }
     "add multiple query parameters at once" in {
@@ -746,7 +746,7 @@ http://example.org/a file
       u must be_==(Uri())
     }
     "replace a parameter" in {
-      val u = Uri(query = Query.fromString("param1=value&param2=value")) +? ("param1", "newValue")
+      val u = Uri(query = Query.fromString("param1=value&param2=value")) +? ("param1" -> "newValue")
       u.multiParams must be_==(
         Uri(query = Query.fromString("param1=newValue&param2=value")).multiParams)
     }
@@ -758,7 +758,7 @@ http://example.org/a file
     }
     "replace the same parameter" in {
       val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) ++?
-        ("param1", Seq("value1", "value2"))
+        ("param1" -> Seq("value1", "value2"))
       u.multiParams must be_==(
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
@@ -768,7 +768,7 @@ http://example.org/a file
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace a parameter set" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param1", "value")
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2")) +? ("param1" -> "value")
       u.multiParams must be_==(Uri(query = Query.fromString("param1=value")).multiParams)
     }
     "set a parameter with a value" in {

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -650,11 +650,11 @@ http://example.org/a file
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2&param2")))
     }
     "add a parameter with many values" in {
-      val u = Uri() +? ("param1", Seq("value1", "value2"))
+      val u = Uri() ++? ("param1", Seq("value1", "value2"))
       u must be_==(Uri(query = Query.fromString("param1=value1&param1=value2")))
     }
     "add a parameter with many long values" in {
-      val u = Uri() +? ("param1", Seq(1L, -1L))
+      val u = Uri() ++? ("param1", Seq(1L, -1L))
       u must be_==(Uri(query = Query.fromString(s"param1=1&param1=-1")))
     }
     "add a query parameter with a QueryParamEncoder" in {
@@ -757,7 +757,7 @@ http://example.org/a file
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)
     }
     "replace the same parameter" in {
-      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) +?
+      val u = Uri(query = Query.fromString("param1=value1&param1=value2&param2")) ++?
         ("param1", Seq("value1", "value2"))
       u.multiParams must be_==(
         Uri(query = Query.fromString("param1=value1&param1=value2&param2")).multiParams)


### PR DESCRIPTION
## What's the problem?

When using [`+?` operator](https://github.com/http4s/http4s/blob/e45ca2c8703c43d7c00a55d47a35d3bd3b79dfdd/core/src/main/scala/org/http4s/QueryOps.scala#L39) to add a query param to an `Uri` value in Scala 2.13.3 the following warning is raised:


```scala
[warn] ${BASE}/Test.scala:14:37: multiarg infix syntax looks like a tuple and will be deprecated
[warn]   val uri = uri"localhost" / "test" +? ("key", "value")
[warn]                                     ^
```

The warning only dissapears if no-infix syntax is used:


```scala
(uri"localhost" / "test").+?("key", "value")
```

...which completely breaks the goal of those operators.

## Changes included in this PR

- Separate usages of `+?` and `+??` in tests to be able to see the error (if someone tries to compile the first commit of this PR it should fail with `multiarg infix syntax looks like a tuple and will be deprecated`.
- Since `+?` has two two-param version methods, we need to rename `+?(T, Seq)` to `++?` to avoid clashing between them once they're changed to their "tuple" version.
- Change `+?`, `++?` and `+??` two-param operators to receive a tuple.

## Referenced PR

This fixes #3719 