### PR TITLE
Add Order Instance For Header and Headers

### DIFF
--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -10,7 +10,7 @@
 
 package org.http4s
 
-import cats.{Eq, Show}
+import cats.{Eq, Order, Show}
 import cats.data.NonEmptyList
 import cats.implicits._
 import org.http4s.syntax.string._
@@ -121,7 +121,16 @@ object Header {
     _.toString
   }
 
-  implicit val HeaderEq: Eq[Header] = Eq.instance[Header] { (a, b) =>
-    a.name === b.name && a.value === b.value
-  }
+  @deprecated(message = "Please use HeaderOrder instead", since = "0.21.12")
+  def HeaderEq: Eq[Header] = HeaderOrder
+
+  implicit lazy val HeaderOrder: Order[Header] =
+    Order.from { case (a, b) =>
+      val nameComparison: Int = a.name.compare(b.name)
+      if (nameComparison === 0) {
+        a.value.compare(b.value)
+      } else {
+        nameComparison
+      }
+    }
 }

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -6,7 +6,7 @@
 
 package org.http4s
 
-import cats.{Eq, Eval, Foldable, Monoid, Show}
+import cats.{Eq, Eval, Foldable, Monoid, Order, Show}
 import cats.implicits._
 import org.http4s.headers.`Set-Cookie`
 import org.http4s.syntax.string._
@@ -160,7 +160,11 @@ object Headers {
       _.iterator.map(_.show).mkString("Headers(", ", ", ")")
     }
 
-  implicit val HeadersEq: Eq[Headers] = Eq.by(_.toList)
+  @deprecated(message = "Please use HeadersOrder instead", since = "0.21.12")
+  def HeadersEq: Eq[Headers] = HeadersOrder
+
+  implicit lazy val HeadersOrder: Order[Headers] =
+    Order.by(_.toList)
 
   implicit val headersMonoid: Monoid[Headers] = new Monoid[Headers] {
     def empty: Headers = Headers.empty

--- a/tests/src/test/scala/org/http4s/HeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeaderSpec.scala
@@ -6,6 +6,7 @@
 
 package org.http4s
 
+import cats.kernel.laws.discipline.OrderTests
 import java.nio.charset.StandardCharsets.ISO_8859_1
 import org.http4s.headers._
 import org.http4s.util.StringWriter
@@ -74,6 +75,12 @@ class HeaderSpec extends Http4sSpec {
         .getBytes(ISO_8859_1)
         .length
         .toLong must_== h.renderedLength
+    }
+  }
+
+  "Order instance for Header" should {
+    "be lawful" in {
+      checkAll("Order[Header]", OrderTests[Header].order)
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeadersSpec.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 import org.http4s.headers._
-import cats.kernel.laws.discipline.{EqTests, MonoidTests}
+import cats.kernel.laws.discipline.{MonoidTests, OrderTests}
 
 class HeadersSpec extends Http4sSpec {
   val clength = `Content-Length`.unsafeFromLong(10)
@@ -100,5 +100,5 @@ class HeadersSpec extends Http4sSpec {
   }
 
   checkAll("Monoid[Headers]", MonoidTests[Headers].monoid)
-  checkAll("Eq[Headers]", EqTests[Headers].eqv)
+  checkAll("Order[Headers]", OrderTests[Headers].order)
 }


### PR DESCRIPTION
 I left the old `Eq` based symbols in place so as not to break binary compatibility.  