### PR TITLE
Blaze-Core: optimise entity body writer

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
@@ -58,7 +58,7 @@ private[http4s] trait EntityBodyWriter[F[_]] {
     * @return the Task which when run will unwind the Process
     */
   def writeEntityBody(p: EntityBody[F]): F[Boolean] = {
-    val writeBody: F[Unit] = p.through(writePipe).compile.drain
+    val writeBody: F[Unit] = writePipe(p).compile.drain
     val writeBodyEnd: F[Boolean] = fromFutureNoShift(F.delay(writeEnd(Chunk.empty)))
     writeBody *> writeBodyEnd
   }
@@ -68,10 +68,19 @@ private[http4s] trait EntityBodyWriter[F[_]] {
     * If it errors the error stream becomes the stream, which performs an
     * exception flush and then the stream fails.
     */
-  private def writePipe: Pipe[F, Byte, Unit] = { s =>
-    val writeStream: Stream[F, Unit] =
-      s.chunks.evalMap(chunk => fromFutureNoShift(F.delay(writeBodyChunk(chunk, flush = false))))
-    val errorStream: Throwable => Stream[F, Unit] = e =>
+  private def writePipe(s: Stream[F, Byte]): Stream[F, INothing] = {
+    def writeChunk(chunk: Chunk[Byte]): F[Unit] =
+      fromFutureNoShift(F.delay(writeBodyChunk(chunk, flush = false)))
+
+    val writeStream: Stream[F, INothing] =
+      s.repeatPull {
+        _.uncons.flatMap {
+          case None => Pull.pure(None)
+          case Some((hd, tl)) => Pull.eval(writeChunk(hd)).as(Some(tl))
+        }
+      }
+
+    val errorStream: Throwable => Stream[F, INothing] = e =>
       Stream
         .eval(fromFutureNoShift(F.delay(exceptionFlush())))
         .flatMap(_ => Stream.raiseError[F](e))


### PR DESCRIPTION
The method `Stream.evalMap` creates a singleton chunk for each element of the input chunk that is written.
There is no need to keep those `Chunk[Unit]`. Using the Pull interface, we can just do the action and continue iterating, without leaving any garbage behind.