### PR TITLE
Make headers consistent / header cleanup

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
@@ -26,8 +26,6 @@ import org.http4s.Status.{BadRequest, Created, InternalServerError, Ok}
 import org.http4s.syntax.all._
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers.Accept
-import org.http4s.util.Renderer
-import org.http4s.Header
 
 class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
   val app = HttpRoutes
@@ -38,8 +36,7 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
         Response[IO](Created).withEntity(r.body).pure[IO]
       case r if r.method == GET && r.pathInfo == path"/echoheaders" =>
         r.headers.get[Accept].fold(IO.pure(Response[IO](BadRequest))) { m =>
-          val raw = implicitly[Header.Select[Accept]].toRaw(m)
-          Response[IO](Ok).withEntity(Renderer.renderString(raw)).pure[IO]
+          Response[IO](Ok).withEntity(m.renderString).pure[IO]
         }
       case r if r.pathInfo == path"/status/500" =>
         Response[IO](InternalServerError).withEntity("Oops").pure[IO]

--- a/core/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/src/main/scala/org/http4s/StaticFile.scala
@@ -27,6 +27,7 @@ import java.io._
 import java.net.URL
 import org.http4s.Status.NotModified
 import org.http4s.headers._
+import org.http4s.syntax.header._
 import org.log4s.getLogger
 import org.typelevel.vault._
 

--- a/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
@@ -21,7 +21,6 @@ import cats.data.NonEmptyList
 import cats.parse.Parser
 import cats.syntax.all._
 import org.http4s.CharsetRange.{Atom, `*`}
