### PR TITLE
Add more missing parens on lambdas

### DIFF
--- a/core/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -103,7 +103,7 @@ object MetricsOps {
       exclude: String => Boolean,
       excludedValue: String = "*",
       pathSeparator: String = "_"
-  ): Request[F] => Option[String] = { request: Request[F] =>
+  ): Request[F] => Option[String] = { (request: Request[F]) =>
     val initial: String = request.method.name
 
     val pathList: List[String] =

--- a/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
+++ b/core/src/main/scala/org/http4s/parser/ForwardedHeader.scala
@@ -54,7 +54,7 @@ private[parser] trait ForwardedHeader {
 
     private def Param: ParamRule =
       rule {
-        Token ~> { token: String =>
+        Token ~> { (token: String) =>
           token.toLowerCase(Locale.ROOT) match {
             case "by" => CreateOrAssignParam_by
             case "for" => CreateOrAssignParam_for


### PR DESCRIPTION
These are compile errors on the Dotty branch and don't hurt anything to clean up now.

Part of #3768.