### PR TITLE
core only depends on cats-effect-std

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val core = libraryProject("core")
     libraryDependencies ++= Seq(
       caseInsensitive,
       catsCore,
-      catsEffect,
+      catsEffectStd,
       catsParse.exclude("org.typelevel", "cats-core_2.13"),
       fs2Core,
       fs2Io,
@@ -116,6 +116,7 @@ lazy val laws = libraryProject("laws")
     startYear := Some(2019),
     libraryDependencies ++= Seq(
       caseInsensitiveTesting,
+      catsEffect,
       catsEffectTestkit,
       catsLaws,
       disciplineCore,

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -331,6 +331,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val caseInsensitiveTesting           = "org.typelevel"          %% "case-insensitive-testing"  % V.caseInsensitive
   lazy val catsCore                         = "org.typelevel"          %% "cats-core"                 % V.cats
   lazy val catsEffect                       = "org.typelevel"          %% "cats-effect"               % V.catsEffect
+  lazy val catsEffectStd                    = "org.typelevel"          %% "cats-effect-std"           % V.catsEffect
   lazy val catsEffectLaws                   = "org.typelevel"          %% "cats-effect-laws"          % V.catsEffect
   lazy val catsEffectTestkit                = "org.typelevel"          %% "cats-effect-testkit"       % V.catsEffect
   lazy val catsLaws                         = "org.typelevel"          %% "cats-laws"                 % V.cats


### PR DESCRIPTION
There are no `IO` dependencies except in tests. This will enable a cleaner classpath for Monix users.