### PR TITLE
Set content header on OKHttpClient

### DIFF
--- a/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttpBuilder.scala
+++ b/okhttp-client/src/main/scala/org/http4s/client/okhttp/OkHttpBuilder.scala
@@ -138,6 +138,9 @@ sealed abstract class OkHttpBuilder[F[_]] private (
           override def contentType(): OKMediaType =
             req.contentType.map(c => OKMediaType.parse(c.toString())).orNull
 
+          //OKHttp will override the content-length header set below and always use "transfer-encoding: chunked" unless this method is overriden
+          override def contentLength(): Long = req.contentLength.getOrElse(-1L)
+
           override def writeTo(sink: BufferedSink): Unit =
             req.body.chunks
               .map(_.toArray)


### PR DESCRIPTION
It turns out that OkHttp sets some headers automagically. Note that this PR does not address all headers but at least content-length so that servers that don't support chuncked encoding don't die.

You can see an example of a request and response (as well as the difference of logging middleware output) below:

Request log :

```
HTTP/1.1 POST https://postman-echo.com/post Headers(Content-Length: 14, Content-Type: application/json; charset=UTF-8) body="{"foo": "bar"}"
```

Response Log:
```
HTTP/2.0 200 OK Headers(content-length: 388, content-type: application/json; charset=utf-8, date: Fri, 11 Dec 2020 14:52:07 GMT, etag: W/"184-OHAl74FrfcR+JkGmLCVlcWDq1ak", set-cookie: sails.sid=s%3A05BViTVw6XwxE18LHgZrn659RR9KlrIX.U1Wu%2FPeaaAMIygPnpaZHgSsrJMXjz3okb%2B8nWEZD6IA; Path=/; HttpOnly, vary: Accept-Encoding) body="{"args":{},"data":{"foo":"bar"},"files":{},"form":{},"headers":{"x-forwarded-proto":"https","x-forwarded-port":"443","host":"postman-echo.com","x-amzn-trace-id":"Root=1-5fd38797-7f1a870d3144d79b3c55aad9","content-length":"14","content-type":"application/json; charset=UTF-8","accept-encoding":"gzip","user-agent":"okhttp/4.9.0"},"json":{"foo":"bar"},"url":"https://postman-echo.com/post"}"
```

This is the bounce back from postman now:
```
{
  "args" : {

  },
  "data" : {
    "foo" : "bar"
  },
  "files" : {

  },
  "form" : {

  },
  "headers" : {
    "x-forwarded-proto" : "https",
    "x-forwarded-port" : "443",
    "host" : "postman-echo.com",
    "x-amzn-trace-id" : "Root=1-5fd38797-52db64d42c072c61176b00ab",
    "content-length" : "14",
    "content-type" : "application/json; charset=UTF-8",
    "accept-encoding" : "gzip",
    "user-agent" : "okhttp/4.9.0"
  },
  "json" : {
    "foo" : "bar"
  },
  "url" : "https://postman-echo.com/post"
}
Echo Content using logged Client:
{
  "args" : {

  },
  "data" : {
    "foo" : "bar"
  },
  "files" : {

  },
  "form" : {

  },
  "headers" : {
    "x-forwarded-proto" : "https",
    "x-forwarded-port" : "443",
    "host" : "postman-echo.com",
    "x-amzn-trace-id" : "Root=1-5fd38797-7f1a870d3144d79b3c55aad9",
    "content-length" : "14",
    "content-type" : "application/json; charset=UTF-8",
    "accept-encoding" : "gzip",
    "user-agent" : "okhttp/4.9.0"
  },
  "json" : {
    "foo" : "bar"
  },
  "url" : "https://postman-echo.com/post"
}
```

This was the pertinent section before:
```
"headers" : {
    "x-forwarded-proto" : "https",
    "x-forwarded-port" : "443",
    "host" : "postman-echo.com",
    "x-amzn-trace-id" : "Root=1-5fd38243-596644700162665523ceb957",
    "transfer-encoding" : "chunked",
    "content-type" : "application/json; charset=UTF-8",
    "accept-encoding" : "gzip",
    "user-agent" : "okhttp/4.9.0"
  },
```