### PR TITLE
Start trying to cross build for 3.0.0-M1

### DIFF
--- a/project/SilencerPlugin2.scala
+++ b/project/SilencerPlugin2.scala
@@ -1,0 +1,39 @@
+package org.http4s.sbt
+
+import sbt._
+import sbt.Keys._
+
+import dotty.tools.sbtplugin.DottyPlugin
+import dotty.tools.sbtplugin.DottyPlugin.autoImport._
+import explicitdeps.ExplicitDepsPlugin.autoImport._
+import CompileTimePlugin.CompileTime
+
+// Hack around bug in sbt-http4s-org
+object SilencerPlugin2 extends AutoPlugin {
+  object autoImport {
+    val silencerVersion = settingKey[String]("Version of the silencer compiler plugin")
+  }
+
+  import autoImport._
+
+  override def trigger = noTrigger
+  override def requires = DottyPlugin && CompileTimePlugin
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    silencerVersion := "1.7.0",
+    libraryDependencies ++= {
+      if (isDotty.value || true) Seq.empty
+      else
+        Seq(
+          compilerPlugin(
+            ("com.github.ghik" % "silencer-plugin" % silencerVersion.value).cross(
+              CrossVersion.full)),
+          ("com.github.ghik" % "silencer-lib" % silencerVersion.value % CompileTime)
+            .cross(CrossVersion.full),
+          ("com.github.ghik" % "silencer-lib" % silencerVersion.value % Test)
+            .cross(CrossVersion.full)
+        )
+    },
+    unusedCompileDependenciesFilter -= moduleFilter("com.github.ghik", name = "silencer-lib")
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,7 @@ libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 // https://github.com/coursier/coursier/issues/450
 classpathTypes += "maven-plugin"
 
+addSbtPlugin("ch.epfl.lamp"               %  "sbt-dotty"                 % "0.4.5")
 addSbtPlugin("ch.epfl.scala"              %  "sbt-scalafix"              % "0.9.23")
 addSbtPlugin("com.earldouglas"            %  "xsbt-web-plugin"           % "4.1.0")
 addSbtPlugin("com.eed3si9n"               %  "sbt-buildinfo"             % "0.9.0")
@@ -16,7 +17,6 @@ addSbtPlugin("com.typesafe.sbt"           %  "sbt-site"                  % "1.4.
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-twirl"                 % "1.5.0")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-native-packager"       % "1.6.1")
 addSbtPlugin("de.heikoseeberger"          %  "sbt-header"                % "5.6.0")
-addSbtPlugin("io.get-coursier"            %  "sbt-coursier"              % "1.0.3")
 addSbtPlugin("io.github.davidgregory084"  %  "sbt-tpolecat"              % "0.1.13")
 addSbtPlugin("io.spray"                   %  "sbt-revolver"              % "0.9.1")
 addSbtPlugin("pl.project13.scala"         %  "sbt-jmh"                   % "0.3.7")


### PR DESCRIPTION
From here, we can run `++3.0.0-M1 core/test` (which still fails), and the Scala 2 builds should be undisturbed.

If we can make progress on Dotty without breaking Scala 2, then we can drop the long-running `dotty` branch, which is almost entirely merge commits.