### PR TITLE
Render request URIs in origin form

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -390,10 +390,7 @@ private object Http1Connection {
 
   private def encodeRequestLine[F[_]](req: Request[F], writer: Writer): writer.type = {
     val uri = req.uri
-    writer << req.method << ' ' << uri.copy(
-      scheme = None,
-      authority = None,
-      fragment = None) << ' ' << req.httpVersion << "\r\n"
+    writer << req.method << ' ' << uri.toOriginForm << ' ' << req.httpVersion << "\r\n"
     if (getHttpMinor(req) == 1 && Host
         .from(req.headers)
         .isEmpty) { // need to add the host header for HTTP/1.1

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -171,6 +171,13 @@ final case class Uri(
       else s"$path$encoded"
     newPath
   }
+
+  /** Converts this request to origin-form, which is the absolute path and optional
+    * query.  If the path is relative, it is assumed to be relative to the root.
+    */
+  def toOriginForm: Uri =
+    if (path.startsWith("/")) Uri(path = path, query = query)
+    else Uri(path = s"/${path}", query = query)
 }
 
 object Uri {

--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -81,7 +81,7 @@ private[ember] object Encoder {
       stringBuilder
         .append(req.method.renderString)
         .append(SPACE)
-        .append(req.uri.renderString)
+        .append(req.uri.toOriginForm.renderString)
         .append(SPACE)
         .append(req.httpVersion.renderString)
         .append(CRLF)

--- a/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/EncoderSpec.scala
@@ -48,7 +48,7 @@ class EncoderSpec extends Specification {
     "encode a no body request correctly" in {
       val req = Request[IO](Method.GET, Uri.unsafeFromString("http://www.google.com"))
       val expected =
-        """GET http://www.google.com HTTP/1.1
+        """GET / HTTP/1.1
       |Host: www.google.com
       |Transfer-Encoding: chunked
       |
@@ -63,7 +63,7 @@ class EncoderSpec extends Specification {
       val req = Request[IO](Method.POST, Uri.unsafeFromString("http://www.google.com"))
         .withEntity("Hello World!")
       val expected =
-        """POST http://www.google.com HTTP/1.1
+        """POST / HTTP/1.1
       |Host: www.google.com
       |Content-Length: 12
       |Content-Type: text/plain; charset=UTF-8
@@ -80,7 +80,7 @@ class EncoderSpec extends Specification {
         headers = Headers.of(Header("foo", "bar"))
       )
       val expected =
-        """GET http://www.google.com HTTP/1.1
+        """GET / HTTP/1.1
         |Host: www.google.com
         |foo: bar
         |Transfer-Encoding: chunked

--- a/ember-core/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package org.http4s.ember.core
+package org.http4s
+package ember.core
 
-import org.specs2.mutable.Specification
 import cats.syntax.all._
 import cats.effect.{IO, Sync}
-import org.http4s._
 
-class EncoderSpec extends Specification {
+class EncoderSuite extends Http4sSuite {
   private object Helpers {
     def stripLines(s: String): String = s.replace("\r\n", "\n")
 
@@ -44,11 +43,10 @@ class EncoderSpec extends Specification {
         .map(stripLines)
   }
 
-  "Encoder.reqToBytes" should {
-    "encode a no body request correctly" in {
-      val req = Request[IO](Method.GET, Uri.unsafeFromString("http://www.google.com"))
-      val expected =
-        """GET / HTTP/1.1
+  test("reqToBytes should encode a no body request correctly") {
+    val req = Request[IO](Method.GET, Uri.unsafeFromString("http://www.google.com"))
+    val expected =
+      """GET / HTTP/1.1
       |Host: www.google.com
       |Transfer-Encoding: chunked
       |
@@ -56,31 +54,31 @@ class EncoderSpec extends Specification {
       |
       |""".stripMargin
 
-      Helpers.encodeRequestRig(req).unsafeRunSync() must_=== expected
-    }
+    Helpers.encodeRequestRig(req).assertEquals(expected)
+  }
 
-    "encode a request with a body correctly" in {
-      val req = Request[IO](Method.POST, Uri.unsafeFromString("http://www.google.com"))
-        .withEntity("Hello World!")
-      val expected =
-        """POST / HTTP/1.1
+  test("reqToBytes should encode a request with a body correctly") {
+    val req = Request[IO](Method.POST, Uri.unsafeFromString("http://www.google.com"))
+      .withEntity("Hello World!")
+    val expected =
+      """POST / HTTP/1.1
       |Host: www.google.com
       |Content-Length: 12
       |Content-Type: text/plain; charset=UTF-8
       |
       |Hello World!""".stripMargin
 
-      Helpers.encodeRequestRig(req).unsafeRunSync() must_=== expected
-    }
+    Helpers.encodeRequestRig(req).assertEquals(expected)
+  }
 
-    "encode headers correctly" in {
-      val req = Request[IO](
-        Method.GET,
-        Uri.unsafeFromString("http://www.google.com"),
-        headers = Headers.of(Header("foo", "bar"))
-      )
-      val expected =
-        """GET / HTTP/1.1
+  test("reqToBytes should encode headers correctly") {
+    val req = Request[IO](
+      Method.GET,
+      Uri.unsafeFromString("http://www.google.com"),
+      headers = Headers.of(Header("foo", "bar"))
+    )
+    val expected =
+      """GET / HTTP/1.1
         |Host: www.google.com
         |foo: bar
         |Transfer-Encoding: chunked
@@ -88,37 +86,34 @@ class EncoderSpec extends Specification {
         |0
         |
         |""".stripMargin
-      Helpers.encodeRequestRig(req).unsafeRunSync() must_=== expected
-    }
+    Helpers.encodeRequestRig(req).assertEquals(expected)
   }
 
-  "Encoder.respToBytes" should {
-    "encode a no body response correctly" in {
-      val resp = Response[IO](Status.Ok)
+  test("respToBytes should encode a no body response correctly") {
+    val resp = Response[IO](Status.Ok)
 
-      val expected =
-        """HTTP/1.1 200 OK
+    val expected =
+      """HTTP/1.1 200 OK
       |Transfer-Encoding: chunked
       |
       |0
       |
       |""".stripMargin
 
-      Helpers.encodeResponseRig(resp).unsafeRunSync() must_=== expected
-    }
+    Helpers.encodeResponseRig(resp).assertEquals(expected)
+  }
 
-    "encode a response with a body correctly" in {
-      val resp = Response[IO](Status.NotFound)
-        .withEntity("Not Found")
+  test("encode a response with a body correctly") {
+    val resp = Response[IO](Status.NotFound)
+      .withEntity("Not Found")
 
-      val expected =
-        """HTTP/1.1 404 Not Found
+    val expected =
+      """HTTP/1.1 404 Not Found
       |Content-Length: 9
       |Content-Type: text/plain; charset=UTF-8
       |
       |Not Found""".stripMargin
 
-      Helpers.encodeResponseRig(resp).unsafeRunSync() must_=== expected
-    }
+    Helpers.encodeResponseRig(resp).assertEquals(expected)
   }
 }

--- a/ember-core/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -89,6 +89,22 @@ class EncoderSuite extends Http4sSuite {
     Helpers.encodeRequestRig(req).assertEquals(expected)
   }
 
+  test("reqToBytes strips the fragment") {
+    val req = Request[IO](
+      Method.GET,
+      Uri.unsafeFromString("https://www.example.com/path?query#fragment")
+    )
+    val expected =
+      """GET /path?query HTTP/1.1
+        |Host: www.example.com
+        |Transfer-Encoding: chunked
+        |
+        |0
+        |
+        |""".stripMargin
+    Helpers.encodeRequestRig(req).assertEquals(expected)
+  }
+
   test("respToBytes should encode a no body response correctly") {
     val resp = Response[IO](Status.Ok)
 

--- a/tests/src/test/scala/org/http4s/UriSuite.scala
+++ b/tests/src/test/scala/org/http4s/UriSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+
+import org.http4s.syntax.all._
+
+class UriSuite extends Http4sSuite {
+  test("toOriginForm strips scheme and authority") {
+    uri"http://example.com/foo?q".toOriginForm == uri"/foo?q"
+  }
+
+  test("toOriginForm strips fragment") {
+    uri"/foo?q#top".toOriginForm == uri"/foo?q"
+  }
+
+  test("toOriginForm infers an empty path") {
+    uri"http://example.com".toOriginForm == uri"/"
+  }
+
+  test("toOriginForm infers paths relative to root") {
+    uri"dubious".toOriginForm == uri"/dubious"
+  }
+}


### PR DESCRIPTION
Before this, Ember was sending requests in absolute-form.  This is legal, but it's also unusual unless going through a proxy, and not all servers support it. even though they "MUST".

Refactored blaze to use the same mechanism.

The absolute form is also giving an ember-server [a hard time on series/0.22](https://github.com/http4s/http4s/runs/1715619314#step:11:3860).

