### PR TITLE
Finish okhttp-client for cats-effect-3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val modules: List[ProjectReference] = List(
   // blazeClient,
   // asyncHttpClient,
   // jettyClient,
-  // okHttpClient,
+  okHttpClient,
   // servlet,
   // jetty,
   // tomcat,


### PR DESCRIPTION
It didn't compile on Scala 2.12 because that doesn't have `chaining`.  @ashwinbhaskar already did the hard work.