### PR TITLE
Use the ParseResult.fromParser helper for errors

### DIFF
--- a/core/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/src/main/scala/org/http4s/ContentCoding.scala
@@ -101,9 +101,7 @@ object ContentCoding {
   /** Parse a Content Coding
     */
   def parse(s: String): ParseResult[ContentCoding] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Content Coding", e.toString)
-    }
+    ParseResult.fromParser(parser, "content coding")(s)
 
   implicit val http4sOrderForContentCoding: Order[ContentCoding] =
     Order.by(c => (c.coding.toLowerCase(ju.Locale.ENGLISH), c.qValue))

--- a/core/src/main/scala/org/http4s/HttpDate.scala
+++ b/core/src/main/scala/org/http4s/HttpDate.scala
@@ -91,9 +91,7 @@ object HttpDate {
     * @see https://tools.ietf.org/html/rfc7231#page-65
     */
   def fromString(s: String): ParseResult[HttpDate] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid HTTP date", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid HTTP date")(s)
 
   /** Like `fromString`, but throws on invalid input */
   def unsafeFromString(s: String): HttpDate =

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -54,9 +54,7 @@ object HttpVersion {
       case "HTTP/1.1" => right_1_1
       case "HTTP/1.0" => right_1_0
       case _ =>
-        parser.parseAll(s).leftMap { _ =>
-          ParseFailure("Invalid HTTP version", s"$s was not found to be a valid HTTP version")
-        }
+        ParseResult.fromParser(parser, "HTTP version")(s)
     }
 
   private val parser: Parser1[HttpVersion] = {

--- a/core/src/main/scala/org/http4s/MediaType.scala
+++ b/core/src/main/scala/org/http4s/MediaType.scala
@@ -87,7 +87,7 @@ object MediaRange {
   /** Parse a MediaRange
     */
   def parse(s: String): ParseResult[MediaRange] =
-    fullParser.parseAll(s).leftMap(e => ParseFailure("Invalid Media Range", e.toString))
+    ParseResult.fromParser(fullParser, "media range")(s)
 
   private[http4s] val parser: Parser1[MediaRange] = mediaRangeParser(getMediaRange)
 
@@ -244,7 +244,7 @@ object MediaType extends MimeDB {
   /** Parse a MediaType
     */
   def parse(s: String): ParseResult[MediaType] =
-    parser.parseAll(s).leftMap(e => ParseFailure("Invalid Media Type", e.toString))
+    ParseResult.fromParser(parser, "media type")(s)
 
   /** Parse a MediaType
     *

--- a/core/src/main/scala/org/http4s/Method.scala
+++ b/core/src/main/scala/org/http4s/Method.scala
@@ -58,9 +58,7 @@ object Method {
   sealed trait NoBody extends Method
 
   def fromString(s: String): ParseResult[Method] =
-    allByKey.getOrElse(
-      s,
-      parser.parseAll(s).leftMap(e => ParseFailure("Invalid method", e.toString)))
+    allByKey.getOrElse(s, ParseResult.fromParser(parser, "method")(s))
 
   private[http4s] val parser: Parser1[Method] =
     Rfc7230.token.map(new Method(_) with Semantics.Default)

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -17,7 +17,6 @@
 package org.http4s
 
 import cats.parse.Parser
-import cats.syntax.all._
 import cats.{Order, Show}
 import org.http4s.util.Writer
 
@@ -119,9 +118,7 @@ object QValue {
   }
 
   def parse(s: String): ParseResult[QValue] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid q-value", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Q-Value")(s)
 
   /** Exists to support compile-time verified literals. Do not call directly. */
   def ☠(thousandths: Int): QValue = new QValue(thousandths)

--- a/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
@@ -24,9 +24,7 @@ import org.http4s.CharsetRange.{Atom, `*`}
 
 object `Accept-Charset` extends HeaderKey.Internal[`Accept-Charset`] with HeaderKey.Recurring {
   override def parse(s: String): ParseResult[`Accept-Charset`] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Accept Charset header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Accept-Charset header")(s)
 
   private[http4s] val parser: Parser1[`Accept-Charset`] = {
     import cats.parse.Parser._

--- a/core/src/main/scala/org/http4s/headers/Accept-Encoding.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Encoding.scala
@@ -19,14 +19,11 @@ package headers
 
 import cats.data.NonEmptyList
 import cats.parse.Parser1
-import cats.syntax.either._
 import cats.syntax.eq._
 
 object `Accept-Encoding` extends HeaderKey.Internal[`Accept-Encoding`] with HeaderKey.Recurring {
   override def parse(s: String): ParseResult[`Accept-Encoding`] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Accept Encoding header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Accept-Encoding header")(s)
 
   private[http4s] val parser: Parser1[`Accept-Encoding`] = {
     import org.http4s.internal.parsing.Rfc7230.headerRep1

--- a/core/src/main/scala/org/http4s/headers/Accept-Language.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Language.scala
@@ -19,14 +19,11 @@ package headers
 
 import cats.data.NonEmptyList
 import cats.parse.Parser1
-import cats.syntax.either._
 import org.http4s.internal.parsing.Rfc7230
 
 object `Accept-Language` extends HeaderKey.Internal[`Accept-Language`] with HeaderKey.Recurring {
   override def parse(s: String): ParseResult[`Accept-Language`] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Accept Language header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Accept-Language header")(s)
 
   private[http4s] val parser: Parser1[`Accept-Language`] = {
     import cats.parse.Parser.{char => ch, _}

--- a/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
@@ -17,7 +17,6 @@
 package org.http4s
 package headers
 import cats.parse.{Parser => P}
-import cats.implicits._
 import org.http4s.internal.parsing.Rfc7230
 import org.http4s.util.Writer
 
@@ -27,9 +26,7 @@ object `Accept-Ranges` extends HeaderKey.Internal[`Accept-Ranges`] with HeaderKe
   def none: `Accept-Ranges` = apply(Nil)
 
   override def parse(s: String): ParseResult[`Accept-Ranges`] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Accept-Ranges header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Accept-Ranges header")(s)
 
   /* https://tools.ietf.org/html/rfc7233#appendix-C */
   val parser: P[`Accept-Ranges`] = {

--- a/core/src/main/scala/org/http4s/headers/Accept.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept.scala
@@ -19,13 +19,12 @@ package headers
 
 import cats.data.NonEmptyList
 import cats.parse.Parser1
-import cats.syntax.either._
 import org.http4s.internal.parsing.Rfc7230.headerRep1
 import org.http4s.util.{Renderable, Writer}
 
 object Accept extends HeaderKey.Internal[Accept] with HeaderKey.Recurring {
   override def parse(s: String): ParseResult[Accept] =
-    parser.parseAll(s).leftMap(e => ParseFailure("Invalid Accept header", e.toString))
+    ParseResult.fromParser(parser, "Invalid Accept header")(s)
 
   private[http4s] val parser: Parser1[Accept] = {
     val acceptParams =

--- a/core/src/main/scala/org/http4s/headers/Content-Type.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Type.scala
@@ -18,7 +18,6 @@ package org.http4s
 package headers
 
 import cats.parse.Parser1
-import cats.syntax.all._
 import org.http4s.util.Writer
 
 object `Content-Type` extends HeaderKey.Internal[`Content-Type`] with HeaderKey.Singleton {
@@ -27,7 +26,7 @@ object `Content-Type` extends HeaderKey.Internal[`Content-Type`] with HeaderKey.
   def apply(mediaType: MediaType): `Content-Type` = apply(mediaType, None)
 
   override def parse(s: String): ParseResult[`Content-Type`] =
-    parser.parseAll(s).leftMap(e => ParseFailure("Invalid Content-Type header", e.toString))
+    ParseResult.fromParser(parser, "Invalid Content-Type header")(s)
 
   private[http4s] val parser: Parser1[`Content-Type`] =
     (MediaRange.parser ~ MediaType.mediaTypeExtension.rep).map {

--- a/core/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/src/main/scala/org/http4s/headers/Cookie.scala
@@ -19,14 +19,11 @@ package headers
 
 import cats.data.NonEmptyList
 import cats.parse.{Parser, Parser1}
-import cats.syntax.all._
 import org.http4s.util.Writer
 
 object Cookie extends HeaderKey.Internal[Cookie] with HeaderKey.Recurring {
   override def parse(s: String): ParseResult[Cookie] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Cookie header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Cookie header")(s)
 
   private[http4s] val parser: Parser1[Cookie] = {
     import Parser.{char, string1}

--- a/core/src/main/scala/org/http4s/headers/Date.scala
+++ b/core/src/main/scala/org/http4s/headers/Date.scala
@@ -18,14 +18,11 @@ package org.http4s
 package headers
 
 import cats.parse.Parser1
-import cats.syntax.all._
 import org.http4s.util.{Renderer, Writer}
 
 object Date extends HeaderKey.Internal[Date] with HeaderKey.Singleton {
   override def parse(s: String): ParseResult[Date] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Date header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Date header")(s)
 
   /* `Date = HTTP-date` */
   private[http4s] val parser: Parser1[`Date`] =

--- a/core/src/main/scala/org/http4s/headers/ETag.scala
+++ b/core/src/main/scala/org/http4s/headers/ETag.scala
@@ -19,7 +19,6 @@ package headers
 
 import cats.parse.{Parser, Parser1, Rfc5234}
 import cats.Show
-import cats.syntax.all._
 import org.http4s.internal.parsing.Rfc7230
 import org.http4s.util.Writer
 
@@ -38,9 +37,7 @@ object ETag extends HeaderKey.Internal[ETag] with HeaderKey.Singleton {
   def apply(tag: String, weak: Boolean = false): ETag = ETag(EntityTag(tag, weak))
 
   override def parse(s: String): ParseResult[ETag] =
-    parser.parseAll(s).leftMap { case e =>
-      ParseFailure("Invalid ETag", e.toString)
-    }
+    ParseResult.fromParser(parser, "ETag header")(s)
 
   /* `ETag = entity-tag`
    *

--- a/core/src/main/scala/org/http4s/headers/Expires.scala
+++ b/core/src/main/scala/org/http4s/headers/Expires.scala
@@ -18,14 +18,11 @@ package org.http4s
 package headers
 
 import cats.parse.Parser
-import cats.syntax.all._
 import org.http4s.util.{Renderer, Writer}
 
 object Expires extends HeaderKey.Internal[Expires] with HeaderKey.Singleton {
   override def parse(s: String): ParseResult[Expires] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Expires header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Expires header")(s)
 
   /* `Expires = HTTP-date` */
   private[http4s] val parser: Parser[Expires] = {

--- a/core/src/main/scala/org/http4s/headers/If-Modified-Since.scala
+++ b/core/src/main/scala/org/http4s/headers/If-Modified-Since.scala
@@ -18,16 +18,13 @@ package org.http4s
 package headers
 
 import cats.parse.Parser1
-import cats.syntax.all._
 import org.http4s.util.{Renderer, Writer}
 
 object `If-Modified-Since`
     extends HeaderKey.Internal[`If-Modified-Since`]
     with HeaderKey.Singleton {
   override def parse(s: String): ParseResult[`If-Modified-Since`] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid If-Modified-Since header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid If-Modified-Since header")(s)
 
   /* `If-Modified-Since = HTTP-date` */
   private[http4s] val parser: Parser1[`If-Modified-Since`] =

--- a/core/src/main/scala/org/http4s/headers/If-Unmodified-Since.scala
+++ b/core/src/main/scala/org/http4s/headers/If-Unmodified-Since.scala
@@ -18,16 +18,13 @@ package org.http4s
 package headers
 
 import cats.parse.Parser1
-import cats.syntax.all._
 import org.http4s.util.{Renderer, Writer}
 
 object `If-Unmodified-Since`
     extends HeaderKey.Internal[`If-Unmodified-Since`]
     with HeaderKey.Singleton {
   override def parse(s: String): ParseResult[`If-Unmodified-Since`] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid If-Unmodified-Since header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid If-Unmodified-Since header")(s)
 
   /* `If-Modified-Since = HTTP-date` */
   private[http4s] val parser: Parser1[`If-Unmodified-Since`] =

--- a/core/src/main/scala/org/http4s/headers/Last-Modified.scala
+++ b/core/src/main/scala/org/http4s/headers/Last-Modified.scala
@@ -18,14 +18,11 @@ package org.http4s
 package headers
 
 import cats.parse.Parser1
-import cats.syntax.all._
 import org.http4s.util.{Renderer, Writer}
 
 object `Last-Modified` extends HeaderKey.Internal[`Last-Modified`] with HeaderKey.Singleton {
   override def parse(s: String): ParseResult[`Last-Modified`] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Last-Modified header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Last-Modified header")(s)
 
   /* `Last-Modified = HTTP-date` */
   private[http4s] val parser: Parser1[`Last-Modified`] =

--- a/core/src/main/scala/org/http4s/headers/Link.scala
+++ b/core/src/main/scala/org/http4s/headers/Link.scala
@@ -18,14 +18,13 @@ package org.http4s.headers
 
 import cats.data.NonEmptyList
 import cats.parse.{Parser, Parser1}
-import cats.syntax.either._
 import org.http4s._
 import org.http4s.internal.parsing.Rfc7230.{headerRep1, quotedString, token}
 import org.http4s.parser.Rfc2616BasicRules.optWs
 
 object Link extends HeaderKey.Internal[Link] with HeaderKey.Recurring {
   override def parse(s: String): ParseResult[Link] =
-    parser.parseAll(s).leftMap(e => ParseFailure("Invalid Link header", e.toString))
+    ParseResult.fromParser(parser, "Link header")(s)
 
   private[http4s] val parser: Parser1[Link] = {
     import cats.parse.Parser._

--- a/core/src/main/scala/org/http4s/headers/Retry-After.scala
+++ b/core/src/main/scala/org/http4s/headers/Retry-After.scala
@@ -18,7 +18,6 @@ package org.http4s
 package headers
 
 import cats.parse.{Parser1, Rfc5234}
-import cats.syntax.all._
 import org.http4s.util.{Renderer, Writer}
 import org.http4s.util.Renderable._
 import scala.concurrent.duration.FiniteDuration
@@ -42,9 +41,7 @@ object `Retry-After` extends HeaderKey.Internal[`Retry-After`] with HeaderKey.Si
     fromLong(retry.toSeconds).fold(throw _, identity)
 
   override def parse(s: String): ParseResult[`Retry-After`] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Retry-After header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Retry-After header")(s)
 
   /* `Retry-After = HTTP-date / delay-seconds` */
   private[http4s] val parser: Parser1[`Retry-After`] = {

--- a/core/src/main/scala/org/http4s/headers/Set-Cookie.scala
+++ b/core/src/main/scala/org/http4s/headers/Set-Cookie.scala
@@ -19,7 +19,6 @@ package headers
 
 import cats.data.NonEmptyList
 import cats.parse.Parser1
-import cats.syntax.all._
 import org.http4s.util.Writer
 
 object `Set-Cookie` extends HeaderKey.Internal[`Set-Cookie`] {
@@ -35,9 +34,7 @@ object `Set-Cookie` extends HeaderKey.Internal[`Set-Cookie`] {
     }
 
   override def parse(s: String): ParseResult[`Set-Cookie`] =
-    parser.parseAll(s).leftMap { e =>
-      ParseFailure("Invalid Set-Cookie header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Set-Cookie header")(s)
 
   /* set-cookie-header = "Set-Cookie:" SP set-cookie-string */
   private[http4s] val parser: Parser1[`Set-Cookie`] =


### PR DESCRIPTION
@aeons added this helper after a bunch of parsers had already been written, or were in flight.  It gives a more consistent error rendering for our cats-parse parsers.