### PR TITLE
Fix docs for client DSL changes in #3903

### DIFF
--- a/docs/src/main/mdoc/client.md
+++ b/docs/src/main/mdoc/client.md
@@ -316,10 +316,13 @@ httpClient.expect[String](request)
 ### Post a form, decoding the JSON response to a case class
 
 ```scala mdoc:nest
+import org.http4s.circe._
+import io.circe.generic.auto._
+
 case class AuthResponse(access_token: String)
 
-// See the JSON page for details on how to define this
-implicit val authResponseEntityDecoder: EntityDecoder[IO, AuthResponse] = null
+implicit val authResponseEntityDecoder: EntityDecoder[IO, AuthResponse] =
+  jsonOf[IO, AuthResponse]
 
 val postRequest = POST(
   UrlForm(

--- a/docs/src/main/mdoc/dsl.md
+++ b/docs/src/main/mdoc/dsl.md
@@ -415,7 +415,8 @@ val dailyWeatherService = HttpRoutes.of[IO] {
     Ok(getTemperatureForecast(localDate).map(s"The temperature on $localDate will be: " + _))
 }
 
-println(GET(uri"/weather/temperature/2016-11-05").flatMap(dailyWeatherService.orNotFound(_)).unsafeRunSync())
+val req = GET(uri"/weather/temperature/2016-11-05")
+dailyWeatherService.orNotFound(req).unsafeRunSync()
 ```
 
 ### Handling query parameters

--- a/docs/src/main/mdoc/json.md
+++ b/docs/src/main/mdoc/json.md
@@ -104,7 +104,7 @@ import org.http4s.client.dsl.io._
 ```
 
 ```scala mdoc
-POST(json"""{"name": "Alice"}""", uri"/hello").unsafeRunSync()
+POST(json"""{"name": "Alice"}""", uri"/hello")
 ```
 
 ## Encoding case classes as JSON
@@ -161,7 +161,7 @@ and responses for our case classes:
 
 ```scala mdoc
 Ok(Hello("Alice").asJson).unsafeRunSync()
-POST(User("Bob").asJson, uri"/hello").unsafeRunSync()
+POST(User("Bob").asJson, uri"/hello")
 ```
 
 If within some route we serve json only, we can use:
@@ -187,7 +187,7 @@ response body to JSON using the [`as` syntax]:
 
 ```scala mdoc
 Ok("""{"name":"Alice"}""").flatMap(_.as[Json]).unsafeRunSync()
-POST("""{"name":"Bob"}""", uri"/hello").flatMap(_.as[Json]).unsafeRunSync()
+POST("""{"name":"Bob"}""", uri"/hello").as[Json].unsafeRunSync()
 ```
 
 Like sending raw JSON, this is useful to a point, but we typically
@@ -205,7 +205,7 @@ an implicit `Decoder[A]` and makes a `EntityDecoder[A]`:
 implicit val userDecoder = jsonOf[IO, User]
 Ok("""{"name":"Alice"}""").flatMap(_.as[User]).unsafeRunSync()
 
-POST("""{"name":"Bob"}""", uri"/hello").flatMap(_.as[User]).unsafeRunSync()
+POST("""{"name":"Bob"}""", uri"/hello").as[User].unsafeRunSync()
 ```
 
 If we are always decoding from JSON to a typed model, we can use


### PR DESCRIPTION
Fixes #3933.  Some of the regular crossbuilds failed with the regular flakes, which failed fast, and we never successfully ran the doc job before we merged #3903.