### PR TITLE
Restore unusedCompileDependenciesTest, inline Unique

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Check binary compatibility
         run: sbt ++${{ matrix.scala }} mimaReportBinaryIssues
 
+      - name: Check unused dependencies
+        run: sbt ++${{ matrix.scala }} unusedCompileDependenciesTest
+
       - name: Run tests
         run: sbt ++${{ matrix.scala }} test
 

--- a/build.sbt
+++ b/build.sbt
@@ -96,8 +96,8 @@ lazy val core = libraryProject("core")
       scalaReflect(scalaVersion.value) % Provided,
       scodecBits,
       slf4jApi, // residual dependency from macros
-      unique,
-      /* vault, */
+      // unique, // temporarily inlined
+      // vault,  // temporarily inlined
     ),
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-lang", "scala-reflect"),
     mimaBinaryIssueFilters ++= Seq(

--- a/core/src/main/scala/io/chrisdavenport/unique/Unique.scala
+++ b/core/src/main/scala/io/chrisdavenport/unique/Unique.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.chrisdavenport.unique
+
+import cats.Hash
+import cats.effect.Sync
+
+final class Unique private extends Serializable {
+  override def toString: String = s"Unique(${hashCode.toHexString})"
+}
+object Unique {
+  def newUnique[F[_]: Sync]: F[Unique] = Sync[F].delay(new Unique)
+
+  implicit val uniqueInstances: Hash[Unique] =
+    Hash.fromUniversalHashCode[Unique]
+}

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -251,7 +251,7 @@ object Http4sPlugin extends AutoPlugin {
         WorkflowStep.Sbt(List("headerCheck", "test:headerCheck"), name = Some("Check headers")),
         WorkflowStep.Sbt(List("test:compile"), name = Some("Compile")),
         WorkflowStep.Sbt(List("mimaReportBinaryIssues"), name = Some("Check binary compatibility")),
-        // WorkflowStep.Sbt(List("unusedCompileDependenciesTest"), name = Some("Check unused dependencies")),
+        WorkflowStep.Sbt(List("unusedCompileDependenciesTest"), name = Some("Check unused dependencies")),
         WorkflowStep.Sbt(List("test"), name = Some("Run tests")),
         // WorkflowStep.Sbt(List("doc"), name = Some("Build docs"))
       ),
@@ -290,12 +290,12 @@ object Http4sPlugin extends AutoPlugin {
     val blaze = "0.14.14"
     val boopickle = "1.3.3"
     val caseInsensitive = "0.3.0"
-    val cats = "2.3.0"
+    val cats = "2.3.1"
     val catsEffect = "3.0.0-M5"
     val catsEffectTesting = "1.0-23-f76ace5"
     val circe = "0.13.0"
     val cryptobits = "1.3"
-    val disciplineCore = "1.1.2"
+    val disciplineCore = "1.1.3"
     val disciplineSpecs2 = "1.1.2"
     val dropwizardMetrics = "4.1.16"
     val fs2 = "3.0.0-M7"
@@ -320,12 +320,12 @@ object Http4sPlugin extends AutoPlugin {
     val prometheusClient = "0.9.0"
     val reactiveStreams = "1.0.3"
     val quasiquotes = "2.1.0"
-    val scalacheck = "1.15.1"
+    val scalacheck = "1.15.2"
     val scalacheckEffect = "0.6.0"
     val scalafix = _root_.scalafix.sbt.BuildInfo.scalafixVersion
     val scalatags = "0.9.2"
     val scalaXml = "1.3.0"
-    val scodecBits = "1.1.22"
+    val scodecBits = "1.1.23"
     val servlet = "3.1.0"
     val slf4j = "1.7.30"
     val specs2 = "4.10.5"


### PR DESCRIPTION
Restores the unusedCompileDependenciesTest to the CE3 branch.

Went ahead and inlined Unique, whose inclusion in CE3 is presently stalled.  We'll go back to a proper Unique release or inherit it from CE3 before this gets merged.