### PR TITLE
Cleanup some attributions

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -52,20 +52,10 @@ https://github.com/scalatra/rl
 Copyright (c) 2011 Mojolly Ltd.
 Licensed under BSD-style license (see licenses/LICENSE_rl)
 
-This software contains portions of code derived from scalaz-specs2
-https://github.com/typelevel/scalaz-specs2
-Copyright (C) 2013 Lars Hupel
-Licensed under BSD-style license (see licenses/LICENSE_scalaz-specs2)
-
 This software contains portions of code derived from shapeless
 https://github.com/milessabin/shapeless
 Copyright (c) 2013-16 Miles Sabin
 Licensed under Apache License 2.0 (see LICENSE)
-
-This software contains portions of code derived from specs2
-https://github.com/etorreborre/specs2
-Copyright (c) 2007-2012 Eric Torreborre <etorreborre@yahoo.com>
-Licensed under MIT license (see licenses/LICENSE_specs2)
 
 This software contains portions of code derived from spray
 https://github.com/spray/spray

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -94,6 +94,8 @@ object Http4sPlugin extends AutoPlugin {
           "src/main/scala/org/http4s/ResponseCookie.scala",
           "src/main/scala/org/http4s/TransferCoding.scala",
           "src/main/scala/org/http4s/Uri.scala",
+          "src/main/scala/org/http4s/dsl/impl/Path.scala",
+          "src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala",
           "src/main/scala/org/http4s/internal/CharPredicate.scala",
           "src/main/scala/org/http4s/parser/AcceptCharsetHeader.scala",
           "src/main/scala/org/http4s/parser/AcceptEncodingHeader.scala",
@@ -110,15 +112,10 @@ object Http4sPlugin extends AutoPlugin {
           "src/main/scala/org/http4s/parser/WwwAuthenticateHeader.scala",
           "src/main/scala/org/http4s/play/Parser.scala",
           "src/main/scala/org/http4s/util/UrlCoding.scala",
-          "src/main/scala/org/http4s/dsl/impl/Path.scala",
-          "src/test/scala/org/http4s/dsl/PathSpec.scala",
-          "src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala",
-          "src/main/scala/org/http4s/testing/ErrorReportingUtils.scala",
-          "src/main/scala/org/http4s/testing/IOMatchers.scala",
-          "src/main/scala/org/http4s/testing/RunTimedMatchers.scala",
           "src/test/scala/org/http4s/Http4sSpec.scala",
+          "src/test/scala/org/http4s/UriSpec.scala",
+          "src/test/scala/org/http4s/dsl/PathSpec.scala",
           "src/test/scala/org/http4s/testing/ErrorReporting.scala",
-          "src/test/scala/org/http4s/UriSpec.scala"
         )
       },
 


### PR DESCRIPTION
* Reorders the attributed sources
* Removes some that no longer exist
* Removes license notices for projects whose code is no longer bundled

Many thanks to Specs2, which served us well for many years.