### PR TITLE
back to small daemon pool for computation

### DIFF
--- a/testing/src/test/scala/org/http4s/Http4sSpec.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSpec.scala
@@ -127,8 +127,7 @@ object Http4sSpec {
 
   val TestIORuntime: IORuntime = {
     val blockingPool = newBlockingPool("http4s-spec-blocking")
-    // val computePool = newDaemonPool("http4s-spec", timeout = true)
-    val computePool = newBlockingPool("http4s-spec")
+    val computePool = newDaemonPool("http4s-spec", timeout = true)
     val scheduledExecutor = TestScheduler
     IORuntime.apply(
       ExecutionContext.fromExecutor(computePool),


### PR DESCRIPTION
Fix https://github.com/http4s/http4s/issues/4058
Follow up on https://github.com/http4s/http4s/pull/4173

Now that there is no unnecessary blocking, we can revert the changes made in https://github.com/http4s/http4s/pull/3857