### PR TITLE
Replace `Accept-Ranges` parser with cats-parse implementation

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
@@ -23,7 +23,6 @@ object `Accept-Ranges` extends HeaderKey.Internal[`Accept-Ranges`] with HeaderKe
 
   /* https://tools.ietf.org/html/rfc7233#appendix-C */
   val parser: P[`Accept-Ranges`] = {
-    val ListSep: P[Unit] = Rfc7230.ows *> P.char(',') *> Rfc7230.ows
 
     val none = P.string1("none").as(Nil)
 
@@ -38,11 +37,11 @@ object `Accept-Ranges` extends HeaderKey.Internal[`Accept-Ranges`] with HeaderKe
       P.oneOf(
         List(
           none,
-          P.repSep(rangeUnit, 1, ListSep)
+          Rfc7230.headerRep1(rangeUnit).map(_.toList)
         )
       )
 
-    acceptableRanges.map(headers.`Accept-Ranges`.apply) /* is EOL necessary? */
+    acceptableRanges.map(headers.`Accept-Ranges`.apply)
   }
 }
 

--- a/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
@@ -18,7 +18,7 @@ object `Accept-Ranges` extends HeaderKey.Internal[`Accept-Ranges`] with HeaderKe
 
   override def parse(s: String): ParseResult[`Accept-Ranges`] =
     parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid accept-ranges", e.toString)
+      ParseFailure("Invalid Accept-Ranges header", e.toString)
     }
 
   /* https://tools.ietf.org/html/rfc7233#appendix-C */

--- a/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
@@ -6,8 +6,9 @@
 
 package org.http4s
 package headers
-
-import org.http4s.parser.HttpHeaderParser
+import cats.parse.{Parser => P}
+import cats.implicits._
+import org.http4s.internal.parsing.Rfc7230
 import org.http4s.util.Writer
 
 object `Accept-Ranges` extends HeaderKey.Internal[`Accept-Ranges`] with HeaderKey.Singleton {
@@ -16,7 +17,33 @@ object `Accept-Ranges` extends HeaderKey.Internal[`Accept-Ranges`] with HeaderKe
   def none: `Accept-Ranges` = apply(Nil)
 
   override def parse(s: String): ParseResult[`Accept-Ranges`] =
-    HttpHeaderParser.ACCEPT_RANGES(s)
+    parser.parseAll(s).leftMap { e =>
+      ParseFailure("Invalid accept-ranges", e.toString)
+    }
+
+  /* https://tools.ietf.org/html/rfc7233#appendix-C */
+  val parser: P[`Accept-Ranges`] = {
+    val ListSep: P[Unit] = Rfc7230.ows *> P.char(',') *> Rfc7230.ows
+
+    val none = P.string1("none").as(Nil)
+
+    val rangeUnit = Rfc7230.token.map(org.http4s.RangeUnit.apply)
+
+    /*
+     Accept-Ranges     = acceptable-ranges
+     OWS               = <OWS, see [RFC7230], Section 3.2.3>
+     acceptable-ranges = ( *( "," OWS ) range-unit *( OWS "," [ OWS range-unit ] ) ) / "none"
+     */
+    val acceptableRanges: P[List[RangeUnit]] =
+      P.oneOf(
+        List(
+          none,
+          P.repSep(rangeUnit, 1, ListSep)
+        )
+      )
+
+    acceptableRanges.map(headers.`Accept-Ranges`.apply) /* is EOL necessary? */
+  }
 }
 
 final case class `Accept-Ranges` private[http4s] (rangeUnits: List[RangeUnit])

--- a/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
+++ b/core/src/main/scala/org/http4s/parser/HttpHeaderParser.scala
@@ -110,7 +110,7 @@ object HttpHeaderParser
     addParser_("ACCEPT-CHARSET".ci, `ACCEPT_CHARSET`)
     addParser_("ACCEPT-ENCODING".ci, `ACCEPT_ENCODING`)
     addParser_("ACCEPT-LANGUAGE".ci, `ACCEPT_LANGUAGE`)
