### PR TITLE
Add 'Running site locally' section into Contributing guide

### DIFF
--- a/docs/src/hugo/config.toml
+++ b/docs/src/hugo/config.toml
@@ -1,4 +1,4 @@
-baseurl = "https://http4s.org/v0.20"
+baseurl = "https://http4s.org/v0.22"
 contentDir = "../../target/mdoc"
 dataDir = "../../target/hugo-data"
 languageCode = "en-us"

--- a/website/src/hugo/content/contributing.md
+++ b/website/src/hugo/content/contributing.md
@@ -52,7 +52,7 @@ This runs:
   builds the static site.
 * `mimaReportBinaryIssues`: checks for binary compatibility changes,
   which are relevant past patch release .0.
-  
+
 [SBT]: http://www.scala-sbt.org/0.13/tutorial/Setup.html
 [Hugo]: https://gohugo.io/getting-started/installing/
 
@@ -70,15 +70,15 @@ your PR fails due to formatting, run `;test:scalafmt`.
 
 #### IntelliJ IDEA specific settings
 
-To setup IntelliJ IDEA to conform with the formatting used in this project, 
+To setup IntelliJ IDEA to conform with the formatting used in this project,
 the following settings should be changed from the default.
 
 Under `Settings > Editor > Code Style > Scala`:
 
-* Set `Formatter` to `scalafmt`. The default path for the `.scalafmt.conf` 
+* Set `Formatter` to `scalafmt`. The default path for the `.scalafmt.conf`
 file should work, if not, point it to the `.scalafmt.conf` in the root of
 the project.
-* In the `Imports` tab, in the `Import layout` pane, delete all entries, 
+* In the `Imports` tab, in the `Import layout` pane, delete all entries,
 except for `all other imports`. This disables the grouping and sorting of
 imports that IntelliJ does by default.
 
@@ -136,11 +136,11 @@ case class Foo(seconds: Long)
 object Foo {
   def fromFiniteDuration(d: FiniteDuration): Foo =
     apply(d.toSeconds)
-    
+
   def fromString(s: String): ParseResult[Foo] =
     try s.toLong
-    catch { case e: NumberFormatException => 
-      new ParseFailure("not a long") 
+    catch { case e: NumberFormatException =>
+      new ParseFailure("not a long")
     }
 }
 ```
@@ -156,7 +156,7 @@ All constructors that are partial on their input should be prefixed with `unsafe
 def fromLong(l: Long): ParseResult[Foo] =
   if (l < 0) Left(ParseFailure("l must be non-negative"))
   else Right(new Foo(l))
-def unsafeFromLong(l: Long): Foo = 
+def unsafeFromLong(l: Long): Foo =
   fromLong(l).fold(throw _, identity)
 
 // Bad
@@ -228,6 +228,53 @@ documentation as part of the build.
 All pages have an edit link at the top right for direct editing of the
 markdown via GitHub.  Be aware that the Travis build will fail if invalid
 code is added.
+
+### Running the common or versioned site locally
+
+To run common or versioned site locally you need [Hugo] version 0.26 (since
+this is what CI uses) installed.
+
+### Running common site locally
+
+In your terminal run this command (in root folder of http4s):
+
+```sh
+hugo -s website/src/hugo server -p 4000
+```
+
+Now you can open browser at http://localhost:4000/ to see local version
+of common site.
+
+If the site looks broken make sure you have Hugo version compatible with
+version 0.26.
+
+Hugo server will automatically detect any changes in Hugo content files
+located in `website/src/hugo/content` and it will reload corresponding
+pages automatically.
+
+### Running versioned site locally
+
+In your terminal run these commands (in root folder of http4s):
+
+```sh
+sbt docs/makeSite
+hugo -s docs/src/hugo server -p 4000
+```
+
+Now you can open browser http://localhost:4000/v0.22 to see local version
+of versioned site.
+
+If the site looks broken make sure you have Hugo version compatible with
+version 0.26.
+
+When you change content files located at `docs/src/main/mdoc` you need
+to run:
+
+```sh
+sbt docs/mdoc
+```
+
+for Hugo server to picks up your changes.
 
 ## Submit a pull request
 


### PR DESCRIPTION
When trying to run website/docs site locally with latest hugo, site is broken. Users noticed this already [three years ago](https://gitter.im/http4s/http4s?at=5af21a03b37eab7d04797c45).

I'm not sure if there are any plans to migrate docs/website to the latest hugo version, but hopefully this description will save time in figuring out that latest version of hugo is not supported.