### PR TITLE
Change WebSocketSupport#F from a def to a val

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/WebSocketSupport.scala
@@ -33,7 +33,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 private[blaze] trait WebSocketSupport[F[_]] extends Http1ServerStage[F] {
-  protected implicit def F: ConcurrentEffect[F]
+  protected implicit val F: ConcurrentEffect[F]
 
   override protected def renderResponse(
       req: Request[F],


### PR DESCRIPTION
Dotty RC1 required a stable val.  I don't like eager abstract vals in traits, but the tests passed.