### PR TITLE
Update to Servlet API 4 and Jetty 10

### DIFF
--- a/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/JettyClient.scala
@@ -23,7 +23,9 @@ import cats.syntax.all._
 import fs2._
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.api.{Request => JettyRequest}
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP
 import org.eclipse.jetty.http.{HttpVersion => JHttpVersion}
+import org.eclipse.jetty.io.ClientConnector
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.log4s.{Logger, getLogger}
 
@@ -38,7 +40,7 @@ object JettyClient {
       .map(client =>
         Client[F] { req =>
           Resource.suspend(F.asyncF[Resource[F, Response[F]]] { cb =>
-            F.bracket(StreamRequestContentProvider()) { dcp =>
+            F.bracket(StreamRequestContent()) { dcp =>
               val jReq = toJettyRequest(client, req, dcp)
               for {
                 rl <- ResponseListener(cb)
@@ -65,8 +67,11 @@ object JettyClient {
     Stream.resource(resource(client))
 
   def defaultHttpClient(): HttpClient = {
-    val sslCtxFactory = new SslContextFactory.Client();
-    val c = new HttpClient(sslCtxFactory)
+    val sslCtxFactory = new SslContextFactory.Client()
+    val connector = new ClientConnector()
+    connector.setSslContextFactory(sslCtxFactory)
+    val transport = new HttpClientTransportOverHTTP(connector)
+    val c = new HttpClient(transport)
     c.setFollowRedirects(false)
     c.setDefaultRequestContentType(null)
     c
@@ -75,7 +80,7 @@ object JettyClient {
   private def toJettyRequest[F[_]](
       client: HttpClient,
       request: Request[F],
-      dcp: StreamRequestContentProvider[F]): JettyRequest = {
+      dcp: StreamRequestContent[F]): JettyRequest = {
     val jReq = client
       .newRequest(request.uri.toString)
       .method(request.method.name)
@@ -88,7 +93,7 @@ object JettyClient {
         }
       )
 
-    for (h <- request.headers.toList) jReq.header(h.name.toString, h.value)
-    jReq.content(dcp)
+    for (h <- request.headers) jReq.headers(c => c.add(h.name.toString, h.value): Unit): Unit
+    jReq.body(dcp)
   }
 }

--- a/jetty-client/src/main/scala/org/http4s/client/jetty/StreamRequestContent.scala
+++ b/jetty-client/src/main/scala/org/http4s/client/jetty/StreamRequestContent.scala
@@ -23,15 +23,14 @@ import cats.effect.concurrent.Semaphore
 import cats.effect.implicits._
 import cats.syntax.all._
 import fs2._
-import org.eclipse.jetty.client.util.DeferredContentProvider
+import org.eclipse.jetty.client.util.AsyncRequestContent
 import org.eclipse.jetty.util.{Callback => JettyCallback}
 import org.http4s.internal.loggingAsyncCallback
 import org.log4s.getLogger
 
-private[jetty] final case class StreamRequestContentProvider[F[_]](s: Semaphore[F])(implicit
-    F: Effect[F])
-    extends DeferredContentProvider {
-  import StreamRequestContentProvider.logger
+private[jetty] final case class StreamRequestContent[F[_]](s: Semaphore[F])(implicit F: Effect[F])
+    extends AsyncRequestContent {
+  import StreamRequestContent.logger
 
   def write(req: Request[F]): F[Unit] =
     req.body.chunks
@@ -57,9 +56,9 @@ private[jetty] final case class StreamRequestContentProvider[F[_]](s: Semaphore[
   }
 }
 
-private[jetty] object StreamRequestContentProvider {
+private[jetty] object StreamRequestContent {
   private val logger = getLogger
 
-  def apply[F[_]]()(implicit F: ConcurrentEffect[F]): F[StreamRequestContentProvider[F]] =
-    Semaphore[F](1).map(StreamRequestContentProvider(_))
+  def apply[F[_]]()(implicit F: ConcurrentEffect[F]): F[StreamRequestContent[F]] =
+    Semaphore[F](1).map(StreamRequestContent(_))
 }

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -338,7 +338,7 @@ sealed class JettyBuilder[F[_]] private (
 
   private def shutdown(jetty: JServer): F[Unit] =
     F.async[Unit] { cb =>
-      jetty.addLifeCycleListener(
+      jetty.addEventListener(
         new AbstractLifeCycle.AbstractLifeCycleListener {
           override def lifeCycleStopped(ev: LifeCycle) = cb(Right(()))
           override def lifeCycleFailure(ev: LifeCycle, cause: Throwable) = cb(Left(cause))

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -65,20 +65,16 @@ object Http4sPlugin extends AutoPlugin {
       IO.write(dest, buildData)
     },
 
-    // servlet-4.0 is not yet supported by jetty-9 or tomcat-9, so don't accidentally depend on its new features
-    dependencyUpdatesFilter -= moduleFilter(organization = "javax.servlet", revision = "4.0.0"),
-    dependencyUpdatesFilter -= moduleFilter(organization = "javax.servlet", revision = "4.0.1"),
     // breaks binary compatibility in caffeine module with 0.8.1
     dependencyUpdatesFilter -= moduleFilter(organization = "io.prometheus", revision = "0.9.0"),
     // servlet containers skipped until we figure out our Jakarta EE strategy
-    dependencyUpdatesFilter -= moduleFilter(organization = "org.eclipse.jetty*", revision = "10.0.*"),
     dependencyUpdatesFilter -= moduleFilter(organization = "org.eclipse.jetty*", revision = "11.0.*"),
     dependencyUpdatesFilter -= moduleFilter(organization = "org.apache.tomcat", revision = "10.0.*"),
     // Broke binary compatibility with 2.10.5
     dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", revision = "2.11.0"),
     dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", revision = "2.12.0"),
     dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", revision = "2.12.1"),
-    dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", revision = "2.12.2"),    
+    dependencyUpdatesFilter -= moduleFilter(organization = "org.asynchttpclient", revision = "2.12.2"),
     // No release notes. If it's compatible with 6.2.5, prove it and PR it.
     dependencyUpdatesFilter -= moduleFilter(organization = "io.argonaut"),
     dependencyUpdatesFilter -= moduleFilter(organization = "io.argonaut", revision = "6.3.1"),
@@ -320,7 +316,7 @@ object Http4sPlugin extends AutoPlugin {
     val jacksonDatabind = "2.11.4"
     val jawn = "1.0.1"
     val jawnFs2 = "1.0.0"
-    val jetty = "9.4.38.v20210224"
+    val jetty = "10.0.1"
     val json4s = "3.6.11"
     val log4cats = "1.1.1"
     val keypool = "0.2.0"
@@ -344,7 +340,7 @@ object Http4sPlugin extends AutoPlugin {
     val scalatags = "0.9.3"
     val scalaXml = "1.3.0"
     val scodecBits = "1.1.24"
-    val servlet = "3.1.0"
+    val servlet = "4.0.1"
     val slf4j = "1.7.30"
     val specs2 = "4.10.6"
     val tomcat = "9.0.44"


### PR DESCRIPTION
Fixes #4643 

Include bump of Jetty version and fixes of multiple deprecation warnings in Jetty API.

So far no API changes or use of Servlet 4.0 specific APIs added.

Haven't tested it a lot yet, but at least it passed all the tests.