### PR TITLE
Adjusts .gitignore for newer SBT version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ atlassian-ide-plugin.xml
 .ensime_lucene
 /TAGS
 .sbtopts
-.ensime_cache
+/.bsp/
 .cache-main
 .cache-tests
 


### PR DESCRIPTION
Adds  `/.bsp/` dir (which was introduced in SBT 1.4.0) to `.gitignore`