### PR TITLE
Deprecate http4s-argonaut

### DIFF
--- a/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/ArgonautInstances.scala
@@ -25,14 +25,18 @@ import org.http4s.headers.`Content-Type`
 import jawn.JawnInstances
 import org.typelevel.jawn.ParseException
 import org.http4s.argonaut.ArgonautInstances.DecodeFailureMessage
+import scala.annotation.nowarn
 
 trait ArgonautInstances extends JawnInstances {
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
   implicit def jsonDecoder[F[_]: Sync]: EntityDecoder[F, Json] =
     jawnDecoder
 
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
   protected def jsonDecodeError: (Json, DecodeFailureMessage, CursorHistory) => DecodeFailure =
     ArgonautInstances.defaultJsonDecodeError
 
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
   def jsonOf[F[_]: Sync, A](implicit decoder: DecodeJson[A]): EntityDecoder[F, A] =
     jsonDecoder[F].flatMapR { json =>
       decoder
@@ -43,24 +47,30 @@ trait ArgonautInstances extends JawnInstances {
         )
     }
 
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
   protected def defaultPrettyParams: PrettyParams = PrettyParams.nospace
 
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
   implicit def jsonEncoder[F[_]]: EntityEncoder[F, Json] =
     jsonEncoderWithPrettyParams[F](defaultPrettyParams)
 
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
   def jsonEncoderWithPrettyParams[F[_]](prettyParams: PrettyParams): EntityEncoder[F, Json] =
     EntityEncoder
       .stringEncoder(Charset.`UTF-8`)
       .contramap[Json](prettyParams.pretty)
       .withContentType(`Content-Type`(MediaType.application.json))
 
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
   def jsonEncoderOf[F[_], A](implicit encoder: EncodeJson[A]): EntityEncoder[F, A] =
     jsonEncoderWithPrinterOf(defaultPrettyParams)
 
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
   def jsonEncoderWithPrinterOf[F[_], A](prettyParams: PrettyParams)(implicit
       encoder: EncodeJson[A]): EntityEncoder[F, A] =
     jsonEncoderWithPrettyParams[F](prettyParams).contramap[A](encoder.encode)
 
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
   implicit val uriCodec: CodecJson[Uri] = CodecJson(
     (uri: Uri) => Json.jString(uri.toString),
     c =>
@@ -71,12 +81,15 @@ trait ArgonautInstances extends JawnInstances {
             .fold(err => ArgDecodeResult.fail(err.toString, c.history), ArgDecodeResult.ok))
   )
 
+  @deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
+  @nowarn("cat=deprecation")
   implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
     def decodeJson[A](implicit decoder: DecodeJson[A]): F[A] =
       self.as(implicitly, jsonOf[F, A])
   }
 }
 
+@deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
 sealed abstract case class ArgonautInstancesBuilder private[argonaut] (
     defaultPrettyParams: PrettyParams = PrettyParams.nospace,
     jsonDecodeError: (Json, String, CursorHistory) => DecodeFailure =
@@ -121,6 +134,7 @@ sealed abstract case class ArgonautInstancesBuilder private[argonaut] (
     }
 }
 
+@deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
 object ArgonautInstances {
   type DecodeFailureMessage = String
   def withPrettyParams(pp: PrettyParams): ArgonautInstancesBuilder =

--- a/argonaut/src/main/scala/org/http4s/argonaut/Parser.scala
+++ b/argonaut/src/main/scala/org/http4s/argonaut/Parser.scala
@@ -15,6 +15,7 @@ import org.typelevel.jawn._
 import scala.collection.mutable
 
 /* Temporary parser until jawn-argonaut supports 6.2.x. */
+@deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
 private[argonaut] object Parser extends SupportParser[Json] {
   implicit val facade: Facade[Json] =
     new Facade.NoIndexFacade[Json] {

--- a/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSuite.scala
+++ b/argonaut/src/test/scala/org/http4s/argonaut/ArgonautSuite.scala
@@ -27,6 +27,7 @@ import org.http4s.syntax.all._
 import org.http4s.argonaut._
 import org.http4s.headers.`Content-Type`
 
+@deprecated("http4s-argonaut support will be dropped in 0.22", "0.21.19")
 class ArgonautSuite extends JawnDecodeSupportSuite[Json] with Argonauts {
   val ArgonautInstancesWithCustomErrors = ArgonautInstances.builder
     .withEmptyBodyMessage(MalformedMessageBodyFailure("Custom Invalid JSON: empty body"))


### PR DESCRIPTION
Argonaut support has required burdensome build hacks over the years, and is again causing problems by publishing its Dotty version using withDottyCompat on its dependencies, rendering us unable to compile with or without Dotty compat.

http4s-argonaut's usage is estimated to be less than 5% of http4s-circe's, and Circe is the recommendation of the http4s team.

If no volunteer steps up by February 13 to fix and maintain this module, we will proceed with this deprecation and removal from series/0.22 and main.