### PR TITLE
Tolerate space in cookie values

### DIFF
--- a/core/src/main/scala/org/http4s/parser/CookieHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/CookieHeader.scala
@@ -59,7 +59,7 @@ private[parser] trait CookieHeader {
       rule {
         "\u003c" - "\u005b" |
           "\u005d" - "\u007e" |
-          '\u0021' |
+          '\u0020' | '\u0021' |
           "\u0023" - "\u002b" |
           "\u002d" - "\u003a"
       }

--- a/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/CookieHeaderSpec.scala
@@ -17,6 +17,7 @@
 package org.http4s
 package parser
 
+import cats.data.NonEmptyList
 import org.http4s.headers.`Set-Cookie`
 import org.specs2.mutable.Specification
 
@@ -104,6 +105,12 @@ class CookieHeaderSpec extends Specification with HeaderParserHelper[headers.Coo
     }
     "parse a cookie (semicolon at the end)" in {
       parse(cookiestrSemicolon).values.toList must be_==(cookies)
+    }
+    "tolerate spaces" in {
+      hparse("initialTrafficSource=utmcsr=(direct)|utmcmd=(none)|utmccn=(not set);").map(
+        _.values) must beRight(
+        NonEmptyList.one(
+          RequestCookie("initialTrafficSource", "utmcsr=(direct)|utmcmd=(none)|utmccn=(not set)")))
     }
   }
 }


### PR DESCRIPTION
Fixes #4003 in the current parboiled2 implementation.

Space is not a valid cookie value, but some popular specifications depend on it anyway.  We don't have an easy way right now to support pluggable header parsers for differing levels of compliance.  This is a compromise for users caught in the crossfire.