### PR TITLE
Extract parsing library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ versionIntroduced := Map(
 )
 
 lazy val modules: List[ProjectReference] = List(
+  parsing,
   core,
   laws,
   testing,
@@ -97,6 +98,16 @@ lazy val root = project.in(file("."))
   )
   .aggregate(modules: _*)
 
+lazy val parsing = project.in(file("parsing"))
+  .settings(
+    name := "http4s-parsing",
+    description := "Parsers for HTTP and related RFCs",
+    startYear := Some(2021),
+    libraryDependencies ++= Seq(
+      catsParse,
+    )
+  )
+
 lazy val core = libraryProject("core")
   .enablePlugins(
     BuildInfoPlugin,
@@ -115,7 +126,6 @@ lazy val core = libraryProject("core")
       caseInsensitive,
       catsCore,
       catsEffect,
-      catsParse.exclude("org.typelevel", "cats-core_2.13"),
       fs2Core,
       fs2Io,
       ip4sCore,
@@ -133,6 +143,7 @@ lazy val core = libraryProject("core")
     },
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-lang", "scala-reflect"),
   )
+  .dependsOn(parsing)
 
 lazy val laws = libraryProject("laws")
   .settings(

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -20,7 +20,7 @@ import cats.{Hash, Order, Show}
 import cats.syntax.all._
 import cats.kernel.BoundedEnumerable
 import cats.parse.{Parser => P}
-import cats.parse.Rfc5234.digit
+import org.http4s.parsing.Rfc7230
 import org.http4s.util._
 
 /** An HTTP version, as seen on the start line of an HTTP request or response.
@@ -51,15 +51,8 @@ object HttpVersion {
         ParseResult.fromParser(parser, "HTTP version")(s)
     }
 
-  private val parser: P[HttpVersion] = {
-    // HTTP-name = %x48.54.54.50 ; HTTP
-    // HTTP-version = HTTP-name "/" DIGIT "." DIGIT
-    val httpVersion = P.string("HTTP/") *> digit ~ (P.char('.') *> digit)
-
-    httpVersion.map { case (major, minor) =>
-      new HttpVersion(major - '0', minor - '0')
-    }
-  }
+  private val parser: P[HttpVersion] =
+    Rfc7230.httpVersion.map { case (major, minor) => new HttpVersion(major, minor) }
 
   def fromVersion(major: Int, minor: Int): ParseResult[HttpVersion] =
     if (major < 0) ParseResult.fail("Invalid HTTP version", s"major must be > 0: $major")

--- a/parsing/src/main/scala/org/http4s/parsing/Rfc7230.scala
+++ b/parsing/src/main/scala/org/http4s/parsing/Rfc7230.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.parsing
+
+import cats.parse.Parser
+import cats.parse.Parser.{char, string}
+import cats.parse.Rfc5234.digit
+
+object Rfc7230 {
+  /* @see [[https://tools.ietf.org/html/rfc7230#section-2.6 RFC7230, Section 2.6]]*/
+  val httpName =
+    // HTTP-name = %x48.54.54.50 ; "HTTP", case-sensitive
+    string("HTTP")
+
+  /* @see [[https://tools.ietf.org/html/rfc7230#section-2.6 RFC7230, Section 2.6]]*/
+  val httpVersion: Parser[(Int, Int)] =
+    // HTTP-version = HTTP-name "/" DIGIT "." DIGIT
+    httpName *> char('/') *> digit.map(_ - '0') ~ (char('.') *> digit.map(_ - '0'))
+}


### PR DESCRIPTION
An experimental take on #4733.

`http4s-parsing` has no dependencies besides cats-parse, even `http4s-core`.  If successful, this would go to live in its own repo.