### PR TITLE
CSRF checkCSRFinHeaderAndForm fails for multipart

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ lazy val tests = libraryProject("tests")
     description := "Tests for core project",
     startYear := Some(2013),
   )
-  .dependsOn(core, client, blazeClient, blazeServer, theDsl, testing % "test->test")
+  .dependsOn(core, client, emberServer, theDsl, testing % "test->test")
 
 lazy val server = libraryProject("server")
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ lazy val tests = libraryProject("tests")
     description := "Tests for core project",
     startYear := Some(2013),
   )
-  .dependsOn(core, testing % "test->test")
+  .dependsOn(core, client, blazeClient, blazeServer, theDsl, testing % "test->test")
 
 lazy val server = libraryProject("server")
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ lazy val tests = libraryProject("tests")
     description := "Tests for core project",
     startYear := Some(2013),
   )
-  .dependsOn(core, client, emberServer, theDsl, testing % "test->test")
+  .dependsOn(core, client, emberClient, emberServer, theDsl, testing % "test->test")
 
 lazy val server = libraryProject("server")
   .settings(

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -413,8 +413,10 @@ object CSRF {
           case Right(dec) =>
             // The `.drop(1)` removes the first empty line from the body value of the field.
             dec.parts
-              .find(_.headers.exists(h =>
-                h.is(headers.`Content-Disposition`) && h.value.contains(s"""name="$fieldName"""")))
+              .find(
+                _.headers
+                  .get(headers.`Content-Disposition`)
+                  .fold(false)(_.value.contains(fieldName)))
               .traverse(_.body.through(fs2.text.utf8Decode).drop(1).compile.fold("")(_ |+| _))
           case Left(_) => Sync[G].pure(none[String])
         }

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -413,7 +413,8 @@ object CSRF {
           case Right(dec) =>
             // The `.drop(1)` removes the first empty line from the body value of the field.
             dec.parts
-              .find(_.headers.exists(_.value.contains(s"""name="$fieldName"""")))
+              .find(_.headers.exists(h =>
+                h.is(headers.`Content-Disposition`) && h.value.contains(s"""name="$fieldName"""")))
               .traverse(_.body.through(fs2.text.utf8Decode).drop(1).compile.fold("")(_ |+| _))
           case Left(_) => Sync[G].pure(none[String])
         }

--- a/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
+++ b/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
@@ -23,8 +23,8 @@ import cats.effect._
 import cats.syntax.all._
 import org.http4s.MediaType
 import org.http4s._
-import org.http4s.client._
 import org.http4s.dsl.io._
+import org.http4s.ember.client._
 import org.http4s.ember.server._
 import org.http4s.headers._
 import org.http4s.implicits._
@@ -66,7 +66,7 @@ class CSRFIntegrationSuite extends Http4sSuite {
           .withPort(port)
           .withHttpApp(service)
           .build
-        client <- IO.delay(JavaNetClientBuilder[IO](testBlocker).create)
+        client <- IO.delay(EmberClientBuilder.default[IO].withBlocker(testBlocker).build)
         baseReq = Request[IO](
           method = Method.POST,
           headers = Headers.of(
@@ -81,8 +81,8 @@ class CSRFIntegrationSuite extends Http4sSuite {
         req = csrfProtect.embedInRequestCookie(baseReq, token)
         fiber <- resource
           .use(server =>
-            IO.delay(println(s"Server started at ${server.address}!")) >> client.expect[String](
-              req))
+            IO.delay(println(s"Server started at ${server.address}!")) >> client.use(
+              _.expect[String](req)))
           .start
         check <- fiber.join
       } yield check
@@ -115,7 +115,7 @@ class CSRFIntegrationSuite extends Http4sSuite {
           .withPort(port)
           .withHttpApp(service)
           .build
-        client <- IO.delay(JavaNetClientBuilder[IO](testBlocker).create)
+        client <- IO.delay(EmberClientBuilder.default[IO].withBlocker(testBlocker).build)
         baseReq = Request[IO](
           method = Method.POST,
           headers = Headers.of(Header("Origin", s"http://localhost:$port")),
@@ -128,8 +128,8 @@ class CSRFIntegrationSuite extends Http4sSuite {
         req = csrfProtect.embedInRequestCookie(baseReq, token)
         fiber <- resource
           .use(server =>
-            IO.delay(println(s"Server started at ${server.address}!")) >> client.expect[String](
-              req))
+            IO.delay(println(s"Server started at ${server.address}!")) >> client.use(
+              _.expect[String](req)))
           .start
         check <- fiber.join
       } yield check
@@ -162,7 +162,7 @@ class CSRFIntegrationSuite extends Http4sSuite {
           .withPort(port)
           .withHttpApp(service)
           .build
-        client <- IO.delay(JavaNetClientBuilder[IO](testBlocker).create)
+        client <- IO.delay(EmberClientBuilder.default[IO].withBlocker(testBlocker).build)
         mf = Part.formData[IO](COOKIE_NAME, unlift(token), `Content-Type`(MediaType.text.plain))
         mp = Multipart(Vector(mf))
         baseReq = Request[IO](
@@ -177,8 +177,8 @@ class CSRFIntegrationSuite extends Http4sSuite {
         req = csrfProtect.embedInRequestCookie(baseReq, token)
         fiber <- resource
           .use(server =>
-            IO.delay(println(s"Server started at ${server.address}!")) >> client.expect[String](
-              req))
+            IO.delay(println(s"Server started at ${server.address}!")) >> client.use(
+              _.expect[String](req)))
           .start
         check <- fiber.join
       } yield check

--- a/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
+++ b/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.middleware
+
+import java.net.{ServerSocket, URI}
+import java.util.concurrent.Executors
+
+import cats._
+import cats.arrow._
+import cats.data._
+import cats.effect._
+import cats.syntax.all._
+import munit.CatsEffectSuite
+import org.http4s.MediaType
+import org.http4s._
+import org.http4s.client._
+import org.http4s.client.dsl.io._
+import org.http4s.dsl.io._
+import org.http4s.headers._
+import org.http4s.implicits._
+import org.http4s.multipart._
+import org.http4s.server._
+import org.http4s.server.blaze._
+import org.http4s.server.middleware.CSRF.unlift
+import org.http4s.server.middleware._
+
+import scala.concurrent.ExecutionContext.global
+
+class CSRFIntegrationSuite extends Http4sSuite {
+  implicit val cs: ContextShift[IO] = IO.contextShift(global)
+  implicit val timer: Timer[IO] = IO.timer(global)
+
+  val COOKIE_NAME = "X-Csrf-Token"
+
+  test("CSRF check must work for headers") {
+    val port = CSRFIntegrationSuite.findAvailablePort(reuseAddress = true)
+    val csrfCheck: Request[IO] => Boolean =
+      CSRF.defaultOriginCheck[IO](_, "localhost", Uri.Scheme.http, port.some)
+    val csrfBuilder = CSRF[IO, IO](CSRF.generateSigningKey[IO]().unsafeRunSync(), csrfCheck)
+    val csrfProtect: CSRF[IO, IO] =
+      csrfBuilder
+        .withCSRFCheck(CSRF.checkCSRFinHeaderAndForm[IO, IO](COOKIE_NAME, FunctionK.id))
+        .build
+    val token = csrfProtect.generateToken[IO].unsafeRunSync()
+    val routes = HttpRoutes.of[IO] { case Method.POST -> Root =>
+      Ok("CSRF passed!")
+    }
+    val service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
+    val server = BlazeServerBuilder[IO](CSRFIntegrationSuite.blocker.blockingContext)
+      .bindHttp(port, "localhost")
+      .withHttpApp(service)
+      .resource
+    val fiber: Fiber[IO, Nothing] = server.use(_ => IO.never).start.unsafeRunSync()
+    val client: Client[IO] = JavaNetClientBuilder[IO](CSRFIntegrationSuite.blocker).create
+
+    val baseReq = Request[IO](
+      method = Method.POST,
+      headers = Headers.of(Header("Origin", s"http://localhost:$port")),
+      uri = Uri(
+        scheme = Uri.Scheme.http.some,
+        authority = Uri.Authority(host = Uri.RegName("localhost"), port = port.some).some,
+        path = "/"
+      )
+    )
+    val req = csrfProtect.embedInRequestCookie(baseReq, token)
+
+    val check = client.expect[String](req).unsafeRunSync()
+    fiber.cancel.unsafeRunSync()
+    assertEquals(check, "CSRF passed!")
+  }
+
+  test("CSRF check must work for url forms") {
+    val port = CSRFIntegrationSuite.findAvailablePort(reuseAddress = true)
+    val csrfCheck: Request[IO] => Boolean =
+      CSRF.defaultOriginCheck[IO](_, "localhost", Uri.Scheme.http, port.some)
+    val csrfBuilder = CSRF[IO, IO](CSRF.generateSigningKey[IO]().unsafeRunSync(), csrfCheck)
+    val csrfProtect: CSRF[IO, IO] =
+      csrfBuilder
+        .withCSRFCheck(CSRF.checkCSRFinHeaderAndForm[IO, IO](COOKIE_NAME, FunctionK.id))
+        .build
+    val token = csrfProtect.generateToken[IO].unsafeRunSync()
+    val routes = HttpRoutes.of[IO] { case Method.POST -> Root =>
+      Ok("CSRF passed!")
+    }
+    val service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
+    val server = BlazeServerBuilder[IO](CSRFIntegrationSuite.blocker.blockingContext)
+      .bindHttp(port, "localhost")
+      .withHttpApp(service)
+      .resource
+    val fiber: Fiber[IO, Nothing] = server.use(_ => IO.never).start.unsafeRunSync()
+    val client: Client[IO] = JavaNetClientBuilder[IO](CSRFIntegrationSuite.blocker).create
+
+    val baseReq = Request[IO](
+      method = Method.POST,
+      headers = Headers.of(Header("Origin", s"http://localhost:$port")),
+      uri = Uri(
+        scheme = Uri.Scheme.http.some,
+        authority = Uri.Authority(host = Uri.RegName("localhost"), port = port.some).some,
+        path = "/"
+      )
+    ).withEntity(UrlForm(COOKIE_NAME -> unlift(token)))
+    val req = csrfProtect.embedInRequestCookie(baseReq, token)
+
+    val check = client.expect[String](req).unsafeRunSync()
+    fiber.cancel.unsafeRunSync()
+    assertEquals(check, "CSRF passed!")
+  }
+
+  test("CSRF check must work for multipart forms") {
+    val port = CSRFIntegrationSuite.findAvailablePort(reuseAddress = true)
+    val csrfCheck: Request[IO] => Boolean =
+      CSRF.defaultOriginCheck[IO](_, "localhost", Uri.Scheme.http, port.some)
+    val csrfBuilder = CSRF[IO, IO](CSRF.generateSigningKey[IO]().unsafeRunSync(), csrfCheck)
+    val csrfProtect: CSRF[IO, IO] =
+      csrfBuilder
+        .withCSRFCheck(CSRF.checkCSRFinHeaderAndForm[IO, IO](COOKIE_NAME, FunctionK.id))
+        .build
+    val token = csrfProtect.generateToken[IO].unsafeRunSync()
+    val routes = HttpRoutes.of[IO] { case Method.POST -> Root =>
+      Ok("CSRF passed!")
+    }
+    val service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
+    val server = BlazeServerBuilder[IO](CSRFIntegrationSuite.blocker.blockingContext)
+      .bindHttp(port, "localhost")
+      .withHttpApp(service)
+      .resource
+    val fiber: Fiber[IO, Nothing] = server.use(_ => IO.never).start.unsafeRunSync()
+    val client: Client[IO] = JavaNetClientBuilder[IO](CSRFIntegrationSuite.blocker).create
+
+    val mf = Part.formData[IO](COOKIE_NAME, unlift(token), `Content-Type`(MediaType.text.plain))
+    val mp = Multipart(Vector(mf))
+    val baseReq = Request(
+      method = Method.POST,
+      uri = Uri(
+        scheme = Uri.Scheme.http.some,
+        authority = Uri.Authority(host = Uri.RegName("localhost"), port = port.some).some,
+        path = "/"
+      ),
+      headers = mp.headers
+    ).withEntity(mp).putHeaders(Header("Origin", s"http://localhost:$port"))
+    val req = csrfProtect.embedInRequestCookie(baseReq, token)
+
+    val check = client.expect[String](req).unsafeRunSync()
+    fiber.cancel.unsafeRunSync()
+    assertEquals(check, "CSRF passed!")
+  }
+
+}
+
+object CSRFIntegrationSuite {
+  val blockingPool = Executors.newFixedThreadPool(2)
+  val blocker = Blocker.liftExecutorService(blockingPool)
+
+  /** Start a server socket and close it. The port number used by
+    * the socket is considered free and returned.
+    *
+    * @param reuseAddress If set to `false` the returned port will not be useable for some time.
+    * @return A port number.
+    */
+  private def findAvailablePort(reuseAddress: Boolean): Int = {
+    val serverSocket = new ServerSocket(0)
+    val freePort = serverSocket.getLocalPort
+    serverSocket.setReuseAddress(reuseAddress)
+    serverSocket.close()
+    freePort
+  }
+
+}

--- a/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
+++ b/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
@@ -64,12 +64,12 @@ class CSRFIntegrationSuite extends Http4sSuite {
             .build
         token <- csrfProtect.generateToken[IO]
         service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
-        server = BlazeServerBuilder[IO](CSRFIntegrationSuite.blocker.blockingContext)
+        server = BlazeServerBuilder[IO](testBlocker.blockingContext)
           .bindHttp(port, "localhost")
           .withHttpApp(service)
           .resource
         fiber <- server.use(_ => IO.never).start
-        client = JavaNetClientBuilder[IO](CSRFIntegrationSuite.blocker).create
+        client = JavaNetClientBuilder[IO](testBlocker).create
         baseReq = Request[IO](
           method = Method.POST,
           headers = Headers.of(
@@ -107,12 +107,12 @@ class CSRFIntegrationSuite extends Http4sSuite {
             .build
         token <- csrfProtect.generateToken[IO]
         service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
-        server = BlazeServerBuilder[IO](CSRFIntegrationSuite.blocker.blockingContext)
+        server = BlazeServerBuilder[IO](testBlocker.blockingContext)
           .bindHttp(port, "localhost")
           .withHttpApp(service)
           .resource
         fiber <- server.use(_ => IO.never).start
-        client = JavaNetClientBuilder[IO](CSRFIntegrationSuite.blocker).create
+        client = JavaNetClientBuilder[IO](testBlocker).create
         baseReq = Request[IO](
           method = Method.POST,
           headers = Headers.of(Header("Origin", s"http://localhost:$port")),
@@ -148,12 +148,12 @@ class CSRFIntegrationSuite extends Http4sSuite {
             .build
         token <- csrfProtect.generateToken[IO]
         service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
-        server = BlazeServerBuilder[IO](CSRFIntegrationSuite.blocker.blockingContext)
+        server = BlazeServerBuilder[IO](testBlocker.blockingContext)
           .bindHttp(port, "localhost")
           .withHttpApp(service)
           .resource
         fiber <- server.use(_ => IO.never).start
-        client = JavaNetClientBuilder[IO](CSRFIntegrationSuite.blocker).create
+        client = JavaNetClientBuilder[IO](testBlocker).create
         mf = Part.formData[IO](COOKIE_NAME, unlift(token), `Content-Type`(MediaType.text.plain))
         mp = Multipart(Vector(mf))
         baseReq = Request[IO](
@@ -176,8 +176,6 @@ class CSRFIntegrationSuite extends Http4sSuite {
 }
 
 object CSRFIntegrationSuite {
-  val blockingPool = Executors.newFixedThreadPool(2)
-  val blocker = Blocker.liftExecutorService(blockingPool)
 
   /** Start a server socket and close it. The port number used by
     * the socket is considered free and returned.

--- a/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
+++ b/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
@@ -59,6 +59,7 @@ class CSRFIntegrationSuite extends Http4sSuite {
         csrfBuilder = CSRF[IO, IO](key, csrfCheck)
         csrfProtect =
           csrfBuilder
+            .withCookieName(COOKIE_NAME)
             .withCSRFCheck(CSRF.checkCSRFinHeaderAndForm[IO, IO](COOKIE_NAME, FunctionK.id))
             .build
         token <- csrfProtect.generateToken[IO]
@@ -101,6 +102,7 @@ class CSRFIntegrationSuite extends Http4sSuite {
         csrfBuilder = CSRF[IO, IO](key, csrfCheck)
         csrfProtect =
           csrfBuilder
+            .withCookieName(COOKIE_NAME)
             .withCSRFCheck(CSRF.checkCSRFinHeaderAndForm[IO, IO](COOKIE_NAME, FunctionK.id))
             .build
         token <- csrfProtect.generateToken[IO]
@@ -141,6 +143,7 @@ class CSRFIntegrationSuite extends Http4sSuite {
         csrfBuilder = CSRF[IO, IO](key, csrfCheck)
         csrfProtect =
           csrfBuilder
+            .withCookieName(COOKIE_NAME)
             .withCSRFCheck(CSRF.checkCSRFinHeaderAndForm[IO, IO](COOKIE_NAME, FunctionK.id))
             .build
         token <- csrfProtect.generateToken[IO]

--- a/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
+++ b/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
@@ -30,11 +30,11 @@ import org.http4s._
 import org.http4s.client._
 import org.http4s.client.dsl.io._
 import org.http4s.dsl.io._
+import org.http4s.ember.server._
 import org.http4s.headers._
 import org.http4s.implicits._
 import org.http4s.multipart._
 import org.http4s.server._
-import org.http4s.server.blaze._
 import org.http4s.server.middleware.CSRF.unlift
 import org.http4s.server.middleware._
 
@@ -64,10 +64,12 @@ class CSRFIntegrationSuite extends Http4sSuite {
             .build
         token <- csrfProtect.generateToken[IO]
         service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
-        server = BlazeServerBuilder[IO](testBlocker.blockingContext)
-          .bindHttp(port, "localhost")
+        server = EmberServerBuilder
+          .default[IO]
+          .withHost("localhost")
+          .withPort(port)
           .withHttpApp(service)
-          .resource
+          .build
         fiber <- server.use(_ => IO.never).start
         client = JavaNetClientBuilder[IO](testBlocker).create
         baseReq = Request[IO](
@@ -107,10 +109,12 @@ class CSRFIntegrationSuite extends Http4sSuite {
             .build
         token <- csrfProtect.generateToken[IO]
         service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
-        server = BlazeServerBuilder[IO](testBlocker.blockingContext)
-          .bindHttp(port, "localhost")
+        server = EmberServerBuilder
+          .default[IO]
+          .withHost("localhost")
+          .withPort(port)
           .withHttpApp(service)
-          .resource
+          .build
         fiber <- server.use(_ => IO.never).start
         client = JavaNetClientBuilder[IO](testBlocker).create
         baseReq = Request[IO](
@@ -148,10 +152,12 @@ class CSRFIntegrationSuite extends Http4sSuite {
             .build
         token <- csrfProtect.generateToken[IO]
         service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
-        server = BlazeServerBuilder[IO](testBlocker.blockingContext)
-          .bindHttp(port, "localhost")
+        server = EmberServerBuilder
+          .default[IO]
+          .withHost("localhost")
+          .withPort(port)
           .withHttpApp(service)
-          .resource
+          .build
         fiber <- server.use(_ => IO.never).start
         client = JavaNetClientBuilder[IO](testBlocker).create
         mf = Part.formData[IO](COOKIE_NAME, unlift(token), `Content-Type`(MediaType.text.plain))

--- a/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
+++ b/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
@@ -17,6 +17,7 @@
 package org.http4s.server.middleware
 
 import java.net.ServerSocket
+import java.nio.charset.StandardCharsets
 
 import cats.arrow._
 import cats.effect._
@@ -164,6 +165,58 @@ class CSRFIntegrationSuite extends Http4sSuite {
         client <- IO.delay(EmberClientBuilder.default[IO].withBlocker(testBlocker).build)
         mf = Part.formData[IO](COOKIE_NAME, unlift(token), `Content-Type`(MediaType.text.plain))
         mp = Multipart(Vector(mf))
+        baseReq = Request[IO](
+          method = Method.POST,
+          uri = Uri(
+            scheme = Uri.Scheme.http.some,
+            authority = Uri.Authority(host = Uri.RegName("localhost"), port = port.some).some,
+            path = "/"
+          ),
+          headers = mp.headers
+        ).withEntity(mp).putHeaders(Header("Origin", s"http://localhost:$port"))
+        req = csrfProtect.embedInRequestCookie(baseReq, token)
+        fiber <- resource
+          .use(server =>
+            IO.delay(println(s"Server started at ${server.address}!")) >> client.use(
+              _.expect[String](req)))
+          .start
+        check <- fiber.join
+      } yield check
+
+    prg.assertEquals("CSRF passed!")
+  }
+
+  test("CSRF check must work for multipart forms with files") {
+    val port = CSRFIntegrationSuite.findAvailablePort(reuseAddress = true)
+    val routes = HttpRoutes.of[IO] { case Method.POST -> Root =>
+      Ok("CSRF passed!")
+    }
+
+    val prg =
+      for {
+        key <- CSRF.generateSigningKey[IO]()
+        csrfCheck = CSRF.defaultOriginCheck[IO](_, "localhost", Uri.Scheme.http, port.some)
+        csrfBuilder = CSRF[IO, IO](key, csrfCheck)
+        csrfProtect =
+          csrfBuilder
+            .withCookieName(COOKIE_NAME)
+            .withCSRFCheck(CSRF.checkCSRFinHeaderAndForm[IO, IO](COOKIE_NAME, FunctionK.id))
+            .build
+        token <- csrfProtect.generateToken[IO]
+        service = csrfProtect.validate()(Router("/" -> routes).orNotFound)
+        resource = EmberServerBuilder
+          .default[IO]
+          .withBlocker(testBlocker)
+          .withHost("localhost")
+          .withPort(port)
+          .withHttpApp(service)
+          .build
+        client <- IO.delay(EmberClientBuilder.default[IO].withBlocker(testBlocker).build)
+        mf1 = Part.formData[IO](COOKIE_NAME, unlift(token), `Content-Type`(MediaType.text.plain))
+        file: EntityBody[IO] = fs2.Stream.emits(
+          scala.util.Random.alphanumeric.take(2048).mkString.getBytes(StandardCharsets.UTF_8))
+        mf2 = Part.fileData("file", "passport.txt", file)
+        mp = Multipart(Vector(mf1, mf2))
         baseReq = Request[IO](
           method = Method.POST,
           uri = Uri(

--- a/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
+++ b/tests/src/test/scala/org/http4s/middleware/CSRFIntegrationSuite.scala
@@ -31,7 +31,6 @@ import org.http4s.implicits._
 import org.http4s.multipart._
 import org.http4s.server._
 import org.http4s.server.middleware.CSRF.unlift
-import org.http4s.server.middleware._
 
 import scala.concurrent.ExecutionContext.global
 


### PR DESCRIPTION
Add support for multipart forms in the checkCSRFinHeaderAndForm function
to avoid getting a 403 error code on otherwise valid forms (see #4612).