### PR TITLE
Allow For Providing HttpConfiguration With Jetty

### DIFF
--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -446,7 +446,7 @@ object JettyBuilder {
     }
 
   /** The default [[org.eclipse.jetty.server.HttpConfiguration]] to use with jetty. */
-  val defaultJettyHttpConfiguration: HttpConfiguration =
+  private val defaultJettyHttpConfiguration: HttpConfiguration =
     new HttpConfiguration()
 }
 

--- a/project/ScaladocApiMapping.scala
+++ b/project/ScaladocApiMapping.scala
@@ -39,6 +39,7 @@ object ScaladocApiMapping {
         vaultMapping(scalaBinaryVersion)(file).toMap ++
         catsEffectMapping(scalaBinaryVersion)(file).toMap ++
         fs2CoreMapping(scalaBinaryVersion)(file).toMap ++
+        jettyMapping(file).toMap ++
         acc
     }
   }
@@ -80,6 +81,16 @@ object ScaladocApiMapping {
       Http4sPlugin.fs2Core
     if(file.toString.matches(""".+/fs2-core_[^/]+\.jar$""")) {
       Some(file -> new URL(s"https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_${scalaBinaryVersion}/${fs2Core.revision}/${fs2Core.name}_${scalaBinaryVersion}-${fs2Core.revision}-javadoc.jar/!/"))
+    } else {
+      None
+    }
+  }
+
+  private def jettyMapping(file: File): Option[(File, URL)] = {
+    val jettyMajorVersion: String =
+      Http4sPlugin.V.jetty.takeWhile(_ != '.')
+    if(file.toString.matches(""".+/jetty[^/]+\.jar$""")) {
+      Some(file -> new URL(s"https://www.eclipse.org/jetty/javadoc/jetty-${jettyMajorVersion}/index.html"))
     } else {
       None
     }


### PR DESCRIPTION
This commit makes two meaningful changes,

* Allow for the user to provide their own `HttpConfiguration` value. This is important as there are many settings which are not modeled in the `JettyBuilder` that one would general expect to have access to.
* Enforces that the `HttpConfiguration` is used whether or not http2 is enabled. Formerly the `HttpConfiguration` was only used if there was not an `SslConnectionFactory` and http2 support was enabled.