### PR TITLE
Ember: Chunked Default like Blaze Semantics

### DIFF
--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -16,10 +16,12 @@ private[ember] object Encoder {
 
   private val SPACE = " "
   private val CRLF = "\r\n"
+  val chunkedTansferEncodingHeaderRaw = "Transfer-Encoding: chunked"
+  
   def respToBytes[F[_]: Sync](
       resp: Response[F],
       writeBufferSize: Int = 32 * 1024): Stream[F, Byte] = {
-    val chunked = resp.isChunked
+    var chunked = resp.isChunked
     val initSection = {
       var appliedContentLength = false
       val stringBuilder = new StringBuilder()
@@ -42,7 +44,8 @@ private[ember] object Encoder {
         ()
       }
       if (!chunked && !appliedContentLength) {
-        stringBuilder.append(`Content-Length`.zero.renderString).append(CRLF)
+        stringBuilder.append(chunkedTansferEncodingHeaderRaw).append(CRLF)
+        chunked = true
         ()
       }
       // Final CRLF terminates headers and signals body to follow.
@@ -58,8 +61,9 @@ private[ember] object Encoder {
         .flatMap(Stream.chunk)
   }
 
+  
   def reqToBytes[F[_]: Sync](req: Request[F], writeBufferSize: Int = 32 * 1024): Stream[F, Byte] = {
-    val chunked = req.isChunked
+    var chunked = req.isChunked
     val initSection = {
       var appliedContentLength = false
       val stringBuilder = new StringBuilder()
@@ -94,7 +98,8 @@ private[ember] object Encoder {
       }
 
       if (!chunked && !appliedContentLength) {
-        stringBuilder.append(`Content-Length`.zero.renderString).append(CRLF)
+        stringBuilder.append(chunkedTansferEncodingHeaderRaw).append(CRLF)
+        chunked = true
         ()
       }
 

--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -17,7 +17,7 @@ private[ember] object Encoder {
   private val SPACE = " "
   private val CRLF = "\r\n"
   val chunkedTansferEncodingHeaderRaw = "Transfer-Encoding: chunked"
-  
+
   def respToBytes[F[_]: Sync](
       resp: Response[F],
       writeBufferSize: Int = 32 * 1024): Stream[F, Byte] = {
@@ -61,7 +61,6 @@ private[ember] object Encoder {
         .flatMap(Stream.chunk)
   }
 
-  
   def reqToBytes[F[_]: Sync](req: Request[F], writeBufferSize: Int = 32 * 1024): Stream[F, Byte] = {
     var chunked = req.isChunked
     val initSection = {

--- a/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
@@ -40,7 +40,9 @@ class EncoderSpec extends Specification {
       val expected =
         """GET http://www.google.com HTTP/1.1
       |Host: www.google.com
-      |Content-Length: 0
+      |Transfer-Encoding: chunked
+      |
+      |0
       |
       |""".stripMargin
 
@@ -71,7 +73,9 @@ class EncoderSpec extends Specification {
         """GET http://www.google.com HTTP/1.1
         |Host: www.google.com
         |foo: bar
-        |Content-Length: 0
+        |Transfer-Encoding: chunked
+        |
+        |0
         |
         |""".stripMargin
       Helpers.encodeRequestRig(req).unsafeRunSync() must_=== expected
@@ -84,7 +88,9 @@ class EncoderSpec extends Specification {
 
       val expected =
         """HTTP/1.1 200 OK
-      |Content-Length: 0
+      |Transfer-Encoding: chunked
+      |
+      |0
       |
       |""".stripMargin
 


### PR DESCRIPTION
Adds `0/crlf/crlf` 5 bytes to every empty request/response and transfer-encoding is just a longer string as well.

But puts us in line with blaze without the cheating based on knowing the buffer is empty.