### PR TITLE
Add Hash and BoundedEnumerable instances for HttpVersion

### DIFF
--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -85,17 +85,21 @@ object HttpVersion {
 
     // BoundedEnumerable
     override def partialNext(a: HttpVersion): Option[HttpVersion] = a match {
-      case `HTTP/1.0` => Some(`HTTP/1.1`)
-      case `HTTP/1.1` => Some(`HTTP/2.0`)
+      case HttpVersion(9, 9) => None
+      case HttpVersion(major, minor) if fromVersion(major, minor).isLeft => None
+      case HttpVersion(major, 9) => Some(HttpVersion(major + 1, 0))
+      case HttpVersion(major, minor) => Some(HttpVersion(major, minor + 1))
       case _ => None
     }
     override def partialPrevious(a: HttpVersion): Option[HttpVersion] = a match {
-      case `HTTP/1.1` => Some(`HTTP/1.0`)
-      case `HTTP/2.0` => Some(`HTTP/1.1`)
+      case HttpVersion(0, 0) => None
+      case HttpVersion(major, minor) if fromVersion(major, minor).isLeft => None
+      case HttpVersion(major, 0) => Some(HttpVersion(major - 1, 9))
+      case HttpVersion(major, minor) => Some(HttpVersion(major, minor - 1))
       case _ => None
     }
     override def order: Order[HttpVersion] = self
-    override def minBound: HttpVersion = `HTTP/1.0`
-    override def maxBound: HttpVersion = `HTTP/2.0`
+    override def minBound: HttpVersion = HttpVersion(0, 0)
+    override def maxBound: HttpVersion = HttpVersion(9, 9)
   }
 }

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.data.{Writer => _}
 import cats.implicits._
-import cats.{Order, Show}
+import cats.{Order, Show, Hash}
 import org.http4s.internal.parboiled2._
 import org.http4s.parser._
 import org.http4s.util._
@@ -65,4 +65,6 @@ object HttpVersion {
     Order.fromComparable
   implicit val http4sHttpShowForVersion: Show[HttpVersion] =
     Show.fromToString
+  implicit val http4sHttpHashForVersion: Hash[HttpVersion] =
+    Hash.by(_.renderString)
 }

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.data.{Writer => _}
 import cats.implicits._
-import cats.{Order, Show, Hash}
+import cats.{Hash, Order, Show}
 import org.http4s.internal.parboiled2._
 import org.http4s.parser._
 import org.http4s.util._

--- a/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
@@ -7,14 +7,21 @@
 package org.http4s
 
 import cats.implicits._
+import cats.kernel.Eq
 import cats.kernel.laws.discipline.OrderTests
+import org.scalacheck.Arbitrary
 import org.scalacheck.Gen._
 import org.scalacheck.Prop._
 
 class HttpVersionSpec extends Http4sSpec {
   import HttpVersion._
 
-  checkAll("HttpVersion", OrderTests[HttpVersion].order)
+  checkAll("HttpVersion", OrderTests[HttpVersion].order(
+    implicitly[Arbitrary[HttpVersion]],
+    implicitly[Arbitrary[HttpVersion => HttpVersion]],
+    implicitly[Eq[Option[HttpVersion]]],
+    cats.Order[HttpVersion]
+  ))
 
   "sort by descending major version" in {
     prop { (x: HttpVersion, y: HttpVersion) =>

--- a/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
@@ -16,12 +16,15 @@ import org.scalacheck.Prop._
 class HttpVersionSpec extends Http4sSpec {
   import HttpVersion._
 
-  checkAll("HttpVersion", OrderTests[HttpVersion].order(
-    implicitly[Arbitrary[HttpVersion]],
-    implicitly[Arbitrary[HttpVersion => HttpVersion]],
-    implicitly[Eq[Option[HttpVersion]]],
-    cats.Order[HttpVersion]
-  ))
+  checkAll(
+    "HttpVersion",
+    OrderTests[HttpVersion].order(
+      implicitly[Arbitrary[HttpVersion]],
+      implicitly[Arbitrary[HttpVersion => HttpVersion]],
+      implicitly[Eq[Option[HttpVersion]]],
+      cats.Order[HttpVersion]
+    )
+  )
 
   "sort by descending major version" in {
     prop { (x: HttpVersion, y: HttpVersion) =>

--- a/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
@@ -7,24 +7,14 @@
 package org.http4s
 
 import cats.implicits._
-import cats.kernel.Eq
 import cats.kernel.laws.discipline.OrderTests
-import org.scalacheck.Arbitrary
 import org.scalacheck.Gen._
 import org.scalacheck.Prop._
 
 class HttpVersionSpec extends Http4sSpec {
   import HttpVersion._
 
-  checkAll(
-    "HttpVersion",
-    OrderTests[HttpVersion].order(
-      implicitly[Arbitrary[HttpVersion]],
-      implicitly[Arbitrary[HttpVersion => HttpVersion]],
-      implicitly[Eq[Option[HttpVersion]]],
-      cats.Order[HttpVersion]
-    )
-  )
+  checkAll("HttpVersion", OrderTests[HttpVersion].order)
 
   "sort by descending major version" in {
     prop { (x: HttpVersion, y: HttpVersion) =>

--- a/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 import cats.implicits._
-import cats.kernel.laws.discipline.OrderTests
+import cats.kernel.laws.discipline.{BoundedEnumerableTests, HashTests, OrderTests}
 import org.scalacheck.Gen._
 import org.scalacheck.Prop._
 
@@ -15,6 +15,10 @@ class HttpVersionSpec extends Http4sSpec {
   import HttpVersion._
 
   checkAll("HttpVersion", OrderTests[HttpVersion].order)
+
+  checkAll("HttpVersion", HashTests[HttpVersion].hash)
+
+  checkAll("HttpVersion", BoundedEnumerableTests[HttpVersion].boundedEnumerable)
 
   "sort by descending major version" in {
     prop { (x: HttpVersion, y: HttpVersion) =>


### PR DESCRIPTION
For https://github.com/http4s/http4s/issues/3869

Test had to be adapted in order to fix the following compile error:
```
ambiguous implicit values:
 both value http4sHttpOrderForVersion in object HttpVersion of type cats.Order[org.http4s.HttpVersion]
 and value http4sHttpHashForVersion in object HttpVersion of type cats.Hash[org.http4s.HttpVersion]
 match expected type cats.kernel.Eq[org.http4s.HttpVersion]
  checkAll("HttpVersion", OrderTests[HttpVersion].order)
```

Do let me know if there's a better way to fix this.