### PR TITLE
deinheritance-package-objects-circe

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -22,8 +22,9 @@ import java.util.concurrent.TimeUnit
 import cats.effect.IO
 import io.circe._
 import io.circe.parser._
-import org.http4s.circe._
+
 import org.openjdk.jmh.annotations._
+import org.http4s.circe.implicits._
 
 // sbt "bench/jmh:run -i 10 -wi 10 -f 2 -t 1 org.http4s.bench.CirceJsonBench"
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -48,6 +49,7 @@ class CirceJsonBench {
 }
 
 object CirceJsonBench {
+
   // val obj = Json.obj("foo" -> Json.obj("foo2" -> Json.fromString("bar")))
   val jsonStr =
     """{"_id":"58fefc19a5eab74376285220","index":0,"guid":"f5740e2b-7bcf-4bb8-9303-774b1ad99f84","isActive":false,"balance":"$1,052.47","picture":"http://placehold.it/32x32","age":34,"eyeColor":"brown","name":"Calhoun Schneider","gender":"male","company":"GEEKMOSIS","email":"calhounschneider@geekmosis.com","phone":"+1 (890) 564-2582","address":"457 Milford Street, Cutter, Nevada, 204","about":"Irure esse sint esse ullamco dolor veniam commodo eiusmod fugiat minim nostrud. Minim occaecat aliquip magna qui ad nisi laboris adipisicing eiusmod amet deserunt ut. Commodo nulla ullamco et esse eu fugiat elit amet nisi dolore id id aliquip qui. In ex excepteur ea labore nulla eu ullamco anim occaecat sint. Consequat do excepteur consequat est.\r\n","registered":"2014-12-04T02:58:51 -06:00","latitude":60.317658,"longitude":-58.313338,"tags":["laboris","ad","ullamco","ea","ex","est","labore"],"friends":[{"id":0,"name":"Angie Johns"},{"id":1,"name":"Francine Mclean"},{"id":2,"name":"Elaine Hebert"}],"greeting":"Hello, Calhoun Schneider! You have 9 unread messages.","favoriteFruit":"apple"}"""

--- a/circe/src/main/scala/org/http4s/circe/CirceEntityDecoder.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceEntityDecoder.scala
@@ -19,6 +19,7 @@ package org.http4s.circe
 import cats.effect.Sync
 import io.circe.Decoder
 import org.http4s.EntityDecoder
+import org.http4s.circe.implicits._
 
 /** Derive [[EntityDecoder]] if implicit [[io.circe.Decoder]] is in the scope
   * without need to explicitly call `jsonOf`.

--- a/circe/src/main/scala/org/http4s/circe/CirceSensitiveDataEntityDecoder.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceSensitiveDataEntityDecoder.scala
@@ -19,6 +19,7 @@ package org.http4s.circe
 import cats.effect.Sync
 import io.circe.Decoder
 import org.http4s.EntityDecoder
+import org.http4s.circe.implicits._
 
 /** Derive [[EntityDecoder]] if implicit [[Decoder]] is in the scope without need to explicitly call `jsonOfSensitive`
   *

--- a/circe/src/main/scala/org/http4s/circe/JsonDecoder.scala
+++ b/circe/src/main/scala/org/http4s/circe/JsonDecoder.scala
@@ -18,7 +18,9 @@ package org.http4s.circe
 
 import cats.effect.Sync
 import org.http4s._
+import org.http4s.circe.implicits._
 import io.circe._
+import org.http4s.circe.syntax.all._
 
 /** F-algebra for separating the Sync required for extracting
   * the Json from the body. As such if F is Sync at some layer,

--- a/circe/src/main/scala/org/http4s/circe/implicits.scala
+++ b/circe/src/main/scala/org/http4s/circe/implicits.scala
@@ -16,16 +16,4 @@
 
 package org.http4s.circe
 
-import io.circe.Encoder
-import org.http4s.EntityEncoder
-import org.http4s.circe.implicits._
-
-/** Derive [[EntityEncoder]] if implicit [[io.circe.Encoder]] is in the scope
-  * without need to explicitly call `jsonEncoderOf`.
-  */
-trait CirceEntityEncoder {
-  implicit def circeEntityEncoder[F[_], A: Encoder]: EntityEncoder[F, A] =
-    jsonEncoderOf[F, A]
-}
-
-object CirceEntityEncoder extends CirceEntityEncoder
+object implicits extends instances.AllInstances

--- a/circe/src/main/scala/org/http4s/circe/instances/AllInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/instances/AllInstances.scala
@@ -15,5 +15,7 @@
  */
 
 package org.http4s
+package circe
+package instances
 
-package object circe extends CirceInstances
+trait AllInstances extends CirceInstances

--- a/circe/src/main/scala/org/http4s/circe/instances/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/instances/CirceInstances.scala
@@ -16,6 +16,7 @@
 
 package org.http4s
 package circe
+package instances
 
 import java.nio.ByteBuffer
 
@@ -170,8 +171,6 @@ trait CirceInstances extends JawnInstances {
       Uri.fromString(str).leftMap(_ => "Uri")
     }
 
-  implicit final def toMessageSynax[F[_]](req: Message[F]): CirceInstances.MessageSyntax[F] =
-    new CirceInstances.MessageSyntax(req)
 }
 
 sealed abstract case class CirceInstancesBuilder private[circe] (
@@ -244,10 +243,10 @@ object CirceInstances {
 
   // These are lazy since they are used when initializing the `builder`!
 
-  private[circe] lazy val defaultCirceParseError: ParsingFailure => DecodeFailure =
+  private[instances] lazy val defaultCirceParseError: ParsingFailure => DecodeFailure =
     pe => MalformedMessageBodyFailure("Invalid JSON", Some(pe))
 
-  private[circe] lazy val defaultJsonDecodeError
+  private[instances] lazy val defaultJsonDecodeError
       : (Json, NonEmptyList[DecodingFailure]) => DecodeFailure = { (json, failures) =>
     jsonDecodeErrorHelper(json, _.toString, failures)
   }
@@ -311,17 +310,4 @@ object CirceInstances {
 
   // Extension methods.
 
-  private[circe] final class MessageSyntax[F[_]](private val req: Message[F]) extends AnyVal {
-    def asJson(implicit F: JsonDecoder[F]): F[Json] =
-      F.asJson(req)
-
-    def asJsonDecode[A](implicit F: JsonDecoder[F], decoder: Decoder[A]): F[A] =
-      F.asJsonDecode(req)
-
-    def decodeJson[A](implicit F: Sync[F], decoder: Decoder[A]): F[A] =
-      req.as(F, jsonOf[F, A])
-
-    def json(implicit F: Sync[F]): F[Json] =
-      req.as(F, jsonDecoder[F])
-  }
 }

--- a/circe/src/main/scala/org/http4s/circe/instances/package.scala
+++ b/circe/src/main/scala/org/http4s/circe/instances/package.scala
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 
-package org.http4s.circe
+package org.http4s
+package circe
+package instances
 
-import io.circe.Encoder
-import org.http4s.EntityEncoder
-import org.http4s.circe.implicits._
-
-/** Derive [[EntityEncoder]] if implicit [[io.circe.Encoder]] is in the scope
-  * without need to explicitly call `jsonEncoderOf`.
-  */
-trait CirceEntityEncoder {
-  implicit def circeEntityEncoder[F[_], A: Encoder]: EntityEncoder[F, A] =
-    jsonEncoderOf[F, A]
+package object instances {
+  object all extends AllInstances
+  object circe extends CirceInstances
 }
-
-object CirceEntityEncoder extends CirceEntityEncoder

--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -22,7 +22,7 @@ import io.circe._
 import io.circe.syntax._
 import org.http4s._
 import org.http4s.headers.Connection
-import org.http4s.circe._
+import org.http4s.circe.implicits._
 import org.typelevel.ci.CIString
 
 object JsonDebugErrorHandler {

--- a/circe/src/main/scala/org/http4s/circe/syntax/AllSyntax.scala
+++ b/circe/src/main/scala/org/http4s/circe/syntax/AllSyntax.scala
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-package org.http4s.circe
+package org.http4s.circe.syntax
 
-import io.circe.Encoder
-import org.http4s.EntityEncoder
-import org.http4s.circe.implicits._
-
-/** Derive [[EntityEncoder]] if implicit [[io.circe.Encoder]] is in the scope
-  * without need to explicitly call `jsonEncoderOf`.
-  */
-trait CirceEntityEncoder {
-  implicit def circeEntityEncoder[F[_], A: Encoder]: EntityEncoder[F, A] =
-    jsonEncoderOf[F, A]
-}
-
-object CirceEntityEncoder extends CirceEntityEncoder
+trait AllSyntax extends MessageSyntax

--- a/circe/src/main/scala/org/http4s/circe/syntax/MessageSyntax.scala
+++ b/circe/src/main/scala/org/http4s/circe/syntax/MessageSyntax.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.circe.syntax
+
+import org.http4s.Message
+import org.http4s.circe.JsonDecoder
+import org.http4s.circe.implicits._
+import io.circe.Json
+import io.circe.Decoder
+import cats.effect.Sync
+
+trait MessageSyntax {
+  implicit def messageSyntax[F[_]: JsonDecoder](req: Message[F]): MessageOps[F] =
+    new MessageOps[F](req)
+}
+
+final class MessageOps[F[_]: JsonDecoder](val req: Message[F]) {
+  def asJson: F[Json] =
+    JsonDecoder[F].asJson(req)
+
+  def asJsonDecode[A](implicit decoder: Decoder[A]): F[A] =
+    JsonDecoder[F].asJsonDecode(req)
+
+  def decodeJson[A](implicit F: Sync[F], decoder: Decoder[A]): F[A] =
+    req.as(F, jsonOf[F, A])
+
+  def json(implicit F: Sync[F]): F[Json] =
+    req.as(F, jsonDecoder[F])
+}

--- a/circe/src/main/scala/org/http4s/circe/syntax/package.scala
+++ b/circe/src/main/scala/org/http4s/circe/syntax/package.scala
@@ -16,16 +16,7 @@
 
 package org.http4s.circe
 
-import io.circe.Encoder
-import org.http4s.EntityEncoder
-import org.http4s.circe.implicits._
-
-/** Derive [[EntityEncoder]] if implicit [[io.circe.Encoder]] is in the scope
-  * without need to explicitly call `jsonEncoderOf`.
-  */
-trait CirceEntityEncoder {
-  implicit def circeEntityEncoder[F[_], A: Encoder]: EntityEncoder[F, A] =
-    jsonEncoderOf[F, A]
+package object syntax {
+  object all extends AllSyntax
+  object message extends MessageSyntax
 }
-
-object CirceEntityEncoder extends CirceEntityEncoder

--- a/circe/src/test/scala/org/http4s/circe/CirceSensitiveDataEntityDecoderSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSensitiveDataEntityDecoderSpec.scala
@@ -21,6 +21,7 @@ import cats.effect.IO
 import io.circe.{Decoder, HCursor, Json}
 import io.circe.syntax._
 import org.http4s.{DecodeFailure, Http4sSuite, InvalidMessageBodyFailure, Response, Status}
+import org.http4s.circe.implicits._
 
 object CirceSensitiveDataEntityDecoderSpec {
 

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -29,10 +29,13 @@ import io.circe.testing.instances._
 import java.nio.charset.StandardCharsets
 import org.http4s.Status.Ok
 import org.http4s.circe._
+import org.http4s.circe.implicits._
+import org.http4s.circe.syntax.all._
 import org.http4s.syntax.all._
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
 import org.http4s.laws.discipline.EntityCodecTests
+import org.http4s.circe.instances.CirceInstances
 
 class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   implicit val testContext: TestContext = TestContext()

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientExample.scala
@@ -19,7 +19,7 @@ package com.example.http4s.blaze
 import cats.effect._
 import io.circe.generic.auto._
 import org.http4s.Status.{NotFound, Successful}
-import org.http4s.circe._
+import org.http4s.circe.syntax.all._
 import org.http4s.syntax.all._
 import org.http4s.client.Client
 import org.http4s.client.blaze.BlazeClientBuilder

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/JsonXmlHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/JsonXmlHttpEndpoint.scala
@@ -20,7 +20,7 @@ import cats.effect.Effect
 import cats.syntax.flatMap._
 import io.circe.generic.auto._
 import org.http4s.{ApiVersion => _, _}
-import org.http4s.circe._
+import org.http4s.circe.implicits._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.scalaxml.implicits._
 

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
@@ -21,7 +21,7 @@ import cats.syntax.functor._
 import com.example.http4s.blaze.demo.server.endpoints.ApiVersion
 import fs2.Stream
 import io.circe.generic.auto._
-import org.http4s.circe._
+import org.http4s.circe.implicits._
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.Request

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
@@ -21,7 +21,7 @@ import cats.effect._
 import cats.syntax.all._
 import org.http4s._
 import org.http4s.client._
-import org.http4s.circe._
+import org.http4s.circe.implicits._
 import org.http4s.implicits._
 
 import _root_.io.circe.Json

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerSimpleExample.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerSimpleExample.scala
@@ -22,7 +22,8 @@ import cats.syntax.all._
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.dsl.Http4sDsl
-import org.http4s.circe._
+import org.http4s.circe.syntax.all._
+import org.http4s.circe.implicits._
 import _root_.io.circe._
 import _root_.org.http4s.ember.server.EmberServerBuilder
 

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -20,7 +20,7 @@ import cats.effect._
 import cats.syntax.all._
 import fs2.Stream
 import io.circe.Json
-import org.http4s.circe._
+import org.http4s.circe.implicits._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers._
 import org.http4s.multipart.Multipart


### PR DESCRIPTION
message extension methods moved out to syntax package, but earlier MethodSyntax was private and now is not.I'm not sure if this is right.
And the same remark as in #4592 - I ended up with a lot of members in CirceInstances without implicit modifier and it looks awkward, but I'm not sure how to address this.