### PR TITLE
Header cleanups

### DIFF
--- a/core/src/main/scala/org/http4s/HeaderKey.scala
+++ b/core/src/main/scala/org/http4s/HeaderKey.scala
@@ -53,7 +53,6 @@ object HeaderKey {
     */
   trait Recurring extends Extractable {
     type HeaderT <: Header.Recurring
-    type GetT = Option[HeaderT]
 
     def apply(values: NonEmptyList[HeaderT#Value]): HeaderT
 

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -42,13 +42,6 @@ final class Headers private (private val headers: List[Header]) extends AnyVal {
     */
   def get(key: HeaderKey.Extractable): Option[key.HeaderT] = key.from(this)
 
-  @deprecated(
-    "Use response.cookies instead. Set-Cookie is unique among HTTP headers in that it can be repeated but can't be joined by a ','. This will return only the first Set-Cookie header. `response.cookies` will return the complete list.",
-    "0.16.0-RC1"
-  )
-  def get(key: `Set-Cookie`.type): Option[`Set-Cookie`] =
-    key.from(this).headOption
-
   /** Attempt to get a [[org.http4s.Header]] from this collection of headers
     *
     * @param key name of the header to find


### PR DESCRIPTION
Some quick wins while we get the header working on Dotty:

* `GetT` is vestigial.
* ``get(`Set-Cookie`)`` has been deprecated since 0.16!
~~* The signature of default `unapply` methods changes in Scala 3, and we're not using the one on `HeaderKey` anyway.~~
