### PR TITLE
Fix Streamed encoder for empty stream

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -231,7 +231,7 @@ object CirceInstances {
 
   private def streamedJsonArray[F[_]](printer: Printer)(s: Stream[F, Json]): Stream[F, Byte] =
     s.pull.uncons1.flatMap {
-      case None => Pull.done
+      case None => Pull.output(CirceInstances.openBrace)
       case Some((hd, tl)) =>
         Pull.output(
           Chunk.concatBytes(Vector(CirceInstances.openBrace, fromJsonToChunk(printer)(hd)))

--- a/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSpec.scala
@@ -151,6 +151,10 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
           |  "test2" : "CirceSupport"
           |}]""".stripMargin)
     }
+
+    "write a valid JSON array for an empty stream" in {
+      writeToString[Stream[IO, Json]](Stream.empty) must_== "[]"
+    }
   }
 
   "stream json array encoder of" should {
@@ -185,6 +189,10 @@ class CirceSpec extends JawnDecodeSupportSpec[Json] with Http4sLegacyMatchersIO 
           |},{
           |  "bar" : 350
           |}]""".stripMargin)
+    }
+
+    "write a valid JSON array for an empty stream" in {
+      writeToString[Stream[IO, Foo]](Stream.empty)(streamJsonArrayEncoderOf) must_== "[]"
     }
   }
 


### PR DESCRIPTION
Follow up of #3891.

It seems we aren't emiting the opening `[` when the stream is empty.