### PR TITLE
Migrate more header

### DIFF
--- a/blaze-core/src/test/scala/org/http4s/blazecore/ResponseParser.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/ResponseParser.scala
@@ -22,6 +22,8 @@ import fs2._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import org.http4s.blaze.http.parser.Http1ClientParser
+import org.typelevel.ci.CIString
+
 import scala.collection.mutable.ListBuffer
 
 class ResponseParser extends Http1ClientParser {
@@ -34,14 +36,14 @@ class ResponseParser extends Http1ClientParser {
   var minorversion = -1
 
   /** Will not mutate the ByteBuffers in the Seq */
-  def parseResponse(buffs: Seq[ByteBuffer]): (Status, Set[Header], String) = {
+  def parseResponse(buffs: Seq[ByteBuffer]): (Status, Set[v2.Header.Raw], String) = {
     val b =
       ByteBuffer.wrap(buffs.map(b => Chunk.byteBuffer(b).toArray).toArray.flatten)
     parseResponseBuffer(b)
   }
 
   /* Will mutate the ByteBuffer */
-  def parseResponseBuffer(buffer: ByteBuffer): (Status, Set[Header], String) = {
+  def parseResponseBuffer(buffer: ByteBuffer): (Status, Set[v2.Header.Raw], String) = {
     parseResponseLine(buffer)
     parseHeaders(buffer)
 
@@ -56,7 +58,12 @@ class ResponseParser extends Http1ClientParser {
       new String(Chunk.concatBytes(bytes).toArray, StandardCharsets.ISO_8859_1)
     }
 
-    val headers = this.headers.result().map { case (k, v) => Header(k, v): Header }.toSet
+    val headers: Set[v2.Header.Raw] = this.headers
+      .result()
+      .toSet
+      .map { (kv: (String, String)) =>
+        v2.Header.Raw(CIString(kv._1), kv._2)
+      }
 
     val status = Status.fromIntAndReason(this.code, reason).valueOr(throw _)
 
@@ -82,10 +89,10 @@ class ResponseParser extends Http1ClientParser {
 }
 
 object ResponseParser {
-  def apply(buff: Seq[ByteBuffer]): (Status, Set[Header], String) =
+  def apply(buff: Seq[ByteBuffer]): (Status, Set[v2.Header.Raw], String) =
     new ResponseParser().parseResponse(buff)
-  def apply(buff: ByteBuffer): (Status, Set[Header], String) = parseBuffer(buff)
+  def apply(buff: ByteBuffer): (Status, Set[v2.Header.Raw], String) = parseBuffer(buff)
 
-  def parseBuffer(buff: ByteBuffer): (Status, Set[Header], String) =
+  def parseBuffer(buff: ByteBuffer): (Status, Set[v2.Header.Raw], String) =
     new ResponseParser().parseResponseBuffer(buff)
 }

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/Http1ServerStageSpec.scala
@@ -53,10 +53,10 @@ class Http1ServerStageSpec extends Http4sSuite {
     new String(a)
   }
 
-  def parseAndDropDate(buff: ByteBuffer): (Status, Set[Header], String) =
+  def parseAndDropDate(buff: ByteBuffer): (Status, Set[v2.Header.Raw], String) =
     dropDate(ResponseParser.apply(buff))
 
-  def dropDate(resp: (Status, Set[Header], String)): (Status, Set[Header], String) = {
+  def dropDate(resp: (Status, Set[v2.Header.Raw], String)): (Status, Set[v2.Header.Raw], String) = {
     val hds = resp._2.filter(_.name != v2.Header[Date].name)
     (resp._1, hds, resp._3)
   }
@@ -121,7 +121,7 @@ class Http1ServerStageSpec extends Http4sSuite {
           s"Http1ServerStage: Common responses should Run request $i Run request: --------\n${req
             .split("\r\n\r\n")(0)}\n") { tw =>
           runRequest(tw, Seq(req), ServerTestRoutes()).result
-            .map((parseAndDropDate _).andThen(normalize))
+            .map(parseAndDropDate)
             .map(assertEquals(_, (status, headers, resp)))
 
         }
@@ -130,7 +130,7 @@ class Http1ServerStageSpec extends Http4sSuite {
           s"Http1ServerStage: Common responses should Run request $i Run request: --------\n${req
             .split("\r\n\r\n")(0)}\n") { tw =>
           runRequest(tw, Seq(req), ServerTestRoutes()).result
-            .map((parseAndDropDate _).andThen(normalize))
+            .map(parseAndDropDate)
             .map(assertEquals(_, (status, headers, resp)))
 
         }
@@ -152,7 +152,7 @@ class Http1ServerStageSpec extends Http4sSuite {
       .map(parseAndDropDate)
       .map { case (s, h, r) =>
         val close = h.exists { h =>
-          h.toRaw.name == CIString("connection") && h.toRaw.value == "close"
+          h.name == CIString("connection") && h.value == "close"
         }
         (s, close, r)
       }
@@ -296,8 +296,8 @@ class Http1ServerStageSpec extends Http4sSuite {
       (runRequest(tw, Seq(r11, r12), routes).result).map { buff =>
         // Both responses must succeed
         assertEquals(
-          normalize(parseAndDropDate(buff)),
-          (Ok, Set(H.`Content-Length`.unsafeFromLong(4).renderString), "done"))
+          parseAndDropDate(buff),
+          (Ok, Set(H.`Content-Length`.unsafeFromLong(4).toRaw), "done"))
       }
   }
 
@@ -319,12 +319,12 @@ class Http1ServerStageSpec extends Http4sSuite {
       (runRequest(tw, Seq(r11, r12), routes).result).map { buff =>
         // Both responses must succeed
         assertEquals(
-          normalize(parseAndDropDate(buff)),
+          parseAndDropDate(buff),
           (
             Ok,
             Set(
-              H.`Content-Length`.unsafeFromLong(8 + 4).renderString,
-              H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).renderString
+              H.`Content-Length`.unsafeFromLong(8 + 4).toRaw,
+              H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw
             ),
             "Result: done")
         )
@@ -346,12 +346,12 @@ class Http1ServerStageSpec extends Http4sSuite {
 
       (runRequest(tw, Seq(req1, req2), routes).result).map { buff =>
         val hs = Set(
-          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).renderString,
-          H.`Content-Length`.unsafeFromLong(3).renderString
+          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw,
+          H.`Content-Length`.unsafeFromLong(3).toRaw
         )
         // Both responses must succeed
-        assertEquals(normalize(dropDate(ResponseParser.parseBuffer(buff))), (Ok, hs, "foo"))
-        assertEquals(normalize(dropDate(ResponseParser.parseBuffer(buff))), (Ok, hs, "foo"))
+        assertEquals(dropDate(ResponseParser.parseBuffer(buff)), (Ok, hs, "foo"))
+        assertEquals(dropDate(ResponseParser.parseBuffer(buff)), (Ok, hs, "foo"))
       }
   }
 
@@ -372,11 +372,11 @@ class Http1ServerStageSpec extends Http4sSuite {
 
       (runRequest(tw, Seq(r11, r12, req2), routes).result).map { buff =>
         val hs = Set(
-          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).renderString,
-          H.`Content-Length`.unsafeFromLong(3).renderString
+          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw,
+          H.`Content-Length`.unsafeFromLong(3).toRaw
         )
         // Both responses must succeed
-        assertEquals(normalize(dropDate(ResponseParser.parseBuffer(buff))), (Ok, hs, "foo"))
+        assertEquals(dropDate(ResponseParser.parseBuffer(buff)), (Ok, hs, "foo"))
         assertEquals(buff.remaining(), 0)
       }
   }
@@ -397,12 +397,12 @@ class Http1ServerStageSpec extends Http4sSuite {
 
       (runRequest(tw, Seq(r11, r12, req2), routes).result).map { buff =>
         val hs = Set(
-          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).renderString,
-          H.`Content-Length`.unsafeFromLong(3).renderString
+          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw,
+          H.`Content-Length`.unsafeFromLong(3).toRaw
         )
         // Both responses must succeed
-        assertEquals(normalize(dropDate(ResponseParser.parseBuffer(buff))), (Ok, hs, "foo"))
-        assertEquals(normalize(dropDate(ResponseParser.parseBuffer(buff))), (Ok, hs, "foo"))
+        assertEquals(dropDate(ResponseParser.parseBuffer(buff)), (Ok, hs, "foo"))
+        assertEquals(dropDate(ResponseParser.parseBuffer(buff)), (Ok, hs, "foo"))
       }
   }
 
@@ -422,12 +422,12 @@ class Http1ServerStageSpec extends Http4sSuite {
       (runRequest(tw, Seq(req1 + req2), routes).result).map { buff =>
         // Both responses must succeed
         assertEquals(
-          normalize(dropDate(ResponseParser.parseBuffer(buff))),
-          (Ok, Set(H.`Content-Length`.unsafeFromLong(4).renderString), "done")
+          dropDate(ResponseParser.parseBuffer(buff)),
+          (Ok, Set(H.`Content-Length`.unsafeFromLong(4).toRaw), "done")
         )
         assertEquals(
-          normalize(dropDate(ResponseParser.parseBuffer(buff))),
-          (Ok, Set(H.`Content-Length`.unsafeFromLong(5).renderString), "total"))
+          dropDate(ResponseParser.parseBuffer(buff)),
+          (Ok, Set(H.`Content-Length`.unsafeFromLong(5).toRaw), "total"))
       }
   }
 
@@ -446,11 +446,11 @@ class Http1ServerStageSpec extends Http4sSuite {
     (runRequest(tw, Seq(req1, req2), routes).result).map { buff =>
       // Both responses must succeed
       assertEquals(
-        normalize(dropDate(ResponseParser.parseBuffer(buff))),
-        (Ok, Set(H.`Content-Length`.unsafeFromLong(4).renderString), "done"))
+        dropDate(ResponseParser.parseBuffer(buff)),
+        (Ok, Set(H.`Content-Length`.unsafeFromLong(4).toRaw), "done"))
       assertEquals(
-        normalize(dropDate(ResponseParser.parseBuffer(buff))),
-        (Ok, Set(H.`Content-Length`.unsafeFromLong(5).renderString), "total"))
+        dropDate(ResponseParser.parseBuffer(buff)),
+        (Ok, Set(H.`Content-Length`.unsafeFromLong(5).toRaw), "total"))
     }
   }
 
