### PR TITLE
Deprecate `as` for `withContext`

### DIFF
--- a/docs/src/main/mdoc/auth.md
+++ b/docs/src/main/mdoc/auth.md
@@ -60,7 +60,7 @@ final `HttpRoutes` to be exposed. Notice that we now have access to the user obj
 ```scala mdoc:silent
 val authedRoutes: AuthedRoutes[User, IO] =
   AuthedRoutes.of {
-    case GET -> Root / "welcome" as user => Ok(s"Welcome, ${user.name}")
+    case GET -> Root / "welcome" withContext user => Ok(s"Welcome, ${user.name}")
   }
 
 val service: HttpRoutes[IO] = middleware(authedRoutes)
@@ -76,7 +76,7 @@ your api for possible unprotected points.
 ```scala mdoc:silent:nest
 val spanishRoutes: AuthedRoutes[User, IO] =
     AuthedRoutes.of {
-        case GET -> Root / "hola" as user => Ok(s"Hola, ${user.name}")
+        case GET -> Root / "hola" withContext user => Ok(s"Hola, ${user.name}")
     }
 
 val frenchRoutes: HttpRoutes[IO] =

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Auth.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Auth.scala
@@ -19,7 +19,13 @@ package org.http4s.dsl.impl
 import org.http4s.{AuthedRequest, Request}
 
 trait Auth {
+  @deprecated("Changed to `withContext`. `as` is a soft keyword in Scala 3.", "0.21.17")
   object as {
+    def unapply[F[_], A](ar: AuthedRequest[F, A]): Option[(Request[F], A)] =
+      Some(ar.req -> ar.context)
+  }
+
+  object withContext {
     def unapply[F[_], A](ar: AuthedRequest[F, A]): Option[(Request[F], A)] =
       Some(ar.req -> ar.context)
   }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/auth/BasicAuthHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/auth/BasicAuthHttpEndpoint.scala
@@ -26,7 +26,7 @@ import org.http4s.server.middleware.authentication.BasicAuth
 class BasicAuthHttpEndpoint[F[_]](implicit F: Sync[F], R: AuthRepository[F, BasicCredentials])
     extends Http4sDsl[F] {
   private val authedRoutes: AuthedRoutes[BasicCredentials, F] = AuthedRoutes.of {
-    case GET -> Root as user =>
+    case GET -> Root withContext user =>
       Ok(s"Access Granted: ${user.username}")
   }
 

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -206,7 +206,7 @@ class ExampleService[F[_]](blocker: Blocker)(implicit F: Effect[F], cs: ContextS
   def authRoutes: HttpRoutes[F] =
     basicAuth(AuthedRoutes.of[String, F] {
       // AuthedRoutes look like HttpRoutes, but the user is extracted with `as`.
-      case GET -> Root / "protected" as user =>
+      case GET -> Root / "protected" withContext user =>
         Ok(s"This page is protected using HTTP authentication; logged in as $user")
     })
 }

--- a/server/src/test/scala/org/http4s/server/ContextRouterSuite.scala
+++ b/server/src/test/scala/org/http4s/server/ContextRouterSuite.scala
@@ -24,27 +24,27 @@ import org.http4s.dsl.io._
 import org.http4s.syntax.all._
 
 class ContextRouterSuite extends Http4sSuite {
-  val numbers = ContextRoutes.of[Unit, IO] { case GET -> Root / "1" as _ =>
+  val numbers = ContextRoutes.of[Unit, IO] { case GET -> Root / "1" withContext _ =>
     Ok("one")
   }
-  val numbers2 = ContextRoutes.of[Unit, IO] { case GET -> Root / "1" as _ =>
+  val numbers2 = ContextRoutes.of[Unit, IO] { case GET -> Root / "1" withContext _ =>
     Ok("two")
   }
 
-  val letters = ContextRoutes.of[Unit, IO] { case GET -> Root / "/b" as _ =>
+  val letters = ContextRoutes.of[Unit, IO] { case GET -> Root / "/b" withContext _ =>
     Ok("bee")
   }
-  val shadow = ContextRoutes.of[Unit, IO] { case GET -> Root / "shadowed" as _ =>
+  val shadow = ContextRoutes.of[Unit, IO] { case GET -> Root / "shadowed" withContext _ =>
     Ok("visible")
   }
   val root = ContextRoutes.of[Unit, IO] {
-    case GET -> Root / "about" as _ =>
+    case GET -> Root / "about" withContext _ =>
       Ok("about")
-    case GET -> Root / "shadow" / "shadowed" as _ =>
+    case GET -> Root / "shadow" / "shadowed" withContext _ =>
       Ok("invisible")
   }
 
-  val notFound = ContextRoutes.of[Unit, IO] { case _ as _ =>
+  val notFound = ContextRoutes.of[Unit, IO] { case _ withContext _ =>
     NotFound("Custom NotFound")
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSuite.scala
@@ -63,7 +63,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
       Kleisli(req => OptionT.liftF(Forbidden(req.context)))
 
     val authedRoutes: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case GET -> Root as user =>
+      AuthedRoutes.of { case GET -> Root withContext user =>
         Ok(user.toString)
       }
 
@@ -91,7 +91,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
       Kleisli(req => OptionT.liftF(Forbidden(req.context)))
 
     val authedRoutes: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case POST -> Root as _ =>
+      AuthedRoutes.of { case POST -> Root withContext _ =>
         Ok()
       }
 
@@ -116,7 +116,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
       Kleisli.pure(userId)
 
     val authedRoutes: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case POST -> Root as _ =>
+      AuthedRoutes.of { case POST -> Root withContext _ =>
         Ok()
       }
 
@@ -134,7 +134,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
       Kleisli.pure(userId)
 
     val authedRoutes: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case POST -> Root as _ =>
+      AuthedRoutes.of { case POST -> Root withContext _ =>
         Ok()
       }
 
@@ -150,7 +150,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
       Kleisli.liftF(OptionT.none)
 
     val authedRoutes: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case POST -> Root as _ =>
+      AuthedRoutes.of { case POST -> Root withContext _ =>
         Ok()
       }
 
@@ -166,7 +166,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
       Kleisli.liftF(OptionT.none)
 
     val authedRoutes: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case POST -> Root as _ =>
+      AuthedRoutes.of { case POST -> Root withContext _ =>
         Ok()
       }
 
@@ -184,12 +184,12 @@ class AuthMiddlewareSuite extends Http4sSuite {
       Kleisli.pure(userId)
 
     val authedRoutes1: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case POST -> Root as _ =>
+      AuthedRoutes.of { case POST -> Root withContext _ =>
         Ok()
       }
 
     val authedRoutes2: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case GET -> Root as _ =>
+      AuthedRoutes.of { case GET -> Root withContext _ =>
         Ok()
       }
 
@@ -206,7 +206,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
       Kleisli.liftF(OptionT.none)
 
     val authedRoutes: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case POST -> Root as _ =>
+      AuthedRoutes.of { case POST -> Root withContext _ =>
         Ok()
       }
 
@@ -231,7 +231,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
       Kleisli.liftF(OptionT.none)
 
     val authedRoutes: AuthedRoutes[User, IO] =
-      AuthedRoutes.of { case POST -> Root as _ =>
+      AuthedRoutes.of { case POST -> Root withContext _ =>
         Ok()
       }
 

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration._
 
 class AuthenticationSuite extends Http4sSuite {
   def nukeService(launchTheNukes: => Unit) =
-    AuthedRoutes.of[String, IO] { case GET -> Root / "launch-the-nukes" as user =>
+    AuthedRoutes.of[String, IO] { case GET -> Root / "launch-the-nukes" withContext user =>
       for {
         _ <- IO(launchTheNukes)
         r <- Gone(s"Oops, $user launched the nukes.")
@@ -52,8 +52,8 @@ class AuthenticationSuite extends Http4sSuite {
     }
 
   val service = AuthedRoutes.of[String, IO] {
-    case GET -> Root as user => Ok(user)
-    case req as _ => Response.notFoundFor(req)
+    case GET -> Root withContext user => Ok(user)
+    case req withContext _ => Response.notFoundFor(req)
   }
 
   val basicAuthMiddleware = BasicAuth(realm, validatePassword _)


### PR DESCRIPTION
Surprise: https://github.com/lampepfl/dotty/issues/9829.