### PR TITLE
Normalize Some Of The HTTP Server Parameters Between Backends

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -399,26 +399,7 @@ class BlazeServerBuilder[F[_]](
 object BlazeServerBuilder {
   @deprecated("Use BlazeServerBuilder.apply with explicit executionContext instead", "0.20.22")
   def apply[F[_]](implicit F: ConcurrentEffect[F], timer: Timer[F]): BlazeServerBuilder[F] =
-    new BlazeServerBuilder(
-      socketAddress = defaults.SocketAddress,
-      executionContext = ExecutionContext.global,
-      responseHeaderTimeout = defaults.ResponseTimeout,
-      idleTimeout = defaults.IdleTimeout,
-      isNio2 = false,
-      connectorPoolSize = DefaultPoolSize,
-      bufferSize = 64 * 1024,
-      selectorThreadFactory = defaultThreadSelectorFactory,
-      enableWebSockets = true,
-      sslConfig = new NoSsl[F](),
-      isHttp2Enabled = false,
-      maxRequestLineLen = 4 * 1024,
-      maxHeadersLen = 40 * 1024,
-      chunkBufferMaxSize = 1024 * 1024,
-      httpApp = defaultApp[F],
-      serviceErrorHandler = DefaultServiceErrorHandler[F],
-      banner = defaults.Banner,
-      channelOptions = ChannelOptions(Vector.empty)
-    )
+    apply(ExecutionContext.global)
 
   def apply[F[_]](executionContext: ExecutionContext)(implicit
       F: ConcurrentEffect[F],
@@ -436,7 +417,7 @@ object BlazeServerBuilder {
       sslConfig = new NoSsl[F](),
       isHttp2Enabled = false,
       maxRequestLineLen = 4 * 1024,
-      maxHeadersLen = 40 * 1024,
+      maxHeadersLen = defaults.MaxHeadersSize,
       chunkBufferMaxSize = 1024 * 1024,
       httpApp = defaultApp[F],
       serviceErrorHandler = DefaultServiceErrorHandler[F],

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -201,8 +201,8 @@ object EmberServerBuilder {
     )
 
   private object Defaults {
-    val host: String = "127.0.0.1"
-    val port: Int = 8000
+    val host: String = server.defaults.Host
+    val port: Int = server.defaults.HttpPort
 
     def httpApp[F[_]: Applicative]: HttpApp[F] = HttpApp.notFound[F]
     def onError[F[_]]: Throwable => Response[F] = { (_: Throwable) =>
@@ -214,9 +214,9 @@ object EmberServerBuilder {
     }
     val maxConcurrency: Int = Int.MaxValue
     val receiveBufferSize: Int = 256 * 1024
-    val maxHeaderSize: Int = 10 * 1024
+    val maxHeaderSize: Int = server.defaults.MaxHeadersSize
     val requestHeaderReceiveTimeout: Duration = 5.seconds
-    val idleTimeout: Duration = 60.seconds
+    val idleTimeout: Duration = server.defaults.IdleTimeout
     val additionalSocketOptions = List.empty[SocketOptionMapping[_]]
   }
 }

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -446,8 +446,11 @@ object JettyBuilder {
     }
 
   /** The default [[org.eclipse.jetty.server.HttpConfiguration]] to use with jetty. */
-  private val defaultJettyHttpConfiguration: HttpConfiguration =
-    new HttpConfiguration()
+  private val defaultJettyHttpConfiguration: HttpConfiguration = {
+    val config: HttpConfiguration = new HttpConfiguration()
+    config.setRequestHeaderSize(defaults.MaxHeadersSize)
+    config
+  }
 }
 
 private final case class Mount[F[_]](f: (ServletContextHandler, Int, JettyBuilder[F]) => Unit)

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -48,6 +48,9 @@ package object server {
 
     /** The time to wait for a graceful shutdown */
     val ShutdownTimeout: Duration = 30.seconds
+
+    /** Default max size of all headers. */
+    val MaxHeadersSize: Int = 40 * 1024
   }
 
   object ServerRequestKeys {


### PR DESCRIPTION
This commit attempts to normalize some of the common server configuration parameters between backends.

When switching between different backends, one would assume that the operational semantics would be as close as possible, assuming there was no direct configuration change in user code. Prior to this commit there was a substantial delta between these parameters in Blaze/Jetty/Ember.

It is likely that _more_ parameters can be shared in the future, but some configuration options are not exposed for any give backend, and some things which are configurable on one backend may not even be expressible on another.

Thus, this commit attempts to be relatively conservative, synchronizing the more obvious parameters only.

When two backends currently differed on the configuration value for a given parameter, the more _permissive_ value was chosen. Here is a summary of the configuration changes with respect to a given backend.

* Ember
    * Default host is now derived from `org.http4s.server.defaults.Host`, though it should be the same.
    * Default Max header size, 10240B -> 40960B, which was the value used by Blaze
* Jetty
    * Default Max header size, 8192B -> 40960B, which was the value used by Blaze
    * See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java#L60