### PR TITLE
3944 cats2.3 switch implicits import to syntax

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -10,7 +10,7 @@ package asynchttpclient
 
 import cats.effect._
 import cats.effect.concurrent._
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.implicits._
 import fs2.Stream._
 import fs2._

--- a/bench/src/main/scala/org/http4s/bench/NioCharsetBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/NioCharsetBench.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package bench
 
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.charset.{UnsupportedCharsetException, Charset => NioCharset}
 import java.util.{HashMap, Locale}
 import java.util.concurrent.TimeUnit

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -11,7 +11,7 @@ package blaze
 import cats.effect._
 import cats.effect.concurrent._
 import cats.effect.implicits._
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeoutException
 import org.http4s.blaze.pipeline.Command

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -8,7 +8,7 @@ package org.http4s
 package client
 package blaze
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import java.nio.channels.AsynchronousChannelGroup
 

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeHttp1ClientParser.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeHttp1ClientParser.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.client.blaze
 
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.ByteBuffer
 import org.http4s._
 import org.http4s.blaze.http.parser.Http1ClientParser

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -10,7 +10,7 @@ package blaze
 
 import cats.effect._
 import cats.effect.implicits._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeoutException

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -9,7 +9,7 @@ package client
 package blaze
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousChannelGroup

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientSpec.scala
@@ -9,7 +9,7 @@ package blaze
 
 import cats.effect._
 import cats.effect.concurrent.{Deferred, Ref}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import java.util.concurrent.TimeoutException
 import javax.net.ssl.SSLContext

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -10,7 +10,7 @@ package blaze
 
 import cats.effect._
 import cats.effect.concurrent.Deferred
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import fs2.concurrent.Queue
 import java.io.IOException

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -10,7 +10,7 @@ package blaze
 
 import cats.effect._
 import cats.effect.concurrent.Deferred
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import fs2.concurrent.Queue
 import java.nio.ByteBuffer

--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -8,7 +8,7 @@ package org.http4s
 package blazecore
 
 import cats.effect.Effect
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.Stream._
 import java.nio.ByteBuffer

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
@@ -9,7 +9,7 @@ package blazecore
 package util
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import java.nio.ByteBuffer
 import org.http4s.blaze.pipeline._

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/ChunkWriter.scala
@@ -9,7 +9,7 @@ package blazecore
 package util
 
 import cats.effect.{Effect, IO}
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.ISO_8859_1

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
@@ -9,7 +9,7 @@ package blazecore
 package util
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import org.http4s.internal.fromFuture
 import scala.concurrent._

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
@@ -8,7 +8,7 @@ package org.http4s
 package blazecore
 package util
 
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import org.http4s.internal.fromFuture

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/IdentityWriter.scala
@@ -9,7 +9,7 @@ package blazecore
 package util
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import java.nio.ByteBuffer
 import org.http4s.blaze.pipeline.TailStage

--- a/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
@@ -10,7 +10,7 @@ package websocket
 
 import cats.effect._
 import cats.effect.concurrent.Semaphore
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.concurrent.SignallingRef
 import java.util.concurrent.atomic.AtomicBoolean

--- a/blaze-core/src/test/scala/org/http4s/blazecore/ResponseParser.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/ResponseParser.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package blazecore
 
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
@@ -11,7 +11,7 @@ package util
 import cats.effect._
 import cats.effect.concurrent.Ref
 import cats.effect.testing.specs2.CatsEffect
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.Stream._
 import fs2.compression.deflate

--- a/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
@@ -10,7 +10,7 @@ package websocket
 import fs2.Stream
 import fs2.concurrent.{Queue, SignallingRef}
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import java.util.concurrent.atomic.AtomicBoolean
 import org.http4s.Http4sSpec
 import org.http4s.blaze.pipeline.LeafBuilder

--- a/blaze-core/src/test/scala/org/http4s/blazecore/websocket/WSTestHead.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/websocket/WSTestHead.scala
@@ -8,7 +8,7 @@ package org.http4s.blazecore.websocket
 
 import cats.effect.{ContextShift, IO, Timer}
 import cats.effect.concurrent.Semaphore
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import fs2.concurrent.Queue
 import org.http4s.blaze.pipeline.HeadStage

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -11,7 +11,7 @@ package blaze
 import cats.{Alternative, Applicative}
 import cats.data.Kleisli
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.{ConcurrentEffect, Resource, Timer}
 import _root_.io.chrisdavenport.vault._
 import java.io.FileInputStream

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerParser.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerParser.scala
@@ -8,7 +8,7 @@ package org.http4s
 package server.blaze
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.ByteBuffer
 import org.log4s.Logger
 import scala.collection.mutable.ListBuffer

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -9,7 +9,7 @@ package server
 package blaze
 
 import cats.effect.{CancelToken, ConcurrentEffect, IO, Sync, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeoutException
 import org.http4s.blaze.http.parser.BaseExceptions.{BadMessage, ParserException}

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http2NodeStage.scala
@@ -9,7 +9,7 @@ package server
 package blaze
 
 import cats.effect.{ConcurrentEffect, IO, Sync, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.Stream._
 import java.util.Locale

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
@@ -7,7 +7,7 @@
 package org.http4s.server.blaze
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2.concurrent.SignallingRef
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets._

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSpec.scala
@@ -8,7 +8,7 @@ package org.http4s
 package server
 package blaze
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.IO
 import java.net.{HttpURLConnection, URL}
 import java.nio.charset.StandardCharsets

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -11,7 +11,7 @@ package blaze
 import cats.data.Kleisli
 import cats.effect._
 import cats.effect.concurrent.Deferred
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import org.http4s.{headers => H}

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSpec.scala
@@ -9,7 +9,6 @@ package booPickle
 
 import boopickle.Default._
 import cats.effect.IO
-import cats.implicits._
 import cats.Eq
 import cats.effect.laws.util.TestContext
 import cats.effect.laws.util.TestInstances._

--- a/client/src/main/scala/org/http4s/client/BasicManager.scala
+++ b/client/src/main/scala/org/http4s/client/BasicManager.scala
@@ -8,7 +8,7 @@ package org.http4s
 package client
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 
 private final class BasicManager[F[_], A <: Connection[F]](builder: ConnectionBuilder[F, A])(
     implicit F: Sync[F])

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -11,7 +11,7 @@ import cats.~>
 import cats.data.Kleisli
 import cats.effect._
 import cats.effect.concurrent.Ref
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import java.io.IOException
 import org.http4s.headers.Host

--- a/client/src/main/scala/org/http4s/client/ConnectionManager.scala
+++ b/client/src/main/scala/org/http4s/client/ConnectionManager.scala
@@ -9,7 +9,7 @@ package client
 
 import cats.effect._
 import cats.effect.concurrent.Semaphore
-import cats.implicits._
+import cats.syntax.all._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -10,7 +10,7 @@ package client
 import cats.Applicative
 import cats.data.{Kleisli, OptionT}
 import cats.effect.{Bracket, Resource}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import org.http4s.Status.Successful
 import org.http4s.headers.{Accept, MediaRangeAndQValue}

--- a/client/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
+++ b/client/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
@@ -8,7 +8,7 @@ package org.http4s
 package client
 
 import cats.effect.{Async, Blocker, ContextShift, Resource, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import fs2.io.{readInputStream, writeOutputStream}
 import java.io.IOException

--- a/client/src/main/scala/org/http4s/client/PoolManager.scala
+++ b/client/src/main/scala/org/http4s/client/PoolManager.scala
@@ -9,7 +9,7 @@ package client
 
 import cats.effect._
 import cats.effect.concurrent.Semaphore
-import cats.implicits._
+import cats.syntax.all._
 import java.time.Instant
 import java.util.concurrent.TimeoutException
 import org.log4s.getLogger

--- a/client/src/main/scala/org/http4s/client/middleware/CookieJar.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/CookieJar.scala
@@ -7,7 +7,7 @@
 package org.http4s.client.middleware
 
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.effect.concurrent._
 import org.http4s._

--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -9,7 +9,7 @@ package client
 package middleware
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.Method._
 import org.http4s.headers._
 import org.http4s.util.CaseInsensitiveString

--- a/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -7,7 +7,7 @@
 package org.http4s.client.middleware
 
 import cats.effect.{Clock, Resource, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import java.util.concurrent.TimeUnit
 
 import cats.effect.concurrent.Ref

--- a/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.effect._
 import cats.effect.concurrent.Ref
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger

--- a/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.effect._
 import cats.effect.concurrent.Ref
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger

--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -9,7 +9,7 @@ package client
 package middleware
 
 import cats.effect.{Concurrent, Resource, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import org.http4s.Status._

--- a/client/src/main/scala/org/http4s/client/oauth1/ProtocolParameter.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/ProtocolParameter.scala
@@ -9,7 +9,7 @@ package org.http4s.client.oauth1
 import cats.{Functor, Show}
 import cats.effect.Clock
 import cats.kernel.Order
-import cats.implicits._
+import cats.syntax.all._
 import java.util.concurrent.TimeUnit
 
 sealed trait ProtocolParameter {

--- a/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -9,7 +9,8 @@ package client
 
 import cats.{Monad, MonadError, Show}
 import cats.data.NonEmptyList
-import cats.implicits._
+import cats.syntax.all._
+import cats.instances.order._
 import java.nio.charset.StandardCharsets
 
 import javax.crypto

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -8,7 +8,7 @@ package org.http4s
 package client
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.io._
 import java.net.InetSocketAddress

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -10,7 +10,7 @@ package client
 import scala.concurrent.duration._
 import cats.effect.concurrent.Deferred
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import java.io.IOException
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Host

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSpec.scala
@@ -9,7 +9,7 @@ package client
 
 import cats.effect._
 import cats.effect.concurrent.Ref
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import org.http4s.Method._
 import org.http4s.Status.{BadRequest, Created, InternalServerError, Ok}

--- a/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientXmlSpec.scala
@@ -8,7 +8,7 @@ package org.http4s
 package client
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.Method.GET
 import org.http4s.Status.Ok
 import scala.xml.Elem

--- a/client/src/test/scala/org/http4s/client/middleware/CookieJarSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/CookieJarSpec.scala
@@ -8,7 +8,7 @@ package org.http4s.client.middleware
 
 import org.specs2.mutable.Specification
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.effect.testing.specs2.CatsIO
 import org.http4s._

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSpec.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.effect._
 import cats.effect.concurrent.Semaphore
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import java.util.concurrent.atomic._
 import org.http4s.Uri.uri

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySpec.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.effect.{IO, Resource}
 import cats.effect.concurrent.{Ref, Semaphore}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import org.http4s.Uri.uri
 import org.http4s.dsl.io._

--- a/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -8,7 +8,7 @@ package org.http4s
 package client.testroutes
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import org.http4s.Status._
 import org.http4s.internal.CollectionCompat

--- a/core/src/main/scala/org/http4s/AuthedRoutes.scala
+++ b/core/src/main/scala/org/http4s/AuthedRoutes.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.{Applicative, Defer}
 import cats.data.{Kleisli, OptionT}
-import cats.implicits._
+import cats.syntax.all._
 
 object AuthedRoutes {
 

--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -11,7 +11,7 @@
 package org.http4s
 
 import cats.{Order, Show}
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.QValue.QValueParser
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
 import org.http4s.parser.Http4sParser

--- a/core/src/main/scala/org/http4s/ContextRequest.scala
+++ b/core/src/main/scala/org/http4s/ContextRequest.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.data.Kleisli
 
 final case class ContextRequest[F[_], A](context: A, req: Request[F]) {

--- a/core/src/main/scala/org/http4s/ContextRoutes.scala
+++ b/core/src/main/scala/org/http4s/ContextRoutes.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.data.{Kleisli, OptionT}
 import cats.{Applicative, Defer}
-import cats.implicits._
+import cats.syntax.all._
 
 object ContextRoutes {
 

--- a/core/src/main/scala/org/http4s/DecodeResult.scala
+++ b/core/src/main/scala/org/http4s/DecodeResult.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.{Applicative, Functor}
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 
 object DecodeResult {
   def apply[F[_], A](fa: F[Either[DecodeFailure, A]]): DecodeResult[F, A] =

--- a/core/src/main/scala/org/http4s/Entity.scala
+++ b/core/src/main/scala/org/http4s/Entity.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 import cats.Monoid
-import cats.implicits._
+import cats.syntax.all._
 
 final case class Entity[+F[_]](body: EntityBody[F], length: Option[Long] = None)
 

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.{Applicative, Functor, Monad, SemigroupK}
 import cats.effect.{Blocker, ContextShift, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.io.file.writeAll
 import java.io.File

--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.{Contravariant, Show}
 import cats.effect.{Blocker, ContextShift, Effect, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.{Chunk, Stream}
 import fs2.io.file.readAll
 import fs2.io.readInputStream

--- a/core/src/main/scala/org/http4s/FormDataDecoder.scala
+++ b/core/src/main/scala/org/http4s/FormDataDecoder.scala
@@ -10,13 +10,13 @@ import cats.Applicative
 import cats.data.Validated.Valid
 import cats.data.{Chain, ValidatedNel}
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 
 /** A decoder ware that uses [[QueryParamDecoder]] to decode values in [[org.http4s.UrlForm]]
   *
   * @example
   * {{{
-  * scala> import cats.implicits._
+  * scala> import cats.syntax.all._
   * scala> import cats.data._
   * scala> import org.http4s.FormDataDecoder._
   * scala> import org.http4s.ParseFailure

--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -12,7 +12,7 @@ package org.http4s
 
 import cats.{Eq, Order, Show}
 import cats.data.NonEmptyList
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.syntax.string._
 import org.http4s.util._
 import scala.util.hashing.MurmurHash3

--- a/core/src/main/scala/org/http4s/HeaderKey.scala
+++ b/core/src/main/scala/org/http4s/HeaderKey.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 import cats.data.NonEmptyList
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.syntax.string._
 import org.http4s.util.CaseInsensitiveString
 import scala.annotation.tailrec

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 import cats.{Eq, Eval, Foldable, Monoid, Order, Show}
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.headers.`Set-Cookie`
 import org.http4s.syntax.string._
 import org.http4s.util.CaseInsensitiveString

--- a/core/src/main/scala/org/http4s/HttpCodec.scala
+++ b/core/src/main/scala/org/http4s/HttpCodec.scala
@@ -6,7 +6,7 @@
 
 package org.http4s
 
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.util.Renderer
 
 trait HttpCodec[A] extends Renderer[A] {

--- a/core/src/main/scala/org/http4s/HttpDate.scala
+++ b/core/src/main/scala/org/http4s/HttpDate.scala
@@ -10,7 +10,7 @@ import java.time.{Instant, ZonedDateTime}
 import org.http4s.parser.AdditionalRules
 import org.http4s.util.{Renderable, Writer}
 import cats.Functor
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.Clock
 import scala.concurrent.duration.SECONDS
 

--- a/core/src/main/scala/org/http4s/HttpRoutes.scala
+++ b/core/src/main/scala/org/http4s/HttpRoutes.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats._
 import cats.data.{Kleisli, OptionT}
-import cats.implicits._
+import cats.syntax.all._
 
 /** Functions for creating [[HttpRoutes]] kleislis. */
 object HttpRoutes {

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 import cats.data.{Writer => _}
-import cats.implicits._
+import cats.syntax.all._
 import cats.kernel.BoundedEnumerable
 import cats.{Hash, Order, Show}
 import org.http4s.internal.parboiled2._

--- a/core/src/main/scala/org/http4s/Media.scala
+++ b/core/src/main/scala/org/http4s/Media.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 import cats.MonadError
-import cats.implicits._
+import cats.syntax.all._
 import fs2.{RaiseThrowable, Stream}
 import fs2.text.utf8Decode
 import org.http4s.headers._

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.{Applicative, Functor, Monad, ~>}
 import cats.data.NonEmptyList
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.IO
 import fs2.{Pure, Stream}
 import fs2.text.utf8Encode

--- a/core/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/src/main/scala/org/http4s/MessageFailure.scala
@@ -7,7 +7,8 @@
 package org.http4s
 
 import cats.{Eq, MonadError}
-import cats.implicits._
+import cats.syntax.all._
+import cats.instances.either._
 import scala.util.control.{NoStackTrace, NonFatal}
 
 /** Indicates a failure to handle an HTTP [[Message]]. */

--- a/core/src/main/scala/org/http4s/Method.scala
+++ b/core/src/main/scala/org/http4s/Method.scala
@@ -6,7 +6,7 @@
 
 package org.http4s
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.{Eq, Hash, Show}
 import org.http4s.Method.Semantics
 import org.http4s.parser.Rfc2616BasicRules

--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -9,7 +9,6 @@ package org.http4s
 import java.nio.charset.StandardCharsets
 
 import cats.{Eval, Foldable}
-import cats.implicits._
 import org.http4s.Query._
 import org.http4s.internal.CollectionCompat
 

--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.{Contravariant, Functor, Hash, MonoidK, Order, Show}
 import cats.data.{Validated, ValidatedNel}
-import cats.implicits._
+import cats.syntax.all._
 import java.time.{Instant, LocalDate, ZonedDateTime}
 import java.time.format.{DateTimeFormatter, DateTimeParseException}
 import java.time.temporal.TemporalAccessor

--- a/core/src/main/scala/org/http4s/Service.scala
+++ b/core/src/main/scala/org/http4s/Service.scala
@@ -9,7 +9,7 @@ package org.http4s
 import cats.{Applicative, Monoid, Semigroup}
 import cats.data.Kleisli
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 
 @deprecated("Deprecated in favor of Kleisli", "0.18")
 object Service {

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -9,7 +9,7 @@ package org.http4s
 import cats.Semigroup
 import cats.data.OptionT
 import cats.effect.{Blocker, ContextShift, IO, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import fs2.io._
 import fs2.io.file.readRange

--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -9,7 +9,7 @@ package org.http4s
 import cats.{Eq, Monoid}
 import cats.data.Chain
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.headers._
 import org.http4s.internal.CollectionCompat
 import org.http4s.parser._

--- a/core/src/main/scala/org/http4s/headers/Connection.scala
+++ b/core/src/main/scala/org/http4s/headers/Connection.scala
@@ -8,7 +8,7 @@ package org.http4s
 package headers
 
 import cats.data.NonEmptyList
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.parser.HttpHeaderParser
 import org.http4s.syntax.all._
 import org.http4s.util.{CaseInsensitiveString, Writer}

--- a/core/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/src/main/scala/org/http4s/internal/Logger.scala
@@ -7,7 +7,7 @@
 package org.http4s.internal
 
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.{Charset, Headers, MediaType, Message, Request, Response}

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -15,7 +15,7 @@ import java.util.concurrent.{
 
 import cats.effect.implicits._
 import cats.effect.{Async, Concurrent, ConcurrentEffect, ContextShift, Effect, IO}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.{Chunk, Pipe, Pull, RaiseThrowable, Stream}
 import java.nio.{ByteBuffer, CharBuffer}
 import org.http4s.util.execution.direct

--- a/core/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -7,7 +7,6 @@
 package org.http4s.metrics
 
 import cats.Foldable
-import cats.implicits._
 import org.http4s.{Method, Request, Status, Uri}
 
 /** Describes an algebra capable of writing metrics to a metrics registry

--- a/core/src/main/scala/org/http4s/multipart/Boundary.scala
+++ b/core/src/main/scala/org/http4s/multipart/Boundary.scala
@@ -7,7 +7,6 @@
 package org.http4s.multipart
 
 import cats.Eq
-import cats.implicits._
 import fs2.Chunk
 import java.nio.charset.StandardCharsets
 import org.http4s.internal.CollectionCompat

--- a/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -8,7 +8,7 @@ package org.http4s
 package multipart
 
 import cats.effect.{Blocker, ContextShift, Sync}
-import cats.implicits._
+import cats.syntax.all._
 
 private[http4s] object MultipartDecoder {
   def decoder[F[_]: Sync]: EntityDecoder[F, Multipart[F]] =

--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -8,7 +8,7 @@ package org.http4s
 package multipart
 
 import cats.effect.{Blocker, ContextShift, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.{Chunk, Pipe, Pull, Pure, Stream}
 import fs2.io.file.{readAll, writeAll}
 import java.nio.file.{Files, Path, StandardOpenOption}

--- a/core/src/main/scala/org/http4s/parser/AcceptCharsetHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/AcceptCharsetHeader.scala
@@ -11,7 +11,7 @@
 package org.http4s
 package parser
 
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.internal.parboiled2._
 import org.http4s.CharsetRange._
 import org.http4s.QValue.QValueParser

--- a/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
+++ b/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
@@ -14,7 +14,7 @@
 package org.http4s
 package parser
 
-import cats.implicits._
+import cats.syntax.all._
 import java.time.{ZoneOffset, ZonedDateTime}
 import org.http4s.internal.parboiled2._
 import org.http4s.internal.parboiled2.support.{::, HNil}

--- a/core/src/main/scala/org/http4s/parser/Http4sHeaderParser.scala
+++ b/core/src/main/scala/org/http4s/parser/Http4sHeaderParser.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package parser
 
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.internal.parboiled2._
 
 private[parser] abstract class Http4sHeaderParser[H <: Header](val input: ParserInput)

--- a/core/src/main/scala/org/http4s/parser/Http4sParser.scala
+++ b/core/src/main/scala/org/http4s/parser/Http4sParser.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package parser
 
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.internal.parboiled2._
 
 /** Helper class that produces a `ParseResult` from the `main` target. */

--- a/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala
@@ -10,7 +10,7 @@
 
 package org.http4s.parser
 
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.{ParseFailure, ParseResult}
 import org.http4s.internal.parboiled2._
 import scala.annotation.nowarn

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package parser
 
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.charset.Charset
 import org.http4s.{Query => Q}
 import org.http4s.internal.parboiled2._

--- a/docs/src/main/mdoc/dsl.md
+++ b/docs/src/main/mdoc/dsl.md
@@ -37,7 +37,7 @@ We'll need the following imports to get started:
 
 ```scala mdoc:silent
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s._, org.http4s.dsl.io._, org.http4s.implicits._
 // Provided by `cats.effect.IOApp`
 implicit val timer : Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)

--- a/docs/src/main/mdoc/middleware.md
+++ b/docs/src/main/mdoc/middleware.md
@@ -26,7 +26,7 @@ and some imports.
 ```scala mdoc:silent
 import cats.data.Kleisli
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.implicits._

--- a/docs/src/main/mdoc/service.md
+++ b/docs/src/main/mdoc/service.md
@@ -123,7 +123,7 @@ Multiple `HttpRoutes` can be combined with the `combineK` method (or its alias
 `scalacOptions ++= Seq("-Ypartial-unification")`
 
 ```scala mdoc:silent
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.server.blaze._
 import org.http4s.implicits._
 import org.http4s.server.Router

--- a/docs/src/main/mdoc/testing.md
+++ b/docs/src/main/mdoc/testing.md
@@ -14,7 +14,7 @@ After reading this doc, the reader should feel comfortable writing a unit test u
 Now, let's define an `org.http4s.HttpService`.
 
 ```scala mdoc:silent
-import cats.implicits._
+import cats.syntax.all._
 import io.circe._
 import io.circe.syntax._
 import io.circe.generic.semiauto._

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -11,7 +11,7 @@ package org.http4s.dsl.impl
 
 import cats.data._
 import cats.data.Validated._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s._
 import scala.util.Try
 import cats.Foldable

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSpec.scala
@@ -9,7 +9,7 @@ package dsl
 
 import cats.data.Validated._
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.http4s.testing.Http4sLegacyMatchersIO

--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -10,7 +10,7 @@ import io.chrisdavenport.keypool._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import scala.concurrent.duration._
 import org.http4s.client._

--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -13,7 +13,7 @@ import cats._
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.effect.concurrent._
-import cats.implicits._
+import cats.syntax.all._
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
 import org.http4s._

--- a/ember-client/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSpec.scala
+++ b/ember-client/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSpec.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.ember.client.internal
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.effect.concurrent._

--- a/ember-core/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
@@ -11,7 +11,7 @@
 package org.http4s.ember.core
 
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.concurrent.Deferred
 import fs2._
 import scodec.bits.ByteVector

--- a/ember-core/src/main/scala/org/http4s/ember/core/EmberException.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/EmberException.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.ember.core
 
-import cats.implicits._
+import cats.syntax.all._
 import java.time.Instant
 
 sealed trait EmberException extends RuntimeException with Product with Serializable

--- a/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -7,7 +7,7 @@
 package org.http4s.ember.core
 
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import org.http4s._
 import cats.effect._

--- a/ember-core/src/main/scala/org/http4s/ember/core/Util.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Util.scala
@@ -8,7 +8,7 @@ package org.http4s.ember.core
 
 import cats._
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.io.tcp.Socket
 import scala.concurrent.duration._

--- a/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
@@ -7,7 +7,7 @@
 package org.http4s.ember.core
 
 import org.specs2.mutable.Specification
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.{IO, Sync}
 import org.http4s._
 

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParsingSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParsingSpec.scala
@@ -16,7 +16,7 @@ import cats.effect.testing.specs2.CatsIO
 import fs2._
 import cats.effect.concurrent._
 import cats.data.OptionT
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Chunk.ByteVectorChunk
 import org.http4s.ember.core.Parser.Request.ReqPrelude.ParsePreludeComplete
 import org.http4s.headers.Expires

--- a/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
@@ -11,7 +11,7 @@ class TraversalSpecItsNotYouItsMe
 /* FIXME Restore after #3935 is worked out
 import org.specs2.mutable.Specification
 import org.specs2.ScalaCheck
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.IO
 import org.http4s._
 // import _root_.io.chrisdavenport.log4cats.testing.TestingLogger

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -7,7 +7,7 @@
 package org.http4s.ember.server
 
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import fs2.concurrent._
 import fs2.io.tcp.SocketGroup

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -11,7 +11,7 @@ import fs2.concurrent._
 import fs2.io.tcp._
 import fs2.io.tls._
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
 import org.http4s._

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeSslExample.scala
@@ -8,7 +8,7 @@ package com.example.http4s
 package blaze
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.server.Server
 import org.http4s.server.blaze.BlazeServerBuilder
 import scala.concurrent.ExecutionContext.global

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeWebSocketExample.scala
@@ -7,7 +7,7 @@
 package com.example.http4s.blaze
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.concurrent.Queue
 import org.http4s._

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/MultipartHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/MultipartHttpEndpoint.scala
@@ -7,7 +7,7 @@
 package com.example.http4s.blaze.demo.server.endpoints
 
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import com.example.http4s.blaze.demo.server.service.FileService
 import org.http4s.EntityDecoder.multipart
 import org.http4s.{ApiVersion => _, _}

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/TimeoutHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/TimeoutHttpEndpoint.scala
@@ -7,7 +7,7 @@
 package com.example.http4s.blaze.demo.server.endpoints
 
 import cats.effect.{Async, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import java.util.concurrent.TimeUnit
 import org.http4s.{ApiVersion => _, _}
 import org.http4s.dsl.Http4sDsl

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
@@ -8,7 +8,7 @@ package com.example.http4s.ember
 
 import cats._
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s._
 import org.http4s.client._
 import org.http4s.circe._

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerSimpleExample.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerSimpleExample.scala
@@ -8,7 +8,7 @@ package com.example.http4s.ember
 
 import fs2._
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.dsl.Http4sDsl

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettySslExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettySslExample.scala
@@ -7,7 +7,7 @@
 package com.example.http4s.jetty
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import com.example.http4s.ssl
 import org.http4s.server.Server
 import org.http4s.server.jetty.JettyBuilder

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -7,7 +7,7 @@
 package com.example.http4s
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import io.circe.Json
 import org.http4s.circe._

--- a/examples/src/main/scala/com/example/http4s/ssl.scala
+++ b/examples/src/main/scala/com/example/http4s/ssl.scala
@@ -7,7 +7,7 @@
 package com.example.http4s
 
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.file.Paths
 import java.security.{KeyStore, Security}
 import javax.net.ssl.{KeyManagerFactory, SSLContext}

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -8,7 +8,7 @@ package org.http4s
 package jawn
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import org.typelevel.jawn.{AsyncParser, Facade, ParseException}
 import jawnfs2._

--- a/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
@@ -9,7 +9,7 @@ package client
 package jetty
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.api.{Request => JettyRequest}

--- a/jetty-client/src/main/scala/org/http4s/client/jetty/ResponseListener.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/ResponseListener.scala
@@ -10,7 +10,7 @@ package jetty
 
 import cats.effect._
 import cats.effect.implicits._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.Stream._
 import fs2.concurrent.Queue

--- a/jetty-client/src/main/scala/org/http4s/client/jetty/StreamRequestContentProvider.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/StreamRequestContentProvider.scala
@@ -11,7 +11,7 @@ package jetty
 import cats.effect._
 import cats.effect.concurrent.Semaphore
 import cats.effect.implicits._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import org.eclipse.jetty.client.util.DeferredContentProvider
 import org.eclipse.jetty.util.{Callback => JettyCallback}

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -9,7 +9,7 @@ package server
 package jetty
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import java.net.InetSocketAddress
 import java.util
 import javax.net.ssl.{SSLContext, SSLParameters}

--- a/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
+++ b/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSpec.scala
@@ -9,7 +9,7 @@ package server
 package jetty
 
 import cats.effect.{IO, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import java.net.{HttpURLConnection, URL}
 import java.io.IOException
 import java.nio.charset.StandardCharsets

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -8,7 +8,7 @@ package org.http4s
 package json4s
 
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.headers.`Content-Type`
 import org.json4s._
 import org.json4s.JsonAST.JValue

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSpec.scala
@@ -8,7 +8,7 @@ package org.http4s
 package json4s
 
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSpec
 import org.http4s.testing.Http4sLegacyMatchersIO

--- a/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
+++ b/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package laws
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.effect.implicits._
 import cats.laws._

--- a/laws/src/main/scala/org/http4s/laws/EntityEncoderLaws.scala
+++ b/laws/src/main/scala/org/http4s/laws/EntityEncoderLaws.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package laws
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.laws._
 import org.http4s.headers.{`Content-Length`, `Transfer-Encoding`}

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -14,7 +14,8 @@ import cats.laws.discipline.arbitrary.catsLawsArbitraryForChain
 import cats.effect.{Effect, IO}
 import cats.effect.laws.discipline.arbitrary._
 import cats.effect.laws.util.TestContext
-import cats.implicits._
+import cats.syntax.all._
+import cats.instances.order._
 import fs2.{Pure, Stream}
 import java.nio.charset.{Charset => NioCharset}
 import java.time._

--- a/laws/src/main/scala/org/http4s/laws/discipline/EntityCodecTests.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/EntityCodecTests.scala
@@ -9,7 +9,6 @@ package laws
 package discipline
 
 import cats.Eq
-import cats.implicits._
 import cats.effect._
 import cats.effect.laws.util.TestContext
 import cats.effect.laws.util.TestInstances._

--- a/laws/src/main/scala/org/http4s/laws/discipline/HttpCodecTests.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/HttpCodecTests.scala
@@ -9,7 +9,6 @@ package laws
 package discipline
 
 import cats.Eq
-import cats.implicits._
 import cats.laws.discipline._
 import org.scalacheck.{Arbitrary, Prop, Shrink}
 import org.typelevel.discipline.Laws

--- a/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttpBuilder.scala
+++ b/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttpBuilder.scala
@@ -9,7 +9,7 @@ package org.http4s.client.okhttp
 import java.io.IOException
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.implicits._
 import fs2.io._
 import okhttp3.{

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
@@ -7,7 +7,7 @@
 package org.http4s.metrics.prometheus
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
 import io.prometheus.client.hotspot._

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -8,7 +8,7 @@ package org.http4s
 package scalaxml
 
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import java.io.StringReader
 import javax.xml.parsers.SAXParserFactory
 

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSpec.scala
@@ -8,7 +8,7 @@ package org.http4s
 package scalaxml
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import fs2.text.utf8Encode
 import org.http4s.Status.Ok

--- a/scalafix/input/src/main/scala/fix/ClientFetchTests.scala
+++ b/scalafix/input/src/main/scala/fix/ClientFetchTests.scala
@@ -5,7 +5,7 @@ package fix
 
 import cats.data.Chain
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s._
 import org.http4s.client.Client
 

--- a/scalafix/output/src/main/scala/fix/ClientFetchTests.scala
+++ b/scalafix/output/src/main/scala/fix/ClientFetchTests.scala
@@ -2,7 +2,7 @@ package fix
 
 import cats.data.Chain
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s._
 import org.http4s.client.Client
 

--- a/server/src/main/scala/org/http4s/server/ContextMiddleware.scala
+++ b/server/src/main/scala/org/http4s/server/ContextMiddleware.scala
@@ -8,7 +8,7 @@ package org.http4s
 package server
 
 import cats.Monad
-import cats.implicits._
+import cats.syntax.all._
 import cats.data.{Kleisli, OptionT}
 
 object ContextMiddleware {

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package server
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.effect.concurrent.Ref
 import fs2._

--- a/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.{Functor, Monad, MonoidK}
 import cats.data.Kleisli
-import cats.implicits._
+import cats.syntax.all._
 
 /** Removes a trailing slash from [[Request]] path
   *

--- a/server/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.{Applicative, Monad}
 import cats.data.Kleisli
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.Method.OPTIONS
 import org.http4s.headers._
 import org.http4s.util.CaseInsensitiveString

--- a/server/src/main/scala/org/http4s/server/middleware/Caching.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Caching.scala
@@ -7,7 +7,7 @@
 package org.http4s.server.middleware
 
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.data._
 import org.http4s._

--- a/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -12,7 +12,7 @@ import cats.arrow.FunctionK
 import cats.{FlatMap, ~>}
 import cats.data.{Kleisli, NonEmptyList, OptionT}
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import org.http4s.headers._
 import scala.collection.mutable.ListBuffer

--- a/server/src/main/scala/org/http4s/server/middleware/Date.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Date.scala
@@ -8,7 +8,7 @@ package org.http4s.server.middleware
 
 import cats._
 import cats.data.Kleisli
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 
 import org.http4s._

--- a/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -11,7 +11,7 @@ package middleware
 import org.http4s.Method.{GET, HEAD}
 import cats.{Functor, MonoidK}
 import cats.data.Kleisli
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import cats.effect.Concurrent
 

--- a/server/src/main/scala/org/http4s/server/middleware/ErrorAction.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ErrorAction.scala
@@ -9,7 +9,7 @@ package middleware
 
 import cats.data.{Kleisli, OptionT}
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s._
 
 object ErrorAction {

--- a/server/src/main/scala/org/http4s/server/middleware/ErrorHandling.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ErrorHandling.scala
@@ -9,7 +9,7 @@ package middleware
 
 import cats.data.Kleisli
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s._
 
 object ErrorHandling {

--- a/server/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.Functor
 import cats.data.Kleisli
-import cats.implicits._
+import cats.syntax.all._
 import fs2.{Chunk, Pipe, Pull, Stream}
 import fs2.Stream.chunk
 import fs2.compress.deflate

--- a/server/src/main/scala/org/http4s/server/middleware/HeaderEcho.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HeaderEcho.scala
@@ -9,7 +9,7 @@ package org.http4s.server.middleware
 import cats.Functor
 import cats.data.Kleisli
 import org.http4s._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.util.CaseInsensitiveString
 
 object HeaderEcho {

--- a/server/src/main/scala/org/http4s/server/middleware/HttpsRedirect.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HttpsRedirect.scala
@@ -9,7 +9,7 @@ package server
 package middleware
 
 import cats.{Applicative, Monad}
-import cats.implicits._
+import cats.syntax.all._
 import cats.data.Kleisli
 import org.http4s.Status.MovedPermanently
 import org.http4s.Uri.{Authority, RegName, Scheme}

--- a/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -13,7 +13,7 @@ import cats.data.Kleisli
 import fs2.Stream._
 import fs2.Chunk
 import java.nio.charset.StandardCharsets
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.headers._
 import org.log4s.getLogger
 

--- a/server/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.~>
 import cats.arrow.FunctionK
-import cats.implicits._
+import cats.syntax.all._
 import cats.data.OptionT
 import cats.effect.{Bracket, Concurrent, Sync}
 import cats.effect.Sync._

--- a/server/src/main/scala/org/http4s/server/middleware/MaxActiveRequests.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/MaxActiveRequests.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.server.middleware
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.data._
 import cats.effect._
 import cats.effect.concurrent.Semaphore

--- a/server/src/main/scala/org/http4s/server/middleware/Metrics.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Metrics.scala
@@ -10,7 +10,7 @@ import cats.data.{Kleisli, OptionT}
 import cats.effect.concurrent.Ref
 import cats.effect.implicits._
 import cats.effect.{Clock, ExitCase, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import java.util.concurrent.TimeUnit
 import org.http4s._

--- a/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/PushSupport.scala
@@ -11,7 +11,7 @@ package middleware
 import cats.{Functor, Monad}
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import org.log4s.getLogger
 import io.chrisdavenport.vault._
 

--- a/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestId.scala
@@ -14,7 +14,7 @@ import cats.{FlatMap, ~>}
 import cats.arrow.FunctionK
 import cats.data.{Kleisli, OptionT}
 import cats.effect.{IO, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.util.{CaseInsensitiveString => CIString}
 import io.chrisdavenport.vault.Key
 import java.util.UUID

--- a/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -14,7 +14,7 @@ import cats.data.{Kleisli, OptionT}
 import cats.effect.{Bracket, Concurrent, ExitCase, Sync}
 import cats.effect.implicits._
 import cats.effect.concurrent.Ref
-import cats.implicits._
+import cats.syntax.all._
 import fs2.{Chunk, Stream}
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -15,7 +15,7 @@ import cats.effect.{Bracket, Concurrent, ExitCase, Sync}
 import cats.effect.implicits._
 import cats.effect.Sync._
 import cats.effect.concurrent.Ref
-import cats.implicits._
+import cats.syntax.all._
 import fs2.{Chunk, Stream}
 import org.http4s.util.CaseInsensitiveString
 import org.log4s.getLogger

--- a/server/src/main/scala/org/http4s/server/middleware/ResponseTiming.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ResponseTiming.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.data.Kleisli
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.util.CaseInsensitiveString
 
 import scala.concurrent.duration._

--- a/server/src/main/scala/org/http4s/server/middleware/StaticHeaders.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/StaticHeaders.scala
@@ -8,7 +8,7 @@ package org.http4s.server.middleware
 
 import cats.Functor
 import cats.data.{Kleisli, NonEmptyList}
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.{CacheDirective, Header, Headers, Response}
 import org.http4s.headers.`Cache-Control`
 

--- a/server/src/main/scala/org/http4s/server/middleware/Throttle.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Throttle.scala
@@ -12,7 +12,7 @@ import cats.data.Kleisli
 import cats.effect.{Clock, Sync}
 import cats.effect.concurrent.Ref
 import scala.concurrent.duration.FiniteDuration
-import cats.implicits._
+import cats.syntax.all._
 import java.util.concurrent.TimeUnit.NANOSECONDS
 import scala.concurrent.duration._
 

--- a/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
@@ -10,7 +10,7 @@ package middleware
 
 import cats.data.Kleisli
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import cats.~>
 
 /** [[Middleware]] for lifting application/x-www-form-urlencoded bodies into the

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
@@ -12,7 +12,7 @@ package authentication
 import cats.Applicative
 import cats.data.Kleisli
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.headers.Authorization
 
 /** Provides Basic Authentication from RFC 2617.

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -12,7 +12,7 @@ package authentication
 import cats.Applicative
 import cats.data.{Kleisli, NonEmptyList}
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all._
 import java.math.BigInteger
 import java.security.SecureRandom
 import java.util.Date

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.{Applicative, Monad}
 import cats.data.{Kleisli, OptionT}
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.IO
 import org.http4s.headers.{Connection, `Content-Length`}
 import org.http4s.syntax.string._

--- a/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -10,7 +10,7 @@ package staticcontent
 
 import cats.data.{Kleisli, NonEmptyList, OptionT}
 import cats.effect.{Blocker, ContextShift, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import java.io.File
 import java.nio.file.NoSuchFileException
 import java.nio.file.{LinkOption, Path, Paths}

--- a/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
@@ -10,7 +10,7 @@ package staticcontent
 
 import cats.data.{Kleisli, OptionT}
 import cats.effect.{Blocker, ContextShift, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.file.Paths
 import org.http4s.server.middleware.TranslateUri
 import org.log4s.getLogger

--- a/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -10,7 +10,7 @@ package staticcontent
 
 import cats.data.{Kleisli, OptionT}
 import cats.effect.{Blocker, ContextShift, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.file.{Path, Paths}
 import org.http4s.internal.CollectionCompat.CollectionConverters._
 import scala.util.control.NoStackTrace

--- a/server/src/main/scala/org/http4s/server/syntax/package.scala
+++ b/server/src/main/scala/org/http4s/server/syntax/package.scala
@@ -9,7 +9,7 @@ package server
 
 import cats.Semigroup
 import cats.data.Kleisli
-import cats.implicits._
+import cats.syntax.all._
 
 package object syntax {
   @deprecated(

--- a/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -7,7 +7,7 @@
 package org.http4s.server.websocket
 
 import cats.Applicative
-import cats.implicits._
+import cats.syntax.all._
 import fs2.{Pipe, Stream}
 import org.http4s.websocket.{WebSocket, WebSocketContext, WebSocketFrame}
 import org.http4s.{Headers, Response, Status}

--- a/server/src/test/scala/org/http4s/server/HttpRoutesSpec.scala
+++ b/server/src/test/scala/org/http4s/server/HttpRoutesSpec.scala
@@ -8,7 +8,7 @@ package org.http4s
 package server
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.Uri.uri
 import org.http4s.testing.Http4sLegacyMatchersIO
 

--- a/server/src/test/scala/org/http4s/server/MockRoute.scala
+++ b/server/src/test/scala/org/http4s/server/MockRoute.scala
@@ -8,7 +8,7 @@ package org.http4s
 package server
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.Status.{Accepted, Ok}
 import org.http4s.server.middleware.PushSupport._
 

--- a/server/src/test/scala/org/http4s/server/middleware/DateSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DateSpec.scala
@@ -7,7 +7,7 @@
 package org.http4s.server.middleware
 
 import cats.data.OptionT
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import org.http4s._
 import org.http4s.headers.{Date => HDate}

--- a/server/src/test/scala/org/http4s/server/middleware/HttpsRedirectSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpsRedirectSuite.scala
@@ -8,7 +8,7 @@ package org.http4s
 package server
 package middleware
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._

--- a/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSuite.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.server.middleware
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.effect.concurrent.Ref
 import org.http4s._

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSpec.scala
@@ -11,7 +11,7 @@ package authentication
 
 import cats.data.NonEmptyList
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.http4s.parser.HttpHeaderParser

--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -9,7 +9,7 @@ package servlet
 
 import cats.effect._
 import cats.effect.concurrent.Deferred
-import cats.implicits._
+import cats.syntax.all._
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import org.http4s.internal.loggingAsyncCallback

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -9,7 +9,7 @@ package servlet
 
 import cats.effect._
 import cats.effect.implicits._
-import cats.implicits._
+import cats.syntax.all._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import org.http4s.server._
 

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -7,7 +7,7 @@
 package org.http4s.servlet
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import io.chrisdavenport.vault._
 import java.net.InetSocketAddress
 import java.security.cert.X509Certificate

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -8,7 +8,7 @@ package org.http4s
 package servlet
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import java.util.concurrent.atomic.AtomicReference
 import javax.servlet.{ReadListener, WriteListener}

--- a/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSpec.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSpec.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package servlet
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.{IO, Resource, Timer}
 import java.net.{HttpURLConnection, URL}
 import java.nio.charset.StandardCharsets

--- a/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
+++ b/testing/src/main/scala/org/http4s/testing/Http4sMatchers.scala
@@ -9,7 +9,7 @@ package testing
 
 import cats.MonadError
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.headers._
 import org.http4s.util.CaseInsensitiveString
 import org.specs2.matcher._

--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -11,7 +11,7 @@
 package org.http4s
 
 import cats.effect.{Blocker, ContextShift, ExitCase, IO, Resource, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.text._
 import java.util.concurrent.{ScheduledExecutorService, ScheduledThreadPoolExecutor, TimeUnit}

--- a/testing/src/test/scala/org/http4s/testing/ErrorReporting.scala
+++ b/testing/src/test/scala/org/http4s/testing/ErrorReporting.scala
@@ -9,7 +9,7 @@
 
 package org.http4s.testing
 import java.io.{ByteArrayOutputStream, PrintStream}
-import cats.implicits._
+import cats.syntax.all._
 import cats.Monad
 import org.http4s.{Headers, MessageFailure, Request, Response, Status}
 import org.http4s.headers.{Connection, `Content-Length`}

--- a/testing/src/test/scala/org/http4s/testing/Http4sLegacyMatchers.scala
+++ b/testing/src/test/scala/org/http4s/testing/Http4sLegacyMatchers.scala
@@ -9,7 +9,7 @@ package testing
 
 import cats.MonadError
 import cats.data.EitherT
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.headers._
 import org.http4s.util.CaseInsensitiveString
 import org.specs2.matcher.{RunTimedMatchers => Specs2RunTimedMatchers, _}

--- a/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/ContentCodingSpec.scala
@@ -6,7 +6,6 @@
 
 package org.http4s
 
-import cats.implicits._
 import cats.kernel.laws.discipline.OrderTests
 import org.http4s.laws.discipline.HttpCodecTests
 import org.http4s.util.Renderer

--- a/tests/src/test/scala/org/http4s/ContextRequestSpec.scala
+++ b/tests/src/test/scala/org/http4s/ContextRequestSpec.scala
@@ -9,7 +9,7 @@ package org.http4s
 import org.specs2.Specification
 import org.typelevel.discipline.specs2.Discipline
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.laws.discipline.NonEmptyTraverseTests
 import org.http4s.laws.discipline.arbitrary._
 

--- a/tests/src/test/scala/org/http4s/DecodeSpec.scala
+++ b/tests/src/test/scala/org/http4s/DecodeSpec.scala
@@ -6,7 +6,7 @@
 
 package org.http4s
 
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.charset.{Charset => JCharset}
 import java.nio.charset.{
   CharacterCodingException,

--- a/tests/src/test/scala/org/http4s/EntityCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityCodecSpec.scala
@@ -10,7 +10,6 @@ import cats.Eq
 import cats.effect.IO
 import cats.effect.laws.util.TestContext
 import cats.effect.laws.util.TestInstances._
-import cats.implicits._
 import fs2.Chunk
 import org.http4s.laws.discipline.EntityCodecTests
 import org.http4s.testing.fs2Arbitraries._

--- a/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSpec.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.effect._
 import cats.effect.laws.util.TestContext
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import fs2.Stream._
 import java.io.{File, FileInputStream, InputStreamReader}

--- a/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.Eq
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import cats.laws.discipline.{ContravariantTests, ExhaustiveCheck, MiniInt}
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/org/http4s/FormDataDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/FormDataDecoderSpec.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{Chain, NonEmptyList}
-import cats.implicits._
+import cats.syntax.all._
 import FormDataDecoder._
 
 class FormDataDecoderSpec extends Http4sSpec {

--- a/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
+++ b/tests/src/test/scala/org/http4s/HttpVersionSpec.scala
@@ -6,7 +6,6 @@
 
 package org.http4s
 
-import cats.implicits._
 import cats.kernel.laws.discipline.{BoundedEnumerableTests, HashTests, OrderTests}
 import org.scalacheck.Gen._
 import org.scalacheck.Prop._

--- a/tests/src/test/scala/org/http4s/Ipv4AddressSpec.scala
+++ b/tests/src/test/scala/org/http4s/Ipv4AddressSpec.scala
@@ -6,7 +6,6 @@
 
 package org.http4s
 
-import cats.implicits._
 import cats.kernel.laws.discipline.{HashTests, OrderTests}
 import org.http4s.Uri.Ipv4Address
 import org.http4s.laws.discipline.HttpCodecTests

--- a/tests/src/test/scala/org/http4s/Ipv6AddressSpec.scala
+++ b/tests/src/test/scala/org/http4s/Ipv6AddressSpec.scala
@@ -6,7 +6,6 @@
 
 package org.http4s
 
-import cats.implicits._
 import cats.kernel.laws.discipline.{HashTests, OrderTests}
 import org.http4s.Uri.Ipv6Address
 import org.http4s.laws.discipline.HttpCodecTests

--- a/tests/src/test/scala/org/http4s/MediaRangeSpec.scala
+++ b/tests/src/test/scala/org/http4s/MediaRangeSpec.scala
@@ -8,7 +8,6 @@ package org.http4s
 
 import cats.kernel.laws.discipline.OrderTests
 import org.http4s.laws.discipline.HttpCodecTests
-import cats.implicits._
 
 class MediaRangeSpec extends Http4sSpec {
   checkAll("Order[MediaRange]", OrderTests[MediaRange].order)

--- a/tests/src/test/scala/org/http4s/MethodSpec.scala
+++ b/tests/src/test/scala/org/http4s/MethodSpec.scala
@@ -9,7 +9,7 @@ package org.http4s
 import java.util.Locale
 
 import cats.Hash
-import cats.implicits._
+import cats.syntax.all._
 import cats.kernel.laws.discipline._
 import org.http4s.parser.Rfc2616BasicRules
 import org.scalacheck.Gen

--- a/tests/src/test/scala/org/http4s/QValueSpec.scala
+++ b/tests/src/test/scala/org/http4s/QValueSpec.scala
@@ -6,7 +6,6 @@
 
 package org.http4s
 
-import cats.implicits._
 import cats.kernel.laws.discipline.OrderTests
 import org.http4s.laws.discipline.HttpCodecTests
 

--- a/tests/src/test/scala/org/http4s/QueryParamCodecLaws.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecLaws.scala
@@ -7,7 +7,7 @@
 package org.http4s
 
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import org.scalacheck.{Arbitrary, Properties}
 import org.scalacheck.Prop._
 

--- a/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSpec.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import cats._
 import cats.data._
-import cats.implicits._
+import cats.syntax.all._
 import cats.laws.discipline.{arbitrary => _, _}
 
 import java.time.format.DateTimeFormatter

--- a/tests/src/test/scala/org/http4s/SchemeSpec.scala
+++ b/tests/src/test/scala/org/http4s/SchemeSpec.scala
@@ -6,7 +6,7 @@
 
 package org.http4s
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.kernel.laws.discipline.OrderTests
 import org.http4s.Uri.Scheme
 import org.http4s.internal.parboiled2.CharPredicate

--- a/tests/src/test/scala/org/http4s/StatusSpec.scala
+++ b/tests/src/test/scala/org/http4s/StatusSpec.scala
@@ -6,7 +6,6 @@
 
 package org.http4s
 
-import cats.implicits._
 import cats.kernel.laws.discipline.OrderTests
 import org.http4s.Status._
 import org.scalacheck.Gen

--- a/tests/src/test/scala/org/http4s/TransferCodingSpec.scala
+++ b/tests/src/test/scala/org/http4s/TransferCodingSpec.scala
@@ -7,7 +7,6 @@
 package org.http4s
 
 import cats.data.NonEmptyList
-import cats.implicits._
 import cats.kernel.laws.discipline.OrderTests
 import org.http4s.laws.discipline.HttpCodecTests
 import org.http4s.util.Renderer

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -10,7 +10,7 @@
 
 package org.http4s
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.kernel.laws.discipline.EqTests
 import java.nio.file.Paths
 import org.http4s.internal.parboiled2.CharPredicate

--- a/tests/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -9,7 +9,7 @@ package org.http4s
 import cats.Monoid
 import cats.data._
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import cats.kernel.laws.discipline.MonoidTests
 import org.http4s.internal.CollectionCompat
 

--- a/tests/src/test/scala/org/http4s/UserInfoSpec.scala
+++ b/tests/src/test/scala/org/http4s/UserInfoSpec.scala
@@ -6,7 +6,7 @@
 
 package org.http4s
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.kernel.laws.discipline.{HashTests, OrderTests}
 import org.http4s.Uri.UserInfo
 import org.http4s.util.UrlCodingUtils._

--- a/tests/src/test/scala/org/http4s/headers/ZipkinHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/ZipkinHeaderSpec.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package headers
 
-import cats.implicits._
+import cats.syntax.all._
 
 class ZipkinHeaderSpec extends Http4sSpec with HeaderLaws {
   checkAll("X-B3-Sampled", headerLaws(`X-B3-Sampled`))

--- a/tests/src/test/scala/org/http4s/metrics/MetricsOpsSpec.scala
+++ b/tests/src/test/scala/org/http4s/metrics/MetricsOpsSpec.scala
@@ -7,7 +7,7 @@
 package org.http4s.metrics
 
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import java.util.UUID
 import org.http4s._
 import org.scalacheck.{Arbitrary, Gen}

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -9,7 +9,7 @@ package multipart
 
 import cats._
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2._
 import java.io.File
 import org.http4s.headers._

--- a/tests/src/test/scala/org/http4s/parser/Rfc2616ParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/Rfc2616ParserSpec.scala
@@ -7,7 +7,7 @@
 package org.http4s
 package parser
 
-import cats.implicits._
+import cats.syntax.all._
 import org.http4s.internal.parboiled2._
 import org.http4s.laws.discipline.ArbitraryInstances._
 import org.scalacheck.{Gen, Prop}

--- a/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.parser
 
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.charset.{StandardCharsets, Charset => NioCharset}
 
 import org.http4s.Uri.Scheme.https

--- a/tests/src/test/scala/org/http4s/util/CaseInsensitiveStringSpec.scala
+++ b/tests/src/test/scala/org/http4s/util/CaseInsensitiveStringSpec.scala
@@ -7,7 +7,7 @@
 package org.http4s.util
 
 import cats.Show
-import cats.implicits._
+import cats.syntax.all._
 import cats.kernel.laws.discipline.{MonoidTests, OrderTests}
 import java.util.Locale
 import org.http4s.Http4sSpec

--- a/tests/src/test/scala/org/http4s/websocket/WebSocketSpec.scala
+++ b/tests/src/test/scala/org/http4s/websocket/WebSocketSpec.scala
@@ -6,7 +6,7 @@
 
 package org.http4s.websocket
 
-import cats.implicits._
+import cats.syntax.all._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 import org.http4s.websocket.WebSocketFrame._

--- a/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSpec.scala
+++ b/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSpec.scala
@@ -9,7 +9,7 @@ package server
 package tomcat
 
 import cats.effect.{IO, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import java.io.IOException
 import java.net.{HttpURLConnection, URL}
 import java.nio.charset.StandardCharsets


### PR DESCRIPTION
This changes addresses the https://github.com/http4s/http4s/issues/3944 
Replace cats.implicits._ with cats.syntax.all._



FIX https://github.com/http4s/http4s/issues/3944