### PR TITLE
Inline pairsToMultiParams from CollectionCompat

### DIFF
--- a/core/src/main/scala-2.12/org/http4s/internal/CollectionCompat.scala
+++ b/core/src/main/scala-2.12/org/http4s/internal/CollectionCompat.scala
@@ -24,7 +24,7 @@ private[http4s] object CollectionCompat {
   type LazyList[A] = Stream[A]
   val LazyList = Stream
 
-  @deprecated("Deprecated in favour of inlining", "0.21.16")
+  @deprecated("Deprecated in favour of inlining", "0.21.17")
   def pairsToMultiParams[K, V](map: collection.Seq[(K, Option[V])]): Map[K, immutable.Seq[V]] =
     if (map.isEmpty) Map.empty
     else {

--- a/core/src/main/scala-2.12/org/http4s/internal/CollectionCompat.scala
+++ b/core/src/main/scala-2.12/org/http4s/internal/CollectionCompat.scala
@@ -16,24 +16,9 @@
 
 package org.http4s.internal
 
-import scala.collection.immutable
-import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
-
 private[http4s] object CollectionCompat {
   type LazyList[A] = Stream[A]
   val LazyList = Stream
-
-  def pairsToMultiParams[K, V](map: collection.Seq[(K, Option[V])]): Map[K, immutable.Seq[V]] =
-    if (map.isEmpty) Map.empty
-    else {
-      val m = mutable.Map.empty[K, ListBuffer[V]]
-      map.foreach {
-        case (k, None) => m.getOrElseUpdate(k, new ListBuffer)
-        case (k, Some(v)) => m.getOrElseUpdate(k, new ListBuffer) += v
-      }
-      m.toMap.mapValues(_.toList)
-    }
 
   def mapValues[K, A, B](map: collection.Map[K, A])(f: A => B): Map[K, B] =
     map.mapValues(f).toMap

--- a/core/src/main/scala-2.12/org/http4s/internal/CollectionCompat.scala
+++ b/core/src/main/scala-2.12/org/http4s/internal/CollectionCompat.scala
@@ -16,9 +16,25 @@
 
 package org.http4s.internal
 
+import scala.collection.immutable
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
 private[http4s] object CollectionCompat {
   type LazyList[A] = Stream[A]
   val LazyList = Stream
+
+  @deprecated("Deprecated in favour of inlining", "0.21.16")
+  def pairsToMultiParams[K, V](map: collection.Seq[(K, Option[V])]): Map[K, immutable.Seq[V]] =
+    if (map.isEmpty) Map.empty
+    else {
+      val m = mutable.Map.empty[K, ListBuffer[V]]
+      map.foreach {
+        case (k, None) => m.getOrElseUpdate(k, new ListBuffer)
+        case (k, Some(v)) => m.getOrElseUpdate(k, new ListBuffer) += v
+      }
+      m.toMap.mapValues(_.toList)
+    }
 
   def mapValues[K, A, B](map: collection.Map[K, A])(f: A => B): Map[K, B] =
     map.mapValues(f).toMap

--- a/core/src/main/scala-2.13/org/http4s/internal/CollectionCompat.scala
+++ b/core/src/main/scala-2.13/org/http4s/internal/CollectionCompat.scala
@@ -24,7 +24,7 @@ private[http4s] object CollectionCompat {
   type LazyList[A] = scala.collection.immutable.LazyList[A]
   val LazyList = scala.collection.immutable.LazyList
 
-  @deprecated("Deprecated in favour of inlining", "0.21.16")
+  @deprecated("Deprecated in favour of inlining", "0.21.17")
   def pairsToMultiParams[K, V](map: collection.Seq[(K, Option[V])]): Map[K, immutable.Seq[V]] =
     if (map.isEmpty) Map.empty
     else {

--- a/core/src/main/scala-2.13/org/http4s/internal/CollectionCompat.scala
+++ b/core/src/main/scala-2.13/org/http4s/internal/CollectionCompat.scala
@@ -16,9 +16,25 @@
 
 package org.http4s.internal
 
+import scala.collection.immutable
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
 private[http4s] object CollectionCompat {
   type LazyList[A] = scala.collection.immutable.LazyList[A]
   val LazyList = scala.collection.immutable.LazyList
+
+  @deprecated("Deprecated in favour of inlining", "0.21.16")
+  def pairsToMultiParams[K, V](map: collection.Seq[(K, Option[V])]): Map[K, immutable.Seq[V]] =
+    if (map.isEmpty) Map.empty
+    else {
+      val m = mutable.Map.empty[K, ListBuffer[V]]
+      map.foreach {
+        case (k, None) => m.getOrElseUpdate(k, new ListBuffer)
+        case (k, Some(v)) => m.getOrElseUpdate(k, new ListBuffer) += v
+      }
+      m.view.mapValues(_.toList).toMap
+    }
 
   def mapValues[K, A, B](map: Map[K, A])(f: A => B): Map[K, B] =
     map.view.mapValues(f).toMap

--- a/core/src/main/scala-2.13/org/http4s/internal/CollectionCompat.scala
+++ b/core/src/main/scala-2.13/org/http4s/internal/CollectionCompat.scala
@@ -16,24 +16,9 @@
 
 package org.http4s.internal
 
-import scala.collection.immutable
-import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
-
 private[http4s] object CollectionCompat {
   type LazyList[A] = scala.collection.immutable.LazyList[A]
   val LazyList = scala.collection.immutable.LazyList
-
-  def pairsToMultiParams[K, V](map: collection.Seq[(K, Option[V])]): Map[K, immutable.Seq[V]] =
-    if (map.isEmpty) Map.empty
-    else {
-      val m = mutable.Map.empty[K, ListBuffer[V]]
-      map.foreach {
-        case (k, None) => m.getOrElseUpdate(k, new ListBuffer)
-        case (k, Some(v)) => m.getOrElseUpdate(k, new ListBuffer) += v
-      }
-      m.view.mapValues(_.toList).toMap
-    }
 
   def mapValues[K, A, B](map: Map[K, A])(f: A => B): Map[K, B] =
     map.view.mapValues(f).toMap


### PR DESCRIPTION
Discovered while working on https://github.com/http4s/http4s/pull/4304 we can inline `pairsToMultiParams` to reduce `CollectionCompat` a bit.