### PR TITLE
Ember Entity Encoding No ContentLength or TransferEncoding on NoEntityAllowed status'

### DIFF
--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -54,7 +54,7 @@ private[ember] object Encoder {
           .append(CRLF)
         ()
       }
-      if (!chunked && !appliedContentLength) {
+      if (!chunked && !appliedContentLength && resp.status.isEntityAllowed) {
         stringBuilder.append(chunkedTansferEncodingHeaderRaw).append(CRLF)
         chunked = true
         ()

--- a/ember-core/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -123,6 +123,16 @@ class EncoderSuite extends Http4sSuite {
     Helpers.encodeResponseRig(resp).assertEquals(expected)
   }
 
+  test("encoder a response where entity is not allowed correctly") {
+    val resp = Response[IO](Status.NoContent)
+    val expected =
+      """HTTP/1.1 204 No Content
+      |
+      |""".stripMargin
+
+    Helpers.encodeResponseRig(resp).assertEquals(expected)
+  }
+
   test("encode a response with a body correctly") {
     val resp = Response[IO](Status.NotFound)
       .withEntity("Not Found")


### PR DESCRIPTION
This previously would have encoded as chunked encoding, and then had a single empty buffer flush which is unnecessary for these.