### PR TITLE
cleanup scalafix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.4, 3.0.0-M3]
+        scala: [2.12.13, 2.13.4]
         java: [adopt@1.8, adopt@1.11, adopt@1.15]
     runs-on: ${{ matrix.os }}
     steps:
@@ -216,7 +216,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.4, 3.0.0-M3]
+        scala: [2.12.13, 2.13.4]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.4]
+        scala: [2.12.13, 2.13.4, 3.0.0-M3]
         java: [adopt@1.8, adopt@1.11, adopt@1.15]
     runs-on: ${{ matrix.os }}
     steps:
@@ -216,7 +216,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.4]
+        scala: [2.12.13, 2.13.4, 3.0.0-M3]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -243,6 +243,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Scalafix tests
+        if: matrix.scala == '2.13.4'
         run: |
           cd scalafix
-          sbt test
+          sbt ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,3 +210,39 @@ jobs:
       
       - name: Build docs
         run: sbt ++${{ matrix.scala }} docs/makeSite
+
+  scalafix:
+    name: Scalafix
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.12.13, 2.13.4]
+        java: [adopt@1.8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Scalafix tests
+        run: |
+          cd scalafix
+          sbt test

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -308,7 +308,6 @@ object Http4sPlugin extends AutoPlugin {
     val quasiquotes = "2.1.0"
     val scalacheck = "1.15.3"
     val scalacheckEffect = "0.7.1"
-    val scalafix = _root_.scalafix.sbt.BuildInfo.scalafixVersion
     val scalatags = "0.9.3"
     val scalaXml = "2.0.0-M5"
     val scodecBits = "1.1.24"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,6 @@ libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 // https://github.com/coursier/coursier/issues/450
 classpathTypes += "maven-plugin"
 
-addSbtPlugin("ch.epfl.scala"              %  "sbt-scalafix"              % "0.9.25")
 addSbtPlugin("com.earldouglas"            %  "xsbt-web-plugin"           % "4.2.2")
 addSbtPlugin("com.eed3si9n"               %  "sbt-buildinfo"             % "0.10.0")
 addSbtPlugin("com.eed3si9n"               %  "sbt-unidoc"                % "0.4.3")

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -40,15 +40,19 @@ lazy val rules = project.settings(
   moduleName := "http4s-scalafix",
   libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
 )
+  .settings(scalafixSettings)
 
 lazy val input = project.settings(
-  skip in publish := true,
-  libraryDependencies ++= Seq(
-    "org.http4s" %% "http4s-blaze-client" % "0.18.21",
-    "org.http4s" %% "http4s-blaze-server" % "0.18.21",
-    "org.http4s" %% "http4s-dsl" % "0.18.21"
-  )
+    libraryDependencies ++= List(
+      "http4s-blaze-client",
+      "http4s-blaze-server",
+      "http4s-client",
+      "http4s-core",
+      "http4s-dsl",
+    ).map("org.http4s" %% _ % "0.21.18"),
+  skip in publish := true
 )
+  .settings(scalafixSettings)
 
 lazy val output = project.settings(
   skip in publish := true,
@@ -59,6 +63,7 @@ lazy val output = project.settings(
     "org.http4s" %% "http4s-dsl" % outputVersion
   )
 )
+  .settings(scalafixSettings)
 
 lazy val tests = project
   .settings(
@@ -73,7 +78,28 @@ lazy val tests = project
     scalafixTestkitInputClasspath :=
       (input / Compile / fullClasspath).value,
   )
+  .settings(scalafixSettings)
   .dependsOn(rules)
   .enablePlugins(ScalafixTestkitPlugin)
+
+lazy val scalafixSettings: Seq[Setting[_]] = Seq(
+  developers ++= List(
+    Developer(
+      "amarrella",
+      "Alessandro Marrella",
+      "hello@alessandromarrella.com",
+      url("https://alessandromarrella.com")
+    ),
+    Developer(
+      "satorg",
+      "Sergey Torgashov",
+      "satorg@gmail.com",
+      url("https://github.com/satorg")
+    ),
+  ),
+  addCompilerPlugin(scalafixSemanticdb),
+  scalacOptions += "-Yrangepos",
+  startYear := Some(2018)
+)
 
 addCommandAlias("ci", ";clean ;test")

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -23,8 +23,7 @@ inThisBuild(
           "Sergey Torgashov",
           "satorg@gmail.com",
           url("https://github.com/satorg")
-        ),
-      )
+        )
     ),
     scalaVersion := V.scala212,
     addCompilerPlugin(scalafixSemanticdb),

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -12,11 +12,18 @@ inThisBuild(
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     scmInfo := Some(ScmInfo(url("https://github.com/http4s/http4s"), "git@github.com:http4s/http4s.git")),
     developers := List(
-      Developer(
-        "amarrella",
-        "Alessandro Marrella",
-        "hello@alessandromarrella.com",
-        url("https://alessandromarrella.com")
+        Developer(
+          "amarrella",
+          "Alessandro Marrella",
+          "hello@alessandromarrella.com",
+          url("https://alessandromarrella.com")
+        ),
+        Developer(
+          "satorg",
+          "Sergey Torgashov",
+          "satorg@gmail.com",
+          url("https://github.com/satorg")
+        ),
       )
     ),
     scalaVersion := V.scala212,

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.7

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += Resolver.sonatypeRepo("releases")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.12")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.25")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")


### PR DESCRIPTION
looking for some feedback, this is a bit of a change in the setup for scalafix.
it's modeled after what cats and [cats-effect](https://github.com/typelevel/cats-effect/pull/1686/files)

this disables the publishing but the scalafix can still be run via `sbt ";scalafixEnable ;scalafixAll github:http4s/http4s/series/0.22"` but would enable any dotty plans