### PR TITLE
Port HttpsRedirectSpec to munit

### DIFF
--- a/server/src/test/scala/org/http4s/server/middleware/HttpsRedirectSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpsRedirectSpec.scala
@@ -8,14 +8,15 @@ package org.http4s
 package server
 package middleware
 
+import cats.implicits._
 import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.headers._
+import org.http4s.syntax.all._
 import org.http4s.Uri.{Authority, RegName, Scheme}
-import org.http4s.testing.Http4sLegacyMatchersIO
 
-class HttpsRedirectSpec extends Http4sSpec with Http4sLegacyMatchersIO {
+class HttpsRedirectSpec extends Http4sSuite {
   val innerRoutes = HttpRoutes.of[IO] { case GET -> Root =>
     Ok("pong")
   }
@@ -23,35 +24,49 @@ class HttpsRedirectSpec extends Http4sSpec with Http4sLegacyMatchersIO {
   val reqHeaders = Headers.of(Header("X-Forwarded-Proto", "http"), Header("Host", "example.com"))
   val req = Request[IO](method = GET, uri = Uri(path = "/"), headers = reqHeaders)
 
-  "HttpsRedirect" should {
-    "redirect to https when 'X-Forwarded-Proto' is http" in {
-      List(
-        HttpsRedirect(innerRoutes).orNotFound,
-        HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
-        HttpsRedirect.httpApp(innerRoutes.orNotFound)
-      ).map { app =>
-        val resp = app(req).unsafeRunSync()
-        val expectedAuthority = Authority(host = RegName("example.com"))
-        val expectedLocation =
-          Location(
-            Uri(path = "/", scheme = Some(Scheme.https), authority = Some(expectedAuthority)))
-        val expectedHeaders = Headers(expectedLocation :: `Content-Type`(MediaType.text.xml) :: Nil)
-        resp.status must_== Status.MovedPermanently
-        resp.headers must_== expectedHeaders
-      }
+  test("redirect to https when 'X-Forwarded-Proto' is http status") {
+    List(
+      HttpsRedirect(innerRoutes).orNotFound,
+      HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
+      HttpsRedirect.httpApp(innerRoutes.orNotFound)
+    ).traverse { app =>
+      app(req).map(_.status).assertEquals(Status.MovedPermanently)
     }
+  }
 
-    "not redirect otherwise" in {
-      List(
-        HttpsRedirect(innerRoutes).orNotFound,
-        HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
-        HttpsRedirect.httpApp(innerRoutes.orNotFound)
-      ).map { app =>
-        val noHeadersReq = Request[IO](method = GET, uri = Uri(path = "/"))
-        val resp = app(noHeadersReq).unsafeRunSync()
-        resp.status must_== Status.Ok
-        resp.as[String] must returnValue("pong")
-      }
+  test("redirect to https when 'X-Forwarded-Proto' is http") {
+    List(
+      HttpsRedirect(innerRoutes).orNotFound,
+      HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
+      HttpsRedirect.httpApp(innerRoutes.orNotFound)
+    ).traverse { app =>
+      val expectedAuthority = Authority(host = RegName("example.com"))
+      val expectedLocation =
+        Location(Uri(path = "/", scheme = Some(Scheme.https), authority = Some(expectedAuthority)))
+      val expectedHeaders = Headers(expectedLocation :: `Content-Type`(MediaType.text.xml) :: Nil)
+      app(req).map(_.headers).assertEquals(expectedHeaders)
+    }
+  }
+
+  test("not redirect otherwise status") {
+    List(
+      HttpsRedirect(innerRoutes).orNotFound,
+      HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
+      HttpsRedirect.httpApp(innerRoutes.orNotFound)
+    ).traverse { app =>
+      val noHeadersReq = Request[IO](method = GET, uri = Uri(path = "/"))
+      app(noHeadersReq).map(_.status).assertEquals(Status.Ok)
+    }
+  }
+
+  test("not redirect otherwise") {
+    List(
+      HttpsRedirect(innerRoutes).orNotFound,
+      HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
+      HttpsRedirect.httpApp(innerRoutes.orNotFound)
+    ).traverse { app =>
+      val noHeadersReq = Request[IO](method = GET, uri = Uri(path = "/"))
+      app(noHeadersReq).flatMap(_.as[String]).assertEquals("pong")
     }
   }
 }


### PR DESCRIPTION
This is a sample of a test using `Http4sLegacyMatchersIO` ported to use `munit.CatsEffectSuite`. IMHO it looks cleaner but I'm happy to get more feedback