### PR TITLE
Replace assertEquals(true) for assert

### DIFF
--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSuite.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSuite.scala
@@ -151,6 +151,6 @@ class ArgonautSuite extends JawnDecodeSupportSuite[Json] with Argonauts {
 
   test("Message[F].decodeJson[A] should fail on invalid json") {
     val req = Request[IO]().withEntity(List(13, 14).asJson)
-    req.decodeJson[Foo].attempt.map(_.isLeft).assertEquals(true)
+    req.decodeJson[Foo].attempt.map(_.isLeft).assert
   }
 }

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSuite.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/BlazeServerSuite.scala
@@ -120,16 +120,16 @@ class BlazeServerSuite extends Http4sSuite {
     }
 
   blazeServer.test("route requests on the service executor") { server =>
-    get(server, "/thread/routing").map(_.startsWith("http4s-spec-")).assertEquals(true)
+    get(server, "/thread/routing").map(_.startsWith("http4s-spec-")).assert
   }
 
   blazeServer.test("execute the service task on the service executor") { server =>
-    get(server, "/thread/effect").map(_.startsWith("http4s-spec-")).assertEquals(true)
+    get(server, "/thread/effect").map(_.startsWith("http4s-spec-")).assert
   }
 
   blazeServer.test("be able to echo its input") { server =>
     val input = """{ "Hello": "world" }"""
-    post(server, "/echo", input).map(_.startsWith(input)).assertEquals(true)
+    post(server, "/echo", input).map(_.startsWith(input)).assert
   }
 
   blazeServer.test("return a 503 if the server doesn't respond") { server =>

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -251,12 +251,10 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] {
     val json = Json.obj("a" -> Json.fromString("sup"), "b" -> Json.fromInt(42))
     val result = accumulatingJsonOf[IO, Bar]
       .decode(Request[IO]().withEntity(json), strict = true)
-    result.value
-      .map {
-        case Left(InvalidMessageBodyFailure(_, Some(DecodingFailures(NonEmptyList(_, _))))) => true
-        case _ => false
-      }
-      .assertEquals(true)
+    result.value.map {
+      case Left(InvalidMessageBodyFailure(_, Some(DecodingFailures(NonEmptyList(_, _))))) => true
+      case _ => false
+    }.assert
   }
 
   test("stream json array encoder of should fail with custom message from a decoder") {
@@ -280,7 +278,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] {
 
   test("Message[F].decodeJson[A] should fail on invalid json") {
     val req = Request[IO]().withEntity(List(13, 14).asJson)
-    req.decodeJson[Foo].attempt.map(_.isLeft).assertEquals(true)
+    req.decodeJson[Foo].attempt.map(_.isLeft).assert
   }
 
   test("CirceEntityEncDec should decode json without defining EntityDecoder") {
@@ -303,12 +301,10 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] {
     val decoder = CirceInstances.builder.build.jsonOf[IO, Int]
     val result = decoder.decode(req, true).value
 
-    result
-      .map {
-        case Left(_: MalformedMessageBodyFailure) => true
-        case _ => false
-      }
-      .assertEquals(true)
+    result.map {
+      case Left(_: MalformedMessageBodyFailure) => true
+      case _ => false
+    }.assert
   }
 
   test("CirceInstances.builder should handle JSON decoding errors") {
@@ -318,12 +314,10 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] {
     val decoder = CirceInstances.builder.build.jsonOf[IO, Int]
     val result = decoder.decode(req, true).value
 
-    result
-      .map {
-        case Left(_: InvalidMessageBodyFailure) => true
-        case _ => false
-      }
-      .assertEquals(true)
+    result.map {
+      case Left(_: InvalidMessageBodyFailure) => true
+      case _ => false
+    }.assert
   }
 
   // checkAll("EntityCodec[IO, Json]", EntityCodecTests[IO, Json].entityCodec)

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
@@ -58,7 +58,7 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
     val disposingClient = Client { (req: Request[IO]) =>
       Resource.make(app(req))(_ => dispose)
     }
-    f(disposingClient).attempt.map(_ => disposed).assertEquals(true)
+    f(disposingClient).attempt.map(_ => disposed).assert
   }
 
   test("Client should ggmatch responses to Uris with get") {
@@ -125,7 +125,7 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
         case Left(_: MatchError) => true
         case _ => false
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("Client should ggfetch Uris with expect") {
@@ -173,11 +173,11 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
   }
 
   test("Client should ggsuccessful returns the success of the status for a request") {
-    client.successful(req).assertEquals(true)
+    client.successful(req).assert
   }
 
   test("Client should ggsuccessful returns the success of the status for a request task") {
-    client.successful(IO.pure(req)).assertEquals(true)
+    client.successful(IO.pure(req)).assert
   }
 
   test("Client should ggstatus returns the status for a request") {
@@ -189,11 +189,11 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
   }
 
   test("Client should ggsuccessful returns the success of the status for a request") {
-    client.successful(req).assertEquals(true)
+    client.successful(req).assert
   }
 
   test("Client should ggsuccessful returns the success of the status for a request task") {
-    client.successful(IO.pure(req)).assertEquals(true)
+    client.successful(IO.pure(req)).assert
   }
 
   test(

--- a/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSuite.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/FollowRedirectSuite.scala
@@ -103,7 +103,7 @@ class FollowRedirectSuite extends Http4sSuite with Http4sClientDsl[IO] {
   //         case Right(r) => r == response
   //         case _ => false
   //       }
-  //       .assertEquals(true)
+  //       .assert
   //   }
   //
   //   "method" | "status" | "body" | "pure" | "response" |>

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
@@ -33,7 +33,7 @@ class ResponseGeneratorSuite extends Http4sSuite {
       .headers
       .toList
       .traverse { h =>
-        resultheaders.map(_.toList.exists(_ == h)).assertEquals(true)
+        resultheaders.map(_.toList.exists(_ == h)).assert
       } *>
       resultheaders
         .map(_.get(`Content-Length`))

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSuite.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSuite.scala
@@ -24,7 +24,7 @@ trait JawnDecodeSupportSuite[J] extends Http4sSuite {
   def testJsonDecoder(decoder: EntityDecoder[IO, J]) = {
     test("return right when the entity is valid") {
       val resp = Response[IO](Status.Ok).withEntity("""{"valid": true}""")
-      decoder.decode(resp, strict = false).value.map(_.isRight).assertEquals(true)
+      decoder.decode(resp, strict = false).value.map(_.isRight).assert
     }
 
     testErrors(decoder)(

--- a/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSuite.scala
+++ b/jetty/src/test/scala/org/http4s/server/jetty/JettyServerSuite.scala
@@ -82,17 +82,17 @@ class JettyServerSuite extends Http4sSuite {
 
   jettyServer.test("ChannelOptions should should route requests on the service executor") {
     server =>
-      get(server, "/thread/routing").map(_.startsWith("http4s-spec-")).assertEquals(true)
+      get(server, "/thread/routing").map(_.startsWith("http4s-spec-")).assert
   }
 
   jettyServer.test(
     "ChannelOptions should should execute the service task on the service executor") { server =>
-    get(server, "/thread/effect").map(_.startsWith("http4s-spec-")).assertEquals(true)
+    get(server, "/thread/effect").map(_.startsWith("http4s-spec-")).assert
   }
 
   jettyServer.test("ChannelOptions should be able to echo its input") { server =>
     val input = """{ "Hello": "world" }"""
-    post(server, "/echo", input).map(_.startsWith(input)).assertEquals(true)
+    post(server, "/echo", input).map(_.startsWith(input)).assert
   }
 
   jettyServer.test("Timeout not fire prematurely") { server =>
@@ -104,6 +104,6 @@ class JettyServerSuite extends Http4sSuite {
   }
 
   jettyServer.test("Timeout should execute the service task on the service executor") { server =>
-    get(server, "/thread/effect").map(_.startsWith("http4s-spec-")).assertEquals(true)
+    get(server, "/thread/effect").map(_.startsWith("http4s-spec-")).assert
   }
 }

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSuite.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSuite.scala
@@ -64,12 +64,10 @@ trait Json4sSuite[J] extends JawnDecodeSupportSuite[JValue] {
   test("jsonOf should handle reader failures") {
     val result =
       jsonOf[IO, Int].decode(Request[IO]().withEntity(""""oops""""), strict = false)
-    result.value
-      .map {
-        case Left(InvalidMessageBodyFailure("Could not map JSON", _)) => true
-        case _ => false
-      }
-      .assertEquals(true)
+    result.value.map {
+      case Left(InvalidMessageBodyFailure("Could not map JSON", _)) => true
+      case _ => false
+    }.assert
   }
 
   implicit val formats = org.json4s.DefaultFormats
@@ -83,12 +81,10 @@ trait Json4sSuite[J] extends JawnDecodeSupportSuite[JValue] {
   test("jsonExtract should handle extract failures") {
     val result = jsonExtract[IO, Foo]
       .decode(Request[IO]().withEntity(""""oops""""), strict = false)
-    result.value
-      .map {
-        case Left(InvalidMessageBodyFailure("Could not extract JSON", _)) => true
-        case _ => false
-      }
-      .assertEquals(true)
+    result.value.map {
+      case Left(InvalidMessageBodyFailure("Could not extract JSON", _)) => true
+      case _ => false
+    }.assert
   }
 
   test("JsonFormat[Uri] should round trip") {
@@ -109,7 +105,7 @@ trait Json4sSuite[J] extends JawnDecodeSupportSuite[JValue] {
     val req = Request[IO]()
       .withEntity("not a number")
       .withContentType(`Content-Type`(MediaType.application.json))
-    req.decodeJson[Int].attempt.map(_.isLeft).assertEquals(true)
+    req.decodeJson[Int].attempt.map(_.isLeft).assert
   }
 }
 

--- a/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
@@ -77,7 +77,7 @@ class PlaySuite extends JawnDecodeSupportSuite[JsValue] {
 
   test("Message[F].decodeJson[A] should fail on invalid json") {
     val req = Request[IO]().withEntity(Json.toJson(List(13, 14)))
-    req.decodeJson[Foo].attempt.map(_.isLeft).assertEquals(true)
+    req.decodeJson[Foo].attempt.map(_.isLeft).assert
   }
 
   test("PlayEntityCodec should decode json without defining EntityDecoder") {

--- a/server/src/test/scala/org/http4s/server/ContextRouterSuite.scala
+++ b/server/src/test/scala/org/http4s/server/ContextRouterSuite.scala
@@ -84,7 +84,7 @@ class ContextRouterSuite extends Http4sSuite {
           b =!= "bee" && b =!= "one" && resp.status === NotFound
         }
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("support root mappings") {
@@ -126,6 +126,6 @@ class ContextRouterSuite extends Http4sSuite {
     val router = ContextRouter[IO, Unit]("/foo" -> notFound)
     router(ContextRequest((), Request[IO](uri = uri"/bar"))).value
       .map(_ == Option.empty[Response[IO]])
-      .assertEquals(true)
+      .assert
   }
 }

--- a/server/src/test/scala/org/http4s/server/HttpRoutesSuite.scala
+++ b/server/src/test/scala/org/http4s/server/HttpRoutesSuite.scala
@@ -76,6 +76,6 @@ class HttpRoutesSuite extends Http4sSuite {
       .apply(Request[IO](uri = uri"/wontMatch"))
       .value
       .map(_ == Option.empty[Response[IO]])
-      .assertEquals(true)
+      .assert
   }
 }

--- a/server/src/test/scala/org/http4s/server/RouterSuite.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSuite.scala
@@ -80,7 +80,7 @@ class RouterSuite extends Http4sSuite {
           b =!= "bee" && b =!= "one" && res.status === NotFound
         }
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("support root mappings") {
@@ -118,6 +118,6 @@ class RouterSuite extends Http4sSuite {
     val router = Router[IO]("/foo" -> notFound)
     router(Request[IO](uri = uri"/bar")).value
       .map(_ == Option.empty[Response[IO]])
-      .assertEquals(true)
+      .assert
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
@@ -64,11 +64,11 @@ class CORSSuite extends Http4sSuite {
     cors1
       .orNotFound(req)
       .map(resp => matchHeader(resp.headers, `Access-Control-Allow-Credentials`, "true"))
-      .assertEquals(true) *>
+      .assert *>
       cors2
         .orNotFound(req)
         .map(resp => matchHeader(resp.headers, `Access-Control-Allow-Credentials`, "false"))
-        .assertEquals(true)
+        .assert
   }
 
   test("Respect Access-Control-Allow-Headers in preflight call") {
@@ -81,7 +81,7 @@ class CORSSuite extends Http4sSuite {
           `Access-Control-Allow-Headers`,
           "User-Agent, Keep-Alive, Content-Type")
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("Respect Access-Control-Expose-Headers in non-preflight call") {
@@ -91,7 +91,7 @@ class CORSSuite extends Http4sSuite {
       .map { resp =>
         matchHeader(resp.headers, `Access-Control-Expose-Headers`, "x-header")
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("Offer a successful reply to OPTIONS on fallthrough") {
@@ -103,7 +103,7 @@ class CORSSuite extends Http4sSuite {
           resp.headers,
           `Access-Control-Allow-Credentials`,
           "true"))
-      .assertEquals(true) *>
+      .assert *>
       cors2
         .orNotFound(req)
         .map(resp =>
@@ -111,13 +111,13 @@ class CORSSuite extends Http4sSuite {
             resp.headers,
             `Access-Control-Allow-Credentials`,
             "false"))
-        .assertEquals(true)
+        .assert
   }
 
   test("Always respond with 200 and empty body for OPTIONS request") {
     val req = buildRequest("/bar", OPTIONS)
-    cors1.orNotFound(req).map(_.headers.toList.exists(headerCheck _)).assertEquals(true) *>
-      cors2.orNotFound(req).map(_.headers.toList.exists(headerCheck _)).assertEquals(true)
+    cors1.orNotFound(req).map(_.headers.toList.exists(headerCheck _)).assert *>
+      cors2.orNotFound(req).map(_.headers.toList.exists(headerCheck _)).assert
   }
 
   test("Respond with 403 when origin is not valid") {
@@ -125,7 +125,7 @@ class CORSSuite extends Http4sSuite {
     cors2
       .orNotFound(req)
       .map(resp => resp.status.code == 403)
-      .assertEquals(true)
+      .assert
   }
 
   test("Fall through") {
@@ -149,7 +149,7 @@ class CORSSuite extends Http4sSuite {
       .map { resp =>
         matchHeader(resp.headers, `Vary`, "Origin,Accept")
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("Be created via httpRoutes constructor") {
@@ -159,7 +159,7 @@ class CORSSuite extends Http4sSuite {
     cors
       .orNotFound(req)
       .map(resp => matchHeader(resp.headers, `Access-Control-Allow-Credentials`, "true"))
-      .assertEquals(true)
+      .assert
   }
 
   test("Be created via httpApp constructor") {
@@ -169,6 +169,6 @@ class CORSSuite extends Http4sSuite {
     cors
       .run(req)
       .map(resp => matchHeader(resp.headers, `Access-Control-Allow-Credentials`, "true"))
-      .assertEquals(true)
+      .assert
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSuite.scala
@@ -64,7 +64,7 @@ class ChunkAggregatorSuite extends Http4sSuite {
   test("handle an empty body") {
     checkRoutesResponse(httpRoutes(EmptyBody, Nil)) { response =>
       response.body.compile.toVector.map(_.isEmpty && response.contentLength.isEmpty)
-    }.assertEquals(true)
+    }.assert
   }
 
   test("handle a none") {
@@ -74,7 +74,7 @@ class ChunkAggregatorSuite extends Http4sSuite {
       .run(Request())
       .value
       .map(_ == Option.empty[Response[IO]])
-      .assertEquals(true)
+      .assert
   }
 
   test("handle chunks") {
@@ -95,8 +95,7 @@ class ChunkAggregatorSuite extends Http4sSuite {
       (
         checkRoutesResponse(httpRoutes(body, transferCodings))(check),
         checkAppResponse(httpApp(body, transferCodings))(check)
-      ).mapN(_ && _)
-        .assertEquals(true)
+      ).mapN(_ && _).assert
     }
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
@@ -53,7 +53,7 @@ class DefaultHeadSuite extends Http4sSuite {
     val head = get.withMethod(Method.HEAD)
     val getHeaders = app(get).map(_.headers)
     val headHeaders = app(head).map(_.headers)
-    (getHeaders, headHeaders).parMapN(_ === _).assertEquals(true)
+    (getHeaders, headHeaders).parMapN(_ === _).assert
   }
 
   test("allow GET body to clean up on fallthrough") {

--- a/server/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
@@ -42,7 +42,7 @@ class GZipSuite extends Http4sSuite {
         resp.status === Status.Ok &&
         resp.headers.get(`Content-Encoding`).isEmpty
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("encodes random content-type if given isZippable is true") {
@@ -63,7 +63,7 @@ class GZipSuite extends Http4sSuite {
     gZIPStream.write(response.getBytes)
     gZIPStream.close()
 
-    actual.map(Arrays.equals(_, byteStream.toByteArray)).assertEquals(true)
+    actual.map(Arrays.equals(_, byteStream.toByteArray)).assert
   }
 
   test("encoding") {
@@ -83,7 +83,7 @@ class GZipSuite extends Http4sSuite {
       gzipStream.close()
       val expected = byteArrayStream.toByteArray
 
-      actual.map(Arrays.equals(_, expected)).assertEquals(true)
+      actual.map(Arrays.equals(_, expected)).assert
     }
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/HSTSSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HSTSSuite.scala
@@ -39,7 +39,7 @@ class HSTSSuite extends Http4sSuite {
       HSTS.httpApp.unsafeFromDuration(innerRoutes.orNotFound, 365.days)
     ).traverse { app =>
       app(req).map(_.status).assertEquals(Status.Ok) *>
-        app(req).map(_.headers.get(`Strict-Transport-Security`).isDefined).assertEquals(true)
+        app(req).map(_.headers.get(`Strict-Transport-Security`).isDefined).assert
     }
   }
 
@@ -52,7 +52,7 @@ class HSTSSuite extends Http4sSuite {
       HSTS.httpApp(innerRoutes.orNotFound)
     ).traverse { app =>
       app(req).map(_.status).assertEquals(Status.Ok) *>
-        app(req).map(_.headers.get(`Strict-Transport-Security`).isDefined).assertEquals(true)
+        app(req).map(_.headers.get(`Strict-Transport-Security`).isDefined).assert
     }
   }
 
@@ -63,7 +63,7 @@ class HSTSSuite extends Http4sSuite {
       HSTS.httpApp(innerRoutes.orNotFound)
     ).traverse { app =>
       app(req).map(_.status).assertEquals(Status.Ok) *>
-        app(req).map(_.headers.get(`Strict-Transport-Security`).isDefined).assertEquals(true)
+        app(req).map(_.headers.get(`Strict-Transport-Security`).isDefined).assert
     }
   }
 

--- a/server/src/test/scala/org/http4s/server/middleware/HeaderEchoSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HeaderEchoSuite.scala
@@ -51,7 +51,7 @@ class HeaderEchoSuite extends Http4sSuite {
   test("echo a single header in addition to the defaults") {
     testSingleHeader(
       HeaderEcho(_ === CaseInsensitiveString("someheaderkey"))(testService).orNotFound
-    ).assertEquals(true)
+    ).assert
   }
 
   test("echo multiple headers") {
@@ -74,7 +74,7 @@ class HeaderEchoSuite extends Http4sSuite {
         responseHeaders.exists(_.value === "anotherheadervalue") &&
         responseHeaders.toList.length === 4
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("echo only the default headers where none match the key") {
@@ -92,18 +92,19 @@ class HeaderEchoSuite extends Http4sSuite {
         !responseHeaders.exists(_.value === "someunmatchedvalue") &&
         responseHeaders.toList.length === 2
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("be created via the httpRoutes constructor") {
     testSingleHeader(
-      HeaderEcho.httpRoutes(_ == CaseInsensitiveString("someheaderkey"))(testService).orNotFound)
-      .assertEquals(true)
+      HeaderEcho
+        .httpRoutes(_ == CaseInsensitiveString("someheaderkey"))(testService)
+        .orNotFound).assert
   }
 
   test("be created via the httpApps constructor") {
     testSingleHeader(
-      HeaderEcho.httpApp(_ == CaseInsensitiveString("someheaderkey"))(testService.orNotFound))
-      .assertEquals(true)
+      HeaderEcho.httpApp(_ == CaseInsensitiveString("someheaderkey"))(
+        testService.orNotFound)).assert
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSuite.scala
@@ -82,18 +82,16 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withHeaders(Header(overrideHeader, "PUT"))
     val app = HttpMethodOverrider(testApp, noMethodHeaderOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ === mkResponseText(
-              msg = "resource's details",
-              reqMethod = GET,
-              overriddenMethod = None) &&
-              res.status === Status.Ok)
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ === mkResponseText(
+            msg = "resource's details",
+            reqMethod = GET,
+            overriddenMethod = None) &&
+            res.status === Status.Ok)
+    }.assert
   }
 
   test(
@@ -103,19 +101,17 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withHeaders(Header(overrideHeader, "PUT"))
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ === mkResponseText(
-              msg = "resource updated",
-              reqMethod = PUT,
-              overriddenMethod = Some(POST)) &&
-              res.status === Status.Ok
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ === mkResponseText(
+            msg = "resource updated",
+            reqMethod = PUT,
+            overriddenMethod = Some(POST)) &&
+            res.status === Status.Ok
+        )
+    }.assert
   }
 
   test(
@@ -124,19 +120,17 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withMethod(DELETE)
     val app = HttpMethodOverrider(testApp, deleteHeaderOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ ===
-              mkResponseText(
-                msg = "resource deleted",
-                reqMethod = DELETE,
-                overriddenMethod = None) && res.status === Status.Ok
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ ===
+            mkResponseText(
+              msg = "resource deleted",
+              reqMethod = DELETE,
+              overriddenMethod = None) && res.status === Status.Ok
+        )
+    }.assert
   }
 
   test(
@@ -145,18 +139,16 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ === mkResponseText(
-              msg = "resource updated",
-              reqMethod = PUT,
-              overriddenMethod = Some(POST)) && res.status === Status.Ok
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ === mkResponseText(
+            msg = "resource updated",
+            reqMethod = PUT,
+            overriddenMethod = Some(POST)) && res.status === Status.Ok
+        )
+    }.assert
   }
 
   test(
@@ -165,19 +157,17 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withMethod(DELETE)
     val app = HttpMethodOverrider(testApp, deleteQueryOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ ===
-              mkResponseText(
-                msg = "resource deleted",
-                reqMethod = DELETE,
-                overriddenMethod = None) && res.status === Status.Ok
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ ===
+            mkResponseText(
+              msg = "resource deleted",
+              reqMethod = DELETE,
+              overriddenMethod = None) && res.status === Status.Ok
+        )
+    }.assert
   }
 
   test(
@@ -188,18 +178,16 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ === mkResponseText(
-              msg = "resource updated",
-              reqMethod = PUT,
-              overriddenMethod = Some(POST)) && res.status === Status.Ok
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ === mkResponseText(
+            msg = "resource updated",
+            reqMethod = PUT,
+            overriddenMethod = Some(POST)) && res.status === Status.Ok
+        )
+    }.assert
   }
 
   test(
@@ -210,18 +198,16 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withMethod(DELETE)
     val app = HttpMethodOverrider(testApp, deleteFormOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ === mkResponseText(
-              msg = "resource deleted",
-              reqMethod = DELETE,
-              overriddenMethod = None) && res.status === Status.Ok
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ === mkResponseText(
+            msg = "resource deleted",
+            reqMethod = DELETE,
+            overriddenMethod = None) && res.status === Status.Ok
+        )
+    }.assert
   }
 
   test(
@@ -371,19 +357,17 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withHeaders(Header(overrideHeader, "DELETE"))
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ === mkResponseText(
-              msg = "resource deleted",
-              reqMethod = DELETE,
-              overriddenMethod = Some(POST)) && res.status === Status.Ok &&
-              res.headers.toList.exists(_ === Header(varyHeader, s"$overrideHeader"))
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ === mkResponseText(
+            msg = "resource deleted",
+            reqMethod = DELETE,
+            overriddenMethod = Some(POST)) && res.status === Status.Ok &&
+            res.headers.toList.exists(_ === Header(varyHeader, s"$overrideHeader"))
+        )
+    }.assert
   }
 
   test(
@@ -392,20 +376,18 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ ===
-              mkResponseText(
-                msg = "resource deleted",
-                reqMethod = DELETE,
-                overriddenMethod = Some(POST)) && res.status === Status.Ok &&
-              !res.headers.exists(_.name === CaseInsensitiveString(varyHeader))
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ ===
+            mkResponseText(
+              msg = "resource deleted",
+              reqMethod = DELETE,
+              overriddenMethod = Some(POST)) && res.status === Status.Ok &&
+            !res.headers.exists(_.name === CaseInsensitiveString(varyHeader))
+        )
+    }.assert
   }
 
   test(
@@ -414,20 +396,18 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ ===
-              mkResponseText(
-                msg = "resource updated",
-                reqMethod = PUT,
-                overriddenMethod = Some(POST)) && res.status === Status.Ok &&
-              res.headers.toList.exists(_ === Header(varyHeader, s"$customHeader"))
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ ===
+            mkResponseText(
+              msg = "resource updated",
+              reqMethod = PUT,
+              overriddenMethod = Some(POST)) && res.status === Status.Ok &&
+            res.headers.toList.exists(_ === Header(varyHeader, s"$customHeader"))
+        )
+    }.assert
   }
 
   test(
@@ -438,18 +418,16 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res.as[String].map {
-          _ ===
-            mkResponseText(
-              msg = "resource deleted",
-              reqMethod = DELETE,
-              overriddenMethod = Some(POST)) && res.status === Status.Ok && !res.headers.toList
-              .exists(_.name === CaseInsensitiveString(varyHeader))
-        }
+    app(req).flatMap { res =>
+      res.as[String].map {
+        _ ===
+          mkResponseText(
+            msg = "resource deleted",
+            reqMethod = DELETE,
+            overriddenMethod = Some(POST)) && res.status === Status.Ok && !res.headers.toList
+            .exists(_.name === CaseInsensitiveString(varyHeader))
       }
-      .assertEquals(true)
+    }.assert
   }
 
   test(
@@ -460,20 +438,18 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
 
-    app(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ ===
-              mkResponseText(
-                msg = "resource updated",
-                reqMethod = PUT,
-                overriddenMethod = Some(POST)) && res.status === Status.Ok &&
-              res.headers.toList.exists(_ === Header(varyHeader, s"$customHeader"))
-          )
-      }
-      .assertEquals(true)
+    app(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ ===
+            mkResponseText(
+              msg = "resource updated",
+              reqMethod = PUT,
+              overriddenMethod = Some(POST)) && res.status === Status.Ok &&
+            res.headers.toList.exists(_ === Header(varyHeader, s"$customHeader"))
+        )
+    }.assert
 
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -53,15 +53,13 @@ class LoggerSuite extends Http4sSuite {
 
   test("response should not affect a Post") {
     val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
-    respApp(req)
-      .flatMap { res =>
-        res
-          .as[String]
-          .map(
-            _ === expectedBody && res.status === (Status.Ok)
-          )
-      }
-      .assertEquals(true)
+    respApp(req).flatMap { res =>
+      res
+        .as[String]
+        .map(
+          _ === expectedBody && res.status === (Status.Ok)
+        )
+    }.assert
   }
 
   val reqApp = RequestLogger.httpApp(logHeaders = true, logBody = true)(testApp)
@@ -73,11 +71,9 @@ class LoggerSuite extends Http4sSuite {
 
   test("request should not affect a Post") {
     val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
-    reqApp(req)
-      .flatMap { res =>
-        res.as[String].map(_ === expectedBody && res.status === Status.Ok)
-      }
-      .assertEquals(true)
+    reqApp(req).flatMap { res =>
+      res.as[String].map(_ === expectedBody && res.status === Status.Ok)
+    }.assert
   }
 
   val loggerApp = Logger.httpApp(logHeaders = true, logBody = true)(testApp)
@@ -89,10 +85,8 @@ class LoggerSuite extends Http4sSuite {
 
   test("logger should not affect a Post") {
     val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
-    loggerApp(req)
-      .flatMap { res =>
-        res.as[String].map(_ === expectedBody && res.status === Status.Ok)
-      }
-      .assertEquals(true)
+    loggerApp(req).flatMap { res =>
+      res.as[String].map(_ === expectedBody && res.status === Status.Ok)
+    }.assert
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/RequestIdSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/RequestIdSuite.scala
@@ -52,7 +52,7 @@ class RequestIdSuite extends Http4sSuite {
         requestIdFromBody(resp).map(_ -> requestIdFromHeaders(resp))
       }
       .map { case (req, resp) => req === "123" && resp === "123" }
-      .assertEquals(true)
+      .assert
   }
 
   test("generate X-Request-ID header when unset") {
@@ -66,7 +66,7 @@ class RequestIdSuite extends Http4sSuite {
       .map { case (reqReqId, respReqId) =>
         reqReqId === respReqId && Either.catchNonFatal(UUID.fromString(respReqId)).isRight
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("generate different request ids on subsequent requests") {
@@ -74,7 +74,7 @@ class RequestIdSuite extends Http4sSuite {
     val resp = RequestId.httpRoutes(testService()).orNotFound(req)
     (resp.map(requestIdFromHeaders(_)), resp.map(requestIdFromHeaders(_)))
       .parMapN(_ =!= _)
-      .assertEquals(true)
+      .assert
   }
 
   test("propagate custom request id header from request to response") {
@@ -90,7 +90,7 @@ class RequestIdSuite extends Http4sSuite {
       .map { case (reqReqId, respReqId) =>
         reqReqId === "abc" && respReqId === "abc"
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("generate custom request id header when unset") {
@@ -105,7 +105,7 @@ class RequestIdSuite extends Http4sSuite {
       .map { case (reqReqId, respReqId) =>
         reqReqId === respReqId && Either.catchNonFatal(UUID.fromString(respReqId)).isRight
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("generate X-Request-ID header when unset using supplied generator") {
@@ -120,7 +120,7 @@ class RequestIdSuite extends Http4sSuite {
       .map { case (reqReqId, respReqId) =>
         reqReqId === uuid.show && respReqId === uuid.show
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("include requestId attribute with request and response") {
@@ -136,6 +136,6 @@ class RequestIdSuite extends Http4sSuite {
       .map { case (reqReqId, respReqId) =>
         reqReqId === "123" && respReqId === "123"
       }
-      .assertEquals(true)
+      .assert
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ResponseTimingSuite.scala
@@ -45,7 +45,7 @@ class ResponseTimingSuite extends Http4sSuite {
       .map(_.headers.find(_.name == CaseInsensitiveString("X-Response-Time")))
     header
       .map(_.forall(_.value.toInt === artificialDelay))
-      .assertEquals(true)
+      .assert
   }
 }
 

--- a/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/StaticHeadersSuite.scala
@@ -35,6 +35,6 @@ class StaticHeadersSuite extends Http4sSuite {
 
     resp
       .map(_.headers.toList.map(_.toString).contains("Cache-Control: no-cache"))
-      .assertEquals(true)
+      .assert
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
@@ -36,16 +36,14 @@ class ThrottleSuite extends Http4sSuite {
     val createBucket =
       TokenBucket.local[IO](capacity, someRefillTime)(ioEffect, munitTimer.clock)
 
-    createBucket
-      .flatMap { testee =>
-        val takeFiveTokens: IO[List[TokenAvailability]] =
-          (1 to 5).toList.traverse(_ => testee.takeToken)
-        val checkTokensUpToCapacity =
-          takeFiveTokens.map(tokens => tokens.exists(_ == TokenAvailable))
-        (checkTokensUpToCapacity, testee.takeToken.map(_.isInstanceOf[TokenUnavailable]))
-          .mapN(_ && _)
-      }
-      .assertEquals(true)
+    createBucket.flatMap { testee =>
+      val takeFiveTokens: IO[List[TokenAvailability]] =
+        (1 to 5).toList.traverse(_ => testee.takeToken)
+      val checkTokensUpToCapacity =
+        takeFiveTokens.map(tokens => tokens.exists(_ == TokenAvailable))
+      (checkTokensUpToCapacity, testee.takeToken.map(_.isInstanceOf[TokenUnavailable]))
+        .mapN(_ && _)
+    }.assert
   }
 
   test("LocalTokenBucket should add another token at specified interval when not at capacity") {
@@ -87,7 +85,7 @@ class ThrottleSuite extends Http4sSuite {
         result
       }
       .map(_.isInstanceOf[TokenUnavailable])
-      .assertEquals(true)
+      .assert
   }
 
   test(
@@ -118,15 +116,13 @@ class ThrottleSuite extends Http4sSuite {
       testee.takeToken *> munitTimer.sleep(75.milliseconds) *> testee.takeToken
     }
 
-    takeTwoTokens
-      .map { result =>
-        ctx.tick(75.milliseconds)
-        result match {
-          case TokenUnavailable(t) => t.exists(_ <= 25.milliseconds)
-          case _ => false
-        }
+    takeTwoTokens.map { result =>
+      ctx.tick(75.milliseconds)
+      result match {
+        case TokenUnavailable(t) => t.exists(_ <= 25.milliseconds)
+        case _ => false
       }
-      .assertEquals(true)
+    }.assert
   }
   val alwaysOkApp = HttpApp[IO] { _ =>
     Ok()
@@ -140,7 +136,7 @@ class ThrottleSuite extends Http4sSuite {
     val testee = Throttle(limitNotReachedBucket, defaultResponse[IO] _)(alwaysOkApp)
     val req = Request[IO](uri = uri"/")
 
-    testee(req).map(_.status === Status.Ok).assertEquals(true)
+    testee(req).map(_.status === Status.Ok).assert
   }
 
   test(" Throttle / should deny a request when the rate limit had been reached") {
@@ -151,6 +147,6 @@ class ThrottleSuite extends Http4sSuite {
     val testee = Throttle(limitReachedBucket, defaultResponse[IO] _)(alwaysOkApp)
     val req = Request[IO](uri = uri"/")
 
-    testee(req).map(_.status === Status.TooManyRequests).assertEquals(true)
+    testee(req).map(_.status === Status.TooManyRequests).assert
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSuite.scala
@@ -50,7 +50,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
           _ === "Unauthorized" && res.status === Forbidden
         }
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("enrich the request with a user when authentication returns Either.Right") {
@@ -78,7 +78,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
           _ === "42" && res.status === Ok
         }
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("not find a route if requested with the wrong verb inside an authenticated route") {

--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSuite.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSuite.scala
@@ -72,7 +72,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultSystemPath).resolve(relativePath).toFile
     val uri = Uri.unsafeFromString("/path-prefix/" + relativePath)
     val req = Request[IO](uri = uri)
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
@@ -88,7 +88,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
         systemPath = systemPath.toString,
         blocker = testBlocker
       ))
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
@@ -98,7 +98,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
 
     val uri = Uri.unsafeFromString("/" + relativePath)
     val req = Request[IO](uri = uri)
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
@@ -114,7 +114,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
         systemPath = Paths.get(defaultSystemPath).resolve("test").toString,
         blocker = testBlocker
       ))
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.NotFound)
   }
 
@@ -131,7 +131,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
         pathPrefix = "/prefix",
         blocker = testBlocker
       ))
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.NotFound)
   }
 
@@ -141,7 +141,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
 
     val uri = Uri.unsafeFromString("///" + absPath)
     val req = Request[IO](uri = uri)
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
@@ -153,9 +153,8 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
 
     val uri = Uri.unsafeFromString("/" + relativePath)
     val req = Request[IO](uri = uri)
-    IO(file.exists()).assertEquals(true) *>
-      IO(Files.isSymbolicLink(Paths.get(defaultSystemPath).resolve("symlink")))
-        .assertEquals(true) *>
+    IO(file.exists()).assert *>
+      IO(Files.isSymbolicLink(Paths.get(defaultSystemPath).resolve("symlink"))).assert *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.Ok) *>
       Stream
         .eval(routes.orNotFound(req))
@@ -175,7 +174,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
           _ === "<html>Hello!</html>" && res.status === Status.Ok
         }
       }
-      .assertEquals(true)
+      .assert
   }
 
   test("Return index.html if request points to '/'") {
@@ -186,7 +185,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
 
     rb.flatMap { res =>
       res.as[String].map(_ === "<html>Hello!</html>" && res.status === Status.Ok)
-    }.assertEquals(true)
+    }.assert
   }
 
   test("Return index.html if request points to a directory") {
@@ -196,7 +195,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     rb.flatMap { case (_, re) =>
       re.as[String]
         .map(_ === "<html>Hello!</html>" && re.status === Status.Ok)
-    }.assertEquals(true)
+    }.assert
   }
 
   test("Not find missing file") {
@@ -257,7 +256,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
           .orNotFound(req)
           .map(_.headers.toList.exists(
             _ === headers.`Content-Range`(SubRange(0, size - 1), Some(size))))
-          .assertEquals(true)
+          .assert
     }
   }
 
@@ -267,7 +266,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
 
   test("handle a relative system path") {
     val s = fileService(FileService.Config[IO](".", blocker = testBlocker))
-    IO(Paths.get(".").resolve("build.sbt").toFile.exists()).assertEquals(true) *>
+    IO(Paths.get(".").resolve("build.sbt").toFile.exists()).assert *>
       s.orNotFound(Request[IO](uri = uri"/build.sbt")).map(_.status).assertEquals(Status.Ok)
   }
 

--- a/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSuite.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSuite.scala
@@ -74,7 +74,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultBase).resolve(relativePath).toFile
     val uri = Uri.unsafeFromString("/path-prefix/" + relativePath)
     val req = Request[IO](uri = uri)
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
@@ -90,7 +90,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
         basePath = "/testDir",
         blocker = testBlocker
       ))
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
@@ -100,7 +100,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
 
     val uri = Uri.unsafeFromString("/" + relativePath)
     val req = Request[IO](uri = uri)
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
@@ -116,7 +116,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
         basePath = "",
         blocker = testBlocker
       ))
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.NotFound)
   }
 
@@ -133,7 +133,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
         blocker = testBlocker,
         pathPrefix = "/test"
       ))
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.NotFound)
   }
 
@@ -148,7 +148,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
         basePath = "/testDir",
         blocker = testBlocker
       ))
-    IO(file.exists()).assertEquals(true) *>
+    IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
@@ -180,7 +180,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
         .assertEquals(MediaType.text.plain.some) *>
       rb.map(_.headers.get(`Content-Encoding`).map(_.contentCoding))
         .map(_ =!= ContentCoding.gzip.some)
-        .assertEquals(true)
+        .assert
   }
 
   test("Generate non on missing content") {

--- a/tests/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -440,8 +440,8 @@ class EntityDecoderSuite extends Http4sSuite {
           response.body.compile.toVector
             .map(_.toArray)
             .map(Arrays.equals(_, "Hello".getBytes))
-            .assertEquals(true) *>
-            readFile(tmpFile).map(Arrays.equals(_, binData)).assertEquals(true)
+            .assert *>
+            readFile(tmpFile).map(Arrays.equals(_, binData)).assert
         }
       }
   }

--- a/tests/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -106,7 +106,7 @@ class StaticFileSuite extends Http4sSuite {
   test("handle an empty file") {
     val emptyFile = File.createTempFile("empty", ".tmp")
 
-    StaticFile.fromFile[IO](emptyFile, testBlocker).value.map(_.isDefined).assertEquals(true)
+    StaticFile.fromFile[IO](emptyFile, testBlocker).value.map(_.isDefined).assert
   }
 
   test("Don't send unmodified files") {
@@ -245,7 +245,7 @@ class StaticFileSuite extends Http4sSuite {
                       .equals(
                         bytes.toArray,
                         java.util.Arrays.copyOfRange(gibberish, 0, fileSize - 1)))
-                  .assertEquals(true)
+                  .assert
             }
             .getOrElse(IO.raiseError(new RuntimeException("test error")))
         }

--- a/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSuite.scala
+++ b/tomcat/src/test/scala/org/http4s/tomcat/TomcatServerSuite.scala
@@ -96,16 +96,16 @@ class TomcatServerSuite extends Http4sSuite {
   tomcatServer.test("server should route requests on the service executor") { server =>
     get(server, "/thread/routing")
       .map(_.startsWith("http4s-spec-"))
-      .assertEquals(true)
+      .assert
   }
 
   tomcatServer.test("server should execute the service task on the service executor") { server =>
-    get(server, "/thread/effect").map(_.startsWith("http4s-spec-")).assertEquals(true)
+    get(server, "/thread/effect").map(_.startsWith("http4s-spec-")).assert
   }
 
   tomcatServer.test("server should be able to echo its input") { server =>
     val input = """{ "Hello": "world" }"""
-    post(server, "/echo", input).map(_.startsWith(input)).assertEquals(true)
+    post(server, "/echo", input).map(_.startsWith(input)).assert
   }
 
   tomcatServer.test("Timeout should not fire prematurely") { server =>


### PR DESCRIPTION
munit-cats-effect added a while ago a plain `assert` method that can be used instead of `assertEquals(true)`. This PR does that substitution across all tests