### PR TITLE
Upgrade to blaze-0.15.0-M1

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -283,7 +283,7 @@ object Http4sPlugin extends AutoPlugin {
     // error-prone merge conflicts in the dependencies below.
     val argonaut = "6.3.3"
     val asyncHttpClient = "2.12.2"
-    val blaze = "0.14.15"
+    val blaze = "0.15.0-M1"
     val boopickle = "1.3.3"
     val caseInsensitive = "1.0.0-RC2"
     val cats = "2.3.1"


### PR DESCRIPTION
This version trims some redundant features from blaze-http and brings Dotty support.