### PR TITLE
Upgrade to vault-2.1.0-M14

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -331,7 +331,7 @@ object Http4sPlugin extends AutoPlugin {
     val tomcat = "9.0.41"
     val treehugger = "0.4.4"
     val twirl = "1.4.2"
-    val vault = "2.1.0-M11"
+    val vault = "2.1.0-M14"
   }
 
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % V.argonaut


### PR DESCRIPTION
M11 had an empty jar for Scala 3.0.0-M3.