### PR TITLE
Add Literally[Uri]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,7 @@ lazy val core = libraryProject("core")
       scodecBits,
       slf4jApi, // residual dependency from macros
       vault,
+      literally
     ),
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-lang", "scala-reflect"),
     mimaBinaryIssueFilters ++= Seq(

--- a/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
@@ -29,7 +29,7 @@ object LiteralSyntaxMacros {
     def validate(c: Context)(s: String) = {
       import c.universe._
       Uri.fromString(s) match {
-        case Right(_) => Right(c.Expr(q"Uri.fromString($s).get"))
+        case Right(_) => Right(c.Expr(q"org.http4s.Uri.fromString($s).get"))
         case Left(parseError) => Left(s"invalid URI: ${parseError.details}")
       }
     }

--- a/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/src/main/scala/org/http4s/LiteralSyntaxMacros.scala
@@ -29,7 +29,7 @@ object LiteralSyntaxMacros {
     def validate(c: Context)(s: String) = {
       import c.universe._
       Uri.fromString(s) match {
-        case Right(_) => Right(c.Expr(q"org.http4s.Uri.fromString($s).get"))
+        case Right(_) => Right(c.Expr(q"org.http4s.Uri.fromString($s).toOption.get"))
         case Left(parseError) => Left(s"invalid URI: ${parseError.details}")
       }
     }

--- a/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/LiteralsSyntax.scala
@@ -23,7 +23,7 @@ trait LiteralsSyntax {
 }
 
 class LiteralsOps(val sc: StringContext) extends AnyVal {
-  def uri(args: Any*): Uri = macro LiteralSyntaxMacros.uriInterpolator
+  def uri(args: Any*): Uri = macro LiteralSyntaxMacros.uri.make
   def scheme(args: Any*): Uri.Scheme = macro LiteralSyntaxMacros.schemeInterpolator
   def ipv4(args: Any*): Uri.Ipv4Address = macro LiteralSyntaxMacros.ipv4AddressInterpolator
   def ipv6(args: Any*): Uri.Ipv6Address = macro LiteralSyntaxMacros.ipv6AddressInterpolator

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -350,6 +350,7 @@ object Http4sPlugin extends AutoPlugin {
     val treehugger = "0.4.4"
     val twirl = "1.4.2"
     val vault = "2.0.0"
+    val literally = "0.1-360f22d"
   }
 
   lazy val argonaut                         = "io.argonaut"            %% "argonaut"                  % V.argonaut
@@ -393,6 +394,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val json4sJackson                    = "org.json4s"             %% "json4s-jackson"            % V.json4s
   lazy val json4sNative                     = "org.json4s"             %% "json4s-native"             % V.json4s
   lazy val keypool                          = "io.chrisdavenport"      %% "keypool"                   % V.keypool
+  lazy val literally                        = "org.typelevel"          %% "literally"                 % V.literally
   lazy val log4catsCore                     = "io.chrisdavenport"      %% "log4cats-core"             % V.log4cats
   lazy val log4catsSlf4j                    = "io.chrisdavenport"      %% "log4cats-slf4j"            % V.log4cats
   lazy val log4catsTesting                  = "io.chrisdavenport"      %% "log4cats-testing"          % V.log4cats

--- a/tests/src/test/scala/org/http4s/LiteralSynxtaxMacrosSuite.scala
+++ b/tests/src/test/scala/org/http4s/LiteralSynxtaxMacrosSuite.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+
+import org.http4s.implicits._
+
+class LiteralSynxtaxMacrosSuite extends Http4sSuite {
+  test("'uri' macro works for valid input") {
+    assertEquals(uri"a.b.c", Uri.fromString("a.b.c").toOption.get)
+  }
+}


### PR DESCRIPTION
Replaces macro definition of `Uri` w/ `typelevel`'s `literally` library. Closes part of #4600.

```scala
$sbt
sbt:core> console
[info] compiling 1 Scala source to /Users/kevinmeredith/Workspace/http4s/core/target/scala-2.13/classes ...
[info] Starting scala interpreter...
Welcome to Scala 2.13.4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_112).
Type in expressions for evaluation. Or try :help.
import fs2._
import cats._
import cats.data._
import cats.effect._
import cats.implicits._

scala> import org.http4s.implicits._
import org.http4s.implicits._

scala> uri"a.b.c"
val res0: org.http4s.Uri = a.b.c

scala> uri"FOOBAR"
val res1: org.http4s.Uri = FOOBAR

scala> uri"    "
       ^
       error: invalid URI: Invalid input ' ', expected AbsoluteUri or RelativeRef (line 1, column 1):

       ^
```