### PR TITLE
Deprecate http4s-json4s

### DIFF
--- a/json4s-jackson/src/test/scala/org/http4s/json4s/jackson/Json4sJacksonSuite.scala
+++ b/json4s-jackson/src/test/scala/org/http4s/json4s/jackson/Json4sJacksonSuite.scala
@@ -19,4 +19,5 @@ package jackson
 
 import org.json4s.JsonAST.JValue
 
+@deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
 class Json4sJacksonSpec extends Json4sSuite[JValue] with Json4sJacksonInstances

--- a/json4s-native/src/test/scala/org/http4s/json4s/native/Json4sNativeSuite.scala
+++ b/json4s-native/src/test/scala/org/http4s/json4s/native/Json4sNativeSuite.scala
@@ -20,4 +20,5 @@ package native
 
 import org.json4s.native.Document
 
+@deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
 class Json4sNativeSpec extends Json4sSuite[Document] with Json4sNativeInstances

--- a/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
+++ b/json4s/src/main/scala/org/http4s/json4s/Json4sInstances.scala
@@ -23,13 +23,17 @@ import org.http4s.headers.`Content-Type`
 import org.json4s._
 import org.json4s.JsonAST.JValue
 import org.typelevel.jawn.support.json4s.Parser
+import scala.annotation.nowarn
 
+@deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
 object CustomParser extends Parser(useBigDecimalForDouble = true, useBigIntForLong = true)
 
 trait Json4sInstances[J] {
+  @deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
   implicit def jsonDecoder[F[_]](implicit F: Sync[F]): EntityDecoder[F, JValue] =
     jawn.jawnDecoder(F, CustomParser.facade)
 
+  @deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
   def jsonOf[F[_], A](implicit reader: Reader[A], F: Sync[F]): EntityDecoder[F, A] =
     jsonDecoder.flatMapR { json =>
       DecodeResult(
@@ -45,6 +49,7 @@ trait Json4sInstances[J] {
     * Editorial: This is heavily dependent on reflection. This is more idiomatic json4s, but less
     * idiomatic http4s, than [[jsonOf]].
     */
+  @deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
   def jsonExtract[F[_], A](implicit
       F: Sync[F],
       formats: Formats,
@@ -55,8 +60,10 @@ trait Json4sInstances[J] {
           .handleError(e => Left(InvalidMessageBodyFailure("Could not extract JSON", Some(e)))))
     }
 
+  @deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
   protected def jsonMethods: JsonMethods[J]
 
+  @deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
   implicit def jsonEncoder[F[_], A <: JValue]: EntityEncoder[F, A] =
     EntityEncoder
       .stringEncoder(Charset.`UTF-8`)
@@ -67,9 +74,11 @@ trait Json4sInstances[J] {
       }
       .withContentType(`Content-Type`(MediaType.application.json))
 
+  @deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
   def jsonEncoderOf[F[_], A](implicit writer: Writer[A]): EntityEncoder[F, A] =
     jsonEncoder[F, JValue].contramap[A](writer.write)
 
+  @deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
   implicit val uriWriter: JsonFormat[Uri] =
     new JsonFormat[Uri] {
       def read(json: JValue): Uri =
@@ -89,7 +98,9 @@ trait Json4sInstances[J] {
         JString(uri.toString)
     }
 
+  @deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
   implicit class MessageSyntax[F[_]: Sync](self: Message[F]) {
+    @nowarn("cat=deprecation")
     def decodeJson[A](implicit decoder: Reader[A]): F[A] =
       self.as(implicitly, jsonOf[F, A])
   }

--- a/json4s/src/test/scala/org/http4s/json4s/Json4sSuite.scala
+++ b/json4s/src/test/scala/org/http4s/json4s/Json4sSuite.scala
@@ -27,6 +27,7 @@ import org.json4s.DefaultReaders._
 import org.json4s.DefaultWriters._
 import org.json4s.JsonAST.{JField, JInt, JObject, JString}
 
+@deprecated("http4s-json4s will be dropped in 0.22.0", "0.21.19")
 trait Json4sSuite[J] extends JawnDecodeSupportSuite[JValue] {
   self: Json4sInstances[J] =>
   import Json4sSuite._


### PR DESCRIPTION
There is no public momentum toward a json4s port on Dotty.  `jawn-json4s` in Dotty compat mode conflicts with the Dotty `jawn-fs2`, so there is no way to nurse it along in 0.22 without copying code.  The interest is estimated less than 5% of http4s-circe.  The http4s team recommends Circe for JSON.

If no volunteer steps up by February 13 to fix and maintain the http4s-json4s modules, we will proceed with this deprecation and removal from series/0.22 and main.

If a new maintainer does emerge for these module, note that the plan is to spin them off into their own repo: #4140