### PR TITLE
Add Order/Hash/Show Instances For Uri And Related Types

### DIFF
--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -8,7 +8,7 @@ package org.http4s
 
 import java.nio.charset.StandardCharsets
 
-import cats.{Eval, Foldable}
+import cats.{Eval, Foldable, Hash, Order, Show}
 import cats.implicits._
 import org.http4s.Query._
 import org.http4s.internal.CollectionCompat
@@ -201,4 +201,16 @@ object Query {
         case Right(query) => query
         case Left(_) => Vector.empty
       }
+
+  implicit val catsInstancesForHttp4sQuery: Hash[Query] with Order[Query] with Show[Query] =
+    new Hash[Query] with Order[Query] with Show[Query] {
+      override def hash(x: Query): Int =
+        x.hashCode
+
+      override def compare(x: Query, y: Query): Int =
+        x.toVector.compare(y.toVector)
+
+      override def show(a: Query): String =
+        a.renderString
+    }
 }

--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -8,6 +8,7 @@ package org.http4s
 
 import java.nio.charset.StandardCharsets
 
+import cats.syntax.all._
 import cats.{Eval, Foldable, Hash, Order, Show}
 import org.http4s.Query._
 import org.http4s.internal.CollectionCompat

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -10,13 +10,15 @@
 
 package org.http4s
 
-import cats.{Eq, Hash, Order, Show}
+import cats.{Eq, Eval, Hash, Order, Show}
 import cats.syntax.either._
+import cats.syntax.hash._
+import cats.syntax.order._
 import java.net.{Inet4Address, Inet6Address, InetAddress}
 import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{Charset => JCharset}
 import java.nio.charset.StandardCharsets
-import org.http4s.internal.{bug, hashLower}
+import org.http4s.internal.{bug, compareField, hashLower, reduceComparisons}
 import org.http4s.internal.parboiled2.{Parser => PbParser, _}
 import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit, HexDigit}
 import org.http4s.parser._
@@ -300,6 +302,37 @@ object Uri {
       }
   }
 