-    addParser_("ACCEPT-RANGES".ci, `ACCEPT_RANGES`)
+    addParser_("ACCEPT-RANGES".ci, `Accept-Ranges`.parse)
     addParser_("AGE".ci, `AGE`)
     addParser_("ALLOW".ci, `ALLOW`)
     addParser_("AUTHORIZATION".ci, `AUTHORIZATION`)

--- a/core/src/main/scala/org/http4s/parser/RangeParser.scala
+++ b/core/src/main/scala/org/http4s/parser/RangeParser.scala
@@ -8,7 +8,7 @@ package org.http4s
 package parser
 
 import cats.data.NonEmptyList
-import org.http4s.headers.{Range, `Accept-Ranges`, `Content-Range`}
+import org.http4s.headers.{Range, `Content-Range`}
 import org.http4s.headers.Range.SubRange
 import org.http4s.internal.parboiled2._
 
@@ -51,39 +51,6 @@ private[parser] trait RangeParser {
         capture(optional('-') ~ oneOrMore(Digit)) ~ optional('-' ~ capture(oneOrMore(Digit))) ~> {
           (d1: String, d2: Option[String]) =>
             SubRange(d1.toLong, d2.map(_.toLong))
-        }
-      }
-  }
-
-  def ACCEPT_RANGES(input: String): ParseResult[`Accept-Ranges`] =
-    new AcceptRangesParser(input).parse
-
-  private class AcceptRangesParser(input: ParserInput)
-      extends Http4sHeaderParser[`Accept-Ranges`](input) {
-    def entry: Rule1[`Accept-Ranges`] =
-      rule {
-        RangeUnitsDef ~ EOL ~> (headers.`Accept-Ranges`(_: List[RangeUnit]))
-      }
-
-    def RangeUnitsDef: Rule1[List[RangeUnit]] =
-      rule {
-        NoRangeUnitsDef | zeroOrMore(RangeUnit).separatedBy(ListSep) ~> {
-          (rangeUnits: collection.Seq[RangeUnit]) =>
-            rangeUnits.toList
-        }
-      }
-
-    def NoRangeUnitsDef: Rule1[List[RangeUnit]] =
-      rule {
-        "none" ~ push(Nil)
-      }
-
-    /* 3.12 Range Units http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html */
-
-    def RangeUnit: Rule1[RangeUnit] =
-      rule {
-        Token ~> { (s: String) =>
-          org.http4s.RangeUnit(s)
         }
       }
   }

--- a/tests/src/test/scala/org/http4s/parser/AcceptRangesSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptRangesSpec.scala
@@ -11,7 +11,7 @@ import org.http4s.headers.`Accept-Ranges`
 import org.specs2.mutable.Specification
 
 class AcceptRangesSpec extends Specification with HeaderParserHelper[`Accept-Ranges`] {
-  def hparse(value: String) = HttpHeaderParser.ACCEPT_RANGES(value)
+  def hparse(value: String) = `Accept-Ranges`.parse(value)
 
   "Accept-Ranges header" should {
     val ranges = List(


### PR DESCRIPTION
This is a preliminary PR to request feedback, it does not fully replace `RangeParser` yet.

I added the cats-parse implementation to the  `Accept-Ranges` companion object and I'd like some general feedback on my usage of cats-parse and any formatting/style stuff.

I also have a question about the previous implementation, ([here](https://github.com/http4s/http4s/blob/c8d349dbf05af3ea76284801e49759778decaea9/core/src/main/scala/org/http4s/parser/RangeParser.scala#L65)) the top level rule for `Accept-Ranges` is matching on EOL  but this caused the cats-parse version to fail tests, I assume that parboiled2 is different from cats-effect and this is not necessary but I want to confirm this.




