### PR TITLE
removing inheritance from package object - booPickle

### DIFF
--- a/boopickle/src/main/scala/org/http4s/booPickle/implicits.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/implicits.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package booPickle
+
+object implicits extends instances.AllInstances

--- a/boopickle/src/main/scala/org/http4s/booPickle/instances/AllInstances.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/instances/AllInstances.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package booPickle
+package instances
+
+trait AllInstances extends BooPickleInstances

--- a/boopickle/src/main/scala/org/http4s/booPickle/instances/BooPickleInstances.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/instances/BooPickleInstances.scala
@@ -16,6 +16,7 @@
 
 package org.http4s
 package booPickle
+package instances
 
 import boopickle.Default._
 import boopickle.Pickler

--- a/boopickle/src/main/scala/org/http4s/booPickle/instances/package.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/instances/package.scala
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
-package org.http4s
+package org.http4s.booPickle
 
-package object booPickle extends BooPickleInstances
+package object instances {
+  object all extends AllInstances
+  object booPickle extends BooPickleInstances
+}

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSuite.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSuite.scala
@@ -27,8 +27,9 @@ import org.http4s.laws.discipline.EntityCodecTests
 import org.http4s.MediaType
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
+import org.http4s.booPickle.implicits._
 
-class BoopickleSuite extends Http4sSuite with BooPickleInstances with Http4sLawSuite {
+class BoopickleSuite extends Http4sSuite with Http4sLawSuite {
   implicit val testContext: TestContext = TestContext()
 
   trait Fruit {


### PR DESCRIPTION
I'm not sure if there is a ticket for that

The other package objects with inheritance I could found are:
/play-json/src/main/scala/org/http4s/play/package.scala
/jawn/src/main/scala/org/http4s/jawn/package.scala
/circe/src/main/scala/org/http4s/circe/package.scala
/http4s/scalatags/src/main/scala/org/http4s/scalatags/package.scala
/http4s/twirl/src/main/scala/org/http4s/twirl/package.scala

If these changes are ok, I can proceed with other files as well- but probably not today ;)