### PR TITLE
ember-client on 3.0.0-M2 (with Typelevel keypool)

### DIFF
--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClient.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClient.scala
@@ -19,7 +19,7 @@ package org.http4s.ember.client
 import cats.effect._
 import org.http4s._
 import org.http4s.client._
-import io.chrisdavenport.keypool._
+import org.typelevel.keypool._
 
 final class EmberClient[F[_]] private[client] (
     private val client: Client[F],

--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -113,15 +113,15 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
         KeyPoolBuilder
           .apply[F, RequestKey, (RequestKeySocket[F], F[Unit])](
             (requestKey: RequestKey) => {
-              val alloced = 
-              org.http4s.ember.client.internal.ClientHelpers
-                .requestKeyToSocketWithKey[F](
-                  requestKey,
-                  tlsContextOptWithDefault,
-                  sg,
-                  additionalSocketOptions
-                )
-                .allocated
+              val alloced =
+                org.http4s.ember.client.internal.ClientHelpers
+                  .requestKeyToSocketWithKey[F](
+                    requestKey,
+                    tlsContextOptWithDefault,
+                    sg,
+                    additionalSocketOptions
+                  )
+                  .allocated
               alloced <* logger.trace(s"Created Connection - RequestKey: ${requestKey}")
             },
             { case (RequestKeySocket(socket, r), shutdown) =>

--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -33,7 +33,7 @@ import _root_.org.http4s.ember.core.{Encoder, Parser}
 import _root_.org.http4s.ember.core.Util.readWithTimeout
 import _root_.fs2.io.tcp.SocketGroup
 import _root_.fs2.io.tls._
-import _root_.io.chrisdavenport.keypool.Reusable
+import org.typelevel.keypool.Reusable
 import javax.net.ssl.SNIHostName
 import org.http4s.headers.{Connection, Date, `User-Agent`}
 

--- a/ember-client/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSpec.scala
+++ b/ember-client/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSpec.scala
@@ -26,7 +26,7 @@ import cats.effect.testing.specs2.CatsIO
 import org.http4s.headers.{Connection, Date, `User-Agent`}
 import org.http4s.ember.client.EmberClientBuilder
 import org.typelevel.ci.CIString
-import io.chrisdavenport.keypool.Reusable
+import org.typelevel.keypool.Reusable
 import scala.concurrent.duration._
 
 class ClientHelpersSpec extends Specification with CatsIO {

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -304,7 +304,7 @@ object Http4sPlugin extends AutoPlugin {
     val jetty = "9.4.36.v20210114"
     val json4s = "3.6.10"
     val log4cats = "1.2.0-RC2"
-    val keypool = "0.2.0"
+    val keypool = "0.3.0-RC1"
     val logback = "1.2.3"
     val log4s = "1.10.0-M4"
     val mockito = "3.5.15"
@@ -377,7 +377,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val json4sCore                       = "org.json4s"             %% "json4s-core"               % V.json4s
   lazy val json4sJackson                    = "org.json4s"             %% "json4s-jackson"            % V.json4s
   lazy val json4sNative                     = "org.json4s"             %% "json4s-native"             % V.json4s
-  lazy val keypool                          = "io.chrisdavenport"      %% "keypool"                   % V.keypool
+  lazy val keypool                          = "org.typelevel"          %% "keypool"                   % V.keypool
   lazy val log4catsCore                     = "org.typelevel"          %% "log4cats-core"             % V.log4cats
   lazy val log4catsSlf4j                    = "org.typelevel"          %% "log4cats-slf4j"            % V.log4cats
   lazy val log4catsTesting                  = "org.typelevel"          %% "log4cats-testing"          % V.log4cats


### PR DESCRIPTION
Includes upgrade to keypool-0.3.0-RC1.