+  object Authority
+      extends scala.runtime.AbstractFunction3[Option[UserInfo], Host, Option[Int], Authority] {
+
+    override def apply(
+        userInfo: Option[UserInfo] = None,
+        host: Host = RegName("localhost"),
+        port: Option[Int] = None): Authority =
+      new Authority(userInfo, host, port)
+
+    implicit val catsInstancesForHttp4sAuthority
+        : Hash[Authority] with Order[Authority] with Show[Authority] =
+      new Hash[Authority] with Order[Authority] with Show[Authority] {
+        override def hash(x: Authority): Int =
+          x.hashCode
+
+        override def compare(x: Authority, y: Authority): Int = {
+          def compareAuthorities[A: Order](focus: Authority => A): Int =
+            compareField(x, y, focus)
+
+          reduceComparisons(
+            compareAuthorities(_.userInfo),
+            Eval.later(compareAuthorities(_.host)),
+            Eval.later(compareAuthorities(_.port))
+          )
+        }
+
+        override def show(a: Authority): String =
+          a.renderString
+      }
+  }
+
   /** The userinfo subcomponent may consist of a user name and,
     * optionally, scheme-specific information about how to gain
     * authorization to access the resource.  The user information, if
@@ -386,6 +419,47 @@ object Uri {
         case a: Ipv4Address => writer << a.value
         case a: Ipv6Address => writer << '[' << a << ']'
         case _ => writer
+      }
+  }
+
+  object Host {
+    implicit val catsInstancesForHttp4sUriHost: Hash[Host] with Order[Host] with Show[Host] =
+      new Hash[Host] with Order[Host] with Show[Host] {
+        override def hash(x: Host): Int =
+          x match {
+            case x: Ipv4Address =>
+              x.hash
+            case x: Ipv6Address =>
+              x.hash
+            case x: RegName =>
+              x.hash
+          }
+
+        override def compare(x: Host, y: Host): Int =
+          (x, y) match {
+            case (x: Ipv4Address, y: Ipv4Address) =>
+              x.compare(y)
+            case (x: Ipv6Address, y: Ipv6Address) =>
+              x.compare(y)
+            case (x: RegName, y: RegName) =>
+              x.compare(y)
+
+            // Differing ADT constructors
+            // Ipv4Address is arbitrarily considered > all Ipv6Address and RegName
+            case (_: Ipv4Address, _) =>
+              1
+            case (_, _: Ipv4Address) =>
+              -1
+
+            // Ipv6Address is arbitrarily considered > all RegName
+            case (_: Ipv6Address, _) =>
+              1
+            case (_, _: Ipv6Address) =>
+              -1
+          }
+
+        override def show(a: Host): String =
+          a.renderString
       }
   }
 
@@ -666,7 +740,21 @@ object Uri {
     def value: String = host.toString
   }
 
-  object RegName { def apply(name: String): RegName = new RegName(name.ci) }
+  object RegName {
+    def apply(name: String): RegName = new RegName(name.ci)
+
+    implicit val catsInstancesForHttp4sUriRegName: Hash[RegName] with Order[RegName] with Show[RegName] =
+      new Hash[RegName] with Order[RegName] with Show[RegName] {
+        override def hash(x: RegName): Int =
+          x.hashCode
+
+        override def compare(x: RegName, y: RegName): Int =
+          x.host.compare(y.host)
+
+        override def show(a: RegName): String =
+          a.toString
+      }
+  }
 
   /**
     * Resolve a relative Uri reference, per RFC 3986 sec 5.2
@@ -901,5 +989,30 @@ object Uri {
   @deprecated("""use uri"" string interpolation instead""", "0.20")
   def uri(s: String): Uri = macro Uri.Macros.uriLiteral
 
-  implicit val http4sUriEq: Eq[Uri] = Eq.fromUniversalEquals
+  @deprecated(message = "Please use catsInstancesForHttp4sUri. Kept for binary compatibility", since = "0.21.14")
+  def http4sUriEq: Eq[Uri] = catsInstancesForHttp4sUri
+
+  implicit val catsInstancesForHttp4sUri: Hash[Uri] with Order[Uri] with Show[Uri] = {
+
+    new Hash[Uri] with Order[Uri] with Show[Uri] {
+      override def hash(x: Uri): Int =
+        x.hashCode
+
+      override def compare(x: Uri, y: Uri): Int = {
+        def compareUris[A: Order](focus: Uri => A): Int =
+          compareField(x, y, focus)
+
+        reduceComparisons(
+          compareUris(_.scheme),
+          Eval.later(compareUris(_.authority)),
+          Eval.later(compareUris(_.path)),
+          Eval.later(compareUris(_.query)),
+          Eval.later(compareUris(_.fragment))
+        )
+      }
+
+      override def show(t: Uri): String =
+        t.renderString
+    }
+  }
 }

--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -13,6 +13,8 @@ import java.util.concurrent.{
   CompletionStage
 }
 
+import cats.{Comonad, Eval, Order}
+import cats.data.NonEmptyChain
 import cats.effect.implicits._
 import cats.effect.{Async, Concurrent, ConcurrentEffect, ContextShift, Effect, IO}
 import cats.implicits._
@@ -274,4 +276,73 @@ package object internal {
     if (chunk.size >= 3 && chunk.take(3) == utf8Bom)
       chunk.drop(3)
     else chunk
+
+  // Helper functions for writing Order instances //
+
+  /** This is the same as `Order.by(f).compare(a, b)`, but with the parameters
+    * re-arraigned to make it easier to partially apply the function to two
+    * instances of a type before supplying the `A => B`.
+    *
+    * The intended use case is that `f: A => B` will extract out a single
+    * field from two instances of some Product type and then compare the value
+    * of the field. This can then be done in turn for each field of a Product,
+    * significantly reducing the amount of code needed to write an `Order`
+    * instance for a Product with many fields.
+    *
+    * See the `Order` instance for `Uri` for an example of this usage.
+    */
+  private[http4s] def compareField[A, B: Order](
+      a: A,
+      b: A,
+      f: A => B
+  ): Int =
+    Order.by[A, B](f).compare(a, b)
+
+  /** Given at least one `Int` intended to represent the result of a comparison
+    * of two fields of some Product type, reduce the result to the first
+    * non-zero value, or return 0 if all comparisons are 0.
+    *
+    * The intended use case for this function is to reduce the amount of code
+    * needed to write an `Order` instance for Product types. One can use
+    * [[#compareField]] to generate a comparison for each field in a product
+    * type, then apply this function to get a ordering for the entire Product
+    * type.
+    *
+    * See the `Order` instance for `Uri` for an example of this usage.
+    *
+    * @note The values of the `NonEmptyChain` are encoded `F[Int]`, where `F`
+    *       is some `Comonad`. The primary Comonads with which we are
+    *       concerned are `Eval` and `Id`. `Eval` will give lazy evaluation of
+    *       the Ordering, stopping as soon as the result is known, and `Id`
+    *       will give strict evaluation, in the case where the caller has good
+    *       reason to believe that evaluating the thunks will be slower than
+    *       strictly evaluating the result over all fields.
+    */
+  private[http4s] def reduceComparisons_[F[_]: Comonad](
+      comparisons: NonEmptyChain[F[Int]]
+  ): Int = {
+    val extractComparison: F[Int] => Option[Int] =
+      _.extract match {
+        case 0 => None
+        case otherwise => Some(otherwise)
+      }
+
+    comparisons
+      .reduceLeftTo(extractComparison) {
+        case (None, next) => extractComparison(next)
+        case (otherwise, _) => otherwise
+      }
+      .getOrElse(0)
+  }
+
+  /** Similar to [[#reduceComparisons_]] but with the `F` type forced to `Eval`
+    * for every comparison other than the first one. This encodes the commonly
+    * desired use case of only evaluating the minimum number of comparisons
+    * required to determine the ordering.
+    */
+  private[http4s] def reduceComparisons(
+      head: Int,
+      tail: Eval[Int]*
+  ): Int =
+    reduceComparisons_(NonEmptyChain(Eval.now(head), tail: _*))
 }

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -6,7 +6,7 @@
 
 package org
 
