### PR TITLE
Add explicit instance for accessing mixed multipart decoder

### DIFF
--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -253,6 +253,14 @@ object EntityDecoder {
   implicit def multipart[F[_]: Sync]: EntityDecoder[F, Multipart[F]] =
     MultipartDecoder.decoder
 
+  def mixedMultipart[F[_] : Sync : ContextShift](
+    blocker: Blocker,
+    headerLimit: Int = 1024,
+    maxSizeBeforeWrite: Int = 52428800,
+    maxParts: Int = 50,
+    failOnLimit: Boolean = false): EntityDecoder[F, Multipart[F]] =
+    MultipartDecoder.mixedMultipart(blocker, headerLimit, maxSizeBeforeWrite, maxParts, failOnLimit)
+
   /** An entity decoder that ignores the content and returns unit. */
   implicit def void[F[_]: Sync]: EntityDecoder[F, Unit] =
     EntityDecoder.decodeBy(MediaRange.`*/*`) { msg =>

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -253,12 +253,12 @@ object EntityDecoder {
   implicit def multipart[F[_]: Sync]: EntityDecoder[F, Multipart[F]] =
     MultipartDecoder.decoder
 
-  def mixedMultipart[F[_] : Sync : ContextShift](
-    blocker: Blocker,
-    headerLimit: Int = 1024,
-    maxSizeBeforeWrite: Int = 52428800,
-    maxParts: Int = 50,
-    failOnLimit: Boolean = false): EntityDecoder[F, Multipart[F]] =
+  def mixedMultipart[F[_]: Sync: ContextShift](
+      blocker: Blocker,
+      headerLimit: Int = 1024,
+      maxSizeBeforeWrite: Int = 52428800,
+      maxParts: Int = 50,
+      failOnLimit: Boolean = false): EntityDecoder[F, Multipart[F]] =
     MultipartDecoder.mixedMultipart(blocker, headerLimit, maxSizeBeforeWrite, maxParts, failOnLimit)
 
   /** An entity decoder that ignores the content and returns unit. */

--- a/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -71,10 +71,10 @@ private[http4s] object MultipartDecoder {
     */
   def mixedMultipart[F[_]: Sync: ContextShift](
       blocker: Blocker,
-      headerLimit: Int = 1024,
-      maxSizeBeforeWrite: Int = 52428800,
-      maxParts: Int = 50,
-      failOnLimit: Boolean = false): EntityDecoder[F, Multipart[F]] =
+      headerLimit: Int,
+      maxSizeBeforeWrite: Int,
+      maxParts: Int,
+      failOnLimit: Boolean): EntityDecoder[F, Multipart[F]] =
     EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
       msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
         case Some(boundary) =>

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSpec.scala
@@ -193,7 +193,7 @@ I am a big moose
   }
 
   multipartSpec("with default decoder")(implicitly)
-  multipartSpec("with mixed decoder")(MultipartDecoder.mixedMultipart[IO](Http4sSpec.TestBlocker))
+  multipartSpec("with mixed decoder")(EntityDecoder.mixedMultipart[IO](Http4sSpec.TestBlocker))
 
   "Part" >> {
     def testPart[F[_]] = Part[F](Headers.empty, EmptyBody)


### PR DESCRIPTION
Add an explicit instance to allow access to the mixed multipart decoder.

Referencing this discussion: https://gitter.im/http4s/http4s?at=5fecd60de7f693041f3efd9c