### PR TITLE
use a different EC for munit

### DIFF
--- a/testing/src/test/scala/org/http4s/Http4sSuite.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSuite.scala
@@ -22,13 +22,17 @@ import cats.syntax.all._
 import fs2._
 import fs2.text.utf8Decode
 import munit._
+import org.http4s.internal.threads.newDaemonPool
+
+import scala.concurrent.ExecutionContext
 
 /** Common stack for http4s' munit based tests
   */
 trait Http4sSuite extends CatsEffectSuite with DisciplineSuite with munit.ScalaCheckEffectSuite {
   // The default munit EC causes an IllegalArgumentException in
   // BatchExecutor on Scala 2.12.
-  override val munitExecutionContext = Http4sSpec.TestExecutionContext
+  override val munitExecutionContext =
+    ExecutionContext.fromExecutor(newDaemonPool("http4s-munit", min = 1, timeout = true))
   override implicit val ioRuntime: IORuntime = Http4sSpec.TestIORuntime
 
   implicit class ParseResultSyntax[A](self: ParseResult[A]) {


### PR DESCRIPTION
To look for blocking code, one can setup the excecution context used by http4s to a minimal number of thread (`Http4sSpec.TestExecutionContext`).
As munit is using the same execution context, it is difficult to find out which code is blocking as munit is always blocking on one thread.
By using a different thread pool for munit, this investigation is much easier.