### PR TITLE
Add Ability to pass own client in AsyncHttpClient so that it's state can be referenced

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -201,6 +201,7 @@ object AsyncHttpClient {
     def getTotalConnectionCount: F[Long] = F.delay(underlying.getTotalConnectionCount)
     def getTotalActiveConnectionCount: F[Long] = F.delay(underlying.getTotalActiveConnectionCount)
     def getTotalIdleConnectionCount: F[Long] = F.delay(underlying.getTotalIdleConnectionCount)
-    def getStatsPerHost: F[mutable.Map[String, HostStats]] = F.delay(underlying.getStatsPerHost.asScala)
+    def getStatsPerHost: F[mutable.Map[String, HostStats]] =
+      F.delay(underlying.getStatsPerHost.asScala)
   }
 }

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -29,6 +29,8 @@ import _root_.io.netty.handler.codec.http.cookie.Cookie
 import org.asynchttpclient.uri.Uri
 import org.asynchttpclient.cookie.CookieStore
 
+import scala.collection.mutable
+
 object AsyncHttpClient {
   val defaultConfig: DefaultAsyncHttpClientConfig = new DefaultAsyncHttpClientConfig.Builder()
     .setMaxConnectionsPerHost(200)
@@ -193,11 +195,12 @@ object AsyncHttpClient {
     override def clear(): Boolean = false
   }
 
-  final case class AsyncHttpClientStats[F[_]: Sync](underlying: ClientStats)(implicit F: Sync[F]) {
+  final case class AsyncHttpClientStats[F[_]: Sync](private val underlying: ClientStats)(implicit
+      F: Sync[F]) {
 
     def getTotalConnectionCount: F[Long] = F.delay(underlying.getTotalConnectionCount)
     def getTotalActiveConnectionCount: F[Long] = F.delay(underlying.getTotalActiveConnectionCount)
     def getTotalIdleConnectionCount: F[Long] = F.delay(underlying.getTotalIdleConnectionCount)
-    def getStatsPerHost: F[Map[String, HostStats]] = F.delay(underlying.getStatsPerHost.asScala)
+    def getStatsPerHost: F[mutable.Map[String, HostStats]] = F.delay(underlying.getStatsPerHost.asScala)
   }
 }

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -29,8 +29,6 @@ import _root_.io.netty.handler.codec.http.cookie.Cookie
 import org.asynchttpclient.uri.Uri
 import org.asynchttpclient.cookie.CookieStore
 
-import scala.collection.mutable
-
 object AsyncHttpClient {
   val defaultConfig: DefaultAsyncHttpClientConfig = new DefaultAsyncHttpClientConfig.Builder()
     .setMaxConnectionsPerHost(200)
@@ -193,15 +191,5 @@ object AsyncHttpClient {
     override def getAll: java.util.List[Cookie] = empty
     override def remove(pred: java.util.function.Predicate[Cookie]): Boolean = false
     override def clear(): Boolean = false
-  }
-
-  final case class AsyncHttpClientStats[F[_]: Sync](private val underlying: ClientStats)(implicit
-      F: Sync[F]) {
-
-    def getTotalConnectionCount: F[Long] = F.delay(underlying.getTotalConnectionCount)
-    def getTotalActiveConnectionCount: F[Long] = F.delay(underlying.getTotalActiveConnectionCount)
-    def getTotalIdleConnectionCount: F[Long] = F.delay(underlying.getTotalIdleConnectionCount)
-    def getStatsPerHost: F[mutable.Map[String, HostStats]] =
-      F.delay(underlying.getStatsPerHost.asScala)
   }
 }

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClientStats.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClientStats.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s.client.asynchttpclient
+
+import cats.effect.Sync
+import org.asynchttpclient.{ClientStats, HostStats}
+
+import scala.jdk.CollectionConverters.MapHasAsScala
+
+class AsyncHttpClientStats[F[_]: Sync](private val underlying: ClientStats)(implicit F: Sync[F]) {
+
+  def getTotalConnectionCount: F[Long] = F.delay(underlying.getTotalConnectionCount)
+  def getTotalActiveConnectionCount: F[Long] = F.delay(underlying.getTotalActiveConnectionCount)
+  def getTotalIdleConnectionCount: F[Long] = F.delay(underlying.getTotalIdleConnectionCount)
+  def getStatsPerHost: F[Map[String, HostStats]] =
+    F.delay(underlying.getStatsPerHost.asScala.toMap)
+}

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClientStats.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClientStats.scala
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.http4s.client.asynchttpclient
+package org.http4s
+package client
+package asynchttpclient
 
 import cats.effect.Sync
-import org.asynchttpclient.{ClientStats, HostStats}
-
-import scala.jdk.CollectionConverters.MapHasAsScala
+import org.asynchttpclient.{ClientStats, HostStats, Response => _}
+import org.http4s.internal.CollectionCompat.CollectionConverters._
 
 class AsyncHttpClientStats[F[_]: Sync](private val underlying: ClientStats)(implicit F: Sync[F]) {
 

--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/AsyncHttpClientSpec.scala
@@ -8,11 +8,13 @@ package org.http4s
 package client
 package asynchttpclient
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
+import org.asynchttpclient.DefaultAsyncHttpClient
+import org.http4s.client.asynchttpclient.AsyncHttpClient.AsyncHttpClientStats
 
 class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient") with Http4sSpec {
 
-  def clientResource = AsyncHttpClient.resource[IO]()
+  def clientResource: Resource[IO, Client[IO]] = AsyncHttpClient.resource[IO]()
 
   "AsyncHttpClient configure" should {
     "evaluate to the defaultConfiguration given the identity function as the configuration function" in {
@@ -61,5 +63,36 @@ class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient") with
       customConfig.getMaxConnections shouldEqual customMaxConnections
       customConfig.getRequestTimeout shouldEqual customRequestTimeout
     }
+  }
+
+  "AsyncHttpClient stats" should {
+    "correctly get the status from the underlying ClientStats" in {
+
+      val clientWithStats: Resource[IO, Client[IO]] = Resource(
+        IO.delay(new DefaultAsyncHttpClient(AsyncHttpClient.defaultConfig))
+          .map(c =>
+            (
+              ClientWithStats(AsyncHttpClient.apply(c), AsyncHttpClientStats[IO](c.getClientStats)),
+              IO.delay(c.close()))))
+
+      val clientStats: Resource[IO, AsyncHttpClientStats[IO]] = clientWithStats.map {
+        case client: ClientWithStats => client.getStats
+      }
+
+      def extractStats[Stats](
+          stats: Resource[IO, AsyncHttpClientStats[IO]],
+          f: AsyncHttpClientStats[IO] => IO[Stats]): Stats =
+        stats.map(f).use(x => x).unsafeRunSync()
+
+      extractStats(clientStats, _.getTotalIdleConnectionCount) shouldEqual 0
+      extractStats(clientStats, _.getTotalConnectionCount) shouldEqual 0
+      extractStats(clientStats, _.getTotalIdleConnectionCount) shouldEqual 0
+      extractStats(clientStats, _.getStatsPerHost) shouldEqual scala.collection.mutable.Map.empty
+    }
+  }
+  case class ClientWithStats(client: Client[IO], private val stats: AsyncHttpClientStats[IO])
+      extends DefaultClient[IO] {
+    def getStats: AsyncHttpClientStats[IO] = stats
+    override def run(req: Request[IO]): Resource[IO, Response[IO]] = client.run(req)
   }
 }


### PR DESCRIPTION
Currently there is no way to access `org.asynchttpclient.DefaultAsyncHttpClient#getClientStat` when we create a `Resource[F, Client[F]]` using `org.http4s.client.asynchttpclient.AsyncHttpClient#resource`.

This PR adds an additional apply method in `AsyncHttpClient` which lets the user pass in their own `DefaultAsyncHttpClient` so that they can have a handle on its state and use it for metrics etc.