### PR TITLE
Pin the Java version in the nix-shell

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,19 @@
+{ java }:
+
+let
+  hostPkgs = import <nixpkgs> { };
+  pinnedVersion = hostPkgs.lib.importJSON ./nixpkgs-version.json;
+  pinnedPkgs = hostPkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs-channels";
+    inherit (pinnedVersion) rev sha256;
+  };
+  config = {
+    packageOverrides = p: {
+      sbt = p.sbt.override {
+        jre = p.${java};
+      };
+    };
+  };
+in
+import pinnedPkgs { inherit config; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,13 @@
 let
-  pkgs = import ./nix;
+  java = "openjdk8_headless";
+  pkgs = import ./nix/pkgs.nix { inherit java; };
   hugo = pkgs.callPackage ./nix/hugo.nix {};
 in
 pkgs.mkShell {
   buildInputs = [
     pkgs.git
-    pkgs.openjdk8_headless
-    pkgs.sbt
     hugo
+    pkgs.${java}
+    pkgs.sbt
   ];
 }


### PR DESCRIPTION
This ensures we get a Java 8 even in SBT.

I realize I'm probably the only one who cares.