### PR TITLE
Backport #4425: Blaze-Core: optimise the writing to the pull.

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
@@ -59,8 +59,8 @@ private[http4s] trait EntityBodyWriter[F[_]] {
     * @return the Task which when run will unwind the Process
     */
   def writeEntityBody(p: EntityBody[F]): F[Boolean] = {
-    val writeBody: F[Unit] = p.through(writePipe).compile.drain
-    val writeBodyEnd: F[Boolean] = fromFuture(F.delay(writeEnd(Chunk.empty)))
+    val writeBody: F[Unit] = writePipe(p).compile.drain
+    val writeBodyEnd: F[Boolean] = fromFutureNoShift(F.delay(writeEnd(Chunk.empty)))
     writeBody *> writeBodyEnd
   }
 
@@ -69,11 +69,22 @@ private[http4s] trait EntityBodyWriter[F[_]] {
     * If it errors the error stream becomes the stream, which performs an
     * exception flush and then the stream fails.
     */
-  private def writePipe: Pipe[F, Byte, Unit] = { s =>
-    val writeStream: Stream[F, Unit] =
-      s.chunks.evalMap(chunk => fromFuture(F.delay(writeBodyChunk(chunk, flush = false))))
-    val errorStream: Throwable => Stream[F, Unit] = e =>
-      Stream.eval(fromFuture(F.delay(exceptionFlush()))).flatMap(_ => Stream.raiseError[F](e))
+  private def writePipe(s: Stream[F, Byte]): Stream[F, INothing] = {
+    def writeChunk(chunk: Chunk[Byte]): F[Unit] =
+      fromFutureNoShift(F.delay(writeBodyChunk(chunk, flush = false)))
+
+    val writeStream: Stream[F, INothing] =
+      s.repeatPull {
+        _.uncons.flatMap {
+          case None => Pull.pure(None)
+          case Some((hd, tl)) => Pull.eval(writeChunk(hd)).as(Some(tl))
+        }
+      }
+
+    val errorStream: Throwable => Stream[F, INothing] = e =>
+      Stream
+        .eval(fromFutureNoShift(F.delay(exceptionFlush())))
+        .flatMap(_ => Stream.raiseError[F](e))
     writeStream.handleErrorWith(errorStream)
   }
 }


### PR DESCRIPTION
I thought I was merging this to 0.21 when I approved it.  It could be relevant here, too.