### PR TITLE
Scalatags testing, without publishing, for Dotty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -492,8 +492,9 @@ lazy val scalatags = http4sProject("scalatags")
     description := "Scalatags template support for http4s",
     startYear := Some(2018),
     libraryDependencies ++= Seq(
-      scalatagsApi,
-    )
+      scalatagsApi.withDottyCompat(scalaVersion.value),
+    ),
+    skip in publish := isDotty.value
   )
   .dependsOn(core, testing % "test->test")
 


### PR DESCRIPTION
There is no Scalatags release for Dotty. It works in compat mode, which lets us keep it part of the build until there is a Dotty release.