### PR TITLE
Upgrade munit-cats-effect to 0.13.0 and enable some ember-server tests

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientBase.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientBase.scala
@@ -79,8 +79,7 @@ trait BlazeClientBase extends Http4sSuite {
       }
     }
 
-  def jettyScaffold: FunFixture[(JettyScaffold, JettyScaffold)] =
-    ResourceFixture(
-      (JettyScaffold[IO](5, false, testServlet), JettyScaffold[IO](1, true, testServlet)).tupled)
+  val jettyScaffold = ResourceFixture(
+    (JettyScaffold[IO](5, false, testServlet), JettyScaffold[IO](1, true, testServlet)).tupled)
 
 }

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSuite.scala
@@ -43,7 +43,7 @@ class Http1ClientStageSuite extends Http4sSuite {
   // Common throw away response
   val resp = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndone"
 
-  private def fooConnection: FunFixture[Http1Connection[IO]] =
+  private val fooConnection =
     ResourceFixture[Http1Connection[IO]] {
       for {
         connection <- Resource[IO, Http1Connection[IO]] {

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSuite.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSuite.scala
@@ -65,7 +65,7 @@ class BlazeServerSuite extends Http4sSuite {
       .withHttpApp(service)
       .resource
 
-  def blazeServer: FunFixture[Server[IO]] =
+  val blazeServer =
     ResourceFixture[Server[IO]](
       serverR,
       (_: TestOptions, _: Server[IO]) => IO.unit,

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -50,8 +50,8 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
       }
     }
 
-  def clientFixture: FunFixture[(JettyScaffold, Client[IO])] =
-    ResourceFixture(((JettyScaffold[IO](1, false, testServlet), clientResource)).tupled)
+  val clientFixture = ResourceFixture(
+    (JettyScaffold[IO](1, false, testServlet), clientResource).tupled)
 
   // Need to override the context shift from munitCatsEffect
   // This is only required for JettyClient

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -50,12 +50,12 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
       }
     }
 
-  val clientFixture = ResourceFixture(
-    (JettyScaffold[IO](1, false, testServlet), clientResource).tupled)
-
   // Need to override the context shift from munitCatsEffect
   // This is only required for JettyClient
   implicit val contextShift: ContextShift[IO] = Http4sSuite.TestContextShift
+
+  val clientFixture = ResourceFixture(
+    (JettyScaffold[IO](1, false, testServlet), clientResource).tupled)
 
   clientFixture.test(s"$name Repeat a simple request") { case (jetty, client) =>
     val address = jetty.addresses.head

--- a/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSuite.scala
+++ b/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSuite.scala
@@ -58,8 +58,7 @@ class JettyServerSuite extends Http4sSuite {
       )
       .resource
 
-  def jettyServer: FunFixture[Server[IO]] =
-    ResourceFixture[Server[IO]](serverR)
+  val jettyServer = ResourceFixture[Server[IO]](serverR)
 
   def get(server: Server[IO], path: String): IO[String] =
     testBlocker.blockOn(

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -323,7 +323,7 @@ object Http4sPlugin extends AutoPlugin {
     val netty = "4.1.58.Final"
     val okio = "2.9.0"
     val munit = "0.7.18"
-    val munitCatsEffect = "0.12.0"
+    val munitCatsEffect = "0.13.0"
     val munitDiscipline = "1.0.4"
     val okhttp = "4.9.0"
     val parboiledHttp4s = "2.0.1"

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusClientMetricsSuite.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusClientMetricsSuite.scala
@@ -16,7 +16,7 @@
 
 package org.http4s.metrics.prometheus
 
-import cats.effect.{Clock, IO, Resource}
+import cats.effect._
 import io.prometheus.client.CollectorRegistry
 import java.io.IOException
 import java.util.concurrent.TimeoutException
@@ -186,6 +186,6 @@ class PrometheusClientMetricsSuite extends Http4sSuite {
 
   def meteredClient(
       classifier: Request[IO] => Option[String] = (_: Request[IO]) => None
-  ): FunFixture[(CollectorRegistry, Client[IO])] =
+  ): SyncIO[FunFixture[(CollectorRegistry, Client[IO])]] =
     ResourceFixture(buildMeteredClient(classifier))
 }

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSuite.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSuite.scala
@@ -16,7 +16,7 @@
 
 package org.http4s.metrics.prometheus
 
-import cats.effect.{Clock, IO, Resource}
+import cats.effect._
 import io.prometheus.client.CollectorRegistry
 import org.http4s.{Http4sSuite, HttpApp, HttpRoutes, Request, Status}
 import org.http4s.Method.GET
@@ -231,6 +231,6 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
 
   def meteredRoutes(
       classifier: Request[IO] => Option[String] = (_: Request[IO]) => None
-  ): FunFixture[(CollectorRegistry, HttpApp[IO])] =
+  ): SyncIO[FunFixture[(CollectorRegistry, HttpApp[IO])]] =
     ResourceFixture(buildMeteredRoutes(classifier))
 }

--- a/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
@@ -47,8 +47,7 @@ class BlockingHttp4sServletSuite extends Http4sSuite {
     }
     .orNotFound
 
-  def servletServer: FunFixture[Int] =
-    ResourceFixture[Int](serverPortR)
+  val servletServer = ResourceFixture[Int](serverPortR)
 
   def get(serverPort: Int, path: String): IO[String] =
     testBlocker.delay[IO, String](

--- a/testing/src/test/scala/org/http4s/Http4sSuite.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSuite.scala
@@ -28,7 +28,10 @@ import munit._
 /** Common stack for http4s' munit based tests
   */
 trait Http4sSuite extends CatsEffectSuite with DisciplineSuite with munit.ScalaCheckEffectSuite {
-
+  // The default munit EC causes an IllegalArgumentException in
+  // BatchExecutor on Scala 2.12.
+  override val munitExecutionContext =
+    ExecutionContext.fromExecutor(newDaemonPool("http4s-munit", min = 1, timeout = true))
   val testBlocker: Blocker = Http4sSpec.TestBlocker
 
   implicit class ParseResultSyntax[A](self: ParseResult[A]) {

--- a/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSuite.scala
+++ b/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSuite.scala
@@ -68,8 +68,7 @@ class TomcatServerSuite extends Http4sSuite {
       )
       .resource
 
-  def tomcatServer: FunFixture[Server[IO]] =
-    ResourceFixture[Server[IO]](serverR)
+  val tomcatServer = ResourceFixture[Server[IO]](serverR)
 
   def get(server: Server[IO], path: String): IO[String] =
     testBlocker.blockOn(


### PR DESCRIPTION
Upgrade to munit-cats-effect 0.13.0 so we get a saner default execution context. Slight tangent, it was discovered awhile back that `ResourceFixture` wasn't referentially transparent, so we had to wrap in `SyncIO`, which is forcing us to delete some type annotations here. We also don't make heavy use of `map2` but that would've necessitated some fixes too