### PR TITLE
Turn Date Header Into Cached Component

### DIFF
--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/DateCaching.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/DateCaching.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.ember.server.internal
 
 import java.time.{Instant, ZoneId}

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/DateCaching.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/DateCaching.scala
@@ -1,0 +1,44 @@
+package org.http4s.ember.server.internal
+
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import cats.effect.Sync
+import org.http4s.Header.Raw
+import org.http4s.implicits._
+import org.http4s.Header
+
+trait DateCaching[F[_]] {
+  def getDate: F[Header]
+}
+
+object DateCaching {
+
+  private case class CachedDateHeader(acquired: Long, header: Raw)
+  private val dateFormat =
+    DateTimeFormatter
+      .ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
+      .withLocale(Locale.US)
+      .withZone(ZoneId.of("GMT"))
+
+  private val date = "date".ci
+
+  def impl[F[_]: Sync]: F[DateCaching[F]] = Sync[F].delay {
+    new DateCaching[F] {
+      // STOLEN From Blaze Is This good?
+      @volatile
+      var dateTime = CachedDateHeader(0L, Raw(date, dateFormat.format(Instant.now())))
+
+      def getDate: F[Header] = Sync[F].delay {
+        val cached = dateTime
+        val current = System.currentTimeMillis()
+        if (current - cached.acquired <= 1000) cached.header
+        else {
+          val next = Raw(date, dateFormat.format(Instant.now()))
+          dateTime = CachedDateHeader(current, next)
+          next
+        }
+      }
+    }
+  }
+}

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 import java.net.InetSocketAddress
 import org.http4s._
 import org.http4s.implicits._
-import org.http4s.headers.{Connection, Date}
+import org.http4s.headers.{Connection}
 import _root_.org.http4s.ember.core.{Encoder, Parser}
 import _root_.org.http4s.ember.core.Util.readWithTimeout
 import _root_.io.chrisdavenport.log4cats.Logger
@@ -48,6 +48,7 @@ private[server] object ServerHelpers {
       tlsInfoOpt: Option[(TLSContext, TLSParameters)],
       ready: Deferred[F, Either[Throwable, Unit]],
       shutdown: Shutdown[F],
+      dateCaching: DateCaching[F],
       // Defaults
       onError: Throwable => Response[F] = { (_: Throwable) =>
         Response[F](Status.InternalServerError)
@@ -124,7 +125,7 @@ private[server] object ServerHelpers {
         if (reqHasClose) close
         else keepAlive
       for {
-        date <- HttpDate.current[F].map(Date(_))
+        date <- dateCaching.getDate
       } yield resp.withHeaders(Headers.of(date, connection) ++ resp.headers)
     }
 


### PR DESCRIPTION
Steals the Blaze Caching Implementation and does it with a Raw Date Header rather than a raw string

BlazeImpl - https://github.com/http4s/blaze/blob/43d9b8f379f6a54ca1a494ef555d77b03a17609c/http/src/main/scala/org/http4s/blaze/http/util/HeaderTools.scala#L29

I'm not really sure how much time this saves us over before.