### PR TITLE
Stop pinning scalameta

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -10,7 +10,3 @@ libraryDependencies ++= List(
   "org.http4s" %% "http4s-blaze-client" % "0.20.17",
   "org.http4s" %% "http4s-circe" % "0.20.17",
 )
-
-// Hack around a binary conflict in scalameta's dependency on
-// fastparse as specified by sbt-doctest-0.9.5.
-libraryDependencies += "org.scalameta" %% "scalameta" % "4.3.24"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.earldouglas"            %  "xsbt-web-plugin"           % "4.1.
 addSbtPlugin("com.eed3si9n"               %  "sbt-buildinfo"             % "0.9.0")
 addSbtPlugin("com.eed3si9n"               %  "sbt-unidoc"                % "0.4.3")
 addSbtPlugin("com.geirsson"               %  "sbt-ci-release"            % "1.5.2")
-addSbtPlugin("com.github.tkawachi"        %  "sbt-doctest"               % "0.9.6")
+addSbtPlugin("com.github.tkawachi"        %  "sbt-doctest"               % "0.9.8")
 addSbtPlugin("org.http4s"                 %  "sbt-http4s-org"            % "0.4.0")
 addSbtPlugin("com.timushev.sbt"           %  "sbt-updates"               % "0.5.0")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-ghpages"               % "0.6.3")


### PR DESCRIPTION
This causes friction on Scala upgrades. Can we remove it yet?