### PR TITLE
Update Prometheus Client To 0.10.0 And Fix Tests

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -315,7 +315,7 @@ object Http4sPlugin extends AutoPlugin {
     val okio = "2.10.0"
     val okhttp = "4.9.0"
     val playJson = "2.9.2"
-    val prometheusClient = "0.9.0"
+    val prometheusClient = "0.10.0"
     val reactiveStreams = "1.0.3"
     val quasiquotes = "2.1.0"
     val scalacheck = "1.15.2"

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/util.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/util.scala
@@ -63,7 +63,7 @@ object util {
       case "2xx_responses" =>
         registry
           .getSampleValue(
-            s"${prefix}_request_count",
+            s"${prefix}_request_count_total",
             Array("classifier", "method", "status"),
             Array(classifier, method, "2xx"))
       case "2xx_headers_duration" =>
@@ -79,7 +79,7 @@ object util {
       case "4xx_responses" =>
         registry
           .getSampleValue(
-            s"${prefix}_request_count",
+            s"${prefix}_request_count_total",
             Array("classifier", "method", "status"),
             Array(classifier, method, "4xx"))
       case "4xx_headers_duration" =>
@@ -95,7 +95,7 @@ object util {
       case "5xx_responses" =>
         registry
           .getSampleValue(
-            s"${prefix}_request_count",
+            s"${prefix}_request_count_total",
             Array("classifier", "method", "status"),
             Array(classifier, method, "5xx"))
       case "5xx_headers_duration" =>


### PR DESCRIPTION
Prometheus is changing the naming scheme of some of their metrics in order to be compatible with the OpenMetrics standard. Part of this means that all counters will have `_total` or `_created` as a suffix. There is no way to create a counter without a `_total` suffix.

See: https://github.com/prometheus/client_java/pull/615