### PR TITLE
Server tests on Scala 3.0.0-M2

### DIFF
--- a/server/src/test/scala/org/http4s/server/middleware/DateSpec.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DateSpec.scala
@@ -41,7 +41,7 @@ class DateSpec extends Http4sSpec with CatsIO {
       for {
         out <- testService(req).value
         now <- HttpDate.current[IO]
-      } yield out.flatMap(_.headers.get(HDate)) must beSome.like { case date =>
+      } yield out.flatMap(_.headers.get(HDate)) must beSome.like { case date: HDate =>
         val diff = now.epochSecond - date.date.epochSecond
         diff must be_<=(2L)
       }

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -204,7 +204,8 @@ class AuthenticationSuite extends Http4sSuite {
             },
             challenge)
         }
-        (res2, res3) <- doDigestAuth2(digestAuthService.orNotFound, challenge, withReplay = true)
+        results <- doDigestAuth2(digestAuthService.orNotFound, challenge, withReplay = true)
+        (res2, res3) = results
       } yield {
         assertEquals(res2.status, Ok)
 


### PR DESCRIPTION
This plus #4289 plus #4290 makes server tests pass on 3.0.0-M2.