### PR TITLE
Expose The apiURL In The Build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -787,6 +787,7 @@ lazy val commonSettings = Seq(
     specs2MatcherExtra,
     specs2Scalacheck
   ).map(_ % Test),
+  apiURL := Some(url(s"https://http4s.org/v${baseVersion.value}/api")),
 )
 
 def initCommands(additionalImports: String*) =


### PR DESCRIPTION
This sets the apiURL in the build to `https://http4s.org/v${baseVersion.value}/api`. Since we use unidoc, all modules should have the same value for the `apiURL`. This allows for third parties to link to our Scaladoc.