### PR TITLE
Issue-3946 Activate and migrate play-json to Cats-effect 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val modules: List[ProjectReference] = List(
    json4s,
    json4sNative,
    json4sJackson,
-  // playJson,
+   playJson,
   // scalaXml,
   twirl,
   scalatags,

--- a/play-json/src/main/scala/org/http4s/play/PlayEntityDecoder.scala
+++ b/play-json/src/main/scala/org/http4s/play/PlayEntityDecoder.scala
@@ -6,14 +6,14 @@
 
 package org.http4s.play
 
-import cats.effect.Sync
+import cats.effect.Concurrent
 import org.http4s.EntityDecoder
 import play.api.libs.json.Reads
 
 /** Derive [[EntityDecoder]] if implicit [[Reads]] is in the scope without need to explicitly call `jsonOf`
   */
 trait PlayEntityDecoder {
-  implicit def playEntityDecoder[F[_]: Sync, A: Reads]: EntityDecoder[F, A] = jsonOf[F, A]
+  implicit def playEntityDecoder[F[_]: Concurrent, A: Reads]: EntityDecoder[F, A] = jsonOf[F, A]
 }
 
 object PlayEntityDecoder extends PlayEntityDecoder

--- a/play-json/src/main/scala/org/http4s/play/PlayInstances.scala
+++ b/play-json/src/main/scala/org/http4s/play/PlayInstances.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.play
 
-import cats.effect.Sync
+import cats.effect.Concurrent
 import fs2.Chunk
 import org.http4s.headers.`Content-Type`
 import org.http4s.{
@@ -23,7 +23,7 @@ import org.typelevel.jawn.support.play.Parser.facade
 import play.api.libs.json._
 
 trait PlayInstances {
-  def jsonOf[F[_]: Sync, A](implicit decoder: Reads[A]): EntityDecoder[F, A] =
+  def jsonOf[F[_]: Concurrent, A](implicit decoder: Reads[A]): EntityDecoder[F, A] =
     jsonDecoder[F].flatMapR { json =>
       decoder
         .reads(json)
@@ -34,7 +34,7 @@ trait PlayInstances {
         )
     }
 
-  implicit def jsonDecoder[F[_]: Sync]: EntityDecoder[F, JsValue] =
+  implicit def jsonDecoder[F[_]: Concurrent]: EntityDecoder[F, JsValue] =
     jawn.jawnDecoder[F, JsValue]
 
   def jsonEncoderOf[F[_], A: Writes]: EntityEncoder[F, A] =
@@ -64,7 +64,7 @@ trait PlayInstances {
         )
     }
 
-  implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
+  implicit class MessageSyntax[F[_]: Concurrent](self: Message[F]) {
     def decodeJson[A: Reads]: F[A] =
       self.as(implicitly, jsonOf[F, A])
   }

--- a/play-json/src/test/scala/org/http4s/play/PlaySpec.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySpec.scala
@@ -9,7 +9,6 @@ package play.test // Get out of play package so we can import custom instances
 
 import _root_.play.api.libs.json._
 import cats.effect.IO
-import cats.effect.laws.util.TestContext
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSpec
 import org.http4s.play._
@@ -17,7 +16,6 @@ import org.http4s.testing.Http4sLegacyMatchersIO
 
 // Originally based on CirceSpec
 class PlaySpec extends JawnDecodeSupportSpec[JsValue] with Http4sLegacyMatchersIO {
-  implicit val testContext = TestContext()
 
   testJsonDecoder(jsonDecoder)
 


### PR DESCRIPTION
As discussed with @rossabaker. Use `Concurrent` instead of `Sync` in the play-json module. Issue: #3962 