### PR TITLE
Remove uses of Uri.uri

### DIFF
--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSuite.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSuite.scala
@@ -23,6 +23,7 @@ import cats.syntax.all._
 import java.nio.charset.StandardCharsets
 import jawn.JawnDecodeSupportSuite
 import org.http4s.Status.Ok
+import org.http4s.syntax.all._
 import org.http4s.argonaut._
 import org.http4s.headers.`Content-Type`
 
@@ -139,7 +140,7 @@ class ArgonautSuite extends JawnDecodeSupportSuite[Json] with Argonauts {
 
   test("Uri codec should round trip") {
     // TODO would benefit from Arbitrary[Uri]
-    val uri = Uri.uri("http://www.example.com/")
+    val uri = uri"http://www.example.com/"
     assertEquals(uri.asJson.as[Uri].result, Right(uri))
   }
 

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/ClientTimeoutSpec.scala
@@ -39,7 +39,7 @@ class ClientTimeoutSpec extends Http4sSpec {
   /** the map method allows to "post-process" the fragments after their creation */
   override def map(fs: => Fragments) = super.map(fs) ^ step(tickWheel.shutdown())
 
-  val www_foo_com = Uri.uri("http://www.foo.com")
+  val www_foo_com = uri"http://www.foo.com"
   val FooRequest = Request[IO](uri = www_foo_com)
   val FooRequestKey = RequestKey.fromRequest(FooRequest)
   val resp = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndone"

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSpec.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration._
 class Http1ClientStageSpec extends Http4sSpec {
   val trampoline = org.http4s.blaze.util.Execution.trampoline
 
-  val www_foo_test = Uri.uri("http://www.foo.test")
+  val www_foo_test = uri"http://www.foo.test"
   val FooRequest = Request[IO](uri = www_foo_test)
   val FooRequestKey = RequestKey.fromRequest(FooRequest)
 

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -27,6 +27,7 @@ import io.circe.syntax._
 import java.nio.charset.StandardCharsets
 import org.http4s.Status.Ok
 import org.http4s.circe._
+import org.http4s.syntax.all._
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
 
@@ -268,7 +269,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] {
 
   test("Uri codec round trip") {
     // TODO would benefit from Arbitrary[Uri]
-    val uri = Uri.uri("http://www.example.com/")
+    val uri = uri"http://www.example.com/"
     assertEquals(uri.asJson.as[Uri], Right(uri))
   }
 

--- a/client/src/test/scala/org/http4s/client/ClientSpec.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSpec.scala
@@ -58,7 +58,7 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
       })
 
       hostClient
-        .expect[String](Request[IO](GET, Uri.uri("https://http4s.org/")))
+        .expect[String](Request[IO](GET, uri"https://http4s.org/"))
         .unsafeRunSync() must_== "http4s.org"
     }
 
@@ -68,7 +68,7 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
       })
 
       hostClient
-        .expect[String](Request[IO](GET, Uri.uri("https://http4s.org:1983/")))
+        .expect[String](Request[IO](GET, uri"https://http4s.org:1983/"))
         .unsafeRunSync() must_== "http4s.org:1983"
     }
 
@@ -80,7 +80,7 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
       val hostClient = Client.fromHttpApp(VirtualHost(exact(routes, "http4s.org")).orNotFound)
 
       hostClient
-        .expect[String](Request[IO](GET, Uri.uri("https://http4s.org/")))
+        .expect[String](Request[IO](GET, uri"https://http4s.org/"))
         .unsafeRunSync() must_== "http4s.org"
     }
 