-import cats.data.{EitherT, Kleisli, OptionT}
+import cats.data._
 import fs2.Stream
 
 package object http4s {

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -570,6 +570,12 @@ private[http4s] trait ArbitraryInstances {
   val genHexDigit: Gen[Char] = oneOf(
     List('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'))
 
+  val genPctEncoded: Gen[String] =
+    const("%") |+| genHexDigit.map(_.toString) |+| genHexDigit.map(_.toString)
+  val genUnreserved: Gen[Char] =
+    oneOf(alphaChar, numChar, const('-'), const('.'), const('_'), const('~'))
+  val genSubDelims: Gen[Char] = oneOf(List('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='))
+
   private implicit def http4sTestingSemigroupForGen[T: Semigroup]: Semigroup[Gen[T]] =
     new Semigroup[Gen[T]] {
       def combine(g1: Gen[T], g2: Gen[T]): Gen[T] = for { t1 <- g1; t2 <- g2 } yield t1 |+| t2
@@ -609,10 +615,14 @@ private[http4s] trait ArbitraryInstances {
     Cogen[(Short, Short, Short, Short, Short, Short, Short, Short)]
       .contramap(ipv6 => (ipv6.a, ipv6.b, ipv6.c, ipv6.d, ipv6.e, ipv6.f, ipv6.g, ipv6.h))
 
-  implicit val http4sTestingArbitraryForUriHost: Arbitrary[Uri.Host] = Arbitrary {
-    val genRegName =
+  implicit val http4sTestingArbitraryForUriHost: Arbitrary[Uri.Host] = {
+    // Duplicated in the companion object for binary compatibility. This should
+    // be removed before 1.0.0.
+    val http4sTestingRegNameGen: Gen[Uri.RegName] =
       listOf(oneOf(genUnreserved, genPctEncoded, genSubDelims)).map(rn => Uri.RegName(rn.mkString))
-    oneOf(getArbitrary[Uri.Ipv4Address], getArbitrary[Uri.Ipv6Address], genRegName)
+    Arbitrary(
+      oneOf(getArbitrary[Uri.Ipv4Address], getArbitrary[Uri.Ipv6Address], http4sTestingRegNameGen)
+    )
   }
 
   implicit val http4sTestingArbitraryForUserInfo: Arbitrary[Uri.UserInfo] =
@@ -633,12 +643,6 @@ private[http4s] trait ArbitraryInstances {
       maybePort <- Gen.option(posNum[Int].suchThat(port => port >= 0 && port <= 65536))
     } yield Uri.Authority(maybeUserInfo, host, maybePort)
   }
-
-  val genPctEncoded: Gen[String] =
-    const("%") |+| genHexDigit.map(_.toString) |+| genHexDigit.map(_.toString)
-  val genUnreserved: Gen[Char] =
-    oneOf(alphaChar, numChar, const('-'), const('.'), const('_'), const('~'))
-  val genSubDelims: Gen[Char] = oneOf(List('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='))
 
   implicit val http4sTestingArbitraryForScheme: Arbitrary[Uri.Scheme] = Arbitrary {
     frequency(
@@ -877,4 +881,26 @@ object ArbitraryInstances extends ArbitraryInstances {
 
   val genListSep: Gen[String] =
     sequence[List[String], String](List(genOptWs, const(","), genOptWs)).map(_.mkString)
+
+  implicit val http4sTestingCogenForQuery: Cogen[Query] =
+    Cogen[Vector[(String, Option[String])]].contramap(_.toVector)
+
+  implicit val http4sTestingArbitraryForRegName: Arbitrary[Uri.RegName] =
+    Arbitrary(
+      listOf(oneOf(genUnreserved, genPctEncoded, genSubDelims)).map(rn => Uri.RegName(rn.mkString)))
+
+  implicit val http4sTestingCogenForRegName: Cogen[Uri.RegName] =
+    Cogen[CaseInsensitiveString].contramap(_.host)
+
+  implicit val http4sTestingCogenForUriHost: Cogen[Uri.Host] =
+    Cogen[Either[Uri.RegName, Either[Uri.Ipv4Address, Uri.Ipv6Address]]].contramap {
+      case value: Uri.RegName => Left(value)
+      case value: Uri.Ipv4Address => Right(Left(value))
+      case value: Uri.Ipv6Address => Right(Right(value))
+    }
+
+  implicit val http4sTestingCogenForAuthority: Cogen[Uri.Authority] =
+    Cogen
+      .tuple3[Option[Uri.UserInfo], Uri.Host, Option[Int]]
+      .contramap(a => (a.userInfo, a.host, a.port))
 }

--- a/tests/src/test/scala/org/http4s/AuthoritySpec.scala
+++ b/tests/src/test/scala/org/http4s/AuthoritySpec.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+
+import org.http4s.laws.discipline.ArbitraryInstances.http4sTestingCogenForAuthority
+import cats.kernel.laws.discipline._
+
+final class AuthoritySpec extends Http4sSpec {
+
+  "Uri.Authority instances" should {
+    "be lawful" in {
+      checkAll("Order[Uri.Authority]", OrderTests[Uri.Authority].order)
+      checkAll("Hash[Uri.Authority]", HashTests[Uri.Authority].hash)
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/QuerySpec.scala
+++ b/tests/src/test/scala/org/http4s/QuerySpec.scala
@@ -6,6 +6,8 @@
 
 package org.http4s
 
+import cats.kernel.laws.discipline._
+import org.http4s.laws.discipline.ArbitraryInstances.http4sTestingCogenForQuery
 import org.scalacheck.Prop._
 
 class QuerySpec extends Http4sSpec {
@@ -59,6 +61,18 @@ class QuerySpec extends Http4sSpec {
     "Encode special chars in the key" in {
       val u = Query(" !$&'()*+,;=:/?@~" -> Some("foo"), "!" -> None)
       u.renderString must_== "%20%21%24%26%27%28%29%2A%2B%2C%3B%3D%3A/?%40~=foo&%21"
+    }
+  }
+
+  "Order instance for Query" should {
+    "be lawful" in {
+      checkAll("Order[Query]", OrderTests[Query].order)
+    }
+  }
+
+  "Hash instance for Query" should {
+    "be lawful" in {
+      checkAll("Hash[Query]", HashTests[Query].hash)
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/RegNameSpec.scala
+++ b/tests/src/test/scala/org/http4s/RegNameSpec.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+
+import cats.kernel.laws.discipline._
+import org.http4s.laws.discipline.ArbitraryInstances.http4sTestingArbitraryForRegName
+import org.http4s.laws.discipline.ArbitraryInstances.http4sTestingCogenForRegName
+
+final class RegNameSpec extends Http4sSpec {
+
+  "Uri.RegName instances" should {
+    "be lawful" in {
+      checkAll("Order[Uri.RegName]", OrderTests[Uri.RegName].order)
+      checkAll("Hash[Uri.RegName]", HashTests[Uri.RegName].hash)
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/UriHostSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriHostSpec.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+
+import cats.kernel.laws.discipline._
+import org.http4s.laws.discipline.ArbitraryInstances.http4sTestingCogenForUriHost
+
+final class UriHostSpec extends Http4sSpec {
+
+  "Uri.Host instances" should {
+    "be lawful" in {
+      checkAll("Order[Uri.Host]", OrderTests[Uri.Host].order)
+      checkAll("Hash[Uri.Host]", HashTests[Uri.Host].hash)
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -11,7 +11,7 @@
 package org.http4s
 
 import cats.implicits._
-import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline._
 import java.nio.file.Paths
 import org.http4s.internal.parboiled2.CharPredicate
 import org.http4s.Uri._
@@ -1094,6 +1094,13 @@ http://example.org/a file
       // This is a silly thing to do, but as long as the API allows it, it would
       // be good to know if it breaks.
       decode(encode("%2f", toSkip = CharPredicate("%")), toSkip = CharPredicate("/")) must_== "%2f"
+    }
+  }
+
+  "Uri instances" should {
+    "be lawful" in {
+      checkAll("Order[Uri]", OrderTests[Uri].order)
+      checkAll("Hash[Uri]", HashTests[Uri].hash)
     }
   }
 }


### PR DESCRIPTION
This commit adds `Order`, `Hash`, and `Show` instances for the following types.

* `org.http4s.Uri.Authority`
* `org.http4s.Query`
* `org.http4s.Uri.Host`
* `org.http4s.Uri.RegName`
* `org.http4s.Uri`

The impetus for all of them was to support instances for `org.http4s.Uri`.

In addition, two functions were added to the package object `org.http4s.internal` scoped to be private to `http4s`, `compareField`, `reduceComparisons_`, and `reduceComparisons`.

These functions substantially reduce the amount of code required to write `Order` instances for Product types.

In order to support testing the laws for these types, several new instances of `Arbitrary` and `Cogen` were added, as not all types had instances for each of these.