### PR TITLE
Disable flaky ZonedDateTime QueryParamCodec spec on JDK8

### DIFF
--- a/tests/src/test/scala/org/http4s/QueryParamCodecSuite.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSuite.scala
@@ -39,7 +39,13 @@ class QueryParamCodecSuite extends Http4sSuite with QueryParamCodecInstances {
   checkAll("String QueryParamCodec", QueryParamCodecLaws[String])
   checkAll("Instant QueryParamCodec", QueryParamCodecLaws[Instant])
   checkAll("LocalDate QueryParamCodec", QueryParamCodecLaws[LocalDate])
-  checkAll("ZonedDateTime QueryParamCodec", QueryParamCodecLaws[ZonedDateTime])
+
+  if (!sys.props.get("java.specification.version").contains("1.8")) {
+    // skipping this property due to bug in JDK8
+    // where round trip conversion fails for region-based zone id & daylight saving time
+    // see https://bugs.openjdk.java.net/browse/JDK-8183553 and https://bugs.openjdk.java.net/browse/JDK-8066982
+    checkAll("ZonedDateTime QueryParamCodec", QueryParamCodecLaws[ZonedDateTime])
+  }
 
   // Law checks for instances.
   checkAll(


### PR DESCRIPTION
This is due to bug in JDK8 where round trip conversion fails
on ZonedDateTime with region-based zone and daylight saving time

See https://bugs.openjdk.java.net/browse/JDK-8066982 and
https://bugs.openjdk.java.net/browse/JDK-8183553

Fixes #4615 