### PR TITLE
Deprecate macros on companions

### DIFF
--- a/core/src/main/scala/org/http4s/MediaType.scala
+++ b/core/src/main/scala/org/http4s/MediaType.scala
@@ -283,6 +283,7 @@ object MediaType extends MimeDB {
       }
     }
 
+  @deprecated("This location of the implementation complicates Dotty support", "0.21.15")
   class Macros(val c: whitebox.Context) {
     import c.universe._
 

--- a/core/src/main/scala/org/http4s/MediaType.scala
+++ b/core/src/main/scala/org/http4s/MediaType.scala
@@ -283,7 +283,7 @@ object MediaType extends MimeDB {
       }
     }
 
-  @deprecated("This location of the implementation complicates Dotty support", "0.21.15")
+  @deprecated("This location of the implementation complicates Dotty support", "0.21.16")
   class Macros(val c: whitebox.Context) {
     import c.universe._
 

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -113,6 +113,7 @@ object QValue {
   /** Exists to support compile-time verified literals. Do not call directly. */
   def ☠(thousandths: Int): QValue = new QValue(thousandths)
 
+  @deprecated("This location of the implementation complicates Dotty support", "0.21.15")
   class Macros(val c: whitebox.Context) {
     import c.universe._
 

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -113,7 +113,7 @@ object QValue {
   /** Exists to support compile-time verified literals. Do not call directly. */
   def ☠(thousandths: Int): QValue = new QValue(thousandths)
 
-  @deprecated("This location of the implementation complicates Dotty support", "0.21.15")
+  @deprecated("This location of the implementation complicates Dotty support", "0.21.16")
   class Macros(val c: whitebox.Context) {
     import c.universe._
 

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -174,6 +174,7 @@ final case class Uri(
 }
 
 object Uri {
+  @deprecated("This location of the implementation complicates Dotty support", "0.21.15")
   class Macros(val c: whitebox.Context) {
     import c.universe._
 

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -174,7 +174,7 @@ final case class Uri(
 }
 
 object Uri {
-  @deprecated("This location of the implementation complicates Dotty support", "0.21.15")
+  @deprecated("This location of the implementation complicates Dotty support", "0.21.16")
   class Macros(val c: whitebox.Context) {
     import c.universe._
 


### PR DESCRIPTION
This doesn't prevent using the macros (see #4078 for discussion of their future).  This sets us up to move them somewhere less burdensome, or remove them entirely, for 1.0.

We don't want imports `scala.reflect.macros` outside the scala-2 directory.