### PR TITLE
EntityDecoder constraints loosened

### DIFF
--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -7,14 +7,13 @@
 package org.http4s
 
 import cats.{Applicative, Functor, Monad, SemigroupK}
-import cats.effect.Sync
+import cats.effect.Concurrent
 import cats.implicits._
 import fs2._
 import fs2.io.file.Files
 import java.io.File
 import org.http4s.multipart.{Multipart, MultipartDecoder}
 import scala.annotation.implicitNotFound
-import cats.effect.Concurrent
 
 /** A type that can be used to decode a [[Message]]
   * EntityDecoder is used to attempt to decode a [[Message]] returning the
@@ -179,49 +178,49 @@ object EntityDecoder {
     }
 
   /** Helper method which simply gathers the body into a single Chunk */
-  def collectBinary[F[_]: Sync](m: Media[F]): DecodeResult[F, Chunk[Byte]] =
+  def collectBinary[F[_]: Concurrent](m: Media[F]): DecodeResult[F, Chunk[Byte]] =
     DecodeResult.success(m.body.chunks.compile.toVector.map(Chunk.concatBytes))
 
   @deprecated(
     "Can go into an infinite loop for charsets other than UTF-8. Replaced by decodeText",
     "0.21.5")
   def decodeString[F[_]](
-      m: Media[F])(implicit F: Sync[F], defaultCharset: Charset = DefaultCharset): F[String] =
+      m: Media[F])(implicit F: Concurrent[F], defaultCharset: Charset = DefaultCharset): F[String] =
     m.bodyAsText.compile.string
 
   /** Decodes a message to a String */
   def decodeText[F[_]](
-      m: Media[F])(implicit F: Sync[F], defaultCharset: Charset = DefaultCharset): F[String] =
+      m: Media[F])(implicit F: Concurrent[F], defaultCharset: Charset = DefaultCharset): F[String] =
     m.bodyText.compile.string
 
   /////////////////// Instances //////////////////////////////////////////////
 
   /** Provides a mechanism to fail decoding */
-  def error[F[_], T](t: Throwable)(implicit F: Sync[F]): EntityDecoder[F, T] =
+  def error[F[_], T](t: Throwable)(implicit F: Concurrent[F]): EntityDecoder[F, T] =
     new EntityDecoder[F, T] {
       override def decode(m: Media[F], strict: Boolean): DecodeResult[F, T] =
         DecodeResult(m.body.compile.drain *> F.raiseError(t))
       override def consumes: Set[MediaRange] = Set.empty
     }
 
-  implicit def binary[F[_]: Sync]: EntityDecoder[F, Chunk[Byte]] =
+  implicit def binary[F[_]: Concurrent]: EntityDecoder[F, Chunk[Byte]] =
     EntityDecoder.decodeBy(MediaRange.`*/*`)(collectBinary[F])
 
   @deprecated("Use `binary` instead", "0.19.0-M2")
-  def binaryChunk[F[_]: Sync]: EntityDecoder[F, Chunk[Byte]] =
+  def binaryChunk[F[_]: Concurrent]: EntityDecoder[F, Chunk[Byte]] =
     binary[F]
 
-  implicit def byteArrayDecoder[F[_]: Sync]: EntityDecoder[F, Array[Byte]] =
+  implicit def byteArrayDecoder[F[_]: Concurrent]: EntityDecoder[F, Array[Byte]] =
     binary.map(_.toArray)
 
   implicit def text[F[_]](implicit
-      F: Sync[F],
+      F: Concurrent[F],
       defaultCharset: Charset = DefaultCharset): EntityDecoder[F, String] =
     EntityDecoder.decodeBy(MediaRange.`text/*`)(msg =>
       collectBinary(msg).map(chunk =>
         new String(chunk.toArray, msg.charset.getOrElse(defaultCharset).nioCharset)))
 
-  implicit def charArrayDecoder[F[_]: Sync]: EntityDecoder[F, Array[Char]] =
+  implicit def charArrayDecoder[F[_]: Concurrent]: EntityDecoder[F, Array[Char]] =
     text.map(_.toArray)
 
   // File operations
@@ -241,7 +240,7 @@ object EntityDecoder {
     MultipartDecoder.decoder
 
   /** An entity decoder that ignores the content and returns unit. */
-  implicit def void[F[_]: Sync]: EntityDecoder[F, Unit] =
+  implicit def void[F[_]: Concurrent]: EntityDecoder[F, Unit] =
     EntityDecoder.decodeBy(MediaRange.`*/*`) { msg =>
       DecodeResult.success(msg.body.drain.compile.drain)
     }

--- a/core/src/main/scala/org/http4s/FormDataDecoder.scala
+++ b/core/src/main/scala/org/http4s/FormDataDecoder.scala
@@ -9,7 +9,7 @@ package org.http4s
 import cats.Applicative
 import cats.data.Validated.Valid
 import cats.data.{Chain, ValidatedNel}
-import cats.effect.Sync
+import cats.effect.Concurrent
 import cats.implicits._
 
 /** A decoder ware that uses [[QueryParamDecoder]] to decode values in [[org.http4s.UrlForm]]
@@ -89,7 +89,7 @@ object FormDataDecoder {
       def apply(data: FormData): Result[A] = f(data)
     }
 
-  implicit def formEntityDecoder[F[_]: Sync, A](implicit
+  implicit def formEntityDecoder[F[_]: Concurrent, A](implicit
       fdd: FormDataDecoder[A]
   ): EntityDecoder[F, A] =
     UrlForm.entityDecoder[F].flatMapR { d =>

--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.{Eq, Monoid}
 import cats.data.Chain
-import cats.effect.Sync
+import cats.effect.Concurrent
 import cats.implicits._
 import org.http4s.headers._
 import org.http4s.internal.CollectionCompat
@@ -95,7 +95,7 @@ object UrlForm {
       .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`, charset))
 
   implicit def entityDecoder[F[_]](implicit
-      F: Sync[F],
+      F: Concurrent[F],
       defaultCharset: Charset = DefaultCharset): EntityDecoder[F, UrlForm] =
     EntityDecoder.decodeBy(MediaType.application.`x-www-form-urlencoded`) { m =>
       DecodeResult(


### PR DESCRIPTION
As per the discussion on gitter.

I also have a separate branch where I went over other `Sync` usages in core, but I think that might need some discussion, so for the sake of expediency I'm PRing this separately first.