### PR TITLE
FileService: Querying /file.png/anything where /file.png is a file throws

### DIFF
--- a/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSuite.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/FileServiceSuite.scala
@@ -56,6 +56,11 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
       routes.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
+  test("Return a 404 for a resource under an existing file") {
+    val req = Request[IO](uri = uri"/testresource.txt/test")
+    routes.orNotFound(req).map(_.status).assertEquals(Status.NotFound)
+  }
+
   test("Decodes path segments") {
     val req = Request[IO](uri = uri"/space+truckin%27.txt")
     routes.orNotFound(req).map(_.status).assertEquals(Status.Ok)


### PR DESCRIPTION
Exception is `java.nio.file.FileSystemException: Not a directory`.
Found bot queries in Scala Algorithms logs that are leading to an HTTP 5xx error.

To avoid this, we explicitly check if what we are querying is a file, before attempting to resolve the real path; the exception is currently raised in particular where `.toRealPath` is called.

Alternative approach would be to capture the `FileSystemException` as well, but it could hide other errors like `AccessDeniedException`. Because we already do a check, the check for `NoSuchFileException` becomes redundant.

Before changing main code:
![image](https://user-images.githubusercontent.com/2464813/112736174-8b27f100-8f48-11eb-8237-ea6aa4808fbd.png)
