### PR TITLE
Status.headers constructor for dsl

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
@@ -200,8 +200,15 @@ object Responses {
   final class ResetContentOps[F[_], G[_]](val status: ResetContent.type)
       extends AnyVal
       with EmptyResponseGenerator[F, G] {
-    override def apply(headers: Header.ToRaw*)(implicit F: Applicative[F]): F[Response[G]] =
-      F.pure(Response(ResetContent, headers = Headers(`Content-Length`.zero, headers.toList)))
+    override def headers(header: Header.ToRaw, _headers: Header.ToRaw*)(implicit
+        F: Applicative[F]): F[Response[G]] =
+      F.pure(
+        Response(
+          ResetContent,
+          headers = Headers(`Content-Length`.zero) ++ Headers(header :: _headers.toList)))
+
+    override def apply()(implicit F: Applicative[F]): F[Response[G]] =
+      F.pure(Response[G](ResetContent, headers = Headers(List(`Content-Length`.zero))))
   }
   // TODO helpers for Content-Range and multipart/byteranges
   final class PartialContentOps[F[_], G[_]](val status: PartialContent.type, val liftG: G ~> F)


### PR DESCRIPTION
The model in 0.22 and 1.0 is changed and Scala does not know how to dispatch to the overloaded apply.

This removes the undispatchable apply method and adds a `headers` constructor.
This should be documented.