### PR TITLE
Port headerLaws to use Header typeclass

### DIFF
--- a/core/src/main/scala/org/http4s/syntax/HeaderSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/HeaderSyntax.scala
@@ -18,6 +18,7 @@ package org.http4s.syntax
 
 import org.http4s.util.Renderer
 import org.http4s.v2
+import org.typelevel.ci.CIString
 
 trait HeaderSyntax {
   implicit def http4sHeaderSyntax[A](a: A)(implicit header: v2.Header[A, _]): HeaderOps[A] =
@@ -25,11 +26,11 @@ trait HeaderSyntax {
 
   implicit def http4sSelectSyntax[A](a: A)(implicit select: v2.Header.Select[A]): SelectOps[A] =
     new SelectOps(a)
-
 }
 
 final class HeaderOps[A](val a: A, header: v2.Header[A, _]) {
   def value: String = header.value(a)
+  def name: CIString = header.name
 }
 
 final class SelectOps[A](val a: A)(implicit ev: v2.Header.Select[A]) {

--- a/tests/src/test/scala/org/http4s/headers/AcceptCharsetSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptCharsetSuite.scala
@@ -22,7 +22,7 @@ import org.http4s.syntax.all._
 import org.http4s.laws.discipline.ArbitraryInstances._
 
 class AcceptCharsetSuite extends HeaderLaws {
-  //checkAll("Accept-Charset", headerLaws(`Accept-Charset`))
+  checkAll("Accept-Charset", headerLaws[`Accept-Charset`])
 
   test("AcceptCharset is satisfied by a charset if the q value is > 0") {
     forAll { (h: `Accept-Charset`, cs: Charset) =>

--- a/tests/src/test/scala/org/http4s/headers/AcceptHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptHeaderSuite.scala
@@ -17,8 +17,8 @@
 package org.http4s
 package headers
 
-// import org.http4s.laws.discipline.ArbitraryInstances._
+import org.http4s.laws.discipline.ArbitraryInstances._
 
 class AcceptHeaderSuite extends HeaderLaws {
-  //checkAll("Accept", headerLaws(Accept))
+  checkAll("Accept", headerLaws[Accept])
 }

--- a/tests/src/test/scala/org/http4s/headers/AcceptPatchSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptPatchSuite.scala
@@ -17,8 +17,8 @@
 package org.http4s
 package headers
 
-// import org.http4s.laws.discipline.arbitrary._
+import org.http4s.laws.discipline.arbitrary._
 
 final class AcceptPatchSuite extends HeaderLaws {
-  //checkAll("AcceptPatch", headerLaws(`Accept-Patch`))
+  checkAll("AcceptPatch", headerLaws[`Accept-Patch`])
 }

--- a/tests/src/test/scala/org/http4s/headers/AccessControlAllowHeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AccessControlAllowHeadersSpec.scala
@@ -17,8 +17,8 @@
 package org.http4s
 package headers
 
-// import org.http4s.laws.discipline.arbitrary._
+import org.http4s.laws.discipline.arbitrary._
 
 final class AccessControlAllowHeadersSpec extends HeaderLaws {
-  //checkAll("Access-Control-Allow-Headers", headerLaws(`Access-Control-Allow-Headers`))
+  checkAll("Access-Control-Allow-Headers", headerLaws[`Access-Control-Allow-Headers`])
 }

--- a/tests/src/test/scala/org/http4s/headers/AccessControlExposeHeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AccessControlExposeHeadersSpec.scala
@@ -17,8 +17,8 @@
 package org.http4s
 package headers
 
-// import org.http4s.laws.discipline.arbitrary._
+import org.http4s.laws.discipline.arbitrary._
 
 final class AccessControlExposeHeadersSpec extends HeaderLaws {
-  //checkAll("Access-Control-Expose-Headers", headerLaws(`Access-Control-Expose-Headers`))
+  checkAll("Access-Control-Expose-Headers", headerLaws[`Access-Control-Expose-Headers`])
 }

--- a/tests/src/test/scala/org/http4s/headers/ExpiresSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/ExpiresSuite.scala
@@ -18,10 +18,10 @@ package org.http4s
 package headers
 
 import java.time.{ZoneId, ZonedDateTime}
-// import org.http4s.laws.discipline.ArbitraryInstances._
+import org.http4s.laws.discipline.ArbitraryInstances._
 
 class ExpiresSuite extends HeaderLaws {
-  //checkAll("Expires", headerLaws(Expires))
+  checkAll("Expires", headerLaws[Expires])
 
   val gmtDate = ZonedDateTime.of(1994, 11, 6, 8, 49, 37, 0, ZoneId.of("GMT"))
   val epochString = "Thu, 01 Jan 1970 00:00:00 GMT"

--- a/tests/src/test/scala/org/http4s/headers/TransferEncodingSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/TransferEncodingSuite.scala
@@ -25,7 +25,7 @@ import org.scalacheck.Prop.forAll
 import org.http4s.laws.discipline.ArbitraryInstances._
 
 class TransferEncodingSuite extends HeaderLaws {
-  //checkAll("TransferEncoding", headerLaws(`Transfer-Encoding`))
+  checkAll("TransferEncoding", headerLaws[`Transfer-Encoding`])
 
   // TODO Temporal class providing methods which will be replaced by syntax later on
   implicit class TemporalSyntax(header: `Transfer-Encoding`) {


### PR DESCRIPTION
Existing header laws can be changed to use new one by replacing
parentheses, for example
```
checkAll("Expires", headerLaws(Expires))
```
to

```
checkAll("Expires", headerLaws[Expires])
```

partially addresses #4535 