### PR TITLE
Deprecate unused Header.Recurring.GetT

### DIFF
--- a/core/src/main/scala/org/http4s/HeaderKey.scala
+++ b/core/src/main/scala/org/http4s/HeaderKey.scala
@@ -54,6 +54,8 @@ object HeaderKey {
     */
   trait Recurring extends Extractable {
     type HeaderT <: Header.Recurring
+
+    @deprecated("Unused. Will be removed in 0.22.", "0.21.19")
     type GetT = Option[HeaderT]
 
     def apply(values: NonEmptyList[HeaderT#Value]): HeaderT


### PR DESCRIPTION
This is unused in http4s.  I had forgotten it exists.  And as of #4352, it's gone.  Let's warn others.