### PR TITLE
Header migration cleanup

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
@@ -57,7 +57,7 @@ object `Accept-Charset` {
     v2.Header.createRendered(
       CIString("Accept-Charset"),
       _.values,
-      ParseResult.fromParser(parser, "Invalid Accept-Charset header")
+      parse
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[`Accept-Charset`] =

--- a/core/src/main/scala/org/http4s/headers/Accept.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept.scala
@@ -27,6 +27,9 @@ object Accept {
   def apply(head: MediaRangeAndQValue, tail: MediaRangeAndQValue*): Accept =
     apply(NonEmptyList(head, tail.toList))
 
+  def parse(s: String): ParseResult[Accept] =
+    ParseResult.fromParser(parser, "Invalid Accept header")(s)
+
   private[http4s] val parser: Parser[Accept] = {
     val acceptParams =
       (QValue.parser ~ MediaRange.mediaTypeExtensionParser.rep0).map { case (qValue, ext) =>
@@ -54,7 +57,7 @@ object Accept {
     v2.Header.createRendered(
       CIString("Accept"),
       _.values,
-      ParseResult.fromParser(parser, "Invalid Accept header")
+      parse
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[Accept] =

--- a/core/src/main/scala/org/http4s/headers/Access-Control-Allow-Headers.scala
+++ b/core/src/main/scala/org/http4s/headers/Access-Control-Allow-Headers.scala
@@ -17,6 +17,7 @@
 package org.http4s
 package headers
 
+import org.http4s.v2.Header
 import org.typelevel.ci.CIString
 import org.http4s.internal.parsing.Rfc7230
 import cats.data.NonEmptyList
@@ -25,19 +26,17 @@ object `Access-Control-Allow-Headers` {
   def apply(head: CIString, tail: CIString*): `Access-Control-Allow-Headers` =
     apply(NonEmptyList(head, tail.toList))
 
-  def parse(s: String): ParseResult[`Access-Control-Allow-Headers`] = parseResult(s)
-
-  private[http4s] def parseResult(s: String): ParseResult[`Access-Control-Allow-Headers`] =
+  def parse(s: String): ParseResult[`Access-Control-Allow-Headers`] =
     ParseResult.fromParser(parser, "Invalid Access-Control-Allow-Headers headers")(s)
 
   private[http4s] val parser =
     Rfc7230.headerRep1(Rfc7230.token.map(CIString(_))).map(`Access-Control-Allow-Headers`(_))
 
-  implicit val headerInstance: v2.Header[`Access-Control-Allow-Headers`, v2.Header.Recurring] =
-    v2.Header.createRendered(
+  implicit val headerInstance: Header[`Access-Control-Allow-Headers`, Header.Recurring] =
+    Header.createRendered(
       CIString("Access-Control-Allow-Headers"),
       _.values,
-      parseResult
+      parse
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[`Access-Control-Allow-Headers`] =

--- a/core/src/main/scala/org/http4s/headers/Forwarded.scala
+++ b/core/src/main/scala/org/http4s/headers/Forwarded.scala
@@ -359,9 +359,11 @@ object Forwarded extends ForwardedRenderers {
       .map(Forwarded.apply)
   }
 
+  val name = CIString("Forwarded")
+
   implicit val headerInstance: Header[Forwarded, Header.Recurring] =
     Header.createRendered(
-      CIString("Forwarded"),
+      name,
       _.values,
       ParseResult.fromParser(parser, "Invalid Forwarded header")
     )
@@ -369,7 +371,6 @@ object Forwarded extends ForwardedRenderers {
   implicit val headerSemigroupInstance: cats.Semigroup[Forwarded] =
     (a, b) => Forwarded(a.values.concatNel(b.values))
 
-  val name = headerInstance.name
 }
 
 final case class Forwarded(values: NonEmptyList[Forwarded.Element])

--- a/core/src/main/scala/org/http4s/headers/Transfer-Encoding.scala
+++ b/core/src/main/scala/org/http4s/headers/Transfer-Encoding.scala
@@ -29,20 +29,24 @@ object `Transfer-Encoding` {
   def apply(head: TransferCoding, tail: TransferCoding*): `Transfer-Encoding` =
     apply(NonEmptyList(head, tail.toList))
 
+  val name = CIString("Transfer-Encoding")
+
+  def parse(s: String): ParseResult[`Transfer-Encoding`] =
+    ParseResult.fromParser(parser, "Invalid Transfer-Encoding header")(s)
+
   private[http4s] val parser: Parser[`Transfer-Encoding`] =
     Rfc7230.headerRep1(TransferCoding.parser).map(apply)
 
   implicit val headerInstance: Header[`Transfer-Encoding`, Header.Recurring] =
     Header.createRendered(
-      CIString("Transfer-Encoding"),
+      name,
       _.values,
-      ParseResult.fromParser(parser, "Invalid Transfer-Encoding header")
+      parse
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[`Transfer-Encoding`] =
     (a, b) => `Transfer-Encoding`(a.values.concatNel(b.values))
 
-  def name = headerInstance.name
 }
 
 final case class `Transfer-Encoding`(values: NonEmptyList[TransferCoding]) {

--- a/core/src/main/scala/org/http4s/headers/User-Agent.scala
+++ b/core/src/main/scala/org/http4s/headers/User-Agent.scala
@@ -26,6 +26,11 @@ object `User-Agent` {
   def apply(id: ProductId, tail: ProductIdOrComment*): `User-Agent` =
     apply(id, tail.toList)
 
+  val name = CIString("User-Agent")
+
+  def parse(s: String): ParseResult[`User-Agent`] =
+    ParseResult.fromParser(parser, "Invalid User-Agent header")(s)
+
   private[http4s] val parser =
     ProductIdOrComment.serverAgentParser.map {
       case (product: ProductId, tokens: List[ProductIdOrComment]) =>
@@ -34,7 +39,7 @@ object `User-Agent` {
 
   implicit val headerInstance: Header[`User-Agent`, Header.Single] =
     Header.createRendered(
-      CIString("User-Agent"),
+      name,
       h =>
         new Renderable {
           def render(writer: Writer): writer.type = {
@@ -47,10 +52,8 @@ object `User-Agent` {
           }
 
         },
-      ParseResult.fromParser(parser, "Invalid User-Agent header")
+      parse
     )
-
-  val name = headerInstance.name
 
   implicit def convert(implicit select: v2.Header.Select[`User-Agent`]): Renderer[`User-Agent`] =
     new Renderer[`User-Agent`] {

--- a/core/src/main/scala/org/http4s/headers/WWW-Authenticate.scala
+++ b/core/src/main/scala/org/http4s/headers/WWW-Authenticate.scala
@@ -45,6 +45,4 @@ object `WWW-Authenticate` {
     (a, b) => `WWW-Authenticate`(a.values.concatNel(b.values))
 }
 
-final case class `WWW-Authenticate`(values: NonEmptyList[Challenge]) {
-  val value = Header[`WWW-Authenticate`].value(this)
-}
+final case class `WWW-Authenticate`(values: NonEmptyList[Challenge])

--- a/core/src/main/scala/org/http4s/headers/X-B3-Flags.scala
+++ b/core/src/main/scala/org/http4s/headers/X-B3-Flags.scala
@@ -24,6 +24,9 @@ import org.typelevel.ci.CIString
 
 object `X-B3-Flags` {
 
+  def parse(s: String): ParseResult[`X-B3-Flags`] =
+    ParseResult.fromParser(parser, "Invalid X-B3-Flags header")(s)
+
   private[http4s] val parser: Parser0[`X-B3-Flags`] =
     Numbers.digits
       .mapFilter { str =>
@@ -76,7 +79,7 @@ object `X-B3-Flags` {
             writer.append(h.flags.foldLeft(0L)((sum, next) => sum + next.longValue).toString)
 
         },
-      ParseResult.fromParser(parser, "Invalid X-B3-Flags header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/X-B3-Sampled.scala
+++ b/core/src/main/scala/org/http4s/headers/X-B3-Sampled.scala
@@ -23,6 +23,9 @@ import org.typelevel.ci.CIString
 
 object `X-B3-Sampled` {
 
+  def parse(s: String): ParseResult[`X-B3-Sampled`] =
+    ParseResult.fromParser(parser, "Invalid X-B3-Sampled header")(s)
+
   private[http4s] val parser: Parser[`X-B3-Sampled`] =
     Rfc5234.bit.map(s => `X-B3-Sampled`(s == '1'))
 
@@ -30,7 +33,7 @@ object `X-B3-Sampled` {
     Header.create(
       CIString("X-B3-Sampled"),
       v => if (v.sampled) "1" else "0",
-      ParseResult.fromParser(parser, "Invalid X-B3-Sampled header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/X-B3-TraceId.scala
+++ b/core/src/main/scala/org/http4s/headers/X-B3-TraceId.scala
@@ -28,6 +28,9 @@ import org.typelevel.ci.CIString
 
 object `X-B3-TraceId` {
 
+  def parse(s: String): ParseResult[`X-B3-TraceId`] =
+    ParseResult.fromParser(parser, "Invalid X-B3-TraceId header")(s)
+
   private[http4s] val parser: Parser0[`X-B3-TraceId`] = {
     val hexValue = Applicative[Parser0].replicateA(16, Rfc5234.hexdig).map { s =>
       ZipkinHeader.idStringToLong(s.mkString(""))
@@ -44,7 +47,7 @@ object `X-B3-TraceId` {
             xB3RenderValueImpl(writer, h.idMostSigBits, h.idLeastSigBits)
 
         },
-      ParseResult.fromParser(parser, "Invalid X-B3-TraceId header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/X-Forwarded-For.scala
+++ b/core/src/main/scala/org/http4s/headers/X-Forwarded-For.scala
@@ -57,12 +57,6 @@ object `X-Forwarded-For` {
 }
 
 final case class `X-Forwarded-For`(values: NonEmptyList[Option[IpAddress]]) {
-  def renderValue(writer: Writer): writer.type = {
-    values.head.fold(writer.append("unknown"))(i => writer.append(i.toString))
-    values.tail.foreach(append(writer, _))
-    writer
-  }
-
   @inline
   private def append(w: Writer, add: Option[IpAddress]): w.type = {
     w.append(", ")

--- a/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -54,7 +54,7 @@ object ChunkAggregator {
     val hh: ListBuffer[v2.Header.ToRaw] = ListBuffer.empty[v2.Header.ToRaw]
     headers.headers.foreach {
       case h if h.name == CIString("Transfer-Encoding") =>
-        v2.Header[`Transfer-Encoding`].parse(h.value) match {
+        `Transfer-Encoding`.parse(h.value) match {
           case Right(te) =>
             te.values.filterNot(_ === TransferCoding.chunked) match {
               case v :: vs =>

--- a/tests/src/test/scala/org/http4s/headers/StrictTransportSecuritySuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/StrictTransportSecuritySuite.scala
@@ -17,22 +17,12 @@
 package org.http4s.headers
 
 import org.http4s.ParseFailure
-import org.http4s.util.Renderer
-import org.http4s.v2.Header
+import org.http4s.syntax.header._
 import scala.concurrent.duration._
 import org.http4s.laws.discipline.ArbitraryInstances._
 
 class StrictTransportSecuritySuite extends HeaderLaws {
   checkAll("StrictTransportSecurity", headerLaws[`Strict-Transport-Security`])
-
-  // TODO Temporal class providing methods which will be replaced by syntax later on
-  implicit class TemporalSyntax(header: org.http4s.headers.`Strict-Transport-Security`) {
-    def value: String = Header[`Strict-Transport-Security`].value(header)
-    def renderString: String = {
-      val raw = implicitly[Header.Select[`Strict-Transport-Security`]].toRaw(header)
-      Renderer.renderString(raw)
-    }
-  }
 
   test("fromLong should support positive max age in seconds") {
     assertEquals(

--- a/tests/src/test/scala/org/http4s/headers/TransferEncodingSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/TransferEncodingSuite.scala
@@ -19,21 +19,12 @@ package headers
 
 import cats.data.NonEmptyList
 import cats.syntax.foldable._
-import org.http4s.util.Renderer
-import org.http4s.v2.Header
+import org.http4s.syntax.header._
 import org.scalacheck.Prop.forAll
 import org.http4s.laws.discipline.ArbitraryInstances._
 
 class TransferEncodingSuite extends HeaderLaws {
   checkAll("TransferEncoding", headerLaws[`Transfer-Encoding`])
-
-  // TODO Temporal class providing methods which will be replaced by syntax later on
-  implicit class TemporalSyntax(header: `Transfer-Encoding`) {
-    def renderString: String = {
-      val raw = implicitly[Header.Select[`Transfer-Encoding`]].toRaw(header)
-      Renderer.renderString(raw)
-    }
-  }
 
   test("render should include all the encodings") {
     assertEquals(
@@ -46,15 +37,15 @@ class TransferEncodingSuite extends HeaderLaws {
 
   test("parse should accept single codings") {
     assertEquals(
-      v2.Header[`Transfer-Encoding`].parse("chunked").map(_.values),
+      `Transfer-Encoding`.parse("chunked").map(_.values),
       Right(NonEmptyList.one(TransferCoding.chunked)))
   }
   test("parse should accept multiple codings") {
     assertEquals(
-      v2.Header[`Transfer-Encoding`].parse("chunked, gzip").map(_.values),
+      `Transfer-Encoding`.parse("chunked, gzip").map(_.values),
       Right(NonEmptyList.of(TransferCoding.chunked, TransferCoding.gzip)))
     assertEquals(
-      v2.Header[`Transfer-Encoding`].parse("chunked,gzip").map(_.values),
+      `Transfer-Encoding`.parse("chunked,gzip").map(_.values),
       Right(NonEmptyList.of(TransferCoding.chunked, TransferCoding.gzip)))
   }
 

--- a/tests/src/test/scala/org/http4s/headers/ZipkinHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/ZipkinHeaderSuite.scala
@@ -19,7 +19,7 @@ package headers
 
 import cats.syntax.all._
 // import org.http4s.laws.discipline.ArbitraryInstances._
-import org.http4s.v2.Header
+import org.http4s.syntax.header._
 
 class ZipkinHeaderSuite extends Http4sSuite with HeaderLaws {
   /* checkAll("X-B3-Sampled", headerLaws(`X-B3-Sampled`))
@@ -30,41 +30,34 @@ class ZipkinHeaderSuite extends Http4sSuite with HeaderLaws {
 
   import `X-B3-Flags`.Flag
   test("flags no parse when arbitrary string") {
-    assert(Header[`X-B3-Flags`].parse("asdf").isLeft)
+    assert(`X-B3-Flags`.parse("asdf").isLeft)
   }
   test("flags no parse when negative") {
-    assert(Header[`X-B3-Flags`].parse("-1").isLeft)
+    assert(`X-B3-Flags`.parse("-1").isLeft)
   }
 
   test("flags parses no flags when 0") {
     val noFlags = "0"
-    assertEquals(Header[`X-B3-Flags`].parse(noFlags), Right(`X-B3-Flags`(Set.empty)))
+    assertEquals(`X-B3-Flags`.parse(noFlags), Right(`X-B3-Flags`(Set.empty)))
   }
   test("flags parses 'debug' flag") {
     val debugFlag = "1"
-    assertEquals(Header[`X-B3-Flags`].parse(debugFlag), Right(`X-B3-Flags`(Set(Flag.Debug))))
+    assertEquals(`X-B3-Flags`.parse(debugFlag), Right(`X-B3-Flags`(Set(Flag.Debug))))
   }
   test("flags parses 'sampling set' flag") {
     val samplingSetFlag = "2"
-    assertEquals(
-      Header[`X-B3-Flags`].parse(samplingSetFlag),
-      Right(`X-B3-Flags`(Set(Flag.SamplingSet))))
+    assertEquals(`X-B3-Flags`.parse(samplingSetFlag), Right(`X-B3-Flags`(Set(Flag.SamplingSet))))
   }
   test("flags parses 'sampled' flag") {
     val sampledFlag = "4"
-    assertEquals(Header[`X-B3-Flags`].parse(sampledFlag), Right(`X-B3-Flags`(Set(Flag.Sampled))))
+    assertEquals(`X-B3-Flags`.parse(sampledFlag), Right(`X-B3-Flags`(Set(Flag.Sampled))))
   }
   test("flags parses multiple flags") {
     val sampledAndDebugFlag = "5"
-    val result = Header[`X-B3-Flags`].parse(sampledAndDebugFlag)
+    val result = `X-B3-Flags`.parse(sampledAndDebugFlag)
     assert(result.isRight)
     assert(result.valueOr(throw _).flags.exists(_ == Flag.Sampled))
     assert(result.valueOr(throw _).flags.exists(_ == Flag.Debug))
-  }
-
-  // Temporal class providing methods which will be replaced by syntax later on
-  implicit class TemporalSyntax[A](header: A)(implicit e: v2.Header[A, v2.Header.Single]) {
-    def value: String = v2.Header[A].value(header)
   }
 
   test("flags renders when no flags") {
@@ -85,44 +78,42 @@ class ZipkinHeaderSuite extends Http4sSuite with HeaderLaws {
   }
 
   test("sampled parses false when 0") {
-    assertEquals(Header[`X-B3-Sampled`].parse("0"), Right(`X-B3-Sampled`(false)))
+    assertEquals(`X-B3-Sampled`.parse("0"), Right(`X-B3-Sampled`(false)))
   }
   test("sampled parses true when 1") {
-    assertEquals(Header[`X-B3-Sampled`].parse("1"), Right(`X-B3-Sampled`(true)))
+    assertEquals(`X-B3-Sampled`.parse("1"), Right(`X-B3-Sampled`(true)))
   }
   test("sampled no parse when not 0 or 1") {
-    assert(Header[`X-B3-Sampled`].parse("01").isLeft)
+    assert(`X-B3-Sampled`.parse("01").isLeft)
   }
 
   // The parsing logic is the same for all ids.
   test("id no parse when less than 16 chars") {
     val not16Chars = "abcd1234"
-    assert(Header[`X-B3-TraceId`].parse(not16Chars).isLeft)
+    assert(`X-B3-TraceId`.parse(not16Chars).isLeft)
   }
   test("id no parse when more than 16 but less than 32 chars") {
     val not16Or32Chars = "abcd1234a"
-    assert(Header[`X-B3-TraceId`].parse(not16Or32Chars).isLeft)
+    assert(`X-B3-TraceId`.parse(not16Or32Chars).isLeft)
   }
   test("id no parse when more than 32 chars") {
     val not16Or32Chars = "2abcd1234a1493b12"
-    assert(Header[`X-B3-TraceId`].parse(not16Or32Chars).isLeft)
+    assert(`X-B3-TraceId`.parse(not16Or32Chars).isLeft)
   }
   test("id no parse when contains non-hex char") {
     val containsZ = "abcd1z34abcd1234"
-    assert(Header[`X-B3-TraceId`].parse(containsZ).isLeft)
+    assert(`X-B3-TraceId`.parse(containsZ).isLeft)
   }
 
   test("id parses a Long when contains 16-char case-insensitive hex string") {
     val long = 2159330025234698493L
     val hexString = "1dF77B37a2f310fD"
-    assertEquals(Header[`X-B3-TraceId`].parse(hexString), Right(`X-B3-TraceId`(long, None)))
+    assertEquals(`X-B3-TraceId`.parse(hexString), Right(`X-B3-TraceId`(long, None)))
   }
   test("id parses a two Longs when contains 32-char case-insensitive hex string") {
     val msbLong = 2159330025234698493L
     val lsbLong = 7000848103853419616L
     val hexString = "1dF77B37a2f310fD6128024224a66C60"
-    assertEquals(
-      Header[`X-B3-TraceId`].parse(hexString),
-      Right(`X-B3-TraceId`(msbLong, Some(lsbLong))))
+    assertEquals(`X-B3-TraceId`.parse(hexString), Right(`X-B3-TraceId`(msbLong, Some(lsbLong))))
   }
 }

--- a/tests/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptHeaderSpec.scala
@@ -22,13 +22,8 @@ import org.http4s.MediaRange._
 import org.http4s.MediaType._
 import org.http4s.headers.{Accept, MediaRangeAndQValue}
 import org.http4s.syntax.all._
-import org.http4s.v2.Header
 
-class AcceptHeaderSpec extends Http4sSuite {
-
-  def parse(value: String): Accept = Header[Accept].parse(value).toOption.get
-
-  def roundTrip(accept: Accept): Accept = parse(Header[Accept].value(accept))
+class AcceptHeaderSpec extends Http4sSuite with HeaderParserHelper[Accept] {
 
   val `audio/mod`: MediaType =
     new MediaType("audio", "mod", MediaType.Uncompressible, MediaType.Binary, List("mod"))

--- a/tests/src/test/scala/org/http4s/parser/AcceptLanguageSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/AcceptLanguageSuite.scala
@@ -20,7 +20,7 @@ package parser
 import org.http4s.headers.`Accept-Language`
 import org.http4s.syntax.all._
 
-class AcceptLanguageSuite extends Http4sSuite with HeaderV2ParserHelper[`Accept-Language`] {
+class AcceptLanguageSuite extends Http4sSuite with HeaderParserHelper[`Accept-Language`] {
 
   val en = `Accept-Language`(LanguageTag("en"))
   val fr = `Accept-Language`(LanguageTag("fr"))

--- a/tests/src/test/scala/org/http4s/parser/CacheControlSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/CacheControlSpec.scala
@@ -22,7 +22,7 @@ import org.http4s.CacheDirective._
 import org.typelevel.ci.CIString
 import scala.concurrent.duration._
 
-class CacheControlSpec extends Http4sSuite with HeaderV2ParserHelper[`Cache-Control`] {
+class CacheControlSpec extends Http4sSuite with HeaderParserHelper[`Cache-Control`] {
 
   // Default values
   val valueless = List(

--- a/tests/src/test/scala/org/http4s/parser/ContentLanguageSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/ContentLanguageSpec.scala
@@ -19,8 +19,9 @@ package org.http4s
 package parser
 
 import org.http4s.headers.`Content-Language`
+import org.http4s.syntax.all._
 
-class ContentLanguageSpec extends Http4sSuite with HeaderV2ParserHelper[`Content-Language`] {
+class ContentLanguageSpec extends Http4sSuite with HeaderParserHelper[`Content-Language`] {
 
   val en = `Content-Language`(LanguageTag("en"))
   val en_IN = `Content-Language`(LanguageTag("en", "IN"))
@@ -29,10 +30,10 @@ class ContentLanguageSpec extends Http4sSuite with HeaderV2ParserHelper[`Content
     `Content-Language`(LanguageTag("en"), LanguageTag("fr"), LanguageTag("da"), LanguageTag("id"))
 
   test("Content-Language should Give correct value") {
-    assertEquals(value(en), "en")
-    assertEquals(value(en_IN), "en-IN")
-    assertEquals(value(en_IN_en_US), "en-IN, en-US")
-    assertEquals(value(multi_lang), "en, fr, da, id")
+    assertEquals(en.value, "en")
+    assertEquals(en_IN.value, "en-IN")
+    assertEquals(en_IN_en_US.value, "en-IN, en-US")
+    assertEquals(multi_lang.value, "en, fr, da, id")
   }
 
   test("Content-Language should Parse Properly") {

--- a/tests/src/test/scala/org/http4s/parser/HeaderParserHelper.scala
+++ b/tests/src/test/scala/org/http4s/parser/HeaderParserHelper.scala
@@ -16,31 +16,17 @@
 
 package org.http4s.parser
 
-import org.http4s.{Header, ParseResult}
-import org.http4s.v2
+import org.http4s.ParseResult
+import org.http4s.v2.Header
+import org.http4s.syntax.header._
 
-@deprecated("Condemned", "LSUG")
-trait HeaderParserHelper[H <: Header] {
-  def hparse(value: String): ParseResult[H]
+trait HeaderParserHelper[H] {
 
-  // Also checks to make sure whitespace doesn't effect the outcome
-  protected def parse(value: String): H = {
-    val a =
-      hparse(value).fold(err => sys.error(s"Couldn't parse: '$value'.\nError: $err"), identity)
-    val b =
-      hparse(value.replace(" ", "")).fold(_ => sys.error(s"Couldn't parse: $value"), identity)
-    assert(a == b, "Whitespace resulted in different headers")
-    a
-  }
-}
-
-trait HeaderV2ParserHelper[H] {
-
-  protected def roundTrip[T <: v2.Header.Type](h: H)(implicit header: v2.Header[H, T]): H =
-    parse(value(h))
+  protected def roundTrip[T <: Header.Type](h: H)(implicit header: Header[H, T]): H =
+    parse(h.value)
 
   // Also checks to make sure whitespace doesn't effect the outcome
-  protected def parse[T <: v2.Header.Type](value: String)(implicit i: v2.Header[H, T]): H = {
+  protected def parse[T <: Header.Type](value: String)(implicit i: Header[H, T]): H = {
     val a = parseOnly(value)
     val b =
       hparse(value.replace(" ", "")).fold(_ => sys.error(s"Couldn't parse: $value"), identity)
@@ -48,14 +34,11 @@ trait HeaderV2ParserHelper[H] {
     a
   }
 
-  protected def parseOnly[T <: v2.Header.Type](value: String)(implicit i: v2.Header[H, T]): H =
+  protected def parseOnly[T <: Header.Type](value: String)(implicit i: Header[H, T]): H =
     hparse(value).fold(err => sys.error(s"Couldn't parse: '$value'.\nError: $err"), identity)
 
-  def value[T <: v2.Header.Type](h: H)(implicit header: v2.Header[H, T]): String =
-    header.value(h)
-
-  private def hparse[T <: v2.Header.Type](value: String)(implicit
-      header: v2.Header[H, T]): ParseResult[H] =
+  private def hparse[T <: Header.Type](value: String)(implicit
+      header: Header[H, T]): ParseResult[H] =
     header.parse(value)
 
 }

--- a/tests/src/test/scala/org/http4s/parser/ProxyAuthenticateHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/ProxyAuthenticateHeaderSuite.scala
@@ -21,7 +21,7 @@ import org.http4s.headers._
 
 class ProxyAuthenticateHeaderSuite
     extends munit.FunSuite
-    with HeaderV2ParserHelper[`Proxy-Authenticate`] {
+    with HeaderParserHelper[`Proxy-Authenticate`] {
 
   val params = Map("a" -> "b", "c" -> "d")
   val c = Challenge("Basic", "foo")

--- a/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -54,7 +54,7 @@ class SimpleHeadersSpec extends Http4sSuite {
       )
     )
 
-    assertEquals(`Access-Control-Allow-Headers`.parse(toRaw(header).value), Right(header))
+    assertEquals(`Access-Control-Allow-Headers`.parse(header.toRaw.value), Right(header))
 
     val invalidHeaderValue = "(non-token-name), non[&token]name"
     assert(`Access-Control-Allow-Headers`.parse(invalidHeaderValue).isLeft)
@@ -69,7 +69,7 @@ class SimpleHeadersSpec extends Http4sSuite {
         CIString("*")
       )
     )
-    assertEquals(`Access-Control-Expose-Headers`.parse(toRaw(header).value), Right(header))
+    assertEquals(`Access-Control-Expose-Headers`.parse(header.toRaw.value), Right(header))
 
     val invalidHeaderValue = "(non-token-name), non[&token]name"
     assert(`Access-Control-Expose-Headers`.parse(invalidHeaderValue).isLeft)
@@ -77,7 +77,7 @@ class SimpleHeadersSpec extends Http4sSuite {
 
   test("parse Connection") {
     val header = Connection(CIString("closed"))
-    assertEquals(Connection.parse(toRaw(header).value), Right(header))
+    assertEquals(Connection.parse(header.toRaw.value), Right(header))
   }
 
   test("Parse Content-Length") {
@@ -167,28 +167,28 @@ class SimpleHeadersSpec extends Http4sSuite {
 
   test("SimpleHeaders should parse Transfer-Encoding") {
     val header = `Transfer-Encoding`(TransferCoding.chunked)
-    assertEquals(v2.Header[`Transfer-Encoding`].parse(header.value), Right(header))
+    assertEquals(`Transfer-Encoding`.parse(header.value), Right(header))
 
     val header2 = `Transfer-Encoding`(TransferCoding.compress)
-    assertEquals(v2.Header[`Transfer-Encoding`].parse(header2.value), Right(header2))
+    assertEquals(`Transfer-Encoding`.parse(header2.value), Right(header2))
   }
 
   test("SimpleHeaders should parse User-Agent") {
     val header = `User-Agent`(ProductId("foo", Some("bar")), List(ProductId("foo")))
     assertEquals(header.value, "foo/bar foo")
 
-    assertEquals(v2.Header[`User-Agent`].parse(header.value), Right(header))
+    assertEquals(`User-Agent`.parse(header.value), Right(header))
 
     val header2 =
       `User-Agent`(ProductId("foo"), List(ProductId("bar", Some("biz")), ProductComment("blah")))
     assertEquals(header2.value, "foo bar/biz (blah)")
-    assertEquals(v2.Header[`User-Agent`].parse(header2.value), Right(header2))
+    assertEquals(`User-Agent`.parse(header2.value), Right(header2))
 
     val headerstr = "Mozilla/5.0 (Android; Mobile; rv:30.0) Gecko/30.0 Firefox/30.0"
 
     val headerraw = v2.Header.Raw(`User-Agent`.name, headerstr)
 
-    val parsed = v2.Header[`User-Agent`].parse(headerraw.value)
+    val parsed = `User-Agent`.parse(headerraw.value)
     assertEquals(
       parsed,
       Right(
@@ -245,16 +245,16 @@ class SimpleHeadersSpec extends Http4sSuite {
   test("SimpleHeaders should parse X-Forwarded-For") {
     // ipv4
     val header2 = `X-Forwarded-For`(NonEmptyList.of(Some(ipv4"127.0.0.1")))
-    assertEquals(`X-Forwarded-For`.parse(toRaw(header2).value), Right(header2))
+    assertEquals(`X-Forwarded-For`.parse(header2.toRaw.value), Right(header2))
 
     // ipv6
     val header3 = `X-Forwarded-For`(
       NonEmptyList.of(Some(ipv6"::1"), Some(ipv6"2001:0db8:85a3:0000:0000:8a2e:0370:7334")))
-    assertEquals(`X-Forwarded-For`.parse(toRaw(header3).value), Right(header3))
+    assertEquals(`X-Forwarded-For`.parse(header3.toRaw.value), Right(header3))
 
     // "unknown"
     val header4 = `X-Forwarded-For`(NonEmptyList.of(None))
-    assertEquals(`X-Forwarded-For`.parse(toRaw(header4).value), Right(header4))
+    assertEquals(`X-Forwarded-For`.parse(header4.toRaw.value), Right(header4))
 
     val bad = "foo"
     assert(`X-Forwarded-For`.parse(bad).isLeft)
@@ -262,8 +262,5 @@ class SimpleHeadersSpec extends Http4sSuite {
     val bad2 = "256.56.56.56"
     assert(`X-Forwarded-For`.parse(bad2).isLeft)
   }
-
-  private def toRaw[H: v2.Header.Select](h: H): v2.Header.Raw =
-    implicitly[v2.Header.Select[H]].toRaw(h)
 
 }

--- a/tests/src/test/scala/org/http4s/parser/WwwAuthenticateHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/WwwAuthenticateHeaderSpec.scala
@@ -19,7 +19,7 @@ package parser
 
 import org.http4s.headers.`WWW-Authenticate`
 
-class WwwAuthenticateHeaderSpec extends Http4sSuite with HeaderV2ParserHelper[`WWW-Authenticate`] {
+class WwwAuthenticateHeaderSpec extends Http4sSuite with HeaderParserHelper[`WWW-Authenticate`] {
 
   val params = Map("a" -> "b", "c" -> "d")
   val c = Challenge("Basic", "foo")

--- a/tests/src/test/scala/org/http4s/parser/WwwAuthenticateHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/WwwAuthenticateHeaderSuite.scala
@@ -19,7 +19,7 @@ package parser
 
 import org.http4s.headers.`WWW-Authenticate`
 
-class WwwAuthenticateHeaderSuite extends Http4sSuite with HeaderV2ParserHelper[`WWW-Authenticate`] {
+class WwwAuthenticateHeaderSuite extends Http4sSuite with HeaderParserHelper[`WWW-Authenticate`] {
 
   val params = Map("a" -> "b", "c" -> "d")
   val c = Challenge("Basic", "foo")


### PR DESCRIPTION
Removing temporal functionality (which was replaced by header syntax) and making header more consistent.