### PR TITLE
Fix Routes Constraint

### DIFF
--- a/core/src/main/scala/org/http4s/ContextRoutes.scala
+++ b/core/src/main/scala/org/http4s/ContextRoutes.scala
@@ -17,7 +17,7 @@
 package org.http4s
 
 import cats.data.{Kleisli, OptionT}
-import cats.{Applicative, Defer}
+import cats.{Applicative, Defer, Monad}
 import cats.syntax.all._
 
 object ContextRoutes {
@@ -45,9 +45,8 @@ object ContextRoutes {
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
   def of[T, F[_]](pf: PartialFunction[ContextRequest[F, T], F[Response[F]]])(implicit
-      F: Defer[F],
-      FA: Applicative[F]): ContextRoutes[T, F] =
-    Kleisli(req => OptionT(F.defer(pf.lift(req).sequence)))
+      F: Monad[F]): ContextRoutes[T, F] =
+    Kleisli(req => OptionT(Applicative[F].unit >> pf.lift(req).sequence))
 
   /** Lifts a partial function into an [[ContextRoutes]].  The application of the
     * partial function is not suspended in `F`, unlike [[of]]. This allows for less

--- a/core/src/main/scala/org/http4s/HttpRoutes.scala
+++ b/core/src/main/scala/org/http4s/HttpRoutes.scala
@@ -75,8 +75,8 @@ object HttpRoutes {
     * @return An [[HttpRoutes]] that returns some [[Response]] in an `OptionT[F, *]`
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
-  def of[F[_]: Defer: Applicative](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] =
-    Kleisli(req => OptionT(Defer[F].defer(pf.lift(req).sequence)))
+  def of[F[_]: Monad](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] =
+    Kleisli(req => OptionT(Applicative[F].unit >> pf.lift(req).sequence))
 
   /** Lifts a partial function into an [[HttpRoutes]].  The application of the
     * partial function is not suspended in `F`, unlike [[of]]. This allows for less


### PR DESCRIPTION
Defer is no longer in Sync hierarchy. This is definitely correct for any F that has Concurrent, but will work fine in most cases that are actually used without a messy api.