### PR TITLE
Deprecate the Status.apply(headers) dsl

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -62,7 +62,13 @@ trait EmptyResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
 trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def liftG: FunctionK[G, F]
 
-  def apply(headers: Header*)(implicit F: Applicative[F]): F[Response[G]] =
+  @deprecated(
+    message = "Use StatusType.headers instead. This will be removed in 0.22",
+    since = "0.21.21")
+  def apply(_headers: Header*)(implicit F: Applicative[F]): F[Response[G]] =
+    headers(_headers: _*)
+
+  def headers(headers: Header*)(implicit F: Applicative[F]): F[Response[G]] =
     F.pure(Response[G](status, headers = Headers(`Content-Length`.zero :: headers.toList)))
 
   def apply[A](body: G[A])(implicit F: Monad[F], w: EntityEncoder[G, A]): F[Response[G]] =

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -68,6 +68,8 @@ trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def apply(_headers: Header*)(implicit F: Applicative[F]): F[Response[G]] =
     headers(_headers: _*)
 
+  def apply()(implicit F: Applicative[F]): F[Response[G]] = headers()
+
   def headers(headers: Header*)(implicit F: Applicative[F]): F[Response[G]] =
     F.pure(Response[G](status, headers = Headers(`Content-Length`.zero :: headers.toList)))
 

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
@@ -200,8 +200,15 @@ object Responses {
   final class ResetContentOps[F[_], G[_]](val status: ResetContent.type)
       extends AnyVal
       with EmptyResponseGenerator[F, G] {
-    override def apply(headers: Header*)(implicit F: Applicative[F]): F[Response[G]] =
-      F.pure(Response(ResetContent, headers = Headers(`Content-Length`.zero :: headers.toList)))
+    override def headers(header: Header, _headers: Header*)(implicit
+        F: Applicative[F]): F[Response[G]] =
+      F.pure(
+        Response(
+          ResetContent,
+          headers = Headers(`Content-Length`.zero :: header :: _headers.toList)))
+
+    override def apply()(implicit F: Applicative[F]): F[Response[G]] =
+      F.pure(Response[G](ResetContent, headers = Headers(List(`Content-Length`.zero))))
   }
   // TODO helpers for Content-Range and multipart/byteranges
   final class PartialContentOps[F[_], G[_]](val status: PartialContent.type, val liftG: G ~> F)

--- a/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
@@ -31,10 +31,10 @@ class DefaultHeadSuite extends Http4sSuite {
       Ok("hello")
 
     case GET -> Root / "special" =>
-      Ok(Header("X-Handled-By", "GET"))
+      Ok.headers(Header("X-Handled-By", "GET"))
 
     case HEAD -> Root / "special" =>
-      Ok(Header("X-Handled-By", "HEAD"))
+      Ok.headers(Header("X-Handled-By", "HEAD"))
   }
   val app = DefaultHead(httpRoutes).orNotFound
 


### PR DESCRIPTION
The model in 0.22 and 1.0 is changed and Scala does not know how to dispatch to the overloaded apply.

This adds a deprecation to the apply method that only accepts headers and adds a `headers` constructor.