### PR TITLE
Replace silent annotation with nowarn

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/GZip.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/GZip.scala
@@ -40,7 +40,7 @@ object GZip {
           req.headers ++ Headers.of(Header(`Accept-Encoding`.name.value, supportedCompressions)))
     }
 
-  @nowarn("msg=deprecated")
+  @nowarn("cat=deprecation")
   private def decompress[F[_]](bufferSize: Int, response: Response[F])(implicit
       F: Bracket[F, Throwable]): Response[F] =
     response.headers.get(`Content-Encoding`) match {

--- a/client/src/main/scala/org/http4s/client/middleware/GZip.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/GZip.scala
@@ -9,9 +9,9 @@ package client
 package middleware
 
 import cats.effect.Bracket
-import com.github.ghik.silencer.silent
 import fs2.{Pipe, Pull, Stream}
 import org.http4s.headers.{`Accept-Encoding`, `Content-Encoding`}
+import scala.annotation.nowarn
 import scala.util.control.NoStackTrace
 
 /** Client middleware for enabling gzip.
@@ -40,7 +40,7 @@ object GZip {
           req.headers ++ Headers.of(Header(`Accept-Encoding`.name.value, supportedCompressions)))
     }
 
-  @silent("deprecated")
+  @nowarn("deprecated")
   private def decompress[F[_]](bufferSize: Int, response: Response[F])(implicit
       F: Bracket[F, Throwable]): Response[F] =
     response.headers.get(`Content-Encoding`) match {

--- a/client/src/main/scala/org/http4s/client/middleware/GZip.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/GZip.scala
@@ -40,7 +40,7 @@ object GZip {
           req.headers ++ Headers.of(Header(`Accept-Encoding`.name.value, supportedCompressions)))
     }
 
-  @nowarn("deprecated")
+  @nowarn("msg=deprecated")
   private def decompress[F[_]](bufferSize: Int, response: Response[F])(implicit
       F: Bracket[F, Throwable]): Response[F] =
     response.headers.get(`Content-Encoding`) match {

--- a/core/src/main/scala-2.12/scala/annotation/nowarn.scala
+++ b/core/src/main/scala-2.12/scala/annotation/nowarn.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package scala.annotation
+
+/** Shims Scala 2.13.2's `@nowarn` so it compiles on Scala 2.12.
+  * Silencer has rudimentary support.
+  */
+class nowarn(val value: String = "") extends StaticAnnotation

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -12,7 +12,6 @@ package org.http4s
 
 import cats.{Eq, Hash, Order, Show}
 import cats.syntax.either._
-import com.github.ghik.silencer.silent
 import java.net.{Inet4Address, Inet6Address, InetAddress}
 import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{Charset => JCharset}
@@ -23,6 +22,7 @@ import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit, HexDigit}
 import org.http4s.parser._
 import org.http4s.syntax.string._
 import org.http4s.util._
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.math.Ordered
 import scala.reflect.macros.whitebox
