### PR TITLE
use blocking where necessary to use the right thread pool

### DIFF
--- a/client/src/test/scala/org/http4s/client/JettyScaffold.scala
+++ b/client/src/test/scala/org/http4s/client/JettyScaffold.scala
@@ -28,10 +28,10 @@ import org.eclipse.jetty.util.ssl.SslContextFactory
 object JettyScaffold {
   def apply[F[_]](num: Int, secure: Boolean, testServlet: HttpServlet)(implicit
       F: Sync[F]): Resource[F, JettyScaffold] =
-    Resource.make(F.delay {
+    Resource.make(F.blocking {
       val scaffold = new JettyScaffold(num, secure)
       scaffold.startServers(testServlet)
-    })(s => F.delay(s.stopServers()))
+    })(s => F.blocking(s.stopServers()))
 }
 
 class JettyScaffold private (num: Int, secure: Boolean) {

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -55,7 +55,7 @@ object StaticFile {
     val normalizedName = name.split("/").filter(_.nonEmpty).mkString("/")
 
     def getResource(name: String) =
-      OptionT(Sync[F].delay(Option(loader.getResource(name))))
+      OptionT(Sync[F].blocking(Option(loader.getResource(name))))
 
     val gzUrl: OptionT[F, URL] =
       if (tryGzipped) getResource(normalizedName + ".gz") else OptionT.none

--- a/tests/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -391,14 +391,14 @@ class EntityDecoderSuite extends Http4sSuite {
 
   val binData: Array[Byte] = "Bytes 10111".getBytes
 
-  def readFile(in: File): IO[Array[Byte]] = IO {
+  def readFile(in: File): IO[Array[Byte]] = IO.blocking {
     val os = new FileInputStream(in)
     val data = new Array[Byte](in.length.asInstanceOf[Int])
     os.read(data)
     data
   }
 
-  def readTextFile(in: File): IO[String] = IO {
+  def readTextFile(in: File): IO[String] = IO.blocking {
     val os = new InputStreamReader(new FileInputStream(in))
     val data = new Array[Char](in.length.asInstanceOf[Int])
     os.read(data, 0, in.length.asInstanceOf[Int])


### PR DESCRIPTION
Those places were found by running the tests with a compute thread pool of 2 threads.
In theory, we should be able to run all the tests on only one thread, but some blocking places are quite difficult to get rid of for now.