### PR TITLE
Drop the NowarnCompatPlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,6 @@ lazy val core = libraryProject("core")
   .enablePlugins(
     BuildInfoPlugin,
     MimeLoaderPlugin,
-    NowarnCompatPlugin,
   )
   .settings(
     description := "Core http4s library for servers and clients",
@@ -149,7 +148,6 @@ lazy val tests = libraryProject("tests")
   .dependsOn(core, testing % "test->test")
 
 lazy val server = libraryProject("server")
-  .enablePlugins(NowarnCompatPlugin)
   .settings(
     description := "Base library for building http4s servers",
     startYear := Some(2014),
@@ -183,7 +181,6 @@ lazy val prometheusMetrics = libraryProject("prometheus-metrics")
   )
 
 lazy val client = libraryProject("client")
-  .enablePlugins(NowarnCompatPlugin)
   .settings(
     description := "Base library for building http4s clients",
     startYear := Some(2014),


### PR DESCRIPTION
All supported versions of Scala now support the `@nowarn` annotation, so we no longer need this build plugin to set up silencer.

The annotation must remain for bincopmat reasons, but is cleaned up in #4239.