### PR TITLE
port ember server to ce3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val modules: List[ProjectReference] = List(
   client,
   dropwizardMetrics,
   emberCore,
-  // emberServer,
+  emberServer,
   // emberClient,
   blazeCore,
   blazeServer,

--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -27,9 +27,7 @@ private[ember] object Encoder {
   private val CRLF = "\r\n"
   val chunkedTansferEncodingHeaderRaw = "Transfer-Encoding: chunked"
 
-  def respToBytes[F[_]](
-      resp: Response[F],
-      writeBufferSize: Int = 32 * 1024): Stream[F, Byte] = {
+  def respToBytes[F[_]](resp: Response[F], writeBufferSize: Int = 32 * 1024): Stream[F, Byte] = {
     var chunked = resp.isChunked
     val initSection = {
       var appliedContentLength = false

--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -16,7 +16,6 @@
 
 package org.http4s.ember.core
 
-import cats.effect._
 import fs2._
 import org.http4s._
 import org.http4s.headers.`Content-Length`
@@ -28,7 +27,7 @@ private[ember] object Encoder {
   private val CRLF = "\r\n"
   val chunkedTansferEncodingHeaderRaw = "Transfer-Encoding: chunked"
 
-  def respToBytes[F[_]: Sync](
+  def respToBytes[F[_]](
       resp: Response[F],
       writeBufferSize: Int = 32 * 1024): Stream[F, Byte] = {
     var chunked = resp.isChunked
@@ -71,7 +70,7 @@ private[ember] object Encoder {
         .flatMap(Stream.chunk)
   }
 
-  def reqToBytes[F[_]: Sync](req: Request[F], writeBufferSize: Int = 32 * 1024): Stream[F, Byte] = {
+  def reqToBytes[F[_]](req: Request[F], writeBufferSize: Int = 32 * 1024): Stream[F, Byte] = {
     var chunked = req.isChunked
     val initSection = {
       var appliedContentLength = false


### PR DESCRIPTION
* removed an unused typeclass constraint in encoder
* removed the deprecated method instead of adapting it
* the `EmberServerBuilder` takes now `Async` as a constraint, alternatively we could use the `Network` effect type introduced by fs2 and refined in https://github.com/typelevel/fs2/pull/2189

fixes https://github.com/http4s/http4s/issues/4086