### PR TITLE
Use test io runtime in munit

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSuite.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSuite.scala
@@ -119,11 +119,11 @@ class BlazeServerSuite extends Http4sSuite {
     }
 
   blazeServer.test("route requests on the service executor") { server =>
-    get(server, "/thread/routing").map(_.startsWith("io-compute-")).assertEquals(true)
+    get(server, "/thread/routing").map(_.startsWith("http4s-spec-")).assertEquals(true)
   }
 
   blazeServer.test("execute the service task on the service executor") { server =>
-    get(server, "/thread/effect").map(_.startsWith("io-compute-")).assertEquals(true)
+    get(server, "/thread/effect").map(_.startsWith("http4s-spec-")).assertEquals(true)
   }
 
   blazeServer.test("be able to echo its input") { server =>

--- a/testing/src/test/scala/org/http4s/Http4sSuite.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSuite.scala
@@ -17,6 +17,7 @@
 package org.http4s
 
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import fs2._
 import fs2.text.utf8Decode
@@ -28,6 +29,7 @@ trait Http4sSuite extends CatsEffectSuite with DisciplineSuite with munit.ScalaC
   // The default munit EC causes an IllegalArgumentException in
   // BatchExecutor on Scala 2.12.
   override val munitExecutionContext = Http4sSpec.TestExecutionContext
+  override implicit val ioRuntime: IORuntime = Http4sSpec.TestIORuntime
 
   implicit class ParseResultSyntax[A](self: ParseResult[A]) {
     def yolo: A = self.valueOr(e => sys.error(e.toString))


### PR DESCRIPTION
I'm wondering if we should use the same `Http4sSpec.TestIORuntime` in all tests / suites.