@@ -97,7 +97,7 @@ class ClientSpec extends Http4sSpec with Http4sDsl[IO] {
           Deferred[IO, ExitCase[Throwable]]
             .flatTap { exitCase =>
               cancelClient
-                .expect[String](Request[IO](GET, Uri.uri("https://http4s.org/")))
+                .expect[String](Request[IO](GET, uri"https://http4s.org/"))
                 .guaranteeCase(exitCase.complete)
                 .start
                 .flatTap(fiber =>

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
@@ -23,7 +23,6 @@ import cats.syntax.all._
 import fs2._
 import org.http4s.Method._
 import org.http4s.Status.{BadRequest, Created, InternalServerError, Ok}
-import org.http4s.Uri.uri
 import org.http4s.syntax.all._
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers.Accept
@@ -46,7 +45,7 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
 
   val client: Client[IO] = Client.fromHttpApp(app)
 
-  val req: Request[IO] = Request(GET, uri("http://www.foo.bar/"))
+  val req: Request[IO] = Request(GET, uri"http://www.foo.bar/")
 
   object SadTrombone extends Exception("sad trombone")
 
@@ -200,7 +199,7 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
   test(
     "Client should ggreturn an unexpected status when expecting a URI returns unsuccessful status") {
     client
-      .expect[String](uri("http://www.foo.com/status/500"))
+      .expect[String](uri"http://www.foo.com/status/500")
       .attempt
       .assertEquals(Left(UnexpectedStatus(Status.InternalServerError)))
   }
@@ -208,7 +207,7 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
   test("Client should gghandle an unexpected status when calling a URI with expectOr") {
     case class Boom(status: Status, body: String) extends Exception
     client
-      .expectOr[String](uri("http://www.foo.com/status/500")) { resp =>
+      .expectOr[String](uri"http://www.foo.com/status/500") { resp =>
         resp.as[String].map(Boom(resp.status, _))
       }
       .attempt
@@ -216,18 +215,18 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
   }
 
   test("Client should ggadd Accept header on expect") {
-    client.expect[String](uri("http://www.foo.com/echoheaders")).assertEquals("Accept: text/*")
+    client.expect[String](uri"http://www.foo.com/echoheaders").assertEquals("Accept: text/*")
   }
 
   test("Client should ggadd Accept header on expect for requests") {
     client
-      .expect[String](Request[IO](GET, uri("http://www.foo.com/echoheaders")))
+      .expect[String](Request[IO](GET, uri"http://www.foo.com/echoheaders"))
       .assertEquals("Accept: text/*")
   }
 
   test("Client should ggadd Accept header on expect for requests") {
     client
-      .expect[String](Request[IO](GET, uri("http://www.foo.com/echoheaders")))
+      .expect[String](Request[IO](GET, uri"http://www.foo.com/echoheaders"))
       .assertEquals("Accept: text/*")
   }
 
@@ -236,19 +235,19 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
     val edec =
       EntityDecoder.decodeBy[IO, String](MediaType.image.jpeg)(_ => DecodeResult.success("foo!"))
     client
-      .expect(Request[IO](GET, uri("http://www.foo.com/echoheaders")))(
+      .expect(Request[IO](GET, uri"http://www.foo.com/echoheaders"))(
         EntityDecoder.text[IO].orElse(edec))
       .assertEquals("Accept: text/*, image/jpeg")
   }
 
   test("Client should ggreturn empty with expectOption and not found") {
     client
-      .expectOption[String](Request[IO](GET, uri("http://www.foo.com/random-not-found")))
+      .expectOption[String](Request[IO](GET, uri"http://www.foo.com/random-not-found"))
       .assertEquals(Option.empty[String])
   }
   test("Client should ggreturn expected value with expectOption and a response") {
     client
-      .expectOption[String](Request[IO](GET, uri("http://www.foo.com/echoheaders")))
+      .expectOption[String](Request[IO](GET, uri"http://www.foo.com/echoheaders"))
       .assertEquals(
         "Accept: text/*".some
       )
@@ -327,7 +326,7 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
 
   test("RequestResponseGenerator should Generate requests based on Method") {
     // The PUT: /put path just echoes the body
-    client.expect[String](GET(uri("http://www.foo.com/"))).assertEquals("hello") *>
-      client.expect[String](PUT("hello?", uri("http://www.foo.com/put"))).assertEquals("hello?")
+    client.expect[String](GET(uri"http://www.foo.com/")).assertEquals("hello") *>
+      client.expect[String](PUT("hello?", uri"http://www.foo.com/put")).assertEquals("hello?")
   }
 }

--- a/client/src/test/scala/org/http4s/client/middleware/CookieJarSpec.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/CookieJarSpec.scala
@@ -77,7 +77,7 @@ class CookieJarSpec extends Specification with CatsIO {
     }
 
     "not apply if not given a domain" in {
-      val req = Request[IO](Method.GET, uri = Uri.uri("http://google.com"))
+      val req = Request[IO](Method.GET, uri = uri"http://google.com")
       val cookie = ResponseCookie(
         "foo",
         "bar",
@@ -87,7 +87,7 @@ class CookieJarSpec extends Specification with CatsIO {
     }
 
     "apply if a subdomain" in {
-      val req = Request[IO](Method.GET, uri = Uri.uri("http://api.google.com"))
+      val req = Request[IO](Method.GET, uri = uri"http://api.google.com")
       val cookie = ResponseCookie(
         "foo",
         "bar",
@@ -97,7 +97,7 @@ class CookieJarSpec extends Specification with CatsIO {
     }
 
     "not apply if the wrong subdomain" in {
-      val req = Request[IO](Method.GET, uri = Uri.uri("http://api.google.com"))
+      val req = Request[IO](Method.GET, uri = uri"http://api.google.com")
       val cookie = ResponseCookie(
         "foo",
         "bar",
@@ -107,7 +107,7 @@ class CookieJarSpec extends Specification with CatsIO {
     }
 
     "not apply if the superdomain" in {
-      val req = Request[IO](Method.GET, uri = Uri.uri("http://google.com"))
+      val req = Request[IO](Method.GET, uri = uri"http://google.com")
       val cookie = ResponseCookie(
         "foo",
         "bar",

--- a/client/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -20,7 +20,7 @@ package middleware
 
 import cats.effect._
 import fs2.io.readInputStream
-import org.http4s.Uri.uri
+import org.http4s.syntax.all._
 import org.http4s.dsl.io._
 import scala.io.Source
 
@@ -47,12 +47,12 @@ class LoggerSuite extends Http4sSuite {
     ResponseLogger(true, true)(Client.fromHttpApp(testApp))
 
   test("ResponseLogger should not affect a Get") {
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     responseLoggerClient.status(req).assertEquals(Status.Ok)
   }
 
   test("ResponseLogger should not affect a Post") {
-    val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
     val res = responseLoggerClient.expect[String](req)
     res.assertEquals(expectedBody)
   }
@@ -60,12 +60,12 @@ class LoggerSuite extends Http4sSuite {
   val requestLoggerClient = RequestLogger.apply(true, true)(Client.fromHttpApp(testApp))
 
   test("RequestLogger should not affect a Get") {
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     requestLoggerClient.status(req).assertEquals(Status.Ok)
   }
 
   test("RequestLogger should not affect a Post") {
-    val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
     val res = requestLoggerClient.expect[String](req)
     res.assertEquals(expectedBody)
   }
@@ -74,12 +74,12 @@ class LoggerSuite extends Http4sSuite {
     Logger(true, true)(Client.fromHttpApp(testApp)).toHttpApp
 
   test("Logger should not affect a Get") {
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     loggerApp(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("Logger should not affect a Post") {
-    val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
     val res = loggerApp(req)
     res.map(_.status).assertEquals(Status.Ok)
     res.flatMap(_.as[String]).assertEquals(expectedBody)

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
@@ -22,7 +22,6 @@ import cats.effect.{IO, Resource}
 import cats.effect.concurrent.{Ref, Semaphore}
 import cats.syntax.all._
 import fs2.Stream
-import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
 import org.http4s.laws.discipline.ArbitraryInstances._
@@ -59,7 +58,7 @@ class RetrySuite extends Http4sSuite {
       }
     }
     val retryClient = Retry[IO](policy)(client)
-    val req = Request[IO](method, uri("http://localhost/") / status.code.toString).withEntity(body)
+    val req = Request[IO](method, uri"http://localhost/" / status.code.toString).withEntity(body)
     retryClient
       .run(req)
       .use { _ =>
@@ -100,7 +99,7 @@ class RetrySuite extends Http4sSuite {
           case false => ref.update(_ => true) *> IO.pure("")
           case true => IO.pure("OK")
         })
-        val req = Request[IO](method, uri("http://localhost/status-from-body")).withEntity(body)
+        val req = Request[IO](method, uri"http://localhost/status-from-body").withEntity(body)
         val policy = RetryPolicy[IO](
           (attempts: Int) =>
             if (attempts >= 2) None

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSuite.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSuite.scala
@@ -27,7 +27,7 @@ import org.http4s.client.{Client, UnexpectedStatus}
 import org.http4s.client.middleware.Metrics
 import org.http4s.dsl.io._
 import org.http4s.metrics.dropwizard.util._
-import org.http4s.Uri.uri
+import org.http4s.syntax.all._
 import java.util.Arrays
 
 class DropwizardClientMetricsSuite extends Http4sSuite {
@@ -130,7 +130,7 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test5")
     val meteredClient = Metrics(Dropwizard[IO](registry, "client"))(client)
 
-    meteredClient.expect[String](Request[IO](POST, uri("ok"))).attempt.map { resp =>
+    meteredClient.expect[String](Request[IO](POST, uri"ok")).attempt.map { resp =>
       assertEquals(resp, Right("200 OK"))
       assertEquals(count(registry, Timer("client.default.post-requests")), 1L)
       assertEquals(count(registry, Counter("client.default.active-requests")), 0L)
@@ -155,7 +155,7 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test6")
     val meteredClient = Metrics(Dropwizard[IO](registry, "client"))(client)
 
-    meteredClient.expect[String](Request[IO](PUT, uri("ok"))).attempt.map { resp =>
+    meteredClient.expect[String](Request[IO](PUT, uri"ok")).attempt.map { resp =>
       assertEquals(resp, Right("200 OK"))
       assertEquals(count(registry, Timer("client.default.put-requests")), 1L)
       assertEquals(count(registry, Counter("client.default.active-requests")), 0L)
@@ -180,7 +180,7 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test7")
     val meteredClient = Metrics(Dropwizard[IO](registry, "client"))(client)
 
-    meteredClient.expect[String](Request[IO](DELETE, uri("ok"))).attempt.map { resp =>
+    meteredClient.expect[String](Request[IO](DELETE, uri"ok")).attempt.map { resp =>
       assertEquals(resp, Right("200 OK"))
       assertEquals(count(registry, Timer("client.default.delete-requests")), 1L)
       assertEquals(count(registry, Counter("client.default.active-requests")), 0L)

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
@@ -18,7 +18,6 @@ package org.http4s.metrics.dropwizard
 
 import cats.effect.IO
 import com.codahale.metrics.{MetricRegistry, SharedMetricRegistries}
-import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
 import org.http4s.metrics.dropwizard.util._
@@ -31,7 +30,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test1")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](uri = uri("/ok"))
+    val req = Request[IO](uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -61,7 +60,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test2")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
 
-    val req = Request[IO](uri = uri("/bad-request"))
+    val req = Request[IO](uri = uri"/bad-request")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -90,7 +89,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test3")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](uri = uri("/internal-server-error"))
+    val req = Request[IO](uri = uri"/internal-server-error")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -119,7 +118,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test4")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = GET, uri = uri("/ok"))
+    val req = Request[IO](method = GET, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -148,7 +147,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test5")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = POST, uri = uri("/ok"))
+    val req = Request[IO](method = POST, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -177,7 +176,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test6")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = PUT, uri = uri("/ok"))
+    val req = Request[IO](method = PUT, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -206,7 +205,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test7")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = DELETE, uri = uri("/ok"))
+    val req = Request[IO](method = DELETE, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -235,7 +234,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test8")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = GET, uri = uri("/error"))
+    val req = Request[IO](method = GET, uri = uri"/error")
 
     meteredRoutes.orNotFound(req).attempt.map { resp =>
       assert(resp.isLeft)
@@ -257,7 +256,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test9")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = GET, uri = uri("/abnormal-termination"))
+    val req = Request[IO](method = GET, uri = uri"/abnormal-termination")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.body.attempt.compile.lastOrError.map { b =>
@@ -284,7 +283,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test10")
     val meteredRoutes =
       Metrics[IO](ops = Dropwizard(registry, "server"), classifierF = classifierFunc)(testRoutes)
-    val req = Request[IO](uri = uri("/ok"))
+    val req = Request[IO](uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSuite.scala
@@ -20,7 +20,7 @@ package dsl
 import cats.data.Validated._
 import cats.effect.IO
 import cats.syntax.all._
-import org.http4s.Uri.uri
+import org.http4s.syntax.all._
 import org.http4s.dsl.io._
 
 final case class Limit(l: Long)
@@ -107,12 +107,12 @@ class PathInHttpRoutesSuite extends Http4sSuite {
       response.flatMap(_.as[String]).assertEquals("id: 12345")
   }
   test("Path DSL within HttpService should GET /?{start}") {
-    val response = serve(Request(GET, uri("/?start=1")))
+    val response = serve(Request(GET, uri"/?start=1"))
     response.map(_.status).assertEquals(Ok) *>
       response.flatMap(_.as[String]).assertEquals("start: 1")
   }
   test("Path DSL within HttpService should GET /?{start,limit}") {
-    val response = serve(Request(GET, uri("/?start=1&limit=2")))
+    val response = serve(Request(GET, uri"/?start=1&limit=2"))
     response.map(_.status).assertEquals(Ok) *>
       response.flatMap(_.as[String]).assertEquals("start: 1, limit: 2")
   }

--- a/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSpec.scala
@@ -11,7 +11,6 @@ package org.http4s
 package dsl
 
 import cats.effect.IO
-import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
@@ -57,7 +56,7 @@ class PathSpec extends Http4sSpec {
     }
 
     "-> extractor /test.json" in {
-      val req = Request[IO](method = Method.GET, uri = uri("/test.json"))
+      val req = Request[IO](method = Method.GET, uri = uri"/test.json")
       (req match {
         case GET -> Root / "test.json" => true
         case _ => false
@@ -65,7 +64,7 @@ class PathSpec extends Http4sSpec {
     }
 
     "-> extractor /foo/test.json" in {
-      val req = Request[IO](method = Method.GET, uri = uri("/foo/test.json"))
+      val req = Request[IO](method = Method.GET, uri = uri"/foo/test.json")
       (req match {
         case GET -> Root / "foo" / "test.json" => true
         case _ => false
@@ -73,7 +72,7 @@ class PathSpec extends Http4sSpec {
     }
 
     "→ extractor /test.json" in {
-      val req = Request[IO](method = Method.GET, uri = uri("/test.json"))
+      val req = Request[IO](method = Method.GET, uri = uri"/test.json")
       (req match {
         case GET → (Root / "test.json") => true
         case _ => false
@@ -81,7 +80,7 @@ class PathSpec extends Http4sSpec {
     }
 
     "request path info extractor for /" in {
-      val req = Request[IO](method = Method.GET, uri = uri("/"))
+      val req = Request[IO](method = Method.GET, uri = uri"/")
       (req match {
         case _ -> Root => true
         case _ => false

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
@@ -18,9 +18,9 @@ package com.example.http4s.blaze
 
 import cats.effect._
 import io.circe.generic.auto._
-import org.http4s.Uri
 import org.http4s.Status.{NotFound, Successful}
 import org.http4s.circe._
+import org.http4s.syntax.all._
 import org.http4s.client.Client
 import org.http4s.client.blaze.BlazeClientBuilder
 import scala.concurrent.ExecutionContext.global
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext.global
 object ClientExample extends IOApp {
   def getSite(client: Client[IO]): IO[Unit] =
     IO {
-      val page: IO[String] = client.expect[String](Uri.uri("https://www.google.com/"))
+      val page: IO[String] = client.expect[String](uri"https://www.google.com/")
 
       for (_ <- 1 to 2)
         println(
@@ -41,7 +41,7 @@ object ClientExample extends IOApp {
       final case class Foo(bar: String)
 
       // Match on response code!
-      val page2 = client.get(Uri.uri("http://http4s.org/resources/foo.json")) {
+      val page2 = client.get(uri"http://http4s.org/resources/foo.json") {
         case Successful(resp) =>
           // decodeJson is defined for Json4s, Argonuat, and Circe, just need the right decoder!
           resp.decodeJson[Foo].map("Received response: " + _)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala
@@ -21,12 +21,13 @@ import org.http4s._
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.dsl.io._
-import org.http4s.Uri.uri
+import org.http4s.syntax.all._
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object ClientPostExample extends IOApp with Http4sClientDsl[IO] {
   def run(args: List[String]): IO[ExitCode] = {
-    val req = POST(UrlForm("q" -> "http4s"), uri("https://duckduckgo.com/"))
+    val req = POST(UrlForm("q" -> "http4s"), uri"https://duckduckgo.com/")
     val responseBody = BlazeClientBuilder[IO](global).resource.use(_.expect[String](req))
     responseBody.flatMap(resp => IO(println(resp))).as(ExitCode.Success)
   }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/client/StreamClient.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/client/StreamClient.scala
@@ -36,7 +36,8 @@ class HttpClient[F[_]](implicit F: ConcurrentEffect[F], S: StreamUtils[F]) {
   def run: F[Unit] =
     BlazeClientBuilder[F](global).stream
       .flatMap { client =>
-        val request = Request[F](uri = Uri.uri("http://localhost:8080/v1/dirs?depth=3"))
+        val request =
+          Request[F](uri = Uri.unsafeFromString("http://localhost:8080/v1/dirs?depth=3"))
         for {
           response <- client.stream(request).flatMap(_.body.chunks.through(fs2.text.utf8DecodeC))
           _ <- S.putStr(response)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
@@ -38,7 +38,7 @@ class GitHubService[F[_]: Sync](client: Client[F]) extends Http4sClientDsl[F] {
 
   val authorize: Stream[F, Byte] = {
     val uri = Uri
-      .uri("https://github.com")
+      .unsafeFromString("https://github.com")
       .withPath("/login/oauth/authorize")
       .withQueryParam("client_id", ClientId)
       .withQueryParam("redirect_uri", RedirectUri)
@@ -50,7 +50,7 @@ class GitHubService[F[_]: Sync](client: Client[F]) extends Http4sClientDsl[F] {
 
   def accessToken(code: String, state: String): F[String] = {
     val uri = Uri
-      .uri("https://github.com")
+      .unsafeFromString("https://github.com")
       .withPath("/login/oauth/access_token")
       .withQueryParam("client_id", ClientId)
       .withQueryParam("client_secret", ClientSecret)
@@ -64,7 +64,7 @@ class GitHubService[F[_]: Sync](client: Client[F]) extends Http4sClientDsl[F] {
   }
 
   def userData(accessToken: String): F[String] = {
-    val request = Request[F](uri = Uri.uri("https://api.github.com/user"))
+    val request = Request[F](uri = Uri.unsafeFromString("https://api.github.com/user"))
       .putHeaders(Header("Authorization", s"token $accessToken"))
 
     client.expect[String](request)

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -26,6 +26,7 @@ import org.http4s.headers._
 import org.http4s.multipart.Multipart
 import org.http4s.scalaxml._
 import org.http4s.server._
+import org.http4s.syntax.all._
 import org.http4s.server.middleware.PushSupport._
 import org.http4s.server.middleware.authentication.BasicAuth
 import org.http4s.server.middleware.authentication.BasicAuth.BasicAuthenticator
@@ -68,7 +69,7 @@ class ExampleService[F[_]](blocker: Blocker)(implicit F: Effect[F], cs: ContextS
 
       case GET -> Root / "redirect" =>
         // Not every response must be Ok using a EntityEncoder: some have meaning only for specific types
-        TemporaryRedirect(Location(Uri.uri("/http4s/")))
+        TemporaryRedirect(Location(uri"/http4s/"))
 
       case GET -> Root / "content-change" =>
         // EntityEncoder typically deals with appropriate headers, but they can be overridden

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSuite.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSuite.scala
@@ -21,6 +21,7 @@ import cats.effect.IO
 import cats.syntax.all._
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
+import org.http4s.syntax.all._
 import org.json4s.{JValue, JsonFormat}
 import org.json4s.DefaultReaders._
 import org.json4s.DefaultWriters._
@@ -92,7 +93,7 @@ trait Json4sSuite[J] extends JawnDecodeSupportSuite[JValue] {
 
   test("JsonFormat[Uri] should round trip") {
     // TODO would benefit from Arbitrary[Uri]
-    val uri = Uri.uri("http://www.example.com/")
+    val uri = uri"http://www.example.com/"
     val format = implicitly[JsonFormat[Uri]]
     assertEquals(format.read(format.write(uri)), uri)
   }

--- a/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
@@ -23,6 +23,7 @@ import cats.effect.laws.util.TestContext
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
 import org.http4s.play._
+import org.http4s.syntax.all._
 
 // Originally based on CirceSpec
 class PlaySuite extends JawnDecodeSupportSuite[JsValue] {
@@ -64,7 +65,7 @@ class PlaySuite extends JawnDecodeSupportSuite[JsValue] {
 
   test("Uri codec should round trip") {
     // TODO would benefit from Arbitrary[Uri]
-    val uri = Uri.uri("http://www.example.com/")
+    val uri = uri"http://www.example.com/"
 
     assertEquals(Json.fromJson[Uri](Json.toJson(uri)).asOpt, Some(uri))
   }

--- a/server/src/test/scala/org/http4s/server/HttpRoutesSuite.scala
+++ b/server/src/test/scala/org/http4s/server/HttpRoutesSuite.scala
@@ -19,7 +19,6 @@ package server
 
 import cats.effect._
 import cats.syntax.all._
-import org.http4s.Uri.uri
 import org.http4s.syntax.all._
 
 class HttpRoutesSuite extends Http4sSuite {
@@ -46,35 +45,35 @@ class HttpRoutesSuite extends Http4sSuite {
 
   test("Return a valid Response from the first service of an aggregate") {
     aggregate1
-      .orNotFound(Request[IO](uri = uri("/match")))
+      .orNotFound(Request[IO](uri = uri"/match"))
       .flatMap(_.as[String])
       .assertEquals("match")
   }
 
   test("Return a custom NotFound from the first service of an aggregate") {
     aggregate1
-      .orNotFound(Request[IO](uri = uri("/notfound")))
+      .orNotFound(Request[IO](uri = uri"/notfound"))
       .flatMap(_.as[String])
       .assertEquals("notfound")
   }
 
   test("Accept the first matching route in the case of overlapping paths") {
     aggregate1
-      .orNotFound(Request[IO](uri = uri("/conflict")))
+      .orNotFound(Request[IO](uri = uri"/conflict"))
       .flatMap(_.as[String])
       .assertEquals("routes1conflict")
   }
 
   test("Fall through the first service that doesn't match to a second matching service") {
     aggregate1
-      .orNotFound(Request[IO](uri = uri("/routes2")))
+      .orNotFound(Request[IO](uri = uri"/routes2"))
       .flatMap(_.as[String])
       .assertEquals("routes2")
   }
 
   test("Properly fall through two aggregated service if no path matches") {
     aggregate1
-      .apply(Request[IO](uri = uri("/wontMatch")))
+      .apply(Request[IO](uri = uri"/wontMatch"))
       .value
       .map(_ == Option.empty[Response[IO]])
       .assertEquals(true)

--- a/server/src/test/scala/org/http4s/server/middleware/AutoSlashSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/AutoSlashSuite.scala
@@ -17,7 +17,6 @@
 package org.http4s.server.middleware
 
 import cats.effect._
-import org.http4s.Uri.uri
 import org.http4s.syntax.all._
 import org.http4s.server.{MockRoute, Router}
 import org.http4s.{Http4sSuite, HttpRoutes, Request, Status}
@@ -33,30 +32,30 @@ class AutoSlashSuite extends Http4sSuite {
   }
 
   test("Auto remove a trailing slash") {
-    val req = Request[IO](uri = uri("/ping/"))
+    val req = Request[IO](uri = uri"/ping/")
     route.orNotFound(req).map(_.status).assertEquals(Status.NotFound) *>
       AutoSlash(route).orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("Match a route defined with a slash") {
     AutoSlash(route)
-      .orNotFound(Request[IO](uri = uri("/withslash")))
+      .orNotFound(Request[IO](uri = uri"/withslash"))
       .map(_.status)
       .assertEquals(Status.Ok) *>
       AutoSlash(route)
-        .orNotFound(Request[IO](uri = uri("/withslash/")))
+        .orNotFound(Request[IO](uri = uri"/withslash/"))
         .map(_.status)
         .assertEquals(Status.Accepted)
   }
 
   test("Respect an absent trailing slash") {
-    val req = Request[IO](uri = uri("/ping"))
+    val req = Request[IO](uri = uri"/ping")
     route.orNotFound(req).map(_.status).assertEquals(Status.Ok)
     AutoSlash(route).orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("Not crash on empty path") {
-    val req = Request[IO](uri = uri(""))
+    val req = Request[IO](uri = uri"")
     AutoSlash(route).orNotFound(req).map(_.status).assertEquals(Status.NotFound)
   }
 
@@ -64,11 +63,11 @@ class AutoSlashSuite extends Http4sSuite {
     // See https://github.com/http4s/http4s/issues/1378
     val router = Router("/public" -> AutoSlash(pingRoutes))
     router
-      .orNotFound(Request[IO](uri = uri("/public/ping")))
+      .orNotFound(Request[IO](uri = uri"/public/ping"))
       .map(_.status)
       .assertEquals(Status.Ok) *>
       router
-        .orNotFound(Request[IO](uri = uri("/public/ping/")))
+        .orNotFound(Request[IO](uri = uri"/public/ping/"))
         .map(_.status)
         .assertEquals(Status.Ok)
   }
@@ -77,17 +76,17 @@ class AutoSlashSuite extends Http4sSuite {
     // See https://github.com/http4s/http4s/issues/1947
     val router = AutoSlash(Router("/public" -> pingRoutes))
     router
-      .orNotFound(Request[IO](uri = uri("/public/ping")))
+      .orNotFound(Request[IO](uri = uri"/public/ping"))
       .map(_.status)
       .assertEquals(Status.Ok) *>
       router
-        .orNotFound(Request[IO](uri = uri("/public/ping/")))
+        .orNotFound(Request[IO](uri = uri"/public/ping/"))
         .map(_.status)
         .assertEquals(Status.Ok)
   }
 
   test("Be created via httpRoutes constructor") {
-    val req = Request[IO](uri = uri("/ping/"))
+    val req = Request[IO](uri = uri"/ping/")
     AutoSlash.httpRoutes(route).orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
@@ -22,7 +22,6 @@ import cats.effect._
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import fs2.Stream
-import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
 
@@ -40,17 +39,17 @@ class DefaultHeadSuite extends Http4sSuite {
   val app = DefaultHead(httpRoutes).orNotFound
 
   test("honor HEAD routes") {
-    val req = Request[IO](Method.HEAD, uri = uri("/special"))
+    val req = Request[IO](Method.HEAD, uri = uri"/special")
     app(req).map(_.headers.get("X-Handled-By".ci).map(_.value)).assertEquals(Some("HEAD"))
   }
 
   test("return truncated body of corresponding GET on fallthrough") {
-    val req = Request[IO](Method.HEAD, uri = uri("/hello"))
+    val req = Request[IO](Method.HEAD, uri = uri"/hello")
     app(req).flatMap(_.as[String]).assertEquals("")
   }
 
   test("retain all headers of corresponding GET on fallthrough") {
-    val get = Request[IO](Method.GET, uri = uri("/hello"))
+    val get = Request[IO](Method.GET, uri = uri"/hello")
     val head = get.withMethod(Method.HEAD)
     val getHeaders = app(get).map(_.headers)
     val headHeaders = app(head).map(_.headers)
@@ -73,7 +72,7 @@ class DefaultHeadSuite extends Http4sSuite {
   }
 
   test("be created via the httpRoutes constructor") {
-    val req = Request[IO](Method.HEAD, uri = uri("/hello"))
+    val req = Request[IO](Method.HEAD, uri = uri"/hello")
     DefaultHead.httpRoutes(httpRoutes).orNotFound(req).flatMap(_.as[String]).assertEquals("")
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
@@ -25,7 +25,6 @@ import fs2.Stream._
 import java.nio.charset.StandardCharsets
 import org.http4s.Method._
 import org.http4s.Status._
-import org.http4s.Uri.uri
 import org.http4s.syntax.all._
 import org.http4s.server.middleware.EntityLimiter.EntityTooLarge
 
@@ -38,7 +37,7 @@ class EntityLimiterSuite extends Http4sSuite {
 
   test("Allow reasonable entities") {
     EntityLimiter(routes, 100)
-      .apply(Request[IO](POST, uri("/echo"), body = b))
+      .apply(Request[IO](POST, uri"/echo", body = b))
       .map(_ => -1)
       .value
       .assertEquals(Some(-1))
@@ -46,7 +45,7 @@ class EntityLimiterSuite extends Http4sSuite {
 
   test("Limit the maximum size of an EntityBody") {
     EntityLimiter(routes, 3)
-      .apply(Request[IO](POST, uri("/echo"), body = b))
+      .apply(Request[IO](POST, uri"/echo", body = b))
       .map(_ => -1L)
       .value
       .handleError { case EntityTooLarge(i) => Some(i) }
@@ -61,11 +60,11 @@ class EntityLimiterSuite extends Http4sSuite {
 
     val st = EntityLimiter(routes, 3) <+> routes2
 
-    st.apply(Request[IO](POST, uri("/echo2"), body = b))
+    st.apply(Request[IO](POST, uri"/echo2", body = b))
       .map(_ => -1)
       .value
       .assertEquals(Some(-1)) *>
-      st.apply(Request[IO](POST, uri("/echo"), body = b))
+      st.apply(Request[IO](POST, uri"/echo", body = b))
         .map(_ => -1L)
         .value
         .handleError { case EntityTooLarge(i) => Some(i) }
@@ -75,7 +74,7 @@ class EntityLimiterSuite extends Http4sSuite {
   test("Be created via the httpRoutes constructor") {
     EntityLimiter
       .httpRoutes(routes, 3)
-      .apply(Request[IO](POST, uri("/echo"), body = b))
+      .apply(Request[IO](POST, uri"/echo", body = b))
       .map(_ => -1L)
       .value
       .handleError { case EntityTooLarge(i) => Some(i) }
@@ -87,7 +86,7 @@ class EntityLimiterSuite extends Http4sSuite {
 
     EntityLimiter
       .httpApp(app, 3L)
-      .apply(Request[IO](POST, uri("/echo"), body = b))
+      .apply(Request[IO](POST, uri"/echo", body = b))
       .map(_ => -1L)
       .handleError { case EntityTooLarge(i) => i }
       .assertEquals(3L)

--- a/server/src/test/scala/org/http4s/server/middleware/ErrorActionSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ErrorActionSuite.scala
@@ -21,7 +21,6 @@ import cats.effect.concurrent.Ref
 import io.chrisdavenport.vault.Vault
 import org.http4s._
 import org.http4s.Request.Connection
-import org.http4s.Uri.uri
 import org.http4s.syntax.all._
 import org.http4s.dsl.io._
 
@@ -37,7 +36,7 @@ class ErrorActionSuite extends Http4sSuite {
 
   val req = Request[IO](
     GET,
-    uri("/error"),
+    uri"/error",
     attributes = Vault.empty.insert(
       Request.Keys.ConnectionInfo,
       Connection(

--- a/server/src/test/scala/org/http4s/server/middleware/ErrorHandlingSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ErrorHandlingSuite.scala
@@ -18,7 +18,6 @@ package org.http4s.server.middleware
 
 import cats.effect.IO
 import org.http4s._
-import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
 
@@ -28,7 +27,7 @@ class ErrorHandlingSuite extends Http4sSuite {
       IO.raiseError(t)
     }
 
-  val request = Request[IO](GET, uri("/error"))
+  val request = Request[IO](GET, uri"/error")
 
   test("Handle errors based on the default service error handler") {
     ErrorHandling(

--- a/server/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
@@ -35,7 +35,7 @@ class GZipSuite extends Http4sSuite {
       Ok("pong")
     }
     val req =
-      Request[IO](Method.GET, Uri.uri("/")).putHeaders(`Accept-Encoding`(ContentCoding.gzip))
+      Request[IO](Method.GET, uri"/").putHeaders(`Accept-Encoding`(ContentCoding.gzip))
     routes
       .orNotFound(req)
       .map { resp =>
@@ -53,7 +53,7 @@ class GZipSuite extends Http4sSuite {
 
     val gzipRoutes: HttpRoutes[IO] = GZip(routes, isZippable = _ => true)
 
-    val req: Request[IO] = Request[IO](Method.GET, Uri.uri("/"))
+    val req: Request[IO] = Request[IO](Method.GET, uri"/")
       .putHeaders(`Accept-Encoding`(ContentCoding.gzip))
     val actual: IO[Array[Byte]] =
       gzipRoutes.orNotFound(req).flatMap(_.as[Chunk[Byte]]).map(_.toArray)
@@ -72,7 +72,7 @@ class GZipSuite extends Http4sSuite {
         Ok(Stream.emits(vector).covary[IO])
       }
       val gzipRoutes: HttpRoutes[IO] = GZip(routes)
-      val req: Request[IO] = Request[IO](Method.GET, Uri.uri("/"))
+      val req: Request[IO] = Request[IO](Method.GET, uri"/")
         .putHeaders(`Accept-Encoding`(ContentCoding.gzip))
       val actual: IO[Array[Byte]] =
         gzipRoutes.orNotFound(req).flatMap(_.as[Chunk[Byte]]).map(_.toArray)

--- a/server/src/test/scala/org/http4s/server/middleware/HSTSSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HSTSSuite.scala
@@ -30,7 +30,7 @@ class HSTSSuite extends Http4sSuite {
     Ok("pong")
   }
 
-  val req = Request[IO](Method.GET, Uri.uri("/"))
+  val req = Request[IO](Method.GET, uri"/")
 
   test("add the Strict-Transport-Security header") {
     List(

--- a/server/src/test/scala/org/http4s/server/middleware/HeaderEchoSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HeaderEchoSuite.scala
@@ -21,7 +21,6 @@ import cats.implicits._
 import cats.effect.IO
 import org.http4s._
 import org.http4s.dsl.io._
-import org.http4s.Uri.uri
 import org.http4s.syntax.all._
 import org.http4s.util.CaseInsensitiveString
 
@@ -36,7 +35,7 @@ class HeaderEchoSuite extends Http4sSuite {
   def testSingleHeader[F[_]: Functor, G[_]](testee: Http[F, G]) = {
     val requestMatchingSingleHeaderKey =
       Request[G](
-        uri = uri("/request"),
+        uri = uri"/request",
         headers = Headers.of(Header("someheaderkey", "someheadervalue"))
       )
 
@@ -58,7 +57,7 @@ class HeaderEchoSuite extends Http4sSuite {
   test("echo multiple headers") {
     val requestMatchingMultipleHeaderKeys =
       Request[IO](
-        uri = uri("/request"),
+        uri = uri"/request",
         headers = Headers.of(
           Header("someheaderkey", "someheadervalue"),
           Header("anotherheaderkey", "anotherheadervalue")))
@@ -81,7 +80,7 @@ class HeaderEchoSuite extends Http4sSuite {
   test("echo only the default headers where none match the key") {
     val requestMatchingNotPresentHeaderKey =
       Request[IO](
-        uri = uri("/request"),
+        uri = uri"/request",
         headers = Headers.of(Header("someunmatchedheader", "someunmatchedvalue")))
 
     val testee = HeaderEcho(_ == CaseInsensitiveString("someheaderkey"))(testService)

--- a/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSuite.scala
@@ -77,7 +77,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   }
 
   test("ignore method override if request method not in the overridable method list") {
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withMethod(GET)
       .withHeaders(Header(overrideHeader, "PUT"))
     val app = HttpMethodOverrider(testApp, noMethodHeaderOverriderConfig)
@@ -98,7 +98,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "override request method when using header method overrider strategy if override method provided") {
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(Header(overrideHeader, "PUT"))
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -120,7 +120,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "not override request method when using header method overrider strategy if override method not provided") {
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withMethod(DELETE)
     val app = HttpMethodOverrider(testApp, deleteHeaderOverriderConfig)
 
@@ -141,7 +141,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "override request method and store the original method when using query method overrider strategy") {
-    val req = Request[IO](uri = Uri.uri("/resources/id?_method=PUT"))
+    val req = Request[IO](uri = uri"/resources/id?_method=PUT")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -161,7 +161,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "not override request method when using query method overrider strategy if override method not provided") {
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withMethod(DELETE)
     val app = HttpMethodOverrider(testApp, deleteQueryOverriderConfig)
 
@@ -183,7 +183,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "override request method and store the original method when using form method overrider strategy") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "PUT")
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -205,7 +205,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "not override request method when using form method overrider strategy if override method not provided") {
     val urlForm = UrlForm("foo" -> "bar")
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(DELETE)
     val app = HttpMethodOverrider(testApp, deleteFormOverriderConfig)
@@ -226,7 +226,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "return 404 when using header method overrider strategy if override method provided is not recognized") {
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(Header(overrideHeader, "INVALID"))
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -236,7 +236,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "return 404 when using query method overrider strategy if override method provided is not recognized") {
-    val req = Request[IO](uri = Uri.uri("/resources/id?_method=INVALID"))
+    val req = Request[IO](uri = uri"/resources/id?_method=INVALID")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -246,7 +246,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "return 404 when using form method overrider strategy if override method provided is not recognized") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "INVALID")
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -256,7 +256,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "return 400 when using header method overrider strategy if override method provided is duped") {
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(Header(overrideHeader, ""))
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -266,7 +266,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "return 400 when using query method overrider strategy if override method provided is duped") {
-    val req = Request[IO](uri = Uri.uri("/resources/id?_method="))
+    val req = Request[IO](uri = uri"/resources/id?_method=")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -276,7 +276,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "return 400 when using form method overrider strategy if override method provided is duped") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "")
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -286,7 +286,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "override request method when using header method overrider strategy and be case insensitive") {
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(Header(overrideHeader, "pUt"))
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -307,7 +307,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "override request method when using query method overrider strategy and be case insensitive") {
-    val req = Request[IO](uri = Uri.uri("/resources/id?_method=pUt"))
+    val req = Request[IO](uri = uri"/resources/id?_method=pUt")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -326,7 +326,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "override request method when form query method overrider strategy and be case insensitive") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "pUt")
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -345,7 +345,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "updates vary header when using query method overrider strategy and vary header comes pre-populated") {
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(Header(overrideHeader, "PUT"))
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -366,7 +366,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "set vary header when using header method overrider strategy and vary header has not been set") {
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(Header(overrideHeader, "DELETE"))
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -388,7 +388,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "not set vary header when using query method overrider strategy and vary header has not been set") {
-    val req = Request[IO](uri = Uri.uri("/resources/id?_method=DELETE"))
+    val req = Request[IO](uri = uri"/resources/id?_method=DELETE")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -410,7 +410,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "not update vary header when using query method overrider strategy and vary header comes pre-populated") {
-    val req = Request[IO](uri = Uri.uri("/resources/id?_method=PUT"))
+    val req = Request[IO](uri = uri"/resources/id?_method=PUT")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -433,7 +433,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "not set vary header when using form method overrider strategy and vary header has not been set") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "DELETE")
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -455,7 +455,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "not update vary header when using form method overrider strategy and vary header comes pre-populated") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "PUT")
-    val req = Request[IO](uri = Uri.uri("/resources/id"))
+    val req = Request[IO](uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)

--- a/server/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -22,7 +22,7 @@ import cats.syntax.all._
 import cats.effect._
 import fs2.io.readInputStream
 import org.http4s.dsl.io._
-import org.http4s.Uri.uri
+import org.http4s.syntax.all._
 import scala.io.Source
 
 /** Common Tests for Logger, RequestLogger, and ResponseLogger
@@ -47,12 +47,12 @@ class LoggerSuite extends Http4sSuite {
   val respApp = ResponseLogger.httpApp(logHeaders = true, logBody = true)(testApp)
 
   test("response should not affect a Get") {
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     respApp(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("response should not affect a Post") {
-    val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
     respApp(req)
       .flatMap { res =>
         res
@@ -67,12 +67,12 @@ class LoggerSuite extends Http4sSuite {
   val reqApp = RequestLogger.httpApp(logHeaders = true, logBody = true)(testApp)
 
   test("request should not affect a Get") {
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     reqApp(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("request should not affect a Post") {
-    val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
     reqApp(req)
       .flatMap { res =>
         res.as[String].map(_ === expectedBody && res.status === Status.Ok)
@@ -83,12 +83,12 @@ class LoggerSuite extends Http4sSuite {
   val loggerApp = Logger.httpApp(logHeaders = true, logBody = true)(testApp)
 
   test("logger should not affect a Get") {
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     loggerApp(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("logger should not affect a Post") {
-    val req = Request[IO](uri = uri("/post"), method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
     loggerApp(req)
       .flatMap { res =>
         res.as[String].map(_ === expectedBody && res.status === Status.Ok)

--- a/server/src/test/scala/org/http4s/server/middleware/RequestIdSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/RequestIdSuite.scala
@@ -21,7 +21,6 @@ import cats.implicits._
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
-import org.http4s.Uri.uri
 import org.http4s.util.{CaseInsensitiveString => CIString}
 import java.util.UUID
 
@@ -45,7 +44,7 @@ class RequestIdSuite extends Http4sSuite {
 
   test("propagate X-Request-ID header from request to response") {
     val req =
-      Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123")))
+      Request[IO](uri = uri"/request", headers = Headers.of(Header("X-Request-ID", "123")))
     RequestId
       .httpRoutes(testService())
       .orNotFound(req)
@@ -57,7 +56,7 @@ class RequestIdSuite extends Http4sSuite {
   }
 
   test("generate X-Request-ID header when unset") {
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     RequestId
       .httpRoutes(testService())
       .orNotFound(req)
@@ -71,7 +70,7 @@ class RequestIdSuite extends Http4sSuite {
   }
 
   test("generate different request ids on subsequent requests") {
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     val resp = RequestId.httpRoutes(testService()).orNotFound(req)
     (resp.map(requestIdFromHeaders(_)), resp.map(requestIdFromHeaders(_)))
       .parMapN(_ =!= _)
@@ -80,7 +79,7 @@ class RequestIdSuite extends Http4sSuite {
 
   test("propagate custom request id header from request to response") {
     val req = Request[IO](
-      uri = uri("/request"),
+      uri = uri"/request",
       headers = Headers.of(Header("X-Request-ID", "123"), Header("X-Correlation-ID", "abc")))
     RequestId
       .httpRoutes(CIString("X-Correlation-ID"))(testService(CIString("X-Correlation-ID")))
@@ -96,7 +95,7 @@ class RequestIdSuite extends Http4sSuite {
 
   test("generate custom request id header when unset") {
     val req =
-      Request[IO](uri = uri("/request"), headers = Headers.of(Header("X-Request-ID", "123")))
+      Request[IO](uri = uri"/request", headers = Headers.of(Header("X-Request-ID", "123")))
     RequestId
       .httpRoutes(CIString("X-Correlation-ID"))(testService(CIString("X-Correlation-ID")))
       .orNotFound(req)
@@ -111,7 +110,7 @@ class RequestIdSuite extends Http4sSuite {
 
   test("generate X-Request-ID header when unset using supplied generator") {
     val uuid = UUID.fromString("00000000-0000-0000-0000-000000000000")
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     RequestId
       .httpRoutes(genReqId = IO.pure(uuid))(testService())
       .orNotFound(req)
@@ -126,7 +125,7 @@ class RequestIdSuite extends Http4sSuite {
 
   test("include requestId attribute with request and response") {
     val req =
-      Request[IO](uri = uri("/attribute"), headers = Headers.of(Header("X-Request-ID", "123")))
+      Request[IO](uri = uri"/attribute", headers = Headers.of(Header("X-Request-ID", "123")))
     RequestId
       .httpRoutes(testService())
       .orNotFound(req)

--- a/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSuite.scala
@@ -22,6 +22,7 @@ import cats.effect.concurrent.Ref
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.util.CaseInsensitiveString
+import org.http4s.syntax.all._
 
 import scala.concurrent.duration.TimeUnit
 
@@ -36,7 +37,7 @@ class ResponseTimingSuite extends Http4sSuite {
   }
 
   test("add a custom header with timing info") {
-    val req = Request[IO](uri = Uri.uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     val app = ResponseTiming(thisService)
     val res = app(req)
 

--- a/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSuite.scala
@@ -20,7 +20,6 @@ import cats.effect._
 import org.http4s._
 import org.http4s.syntax.all._
 import org.http4s.dsl.io._
-import org.http4s.Uri.uri
 
 class StaticHeadersSuite extends Http4sSuite {
   val testService = HttpRoutes.of[IO] {
@@ -31,7 +30,7 @@ class StaticHeadersSuite extends Http4sSuite {
   }
 
   test("add a no-cache header to a response") {
-    val req = Request[IO](uri = uri("/request"))
+    val req = Request[IO](uri = uri"/request")
     val resp = StaticHeaders.`no-cache`(testService).orNotFound(req)
 
     resp

--- a/server/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
@@ -21,7 +21,7 @@ import cats.effect.laws.util.TestContext
 import cats.effect.{IO, Timer}
 import cats.implicits._
 import org.http4s.{Http4sSuite, HttpApp, Request, Status}
-import org.http4s.Uri.uri
+import org.http4s.syntax.all._
 import org.http4s.dsl.io._
 import org.http4s.server.middleware.Throttle._
 import scala.concurrent.duration._
@@ -138,7 +138,7 @@ class ThrottleSuite extends Http4sSuite {
     }
 
     val testee = Throttle(limitNotReachedBucket, defaultResponse[IO] _)(alwaysOkApp)
-    val req = Request[IO](uri = uri("/"))
+    val req = Request[IO](uri = uri"/")
 
     testee(req).map(_.status === Status.Ok).assertEquals(true)
   }
@@ -149,7 +149,7 @@ class ThrottleSuite extends Http4sSuite {
     }
 
     val testee = Throttle(limitReachedBucket, defaultResponse[IO] _)(alwaysOkApp)
-    val req = Request[IO](uri = uri("/"))
+    val req = Request[IO](uri = uri"/")
 
     testee(req).map(_.status === Status.TooManyRequests).assertEquals(true)
   }

--- a/server/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
@@ -21,7 +21,6 @@ package middleware
 import cats.data.OptionT
 import cats.effect._
 import java.util.concurrent.atomic.AtomicBoolean
-import org.http4s.Uri.uri
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
 import scala.concurrent.duration._
@@ -42,8 +41,8 @@ class TimeoutSuite extends Http4sSuite {
 
   val app = TimeoutMiddleware(5.milliseconds)(routes).orNotFound
 
-  val fastReq = Request[IO](GET, uri("/fast"))
-  val neverReq = Request[IO](GET, uri("/never"))
+  val fastReq = Request[IO](GET, uri"/fast")
+  val neverReq = Request[IO](GET, uri"/never")
 
   def checkStatus(resp: IO[Response[IO]], status: Status): IO[Unit] =
     IO.race(IO.sleep(3.seconds), resp.map(_.status)).assertEquals(Right(status))

--- a/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/UrlFormLifterSuite.scala
@@ -43,7 +43,7 @@ class UrlFormLifterSuite extends Http4sSuite {
 
   test("Add application/x-www-form-urlencoded bodies after query params") {
     val req =
-      Request[IO](method = Method.POST, uri = Uri.uri("/foo?foo=biz"))
+      Request[IO](method = Method.POST, uri = uri"/foo?foo=biz")
         .withEntity(urlForm)
         .pure[IO]
     req.flatMap(app.run).map(_.status).assertEquals(Ok) *>

--- a/server/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -23,7 +23,6 @@ import cats.effect._
 import org.http4s.Method._
 import org.http4s.Status.{BadRequest, NotFound, Ok}
 import org.http4s.syntax.all._
-import org.http4s.Uri.uri
 import org.http4s.headers.Host
 
 class VirtualHostSuite extends Http4sSuite {
@@ -46,36 +45,36 @@ class VirtualHostSuite extends Http4sSuite {
   ).orNotFound
 
   test("exact should return a 400 BadRequest when no header is present on a NON HTTP/1.0 request") {
-    val req1 = Request[IO](GET, uri("/numbers/1"), httpVersion = HttpVersion.`HTTP/1.1`)
-    val req2 = Request[IO](GET, uri("/numbers/1"), httpVersion = HttpVersion.`HTTP/2.0`)
+    val req1 = Request[IO](GET, uri"/numbers/1", httpVersion = HttpVersion.`HTTP/1.1`)
+    val req2 = Request[IO](GET, uri"/numbers/1", httpVersion = HttpVersion.`HTTP/2.0`)
 
     vhostExact(req1).map(_.status).assertEquals(BadRequest) *>
       vhostExact(req2).map(_.status).assertEquals(BadRequest)
   }
 
   test("exact should honor the Host header host") {
-    val req = Request[IO](GET, uri("/numbers/1"))
+    val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesA"))
 
     vhostExact(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
   test("exact should honor the Host header port") {
-    val req = Request[IO](GET, uri("/numbers/1"))
+    val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesB", Some(80)))
 
     vhostExact(req).flatMap(_.as[String]).assertEquals("routesB")
   }
 
   test("exact should ignore the Host header port if not specified") {
-    val good = Request[IO](GET, uri("/numbers/1"))
+    val good = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesA", Some(80)))
 
     vhostExact(good).flatMap(_.as[String]).assertEquals("routesA")
   }
 
   test("exact should result in a 404 if the hosts fail to match") {
-    val req = Request[IO](GET, uri("/numbers/1"))
+    val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesB", Some(8000)))
 
     vhostExact(req).map(_.status).assertEquals(NotFound)
@@ -88,21 +87,21 @@ class VirtualHostSuite extends Http4sSuite {
   ).orNotFound
 
   test("wildcard match an exact route") {
-    val req = Request[IO](GET, uri("/numbers/1"))
+    val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesa", Some(80)))
 
     vhostWildcard(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
   test("wildcard allow for a dash in the service") {
-    val req = Request[IO](GET, uri("/numbers/1"))
+    val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("foo.foo-service", Some(80)))
 
     vhostWildcard(req).flatMap(_.as[String]).assertEquals("default")
   }
 
   test("wildcard match a route with a wildcard route") {
-    val req = Request[IO](GET, uri("/numbers/1"))
+    val req = Request[IO](GET, uri"/numbers/1")
     val reqs = List(
       req.withHeaders(Host("a.service", Some(80))),
       req.withHeaders(Host("A.service", Some(80))),
@@ -114,7 +113,7 @@ class VirtualHostSuite extends Http4sSuite {
   }
 
   test("wildcard not match a route with an abscent wildcard") {
-    val req = Request[IO](GET, uri("/numbers/1"))
+    val req = Request[IO](GET, uri"/numbers/1")
     val reqs =
       List(req.withHeaders(Host(".service", Some(80))), req.withHeaders(Host("service", Some(80))))
 

--- a/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSuite.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSuite.scala
@@ -22,7 +22,6 @@ import cats.effect.IO
 import cats.syntax.all._
 import java.nio.file.Paths
 import fs2._
-import org.http4s.Uri.uri
 import org.http4s.headers.{
   `Accept-Encoding`,
   `Content-Encoding`,
@@ -42,11 +41,11 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
     val app = TranslateUri("/foo")(routes).orNotFound
 
     {
-      val req = Request[IO](uri = uri("/foo/testresource.txt"))
+      val req = Request[IO](uri = uri"/foo/testresource.txt")
       Stream.eval(app(req)).flatMap(_.body.chunks).compile.lastOrError.assertEquals(testResource) *>
         app(req).map(_.status).assertEquals(Status.Ok)
     } *> {
-      val req = Request[IO](uri = uri("/testresource.txt"))
+      val req = Request[IO](uri = uri"/testresource.txt")
       app(req).map(_.status).assertEquals(Status.NotFound)
     }
   }
@@ -60,7 +59,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Decodes path segments") {
-    val req = Request[IO](uri = uri("/space+truckin%27.txt"))
+    val req = Request[IO](uri = uri"/space+truckin%27.txt")
     routes.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
@@ -190,13 +189,13 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Not send unmodified files") {
-    val req = Request[IO](uri = uri("/testresource.txt"))
+    val req = Request[IO](uri = uri"/testresource.txt")
       .putHeaders(`If-Modified-Since`(HttpDate.MaxValue))
 
     runReq(req).map(_._2.status).assertEquals(Status.NotModified)
   }
 
   test("doesn't crash on /") {
-    routes.orNotFound(Request[IO](uri = uri("/"))).map(_.status).assertEquals(Status.NotFound)
+    routes.orNotFound(Request[IO](uri = uri"/")).map(_.status).assertEquals(Status.NotFound)
   }
 }

--- a/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSute.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSute.scala
@@ -21,7 +21,6 @@ package staticcontent
 import cats.effect.IO
 import java.nio.file.Paths
 import org.http4s.Method.{GET, POST}
-import org.http4s.Uri.uri
 import org.http4s.syntax.all._
 import org.http4s.server.staticcontent.WebjarService.Config
 
@@ -53,7 +52,7 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Decodes path segments") {
-    val req = Request[IO](uri = uri("/deep+purple/machine+head/space+truckin%27.txt"))
+    val req = Request[IO](uri = uri"/deep+purple/machine+head/space+truckin%27.txt")
     routes.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
@@ -88,22 +87,22 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Not find missing file") {
-    val req = Request[IO](uri = uri("/test-lib/1.0.0/doesnotexist.txt"))
+    val req = Request[IO](uri = uri"/test-lib/1.0.0/doesnotexist.txt")
     routes.apply(req).value.assertEquals(Option.empty[Response[IO]])
   }
 
   test("Not find missing library") {
-    val req = Request[IO](uri = uri("/1.0.0/doesnotexist.txt"))
+    val req = Request[IO](uri = uri"/1.0.0/doesnotexist.txt")
     routes.apply(req).value.assertEquals(Option.empty[Response[IO]])
   }
 
   test("Return bad request on missing version") {
-    val req = Request[IO](uri = uri("/test-lib//doesnotexist.txt"))
+    val req = Request[IO](uri = uri"/test-lib//doesnotexist.txt")
     routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
   test("Not find blank asset") {
-    val req = Request[IO](uri = uri("/test-lib/1.0.0/"))
+    val req = Request[IO](uri = uri"/test-lib/1.0.0/")
     routes.apply(req).value.assertEquals(Option.empty[Response[IO]])
   }
 

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -171,18 +171,18 @@ http://example.org/a file
 
   "Uri copy" should {
     "support updating the schema" in {
-      uri("http://example.com/").copy(scheme = Scheme.https.some) must_== uri(
-        "https://example.com/")
+      uri"http://example.com/".copy(scheme = Scheme.https.some) must_==
+        uri"https://example.com/"
       // Must add the authority to set the scheme and host
-      uri("/route/").copy(
+      uri"/route/".copy(
         scheme = Scheme.https.some,
-        authority = Some(Authority(None, RegName("example.com")))) must_== uri(
-        "https://example.com/route/")
+        authority = Some(Authority(None, RegName("example.com")))) must_==
+        uri"https://example.com/route/"
       // You can add a port too
-      uri("/route/").copy(
+      uri"/route/".copy(
         scheme = Scheme.https.some,
-        authority = Some(Authority(None, RegName("example.com"), Some(8443)))) must_== uri(
-        "https://example.com:8443/route/")
+        authority = Some(Authority(None, RegName("example.com"), Some(8443)))) must_==
+        uri"https://example.com:8443/route/"
     }
   }
 
@@ -291,7 +291,7 @@ http://example.org/a file
     }
 
     "not append a '/' unless it's in the path" in {
-      uri("http://www.example.com").toString must_== "http://www.example.com"
+      uri"http://www.example.com".toString must_== "http://www.example.com"
     }
 
     "render email address" in {
@@ -974,7 +974,7 @@ http://example.org/a file
 
   "Uri.equals" should {
     "be false between an empty path and a trailing slash after an authority" in {
-      uri("http://example.com") must_!= uri("http://example.com/")
+      uri"http://example.com" must_!= uri"http://example.com/"
     }
   }
 
@@ -986,28 +986,28 @@ http://example.org/a file
 
   "/" should {
     "encode space as %20" in {
-      uri("http://example.com/") / " " must_== uri("http://example.com/%20")
+      uri"http://example.com/" / " " must_== uri"http://example.com/%20"
     }
 
     "encode generic delimiters that aren't pchars" in {
       // ":" and "@" are valid pchars
-      uri("http://example.com") / ":/?#[]@" must_== uri("http://example.com/:%2F%3F%23%5B%5D@")
+      uri"http://example.com" / ":/?#[]@" must_== uri"http://example.com/:%2F%3F%23%5B%5D@"
     }
 
     "encode percent sequences" in {
-      uri("http://example.com") / "%2F" must_== uri("http://example.com/%252F")
+      uri"http://example.com" / "%2F" must_== uri"http://example.com/%252F"
     }
 
     "not encode sub-delims" in {
-      uri("http://example.com") / "!$&'()*+,;=" must_== uri("http://example.com/!$&'()*+,;=")
+      uri"http://example.com" / "!$&'()*+,;=" must_== uri"http://example.com/!$$&'()*+,;="
     }
 
     "UTF-8 encode characters" in {
-      uri("http://example.com/") / "ö" must_== uri("http://example.com/%C3%B6")
+      uri"http://example.com/" / "ö" must_== uri"http://example.com/%C3%B6"
     }
 
     "not make bad URIs" >> forAll { (s: String) =>
-      Uri.fromString((uri("http://example.com/") / s).toString) must beRight
+      Uri.fromString((uri"http://example.com/" / s).toString) must beRight
     }
   }
 


### PR DESCRIPTION
As a part of removing the Uri.uri macro.

We can then remove it from Scala 3, but keep it around for Scala 2 if we want.
