### PR TITLE
Changes to make core tests compile on Scala 3

### DIFF
--- a/tests/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -90,7 +90,7 @@ class EntityDecoderSuite extends Http4sSuite {
         EntityDecoder
           .text[IO]
           .flatMapR(_ => DecodeResult.failure[IO, String](MalformedMessageBodyFailure("bummer")))
-          .handleErrorWith(_ => DecodeResult.success("SAVED"))
+          .handleErrorWith(_ => DecodeResult.success[IO, String]("SAVED"))
           .decode(r, strict = false)
       }
       .value
@@ -161,7 +161,7 @@ class EntityDecoderSuite extends Http4sSuite {
           .flatMapR(_ => DecodeResult.failure[IO, String](MalformedMessageBodyFailure("bummer")))
           .biflatMap(
             _ => DecodeResult.failure[IO, String](MalformedMessageBodyFailure("double bummer")),
-            s => DecodeResult.success(s)
+            s => DecodeResult.success[IO, String](s)
           )
           .decode(r, strict = false)
       }

--- a/tests/src/test/scala/org/http4s/FormDataDecoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/FormDataDecoderSpec.scala
@@ -64,7 +64,7 @@ class FormDataDecoderSpec extends Http4sSpec {
   "mapN to decode case class" should {
     case class Foo(a: String, b: Boolean)
 
-    implicit val fooMapper =
+    implicit val fooMapper: FormDataDecoder[Foo] =
       (field[String]("a"), field[Boolean]("b")).mapN(Foo.apply)
 
     "map successfully for valid data" in {
@@ -84,7 +84,7 @@ class FormDataDecoderSpec extends Http4sSpec {
 
     case class FooStrings(a: List[String])
 
-    implicit val fooStringMapper =
+    implicit val fooStringMapper: FormDataDecoder[FooStrings] =
       listOf[String]("a").map(FooStrings.apply)
 
     "decode list successfully for valid data" in {
@@ -101,7 +101,7 @@ class FormDataDecoderSpec extends Http4sSpec {
 
     case class FooNested(f: Foo, c: String)
 
-    val fooNestedMapper = (
+    val fooNestedMapper: FormDataDecoder[FooNested] = (
       nested[Foo]("f"),
       field[String]("c")
     ).mapN(FooNested.apply)
@@ -142,7 +142,7 @@ class FormDataDecoderSpec extends Http4sSpec {
 
     case class FooList(fs: List[Foo], d: Boolean)
 
-    val fooListMapper = (
+    val fooListMapper: FormDataDecoder[FooList] = (
       list[Foo]("fs"),
       field[Boolean]("d")
     ).mapN(FooList.apply)

--- a/tests/src/test/scala/org/http4s/Ipv4AddressSpec.scala
+++ b/tests/src/test/scala/org/http4s/Ipv4AddressSpec.scala
@@ -20,8 +20,6 @@ import cats.kernel.laws.discipline.{HashTests, OrderTests}
 import org.http4s.Uri.Ipv4Address
 import org.http4s.laws.discipline.HttpCodecTests
 import org.http4s.util.Renderer.renderString
-import org.specs2.execute._, Typecheck._
-import org.specs2.matcher.TypecheckMatchers._
 
 class Ipv4AddressSpec extends Http4sSpec {
   checkAll("Order[Ipv4Address]", OrderTests[Ipv4Address].order)
@@ -42,7 +40,7 @@ class Ipv4AddressSpec extends Http4sSpec {
 
   "fromByteArray" should {
     "round trip with toByteArray" in prop { (ipv4: Ipv4Address) =>
-      Ipv4Address.fromByteArray(ipv4.toByteArray) must_== Right(ipv4)
+      Ipv4Address.fromByteArray(ipv4.toByteArray) must beRight(ipv4)
     }
   }
 
@@ -64,7 +62,8 @@ class Ipv4AddressSpec extends Http4sSpec {
     }
 
     "reject invalid values" in {
-      typecheck("""ipv4"256.0.0.0"""") must not succeed
+      illTyped("""ipv4"256.0.0.0"""")
+      true
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/Ipv6AddressSpec.scala
+++ b/tests/src/test/scala/org/http4s/Ipv6AddressSpec.scala
@@ -20,8 +20,6 @@ import cats.kernel.laws.discipline.{HashTests, OrderTests}
 import org.http4s.Uri.Ipv6Address
 import org.http4s.laws.discipline.HttpCodecTests
 import org.http4s.util.Renderer.renderString
-import org.specs2.execute._, Typecheck._
-import org.specs2.matcher.TypecheckMatchers._
 
 class Ipv6AddressSpec extends Http4sSpec {
   checkAll("Order[Ipv6Address]", OrderTests[Ipv6Address].order)
@@ -55,7 +53,7 @@ class Ipv6AddressSpec extends Http4sSpec {
 
   "fromByteArray" should {
     "round trip with toByteArray" in prop { (ipv6: Ipv6Address) =>
-      Ipv6Address.fromByteArray(ipv6.toByteArray) must_== Right(ipv6)
+      Ipv6Address.fromByteArray(ipv6.toByteArray) must beRight(ipv6)
     }
   }
 
@@ -78,7 +76,8 @@ class Ipv6AddressSpec extends Http4sSpec {
     }
 
     "reject invalid values" in {
-      typecheck("""ipv6"127.0.0.1"""") must not succeed
+      illTyped("""ipv6"127.0.0.1"""")
+      true
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/MediaTypeSpec.scala
+++ b/tests/src/test/scala/org/http4s/MediaTypeSpec.scala
@@ -64,20 +64,18 @@ class MediaTypeSpec extends Http4sSpec {
     }
 
     "reject invalid literals" in {
-      import org.specs2.execute._, Typecheck._
-      import org.specs2.matcher.TypecheckMatchers._
-
-      typecheck {
+      illTyped {
         """
            MediaType.mediaType("not valid")
         """
-      } must not succeed
+      }
 
-      typecheck {
+      illTyped {
         """
            mediaType"not valid"
         """
-      } must not succeed
+      }
+      true
     }
   }
 

--- a/tests/src/test/scala/org/http4s/QValueSpec.scala
+++ b/tests/src/test/scala/org/http4s/QValueSpec.scala
@@ -51,19 +51,17 @@ class QValueSpec extends Http4sSpec {
   }
 
   "literal syntax should reject invalid values" in {
-    import org.specs2.execute._, Typecheck._
-    import org.specs2.matcher.TypecheckMatchers._
-
-    typecheck {
+    illTyped {
       """
         qValue"2.0" // doesn't compile: out of range
       """
-    } should not succeed
+    }
 
-    typecheck {
+    illTyped {
       """
         qValue"invalid" // doesn't compile, not parsable as a double
       """
-    } should not succeed
+    }
+    true
   }
 }

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -23,10 +23,11 @@ import org.specs2.matcher.MustThrownMatchers
 class UriSpec extends Http4sSpec with MustThrownMatchers {
   sealed case class Ttl(seconds: Int)
   object Ttl {
-    implicit val queryParamInstance = new QueryParamEncoder[Ttl] with QueryParam[Ttl] {
-      def key: QueryParameterKey = QueryParameterKey("ttl")
-      def encode(value: Ttl): QueryParameterValue = QueryParameterValue(value.seconds.toString)
-    }
+    implicit val queryParamInstance: QueryParamEncoder[Ttl] with QueryParam[Ttl] =
+      new QueryParamEncoder[Ttl] with QueryParam[Ttl] {
+        def key: QueryParameterKey = QueryParameterKey("ttl")
+        def encode(value: Ttl): QueryParameterValue = QueryParameterValue(value.seconds.toString)
+      }
   }
 
   def getUri(uri: String): Uri =

--- a/tests/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -19,7 +19,7 @@ package org.http4s
 import cats.Monoid
 import cats.data._
 import cats.effect.IO
-import cats.syntax.all._
+import cats.syntax.all.{catsSyntaxEq => _, _}
 import cats.kernel.laws.discipline.MonoidTests
 import org.http4s.internal.CollectionCompat
 
@@ -121,9 +121,8 @@ class UrlFormSpec extends Http4sSpec {
     }
 
     "construct consistently from kv-pairs or and Map[String, Chain[String]]" in prop {
-      map: Map[String, NonEmptyList[
-        String
-      ]] => // non-empty because the kv-constructor can't represent valueless fields
+      (map: Map[String, NonEmptyList[String]]) =>
+        // non-empty because the kv-constructor can't represent valueless fields
         val flattened = for {
           (k, vs) <- map.toSeq
           v <- vs.toList
@@ -133,11 +132,12 @@ class UrlFormSpec extends Http4sSpec {
     }
 
     "construct consistently from Chain of kv-pairs and Map[String, Chain[String]]" in prop {
-      map: Map[String, NonEmptyList[
-        String
-      ]] => // non-empty because the kv-constructor can't represent valueless fields
+      (map: Map[String, NonEmptyList[String]]) =>
+        // non-empty because the kv-constructor can't represent valueless fields
         val flattened = for {
-          (k, vs) <- Chain.fromSeq(map.toSeq)
+          kv <- Chain.fromSeq(map.toSeq)
+          k = kv._1
+          vs = kv._2
           v <- Chain.fromSeq(vs.toList)
         } yield k -> v
         UrlForm.fromChain(flattened) === UrlForm(

--- a/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSpec.scala
@@ -297,14 +297,12 @@ class UriParserSpec extends Http4sSpec {
     }
 
     "reject invalid URIs" in {
-      import org.specs2.execute._, Typecheck._
-      import org.specs2.matcher.TypecheckMatchers._
-
-      typecheck {
+      illTyped {
         """
            uri"not valid"
         """
-      } must not succeed
+      }
+      true
     }
   }
 }


### PR DESCRIPTION
* Use illTyped macro instead of typecheck
* parameters around lambdas
* add types to implicits
* Remove cats Eq typeclass to avoid multiple syntax implicits