### PR TITLE
[WIP] adding first pass at parenthesizing lambdas with regexp

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -85,7 +85,7 @@ object Metrics {
       _ <- Resource.liftF(statusRef.set(Some(resp.status)))
       end <- Resource.liftF(clock.monotonic(TimeUnit.NANOSECONDS))
       _ <- Resource.liftF(ops.recordHeadersTime(req.method, end - start, classifierF(req)))
-    } yield resp).handleErrorWith { e: Throwable =>
+    } yield resp).handleErrorWith { (e: Throwable) =>
       Resource.liftF(registerError(start, ops, classifierF(req))(e) *> F.raiseError[Response[F]](e))
     }
 

--- a/core/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -100,7 +100,7 @@ object MetricsOps {
     val pathList: List[String] =
       request.pathInfo.segments.map(_.decoded()).toList
 
-    val minusExcluded: List[String] = pathList.map { value: String =>
+    val minusExcluded: List[String] = pathList.map { (value: String) =>
       if (exclude(value)) excludedValue else value
     }
 

--- a/server/src/test/scala/org/http4s/server/middleware/MaxActiveRequestsSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/MaxActiveRequestsSpec.scala
@@ -17,7 +17,7 @@ class MaxActiveRequestsSpec extends Http4sSpec with CatsEffect {
   val req = Request[IO]()
 
   def routes(startedGate: Deferred[IO, Unit], deferred: Deferred[IO, Unit]) =
-    Kleisli { req: Request[IO] =>
+    Kleisli { (req: Request[IO]) =>
       req match {
         case other if other.method == Method.PUT => OptionT.none[IO, Response[IO]]
         case _ =>

--- a/tests/src/test/scala/org/http4s/metrics/MetricsOpsSpec.scala
+++ b/tests/src/test/scala/org/http4s/metrics/MetricsOpsSpec.scala
@@ -31,7 +31,7 @@ class MetricsOpsSpec extends Http4sSpec {
           uri = Uri.unsafeFromString(s"/users/$uuid/comments")
         )
 
-        val excludeUUIDs: String => Boolean = { str: String =>
+        val excludeUUIDs: String => Boolean = { (str: String) =>
           Either
             .catchOnly[IllegalArgumentException](UUID.fromString(str))
             .isRight
@@ -60,7 +60,7 @@ class MetricsOpsSpec extends Http4sSpec {
 
         result ==== expected
     }
-    "return '$method' if the path is '/'" in prop { method: Method =>
+    "return '$method' if the path is '/'" in prop { (method: Method) =>
       val request: Request[IO] = Request[IO](
         method = method,
         uri = uri"""/"""


### PR DESCRIPTION
Used regexp: `\{ .*:.*=>` since I had issues getting the `simulacrum-scalafix` plugin working.
 
See #3768 for more details.

I'm not _super_ confident that a regexp fix is great, since it's so fragile. That said I'll keep looking at making the scalafix rule work.