### PR TITLE
Improve Link header parser conformance to RFC 8288

### DIFF
--- a/core/src/main/scala/org/http4s/parser/LinkHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/LinkHeader.scala
@@ -46,7 +46,11 @@ private[parser] trait LinkHeader {
     def LinkValueAttr: Rule[LinkValue :: HNil, LinkValue :: HNil] =
       rule {
         "rel=" ~ (Token | QuotedString) ~> { (link: LinkValue, rel: String) =>
-          link.copy(rel = Some(rel))
+          // https://tools.ietf.org/html/rfc8288#section-3.3
+          if (link.rel.isDefined)
+            link
+          else
+            link.copy(rel = Some(rel))
         } |
           "rev=" ~ (Token | QuotedString) ~> { (link: LinkValue, rev: String) =>
             link.copy(rev = Some(rev))

--- a/tests/src/test/scala/org/http4s/headers/LinkSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/LinkSpec.scala
@@ -37,6 +37,16 @@ class LinkSpec extends HeaderLaws {
 
       parsedLinks.map(_.size) must beRight(links.size)
     }
+
+    "retain the value of the first 'rel' param when multiple present (RFC 8288, Section 3.3)" in {
+      val link = """<http://example.com/foo>; rel=prev; rel=next;title=foo; rel="last""""
+      val parsedLinks = Link.parse(link).map(_.values)
+      val parsedLink = parsedLinks.map(_.head)
+
+      parsedLink.map(_.uri) must beRight(uri"http://example.com/foo")
+      parsedLink.map(_.rel) must beRight(Option("prev"))
+      parsedLink.map(_.title) must beRight(Option("foo"))
+    }
   }
 
   "render" should {


### PR DESCRIPTION
[RFC 8288, Section 3.3](https://tools.ietf.org/html/rfc8288#section-3.3) states that any occurrences of the `rel` parameter after the first one must be ignored. This fixes the `Link` header parser to conform to this behavior.