### PR TITLE
Loosened some constraints in core

### DIFF
--- a/core/src/main/scala/org/http4s/HttpApp.scala
+++ b/core/src/main/scala/org/http4s/HttpApp.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.Applicative
 import cats.data.Kleisli
-import cats.effect.Sync
+import cats.Defer
 
 /** Functions for creating [[HttpApp]] kleislis. */
 object HttpApp {
@@ -21,7 +21,7 @@ object HttpApp {
     * @param run the function to lift
     * @return an [[HttpApp]] that wraps `run`
     */
-  def apply[F[_]: Sync](run: Request[F] => F[Response[F]]): HttpApp[F] =
+  def apply[F[_]: Defer](run: Request[F] => F[Response[F]]): HttpApp[F] =
     Http(run)
 
   /** Lifts an effectful [[Response]] into an [[HttpApp]].
@@ -52,7 +52,7 @@ object HttpApp {
     * @return An [[HttpApp]] whose input is transformed by `f` before
     * being applied to `fa`
     */
-  def local[F[_]](f: Request[F] => Request[F])(fa: HttpApp[F])(implicit F: Sync[F]): HttpApp[F] =
+  def local[F[_]](f: Request[F] => Request[F])(fa: HttpApp[F])(implicit F: Defer[F]): HttpApp[F] =
     Http.local(f)(fa)
 
   /** An app that always returns `404 Not Found`. */

--- a/core/src/main/scala/org/http4s/implicits.scala
+++ b/core/src/main/scala/org/http4s/implicits.scala
@@ -6,4 +6,4 @@
 
 package org.http4s
 
-object implicits extends syntax.AllSyntaxBinCompat
+object implicits extends syntax.AllSyntax

--- a/core/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/src/main/scala/org/http4s/internal/Logger.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.internal
 
-import cats.effect.Sync
+import cats.effect.Concurrent
 import cats.implicits._
 import fs2.Stream
 import org.http4s.{Charset, Headers, MediaType, Message, Request, Response}
@@ -18,7 +18,7 @@ object Logger {
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains)(
-      log: String => F[Unit])(implicit F: Sync[F]): F[Unit] = {
+      log: String => F[Unit])(implicit F: Concurrent[F]): F[Unit] = {
     val charset = message.charset
     val isBinary = message.contentType.exists(_.mediaType.binary)
     val isJson = message.contentType.exists(mT =>
@@ -67,7 +67,7 @@ object Logger {
       logHeaders: Boolean,
       logBodyText: Stream[F, Byte] => Option[F[String]],
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains)(
-      log: String => F[Unit])(implicit F: Sync[F]): F[Unit] = {
+      log: String => F[Unit])(implicit F: Concurrent[F]): F[Unit] = {
     def prelude =
       message match {
         case Request(method, uri, httpVersion, _, _, _) =>

--- a/core/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/src/main/scala/org/http4s/multipart/Part.scala
@@ -41,13 +41,13 @@ object Part {
       Headers(`Content-Disposition`("form-data", Map("name" -> name)) :: headers.toList),
       Stream.emit(value).through(utf8Encode))
 
-  def fileData[F[_]: Sync: Files](name: String, file: File, headers: Header*): Part[F] =
+  def fileData[F[_]: Files](name: String, file: File, headers: Header*): Part[F] =
     fileData(name, file.getName, Files[F].readAll(file.toPath, ChunkSize), headers: _*)
 
   def fileData[F[_]: Sync](name: String, resource: URL, headers: Header*): Part[F] =
     fileData(name, resource.getPath.split("/").last, resource.openStream(), headers: _*)
 
-  def fileData[F[_]: Sync](
+  def fileData[F[_]](
       name: String,
       filename: String,
       entityBody: EntityBody[F],

--- a/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/AllSyntax.scala
@@ -7,11 +7,6 @@
 package org.http4s
 package syntax
 
-abstract class AllSyntaxBinCompat
-    extends AllSyntax
-    with KleisliSyntaxBinCompat0
-    with KleisliSyntaxBinCompat1
-
 trait AllSyntax
     extends AnyRef
     with KleisliSyntax

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -16,18 +16,14 @@ trait KleisliSyntax {
   implicit def http4sKleisliResponseSyntaxOptionT[F[_]: Functor, A](
       kleisli: Kleisli[OptionT[F, *], A, Response[F]]): KleisliResponseOps[F, A] =
     new KleisliResponseOps[F, A](kleisli)
-}
 
-trait KleisliSyntaxBinCompat0 {
   implicit def http4sKleisliHttpRoutesSyntax[F[_]: Functor](
       routes: HttpRoutes[F]): KleisliHttpRoutesOps[F] =
     new KleisliHttpRoutesOps[F](routes)
 
   implicit def http4sKleisliHttpAppSyntax[F[_]: Functor](app: HttpApp[F]): KleisliHttpAppOps[F] =
     new KleisliHttpAppOps[F](app)
-}
 
-trait KleisliSyntaxBinCompat1 {
   implicit def http4sKleisliAuthedRoutesSyntax[F[_]: Functor, A](
       authedRoutes: AuthedRoutes[A, F]): KleisliAuthedRoutesOps[F, A] =
     new KleisliAuthedRoutesOps[F, A](authedRoutes)

--- a/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -9,8 +9,8 @@ package syntax
 
 import cats.{Functor, ~>}
 import cats.syntax.functor._
-import cats.effect.Sync
 import cats.data.{Kleisli, OptionT}
+import cats.Defer
 
 trait KleisliSyntax {
   implicit def http4sKleisliResponseSyntaxOptionT[F[_]: Functor, A](
@@ -19,16 +19,16 @@ trait KleisliSyntax {
 }
 
 trait KleisliSyntaxBinCompat0 {
-  implicit def http4sKleisliHttpRoutesSyntax[F[_]: Sync](
+  implicit def http4sKleisliHttpRoutesSyntax[F[_]: Functor](
       routes: HttpRoutes[F]): KleisliHttpRoutesOps[F] =
     new KleisliHttpRoutesOps[F](routes)
 
-  implicit def http4sKleisliHttpAppSyntax[F[_]: Sync](app: HttpApp[F]): KleisliHttpAppOps[F] =
+  implicit def http4sKleisliHttpAppSyntax[F[_]: Functor](app: HttpApp[F]): KleisliHttpAppOps[F] =
     new KleisliHttpAppOps[F](app)
 }
 
 trait KleisliSyntaxBinCompat1 {
-  implicit def http4sKleisliAuthedRoutesSyntax[F[_]: Sync, A](
+  implicit def http4sKleisliAuthedRoutesSyntax[F[_]: Functor, A](
       authedRoutes: AuthedRoutes[A, F]): KleisliAuthedRoutesOps[F, A] =
     new KleisliAuthedRoutesOps[F, A](authedRoutes)
 }
@@ -38,17 +38,17 @@ final class KleisliResponseOps[F[_]: Functor, A](self: Kleisli[OptionT[F, *], A,
     Kleisli(a => self.run(a).getOrElse(Response.notFound))
 }
 
-final class KleisliHttpRoutesOps[F[_]: Sync](self: HttpRoutes[F]) {
-  def translate[G[_]: Sync](fk: F ~> G)(gK: G ~> F): HttpRoutes[G] =
+final class KleisliHttpRoutesOps[F[_]: Functor](self: HttpRoutes[F]) {
+  def translate[G[_]: Defer: Functor](fk: F ~> G)(gK: G ~> F): HttpRoutes[G] =
     HttpRoutes(request => self.run(request.mapK(gK)).mapK(fk).map(_.mapK(fk)))
 }
 
-final class KleisliHttpAppOps[F[_]: Sync](self: HttpApp[F]) {
-  def translate[G[_]: Sync](fk: F ~> G)(gK: G ~> F): HttpApp[G] =
+final class KleisliHttpAppOps[F[_]: Functor](self: HttpApp[F]) {
+  def translate[G[_]: Defer](fk: F ~> G)(gK: G ~> F): HttpApp[G] =
     HttpApp(request => fk(self.run(request.mapK(gK)).map(_.mapK(fk))))
 }
 
-final class KleisliAuthedRoutesOps[F[_]: Sync, A](self: AuthedRoutes[A, F]) {
-  def translate[G[_]: Sync](fk: F ~> G)(gK: G ~> F): AuthedRoutes[A, G] =
+final class KleisliAuthedRoutesOps[F[_]: Functor, A](self: AuthedRoutes[A, F]) {
+  def translate[G[_]: Defer: Functor](fk: F ~> G)(gK: G ~> F): AuthedRoutes[A, G] =
     AuthedRoutes(authedReq => self.run(authedReq.mapK(gK)).mapK(fk).map(_.mapK(fk)))
 }

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 package object syntax {
   object all extends AllSyntax
-  object kleisli extends KleisliSyntax with KleisliSyntaxBinCompat0 with KleisliSyntaxBinCompat1
+  object kleisli extends KleisliSyntax 
   object literals extends LiteralsSyntax
   @deprecated("Use cats.foldable._", "0.18.5")
   object nonEmptyList extends NonEmptyListSyntax

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 package object syntax {
   object all extends AllSyntax
-  object kleisli extends KleisliSyntax 
+  object kleisli extends KleisliSyntax
   object literals extends LiteralsSyntax
   @deprecated("Use cats.foldable._", "0.18.5")
   object nonEmptyList extends NonEmptyListSyntax

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 package object syntax {
-  object all extends AllSyntaxBinCompat
+  object all extends AllSyntax
   object kleisli extends KleisliSyntax with KleisliSyntaxBinCompat0 with KleisliSyntaxBinCompat1
   object literals extends LiteralsSyntax
   @deprecated("Use cats.foldable._", "0.18.5")


### PR DESCRIPTION
Still using `Sync` given the changes
- `EntityEncoder`: `inputStreamEncoder` (uses `readInputStream`), `readerEncoder`
- `StaticFile`: `fromResource`, `fromURL`
- `org.http4s.internal.package.scala`: `CompletionStage` interop

Some notes on the changes:
- Changed `HttpApp` to `Defer` from `Sync`. My gut says that that's not right, but it's possible so I did it 🤷‍♂️ 
- `KleisliSyntax` has the sacred words `BinCompat` - not sure if that means that _no_ changes should be done there or something else in this case (my binary compatibility understanding is admittedly lackluster) 