### PR TITLE
Lower constraint for EntityEncoder#fileEncoder from Effect to Sync

### DIFF
--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -17,7 +17,7 @@
 package org.http4s
 
 import cats.{Contravariant, Show}
-import cats.effect.{Blocker, ContextShift, Effect, Sync}
+import cats.effect.{Blocker, ContextShift, Sync}
 import cats.syntax.all._
 import fs2.{Chunk, Stream}
 import fs2.io.file.readAll
@@ -156,8 +156,7 @@ object EntityEncoder {
 
   // TODO parameterize chunk size
   // TODO if Header moves to Entity, can add a Content-Disposition with the filename
-  def fileEncoder[F[_]](
-      blocker: Blocker)(implicit F: Effect[F], cs: ContextShift[F]): EntityEncoder[F, File] =
+  def fileEncoder[F[_]: Sync: ContextShift](blocker: Blocker): EntityEncoder[F, File] =
     filePathEncoder[F](blocker).contramap(_.toPath)
 
   // TODO parameterize chunk size


### PR DESCRIPTION
Probably an oversight from https://github.com/http4s/http4s/commit/2635573b43975dd4fb4a7b66efeeca978d220381