### PR TITLE
Revert "Fix binary compatibility issues uncovered by MiMa-0.8"

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -36,16 +36,6 @@ trait Http4sDsl2[F[_], G[_]] extends RequestDsl with Statuses with Responses[F, 
   val IntVar: impl.IntVar.type = impl.IntVar
   val LongVar: impl.LongVar.type = impl.LongVar
   val UUIDVar: impl.UUIDVar.type = impl.UUIDVar
-
-  // Restore binary compatibility with mixin forwarder
-  // TODO remove in 1.0
-  override implicit def http4sMethodSyntax(method: Method): Http4sDsl.MethodOps =
-    new Http4sDsl.MethodOps(method)
-
-  // Restore binary compatibility with mixin forwarder
-  // TODO remove in 1.0
-  override implicit def http4sMethodConcatSyntax(methods: MethodConcat): Http4sDsl.MethodConcatOps =
-    new Http4sDsl.MethodConcatOps(methods)
 }
 
 trait Http4sDsl[F[_]] extends Http4sDsl2[F, F] {


### PR DESCRIPTION
This reverts commit 1db158894111c555a60312066197538cca2d8a6e.

It is necessary in 0.21, but it's noise in 1.x.