@@ -520,12 +520,5 @@ class Http1ServerStageSpec extends Http4sSuite {
     head.result.map { _ =>
       assert(head.closeCauses == Seq(None))
     }
-  }
-
-  /** Temporary workaround to compare old Header and v2 header
-    */
-  private def normalize(old: (Status, Set[Header], String)): (Status, Set[String], String) = {
-    val (status, headers, s) = old
-    (status, headers.map(_.renderString), s)
   }
 }

--- a/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
+++ b/blaze-server/src/test/scala/org/http4s/server/blaze/ServerTestRoutes.scala
@@ -28,13 +28,13 @@ import org.typelevel.ci.CIString
 
 object ServerTestRoutes extends Http4sDsl[IO] {
   //TODO: bring back well-typed value once all headers are moved to new model
-  val textPlain: String = `Content-Type`(MediaType.text.plain, `UTF-8`).renderString
-  val connClose = Connection(CIString("close")).renderString
-  val connKeep = Connection(CIString("keep-alive")).renderString
-  val chunked = `Transfer-Encoding`(TransferCoding.chunked).renderString
+  val textPlain = `Content-Type`(MediaType.text.plain, `UTF-8`).toRaw
+  val connClose = Connection(CIString("close")).toRaw
+  val connKeep = Connection(CIString("keep-alive")).toRaw
+  val chunked = `Transfer-Encoding`(TransferCoding.chunked).toRaw
 
-  def length(l: Long): String = `Content-Length`.unsafeFromLong(l).renderString
-  def testRequestResults: Seq[(String, (Status, Set[String], String))] =
+  def length(l: Long) = `Content-Length`.unsafeFromLong(l).toRaw
+  def testRequestResults: Seq[(String, (Status, Set[v2.Header.Raw], String))] =
     Seq(
       ("GET /get HTTP/1.0\r\n\r\n", (Status.Ok, Set(length(3), textPlain), "get")),
       /////////////////////////////////
@@ -59,13 +59,11 @@ object ServerTestRoutes extends Http4sDsl[IO] {
       (
         "GET /get HTTP/1.1\r\nConnection:close\r\n\r\n",
         (Status.Ok, Set(length(3), textPlain, connClose), "get")),
-      //////////////////////////////////////////////////////////////////////
-      // TODO bring these test cases back once old Header is gone
-      /* ("GET /chunked HTTP/1.1\r\n\r\n", (Status.Ok, Set(textPlain, chunked), "chunk")),
-       * /////////////////////////////////
-       * (
-       *   "GET /chunked HTTP/1.1\r\nConnection:close\r\n\r\n",
-       *   (Status.Ok, Set(textPlain, chunked, connClose), "chunk")), */
+      ("GET /chunked HTTP/1.1\r\n\r\n", (Status.Ok, Set(textPlain, chunked), "chunk")),
+      /////////////////////////////////
+      (
+        "GET /chunked HTTP/1.1\r\nConnection:close\r\n\r\n",
+        (Status.Ok, Set(textPlain, chunked, connClose), "chunk")),
       ///////////////////////////////// Content-Length and Transfer-Encoding free responses for HTTP/1.0
       ("GET /chunked HTTP/1.0\r\n\r\n", (Status.Ok, Set(textPlain), "chunk")),
       /////////////////////////////////

--- a/tests/src/test/scala/org/http4s/HeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/HeaderSuite.scala
@@ -37,38 +37,6 @@ class HeaderSuite extends munit.DisciplineSuite {
     assert(!(h2 == h1))
   }
 
-  test("Headers should equal same raw headers".ignore) {
-    val h1 = `Content-Length`.unsafeFromLong(44)
-    val h2 = Header("Content-Length", "44")
-
-    assert(h1 == h2)
-    assert(h2 == h1)
-  }
-
-  test("Headers should not equal same raw headers") {
-    val h1 = `Content-Length`.unsafeFromLong(4)
-    val h2 = Header("Content-Length", "5")
-
-    assert(!(h1 == h2))
-    assert(!(h2 == h1))
-  }
-
-  test("Headers should equate raw to same raw headers") {
-    val h1 = Header("Content-Length", "4")
-    val h2 = Header("Content-Length", "4")
-
-    assertEquals(h1, h2)
-    assertEquals(h2, h1)
-  }
-
-  test("Headers should not equate raw to same raw headers") {
-    val h1 = Header("Content-Length", "4")
-    val h2 = Header("Content-Length", "5")
-
-    assert(!(h1 == h2))
-    assert(!(h2 == h1))
-  }
-
   /*
   test("rendered length should is rendered length including \\r\\n") {
     forAll { (h: v2.Header.Raw) =>


### PR DESCRIPTION
Remove deprecation warnings from
- `ResponseParser.scala`
- `Http1ServerStageSpec.scala`
- `HeaderSuite.scala`

looks like after this it's only the headers and their own test + `HttpHeaderParser`

btw, sorry for too many small PRs!