### PR TITLE
CirceEntityEncoder: avoid intermediate ByteBuffer duplication

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -268,7 +268,7 @@ object CirceInstances {
   // Constant byte chunks for the stream as JSON array encoder.
 
   private def fromJsonToChunk(printer: Printer)(json: Json): Chunk[Byte] =
-    Chunk.byteBuffer(printer.printToByteBuffer(json))
+    Chunk.ByteBuffer.view(printer.printToByteBuffer(json))
 
   private def streamedJsonArray[F[_]](printer: Printer)(s: Stream[F, Json]): Stream[F, Byte] =
     s.pull.uncons1.flatMap {


### PR DESCRIPTION
In the `EntityEncoder` for Json, there is a call to the `apply` method of `fs2.Chunk.ByteBuffer` companion object, which
_duplicates_ the given byte buffer. By default, the printer from `circe` generates a new ByteBuffer for each Json, so we do not need to duplicate it. WE avoid it by calling the `view` method instead.

This should save memory allocations proportional to the size of the response. 