### PR TITLE
Advance cleanup of Dotty warnings

### DIFF
--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -99,14 +99,12 @@ object HttpVersion {
       case HttpVersion(major, minor) if fromVersion(major, minor).isLeft => None
       case HttpVersion(major, 9) => Some(HttpVersion(major + 1, 0))
       case HttpVersion(major, minor) => Some(HttpVersion(major, minor + 1))
-      case _ => None
     }
     override def partialPrevious(a: HttpVersion): Option[HttpVersion] = a match {
       case HttpVersion(0, 0) => None
       case HttpVersion(major, minor) if fromVersion(major, minor).isLeft => None
       case HttpVersion(major, 0) => Some(HttpVersion(major - 1, 9))
       case HttpVersion(major, minor) => Some(HttpVersion(major, minor - 1))
-      case _ => None
     }
     override def order: Order[HttpVersion] = self
     override def minBound: HttpVersion = HttpVersion(0, 0)

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -306,7 +306,6 @@ object Uri {
         case Authority(Some(u), h, Some(p)) => writer << u << '@' << h << ':' << p
         case Authority(None, h, Some(p)) => writer << h << ':' << p
         case Authority(_, h, _) => writer << h
-        case _ => writer
       }
   }
 
@@ -426,7 +425,6 @@ object Uri {
         case RegName(n) => writer << n
         case a: Ipv4Address => writer << a.value
         case a: Ipv6Address => writer << '[' << a << ']'
-        case _ => writer
       }
   }
 

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -218,7 +218,6 @@ object UriTemplate {
       case Authority(Some(u), h, Some(p)) => s"${renderUserInfo(u)}@${renderHost(h)}:${p}"
       case Authority(None, h, Some(p)) => renderHost(h) + ":" + p
       case Authority(_, h, _) => renderHost(h)
-      case _ => ""
     }
 
   protected def renderUserInfo(u: UserInfo): String =
@@ -233,7 +232,6 @@ object UriTemplate {
       case RegName(n) => n.toString
       case a: Ipv4Address => a.value
       case a: Ipv6Address => "[" + a.value + "]"
-      case _ => ""
     }
 
   protected def renderScheme(s: Scheme): String =
@@ -329,7 +327,6 @@ object UriTemplate {
           case VarExp(ns) => elements.append("{" + ns.mkString(",") + "}")
           case ReservedExp(ns) => elements.append("{+" + ns.mkString(",") + "}")
           case PathExp(ns) => elements.append("{/" + ns.mkString(",") + "}")
-          case u => throw new IllegalStateException(s"type ${u.getClass.getName} not supported")
         }
         elements.mkString
     }
@@ -345,8 +342,6 @@ object UriTemplate {
       case UriTemplate(_, _, path, Nil, f) => renderPath(path) + renderFragment(f)
       case UriTemplate(_, _, path, query, f) =>
         renderPath(path) + renderQuery(query) + renderFragment(f)
-
-      case _ => ""
     }
 
   protected def renderUriTemplate(t: UriTemplate): String =
@@ -355,7 +350,6 @@ object UriTemplate {
       case UriTemplate(Some(_), Some(_), Nil, Nil, Nil) => renderSchemeAndAuthority(t)
       case UriTemplate(scheme @ _, authority @ _, path @ _, params @ _, fragment @ _) =>
         renderSchemeAndAuthority(t) + renderPathAndQueryAndFragment(t)
-      case _ => ""
     }
 
   protected def fragmentExp(f: FragmentDef): Boolean =


### PR DESCRIPTION
These only warn on Dotty, but Dotty is right.  They can only match null, and we don't need them.