### PR TITLE
handle errors/close socket in ember server initial req read

### DIFF
--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -200,10 +200,11 @@ private[server] object ServerHelpers {
         .unfoldLoopEval((Array.emptyByteArray, false)) { case (incoming, reused) =>
           if (incoming.isEmpty || !reused) {
             read.attempt.map {
-              case Right(chunkOpt) => (
-                Option.empty[Either[Throwable, (Request[F], Response[F])]],
-                chunkOpt.map(c => (c.toArray, true))
-              )
+              case Right(chunkOpt) =>
+                (
+                  Option.empty[Either[Throwable, (Request[F], Response[F])]],
+                  chunkOpt.map(c => (c.toArray, true))
+                )
               case Left(e) => (Left(e).some, None)
             }
           } else {

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -199,10 +199,13 @@ private[server] object ServerHelpers {
       Stream
         .unfoldLoopEval((Array.emptyByteArray, false)) { case (incoming, reused) =>
           if (incoming.isEmpty || !reused) {
-            read.map(chunkOpt =>
-              (
+            read.attempt.map {
+              case Right(chunkOpt) => (
                 Option.empty[Either[Throwable, (Request[F], Response[F])]],
-                chunkOpt.map(c => (c.toArray, true))))
+                chunkOpt.map(c => (c.toArray, true))
+              )
+              case Left(e) => (Left(e).some, None)
+            }
           } else {
             runApp(
               incoming,


### PR DESCRIPTION
This fixes the issue #4714 by adding the same error handling around the initial `read` as is around the `runApp` such that errors are converted to `Left`s, the stream is ended and the socket closed.