### PR TITLE
CE3 Laws upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,7 @@ lazy val laws = libraryProject("laws")
     libraryDependencies ++= Seq(
       caseInsensitiveTesting,
       catsEffectLaws,
+      catsEffectTestkit
     ),
   )
   .dependsOn(core)

--- a/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
+++ b/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package laws
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.laws._
 
@@ -26,11 +26,11 @@ trait EntityCodecLaws[F[_], A] extends EntityEncoderLaws[F, A] {
 
 object EntityCodecLaws {
   def apply[F[_], A](implicit
-      F0: Concurrent[F],
+      concurrent: Concurrent[F],
       entityEncoderFA: EntityEncoder[F, A],
       entityDecoderFA: EntityDecoder[F, A]): EntityCodecLaws[F, A] =
     new EntityCodecLaws[F, A] {
-      val F = F0
+      val F = concurrent
       val encoder = entityEncoderFA
       val decoder = entityDecoderFA
     }

--- a/laws/src/main/scala/org/http4s/laws/EntityEncoderLaws.scala
+++ b/laws/src/main/scala/org/http4s/laws/EntityEncoderLaws.scala
@@ -13,7 +13,7 @@ import cats.laws._
 import org.http4s.headers.{`Content-Length`, `Transfer-Encoding`}
 
 trait EntityEncoderLaws[F[_], A] {
-  implicit def F: Sync[F]
+  implicit def F: Concurrent[F]
 
   implicit def encoder: EntityEncoder[F, A]
 
@@ -34,7 +34,7 @@ trait EntityEncoderLaws[F[_], A] {
 
 object EntityEncoderLaws {
   def apply[F[_], A](implicit
-      F0: Sync[F],
+      F0: Concurrent[F],
       entityEncoderFA: EntityEncoder[F, A]
   ): EntityEncoderLaws[F, A] =
     new EntityEncoderLaws[F, A] {

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -785,15 +785,6 @@ private[http4s] trait ArbitraryInstances {
       dispatcher.unsafeToFuture(stream.compile.toVector)
     }
 
-  // catsEffectLawsCogenForIO[Vector[Byte]].contramap { stream =>
-  //   var bytes: Vector[Byte] = null
-  //   val readBytes = IO(bytes)
-  //   F.runAsync(stream.compile.toVector) {
-  //     case Right(bs) => IO { bytes = bs }
-  //     case Left(t) => IO.raiseError(t)
-  //   }.toIO *> readBytes
-  // }
-
   implicit def http4sTestingArbitraryForEntity[F[_]]: Arbitrary[Entity[F]] =
     Arbitrary(Gen.sized { size =>
       for {

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -11,9 +11,8 @@ package discipline
 import cats._
 import cats.data.{Chain, NonEmptyList}
 import cats.laws.discipline.arbitrary.catsLawsArbitraryForChain
-import cats.effect.{Effect, IO}
-import cats.effect.laws.discipline.arbitrary._
-import cats.effect.laws.util.TestContext
+import cats.effect.IO
+import cats.effect.testkit._
 import cats.implicits._
 import fs2.{Pure, Stream}
 import java.nio.charset.{Charset => NioCharset}

--- a/laws/src/main/scala/org/http4s/laws/discipline/EntityCodecTests.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/EntityCodecTests.scala
@@ -9,7 +9,6 @@ package laws
 package discipline
 
 import cats.Eq
-// import cats.implicits._
 import cats.effect._
 import cats.laws.discipline._
 import org.scalacheck.{Arbitrary, Prop, Shrink}

--- a/laws/src/main/scala/org/http4s/laws/discipline/EntityCodecTests.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/EntityCodecTests.scala
@@ -9,12 +9,11 @@ package laws
 package discipline
 
 import cats.Eq
-import cats.implicits._
+// import cats.implicits._
 import cats.effect._
-import cats.effect.laws.util.TestContext
-import cats.effect.laws.util.TestInstances._
 import cats.laws.discipline._
 import org.scalacheck.{Arbitrary, Prop, Shrink}
+import cats.effect.std.Dispatcher
 
 trait EntityCodecTests[F[_], A] extends EntityEncoderTests[F, A] {
   def laws: EntityCodecLaws[F, A]
@@ -27,7 +26,12 @@ trait EntityCodecTests[F[_], A] extends EntityEncoderTests[F, A] {
       shrinkA: Shrink[A],
       eqA: Eq[A],
       eqFBoolean: Eq[F[Boolean]],
-      testContext: TestContext): RuleSet =
+      dispatcher: Dispatcher[F]
+  ): RuleSet = {
+
+    implicit def eqF[T](implicit eqT: Eq[T]): Eq[F[T]] =
+      Eq.by[F[T], T](f => dispatcher.unsafeRunSync(f))
+
     new DefaultRuleSet(
       name = "EntityCodec",
       parent = Some(entityEncoder),
@@ -35,11 +39,12 @@ trait EntityCodecTests[F[_], A] extends EntityEncoderTests[F, A] {
         laws.entityCodecRoundTrip(a)
       }
     )
+  }
 }
 
 object EntityCodecTests {
   def apply[F[_], A](implicit
-      effectF: Effect[F],
+      F: Concurrent[F],
       entityEncoderFA: EntityEncoder[F, A],
       entityDecoderFA: EntityDecoder[F, A]
   ): EntityCodecTests[F, A] =

--- a/laws/src/main/scala/org/http4s/laws/discipline/EntityEncoderTests.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/EntityEncoderTests.scala
@@ -35,7 +35,7 @@ trait EntityEncoderTests[F[_], A] extends Laws {
 
 object EntityEncoderTests {
   def apply[F[_], A](implicit
-      effectF: Effect[F],
+      effectF: Concurrent[F],
       entityEncoderFA: EntityEncoder[F, A]
   ): EntityEncoderTests[F, A] =
     new EntityEncoderTests[F, A] {

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -261,6 +261,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val cats                             = "org.typelevel"          %% "cats-core"                 % V.cats
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % V.catsEffect
   lazy val catsEffectLaws                   = "org.typelevel"          %% "cats-effect-laws"          % V.catsEffect
+  lazy val catsEffectTestkit                = "org.typelevel"          %% "cats-effect-testkit"       % V.catsEffect
   lazy val catsEffectTestingSpecs2          = "com.codecommit"         %% "cats-effect-testing-specs2" % V.catsEffectTesting
   lazy val catsKernelLaws                   = "org.typelevel"          %% "cats-kernel-laws"          % V.cats
   lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % V.cats


### PR DESCRIPTION
As per the title. I spent a good chunk of time reading docs and sources and wasn't getting anywhere, so I though I'll take Fabio's advice and open a draft PR for guidance.

My troubles come from 2 places:
- `EntityCodecTests`
- `ArbitraryInstances`

I'll start with `EntityCodecTests`. To refresh your memory it currently looks like this 
```scala
    def entityCodec(implicit
        arbitraryA: Arbitrary[A],
        shrinkA: Shrink[A],
        eqA: Eq[A],
        eqFBoolean: Eq[F[Boolean]],
        testContext: TestContext): RuleSet =
      new DefaultRuleSet(
        name = "EntityCodec",
        parent = Some(entityEncoder),
        "roundTrip" -> Prop.forAll { (a: A) =>
          laws.entityCodecRoundTrip(a)
        }
      )
```

Because I changed `Effect` for `Concurrent` in `EntityCodecLaws` now `entityCodecRoundTrip` is a `IsEq[F[Either[Decodefailure, A]]`. And that is failing to be converted to a prop, and I wasn't sure what a good way forward would be. 

Admittedly I'm not very well practiced with `IsEq`. But my understanding is that for `IsEq[A]` to be converted to a prop it needs an `Eq[A]` and a `A => Pretty`. I could of course add those as implicits, but that doesn't seem like the right solution as it would shift a significant burden to the caller of this method that was previously handled internally. However, I'm not sure how to keep it inside this method either. In cats-effect tests the `Eq[IO[A]]` instance is defined by running the `IO`. As such, one option would be to add a dispatcher implicit parameter and similarly define the `Eq[F[A]]` instance in terms of running the `F` using the dispatcher. However, Daniel previously mentioned that passing a dispatcher around using implicits does not seem like a good idea. One could add an explicit parameter list with `Dispatcher` to remedy that, but that feels like it could have downstream implications that would result in requiring a not insignificant rewrite to accommodate the new `Dispatcher` requirement.

Writing this all down the last option seems like it could be the most viable, but at this point my confidence of delivering a quality replacement here is pretty low, so I'd appreciate some advice.

Anyway, on to number 2: `ArbitraryInstances`. The problem here stems from `Cogen[EntityBody[F]]`. Previously it required `F[_]` to be `Effect` and then defined the cogen in terms of `Cogen[IO[A]]` imported from cats' own `arbitraries`. There is no more `Cogen[IO[A]]` (and of course no more `Effect`) and as such this poses a problem.

The problem here is very similar to `EntityCodecTests`. Now that cats-effect-laws (or the new `testkit`) do not provide the `Cogen[IO[A]]`, one has to introduce a `Cogen[F[A]]`. This can similarly be remedied with the help of `Dispatcher`, however the question of where to source the dispatcher pops up once more. Here I thought about 4 potential solutions.

First option is similar to that of `EntityCodecTests`: add an implicit `Dispatcher`, but as I mentioned - I have some reservations as per Daniel's advice. 

Second option is to define an abstract `Dispatcher` val on the whole trait and use that to define the cogens in terms of running unsafely. This has the huge downside of one not being able to just import `arbitraries` - one would have to mix `ArbitraryInstances` in to provide the dispatcher or create per-test instances of some concrete implementation of `ArbitraryInstances` which seems like it'd introduce significant boilerplate.

Option no3 is the same as 2 except I'd extract cogens into their own trait.

Option no4 is basically 2 and 3 except the abstract val is a `Resource[Dispatcher[F]]` and is acquired in the cogen every time.

Here I'm leaning towards the implicit since it is the least intrusive, but I am wary that it is the wrong choice.


Nonetheless, I implore you for guidance. This has been rattling around in my brain not going anywhere for a number of days now and I'm anxious about moving this forward. If it'd be too much time guiding me through getting this remedied I am perfectly fine handing this off to someone else too.

Thanks for sticking through to the end of this very long read 😅 
