### PR TITLE
Provide an SslContextFactory to jetty-client

### DIFF
--- a/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
@@ -24,6 +24,7 @@ import fs2._
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.api.{Request => JettyRequest}
 import org.eclipse.jetty.http.{HttpVersion => JHttpVersion}
+import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.log4s.{Logger, getLogger}
 
 object JettyClient {
@@ -64,7 +65,8 @@ object JettyClient {
     Stream.resource(resource(client))
 
   def defaultHttpClient(): HttpClient = {
-    val c = new HttpClient()
+    val sslCtxFactory = new SslContextFactory.Client();
+    val c = new HttpClient(sslCtxFactory)
     c.setFollowRedirects(false)
     c.setDefaultRequestContentType(null)
     c


### PR DESCRIPTION
Without this, https requests fail out of the box.  That's a hostile default.

```
java.lang.NullPointerException: Missing SslContextFactory
	at java.util.Objects.requireNonNull(Objects.java:228)
	at org.eclipse.jetty.io.ssl.SslClientConnectionFactory.<init>(SslClientConnectionFactory.java:54)
	at org.eclipse.jetty.client.HttpClient.newSslClientConnectionFactory(HttpClient.java:1208)
	at org.eclipse.jetty.client.HttpClient.newSslClientConnectionFactory(HttpClient.java:1214)
	at org.eclipse.jetty.client.HttpDestination.newSslClientConnectionFactory(HttpDestination.java:149)
	at org.eclipse.jetty.client.HttpDestination.newSslClientConnectionFactory(HttpDestination.java:155)
	at org.eclipse.jetty.client.HttpDestination.<init>(HttpDestination.java:95)
	at org.eclipse.jetty.client.PoolingHttpDestination.<init>(PoolingHttpDestination.java:25)
	at org.eclipse.jetty.client.http.HttpDestinationOverHTTP.<init>(HttpDestinationOverHTTP.java:32)
	at org.eclipse.jetty.client.http.HttpClientTransportOverHTTP.newHttpDestination(HttpClientTransportOverHTTP.java:54)
	at org.eclipse.jetty.client.HttpClient.lambda$resolveDestination$0(HttpClient.java:575)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
	at org.eclipse.jetty.client.HttpClient.resolveDestination(HttpClient.java:573)
	at org.eclipse.jetty.client.HttpClient.resolveDestination(HttpClient.java:551)
	at org.eclipse.jetty.client.HttpClient.send(HttpClient.java:599)
	at org.eclipse.jetty.client.HttpRequest.sendAsync(HttpRequest.java:778)
	at org.eclipse.jetty.client.HttpRequest.send(HttpRequest.java:765)
	at org.http4s.client.jetty.JettyClient$.$anonfun$allocate$8(JettyClient.scala:44)
```

This client doesn't follow the builder pattern of the other backends.  If it did, it should take an `SslContextFactory` parameter.

The workaround until this is released is to pass a fully configured client.  See the `defaultHttpClient` function for how.