### PR TITLE
http4s-0.21.15, filter ahc-2.12.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -716,7 +716,7 @@ lazy val scalafixInput = project
       "http4s-client",
       "http4s-core",
       "http4s-dsl",
-    ).map("org.http4s" %% _ % "0.21.14"),
+    ).map("org.http4s" %% _ % "0.21.15"),
     // TODO: I think these are false positives
     unusedCompileDependenciesFilter -= moduleFilter(organization = "org.http4s"),
     scalacOptions -= "-Xfatal-warnings",

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -78,6 +78,7 @@ object Http4sPlugin extends AutoPlugin {
     dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", revision = "2.11.0"),
     dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", revision = "2.12.0"),
     dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", revision = "2.12.1"),
+    dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", revision = "2.12.2"),    
     // No release notes. If it's compatible with 6.2.5, prove it and PR it.
     dependencyUpdatesFilter -= moduleFilter(organization = "io.argonaut"),
     dependencyUpdatesFilter -= moduleFilter(organization = "io.argonaut", revision = "6.3.1"),


### PR DESCRIPTION
I meant to pick up async-http-client-2.12.2, but we blocked that for binary compatibility.  And http4s is only used in MimeDb.  This is a thoroughly uninteresting PR, but it will make the next bumps smaller. :shrug: