### PR TITLE
Add custom dns resolver to BlazeClientBuilder.

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClientBuilder.scala
@@ -65,6 +65,52 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     with BackendBuilder[F, Client[F]] {
   type Self = BlazeClientBuilder[F]
 
+  @deprecated("Kept for binary compatibility", "0.21.21")
+  private[BlazeClientBuilder] def this(
+      responseHeaderTimeout: Duration,
+      idleTimeout: Duration,
+      requestTimeout: Duration,
+      connectTimeout: Duration,
+      userAgent: Option[`User-Agent`],
+      maxTotalConnections: Int,
+      maxWaitQueueLimit: Int,
+      maxConnectionsPerRequestKey: RequestKey => Int,
+      sslContext: Option[SSLContext],
+      checkEndpointIdentification: Boolean,
+      maxResponseLineSize: Int,
+      maxHeaderLength: Int,
+      maxChunkSize: Int,
+      chunkBufferMaxSize: Int,
+      parserMode: ParserMode,
+      bufferSize: Int,
+      executionContext: ExecutionContext,
+      scheduler: Resource[F, TickWheelExecutor],
+      asynchronousChannelGroup: Option[AsynchronousChannelGroup],
+      channelOptions: ChannelOptions
+  )(implicit F: ConcurrentEffect[F]) = this(
+    responseHeaderTimeout = responseHeaderTimeout,
+    idleTimeout = idleTimeout,
+    requestTimeout = requestTimeout,
+    connectTimeout = connectTimeout,
+    userAgent = userAgent,
+    maxTotalConnections = maxTotalConnections,
+    maxWaitQueueLimit = maxWaitQueueLimit,
+    maxConnectionsPerRequestKey = maxConnectionsPerRequestKey,
+    sslContext = sslContext,
+    checkEndpointIdentification = checkEndpointIdentification,
+    maxResponseLineSize = maxResponseLineSize,
+    maxHeaderLength = maxHeaderLength,
+    maxChunkSize = maxChunkSize,
+    chunkBufferMaxSize = chunkBufferMaxSize,
+    parserMode = parserMode,
+    bufferSize = bufferSize,
+    executionContext = executionContext,
+    scheduler = scheduler,
+    asynchronousChannelGroup = asynchronousChannelGroup,
+    channelOptions = channelOptions,
+    customDnsResolver = None
+  )
+
   final protected val logger = getLogger(this.getClass)
 
   private def copy(

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -48,7 +48,8 @@ object Http1Client {
       parserMode = if (config.lenientParser) ParserMode.Lenient else ParserMode.Strict,
       userAgent = config.userAgent,
       channelOptions = ChannelOptions(Vector.empty),
-      connectTimeout = Duration.Inf
+      connectTimeout = Duration.Inf,
+      customDnsResolver = None
     ).makeClient
 
     Resource

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Client.scala
@@ -49,7 +49,7 @@ object Http1Client {
       userAgent = config.userAgent,
       channelOptions = ChannelOptions(Vector.empty),
       connectTimeout = Duration.Inf,
-      customDnsResolver = None
+      getAddress = BlazeClientBuilder.getAddress(_)
     ).makeClient
 
     Resource

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala
@@ -61,6 +61,41 @@ final private class Http1Support[F[_]](
     connectTimeout
   )
 
+  @deprecated("Kept for binary compatibility", "0.21.21")
+  private[Http1Support] def this(
+      sslContextOption: Option[SSLContext],
+      bufferSize: Int,
+      asynchronousChannelGroup: Option[AsynchronousChannelGroup],
+      executionContext: ExecutionContext,
+      scheduler: TickWheelExecutor,
+      checkEndpointIdentification: Boolean,
+      maxResponseLineSize: Int,
+      maxHeaderLength: Int,
+      maxChunkSize: Int,
+      chunkBufferMaxSize: Int,
+      parserMode: ParserMode,
+      userAgent: Option[`User-Agent`],
+      channelOptions: ChannelOptions,
+      connectTimeout: Duration
+  )(implicit F: ConcurrentEffect[F]) =
+    this(
+      sslContextOption = sslContextOption,
+      bufferSize = bufferSize,
+      asynchronousChannelGroup = asynchronousChannelGroup,
+      executionContext = executionContext,
+      scheduler = scheduler,
+      checkEndpointIdentification = checkEndpointIdentification,
+      maxResponseLineSize = maxResponseLineSize,
+      maxHeaderLength = maxHeaderLength,
+      maxChunkSize = maxChunkSize,
+      chunkBufferMaxSize = chunkBufferMaxSize,
+      parserMode = parserMode,
+      userAgent = userAgent,
+      channelOptions = channelOptions,
+      connectTimeout = connectTimeout,
+      getAddress = BlazeClientBuilder.getAddress(_)
+    )
+
 ////////////////////////////////////////////////////
 
   def makeClient(requestKey: RequestKey): F[BlazeConnection[F]] =


### PR DESCRIPTION
Hi, AFAIK there is currently no way to add custom DNS resolver for blaze-client (similar to one provided in akka-http ([this PR](https://github.com/akka/akka-http/pull/3202) and [here in docs](https://github.com/akka/akka-http/blob/master/docs/src/main/paradox/client-side/client-transport.md#custom-host-name-resolution-transport)).
I kinda need that feature, potential use cases are in linked akkka-http doc.

I added new parameter in `BlazeClientBuilder` - `customDnsResolver` - which is passed to `Http1Support` and if present - used instead of [getAddress](https://github.com/http4s/http4s/blob/e522b34ad9dbf6866a8faddb6e102503ac5822a0/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Support.scala#L137).

 I'm glad to adjust/change implementation if it is not suitable.

Also, are changes from `series/0.21` eventually merged to 1.0.0 series (`main`), or should I submit separate PR for it?