### PR TITLE
Render okhttp request body synchronously

### DIFF
--- a/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttpBuilder.scala
+++ b/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttpBuilder.scala
@@ -148,12 +148,9 @@ sealed abstract class OkHttpBuilder[F[_]] private (
               }
               .compile
               .drain
-              .runAsync {
-                case Left(t) =>
-                  IO(logger.warn(t)("Unable to write to OkHttp sink"))
-                case Right(_) =>
-                  IO.unit
-              }
+              // This has to be synchronous with this method, or else
+              // chunks get silently dropped.
+              .toIO
               .unsafeRunSync()
         }
       // if it's a GET or HEAD, okhttp wants us to pass null


### PR DESCRIPTION
Fixes #3810.  If the body is not rendered before the callback completes, chunks are silently dropped.

I think this needs to block one of okhttp's threads, so there's no integration with Blocker.  I don't know this backend particularly well, so we may be able to do better.  Anyhow, this fixes the sample code in #3810 for me.

Thanks to @GrafBlutwurst for the bug report.