### PR TITLE
Fix flaky User-Agent header test

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/Http1ClientStageSuite.scala
@@ -114,6 +114,7 @@ class Http1ClientStageSuite extends Http4sSuite {
       result <- response.as[String]
       _ <- IO(h.stageShutdown())
       buff <- IO.fromFuture(IO(h.result))
+      _ <- d.get
       request = new String(buff.array(), StandardCharsets.ISO_8859_1)
     } yield (request, result)
 


### PR DESCRIPTION
Wait for request to be read before gathering it.  Without this, there's a race condition, and sometimes we assert on a partial request.

Fixes #4151.