### PR TITLE
Link to mdoc and final cleanup of tut references

### DIFF
--- a/docs/src/main/mdoc/client.md
+++ b/docs/src/main/mdoc/client.md
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
 )
 ```
 
-Then we create the [service] again so tut picks it up:
+Then we create the [service] again so [mdoc] picks it up:
 >
 ```scala mdoc:silent
 import cats.effect._
@@ -85,7 +85,7 @@ BlazeClientBuilder[IO](global).resource.use { client =>
 }
 ```
 
-For the remainder of this tut, we'll use an alternate client backend
+For the remainder of this tutorial, we'll use an alternate client backend
 built on the standard `java.net` library client.  Unlike the blaze
 client, it does not need to be shut down.  Like the blaze-client, and
 any other http4s backend, it presents the exact same `Client`
@@ -389,3 +389,4 @@ blockingPool.shutdown()
 [Request Logger]: ../api/org/http4s/client/middleware/RequestLogger$
 [Response Logger]: ../api/org/http4s/client/middleware/ResponseLogger$
 [Logger]: ../api/org/http4s/client/middleware/Logger$
+[mdoc]: https://scalameta.org/mdoc/

--- a/docs/src/main/mdoc/service.md
+++ b/docs/src/main/mdoc/service.md
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
 // scalacOptions ++= Seq("-Ypartial-unification")
 ```
 
-This tutorial is compiled as part of the build using [tut].  Each page
+This tutorial is compiled as part of the build using [mdoc].  Each page
 is its own REPL session.  If you copy and paste code samples starting
 from the top, you should be able to follow along in a REPL.
 
@@ -219,7 +219,7 @@ object MainWithResource extends IOApp {
 ```
 
 [blaze]: https://github.com/http4s/blaze
-[tut]: https://github.com/tpolecat/tut
+[mdoc]: https://scalameta.org/mdoc/
 [Cats Kleisli Datatype]: https://typelevel.org/cats/datatypes/kleisli.html
 [cats-effect: The IO Monad for Scala]: https://typelevel.org/cats-effect/
 [http4s-dsl]: ../dsl

--- a/docs/src/main/mdoc/static.md
+++ b/docs/src/main/mdoc/static.md
@@ -66,7 +66,7 @@ You can create a `Resource[F, Blocker]` by calling `Blocker[F]`, which will hand
 creating and disposing of an underlying thread pool. You can also create your
 own by lifting an execution context or an executor service.
 
-For now, we will lift an executor service, since using `Resource` in a `tut` 
+For now, we will lift an executor service, since using `Resource` in a [mdoc]
 example is not feasible.
 
 ```scala mdoc:silent:nest
@@ -165,3 +165,4 @@ blockingPool.shutdown()
 Assuming that the service is mounted as root on port `8080`, and you included the webjar `swagger-ui-3.20.9.jar` on your classpath, you would reach the assets with the path: `http://localhost:8080/swagger-ui/3.20.9/index.html`
 
 [StaticFile]: ../api/org/http4s/StaticFile$
+[mdoc]: https://scalameta.org/mdoc/

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -159,7 +159,7 @@ object Http4sPlugin extends AutoPlugin {
     extractApiVersion(version).productIterator.mkString("/v", ".", "")
 
   /**
-    * @return the version we want to document, for example in tuts,
+    * @return the version we want to document, for example in mdoc,
     * given the version being built.
     *
     * For snapshots after a stable release, return the previous stable

--- a/website/src/hugo/content/contributing.md
+++ b/website/src/hugo/content/contributing.md
@@ -220,7 +220,7 @@ markdown via GitHub.
 Each branch `main` and `series/X.Y`, publishes documentation per
 minor version into the `/vX.Y` directory of http4s.org.  The Hugo site
 chrome lives in the `docs/src/hugo` directory, and the [mdoc] content
-lives in `docs/src/main/mdoc`.  Tut is used to typecheck our
+lives in `docs/src/main/mdoc`.  [mdoc] is used to typecheck our
 documentation as part of the build.
 
 #### Editing the versioned site
@@ -229,13 +229,11 @@ All pages have an edit link at the top right for direct editing of the
 markdown via GitHub.  Be aware that the Travis build will fail if invalid
 code is added.
 
-[mdoc]: https://github.com/scalameta/mdoc
-
 ## Submit a pull request
 
 Before you open a pull request, you should make sure that `sbt ci` runs
 successfully. Travis CI will run this as well, but it may save you some
-time to be alerted to style or tut problems earlier.
+time to be alerted to style or [mdoc] problems earlier.
 
 If your pull request addresses an existing issue, please tag that
 issue number in the body of your pull request or commit message. For
@@ -254,3 +252,4 @@ branch.
 contributors guide]</small>
 
 [Cats' contributors guide]: https://github.com/typelevel/cats/blob/master/CONTRIBUTING.md
+[mdoc]: https://scalameta.org/mdoc/

--- a/website/src/hugo/themes/http4s.org/layouts/shortcodes/version.html
+++ b/website/src/hugo/themes/http4s.org/layouts/shortcodes/version.html
@@ -6,7 +6,7 @@
 
       Site generated for http4s version {{< version "http4s.current" >}}.
 
-  or in a tut:
+  or in mdoc:
 
        libraryDependencies ++= Seq(
          "org.http4s" %% "http4s-circe" % "{{< version "http4s.doc" >}}",


### PR DESCRIPTION
This PR removes the final lingering mentions of `tut` and updates them to link to mdoc.