### PR TITLE
Postpone using Query model until we need it

### DIFF
--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -234,7 +234,7 @@ object Query {
     import cats.parse.Parser.charIn
     import Rfc3986.pchar
 
-    pchar.orElse(charIn("/?[]")).rep0.string.map(Query.unsafeFromString)
+    pchar.orElse(charIn("/?[]")).rep0.string.map(pchars => new Query(Right(pchars)))
   }
 
   implicit val catsInstancesForHttp4sQuery: Hash[Query] with Order[Query] with Show[Query] =

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -504,14 +504,11 @@ class UriSpec extends Http4sSuite {
     }
 
     test("Uri toString should handle brackets in query string") {
-      // These are illegal, but common in the wild.  We will be "conservative
-      // in our sending behavior and liberal in our receiving behavior", and
-      // encode them.
       assertEquals(
         Uri
           .fromString("http://localhost:8080/index?filter[state]=public")
           .map(_.toString),
-        Right("http://localhost:8080/index?filter%5Bstate%5D=public"))
+        Right("http://localhost:8080/index?filter[state]=public"))
     }
 
     test("Uri toString should round trip with toString".fail) {

--- a/tests/src/test/scala/org/http4s/UriSuite.scala
+++ b/tests/src/test/scala/org/http4s/UriSuite.scala
@@ -34,4 +34,10 @@ class UriSuite extends Http4sSuite {
   test("toOriginForm infers paths relative to root") {
     uri"dubious".toOriginForm == uri"/dubious"
   }
+
+  test("Use lazy query model parsing in uri parsing") {
+    val ori = "http://domain.com/path?param1=asd;fgh"
+    val res = org.http4s.Uri.unsafeFromString(ori).renderString
+    assert(ori == res, s"urls don't match:\n$ori\n$res")
+  }
 }


### PR DESCRIPTION
Should make #1813 #3277 and  #3233 work better on 0.22+.
I think this also was done on 0.21 a while ago, must have been lost in the parsing update.

The test failure assumes that we encode the `[]` brackets. this change would then pass them through, since we have allowed them in the parser.