### PR TITLE
http4s-play-json on Dotty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -462,7 +462,7 @@ lazy val playJson = libraryProject("play-json")
     description := "Provides Play json codecs for http4s",
     startYear := Some(2018),
     libraryDependencies ++= Seq(
-      jawnPlay,
+      // jawnPlay,
       Http4sPlugin.playJson,
     ),
   )

--- a/play-json/src/main/scala/org/http4s/play/Parser.scala
+++ b/play-json/src/main/scala/org/http4s/play/Parser.scala
@@ -1,0 +1,27 @@
+/*
+ * Based on https://github.com/typelevel/jawn/blob/v1.0.3/support/play/src/main/scala/Parser.scala
+ * Copyright Erik Osheim, 2012-2020
+ * See licenses/LICENSE_jawn
+ */
+
+package org.http4s.play
+
+import org.typelevel.jawn.{Facade, SupportParser}
+import play.api.libs.json._
+
+private[play] object Parser extends SupportParser[JsValue] {
+
+  implicit val facade: Facade[JsValue] =
+    new Facade.SimpleFacade[JsValue] {
+      def jnull: JsValue = JsNull
+      val jfalse: JsValue = JsBoolean(false)
+      val jtrue: JsValue = JsBoolean(true)
+
+      def jnum(s: CharSequence, decIndex: Int, expIndex: Int): JsValue = JsNumber(
+        BigDecimal(s.toString))
+      def jstring(s: CharSequence): JsValue = JsString(s.toString)
+
+      def jarray(vs: List[JsValue]): JsValue = JsArray(vs)
+      def jobject(vs: Map[String, JsValue]): JsValue = JsObject(vs)
+    }
+}

--- a/play-json/src/main/scala/org/http4s/play/PlayInstances.scala
+++ b/play-json/src/main/scala/org/http4s/play/PlayInstances.scala
@@ -29,7 +29,7 @@ import org.http4s.{
   Uri,
   jawn
 }
-import org.typelevel.jawn.support.play.Parser.facade
+import org.http4s.play.Parser.facade
 import play.api.libs.json._
 
 trait PlayInstances {

--- a/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
@@ -27,7 +27,7 @@ import org.http4s.syntax.all._
 
 // Originally based on CirceSpec
 class PlaySuite extends JawnDecodeSupportSuite[JsValue] {
-  implicit val testContext = TestContext()
+  implicit val testContext: TestContext = TestContext()
 
   testJsonDecoder(jsonDecoder)
 

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -115,6 +115,7 @@ object Http4sPlugin extends AutoPlugin {
           "src/main/scala/org/http4s/parser/Rfc2616BasicRules.scala",
           "src/main/scala/org/http4s/parser/SimpleHeaders.scala",
           "src/main/scala/org/http4s/parser/WwwAuthenticateHeader.scala",
+          "src/main/scala/org/http4s/play/Parser.scala",
           "src/main/scala/org/http4s/util/UrlCoding.scala",
           "src/main/scala/org/http4s/dsl/impl/Path.scala",
           "src/test/scala/org/http4s/dsl/PathSpec.scala",


### PR DESCRIPTION
Had to copy the jawn facade, which is published withDottyCompat.  This could be resolved with https://github.com/typelevel/jawn/issues/312.

Needing to dance around withDottyCompat was the breaking point for me on a couple other JSON libraries, but the play-json team delivered a working Dotty release on request, and it has an active open source dependency.