-import org.http4s.util.Renderer
 import org.typelevel.ci.CIString
 
 object `Accept-Charset` {
@@ -73,13 +72,6 @@ object `Accept-Charset` {
   * From [http//tools.ietf.org/html/rfc7231#section-5.3.3 RFC-7231].
   */
 final case class `Accept-Charset`(values: NonEmptyList[CharsetRange]) {
-
-  def value: String = Renderer.renderString(values)
-
-  def renderString: String = s"Accept-Charset: $value"
-
-  def key: `Accept-Charset`.type = `Accept-Charset`
-  type Value = CharsetRange
 
   def qValue(charset: Charset): QValue = {
     def specific =

--- a/core/src/main/scala/org/http4s/headers/Accept-Encoding.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Encoding.scala
@@ -40,7 +40,7 @@ object `Accept-Encoding` {
     Header.createRendered(
       CIString("Accept-Encoding"),
       _.values,
-      ParseResult.fromParser(parser, "Invalid Accept-Encoding header")
+      parse
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[`Accept-Encoding`] =

--- a/core/src/main/scala/org/http4s/headers/Accept-Language.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Language.scala
@@ -21,7 +21,6 @@ import cats.data.NonEmptyList
 import cats.parse.Parser
 import org.http4s.internal.parsing.Rfc7230
 import org.typelevel.ci.CIString
-import org.http4s.util.Renderer
 
 object `Accept-Language` {
   def apply(head: LanguageTag, tail: LanguageTag*): `Accept-Language` =
@@ -47,7 +46,7 @@ object `Accept-Language` {
     Header.createRendered(
       CIString("Accept-Language"),
       _.values,
-      ParseResult.fromParser(parser, "Invalid Accept-Language header")
+      parse
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[`Accept-Language`] =
@@ -60,8 +59,6 @@ object `Accept-Language` {
   * [[https://tools.ietf.org/html/rfc7231#section-5.3.5 RFC-7231 Section 5.3.5]]
   */
 final case class `Accept-Language`(values: NonEmptyList[LanguageTag]) {
-
-  def value = Renderer.renderString(values)
 
   @deprecated("Has confusing semantics in the presence of splat. Do not use.", "0.16.1")
   def preferred: LanguageTag = values.tail.fold(values.head)((a, b) => if (a.q >= b.q) a else b)

--- a/core/src/main/scala/org/http4s/headers/Accept-Patch.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Patch.scala
@@ -18,7 +18,6 @@ package org.http4s
 
 package headers
 
-import org.http4s.util.Renderer
 import cats.data.NonEmptyList
 import org.http4s.internal.parsing.Rfc7230
 import org.typelevel.ci.CIString
@@ -37,7 +36,7 @@ object `Accept-Patch` {
     Header.createRendered(
       CIString("Accept-Patch"),
       _.values,
-      ParseResult.fromParser(parser, "Invalid Accept-Patch header")
+      parse
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[`Accept-Patch`] =
@@ -45,7 +44,4 @@ object `Accept-Patch` {
 }
 
 // see https://tools.ietf.org/html/rfc5789#section-3.1
-final case class `Accept-Patch`(values: NonEmptyList[MediaType]) {
-  def renderString: String = s"Accept-Patch: $value"
-  def value: String = Renderer.renderString(values)
-}
+final case class `Accept-Patch`(values: NonEmptyList[MediaType])

--- a/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
@@ -28,7 +28,7 @@ object `Accept-Ranges` {
   def none: `Accept-Ranges` = apply(Nil)
 
   def parse(s: String): ParseResult[`Accept-Ranges`] =
-    ParseResult.fromParser(parser, "Accept-Ranges header")(s)
+    ParseResult.fromParser(parser, "Invalid Accept-Ranges header")(s)
 
   /* https://tools.ietf.org/html/rfc7233#appendix-C */
   val parser: P0[`Accept-Ranges`] = {
@@ -60,7 +60,7 @@ object `Accept-Ranges` {
         case None => "none"
         case Some(nel) => Renderer.renderString(nel)
       },
-      ParseResult.fromParser(parser, "Invalid Accept-Ranges header")
+      parse
     )
 }
 

--- a/core/src/main/scala/org/http4s/headers/Age.scala
+++ b/core/src/main/scala/org/http4s/headers/Age.scala
@@ -37,13 +37,14 @@ object Age {
 
   def parse(s: String): ParseResult[Age] =
     ParseResult.fromParser(parser, "Invalid Age header")(s)
+
   private[http4s] val parser = AdditionalRules.NonNegativeLong.map(unsafeFromLong)
 
   implicit val headerInstance: Header[Age, Header.Single] =
     Header.createRendered(
       CIString("Age"),
       _.age,
-      ParseResult.fromParser(parser, "Invalid Age header")
+      parse
     )
 }
 

--- a/core/src/main/scala/org/http4s/headers/Allow.scala
+++ b/core/src/main/scala/org/http4s/headers/Allow.scala
@@ -24,7 +24,7 @@ object Allow {
   def apply(ms: Method*): Allow = Allow(ms.toSet)
 
   def parse(s: String): ParseResult[Allow] =
-    ParseResult.fromParser(parser, "Invalid Allow")(s)
+    ParseResult.fromParser(parser, "Invalid Allow header")(s)
 
   private[http4s] val parser = Rfc7230
     .headerRep1(Rfc7230.token.mapFilter(s => Method.fromString(s).toOption))
@@ -37,7 +37,7 @@ object Allow {
     Header.createRendered(
       CIString("Allow"),
       _.methods,
-      ParseResult.fromParser(parser, "Invalid Allow")
+      parse
     )
 }
 

--- a/core/src/main/scala/org/http4s/headers/Authorization.scala
+++ b/core/src/main/scala/org/http4s/headers/Authorization.scala
@@ -28,7 +28,7 @@ object Authorization {
   }
 
   def parse(s: String): ParseResult[Authorization] =
-    ParseResult.fromParser(parser, "Invalid Authorization")(s)
+    ParseResult.fromParser(parser, "Invalid Authorization header")(s)
 
   def apply(basic: BasicCredentials): Authorization =
     Authorization(Credentials.Token(AuthScheme.Basic, basic.token))
@@ -37,7 +37,7 @@ object Authorization {
     Header.createRendered(
       CIString("Authorization"),
       _.credentials,
-      ParseResult.fromParser(parser, "Invalid Authorization")
+      parse
     )
 }
 

--- a/core/src/main/scala/org/http4s/headers/Connection.scala
+++ b/core/src/main/scala/org/http4s/headers/Connection.scala
@@ -39,7 +39,7 @@ object Connection {
     Header.createRendered(
       CIString("Connection"),
       _.values,
-      ParseResult.fromParser(parser, "Invalid Connection header")
+      parse
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[Connection] =

--- a/core/src/main/scala/org/http4s/headers/Content-Disposition.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Disposition.scala
@@ -83,7 +83,7 @@ object `Content-Disposition` {
             writer
           }
         },
-      ParseResult.fromParser(parser, "Invalid Content-Disposition header")
+      parse
     )
 }
 

--- a/core/src/main/scala/org/http4s/headers/Content-Encoding.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Encoding.scala
@@ -29,7 +29,7 @@ object `Content-Encoding` {
     Header.createRendered(
       CIString("Content-Encoding"),
       _.contentCoding,
-      ParseResult.fromParser(parser, "Invalid Content-Encoding header")
+      parse
     )
 }
 

--- a/core/src/main/scala/org/http4s/headers/Content-Length.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Length.scala
@@ -53,7 +53,7 @@ object `Content-Length` {
     Header.createRendered(
       name,
       _.length,
-      ParseResult.fromParser(parser, "Invalid Content-Length header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Content-Location.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Location.scala
@@ -22,7 +22,7 @@ import org.typelevel.ci.CIString
 
 object `Content-Location` {
   def parse(s: String): ParseResult[`Content-Location`] =
-    ParseResult.fromParser(parser, "Invalid Content-Location")(s)
+    ParseResult.fromParser(parser, "Invalid Content-Location header")(s)
 
   private[http4s] val parser = Uri.Parser
     .absoluteUri(StandardCharsets.ISO_8859_1)
@@ -33,7 +33,7 @@ object `Content-Location` {
     Header.create(
       CIString("Content-Location"),
       _.uri.toString,
-      ParseResult.fromParser(parser, "Invalid Content-Location header")
+      parse
     )
 }
 

--- a/core/src/main/scala/org/http4s/headers/Content-Range.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Range.scala
@@ -33,9 +33,7 @@ object `Content-Range` {
     apply(Range.SubRange(start, None), None)
 
   def parse(s: String): ParseResult[`Content-Range`] =
-    parser.parseAll(s).left.map { e =>
-      ParseFailure("Invalid Content-Range header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Content-Range header")(s)
 
   val parser: P[`Content-Range`] = {
 
@@ -77,7 +75,7 @@ object `Content-Range` {
             }
           }
         },
-      ParseResult.fromParser(parser, "Invalid Content-Range header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Content-Type.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Type.scala
@@ -61,7 +61,7 @@ object `Content-Type` {
               case _ => MediaRange.http4sHttpCodecForMediaRange.render(writer, h.mediaType)
             }
         },
-      ParseResult.fromParser(parser, "Invalid Content-Type header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Date.scala
+++ b/core/src/main/scala/org/http4s/headers/Date.scala
@@ -18,7 +18,6 @@ package org.http4s
 package headers
 
 import cats.parse.Parser
-import org.http4s.util.{Renderer}
 import org.typelevel.ci.CIString
 
 object Date {
@@ -33,10 +32,8 @@ object Date {
     Header.createRendered(
       CIString("Date"),
       _.date,
-      ParseResult.fromParser(parser, "Invalid Date header")
+      parse
     )
 }
 
-final case class Date(date: HttpDate) {
-  def value: String = Renderer.renderString(date)
-}
+final case class Date(date: HttpDate)

--- a/core/src/main/scala/org/http4s/headers/ETag.scala
+++ b/core/src/main/scala/org/http4s/headers/ETag.scala
@@ -31,7 +31,7 @@ object ETag {
     ETag(http4s.EntityTag(tag, weakness))
 
   def parse(s: String): ParseResult[ETag] =
-    ParseResult.fromParser(parser, "ETag header")(s)
+    ParseResult.fromParser(parser, "Invalid ETag header")(s)
 
   /* `ETag = entity-tag`
    *
@@ -44,10 +44,8 @@ object ETag {
     Header.create(
       CIString("ETag"),
       _.tag.toString,
-      ParseResult.fromParser(parser, "Invalid ETag header")
+      parse
     )
 }
 
-final case class ETag(tag: EntityTag) {
-  def value: String = tag.toString()
-}
+final case class ETag(tag: EntityTag)

--- a/core/src/main/scala/org/http4s/headers/Expires.scala
+++ b/core/src/main/scala/org/http4s/headers/Expires.scala
@@ -18,7 +18,6 @@ package org.http4s
 package headers
 
 import cats.parse.{Parser, Parser0}
-import org.http4s.util.{Renderer}
 import org.typelevel.ci.CIString
 
 object Expires {
@@ -43,7 +42,7 @@ object Expires {
     Header.createRendered(
       CIString("Expires"),
       _.expirationDate,
-      ParseResult.fromParser(parser, "Invalid Expires header")
+      parse
     )
 
 }
@@ -59,6 +58,4 @@ object Expires {
   * @param expirationDate the date of expiration. The RFC has a warning, that using large values
   * can cause problems due to integer or clock overflows.
   */
-final case class Expires(expirationDate: HttpDate) {
-  val value = Renderer.renderString(expirationDate)
-}
+final case class Expires(expirationDate: HttpDate)

--- a/core/src/main/scala/org/http4s/headers/Forwarded.scala
+++ b/core/src/main/scala/org/http4s/headers/Forwarded.scala
@@ -286,9 +286,7 @@ object Forwarded extends ForwardedRenderers {
   }
 
   def parse(s: String): ParseResult[Forwarded] =
-    parser.parseAll(s).left.map { e =>
-      ParseFailure("Invalid header", e.toString)
-    }
+    ParseResult.fromParser(parser, "Invalid Forwarded header")(s)
 
   private val parser: P[Forwarded] = {
     // https://tools.ietf.org/html/rfc7239#section-4
@@ -365,7 +363,7 @@ object Forwarded extends ForwardedRenderers {
     Header.createRendered(
       name,
       _.values,
-      ParseResult.fromParser(parser, "Invalid Forwarded header")
+      parse
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[Forwarded] =

--- a/core/src/main/scala/org/http4s/headers/Host.scala
+++ b/core/src/main/scala/org/http4s/headers/Host.scala
@@ -27,7 +27,7 @@ object Host {
   def apply(host: String, port: Int): Host = apply(host, Some(port))
 
   def parse(s: String): ParseResult[Host] =
-    ParseResult.fromParser(parser, "Invalid Host")(s)
+    ParseResult.fromParser(parser, "Invalid Host header")(s)
 
   private[http4s] val parser = {
     val port = Parser.string(":") *> Rfc3986.digit.rep.string.mapFilter { s =>
@@ -49,7 +49,7 @@ object Host {
             writer
           }
         },
-      ParseResult.fromParser(parser, "Invalid Host header")
+      parse
     )
 }
 
@@ -65,9 +65,4 @@ object Host {
   *
   * [[https://tools.ietf.org/html/rfc7230#section-5.4 RFC-7230 Section 5.4]]
   */
-final case class Host(host: String, port: Option[Int] = None) {
-  def value: String = port match {
-    case Some(p) => s"$host:$p"
-    case None => host
-  }
-}
+final case class Host(host: String, port: Option[Int] = None)

--- a/core/src/main/scala/org/http4s/headers/If-Match.scala
+++ b/core/src/main/scala/org/http4s/headers/If-Match.scala
@@ -50,7 +50,7 @@ object `If-Match` {
         case Some(nel) => nel.mkString_("", ",", "")
 
       },
-      ParseResult.fromParser(parser, "Invalid If-Match header")
+      parse
     )
 
 }
@@ -60,10 +60,4 @@ object `If-Match` {
   *
   * [[https://tools.ietf.org/html/rfc7232#section-3.1 RFC-7232 Section 3.1]]
   */
-final case class `If-Match`(tags: Option[NonEmptyList[EntityTag]]) {
-  def value: String =
-    tags match {
-      case None => "*"
-      case Some(tags) => tags.mkString_("", ",", "")
-    }
-}
+final case class `If-Match`(tags: Option[NonEmptyList[EntityTag]])

--- a/core/src/main/scala/org/http4s/headers/If-Modified-Since.scala
+++ b/core/src/main/scala/org/http4s/headers/If-Modified-Since.scala
@@ -18,7 +18,6 @@ package org.http4s
 package headers
 
 import cats.parse.Parser
-import org.http4s.util.Renderer
 import org.typelevel.ci.CIString
 
 object `If-Modified-Since` {
@@ -33,7 +32,7 @@ object `If-Modified-Since` {
     Header.createRendered(
       CIString("If-Modified-Since"),
       _.date,
-      ParseResult.fromParser(parser, "Invalid If-Modified-Since header")
+      parse
     )
 
 }
@@ -46,6 +45,4 @@ object `If-Modified-Since` {
   *
   * [[https://tools.ietf.org/html/rfc7232#section-3.3 RFC-7232]]
   */
-final case class `If-Modified-Since`(date: HttpDate) {
-  def value: String = Renderer.renderString(date)
-}
+final case class `If-Modified-Since`(date: HttpDate)

--- a/core/src/main/scala/org/http4s/headers/If-None-Match.scala
+++ b/core/src/main/scala/org/http4s/headers/If-None-Match.scala
@@ -58,14 +58,8 @@ object `If-None-Match` {
         case None => "*"
         case Some(tags) => tags.mkString_("", ",", "")
       },
-      ParseResult.fromParser(parser, "Invalid If-None-Match header")
+      parse
     )
 }
 
-final case class `If-None-Match`(tags: Option[NonEmptyList[EntityTag]]) {
-  def value: String =
-    tags match {
-      case None => "*"
-      case Some(tags) => tags.mkString_("", ",", "")
-    }
-}
+final case class `If-None-Match`(tags: Option[NonEmptyList[EntityTag]])

--- a/core/src/main/scala/org/http4s/headers/If-Unmodified-Since.scala
+++ b/core/src/main/scala/org/http4s/headers/If-Unmodified-Since.scala
@@ -18,7 +18,6 @@ package org.http4s
 package headers
 
 import cats.parse.Parser
-import org.http4s.util.Renderer
 import org.typelevel.ci.CIString
 
 object `If-Unmodified-Since` {
@@ -33,11 +32,9 @@ object `If-Unmodified-Since` {
     Header.createRendered(
       CIString("If-Unmodified-Since"),
       _.date,
-      ParseResult.fromParser(parser, "Invalid If-Unmodified-Since header")
+      parse
     )
 
 }
 
-final case class `If-Unmodified-Since`(date: HttpDate) {
-  def value: String = Renderer.renderString(date)
-}
+final case class `If-Unmodified-Since`(date: HttpDate)

--- a/core/src/main/scala/org/http4s/headers/Last-Event-Id.scala
+++ b/core/src/main/scala/org/http4s/headers/Last-Event-Id.scala
@@ -22,9 +22,7 @@ import org.http4s.internal.CharPredicate
 import org.http4s.ServerSentEvent._
 import org.typelevel.ci.CIString
 
-final case class `Last-Event-Id`(id: EventId) {
-  def value: String = id.value
-}
+final case class `Last-Event-Id`(id: EventId)
 
 object `Last-Event-Id` {
   def parse(s: String): ParseResult[`Last-Event-Id`] =
@@ -37,8 +35,8 @@ object `Last-Event-Id` {
   implicit val headerInstance: Header[`Last-Event-Id`, Header.Single] =
     Header.create(
       CIString("Last-Event-Id"),
-      _.value,
-      ParseResult.fromParser(parser, "Invalid Last-Event-Id header")
+      _.id.value,
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Last-Modified.scala
+++ b/core/src/main/scala/org/http4s/headers/Last-Modified.scala
@@ -22,6 +22,9 @@ import org.typelevel.ci.CIString
 
 object `Last-Modified` {
 
+  def parse(s: String): ParseResult[`Last-Modified`] =
+    ParseResult.fromParser(parser, "Invalid Last-Modified header")(s)
+
   /* `Last-Modified = HTTP-date` */
   private[http4s] val parser: Parser[`Last-Modified`] =
     HttpDate.parser.map(apply)
@@ -30,7 +33,7 @@ object `Last-Modified` {
     Header.createRendered(
       CIString("Last-Modified"),
       _.date,
-      ParseResult.fromParser(parser, "Invalid Last-Modified header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Location.scala
+++ b/core/src/main/scala/org/http4s/headers/Location.scala
@@ -21,6 +21,10 @@ import java.nio.charset.StandardCharsets
 import org.typelevel.ci.CIString
 
 object Location {
+
+  def parse(s: String): ParseResult[Location] =
+    ParseResult.fromParser(parser, "Invalid Location header")(s)
+
   private[http4s] val parser = Uri.Parser
     .absoluteUri(StandardCharsets.ISO_8859_1)
     .orElse(Uri.Parser.relativeRef(StandardCharsets.ISO_8859_1))
@@ -30,7 +34,7 @@ object Location {
     Header.create(
       CIString("Location"),
       _.uri.toString,
-      ParseResult.fromParser(parser, "Invalid Location header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Max-Forwards.scala
+++ b/core/src/main/scala/org/http4s/headers/Max-Forwards.scala
@@ -40,13 +40,16 @@ object `Max-Forwards` {
   def unsafeFromLong(length: Long): `Max-Forwards` =
     fromLong(length).fold(throw _, identity)
 
+  def parse(s: String): ParseResult[`Max-Forwards`] =
+    ParseResult.fromParser(parser, "Invalid Max-Forwards header")(s)
+
   private[http4s] val parser = AdditionalRules.NonNegativeLong.mapFilter(l => fromLong(l).toOption)
 
   implicit val headerInstance: Header[`Max-Forwards`, Header.Single] =
     Header.createRendered(
       CIString("Max-Forwards"),
       _.count,
-      ParseResult.fromParser(parser, "Invalid Max-Forwards header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Origin.scala
+++ b/core/src/main/scala/org/http4s/headers/Origin.scala
@@ -72,7 +72,10 @@ object Origin {
     nullHost.orElse(singleHost.repSep(char(' ')).map(hosts => Origin.HostList(hosts)))
   }
 
-  implicit val headerInstance: Header[`Origin`, Header.Single] =
+  def parse(s: String): ParseResult[Origin] =
+    ParseResult.fromParser(parser, "Invalid Origin header")(s)
+
+  implicit val headerInstance: Header[Origin, Header.Single] =
     Header.createRendered(
       CIString("Origin"),
       v =>
@@ -90,7 +93,7 @@ object Origin {
             }
 
         },
-      ParseResult.fromParser(parser, "Invalid Origin header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Proxy-Authorization.scala
+++ b/core/src/main/scala/org/http4s/headers/Proxy-Authorization.scala
@@ -36,11 +36,14 @@ object `Proxy-Authorization` {
   def apply(basic: BasicCredentials): Authorization =
     Authorization(Credentials.Token(AuthScheme.Basic, basic.token))
 
+  def parse(s: String): ParseResult[`Proxy-Authorization`] =
+    ParseResult.fromParser(parser, "Invalid Proxy-Authorization header")(s)
+
   implicit val headerInstance: Header[`Proxy-Authorization`, Header.Single] =
     Header.createRendered(
       CIString("Proxy-Authorization"),
       _.credentials,
-      ParseResult.fromParser(parser, "Invalid Proxy-Authorization header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Range.scala
+++ b/core/src/main/scala/org/http4s/headers/Range.scala
@@ -86,6 +86,9 @@ object Range {
     byteRangesSpecifier
   }
 
+  def parse(s: String): ParseResult[Range] =
+    ParseResult.fromParser(parser, "Invalid Range header")(s)
+
   implicit val headerInstance: Header[Range, Header.Single] =
     Header.createRendered(
       CIString("Range"),
@@ -97,7 +100,7 @@ object Range {
             writer
           }
         },
-      ParseResult.fromParser(parser, "Invalid Range header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
+++ b/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
@@ -59,7 +59,7 @@ object `Strict-Transport-Security` {
     fromLong(maxAge, includeSubDomains, preload).fold(throw _, identity)
 
   def parse(s: String): ParseResult[`Strict-Transport-Security`] =
-    ParseResult.fromParser(parser, "Invalid `Strict-Transport-Security` header")(s)
+    ParseResult.fromParser(parser, "Invalid Strict-Transport-Security header")(s)
 
   private[http4s] val parser: Parser0[`Strict-Transport-Security`] = {
     val maxAge: Parser[`Strict-Transport-Security`] =
@@ -98,7 +98,7 @@ object `Strict-Transport-Security` {
           }
 
         },
-      ParseResult.fromParser(parser, "Invalid Strict-Transport-Security header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/Transfer-Encoding.scala
+++ b/core/src/main/scala/org/http4s/headers/Transfer-Encoding.scala
@@ -51,6 +51,4 @@ object `Transfer-Encoding` {
 
 final case class `Transfer-Encoding`(values: NonEmptyList[TransferCoding]) {
   def hasChunked: Boolean = values.exists(_ === TransferCoding.chunked)
-
-  def value: String = Header[`Transfer-Encoding`].value(this)
 }

--- a/core/src/main/scala/org/http4s/headers/X-B3-ParentSpanId.scala
+++ b/core/src/main/scala/org/http4s/headers/X-B3-ParentSpanId.scala
@@ -26,6 +26,9 @@ import org.typelevel.ci.CIString
 
 object `X-B3-ParentSpanId` {
 
+  def parse(s: String): ParseResult[`X-B3-ParentSpanId`] =
+    ParseResult.fromParser(parser, "Invalid X-B3-ParentSpanId header")(s)
+
   private[http4s] val parser: Parser0[`X-B3-ParentSpanId`] =
     Applicative[Parser0]
       .replicateA(16, Rfc5234.hexdig)
@@ -41,7 +44,7 @@ object `X-B3-ParentSpanId` {
           def render(writer: Writer): writer.type =
             xB3RenderValueImpl(writer, h.id)
         },
-      ParseResult.fromParser(parser, "Invalid X-B3-ParentSpanId header")
+      parse
     )
 
 }

--- a/core/src/main/scala/org/http4s/headers/X-B3-SpanId.scala
+++ b/core/src/main/scala/org/http4s/headers/X-B3-SpanId.scala
@@ -26,6 +26,9 @@ import org.typelevel.ci.CIString
 
 object `X-B3-SpanId` {
 
+  def parse(s: String): ParseResult[`X-B3-SpanId`] =
+    ParseResult.fromParser(parser, "Invalid X-B3-SpanId header")(s)
+
   private[http4s] val parser: Parser0[`X-B3-SpanId`] =
     Applicative[Parser0]
       .replicateA(16, Rfc5234.hexdig)
@@ -42,7 +45,7 @@ object `X-B3-SpanId` {
             xB3RenderValueImpl(writer, h.id)
 
         },
-      ParseResult.fromParser(parser, "Invalid X-B3-SpanId header")
+      parse
     )
 
 }

--- a/server/src/main/scala/org/http4s/server/middleware/HttpsRedirect.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/HttpsRedirect.scala
@@ -24,6 +24,7 @@ import cats.data.Kleisli
 import org.http4s.Status.MovedPermanently
 import org.http4s.Uri.{Authority, RegName, Scheme}
 import org.http4s.headers.{Host, Location, `Content-Type`}
+import org.http4s.syntax.header._
 import org.typelevel.ci.CIString
 
 import org.log4s.getLogger

--- a/tests/src/test/scala/org/http4s/headers/AcceptPatchSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/AcceptPatchSpec.scala
@@ -17,6 +17,7 @@
 package org.http4s
 package headers
 
+import org.http4s.syntax.header._
 import cats.data.NonEmptyList
 
 class AcceptPatchSpec extends Http4sSuite {

--- a/tests/src/test/scala/org/http4s/headers/DateSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/DateSuite.scala
@@ -19,6 +19,7 @@ package headers
 
 import java.time.{ZoneId, ZonedDateTime}
 import org.http4s.laws.discipline.ArbitraryInstances._
+import org.http4s.syntax.header._
 
 class DateSuite extends HeaderLaws {
   checkAll("Date", headerLaws[Date])

--- a/tests/src/test/scala/org/http4s/headers/ExpiresSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/ExpiresSuite.scala
@@ -19,6 +19,7 @@ package headers
 
 import java.time.{ZoneId, ZonedDateTime}
 import org.http4s.laws.discipline.ArbitraryInstances._
+import org.http4s.syntax.header._
 
 class ExpiresSuite extends HeaderLaws {
   checkAll("Expires", headerLaws[Expires])

--- a/tests/src/test/scala/org/http4s/headers/ForwardedRenderersSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedRenderersSuite.scala
@@ -18,8 +18,8 @@ package org.http4s.headers
 
 import cats.data.NonEmptyList
 import com.comcast.ip4s.{Ipv4Address, Ipv6Address}
+import org.http4s.syntax.all._
 import org.http4s.util.Renderer
-import org.http4s.Header
 import org.scalacheck.Prop._
 
 class ForwardedRenderersSuite extends munit.ScalaCheckSuite with ForwardedArbitraryInstances {
@@ -93,8 +93,7 @@ class ForwardedRenderersSuite extends munit.ScalaCheckSuite with ForwardedArbitr
     val headerInit = Forwarded.name.toString + ": "
 
     forAll { (fwd: Forwarded) =>
-      val raw = implicitly[Header.Select[Forwarded]].toRaw(fwd)
-      val rendered = Renderer.renderString(raw)
+      val rendered = Renderer.renderString(fwd.toRaw)
       assert(rendered.startsWith(headerInit))
 
       assertEquals(Forwarded.parse(rendered.drop(headerInit.length)), Right(fwd))

--- a/tests/src/test/scala/org/http4s/headers/LinkSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/LinkSuite.scala
@@ -18,8 +18,6 @@ package org.http4s
 package headers
 
 import org.http4s.syntax.all._
-import org.http4s.util.Renderer
-import org.http4s.Header
 
 class LinkSuite extends HeaderLaws {
   // FIXME Uri does not round trip properly: https://github.com/http4s/http4s/issues/1651
@@ -71,9 +69,6 @@ class LinkSuite extends HeaderLaws {
         `type` = Some(MediaRange.`text/*`)
       ))
 
-    val raw = implicitly[Header.Select[Link]].toRaw(links)
-    val rendered = Renderer.renderString(raw)
-
-    assertEquals(rendered, "Link: </feed>; rel=alternate; title=main; type=text/*")
+    assertEquals(links.renderString, "Link: </feed>; rel=alternate; title=main; type=text/*")
   }
 }

--- a/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/ForwardedHeaderSpec.scala
@@ -121,7 +121,7 @@ class ForwardedHeaderSpec extends Http4sSuite {
     values.foreach { headerStr =>
       parse(headerStr) match {
         case Right(_) => fail("Expected parser failure")
-        case Left(e) => assertNoDiff(e.sanitized, "Invalid header")
+        case Left(e) => assertNoDiff(e.sanitized, "Invalid Forwarded header")
       }
     }
 
@@ -137,7 +137,7 @@ class ForwardedHeaderSpec extends Http4sSuite {
     values.foreach { headerStr =>
       parse(headerStr) match {
         case Right(_) => fail("Expected parser failure")
-        case Left(e) => assertNoDiff(e.sanitized, "Invalid header")
+        case Left(e) => assertNoDiff(e.sanitized, "Invalid Forwarded header")
       }
     }
   }


### PR DESCRIPTION
Hi, I thought it worthwhile to check all the headers once more to check they are consistent.

Core of this PR are following changes:

- Any extra `def value ...`, `def renderString` are removed form header class (in preference for syntax).
- Every header's companion defines `parse` method, and instance depends on it (to avoid two implementations).
- Couple of small tweaks