### PR TITLE
netty-4.1.61.Final, block new test libraries

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -103,6 +103,8 @@ object Http4sPlugin extends AutoPlugin {
     // Major
     dependencyUpdatesFilter -= moduleFilter(organization = "co.fs2", revision="3.*"),
     dependencyUpdatesFilter -= moduleFilter(organization = "org.typelevel", name = "cats-effect*", revision="3.*"),
+    dependencyUpdatesFilter -= moduleFilter(organization = "org.typelevel", name = "scalacheck-effect*", revision="1.*"),
+    dependencyUpdatesFilter -= moduleFilter(organization = "org.typelevel", name = "munit-cats-effect*", revision="1.*"),
 
     excludeFilter.in(headerSources) := HiddenFileFilter ||
       new FileFilter {
@@ -328,7 +330,7 @@ object Http4sPlugin extends AutoPlugin {
     val munit = "0.7.18"
     val munitCatsEffect = "1.0.0"
     val munitDiscipline = "1.0.7"
-    val netty = "4.1.60.Final"
+    val netty = "4.1.61.Final"
     val okio = "2.9.0"
     val okhttp = "4.9.1"
     val parboiledHttp4s = "2.0.1"


### PR DESCRIPTION
I don't think the 1.0 of the test libraries are public API anymore, but there's no reason to risk it.  They'll be upgraded in 0.22.