### PR TITLE
blaze-client WritePendingException fix

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSuite.scala
@@ -157,15 +157,6 @@ class Http1ClientStageSuite extends Http4sSuite {
     } yield ()).intercept[Http1Connection.InProgressException.type]
   }
 
-  fooConnection.test("Reset correctly") { tail =>
-    val h = new SeqTestHead(List(mkBuffer(resp), mkBuffer(resp)))
-    LeafBuilder(tail).base(h)
-
-    // execute the first request and run the body to reset the stage
-    tail.runRequest(FooRequest, IO.never).flatMap(_.body.compile.drain) >>
-      tail.runRequest(FooRequest, IO.never).map(_.headers.size).assertEquals(1)
-  }
-
   fooConnection.test("Alert the user if the body is to short") { tail =>
     val resp = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\ndone"
 


### PR DESCRIPTION
This is (hopefully) the solution to the notorious bug that has plagued the reputation of blaze-client in the past several years (#2278). I could do a longer write up here, but essentially the bug is a race condition that manifests as an interaction between channel writes and connection pooling. 

The offending line of code is here (https://github.com/http4s/http4s/blob/cats-effect-3/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala#L181). What's happening here is that connection starts a fiber that writes to the underlying NIO channel, while concurrently starting to read from the same channel. Each connection maintains a state machine that reflects whether the connection is idle or active. The state machine is reset to `Idle` after the streaming read of the response body is complete. 

However, this poses a problem! The write fiber might still be chugging away (or at the very least, the channel's write status hasn't been reset yet), meanwhile, the connection is set to `Idle` which indicates to the connection pool that it's ready for reuse. When the connection is picked up again and written to, the previous write is still "active" and thus the `WritePendingException` is raised.

The solution here is to enrich the state machine: the `Running` state must now reflect whether there is ongoing read or write activity. At release time, if there is ongoing read/write activity, the connection should be deemed unrecyclable and shutdown accordingly.

I'm fairly confident that this is going to work, but only time will tell :) I think there are still some other bugs too, so tests may still be flaky. This should probably be backported to `series/0.21` and `series/0.22`.