### PR TITLE
Adds CollectionCompat trait for Dotty

### DIFF
--- a/core/src/main/scala-0.27/org/http4s/internal/CollectionCompat.scala
+++ b/core/src/main/scala-0.27/org/http4s/internal/CollectionCompat.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.internal
+
+import scala.collection.immutable
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+private[http4s] object CollectionCompat {
+  type LazyList[A] = Stream[A]
+  val LazyList = Stream
+
+  def pairsToMultiParams[K, V](map: collection.Seq[(K, Option[V])]): Map[K, immutable.Seq[V]] =
+    if (map.isEmpty) Map.empty
+    else {
+      val m = mutable.Map.empty[K, ListBuffer[V]]
+      map.foreach {
+        case (k, None) => m.getOrElseUpdate(k, new ListBuffer)
+        case (k, Some(v)) => m.getOrElseUpdate(k, new ListBuffer) += v
+      }
+      m.toMap.mapValues(_.toList)
+    }
+
+  def mapValues[K, A, B](map: collection.Map[K, A])(f: A => B): Map[K, B] =
+    map.mapValues(f).toMap
+
+  val CollectionConverters = scala.collection.JavaConverters
+}


### PR DESCRIPTION
We could add scala-collection-compat, and also pick up `@nowarn` support (see #3764).  I'm not so sure we can do that without breaking binary compatibility, and this hasn't grown out of control _yet_.  This just copies the 2.13 trait.

This build will not pass yet, and targets the dotty branch.