### PR TITLE
WIP: Use ip4s in Uri.Host model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,7 @@ lazy val core = libraryProject("core")
       catsParse.exclude("org.typelevel", "cats-core_2.13"),
       fs2Core,
       fs2Io,
+      ip4sCore,
       log4s,
       scodecBits,
       slf4jApi, // residual dependency from macros
@@ -125,6 +126,7 @@ lazy val laws = libraryProject("laws")
       catsEffectLaws,
       catsLaws,
       disciplineCore,
+      ip4sTestKit,
       scalacheck,
       scalacheckEffectMunit,
       munitCatsEffect

--- a/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
@@ -43,12 +43,12 @@ object LiteralSyntaxMacros {
       Uri.Scheme.fromString(_).isRight,
       s => c.universe.reify(Uri.Scheme.unsafeFromString(s.splice)))
 
-  def ipv4AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Ipv4Address] =
+  def ipv4AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Host] =
     singlePartInterpolator(c)(
       args,
       "Ipv4Address",
-      Uri.Ipv4Address.fromString(_).isRight,
-      s => c.universe.reify(Uri.Ipv4Address.unsafeFromString(s.splice)))
+      Uri.Host.Ipv4.fromString(_).isRight,
+      s => c.universe.reify(Uri.Host.Ipv4.unsafeFromString(s.splice)))
 
   def ipv6AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Ipv6Address] =
     singlePartInterpolator(c)(

--- a/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
@@ -43,13 +43,6 @@ object LiteralSyntaxMacros {
       Uri.Scheme.fromString(_).isRight,
       s => c.universe.reify(Uri.Scheme.unsafeFromString(s.splice)))
 
-  def ipv4AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Host] =
-    singlePartInterpolator(c)(
-      args,
-      "Ipv4Address",
-      Uri.Host.Ipv4.fromString(_).isRight,
-      s => c.universe.reify(Uri.Host.Ipv4.unsafeFromString(s.splice)))
-
   def ipv6AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Ipv6Address] =
     singlePartInterpolator(c)(
       args,

--- a/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
@@ -43,6 +43,14 @@ object LiteralSyntaxMacros {
       Uri.Scheme.fromString(_).isRight,
       s => c.universe.reify(Uri.Scheme.unsafeFromString(s.splice)))
 
+  @deprecated("Use the ip4s macro", "0.22.0-RC1")
+  def ipv4AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Host] =
+    singlePartInterpolator(c)(
+      args,
+      "Ipv4Address",
+      Uri.Host.ipv4Parser.parseAll(_).isRight,
+      s => c.universe.reify(Uri.Host.unsafeFromString(s.splice)))
+
   def ipv6AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Ipv6Address] =
     singlePartInterpolator(c)(
       args,

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -420,6 +420,16 @@ object Uri {
         case Authority(_, h, _) => writer << h
         case _ => writer
       }
+
+    def asSocketAddress: Option[ip4s.SocketAddress[ip4s.IpAddress]] =
+      port.flatMap(ip4s.Port.apply).flatMap { p =>
+        host.fold(
+          ipv4 => Some(ip4s.SocketAddress[ip4s.Ipv4Address](ipv4, p)),
+          // TODO ipv6 when we incorporate the Comcast one
+          _ => None,
+          _ => None
+        )
+      }
   }
 
   object Authority {

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -804,6 +804,9 @@ object Uri {
   sealed abstract class Host extends Renderable with Product with Serializable {
     def value: String
 
+    def asIpAddress: Option[ip4s.IpAddress]
+    def asIpv4Address: Option[ip4s.Ipv4Address]
+
     def fold[A](
         ipv4: ip4s.Ipv4Address => A,
         ipv6: Ipv6Address => A,
@@ -825,6 +828,8 @@ object Uri {
   object Host {
     private[Host] case class Ipv4(address: ip4s.Ipv4Address) extends Host {
       def value = address.toUriString
+      def asIpAddress: Option[ip4s.IpAddress] = Some(address)
+      def asIpv4Address: Option[ip4s.Ipv4Address] = Some(address)
     }
 
     def ipv4(address: ip4s.Ipv4Address): Ipv4 =
@@ -1013,6 +1018,9 @@ object Uri {
         }
       sb.toString
     }
+
+    def asIpAddress: Option[ip4s.IpAddress] = None
+    def asIpv4Address: Option[ip4s.Ipv4Address] = None
   }
 
   object Ipv6Address {
@@ -1196,6 +1204,8 @@ object Uri {
 
   final case class RegName(host: CIString) extends Host {
     def value: String = host.toString
+    def asIpAddress: Option[ip4s.IpAddress] = None
+    def asIpv4Address: Option[ip4s.Ipv4Address] = None
   }
 
   object RegName {

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -231,9 +231,8 @@ object UriTemplate {
   protected def renderHost(h: Host): String =
     h match {
       case RegName(n) => n.toString
-      case a: Ipv4Address => a.value
       case a: Ipv6Address => "[" + a.value + "]"
-      case _ => ""
+      case a => a.value
     }
 
   protected def renderScheme(s: Scheme): String =

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -229,11 +229,11 @@ object UriTemplate {
     }
 
   protected def renderHost(h: Host): String =
-    h match {
-      case RegName(n) => n.toString
-      case a: Ipv6Address => "[" + a.value + "]"
-      case a => a.value
-    }
+    h.fold(
+      _.toUriString,
+      "[" + _.value + "]",
+      _.toString
+    )
 
   protected def renderScheme(s: Scheme): String =
     (new StringWriter << s << ":").result

--- a/core/src/main/scala/org/http4s/headers/Forwarded.scala
+++ b/core/src/main/scala/org/http4s/headers/Forwarded.scala
@@ -20,6 +20,7 @@ import java.net.{Inet4Address, Inet6Address}
 
 import cats.data.NonEmptyList
 import cats.syntax.either._
+import com.comcast.ip4s.Ipv4Address
 import org.http4s._
 import org.http4s.util.{Renderable, Writer}
 
@@ -39,14 +40,14 @@ object Forwarded
     sealed trait Name { self: Product => }
 
     object Name {
-      case class Ipv4(address: Uri.Ipv4Address) extends Name
+      case class Ipv4(address: Ipv4Address) extends Name
       case class Ipv6(address: Uri.Ipv6Address) extends Name
       case object Unknown extends Name
 
-      def ofInet4Address(address: Inet4Address): Name = Ipv4(
-        Uri.Ipv4Address.fromInet4Address(address))
-      def ofIpv4Address(a: Byte, b: Byte, c: Byte, d: Byte): Name = Ipv4(
-        Uri.Ipv4Address(a, b, c, d))
+      def ofInet4Address(address: Inet4Address): Name =
+        Ipv4(Ipv4Address.fromInet4Address(address))
+      def ofIpv4Address(a: Byte, b: Byte, c: Byte, d: Byte): Name =
+        Ipv4(Ipv4Address.fromBytes(a.toInt, b.toInt, c.toInt, d.toInt))
 
       def ofInet6Address(address: Inet6Address): Name = Ipv6(
         Uri.Ipv6Address.fromInet6Address(address))

--- a/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
+++ b/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
@@ -33,7 +33,7 @@ private[http4s] trait ForwardedRenderers {
     new Renderer[Node.Name] {
       override def render(writer: Writer, nodeName: Node.Name): writer.type =
         nodeName match {
-          case Node.Name.Ipv4(ipv4addr) => writer << ipv4addr
+          case Node.Name.Ipv4(ipv4addr) => writer << ipv4addr.toUriString
           case Node.Name.Ipv6(ipv6addr) => writer << '[' << ipv6addr << ']'
           case Node.Name.Unknown => writer << "unknown"
           case Node.Obfuscated(str) => writer << str

--- a/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
+++ b/core/src/main/scala/org/http4s/headers/ForwardedRenderers.scala
@@ -16,11 +16,8 @@
 
 package org.http4s.headers
 
-import java.nio.charset.StandardCharsets
-
 import cats.Eval
 import cats.syntax.flatMap._
-import org.http4s.Uri
 import org.http4s.parser.Rfc2616BasicRules
 import org.http4s.util.{Renderer, Writer}
 
@@ -56,17 +53,8 @@ private[http4s] trait ForwardedRenderers {
   }
 
   implicit val http4sForwardedHostRenderer: Renderer[Host] = new Renderer[Host] {
-    // See in `Rfc3986Parser`: `RegName` -> `SubDelims`
-    private val RegNameChars = Uri.Unreserved ++ "!$&'()*+,;="
-
     override def render(writer: Writer, host: Host): writer.type = {
-      host.host match {
-        case Uri.RegName(name) =>
-          // TODO: A workaround for #1651, remove when the former issue gets fixed.
-          writer << Uri.encode(name.toString, StandardCharsets.ISO_8859_1, toSkip = RegNameChars)
-        case other =>
-          writer << other
-      }
+      writer << host
       host.port.fold[writer.type](writer)(writer << ':' << _)
     }
   }

--- a/core/src/main/scala/org/http4s/headers/Origin.scala
+++ b/core/src/main/scala/org/http4s/headers/Origin.scala
@@ -76,7 +76,7 @@ object Origin extends HeaderKey.Internal[Origin] with HeaderKey.Singleton {
       .map(Uri.Scheme.unsafeFromString)
     val stringHost = until(char(':').orElse(`end`)).map(RegName.apply)
     val bracketedIpv6 = char('[') *> Uri.Ipv6Address.parser <* char(']')
-    val host = List(bracketedIpv6, Uri.Host.Ipv4.parser, stringHost).reduceLeft(_ orElse _)
+    val host = List(bracketedIpv6, Uri.Host.ipv4Parser, stringHost).reduceLeft(_ orElse _)
     val port = char(':') *> digit.rep.string.map(_.toInt)
     val nullHost = (string("null") *> `end`).orElse(`end`).as(Origin.Null)
 

--- a/core/src/main/scala/org/http4s/headers/Origin.scala
+++ b/core/src/main/scala/org/http4s/headers/Origin.scala
@@ -76,7 +76,7 @@ object Origin extends HeaderKey.Internal[Origin] with HeaderKey.Singleton {
       .map(Uri.Scheme.unsafeFromString)
     val stringHost = until(char(':').orElse(`end`)).map(RegName.apply)
     val bracketedIpv6 = char('[') *> Uri.Ipv6Address.parser <* char(']')
-    val host = List(bracketedIpv6, Uri.Ipv4Address.parser, stringHost).reduceLeft(_ orElse _)
+    val host = List(bracketedIpv6, Uri.Host.Ipv4.parser, stringHost).reduceLeft(_ orElse _)
     val port = char(':') *> digit.rep.string.map(_.toInt)
     val nullHost = (string("null") *> `end`).orElse(`end`).as(Origin.Null)
 

--- a/core/src/main/scala/org/http4s/headers/Origin.scala
+++ b/core/src/main/scala/org/http4s/headers/Origin.scala
@@ -20,7 +20,6 @@ package headers
 import cats.data.NonEmptyList
 import cats.implicits.toBifunctorOps
 import cats.parse.{Parser, Parser0, Rfc5234}
-import org.http4s.Uri.RegName
 import org.http4s.util.{Renderable, Writer}
 
 sealed abstract class Origin extends Header.Parsed {
@@ -74,7 +73,7 @@ object Origin extends HeaderKey.Internal[Origin] with HeaderKey.Singleton {
       .reduceLeft(_ orElse _)
       .string
       .map(Uri.Scheme.unsafeFromString)
-    val stringHost = until(char(':').orElse(`end`)).map(RegName.apply)
+    val stringHost = until(char(':').orElse(`end`)).map(Uri.Host.unsafeFromString)
     val bracketedIpv6 = char('[') *> Uri.Ipv6Address.parser <* char(']')
     val host = List(bracketedIpv6, Uri.Host.ipv4Parser, stringHost).reduceLeft(_ orElse _)
     val port = char(':') *> digit.rep.string.map(_.toInt)

--- a/core/src/main/scala/org/http4s/parser/ForwardedModelParsing.scala
+++ b/core/src/main/scala/org/http4s/parser/ForwardedModelParsing.scala
@@ -40,7 +40,8 @@ private[http4s] trait ForwardedModelParsing { model: Forwarded.type =>
 
     protected final def ModelNodeName: Rule1[model.Node.Name] =
       rule {
-        (rfc.ipv4Address ~> model.Node.Name.Ipv4) |
+        (rfc.ipv4Bytes ~> ((a: Byte, b: Byte, c: Byte, d: Byte) =>
+          model.Node.Name.ofIpv4Address(a, b, c, d))) |
           ('[' ~ rfc.ipv6Address ~ ']' ~> model.Node.Name.Ipv6) |
           ("unknown" ~ push(model.Node.Name.Unknown)) |
           ModelNodeObfuscated

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -29,7 +29,7 @@ private[http4s] trait Rfc3986Parser
     extends Parser
     with Uri.Scheme.Parser
     with Uri.UserInfo.Parser
-    with Uri.Ipv4Address.Parser
+    with Uri.Ipv4Parser
     with Uri.Ipv6Address.Parser
     with IpParser
     with StringBuilding {

--- a/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
+++ b/core/src/main/scala/org/http4s/parser/Rfc3986Parser.scala
@@ -23,7 +23,6 @@ import org.http4s.{Query => Q}
 import org.http4s.internal.parboiled2._
 import org.http4s.internal.parboiled2.CharPredicate.{Alpha, Digit, HexDigit}
 import org.http4s.internal.parboiled2.support.HNil
-import org.typelevel.ci.CIString
 
 private[http4s] trait Rfc3986Parser
     extends Parser
@@ -100,7 +99,7 @@ private[http4s] trait Rfc3986Parser
     ipv4Address |
     "[" ~ ipv6Address ~ "]" |
     capture(RegName) ~> { (s: String) =>
-      org.http4s.Uri.RegName(CIString(decode(s)))
+      org.http4s.Uri.Host.unsafeFromString(decode(s))
     }
     // format:on
   }

--- a/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
@@ -26,7 +26,7 @@ class LiteralsOps(val sc: StringContext) extends AnyVal {
   def uri(args: Any*): Uri = macro LiteralSyntaxMacros.uriInterpolator
   def path(args: Any*): Uri.Path = macro LiteralSyntaxMacros.pathInterpolator
   def scheme(args: Any*): Uri.Scheme = macro LiteralSyntaxMacros.schemeInterpolator
-  def ipv4(args: Any*): Uri.Ipv4Address = macro LiteralSyntaxMacros.ipv4AddressInterpolator
+  def ipv4(args: Any*): Uri.Host = macro LiteralSyntaxMacros.ipv4AddressInterpolator
   def ipv6(args: Any*): Uri.Ipv6Address = macro LiteralSyntaxMacros.ipv6AddressInterpolator
   def mediaType(args: Any*): MediaType = macro LiteralSyntaxMacros.mediaTypeInterpolator
   def qValue(args: Any*): QValue = macro LiteralSyntaxMacros.qValueInterpolator

--- a/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
@@ -26,7 +26,6 @@ class LiteralsOps(val sc: StringContext) extends AnyVal {
   def uri(args: Any*): Uri = macro LiteralSyntaxMacros.uriInterpolator
   def path(args: Any*): Uri.Path = macro LiteralSyntaxMacros.pathInterpolator
   def scheme(args: Any*): Uri.Scheme = macro LiteralSyntaxMacros.schemeInterpolator
-  def ipv4(args: Any*): Uri.Host = macro LiteralSyntaxMacros.ipv4AddressInterpolator
   def ipv6(args: Any*): Uri.Ipv6Address = macro LiteralSyntaxMacros.ipv6AddressInterpolator
   def mediaType(args: Any*): MediaType = macro LiteralSyntaxMacros.mediaTypeInterpolator
   def qValue(args: Any*): QValue = macro LiteralSyntaxMacros.qValueInterpolator

--- a/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
@@ -26,6 +26,7 @@ class LiteralsOps(val sc: StringContext) extends AnyVal {
   def uri(args: Any*): Uri = macro LiteralSyntaxMacros.uriInterpolator
   def path(args: Any*): Uri.Path = macro LiteralSyntaxMacros.pathInterpolator
   def scheme(args: Any*): Uri.Scheme = macro LiteralSyntaxMacros.schemeInterpolator
+  def ipv4(args: Any*): Uri.Host = macro LiteralSyntaxMacros.ipv4AddressInterpolator
   def ipv6(args: Any*): Uri.Ipv6Address = macro LiteralSyntaxMacros.ipv6AddressInterpolator
   def mediaType(args: Any*): MediaType = macro LiteralSyntaxMacros.mediaTypeInterpolator
   def qValue(args: Any*): QValue = macro LiteralSyntaxMacros.qValueInterpolator

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -672,7 +672,7 @@ private[http4s] trait ArbitraryInstances {
       listOf(oneOf(genUnreserved, genPctEncoded, genSubDelims)).map(rn => Uri.RegName(rn.mkString))
     Arbitrary(
       oneOf(
-        getArbitrary[Ipv4Address].map(Uri.Host.Ipv4.apply),
+        getArbitrary[Ipv4Address].map(Uri.Host.ipv4),
         getArbitrary[Uri.Ipv6Address],
         http4sTestingRegNameGen)
     )

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -298,6 +298,7 @@ object Http4sPlugin extends AutoPlugin {
     val disciplineSpecs2 = "1.1.3"
     val dropwizardMetrics = "4.1.17"
     val fs2 = "2.5.0"
+    val ip4s = "1.4-94-7b5d4a4"
     val jacksonDatabind = "2.12.1"
     val jawn = "1.0.1"
     val jawnFs2 = "1.0.0"
@@ -362,6 +363,8 @@ object Http4sPlugin extends AutoPlugin {
   lazy val fs2Core                          = "co.fs2"                 %% "fs2-core"                  % V.fs2
   lazy val fs2Io                            = "co.fs2"                 %% "fs2-io"                    % V.fs2
   lazy val fs2ReactiveStreams               = "co.fs2"                 %% "fs2-reactive-streams"      % V.fs2
+  lazy val ip4sCore                         = "com.comcast"            %% "ip4s-core"                 % V.ip4s
+  lazy val ip4sTestKit                      = "com.comcast"            %% "ip4s-test-kit"             % V.ip4s  
   lazy val jacksonDatabind                  = "com.fasterxml.jackson.core" % "jackson-databind"       % V.jacksonDatabind
   lazy val javaxServletApi                  = "javax.servlet"          %  "javax.servlet-api"         % V.servlet
   lazy val jawnFs2                          = "org.http4s"             %% "jawn-fs2"                  % V.jawnFs2

--- a/server/src/main/scala/org/http4s/server/Server.scala
+++ b/server/src/main/scala/org/http4s/server/Server.scala
@@ -34,7 +34,7 @@ abstract class Server {
         Uri.Authority(
           host = address.getAddress match {
             case ipv4: Inet4Address =>
-              Uri.Ipv4Address.fromInet4Address(ipv4)
+              Uri.Host.Ipv4.fromInet4Address(ipv4)
             case ipv6: Inet6Address =>
               Uri.Ipv6Address.fromInet6Address(ipv6)
             case weird =>


### PR DESCRIPTION
ip4s will imminently be a dependency of fs2-3.0, which means at least 1.0 will have it on the classpath anyway.  It is a much richer model of IP addresses than ours, and it's safer than java.net's.

Some things representable in RFC3986 are not in ip4s.  For example:
* RFC3986 ports are boundless.  ip4s constrains to 65535.
* RFC3986 hotsnames are lenient.  ip4s focuses on domain names.
* RFC3986 has syntax for "future IP" addresses.  ip4s doesn't.

So I don't think we can put a `SocketAddress` directly on `Uri.Authority`.  What we can do is eliminate some of our public type constructors, and create (some) implementations backed by ip4s.  The encoding looks a lot like Circe's `Json`, where there are operations to extract to `Option`, and a general `fold`.  We remain compliant with RFC3986, get a smarter IP representation, and don't duplicate names like `Ipv4Address` with the coming fs2.