### PR TITLE
Add ContextResponse Type

### DIFF
--- a/core/src/main/scala/org/http4s/ContextResponse.scala
+++ b/core/src/main/scala/org/http4s/ContextResponse.scala
@@ -16,4 +16,6 @@ final case class ContextResponse[F[_], A](context: A, response: Response[F]) {
     ContextResponse(context, response.mapK(fk))
 }
 
-object ContextResponse{}
+// Include to avoid binary compatibility issues with the apply method if/when
+// we ever need a companion object in the future.
+object ContextResponse {}

--- a/core/src/main/scala/org/http4s/ContextResponse.scala
+++ b/core/src/main/scala/org/http4s/ContextResponse.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2013-2020 http4s.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.http4s
+
+import cats._
+
+final case class ContextResponse[F[_], A](context: A, response: Response[F]) {
+  def mapContext[B](f: A => B): ContextResponse[F, B] =
+    ContextResponse(f(context), response)
+
+  def mapK[G[_]](fk: F ~> G): ContextResponse[G, A] =
+    ContextResponse(context, response.mapK(fk))
+}
+
+object ContextResponse{}


### PR DESCRIPTION
Similar to ContextRequest, but for Response[F].

I didn't add corresponding type aliases, e.g. 

```
type ResponseContextRoutes[T, F[_]] =  Kleisli[OptionT[F, *], Request[F], ContextResponse[F, T]]
```

The reason I didn't add this is that we'd probably also want to add a `FullContextRoutes` for something using context on both the request/response. Then we'd probably also want to add `ResponseContextMiddleware` types and helpers like we have in `object ContextRoutes`. 

All that to say, we will start to have many, many, helpers just to provide aliases for functions and types already available more generically in cats, albeit this may be a bit less accessible.

Given the use cases for these various permutations are likely to only effect a small number of users, it seemed like keeping the code base lighter would be a good idea.