### PR TITLE
Skip Boopickle in Dotty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -409,8 +409,10 @@ lazy val boopickle = libraryProject("boopickle")
     description := "Provides Boopickle codecs for http4s",
     startYear := Some(2018),
     libraryDependencies ++= Seq(
-      Http4sPlugin.boopickle,
-    )
+      Http4sPlugin.boopickle.withDottyCompat(scalaVersion.value),
+    ),
+    skip in compile := isDotty.value,
+    skip in publish := isDotty.value
   )
   .dependsOn(core, testing % "test->test")
 


### PR DESCRIPTION
There is no Boopickle release for Dotty (https://github.com/suzaku-io/boopickle/issues/148), and we can't yet compile it withDottyCompat because of its macro.  This can keep the project alive until the Great Schism of this repo.