### PR TITLE
Make scalatags encoder a bit more generic

### DIFF
--- a/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
+++ b/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
@@ -7,15 +7,15 @@
 package org.http4s
 package scalatags
 
-import _root_.scalatags.Text.TypedTag
+import _root_.scalatags.generic.Frag
 import org.http4s.headers.`Content-Type`
 
 trait ScalatagsInstances {
-  implicit def scalatagsEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, TypedTag[String]] =
+  implicit def scalatagsEncoder[F[_], C <: Frag[_, String]](implicit
+      charset: Charset = DefaultCharset): EntityEncoder[F, C] =
     contentEncoder(MediaType.text.html)
 
-  private def contentEncoder[F[_], C <: TypedTag[String]](mediaType: MediaType)(implicit
+  private def contentEncoder[F[_], C <: Frag[_, String]](mediaType: MediaType)(implicit
       charset: Charset): EntityEncoder[F, C] =
     EntityEncoder
       .stringEncoder[F]


### PR DESCRIPTION
This is necessary to render fragments with `Frag` annotations.