@@ -246,7 +246,7 @@ object Uri {
     def unsafeFromString(s: String): Scheme =
       fromString(s).fold(throw _, identity)
 
-    @silent("deprecated")
+    @nowarn("deprecated")
     private[http4s] trait Parser { self: PbParser =>
       def scheme =
         rule {

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -246,7 +246,7 @@ object Uri {
     def unsafeFromString(s: String): Scheme =
       fromString(s).fold(throw _, identity)
 
-    @nowarn("deprecated")
+    @nowarn("msg=deprecated")
     private[http4s] trait Parser { self: PbParser =>
       def scheme =
         rule {

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -246,7 +246,7 @@ object Uri {
     def unsafeFromString(s: String): Scheme =
       fromString(s).fold(throw _, identity)
 
-    @nowarn("msg=deprecated")
+    @nowarn("cat=deprecation")
     private[http4s] trait Parser { self: PbParser =>
       def scheme =
         rule {

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -11,11 +11,11 @@
 package org.http4s
 package parser
 
-import com.github.ghik.silencer.silent
 import org.http4s.SameSite._
 import org.http4s.headers.`Set-Cookie`
 import org.http4s.internal.parboiled2._
 import org.http4s.internal.parboiled2.support.{::, HNil}
+import scala.annotation.nowarn
 
 private[parser] trait CookieHeader {
   def SET_COOKIE(value: String): ParseResult[`Set-Cookie`] =
@@ -112,7 +112,7 @@ private[parser] trait CookieHeader {
 
     def DomainNamePart: Rule0 = rule(AlphaNum ~ zeroOrMore(AlphaNum | ch('-')))
 
-    @silent("deprecated")
+    @nowarn("deprecated")
     def StringValue: Rule1[String] = rule(capture(oneOrMore((!(CTL | ch(';'))) ~ Char)))
 
     def SameSite: Rule1[SameSite] =

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -112,7 +112,7 @@ private[parser] trait CookieHeader {
 
     def DomainNamePart: Rule0 = rule(AlphaNum ~ zeroOrMore(AlphaNum | ch('-')))
 
-    @nowarn("deprecated")
+    @nowarn("msg=deprecated")
     def StringValue: Rule1[String] = rule(capture(oneOrMore((!(CTL | ch(';'))) ~ Char)))
 
     def SameSite: Rule1[SameSite] =

--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -112,7 +112,7 @@ private[parser] trait CookieHeader {
 
     def DomainNamePart: Rule0 = rule(AlphaNum ~ zeroOrMore(AlphaNum | ch('-')))
 
-    @nowarn("msg=deprecated")
+    @nowarn("cat=deprecation")
     def StringValue: Rule1[String] = rule(capture(oneOrMore((!(CTL | ch(';'))) ~ Char)))
 
     def SameSite: Rule1[SameSite] =

--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -11,9 +11,9 @@
 package org.http4s.parser
 
 import cats.implicits._
-import com.github.ghik.silencer.silent
 import org.http4s.{ParseFailure, ParseResult}
 import org.http4s.internal.parboiled2._
+import scala.annotation.nowarn
 
 // direct implementation of http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2
 private[http4s] trait Rfc2616BasicRules extends Parser {
@@ -37,14 +37,14 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
 
   def LWS = rule(optional(CRLF) ~ oneOrMore(anyOf(" \t")))
 
-  @silent("deprecated")
+  @nowarn("deprecated")
   def Text = rule(!CTL ~ ANY | LWS)
 
   def Hex = rule("A" - "F" | "a" - "f" | Digit)
 
   def Separator = rule(anyOf("()<>@,;:\\\"/[]?={} \t"))
 
-  @silent("deprecated")
+  @nowarn("deprecated")
   def Token: Rule1[String] = rule(capture(oneOrMore(!CTL ~ !Separator ~ ANY)))
 
   // TODO What's the replacement for DROP?
@@ -54,7 +54,7 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
     ()
   }
 
-  @silent("deprecated")
+  @nowarn("deprecated")
   def CText = rule(!anyOf("()") ~ Text)
 
   // TODO This parser cannot handle strings terminating on \" which is a border case but still valid quoted pair
@@ -65,7 +65,7 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
       } ~ "\""
     }
 
-  @silent("deprecated")
+  @nowarn("deprecated")
   def QDText: Rule1[Char] = rule(!ch('"') ~ Text ~ LASTCHAR)
 
   def QuotedPair: Rule1[Char] = rule("\\" ~ Char ~ LASTCHAR)

--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -37,14 +37,14 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
 
   def LWS = rule(optional(CRLF) ~ oneOrMore(anyOf(" \t")))
 
-  @nowarn("deprecated")
+  @nowarn("msg=deprecated")
   def Text = rule(!CTL ~ ANY | LWS)
 
   def Hex = rule("A" - "F" | "a" - "f" | Digit)
 
   def Separator = rule(anyOf("()<>@,;:\\\"/[]?={} \t"))
 
-  @nowarn("deprecated")
+  @nowarn("msg=deprecated")
   def Token: Rule1[String] = rule(capture(oneOrMore(!CTL ~ !Separator ~ ANY)))
 
   // TODO What's the replacement for DROP?
@@ -54,7 +54,7 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
     ()
   }
 
-  @nowarn("deprecated")
+  @nowarn("msg=deprecated")
   def CText = rule(!anyOf("()") ~ Text)
 
   // TODO This parser cannot handle strings terminating on \" which is a border case but still valid quoted pair
@@ -65,7 +65,7 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
       } ~ "\""
     }
 
-  @nowarn("deprecated")
+  @nowarn("msg=deprecated")
   def QDText: Rule1[Char] = rule(!ch('"') ~ Text ~ LASTCHAR)
 
   def QuotedPair: Rule1[Char] = rule("\\" ~ Char ~ LASTCHAR)

--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -37,14 +37,14 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
 
   def LWS = rule(optional(CRLF) ~ oneOrMore(anyOf(" \t")))
 
-  @nowarn("msg=deprecated")
+  @nowarn("cat=deprecation")
   def Text = rule(!CTL ~ ANY | LWS)
 
   def Hex = rule("A" - "F" | "a" - "f" | Digit)
 
   def Separator = rule(anyOf("()<>@,;:\\\"/[]?={} \t"))
 
-  @nowarn("msg=deprecated")
+  @nowarn("cat=deprecation")
   def Token: Rule1[String] = rule(capture(oneOrMore(!CTL ~ !Separator ~ ANY)))
 
   // TODO What's the replacement for DROP?
@@ -54,7 +54,7 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
     ()
   }
 
-  @nowarn("msg=deprecated")
+  @nowarn("cat=deprecation")
   def CText = rule(!anyOf("()") ~ Text)
 
   // TODO This parser cannot handle strings terminating on \" which is a border case but still valid quoted pair
@@ -65,7 +65,7 @@ private[http4s] trait Rfc2616BasicRules extends Parser {
       } ~ "\""
     }
 
-  @nowarn("msg=deprecated")
+  @nowarn("cat=deprecation")
   def QDText: Rule1[Char] = rule(!ch('"') ~ Text ~ LASTCHAR)
 
   def QuotedPair: Rule1[Char] = rule("\\" ~ Char ~ LASTCHAR)

--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -60,7 +60,7 @@ object GZip {
       case resp => resp // Don't touch it, Content-Encoding already set
     }
 
-  @nowarn("deprecated")
+  @nowarn("msg=deprecated")
   private def zipResponse[F[_]: Functor](
       bufferSize: Int,
       level: Int,

--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -60,7 +60,7 @@ object GZip {
       case resp => resp // Don't touch it, Content-Encoding already set
     }
 
-  @nowarn("msg=deprecated")
+  @nowarn("cat=deprecation")
   private def zipResponse[F[_]: Functor](
       bufferSize: Int,
       level: Int,

--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -11,7 +11,6 @@ package middleware
 import cats.Functor
 import cats.data.Kleisli
 import cats.implicits._
-import com.github.ghik.silencer.silent
 import fs2.{Chunk, Pipe, Pull, Stream}
 import fs2.Stream.chunk
 import fs2.compress.deflate
@@ -19,6 +18,7 @@ import java.nio.{ByteBuffer, ByteOrder}
 import java.util.zip.{CRC32, Deflater}
 import org.http4s.headers._
 import org.log4s.getLogger
+import scala.annotation.nowarn
 
 object GZip {
   private[this] val logger = getLogger
@@ -60,7 +60,7 @@ object GZip {
       case resp => resp // Don't touch it, Content-Encoding already set
     }
 
-  @silent("deprecated")
+  @nowarn("deprecated")
   private def zipResponse[F[_]: Functor](
       bufferSize: Int,
       level: Int,


### PR DESCRIPTION
It's the basic idea @Daenyth suggested on #3764.  I'm still avoiding the (nice) scala-collection-compat library for now, just to avoid taking on more heft.

Paired with https://github.com/http4s/sbt-http4s-org/pull/33, we should be able to re-enable the `SilencerPlugin` on the dotty branch.