### PR TITLE
Test, but don't publish, Twirl in withDottyCompat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -482,7 +482,15 @@ lazy val twirl = http4sProject("twirl")
   .settings(
     description := "Twirl template support for http4s",
     startYear := Some(2014),
-    TwirlKeys.templateImports := Nil
+    TwirlKeys.templateImports := Nil,
+    libraryDependencies := {
+      libraryDependencies.value.map {
+        case module if module.name == "twirl-api" =>
+          module.withDottyCompat(scalaVersion.value)
+        case module => module
+      }
+    },
+    skip in publish := isDotty.value
   )
   .enablePlugins(SbtTwirl)
   .dependsOn(core, testing % "test->test")


### PR DESCRIPTION
The `libraryDependencies` is a nasty hack that I think every Twirl application needs to do, but it does work!

This allows us to keep the module compiling until The Great Schism.  @SethTisue has expressed optimism about an eventual Dotty release, and I don't think there's a better alternative in this space.  I'd like to save it from the burn pile for now.

We won't publish it for Dotty until we can remove the `withDottyCompat`.