### PR TITLE
Http4sLegacyMatchersIO

### DIFF
--- a/testing/src/test/scala/org/http4s/testing/Http4sLegacyMatchersIO.scala
+++ b/testing/src/test/scala/org/http4s/testing/Http4sLegacyMatchersIO.scala
@@ -8,6 +8,12 @@ package org.http4s
 package testing
 
 import cats.effect.IO
-import org.specs2.matcher.{IOMatchers => Specs2IOMatchers}
+import cats.effect.unsafe.implicits.global
+import scala.concurrent.duration.FiniteDuration
 
-trait Http4sLegacyMatchersIO extends Http4sLegacyMatchers[IO] with Specs2IOMatchers
+trait Http4sLegacyMatchersIO extends Http4sLegacyMatchers[IO] {
+
+  protected def runWithTimeout[A](fa: IO[A], d: FiniteDuration): A = fa.timeout(d).unsafeRunSync()
+  protected def runAwait[A](fa: IO[A]): A = fa.unsafeRunSync()
+
+}


### PR DESCRIPTION
Previously it depended on `org.specs2.matcher.IOMatchers`, which was using ce2 classes in the implementation. I removed it as a mix-in and attempted to reimplement its behavior straight on `Http4sLegacyMatchersIO`. While I _think_ this is the correct implementation, `IOMatchers` ([link](https://github.com/etorreborre/specs2/blob/master/cats/shared/src/main/scala/org/specs2/matcher/IOMatchers.scala#L71)) also had a section which I didn't quite get

```scala
  protected[specs2] override def attemptRun[T](check: ValueCheck[T], duration: Option[FiniteDuration]): IOMatcher[T] =
    IOMatcher(check, duration)

  case class IOMatcher[T](check: ValueCheck[T], duration: Option[FiniteDuration])
      extends TimedMatcher[T](check, duration) {
    def checkIOWithDuration[S <: IO[T]](e: Expectable[S], d: FiniteDuration): MatchResult[S] =
      checkWithDuration(e, d)
    def checkIO[S <: IO[T]](e: Expectable[S]) = checkAwait(e)
  }
```

I don't quite get what the deal with `IOMatcher` is; it defines new methods, and is returned from attemptRun; but unless the callers of `attemptRun` check whether they got an `IOMatcher` surely they can't use those newly defined methods? 

Either way, hopefully that override is not important because it is `protected[specs2]` so if it is required, then we'd need a ce3 version of specs2.

I wanted to test these changes in action by testing `dsl`, but ran into a different issue with `vault` depending on ce2. I raised an [issue](https://github.com/ChristopherDavenport/vault/issues/159) on `vault` about it; I'll try to get it remedied asap, but it might still take a moment and further upgrades could similarly be stuck on `Http4sLegacyMatchersIO` be broken as DSL was (hence me discovering the issue).

I'll leave it up to you if further testing/investigation is required or if this is good for now.