### PR TITLE
Match HttpDateSuite current test with HttpDateSpec

### DIFF
--- a/tests/src/test/scala/org/http4s/HttpDateSuite.scala
+++ b/tests/src/test/scala/org/http4s/HttpDateSuite.scala
@@ -23,8 +23,8 @@ class HttpDateSuite extends Http4sSuite {
   test("current should be within a second of Instant.now") {
     for {
       current <- HttpDate.current[IO]
-      now <- IO.delay(java.time.Instant.now).map(HttpDate.unsafeFromInstant)
-      diff = current.epochSecond - now.epochSecond
+      now <- IO(HttpDate.unsafeFromInstant(java.time.Instant.now))
+      diff = now.epochSecond - current.epochSecond
     } yield assert(diff == 0 || diff == 1, "diff was " + diff)
   }
 


### PR DESCRIPTION
This is kind of a wild guess attempt to fix https://github.com/http4s/http4s/issues/4341

All I've done is change this test to match the existing one in HttpDateSpec which does not have the "extra" `IO.map` call:
https://github.com/http4s/http4s/blob/79c78d164b1d05e812a10bc10f4160f89b2d8ef5/tests/src/test/scala/org/http4s/HttpDateSpec.scala#L27

