### PR TITLE
Ember: Idle vs Header Receive Timeouts

### DIFF
--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -109,7 +109,11 @@ private[client] object ClientHelpers {
             connection.keySocket.socket.read(chunkSize, durationToFinite(idleTimeout))
           )
 
-          finiteDuration.fold(parse)(duration => parse.timeout(duration))
+          finiteDuration.fold(parse)(duration =>
+            parse.timeoutTo(
+              duration,
+              ApplicativeThrow[F].raiseError(new java.util.concurrent.TimeoutException(
+                s"Timed Out on EmberClient Header Receive Timeout: $duration"))))
         }
 
     for {

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -132,7 +132,12 @@ private[server] object ServerHelpers {
 
     val parse = Parser.Request.parser(maxHeaderSize)(head, read)
     val parseWithHeaderTimeout =
-      durationToFinite(requestHeaderReceiveTimeout).fold(parse)(duration => parse.timeout(duration))
+      durationToFinite(requestHeaderReceiveTimeout).fold(parse)(duration =>
+        parse.timeoutTo(
+          duration,
+          ApplicativeThrow[F].raiseError(
+            new java.util.concurrent.TimeoutException(
+              s"Timed Out on EmberServer Header Receive Timeout: $duration"))))
 
     for {
       (req, drain) <- parseWithHeaderTimeout
@@ -192,18 +197,27 @@ private[server] object ServerHelpers {
     val read: F[Option[Chunk[Byte]]] = socket.read(receiveBufferSize, durationToFinite(idleTimeout))
     Stream.eval(mkRequestVault(socket)).flatMap { requestVault =>
       Stream
-        .unfoldLoopEval(Array.emptyByteArray)(incoming =>
-          runApp(
-            incoming,
-            read,
-            maxHeaderSize,
-            requestHeaderReceiveTimeout,
-            httpApp,
-            errorHandler,
-            requestVault).attempt.map {
-            case Right((req, resp, rest)) => (Right((req, resp)), rest)
-            case Left(e) => (Left(e), None)
-          })
+        .unfoldLoopEval((Array.emptyByteArray, false)) { case (incoming, reused) =>
+          if (incoming.isEmpty || !reused) {
+            read.map(chunkOpt =>
+              (
+                Option.empty[Either[Throwable, (Request[F], Response[F])]],
+                chunkOpt.map(c => (c.toArray, true))))
+          } else {
+            runApp(
+              incoming,
+              read,
+              maxHeaderSize,
+              requestHeaderReceiveTimeout,
+              httpApp,
+              errorHandler,
+              requestVault).attempt.map {
+              case Right((req, resp, rest)) => (Right((req, resp)).some, rest.map((_, true)))
+              case Left(e) => (Left(e).some, None)
+            }
+          }
+        }
+        .unNone
         .evalMap {
           case Right((req, resp)) =>
             postProcessResponse(req, resp).map(resp => (req, resp).asRight[Throwable])


### PR DESCRIPTION
1. On reused connections which have empty buffers we should delay for the full idle period, and not timeout on the shorter header timeout. This addresses that.
2. On the very first connection we should automatically start reading headers.
3. We should be clear what is the cause of our timeouts, perhaps in even more places. This doesn't change the class but changes the message to more clearly indicate the cause of the timeout.