### PR TITLE
HeaderTests now compile on Scala 3

### DIFF
--- a/tests/src/test/scala/org/http4s/headers/RefererSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/RefererSuite.scala
@@ -48,6 +48,7 @@ class RefererSuite extends MHeaderLaws {
     val referer = Referer(getUri("http://localhost:8080"))
     val request = Request[IO](headers = Headers.of(referer))
 
-    assertEquals(request.headers.get(Referer), Some(referer))
+    val extracted = request.headers.get(Referer)
+    assertEquals(extracted, Some(referer))
   }
 }

--- a/tests/src/test/scala/org/http4s/parser/LocationHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/LocationHeaderSuite.scala
@@ -26,7 +26,8 @@ class LocationHeaderSuite extends munit.FunSuite {
     val Right(uri) = Uri.fromString(s)
     val hs = Headers.of(Header("Location", s))
 
-    assertEquals(hs.get(Location), Some(Location(uri)))
+    val extracted = hs.get(Location)
+    assertEquals(extracted, Some(Location(uri)))
   }
 
   test("LocationHeader parser shouldParse a simple uri with a path but no authority") {
@@ -34,7 +35,8 @@ class LocationHeaderSuite extends munit.FunSuite {
     val Right(uri) = Uri.fromString(s)
     val hs = Headers.of(Header("Location", s))
 
-    assertEquals(hs.get(Location), Some(Location(uri)))
+    val extracted = hs.get(Location)
+    assertEquals(extracted, Some(Location(uri)))
   }
 
   test("LocationHeader parser shouldParse a relative reference") {
@@ -42,6 +44,7 @@ class LocationHeaderSuite extends munit.FunSuite {
     val Right(uri) = Uri.fromString(s)
     val hs = Headers.of(Header("Location", s))
 
-    assertEquals(hs.get(Location), Some(Location(uri)))
+    val extracted = hs.get(Location)
+    assertEquals(extracted, Some(Location(uri)))
   }
 }

--- a/tests/src/test/scala/org/http4s/parser/OriginHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/OriginHeaderSuite.scala
@@ -52,34 +52,39 @@ class OriginHeaderSuite extends munit.FunSuite {
     val text = hostString1
     val origin = Origin.HostList(NonEmptyList.of(host1))
     val headers = Headers.of(Header("Origin", text))
-    assertEquals(headers.get(Origin), (Some(origin)))
+    val extracted = headers.get(Origin)
+    assertEquals(extracted, Some(origin))
   }
 
   test("OriginHeader parser should Parse a host without a port number") {
     val text = hostString2
     val origin = Origin.HostList(NonEmptyList.of(host2))
     val headers = Headers.of(Header("Origin", text))
-    assertEquals(headers.get(Origin), (Some(origin)))
+    val extracted = headers.get(Origin)
+    assertEquals(extracted, Some(origin))
   }
 
   test("OriginHeader parser should Parse a list of multiple hosts") {
     val text = s"$hostString1 $hostString2"
     val origin = Origin.HostList(NonEmptyList.of(host1, host2))
     val headers = Headers.of(Header("Origin", text))
-    assertEquals(headers.get(Origin), (Some(origin)))
+    val extracted = headers.get(Origin)
+    assertEquals(extracted, Some(origin))
   }
 
   test("OriginHeader parser should Parse an empty origin") {
     val text = ""
     val origin = Origin.Null
     val headers = Headers.of(Header("Origin", text))
-    assertEquals(headers.get(Origin), (Some(origin)))
+    val extracted = headers.get(Origin)
+    assertEquals(extracted, Some(origin))
   }
 
   test("OriginHeader parser should Parse a 'null' origin") {
     val text = "null"
     val origin = Origin.Null
     val headers = Headers.of(Header("Origin", text))
-    assertEquals(headers.get(Origin), (Some(origin)))
+    val extracted = headers.get(Origin)
+    assertEquals(extracted, Some(origin))
   }
 }


### PR DESCRIPTION
HeaderKey#HeaderT values needs to be own vals for Scala 3 to be able 
type them correctly.