### PR TITLE
Remove our ipv4 and ipv6 literals

### DIFF
--- a/client/src/test/scala/org/http4s/client/PoolManagerSuite.scala
+++ b/client/src/test/scala/org/http4s/client/PoolManagerSuite.scala
@@ -18,13 +18,14 @@ package org.http4s
 package client
 
 import cats.effect._
+import com.comcast.ip4s._
 import fs2.Stream
 import org.http4s.syntax.AllSyntax
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 
 class PoolManagerSuite extends Http4sSuite with AllSyntax {
-  val key = RequestKey(Uri.Scheme.http, Uri.Authority(host = ipv4"127.0.0.1"))
+  val key = RequestKey(Uri.Scheme.http, Uri.Authority(host = Uri.Ipv4Address(ipv4"127.0.0.1")))
   val otherKey = RequestKey(Uri.Scheme.http, Uri.Authority(host = Uri.RegName("localhost")))
 
   class TestConnection extends Connection[IO] {

--- a/core/src/main/scala-2/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala-2/org/http4s/LiteralSyntaxMacros.scala
@@ -43,20 +43,6 @@ object LiteralSyntaxMacros {
       Uri.Scheme.fromString(_).isRight,
       s => c.universe.reify(Uri.Scheme.unsafeFromString(s.splice)))
 
-  def ipv4AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Ipv4Address] =
-    singlePartInterpolator(c)(
-      args,
-      "Ipv4Address",
-      Uri.Ipv4Address.fromString(_).isRight,
-      s => c.universe.reify(Uri.Ipv4Address.unsafeFromString(s.splice)))
-
-  def ipv6AddressInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[Uri.Ipv6Address] =
-    singlePartInterpolator(c)(
-      args,
-      "Ipv6Address",
-      Uri.Ipv6Address.fromString(_).isRight,
-      s => c.universe.reify(Uri.Ipv6Address.unsafeFromString(s.splice)))
-
   def mediaTypeInterpolator(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[MediaType] =
     singlePartInterpolator(c)(
       args,

--- a/core/src/main/scala-2/org/http4s/syntax/LiteralsSyntax.scala
+++ b/core/src/main/scala-2/org/http4s/syntax/LiteralsSyntax.scala
@@ -26,8 +26,6 @@ class LiteralsOps(val sc: StringContext) extends AnyVal {
   def uri(args: Any*): Uri = macro LiteralSyntaxMacros.uriInterpolator
   def path(args: Any*): Uri.Path = macro LiteralSyntaxMacros.pathInterpolator
   def scheme(args: Any*): Uri.Scheme = macro LiteralSyntaxMacros.schemeInterpolator
-  def ipv4(args: Any*): Uri.Ipv4Address = macro LiteralSyntaxMacros.ipv4AddressInterpolator
-  def ipv6(args: Any*): Uri.Ipv6Address = macro LiteralSyntaxMacros.ipv6AddressInterpolator
   def mediaType(args: Any*): MediaType = macro LiteralSyntaxMacros.mediaTypeInterpolator
   def qValue(args: Any*): QValue = macro LiteralSyntaxMacros.qValueInterpolator
 }

--- a/core/src/main/scala-3/org/http4s/syntax/LiteralsSyntax.scala
+++ b/core/src/main/scala-3/org/http4s/syntax/LiteralsSyntax.scala
@@ -25,8 +25,6 @@ trait LiteralsSyntax {
     inline def uri(args: Any*): Uri = ${LiteralsSyntax.validateUri('{ctx}, '{args})}
     inline def path(args: Any*): Uri.Path = ${LiteralsSyntax.validatePath('{ctx}, '{args})}
     inline def scheme(args: Any*): Uri.Scheme = ${LiteralsSyntax.validateUriScheme('{ctx}, '{args})}
-    inline def ipv4(args: Any*): Uri.Ipv4Address = ${LiteralsSyntax.validateIpv4('{ctx}, '{args})}
-    inline def ipv6(args: Any*): Uri.Ipv6Address = ${LiteralsSyntax.validateIpv6('{ctx}, '{args})}
     inline def mediaType(args: Any*): MediaType = ${LiteralsSyntax.validateMediatype('{ctx}, '{args})}
     inline def qValue(args: Any*): QValue = ${LiteralsSyntax.validateQvalue('{ctx}, '{args})}
   }
@@ -45,10 +43,6 @@ private[syntax] object LiteralsSyntax {
     validate(urischeme, strCtxExpr, argsExpr)
   def validatePath(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes) =
     validate(uripath, strCtxExpr, argsExpr)
-  def validateIpv4(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes) =
-    validate(ipv4, strCtxExpr, argsExpr)
-  def validateIpv6(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes) =
-    validate(ipv6, strCtxExpr, argsExpr)
   def validateMediatype(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes) =
     validate(mediatype, strCtxExpr, argsExpr)
   def validateQvalue(strCtxExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using Quotes) =
@@ -91,20 +85,6 @@ private[syntax] object LiteralsSyntax {
 
     override def construct(literal: String)(using Quotes): Expr[Uri.Path] =
       '{Uri.unsafeFromString(${Expr(literal)}).path}
-  }
-
-  object ipv4 extends Validator[Uri.Ipv4Address] {
-    override def validate(literal: String): Option[ParseFailure] = Uri.Ipv4Address.fromString(literal).swap.toOption
-
-    override def construct(literal: String)(using Quotes): Expr[Uri.Ipv4Address] =
-      '{Uri.Ipv4Address.unsafeFromString(${Expr(literal)})}
-  }
-
-  object ipv6 extends Validator[Uri.Ipv6Address] {
-    override def validate(literal: String): Option[ParseFailure] = Uri.Ipv6Address.fromString(literal).swap.toOption
-
-    override def construct(literal: String)(using Quotes): Expr[Uri.Ipv6Address] =
-      '{Uri.Ipv6Address.unsafeFromString(${Expr(literal)})}
   }
 
   object mediatype extends Validator[MediaType] {

--- a/tests/src/test/scala/org/http4s/Ipv4AddressSuite.scala
+++ b/tests/src/test/scala/org/http4s/Ipv4AddressSuite.scala
@@ -17,10 +17,10 @@
 package org.http4s
 
 import cats.kernel.laws.discipline.{HashTests, OrderTests}
+import com.comcast.ip4s._
 import org.http4s.Uri.Ipv4Address
 import org.http4s.laws.discipline.HttpCodecTests
 import org.http4s.laws.discipline.arbitrary._
-import org.http4s.syntax.all._
 import org.http4s.util.Renderer.renderString
 import org.scalacheck.Prop._
 
@@ -30,7 +30,7 @@ class Ipv4AddressSuite extends Http4sSuite {
   checkAll("HttpCodec[Ipv4Address]", HttpCodecTests[Ipv4Address].httpCodec)
 
   test("render should render all 4 octets") {
-    assert(renderString(ipv4"192.168.0.1") == "192.168.0.1")
+    assert(renderString(Ipv4Address(ipv4"192.168.0.1")) == "192.168.0.1")
   }
 
   test("fromInet4Address should round trip with toInet4Address") {
@@ -56,14 +56,4 @@ class Ipv4AddressSuite extends Http4sSuite {
       assert(math.signum(a.compareTo(b)) == math.signum(a.compare(b)))
     }
   }
-
-  test("ipv4 interpolator should be consistent with fromString") {
-    assert(Right(ipv4"127.0.0.1") == Ipv4Address.fromString("127.0.0.1"))
-    assert(Right(ipv4"192.168.0.1") == Ipv4Address.fromString("192.168.0.1"))
-  }
-
-  test("ipv4 interpolator should reject invalid values") {
-    assert(compileErrors("""ipv4"256.0.0.0"""").nonEmpty)
-  }
-
 }

--- a/tests/src/test/scala/org/http4s/Ipv6AddressSuite.scala
+++ b/tests/src/test/scala/org/http4s/Ipv6AddressSuite.scala
@@ -17,10 +17,10 @@
 package org.http4s
 
 import cats.kernel.laws.discipline.{HashTests, OrderTests}
+import com.comcast.ip4s._
 import org.http4s.Uri.Ipv6Address
 import org.http4s.laws.discipline.HttpCodecTests
 import org.http4s.laws.discipline.arbitrary._
-import org.http4s.syntax.all._
 import org.http4s.util.Renderer.renderString
 import org.scalacheck.Prop._
 
@@ -30,20 +30,20 @@ class Ipv6AddressSuite extends Http4sSuite {
   checkAll("HttpCodec[Ipv6Address]", HttpCodecTests[Ipv6Address].httpCodec)
 
   test("render consistently with RFC5952 should 4.1: handle leading zeroes in a 16-bit field") {
-    assert(renderString(ipv6"2001:0db8::0001") == "2001:db8::1")
+    assert(renderString(Ipv6Address(ipv6"2001:0db8::0001")) == "2001:db8::1")
   }
   test("render consistently with RFC5952 should 4.2.1: shorten as much as possible") {
-    assert(renderString(ipv6"2001:db8:0:0:0:0:2:1") == "2001:db8::2:1")
+    assert(renderString(Ipv6Address(ipv6"2001:db8:0:0:0:0:2:1")) == "2001:db8::2:1")
   }
   test("render consistently with RFC5952 should 4.2.2: handle one 16-bit 0 field") {
-    assert(renderString(ipv6"2001:db8:0:1:1:1:1:1") == "2001:db8:0:1:1:1:1:1")
+    assert(renderString(Ipv6Address(ipv6"2001:db8:0:1:1:1:1:1")) == "2001:db8:0:1:1:1:1:1")
   }
   test("""render consistently with RFC5952 should 4.2.3: chose placement of "::"""") {
-    assert(renderString(ipv6"2001:0:0:1:0:0:0:1") == "2001:0:0:1::1")
-    renderString(ipv6"2001:db8:0:0:1:0:0:1") == "2001:db8::1:0:0:1"
+    assert(renderString(Ipv6Address(ipv6"2001:0:0:1:0:0:0:1")) == "2001:0:0:1::1")
+    renderString(Ipv6Address(ipv6"2001:db8:0:0:1:0:0:1")) == "2001:db8::1:0:0:1"
   }
   test("render consistently with RFC5952 should 4.3: lowercase") {
-    assert(renderString(ipv6"::A:B:C:D:E:F") == "::a:b:c:d:e:f")
+    assert(renderString(Ipv6Address(ipv6"::A:B:C:D:E:F")) == "::a:b:c:d:e:f")
   }
 
   test("fromInet6Address should round trip with toInet6Address") {
@@ -71,13 +71,13 @@ class Ipv6AddressSuite extends Http4sSuite {
   }
 
   test("ipv6 interpolator should be consistent with fromString") {
-    assert(Right(ipv6"::1") == Ipv6Address.fromString("::1"))
-    assert(Right(ipv6"::") == Ipv6Address.fromString("::"))
-    assert(Right(ipv6"2001:db8::7") == Ipv6Address.fromString("2001:db8::7"))
+    assert(Right(Ipv6Address(ipv6"::1")) == Ipv6Address.fromString("::1"))
+    assert(Right(Ipv6Address(ipv6"::")) == Ipv6Address.fromString("::"))
+    assert(Right(Ipv6Address(ipv6"2001:db8::7")) == Ipv6Address.fromString("2001:db8::7"))
   }
 
   test("ipv6 interpolator should reject invalid values") {
-    assert(compileErrors("""ipv6"127.0.0.1"""").nonEmpty)
+    assert(compileErrors("""Ipv6Address(ipv6"127.0.0.1")""").nonEmpty)
   }
 
 }

--- a/tests/src/test/scala/org/http4s/MessageSuite.scala
+++ b/tests/src/test/scala/org/http4s/MessageSuite.scala
@@ -18,15 +18,15 @@ package org.http4s
 
 import cats.data.NonEmptyList
 import cats.effect.IO
-import com.comcast.ip4s.{Port, SocketAddress}
+import com.comcast.ip4s._
 import fs2.Pure
 import org.http4s.headers.{Authorization, Cookie, `Content-Type`, `X-Forwarded-For`}
 import org.http4s.syntax.all._
 import org.typelevel.vault._
 
 class MessageSuite extends Http4sSuite {
-  val local = SocketAddress(ipv4"127.0.0.1".address, Port.fromInt(8080).get)
-  val remote = SocketAddress(ipv4"192.168.0.1".address, Port.fromInt(45444).get)
+  val local = SocketAddress(ipv4"127.0.0.1", port"8080")
+  val remote = SocketAddress(ipv4"192.168.0.1", port"45444")
 
   test("ConnectionInfo should get remote connection info when present") {
     val r = Request()
@@ -58,7 +58,7 @@ class MessageSuite extends Http4sSuite {
   test(
     "ConnectionInfo should be utilized to determine the from value (first X-Forwarded-For if present)") {
     val forwardedValues =
-      NonEmptyList.of(Some(ipv4"192.168.1.1".address), Some(ipv4"192.168.1.2".address))
+      NonEmptyList.of(Some(ipv4"192.168.1.1"), Some(ipv4"192.168.1.2"))
     val r = Request()
       .withHeaders(Headers(`X-Forwarded-For`(forwardedValues)))
       .withAttribute(Request.Keys.ConnectionInfo, Request.Connection(local, remote, false))

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -12,8 +12,8 @@ package org.http4s
 
 import cats.kernel.laws.discipline._
 import cats.syntax.all._
+import com.comcast.ip4s._
 import java.nio.file.Paths
-
 import org.http4s.internal.CharPredicate
 import org.http4s.laws.discipline.arbitrary._
 import org.http4s.Uri._
@@ -223,7 +223,7 @@ class UriSpec extends Http4sSuite {
         assertEquals(
           Uri(
             Some(Scheme.http),
-            Some(Authority(host = Ipv6Address.unsafeFromString(s))),
+            Some(Authority(host = Uri.Ipv6Address.unsafeFromString(s))),
             Uri.Path.unsafeFromString("/foo"),
             Query.fromPairs("bar" -> "baz")).toString,
           s"http://[$s]/foo?bar=baz"
@@ -260,7 +260,7 @@ class UriSpec extends Http4sSuite {
       assertEquals(
         Uri(
           Some(Scheme.http),
-          Some(Authority(host = ipv4"192.168.1.1", port = Some(80))),
+          Some(Authority(host = Uri.Ipv4Address(ipv4"192.168.1.1"), port = Some(80))),
           Uri.Path.unsafeFromString("/c"),
           Query.fromPairs("GB" -> "object", "Class" -> "one")
         ).toString,
@@ -272,13 +272,13 @@ class UriSpec extends Http4sSuite {
       assertEquals(
         Uri(
           Some(Scheme.http),
-          Some(Authority(host = ipv4"192.168.1.1", port = Some(8080)))).toString,
+          Some(Authority(host = Uri.Ipv4Address(ipv4"192.168.1.1"), port = Some(8080)))).toString,
         "http://192.168.1.1:8080")
     }
 
     test("Uri toString should render IPv4 URL without port") {
       assertEquals(
-        Uri(Some(Scheme.http), Some(Authority(host = ipv4"192.168.1.1"))).toString,
+        Uri(Some(Scheme.http), Some(Authority(host = Uri.Ipv4Address(ipv4"192.168.1.1")))).toString,
         "http://192.168.1.1")
     }
 
@@ -286,9 +286,10 @@ class UriSpec extends Http4sSuite {
       assertEquals(
         Uri(
           Some(Scheme.http),
-          Some(Authority(host = ipv6"2001:db8::7")),
+          Some(Authority(host = Uri.Ipv6Address(ipv6"2001:db8::7"))),
           Uri.Path.unsafeFromString("/c"),
-          Query.fromPairs("GB" -> "object", "Class" -> "one")).toString,
+          Query.fromPairs("GB" -> "object", "Class" -> "one")
+        ).toString,
         "http://[2001:db8::7]/c?GB=object&Class=one"
       )
     }
@@ -299,7 +300,7 @@ class UriSpec extends Http4sSuite {
           Some(Scheme.http),
           Some(
             Authority(
-              host = ipv6"2001:db8:85a3:8d3:1319:8a2e:370:7344",
+              host = Uri.Ipv6Address(ipv6"2001:db8:85a3:8d3:1319:8a2e:370:7344"),
               port = Some(8080)))).toString,
         "http://[2001:db8:85a3:8d3:1319:8a2e:370:7344]:8080"
       )
@@ -309,8 +310,11 @@ class UriSpec extends Http4sSuite {
       assertEquals(
         Uri(
           Some(Scheme.http),
-          Some(Authority(host = ipv6"2001:db8:85a3:8d3:1319:8a2e:370:7344"))).toString,
-        "http://[2001:db8:85a3:8d3:1319:8a2e:370:7344]")
+          Some(
+            Authority(host =
+              Uri.Ipv6Address(ipv6"2001:db8:85a3:8d3:1319:8a2e:370:7344")))).toString,
+        "http://[2001:db8:85a3:8d3:1319:8a2e:370:7344]"
+      )
     }
 
     test("Uri toString should not append a '/' unless it's in the path") {

--- a/tests/src/test/scala/org/http4s/parser/OriginHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/OriginHeaderSuite.scala
@@ -18,12 +18,13 @@ package org.http4s
 package parser
 
 import cats.data.NonEmptyList
+import com.comcast.ip4s._
 import org.http4s.headers.Origin
 import org.http4s.syntax.all._
 
 class OriginHeaderSuite extends munit.FunSuite {
   val host1 = Origin.Host(Uri.Scheme.http, Uri.RegName("www.foo.com"), Some(12345))
-  val host2 = Origin.Host(Uri.Scheme.https, ipv4"127.0.0.1", None)
+  val host2 = Origin.Host(Uri.Scheme.https, Uri.Ipv4Address(ipv4"127.0.0.1"), None)
 
   val hostString1 = "http://www.foo.com:12345"
   val hostString2 = "https://127.0.0.1"

--- a/tests/src/test/scala/org/http4s/parser/UriParserSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSuite.scala
@@ -16,6 +16,7 @@
 
 package org.http4s.parser
 
+import com.comcast.ip4s._
 import org.http4s._
 import org.http4s.Uri._
 import org.http4s.Uri.Scheme.https
@@ -44,14 +45,14 @@ class UriParserSuite extends Http4sSuite {
       } yield f + "::" + b)
 
       v.foreach { s =>
-        assertEquals(Ipv6Address.fromString(s).map(_.value), Right(s))
+        assertEquals(Uri.Ipv6Address.fromString(s).map(_.value), Right(s))
       }
     }
 
     test("Uri.requestTarget should parse a IPv4 address") {
       (0 to 255).foreach { i =>
         val addr = s"$i.$i.$i.$i"
-        assertEquals(Ipv4Address.fromString(addr).map(_.value), Right(addr))
+        assertEquals(Uri.Ipv4Address.fromString(addr).map(_.value), Right(addr))
       }
     }
 
@@ -59,7 +60,7 @@ class UriParserSuite extends Http4sSuite {
       val s = "[01ab::32ba:32ba]"
       assertEquals(
         Uri.requestTarget(s),
-        Right(Uri(authority = Some(Authority(host = ipv6"01ab::32ba:32ba")))))
+        Right(Uri(authority = Some(Authority(host = Uri.Ipv6Address(ipv6"01ab::32ba:32ba"))))))
     }
 
     test("Uri.requestTarget should handle port configurations") {
@@ -96,19 +97,21 @@ class UriParserSuite extends Http4sSuite {
             Some(Authority(host = RegName(CIString("www.foo.com")))),
             path"/foo",
             Query.fromPairs("bar" -> "baz"))),
-        ("http://192.168.1.1", Uri(Some(Scheme.http), Some(Authority(host = ipv4"192.168.1.1")))),
+        (
+          "http://192.168.1.1",
+          Uri(Some(Scheme.http), Some(Authority(host = Uri.Ipv4Address(ipv4"192.168.1.1"))))),
         (
           "http://192.168.1.1:80/c?GB=object&Class=one",
           Uri(
             Some(Scheme.http),
-            Some(Authority(host = ipv4"192.168.1.1", port = Some(80))),
+            Some(Authority(host = Uri.Ipv4Address(ipv4"192.168.1.1"), port = Some(80))),
             path"/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         (
           "http://[2001:db8::7]/c?GB=object&Class=one",
           Uri(
             Some(Scheme.http),
-            Some(Authority(host = ipv6"2001:db8::7")),
+            Some(Authority(host = Uri.Ipv6Address(ipv6"2001:db8::7"))),
             path"/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         (
@@ -175,19 +178,21 @@ class UriParserSuite extends Http4sSuite {
             Some(Authority(host = RegName(CIString("www.foo.com")))),
             path"/foo",
             Query.fromPairs("bar" -> "baz"))),
-        ("http://192.168.1.1", Uri(Some(Scheme.http), Some(Authority(host = ipv4"192.168.1.1")))),
+        (
+          "http://192.168.1.1",
+          Uri(Some(Scheme.http), Some(Authority(host = Uri.Ipv4Address(ipv4"192.168.1.1"))))),
         (
           "http://192.168.1.1:80/c?GB=object&Class=one",
           Uri(
             Some(Scheme.http),
-            Some(Authority(host = ipv4"192.168.1.1", port = Some(80))),
+            Some(Authority(host = Uri.Ipv4Address(ipv4"192.168.1.1"), port = Some(80))),
             path"/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         (
           "http://[2001:db8::7]/c?GB=object&Class=one",
           Uri(
             Some(Scheme.http),
-            Some(Authority(host = ipv6"2001:db8::7")),
+            Some(Authority(host = Uri.Ipv6Address(ipv6"2001:db8::7"))),
             path"/c",
             Query.fromPairs("GB" -> "object", "Class" -> "one"))),
         (


### PR DESCRIPTION
Our `ipv4` and `ipv6` clash with ip4s'.

I think this change actually make the ergnomics of the Uri model worse, but so does this conflict.  all the more reason to invest in a good URI interpolator?