### PR TITLE
migrate json4s, json4s-native, json4s-jackson to cats-effect 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val modules: List[ProjectReference] = List(
   // circe,
    json4s,
    json4sNative,
-  // json4sJackson,
+   json4sJackson,
   // playJson,
   // scalaXml,
   twirl,

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val modules: List[ProjectReference] = List(
   // argonaut,
   // boopickle,
   // circe,
-  // json4s,
+   json4s,
    json4sNative,
   // json4sJackson,
   // playJson,

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val modules: List[ProjectReference] = List(
   // boopickle,
   // circe,
   // json4s,
-  // json4sNative,
+   json4sNative,
   // json4sJackson,
   // playJson,
   // scalaXml,

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -7,27 +7,28 @@
 package org.http4s
 package json4s
 
-import cats.effect.Sync
+import cats.effect.Concurrent
 import cats.implicits._
 import org.http4s.headers.`Content-Type`
 import org.json4s._
 import org.json4s.JsonAST.JValue
 import org.typelevel.jawn.support.json4s.Parser
 
+import scala.util.Try
+
 object CustomParser extends Parser(useBigDecimalForDouble = true, useBigIntForLong = true)
 
 trait Json4sInstances[J] {
-  implicit def jsonDecoder[F[_]](implicit F: Sync[F]): EntityDecoder[F, JValue] =
+  implicit def jsonDecoder[F[_]](implicit F: Concurrent[F]): EntityDecoder[F, JValue] =
     jawn.jawnDecoder(F, CustomParser.facade)
 
-  def jsonOf[F[_], A](implicit reader: Reader[A], F: Sync[F]): EntityDecoder[F, A] =
+  def jsonOf[F[_], A](implicit reader: Reader[A], F: Concurrent[F]): EntityDecoder[F, A] =
     jsonDecoder.flatMapR { json =>
       DecodeResult(
-        F.delay(reader.read(json))
-          .map[Either[DecodeFailure, A]](Right(_))
-          .recover { case e: MappingException =>
-            Left(InvalidMessageBodyFailure("Could not map JSON", Some(e)))
-          })
+        F.pure(
+          Try(reader.read(json)).toEither
+            .leftMap[DecodeFailure](e => InvalidMessageBodyFailure("Could not map JSON", Some(e)))
+        ))
     }
 
   /** Uses formats to extract a value from JSON.
@@ -36,13 +37,16 @@ trait Json4sInstances[J] {
     * idiomatic http4s, than [[jsonOf]].
     */
   def jsonExtract[F[_], A](implicit
-      F: Sync[F],
+      F: Concurrent[F],
       formats: Formats,
       manifest: Manifest[A]): EntityDecoder[F, A] =
     jsonDecoder.flatMapR { json =>
       DecodeResult(
-        F.delay[Either[DecodeFailure, A]](Right(json.extract[A]))
-          .handleError(e => Left(InvalidMessageBodyFailure("Could not extract JSON", Some(e)))))
+        F.pure(
+          Try(json.extract[A]).toEither
+            .leftMap[DecodeFailure](e =>
+              InvalidMessageBodyFailure("Could not extract JSON", Some(e)))
+        ))
     }
 
   protected def jsonMethods: JsonMethods[J]
@@ -79,7 +83,7 @@ trait Json4sInstances[J] {
         JString(uri.toString)
     }
 
-  implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
+  implicit class MessageSyntax[F[_]: Concurrent](self: Message[F]) {
     def decodeJson[A](implicit decoder: Reader[A]): F[A] =
       self.as(implicitly, jsonOf[F, A])
   }

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -8,11 +8,12 @@ package org.http4s
 package json4s
 
 import cats.effect.Concurrent
-import cats.implicits._
 import org.http4s.headers.`Content-Type`
 import org.json4s._
 import org.json4s.JsonAST.JValue
 import org.typelevel.jawn.support.json4s.Parser
+
+import scala.util.control.NonFatal
 
 object CustomParser extends Parser(useBigDecimalForDouble = true, useBigIntForLong = true)
 
@@ -26,7 +27,7 @@ trait Json4sInstances[J] {
         F.pure {
           try Right(reader.read(json))
           catch {
-            case e: Exception => Left(InvalidMessageBodyFailure("Could not map JSON", Some(e)))
+            case NonFatal(e) => Left(InvalidMessageBodyFailure("Could not map JSON", Some(e)))
           }
         }
       )
@@ -46,7 +47,7 @@ trait Json4sInstances[J] {
         F.pure {
           try Right(json.extract[A])
           catch {
-            case e: Exception => Left(InvalidMessageBodyFailure("Could not extract JSON", Some(e)))
+            case NonFatal(e) => Left(InvalidMessageBodyFailure("Could not extract JSON", Some(e)))
           }
         }
       )


### PR DESCRIPTION
I'd like to enable some tests to check https://github.com/http4s/http4s/pull/3871

Now that we are using `Concurrent` instead of `Sync`, we cannot use `F.delay` anymore.
I'm not sure that would be the right approach here.

I've started with `pure`.
As the parsing of a json can take CPU time, should we signal it that some way so that maybe a new thread should be used for it? Could this block a fiber?

Should we use something different from `F.pure()`? `F.unit.as()`?