### PR TITLE
Remove sbt-coursier

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,6 @@ addSbtPlugin("com.typesafe.sbt"           %  "sbt-site"                  % "1.4.
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-twirl"                 % "1.5.0")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-native-packager"       % "1.6.1")
 addSbtPlugin("de.heikoseeberger"          %  "sbt-header"                % "5.6.0")
-addSbtPlugin("io.get-coursier"            %  "sbt-coursier"              % "1.0.3")
 addSbtPlugin("io.github.davidgregory084"  %  "sbt-tpolecat"              % "0.1.13")
 addSbtPlugin("io.spray"                   %  "sbt-revolver"              % "0.9.1")
 addSbtPlugin("pl.project13.scala"         %  "sbt-jmh"                   % "0.3.7")


### PR DESCRIPTION
Not needed in modern SBT, and is causing the dotty branch to fail to load.

Thanks to @mpilquist for finding this one.