### PR TITLE
Filter nowarn annotation from jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,6 +103,7 @@ lazy val core = libraryProject("core")
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.headers.Forwarded$Node$Port$C"),
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.headers.Forwarded$Node$Port$C$"),
     ),
+    Compile / packageBin / mappings ~= { _.filterNot(_._2.startsWith("scala/")) },
   )
 
 lazy val laws = libraryProject("laws")


### PR DESCRIPTION
Alternative to #4067.  We just simply filter the `@nowarn` annotation out of the jar.

Pros:
- No new core dependencies
- Preserves fatal warnings without further complexity

Cons:
- Compat trait will need to be copied to a scala-3 directory on the Dotty branch.
- Doesn't steer our source toward modernity.
- MiMa doesn't catch that the annotations are missing. But we'll note it and move on, and it's 2.12 only.