### PR TITLE
Replace `Accept-Ranges` parser with cats-parse implementation

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
@@ -6,8 +6,9 @@
 
 package org.http4s
 package headers
-
-import org.http4s.parser.HttpHeaderParser
+import cats.parse.{Parser => P}
+import cats.implicits._
+import org.http4s.internal.parsing.Rfc7230
 import org.http4s.util.Writer
 
 object `Accept-Ranges` extends HeaderKey.Internal[`Accept-Ranges`] with HeaderKey.Singleton {
@@ -16,7 +17,33 @@ object `Accept-Ranges` extends HeaderKey.Internal[`Accept-Ranges`] with HeaderKe
   def none: `Accept-Ranges` = apply(Nil)
 
   override def parse(s: String): ParseResult[`Accept-Ranges`] =
-    HttpHeaderParser.ACCEPT_RANGES(s)
+    parser.parseAll(s).leftMap { e =>
+      ParseFailure("Invalid accept-ranges", e.toString)
+    }
+
+  /* https://tools.ietf.org/html/rfc7233#appendix-C */
+  val parser: P[`Accept-Ranges`] = {
+    val ListSep: P[Unit] = Rfc7230.ows *> P.char(',') *> Rfc7230.ows
+
+    val none = P.string1("none").as(Nil)
+
+    val rangeUnit = Rfc7230.token.map(org.http4s.RangeUnit.apply)
+
+    /*
+     Accept-Ranges     = acceptable-ranges
+     OWS               = <OWS, see [RFC7230], Section 3.2.3>
+     acceptable-ranges = ( *( "," OWS ) range-unit *( OWS "," [ OWS range-unit ] ) ) / "none"
+     */
+    val acceptableRanges: P[List[RangeUnit]] =
+      P.oneOf(
+        List(
+          none,
+          P.repSep(rangeUnit, 1, ListSep)
+        )
+      )
+
+    acceptableRanges.map(headers.`Accept-Ranges`.apply) // <* EOL -- necessary? makes AcceptRangesSpec tests fail
+  }
 }
 
 final case class `Accept-Ranges` private[http4s] (rangeUnits: List[RangeUnit])

--- a/tests/src/test/scala/org/http4s/parser/AcceptRangesSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptRangesSpec.scala
@@ -11,7 +11,7 @@ import org.http4s.headers.`Accept-Ranges`
 import org.specs2.mutable.Specification
 
 class AcceptRangesSpec extends Specification with HeaderParserHelper[`Accept-Ranges`] {
-  def hparse(value: String) = HttpHeaderParser.ACCEPT_RANGES(value)
+  def hparse(value: String) = `Accept-Ranges`.parse(value)
 
   "Accept-Ranges header" should {
     val ranges = List(


### PR DESCRIPTION
This is a preliminary PR to request feedback, it does not fully replace `RangeParser` yet.

I added the cats-parse implementation to the  `Accept-Ranges` companion object and I'd like some general feedback on my usage of cats-parse and any formatting/style stuff.

I also have a question about the previous implementation, ([here](https://github.com/http4s/http4s/blob/c8d349dbf05af3ea76284801e49759778decaea9/core/src/main/scala/org/http4s/parser/RangeParser.scala#L65)) the top level rule for `Accept-Ranges` is matching on EOL  but this caused the cats-parse version to fail tests, I assume that parboiled2 is different from cats-effect and this is not necessary but I want to confirm this.




