### PR TITLE
Add CirceSensitiveDataEntityDecoder

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -217,6 +217,8 @@ object CirceInstances {
 
   private[circe] lazy val defaultJsonDecodeError
       : (Json, NonEmptyList[DecodingFailure]) => DecodeFailure = { (json, failures) =>
+    sensitiveDataJsonDecodeError(json, _.toString, failures)
+  }
 
   private def sensitiveDataJsonDecodeError(
       json: Json,

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -80,6 +80,17 @@ trait CirceInstances extends JawnInstances {
       F: Sync[F],
       decoder: Decoder[A]): EntityDecoder[F, A] =
     jsonOfWithMediaHelper[F, A](r1, jsonDecodeError, rs: _*)
+
+  def jsonOfWithSensitiveMedia[F[_], A](r1: MediaRange, rs: MediaRange*)(implicit
+      F: Sync[F],
+      decoder: Decoder[A]): EntityDecoder[F, A] =
+    jsonOfWithMediaHelper[F, A](
+      r1,
+      (json, nelDecodeFailures) =>
+        CirceInstances.sensitiveDataJsonDecodeError(json, _ => "<REDACTED>", nelDecodeFailures),
+      rs: _*
+    )
+
   private def jsonOfWithMediaHelper[F[_], A](
       r1: MediaRange,
       decodeErrorHandler: (Json, NonEmptyList[DecodingFailure]) => DecodeFailure,

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -76,6 +76,9 @@ trait CirceInstances extends JawnInstances {
   def jsonOf[F[_]: Sync, A: Decoder]: EntityDecoder[F, A] =
     jsonOfWithMedia(MediaType.application.json)
 
+  def jsonOfSensitive[F[_]: Sync, A: Decoder]: EntityDecoder[F, A] =
+    jsonOfWithSensitiveMedia(MediaType.application.json)
+
   def jsonOfWithMedia[F[_], A](r1: MediaRange, rs: MediaRange*)(implicit
       F: Sync[F],
       decoder: Decoder[A]): EntityDecoder[F, A] =

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -217,8 +217,17 @@ object CirceInstances {
 
   private[circe] lazy val defaultJsonDecodeError
       : (Json, NonEmptyList[DecodingFailure]) => DecodeFailure = { (json, failures) =>
+
+  private def sensitiveDataJsonDecodeError(
+      json: Json,
+      jsonToString: Json => String,
+      failures: NonEmptyList[DecodingFailure]
+  ): DecodeFailure = {
+
+    val str: String = jsonToString(json)
+
     InvalidMessageBodyFailure(
-      s"Could not decode JSON: $json",
+      s"Could not decode JSON: $str",
       if (failures.tail.isEmpty) Some(failures.head) else Some(DecodingFailures(failures)))
   }
 

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -79,6 +79,7 @@ trait CirceInstances extends JawnInstances {
   def jsonOfWithMedia[F[_], A](r1: MediaRange, rs: MediaRange*)(implicit
       F: Sync[F],
       decoder: Decoder[A]): EntityDecoder[F, A] =
+    jsonOfWithMediaHelper[F, A](r1, jsonDecodeError, rs: _*)
   private def jsonOfWithMediaHelper[F[_], A](
       r1: MediaRange,
       decodeErrorHandler: (Json, NonEmptyList[DecodingFailure]) => DecodeFailure,

--- a/circe/src/main/scala/org/http4s/circe/CirceSensitiveDataEntityDecoder.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceSensitiveDataEntityDecoder.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.circe
+
+import cats.effect.Sync
+import io.circe.Decoder
+import org.http4s.EntityDecoder
+
+/** Derive [[EntityDecoder]] if implicit [[Decoder]] is in the scope without need to explicitly call `jsonOfSensitive`
+  *
+  * Note that it varies from [[CirceEntityDecoder]] in that, when failing to decode [[io.circe.Json]] to an `A`,
+  * the JSON will not be logged. In the event the JSON includes sensitive data, this trait is, arguably, a better choice
+  * since it eliminates the risk of logging sensitive data, e.g. due to logging a raised [[Throwable]] that includes
+  * the sensitive JSON.
+  */
+trait CirceSensitiveDataEntityDecoder {
+  implicit def circeEntityDecoder[F[_]: Sync, A: Decoder]: EntityDecoder[F, A] =
+    jsonOfSensitive[F, A]
+}
+
+object CirceSensitiveDataEntityDecoder extends CirceEntityDecoder


### PR DESCRIPTION
The new method's scaladoc explains the rationale:

```scala
/** Derive [[EntityDecoder]] if implicit [[Decoder]] is in the scope without need to explicitly call `jsonOfSensitive`
  *
  * Note that it varies from [[CirceEntityDecoder]] in that, when failing to decode [[io.circe.Json]] to an `A`,
  * the JSON will not be logged. In the event the JSON includes sensitive data, this trait is, arguably, a better choice
  * since it eliminates the risk of logging sensitive data, e.g. due to logging a raised [[Throwable]] that includes
  * the sensitive JSON.
  */
```