### PR TITLE
Retry based on Idempotent-Key header.

### DIFF
--- a/client/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -20,12 +20,13 @@ package middleware
 
 import cats.effect.{Concurrent, Resource, Timer}
 import cats.syntax.all._
-import java.time.Instant
-import java.time.temporal.ChronoUnit
 import org.http4s.Status._
-import org.http4s.headers.`Retry-After`
+import org.http4s.headers.{`Idempotency-Key`, `Retry-After`}
 import org.log4s.getLogger
 import org.typelevel.ci.CIString
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import scala.concurrent.duration._
 import scala.math.{min, pow, random}
 
@@ -125,15 +126,16 @@ object RetryPolicy {
     GatewayTimeout
   )
 
-  /** Returns true if the request method is idempotent and the result is
-    * either a throwable or has one of the `RetriableStatuses`.
+  /** Returns true if (the request method is idempotent or request contains Idempotency-Key header)
+    * and the result is either a throwable or has one of the `RetriableStatuses`.
     *
     * Caution: if the request body is effectful, the effects will be
     * run twice.  The most common symptom of this will be resubmitting
     * an idempotent request.
     */
   def defaultRetriable[F[_]](req: Request[F], result: Either[Throwable, Response[F]]): Boolean =
-    req.method.isIdempotent && isErrorOrRetriableStatus(result)
+    (req.method.isIdempotent || req.headers.get[`Idempotency-Key`].isDefined) &&
+      isErrorOrRetriableStatus(result)
 
   @deprecated("Use defaultRetriable instead", "0.19.0")
   def unsafeRetriable[F[_]](req: Request[F], result: Either[Throwable, Response[F]]): Boolean =

--- a/client/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
@@ -27,7 +27,6 @@ import org.http4s.headers.`Idempotency-Key`
 import org.http4s.laws.discipline.ArbitraryInstances._
 import org.http4s.syntax.all._
 import org.scalacheck.effect.PropF
-import org.typelevel.ci._
 
 import scala.concurrent.duration._
 
@@ -118,7 +117,7 @@ class RetrySuite extends Http4sSuite {
     resubmit(POST)(RetryPolicy.defaultRetriable).assertEquals(Status.InternalServerError)
   }
   test("default retriable should defaultRetriable resubmits bodies on idempotent header") {
-    resubmit(POST, Headers(`Idempotency-Key`(ci"key")))(RetryPolicy.defaultRetriable)
+    resubmit(POST, Headers(`Idempotency-Key`("key")))(RetryPolicy.defaultRetriable)
       .assertEquals(Status.Ok)
   }
   test("default retriable should defaultRetriable resubmits bodies on idempotent methods") {

--- a/core/src/main/scala/org/http4s/headers/`Idempotency-Key`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Idempotency-Key`.scala
@@ -25,18 +25,14 @@ object `Idempotency-Key` {
     ParseResult.fromParser(parser, "Invalid Idempotency-Key header")(s)
 
   private[http4s] val parser =
-    token.orElse(quotedString).map(CIString(_)).map(`Idempotency-Key`.apply)
+    token.orElse(quotedString).map(`Idempotency-Key`.apply)
 
   implicit val headerInstance: Header[`Idempotency-Key`, Header.Single] =
-    Header.createRendered(
-      ci"Idempotency-Key",
-      _.key,
-      parse
-    )
+    Header.create(ci"Idempotency-Key", _.key, parse)
 }
 
 /** Request header defines request to be idempotent used by client retry middleware.
   *
   *  [[https://tools.ietf.org/html/draft-idempotency-header-00#section-2.1 idempotency-header]]
   */
-final case class `Idempotency-Key`(key: CIString)
+final case class `Idempotency-Key`(key: String)

--- a/core/src/main/scala/org/http4s/headers/`Idempotency-Key`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Idempotency-Key`.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.headers
+
+import org.http4s.internal.parsing.Rfc7230.{quotedString, token}
+import org.http4s.{Header, ParseResult}
+import org.typelevel.ci._
+
+object `Idempotency-Key` {
+  def parse(s: String): ParseResult[`Idempotency-Key`] =
+    ParseResult.fromParser(parser, "Invalid Idempotency-Key header")(s)
+
+  private[http4s] val parser =
+    token.orElse(quotedString).map(CIString(_)).map(`Idempotency-Key`.apply)
+
+  implicit val headerInstance: Header[`Idempotency-Key`, Header.Single] =
+    Header.createRendered(
+      ci"Idempotency-Key",
+      _.key,
+      parse
+    )
+}
+
+/** Request header defines request to be idempotent used by client retry middleware.
+  *
+  *  [[https://tools.ietf.org/html/draft-idempotency-header-00#section-2.1 idempotency-header]]
+  */
+final case class `Idempotency-Key`(key: CIString)


### PR DESCRIPTION
Hi, small enhancement for consideration.

At the moment retry middleware is retrying failed requests only if method is idempotent.
Idempotency defined in rfc7231 (https://tools.ietf.org/html/rfc7231#section-4.2.2): as PUT, DELETE and safe methods.
However, it does not say that POST requests can’t be idempotent.

Enhancement is about giving user flexibility to make their requests idempotent by adding to request http header: `Idempotency-Key`. If method is idempotent by definition or if header present allow retrying failed requests.

This is in line with how some public API designed: https://stripe.com/docs/api/idempotent_requests
Moreover, there is a draft RFC to standardise it: https://tools.ietf.org/html/draft-idempotency-header-00#section-2.1