### PR TITLE
Conditionally omit empty content length in blaze-client

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -85,7 +85,8 @@ private[http4s] trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
       rr,
       minor,
       closeOnFinish,
-      Http1Stage.omitEmptyContentLength(req))
+      Http1Stage.omitEmptyContentLength(req)
+    )
   }
 
   /** Get the proper body encoder based on the request,

--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -70,24 +70,25 @@ private[http4s] trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
       true
     }
 
-  /** Get the proper body encoder based on the message headers */
+  /** Get the proper body encoder based on the request */
   final protected def getEncoder(
-      msg: Message[F],
+      req: Request[F],
       rr: StringWriter,
       minor: Int,
       closeOnFinish: Boolean): Http1Writer[F] = {
-    val headers = msg.headers
+    val headers = req.headers
     getEncoder(
       Connection.from(headers),
       `Transfer-Encoding`.from(headers),
       `Content-Length`.from(headers),
-      msg.trailerHeaders,
+      req.trailerHeaders,
       rr,
       minor,
-      closeOnFinish)
+      closeOnFinish,
+      Http1Stage.omitEmptyContentLength(req))
   }
 
-  /** Get the proper body encoder based on the message headers,
+  /** Get the proper body encoder based on the request,
     * adding the appropriate Connection and Transfer-Encoding headers along the way
     */
   final protected def getEncoder(
@@ -97,7 +98,8 @@ private[http4s] trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
       trailer: F[Headers],
       rr: StringWriter,
       minor: Int,
-      closeOnFinish: Boolean): Http1Writer[F] =
+      closeOnFinish: Boolean,
+      omitEmptyContentLength: Boolean): Http1Writer[F] =
     lengthHeader match {
       case Some(h) if bodyEncoding.forall(!_.hasChunked) || minor == 0 =>
         // HTTP 1.1: we have a length and no chunked encoding
@@ -145,7 +147,7 @@ private[http4s] trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
 
             case None => // use a cached chunk encoder for HTTP/1.1 without length of transfer encoding
               logger.trace("Using Caching Chunk Encoder")
-              new CachingChunkWriter(this, trailer, chunkBufferMaxSize)
+              new CachingChunkWriter(this, trailer, chunkBufferMaxSize, omitEmptyContentLength)
           }
     }
 
@@ -271,6 +273,9 @@ object Http1Stage {
   private var currentEpoch: Long = _
   private var cachedString: String = _
 
+  private val NoPayloadMethods: Set[Method] =
+    Set(Method.GET, Method.DELETE, Method.CONNECT, Method.TRACE)
+
   private def currentDate: String = {
     val now = Instant.now()
     val epochSecond = now.getEpochSecond
@@ -305,4 +310,7 @@ object Http1Stage {
       rr << Date.name << ": " << currentDate << "\r\n"
     ()
   }
+
+  private def omitEmptyContentLength[F[_]](req: Request[F]) =
+    NoPayloadMethods.contains(req.method)
 }

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
@@ -33,7 +33,8 @@ import scala.concurrent._
 private[http4s] class CachingChunkWriter[F[_]](
     pipe: TailStage[ByteBuffer],
     trailer: F[Headers],
-    bufferMaxSize: Int)(
+    bufferMaxSize: Int,
+    omitEmptyContentLength: Boolean)(
     implicit protected val F: Async[F],
     protected val ec: ExecutionContext,
     implicit protected val dispatcher: Dispatcher[F])
@@ -89,14 +90,19 @@ private[http4s] class CachingChunkWriter[F[_]](
           val hbuff = ByteBuffer.wrap(h.result.getBytes(ISO_8859_1))
           pipe.channelWrite(hbuff :: body :: Nil)
         } else {
-          h << s"Content-Length: 0\r\n\r\n"
+          if (!omitEmptyContentLength)
+            h << s"Content-Length: 0\r\n"
+          h << "\r\n"
           val hbuff = ByteBuffer.wrap(h.result.getBytes(ISO_8859_1))
           pipe.channelWrite(hbuff)
         }
-      } else if (!chunk.isEmpty) writeBodyChunk(chunk, true).flatMap { _ =>
+      } else if (!chunk.isEmpty) {
+        writeBodyChunk(chunk, true).flatMap { _ =>
+          writeTrailer(pipe, trailer)
+        }
+      } else {
         writeTrailer(pipe, trailer)
       }
-      else writeTrailer(pipe, trailer)
 
     f.map(Function.const(false))
   }

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
@@ -124,12 +124,12 @@ class Http1WriterSpec extends Http4sSpec with CatsEffect {
 
   "CachingChunkWriter" should {
     runNonChunkedTests(implicit dispatcher =>
-      tail => new CachingChunkWriter[IO](tail, IO.pure(Headers.empty), 1024 * 1024))
+      tail => new CachingChunkWriter[IO](tail, IO.pure(Headers.empty), 1024 * 1024, false))
   }
 
   "CachingStaticWriter" should {
     runNonChunkedTests(implicit dispatcher =>
-      tail => new CachingChunkWriter[IO](tail, IO.pure(Headers.empty), 1024 * 1024))
+      tail => new CachingChunkWriter[IO](tail, IO.pure(Headers.empty), 1024 * 1024, false))
   }
 
   "FlushingChunkWriter" should {

--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -273,7 +273,8 @@ private[blaze] class Http1ServerStage[F[_]](
           resp.trailerHeaders,
           rr,
           parser.minorVersion(),
-          closeOnFinish)
+          closeOnFinish,
+          false)
     }
 
     // TODO: pool shifting: https://github.com/http4s/http4s/blob/main/core/src/main/scala/org/http4s/internal/package.scala#L45


### PR DESCRIPTION
Alternative approach to #4109. It seems kind of awkward that we have to do this but it is what it is. Though I think it's worth entertaining because it doesn't make a semantically breaking change: people may be submitting bodies on GET requests today, even though that may be frowned upon

Also, apologies for submitting this on the cats-effect-3 branch