### PR TITLE
Remove `Content-Length` and `Content-Encoding` when decompressing

### DIFF
--- a/client/src/test/scala/org/http4s/client/middleware/GZipSuite.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/GZipSuite.scala
@@ -20,7 +20,7 @@ package middleware
 
 import cats.effect.IO
 import org.http4s.dsl.io._
-import org.http4s.headers.`Content-Encoding`
+import org.http4s.headers.{`Content-Encoding`, `Content-Length`}
 
 class GZipSuite extends Http4sSuite {
   private val service = server.middleware.GZip(HttpApp[IO] {
@@ -35,8 +35,8 @@ class GZipSuite extends Http4sSuite {
     gzipClient
       .get(Uri.unsafeFromString("/gziptest")) { response =>
         assert(response.status == Status.Ok)
-        assert(
-          response.headers.get(`Content-Encoding`).contains(`Content-Encoding`(ContentCoding.gzip)))
+        assert(response.headers.get(`Content-Encoding`).isEmpty)
+        assert(response.headers.get(`Content-Length`).isEmpty)
 
         response.as[String]
       }
@@ -51,8 +51,8 @@ class GZipSuite extends Http4sSuite {
       .run(request)
       .use { response =>
         assert(response.status == Status.Ok)
-        assert(
-          response.headers.get(`Content-Encoding`).contains(`Content-Encoding`(ContentCoding.gzip)))
+        assert(response.headers.get(`Content-Encoding`).isEmpty)
+        assert(response.headers.get(`Content-Length`).isEmpty)
 
         response.as[String]
       }


### PR DESCRIPTION
When the gzip middleware decompresses a response, these headers are no
longer correct, so it seems best to remove them. This is crucial when
the client is used as a proxy (or, in my case, as an STTP backend) to
prevent downstream consumers attempting to decompress the response
again.

This change was previously introduced here: https://github.com/http4s/http4s/pull/2673#discussion_r298684594 but was removed in this PR: https://github.com/http4s/http4s/pull/3476