### PR TITLE
Package object disinheritance for scala-xml

### DIFF
--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/JsonXmlHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/JsonXmlHttpEndpoint.scala
@@ -22,6 +22,7 @@ import io.circe.generic.auto._
 import org.http4s.{ApiVersion => _, _}
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
+import org.http4s.scalaxml.implicits._
 
 import scala.xml._
 
@@ -45,7 +46,7 @@ class JsonXmlHttpEndpoint[F[_]](implicit F: Effect[F]) extends Http4sDsl[F] {
   }
 
   def personXmlDecoder: EntityDecoder[F, Person] =
-    org.http4s.scalaxml.xml[F].map(Person.fromXml)
+    EntityDecoder[F, Elem].map(Person.fromXml)
 
   implicit def jsonXmlDecoder: EntityDecoder[F, Person] = jsonOf[F, Person].orElse(personXmlDecoder)
 

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -24,7 +24,7 @@ import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers._
 import org.http4s.multipart.Multipart
-import org.http4s.scalaxml._
+import org.http4s.scalaxml.implicits._
 import org.http4s.server._
 import org.http4s.syntax.all._
 import org.http4s.server.middleware.PushSupport._

--- a/scala-xml/src/main/scala/scalaxml/implicits.scala
+++ b/scala-xml/src/main/scala/scalaxml/implicits.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.scalaxml
+
+object implicits extends instances.AllInstances

--- a/scala-xml/src/main/scala/scalaxml/instances/AllInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/instances/AllInstances.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.scalaxml.instances
+
+trait AllInstances extends ElemInstances

--- a/scala-xml/src/main/scala/scalaxml/instances/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/instances/ElemInstances.scala
@@ -16,20 +16,19 @@
 
 package org.http4s
 package scalaxml
+package instances
 
+import cats.data.EitherT
 import cats.effect.Sync
 import cats.syntax.all._
 import java.io.StringReader
 import javax.xml.parsers.SAXParserFactory
-
-import cats.data.EitherT
 import org.http4s.headers.`Content-Type`
-
 import scala.util.control.NonFatal
 import scala.xml.{Elem, InputSource, SAXParseException, XML}
 
 trait ElemInstances {
-  protected def saxFactory: SAXParserFactory
+  protected def saxFactory: SAXParserFactory = DefaultSaxParserFactory
 
   implicit def xmlEncoder[F[_]](implicit
       charset: Charset = DefaultCharset): EntityEncoder[F, Elem] =

--- a/scala-xml/src/main/scala/scalaxml/instances/package.scala
+++ b/scala-xml/src/main/scala/scalaxml/instances/package.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.scalaxml
+
+package object instances {
+  object all extends AllInstances
+  object elem extends ElemInstances
+}

--- a/scala-xml/src/main/scala/scalaxml/package.scala
+++ b/scala-xml/src/main/scala/scalaxml/package.scala
@@ -18,8 +18,8 @@ package org.http4s
 
 import javax.xml.parsers.SAXParserFactory
 
-package object scalaxml extends ElemInstances {
-  override val saxFactory = {
+package object scalaxml {
+  val DefaultSaxParserFactory: SAXParserFactory = {
     val factory = SAXParserFactory.newInstance
     // Safer parsing settings to avoid certain class of XML attacks
     // See https://github.com/scala/scala-xml/issues/17

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
@@ -22,6 +22,7 @@ import cats.syntax.all._
 import fs2.Stream
 import fs2.text.{utf8Decode, utf8Encode}
 import org.http4s.Status.Ok
+import org.http4s.scalaxml.implicits._
 import scala.xml.Elem
 
 class ScalaXmlSuite extends Http4sSuite {


### PR DESCRIPTION
Inheriting from package objects is on the way out in Scala 3, after being briefly deprecated in Scala 2.13.  It also causes problems with sbt's incremental compiler.

It's extensible as a codec project grows, and Cats users should feel at home.  It also feels quite overengineered.

The net effect is former importers of

```scala
import org.http4s.scalaxml._
```

would now need to do:

```scala
import org.http4s.scalaxml.instances.all._
```

or 

```scala
import org.http4s.scalaxml.instances.elem._ // a la carte
```

or

```scala
import org.http4s.scalaxml.implicits._
```

The choice is bad and the verbosity is bad and the boilerplate in the code is bad but the futureproofing is good and the consistency with upstream is good.

Discuss.