### PR TITLE
Handle CompletableFuture Correctly

### DIFF
--- a/core/src/main/scala/org/http4s/internal/package.scala
+++ b/core/src/main/scala/org/http4s/internal/package.scala
@@ -189,10 +189,8 @@ package object internal {
     }
 
   private[http4s] def fromCompletableFutureShift[F[_], A](
-      fcs: F[CompletableFuture[A]])(implicit
-      F: Concurrent[F],
-      CS: ContextShift[F]): F[A] =
-    F.bracketCase(fcs){ cs =>
+      fcs: F[CompletableFuture[A]])(implicit F: Concurrent[F], CS: ContextShift[F]): F[A] =
+    F.bracketCase(fcs) { cs =>
       F.async[A] { cb =>
         cs.handle[Unit] { (result, err) =>
           err match {
@@ -210,8 +208,7 @@ package object internal {
           F.delay(cs.completeExceptionally(e))
         case ExitCase.Canceled =>
           F.delay(cs.cancel(true))
-      }).void.guarantee(CS.shift)
-    )
+      }).void.guarantee(CS.shift))
 
   private[http4s] def unsafeToCompletionStage[F[_], A](
       fa: F[A]


### PR DESCRIPTION
This commit adds a new function `fromCompletableFutureShift` which brackets the usage of a `CompletableFuture` so that if the outer effect is canceled or terminates in error, then the `CompletableFuture` is canceled or terminated as well.

This is _similar_ to the deprecated `fromCompletableFuture`, but differs in that it handles exceptional cases, not just cancellation, and properly handles the thread shifting, as `fromCompletionStage` does.

`fromCompletionStage` is used in `http4s-jdk-http-client` and under the current usage causes a resource leak if the outer effect terminates before the callback has been invoked.