### PR TITLE
Fixup Most Of The ScalaDoc Issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import com.typesafe.tools.mima.core._
 import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
 import org.http4s.sbt.Http4sPlugin._
+import org.http4s.sbt.ScaladocApiMapping
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 // Global settings
@@ -564,6 +565,11 @@ lazy val docs = http4sProject("docs")
             (ghpagesRepository.value / s"${docsPrefix}").getCanonicalPath)
       }
     },
+    apiMappings ++= {
+      ScaladocApiMapping.mappings(
+        (ScalaUnidoc / unidoc / unidocAllClasspaths).value, scalaBinaryVersion.value
+      )
+    }
   )
   .dependsOn(client, core, theDsl, blazeServer, blazeClient, circe, dropwizardMetrics, prometheusMetrics)
 

--- a/circe/src/main/scala/org/http4s/circe/CirceEntityDecoder.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceEntityDecoder.scala
@@ -20,7 +20,8 @@ import cats.effect.Sync
 import io.circe.Decoder
 import org.http4s.EntityDecoder
 
-/** Derive [[EntityDecoder]] if implicit [[Decoder]] is in the scope without need to explicitly call `jsonOf`
+/** Derive [[EntityDecoder]] if implicit [[io.circe.Decoder]] is in the scope
+  * without need to explicitly call `jsonOf`.
   */
 trait CirceEntityDecoder {
   implicit def circeEntityDecoder[F[_]: Sync, A: Decoder]: EntityDecoder[F, A] = jsonOf[F, A]

--- a/circe/src/main/scala/org/http4s/circe/CirceEntityEncoder.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceEntityEncoder.scala
@@ -19,7 +19,8 @@ package org.http4s.circe
 import io.circe.Encoder
 import org.http4s.EntityEncoder
 
-/** Derive [[EntityEncoder]] if implicit [[Encoder]] is in the scope without need to explicitly call `jsonEncoderOf`
+/** Derive [[EntityEncoder]] if implicit [[io.circe.Encoder]] is in the scope
+  * without need to explicitly call `jsonEncoderOf`.
   */
 trait CirceEntityEncoder {
   implicit def circeEntityEncoder[F[_], A: Encoder]: EntityEncoder[F, A] =

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -121,7 +121,7 @@ trait CirceInstances extends JawnInstances {
   implicit def streamJsonArrayEncoder[F[_]]: EntityEncoder[F, Stream[F, Json]] =
     streamJsonArrayEncoderWithPrinter(defaultPrinter)
 
-  /** An [[EntityEncoder]] for a [[Stream]] of JSONs, which will encode it as a single JSON array. */
+  /** An [[EntityEncoder]] for a [[fs2.Stream]] of JSONs, which will encode it as a single JSON array. */
   def streamJsonArrayEncoderWithPrinter[F[_]](printer: Printer): EntityEncoder[F, Stream[F, Json]] =
     EntityEncoder
       .streamEncoder[F, Chunk[Byte]]
@@ -133,7 +133,7 @@ trait CirceInstances extends JawnInstances {
   def streamJsonArrayEncoderOf[F[_], A: Encoder]: EntityEncoder[F, Stream[F, A]] =
     streamJsonArrayEncoderWithPrinterOf(defaultPrinter)
 
-  /** An [[EntityEncoder]] for a [[Stream]] of values, which will encode it as a single JSON array. */
+  /** An [[EntityEncoder]] for a [[fs2.Stream]] of values, which will encode it as a single JSON array. */
   def streamJsonArrayEncoderWithPrinterOf[F[_], A](printer: Printer)(implicit
       encoder: Encoder[A]): EntityEncoder[F, Stream[F, A]] =
     streamJsonArrayEncoderWithPrinter[F](printer).contramap[Stream[F, A]](_.map(encoder.apply))

--- a/circe/src/main/scala/org/http4s/circe/DecodingFailures.scala
+++ b/circe/src/main/scala/org/http4s/circe/DecodingFailures.scala
@@ -20,8 +20,8 @@ import cats.data.NonEmptyList
 import io.circe.DecodingFailure
 import cats.syntax.show._
 
-/** Wraps a list of decoding failures as an [[Exception]] when using [[accumulatingJsonOf]] to
-  * decode JSON messages.
+/** Wraps a list of decoding failures as an [[java.lang.Exception]] when using
+  * [[accumulatingJsonOf]] to decode JSON messages.
   */
 final case class DecodingFailures(failures: NonEmptyList[DecodingFailure]) extends Exception {
   override def getMessage: String = failures.toList.map(_.show).mkString("\n")

--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -54,8 +54,8 @@ trait Client[F[_]] {
   @deprecated("Use req.flatMap(run(_).use(f))", "0.21.5")
   def fetch[A](req: F[Request[F]])(f: Response[F] => F[A]): F[A]
 
-  /** Returns this client as a [[Kleisli]].  All connections created by this
-    * service are disposed on completion of callback task f.
+  /** Returns this client as a [[cats.data.Kleisli]].  All connections created
+    * by this service are disposed on completion of callback task f.
     *
     * This method effectively reverses the arguments to `run` followed by `use`, and is
     * preferred when an HTTP client is composed into a larger Kleisli function,
@@ -81,7 +81,7 @@ trait Client[F[_]] {
     * body to dispose of the underlying HTTP connection.
     *
     * This is intended for use in proxy servers. `run`, `fetchAs`,
-    * [[toKleisli]], and [[streaming]] are safer alternatives, as their
+    * [[toKleisli]] and [[streaming]] are safer alternatives, as their
     * signatures guarantee disposal of the HTTP connection.
     */
   @deprecated("Use toHttpApp. Call `.mapF(OptionT.liftF)` if OptionT is really desired.", "0.19")

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -51,8 +51,8 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
   def fetch[A](req: F[Request[F]])(f: Response[F] => F[A]): F[A] =
     req.flatMap(run(_).use(f))
 
-  /** Returns this client as a [[Kleisli]].  All connections created by this
-    * service are disposed on completion of callback task f.
+  /** Returns this client as a [[cats.data.Kleisli]].  All connections created
+    * by this service are disposed on completion of callback task f.
     *
     * This method effectively reverses the arguments to `run` followed by `use`, and is
     * preferred when an HTTP client is composed into a larger Kleisli function,
@@ -70,8 +70,8 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     * underlying HTTP connection.
     *
     * This is intended for use in proxy servers.  `run`, `fetchAs`,
-    * [[toKleisli]], and [[streaming]] are safer alternatives, as their
-    * signatures guarantee disposal of the HTTP connection.
+    * [[toKleisli]] and [[streaming]] signatures guarantee disposal of the
+    * HTTP connection.
     */
   def toHttpApp: HttpApp[F] =
     Kleisli { req =>
@@ -85,8 +85,8 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: Bracket[F, Throwa
     * body to dispose of the underlying HTTP connection.
     *
     * This is intended for use in proxy servers.  `run`, `fetchAs`,
-    * [[toKleisli]], and [[streaming]] are safer alternatives, as their
-    * signatures guarantee disposal of the HTTP connection.
+    * [[toKleisli]], [[streaming]] are safer alternatives, as their signatures
+    * guarantee disposal of the HTTP connection.
     */
   @deprecated("Use toHttpApp. Call `.mapF(OptionT.liftF)` if OptionT is really desired.", "0.19")
   def toHttpService: HttpService[F] =

--- a/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -36,7 +36,8 @@ import scala.concurrent.TimeoutException
   * - Time duration to process the whole response body
   * - Time duration of errors, timeouts and other abnormal terminations
   *
-  * This middleware can be extended to support any metrics ecosystem by implementing the [[MetricsOps]] type
+  * This middleware can be extended to support any metrics ecosystem by
+  * implementing the [[org.http4s.metrics.MetricsOps]] type
   */
 object Metrics {
 

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -166,9 +166,9 @@ object EntityDecoder {
     * The new [[EntityDecoder]] will attempt to decode messages of type `T`
     * only if the [[Message]] satisfies the provided [[MediaRange]].
     *
-    * Exceptions thrown by `f` are not caught.  Care should be taken
-    * that recoverable errors are returned as a
-    * [[DecodeResult.failure]], or that system errors are raised in `F`.
+    * Exceptions thrown by `f` are not caught.  Care should be taken that
+    * recoverable errors are returned as a [[DecodeResult#failure]], or that
+    * system errors are raised in `F`.
     */
   def decodeBy[F[_]: Applicative, T](r1: MediaRange, rs: MediaRange*)(
       f: Media[F] => DecodeResult[F, T]): EntityDecoder[F, T] =

--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -33,7 +33,7 @@ import scala.annotation.implicitNotFound
   "Cannot convert from ${A} to an Entity, because no EntityEncoder[${F}, ${A}] instance could be found.")
 trait EntityEncoder[F[_], A] { self =>
 
-  /** Convert the type `A` to an [[EntityEncoder.Entity]] in the effect type `F` */
+  /** Convert the type `A` to an [[Entity]] in the effect type `F` */
   def toEntity(a: A): Entity[F]
 
   /** Headers that may be added to a [[Message]]

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -171,9 +171,10 @@ sealed trait Message[F[_]] extends Media[F] { self =>
 
   // Attribute methods
 
-  /** Generates a new message object with the specified key/value pair appended to the [[AttributeMap]]
+  /** Generates a new message object with the specified key/value pair appended
+    * to the [[#attributes]].
     *
-    * @param key [[Key]] with which to associate the value
+    * @param key [[io.chrisdavenport.vault.Key]] with which to associate the value
     * @param value value associated with the key
     * @tparam A type of the value to store
     * @return a new message object with the key/value pair appended
@@ -181,9 +182,10 @@ sealed trait Message[F[_]] extends Media[F] { self =>
   def withAttribute[A](key: Key[A], value: A): Self =
     change(attributes = attributes.insert(key, value))
 
-  /** Returns a new message object without the specified key in the [[AttributeMap]]
+  /** Returns a new message object without the specified key in the
+    * [[#attributes]].
     *
-    * @param key [[Key]] to remove
+    * @param key [[io.chrisdavenport.vault.Key]] to remove
     * @return a new message object without the key
     */
   def withoutAttribute(key: Key[_]): Self =
@@ -344,14 +346,14 @@ final class Request[F[_]](
     */
   def params: Map[String, String] = uri.params
 
-  /** Parses all available [[Cookie]] headers into a list of [[RequestCookie]] objects. This
-    * implementation is compatible with cookie headers formatted per HTTP/1 and HTTP/2, or even both
-    * at the same time.
+  /** Parses all available [[org.http4s.headers.Cookie]] headers into a list of
+    * [[RequestCookie]] objects. This implementation is compatible with cookie
+    * headers formatted per HTTP/1 and HTTP/2, or even both at the same time.
     */
   def cookies: List[RequestCookie] =
     headers.get(Cookie).fold(List.empty[RequestCookie])(_.values.toList)
 
-  /** Add a Cookie header for the provided [[Cookie]] */
+  /** Add a Cookie header for the provided [[org.http4s.headers.Cookie]] */
   def addCookie(cookie: RequestCookie): Self =
     headers
       .get(Cookie)
@@ -517,8 +519,9 @@ object Request {
   * @param status [[Status]] code and message
   * @param headers [[Headers]] containing all response headers
   * @param body EntityBody[F] representing the possible body of the response
-  * @param attributes [[Vault]] containing additional parameters which may be used by the http4s
-  *                   backend for additional processing such as java.io.File object
+  * @param attributes [[io.chrisdavenport.vault.Vault]] containing additional
+  *                   parameters which may be used by the http4s backend for
+  *                   additional processing such as java.io.File object
   */
 final case class Response[F[_]](
     status: Status = Status.Ok,
@@ -558,19 +561,21 @@ final case class Response[F[_]](
   def addCookie(cookie: ResponseCookie): Self =
     putHeaders(`Set-Cookie`(cookie))
 
-  /** Add a [[`Set-Cookie`]] header with the provided values */
+  /** Add a [[org.http4s.headers.Set-Cookie]] header with the provided values */
   def addCookie(name: String, content: String, expires: Option[HttpDate] = None): Self =
     addCookie(ResponseCookie(name, content, expires))
 
-  /** Add a [[`Set-Cookie`]] which will remove the specified cookie from the client */
+  /** Add a [[org.http4s.headers.Set-Cookie]] which will remove the specified
+    * cookie from the client
+    */
   def removeCookie(cookie: ResponseCookie): Self =
     putHeaders(cookie.clearCookie)
 
-  /** Add a [[`Set-Cookie`]] which will remove the specified cookie from the client */
+  /** Add a [[org.http4s.headers.Set-Cookie]] which will remove the specified cookie from the client */
   def removeCookie(name: String): Self =
     putHeaders(ResponseCookie(name, "").clearCookie)
 
-  /** Returns a list of cookies from the [[`Set-Cookie`]]
+  /** Returns a list of cookies from the [[org.http4s.headers.Set-Cookie]]
     * headers. Includes expired cookies, such as those that represent cookie
     * deletion.
     */

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -64,7 +64,7 @@ final case class Uri(
     */
   def addSegment(newSegment: Path): Uri = copy(path = toSegment(path, newSegment))
 
-  /** This is an alias to [[addSegment(Path)]]
+  /** This is an alias to [[#addSegment]]
     */
   def /(newSegment: Path): Uri = addSegment(newSegment)
 

--- a/play-json/src/main/scala/org/http4s/play/PlayEntityDecoder.scala
+++ b/play-json/src/main/scala/org/http4s/play/PlayEntityDecoder.scala
@@ -20,7 +20,8 @@ import cats.effect.Sync
 import org.http4s.EntityDecoder
 import play.api.libs.json.Reads
 
-/** Derive [[EntityDecoder]] if implicit [[Reads]] is in the scope without need to explicitly call `jsonOf`
+/** Derive [[EntityDecoder]] if implicit [[play.api.libs.json.Reads]] is in
+  * the scope without need to explicitly call `jsonOf`.
   */
 trait PlayEntityDecoder {
   implicit def playEntityDecoder[F[_]: Sync, A: Reads]: EntityDecoder[F, A] = jsonOf[F, A]

--- a/play-json/src/main/scala/org/http4s/play/PlayEntityEncoder.scala
+++ b/play-json/src/main/scala/org/http4s/play/PlayEntityEncoder.scala
@@ -19,7 +19,8 @@ package org.http4s.play
 import play.api.libs.json.Writes
 import org.http4s.EntityEncoder
 
-/** Derive [[EntityEncoder]] if implicit [[Writes]] is in the scope without need to explicitly call `jsonEncoderOf`
+/** Derive [[EntityEncoder]] if implicit [[play.api.libs.json.Writes]] is in
+  * the scope without need to explicitly call `jsonEncoderOf`.
   */
 trait PlayEntityEncoder {
   implicit def playEntityEncoder[F[_], A: Writes]: EntityEncoder[F, A] =

--- a/project/ScaladocApiMapping.scala
+++ b/project/ScaladocApiMapping.scala
@@ -1,0 +1,87 @@
+package org.http4s.sbt
+
+import java.io.File
+import java.net.URL
+import sbt.Keys._
+import sbtunidoc.BaseUnidocPlugin.autoImport._
+import sbt.librarymanagement._
+
+/** Provides API File -> URL mappings for dependencies which don't expose an
+  * `apiURL` in their POM or if they do, they are doing so incorrectly and
+  * SBT/Scaladoc can't reconstruct the mapping automatically.
+  *
+  * If the project for which we are providing a mapping provides a specific
+  * Scaladoc link, we prefer that one. Otherwise we use [[https://javadoc.io]]
+  * to fill in the gaps.
+  *
+  * There is a bit of fuzzy logic in here. Scaladoc requires a File -> URL
+  * mapping for the linking to work. SBT does not seem to expose a ModuleId ->
+  * File mapping in any API, which is what would be ideal to solve this
+  * problem. What we do have is the classpath constructed by the Unidoc
+  * plugin. Because we are lacking a full ModuleID construct here, we use some
+  * regular expressions on the `File` in the classpath as a heuristic to match
+  * the given `File` to a dependency module.
+  */
+object ScaladocApiMapping {
+
+  /** Construct mappings for dependencies for which SBT/Scaladoc can not do so automatically.
+    *
+    * @param classpaths In practice this will need to be the ScalaUnidoc
+    *        classpath, which is the aggregation of all classpaths.
+    * @param scalaBinaryVersion The current scala binary version,
+    *        e.g. `scalaBinaryVersion.value`.
+    */
+  def mappings(classpaths: Seq[Classpath], scalaBinaryVersion: String): Map[File, URL] = {
+    classpaths.flatten.foldLeft(Map.empty[File, URL]){
+      case (acc, value) =>
+        val file: File = value.data
+        playJsonMapping(scalaBinaryVersion)(file).toMap ++
+        vaultMapping(scalaBinaryVersion)(file).toMap ++
+        catsEffectMapping(scalaBinaryVersion)(file).toMap ++
+        fs2CoreMapping(scalaBinaryVersion)(file).toMap ++
+        acc
+    }
+  }
+
+  private def maybeScalaBinaryVersionToSuffix(value: Option[String]): String =
+    value.fold("")(value => s"_${value}")
+
+  private def javadocIOAPIUrl(scalaBinaryVersion: Option[String], moduleId: ModuleID): URL = {
+    val suffix: String =
+      maybeScalaBinaryVersionToSuffix(scalaBinaryVersion)
+    new URL(s"https://javadoc.io/doc/${moduleId.organization}/${moduleId.name}${suffix}/${moduleId.revision}/")
+  }
+
+  private def playJsonMapping(scalaBinaryVersion: String)(file: File): Option[(File, URL)] =
+    if(file.toString.matches(""".+/play-json_[^/]+\.jar$""")) {
+      Some(file -> javadocIOAPIUrl(Some(scalaBinaryVersion), Http4sPlugin.playJson))
+    } else {
+      None
+    }
+
+  private def vaultMapping(scalaBinaryVersion: String)(file: File): Option[(File, URL)] =
+    // Be a _little_ more specific, since vault is an overloaded term,
+    // e.g. hashicorp vault.
+    if(file.toString.matches(""".+io.chrisdavenport.+/vault[^/]+\.jar$""")) {
+      Some(file -> javadocIOAPIUrl(Some(scalaBinaryVersion), Http4sPlugin.vault))
+    } else {
+      None
+    }
+
+  private def catsEffectMapping(scalaBinaryVersion: String)(file: File): Option[(File, URL)] =
+    if(file.toString.matches(""".+/cats-effect_[^/]+\.jar$""")) {
+      Some(file -> new URL("https://typelevel.org/cats-effect/api/"))
+    } else {
+      None
+    }
+
+  private def fs2CoreMapping(scalaBinaryVersion: String)(file: File): Option[(File, URL)] = {
+    val fs2Core: ModuleID =
+      Http4sPlugin.fs2Core
+    if(file.toString.matches(""".+/fs2-core_[^/]+\.jar$""")) {
+      Some(file -> new URL(s"https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_${scalaBinaryVersion}/${fs2Core.revision}/${fs2Core.name}_${scalaBinaryVersion}-${fs2Core.revision}-javadoc.jar/!/"))
+    } else {
+      None
+    }
+  }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/Caching.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Caching.scala
@@ -66,8 +66,8 @@ object Caching {
     Expires(HttpDate.Epoch) // Expire at the epoch for no time confusion
   )
 
-  /** Helpers Contains the default arguments used to help construct
-    * middleware with [[caching]]. They serve to support the default arguments for
+  /** Helpers Contains the default arguments used to help construct middleware
+    * with caching. They serve to support the default arguments for
     * [[publicCache]] and [[privateCache]].
     */
   object Helpers {

--- a/server/src/main/scala/org/http4s/server/middleware/ConcurrentRequests.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ConcurrentRequests.scala
@@ -72,7 +72,7 @@ object ConcurrentRequests {
   ): F[ContextMiddleware[F, Long]] =
     route2[F, F](onIncrement, onDecrement)
 
-  /** As [[#apply]], but runs the same effect on increment and decrement of the concurrent request count. */
+  /** As [[#route]], but runs the same effect on increment and decrement of the concurrent request count. */
   def onChangeRoute[F[_]: Sync](onChange: Long => F[Unit]): F[ContextMiddleware[F, Long]] =
     route[F](onChange, onChange)
 
@@ -114,7 +114,7 @@ object ConcurrentRequests {
   ): F[Kleisli[F, ContextRequest[F, Long], Response[F]] => Kleisli[F, Request[F], Response[F]]] =
     app2[F, F](onIncrement, onDecrement)
 
-  /** As [[#apply]], but runs the same effect on increment and decrement of the concurrent request count. */
+  /** As [[#app]], but runs the same effect on increment and decrement of the concurrent request count. */
   def onChangeApp[F[_]: Sync](onChange: Long => F[Unit])
       : F[Kleisli[F, ContextRequest[F, Long], Response[F]] => Kleisli[F, Request[F], Response[F]]] =
     app[F](onChange, onChange)

--- a/server/src/main/scala/org/http4s/server/middleware/Metrics.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/Metrics.scala
@@ -32,7 +32,7 @@ import org.http4s.metrics.TerminationType.{Abnormal, Error}
   * - Time duration to send the whole response body
   * - Time duration of errors and other abnormal terminations
   *
-  * This middleware can be extended to support any metrics ecosystem by implementing the [[MetricsOps]] type
+  * This middleware can be extended to support any metrics ecosystem by implementing the [[org.http4s.metrics.MetricsOps]] type
   */
 object Metrics {
 
@@ -46,7 +46,7 @@ object Metrics {
     *
     * @param ops a algebra describing the metrics operations
     * @param emptyResponseHandler an optional http status to be registered for requests that do not match
-    * @param errorResponseHandler a function that maps a [[Throwable]] to an optional http status code to register
+    * @param errorResponseHandler a function that maps a [[java.lang.Throwable]] to an optional http status code to register
     * @param classifierF a function that allows to add a classifier that can be customized per request
     * @return the metrics middleware
     */

--- a/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
+++ b/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
@@ -27,7 +27,7 @@ trait TwirlInstances {
     contentEncoder(MediaType.text.html)
 
   /** Note: Twirl uses a media type of `text/javascript`.  This is obsolete, so we instead return
-    * [[org.http4s.MediaType.application/javascript]].
+    * `application/javascript`.
     */
   implicit def jsContentEncoder[F[_]](implicit
       charset: Charset = DefaultCharset): EntityEncoder[F, JavaScript] =


### PR DESCRIPTION
This commit corrects _most_ of the Scaladoc issues.

The Scaladoc issues fell into one or more of the following categories.

* Reference was not fully qualified.
    * For external links, and for _some_ internal links, Scaladoc wants a fully qualified symbol to link against, even if the given symbol is in scope.
    * For example, `[[Kleisli]]` -> `[[cats.data.Kleisli]]`.
* Third party library is not exposing `apiURL` in the POM, or is doing so incorrectly.
    * This prevents SBT from automatically configuring the URLs for linking into the third party Scaladoc.
    * To solve this issue `ScaladocApiMapping` was added in `project/`. This contains manual code to construct the linking,
      using `https://javadoc.io` if the project does not provide another more specific URL.
* Overloaded references
    * These are warnings caused by a reference to an overloaded symbol.
    * These were _not fixed as part of this commit_. I tried for quite some time, but I just couldn't get the disambiguation logic to work.
* The Scaladoc was just wrong.
    * In this some cases the Scaladoc just didn't link to a real symbol, usually because of typos or change symbol names.

Prior to this commit there were 35 warnings issued for Scaladoc (you need to enable `link-warnings` to see this), now there are 5 and they are all related to overloaded symbols.