### PR TITLE
Move ConnectionManager to blaze-client

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BasicManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BasicManager.scala
@@ -16,6 +16,7 @@
 
 package org.http4s
 package client
+package blaze
 
 import cats.effect._
 import cats.syntax.all._

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
@@ -32,7 +32,7 @@ import scala.concurrent.duration.Duration
   * CPU time, SSL handshakes, etc. Because it can contain significant resources it
   * must have a mechanism to free resources associated with it.
   */
-trait ConnectionManager[F[_], A <: Connection[F]] {
+private trait ConnectionManager[F[_], A <: Connection[F]] {
 
   /** Bundle of the connection and whether its new or not */
   // Sealed, rather than final, because SI-4440.
@@ -55,7 +55,7 @@ trait ConnectionManager[F[_], A <: Connection[F]] {
   def invalidate(connection: A): F[Unit]
 }
 
-object ConnectionManager {
+private object ConnectionManager {
 
   /** Create a [[ConnectionManager]] that creates new connections on each request
     *

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/ConnectionManager.scala
@@ -16,6 +16,7 @@
 
 package org.http4s
 package client
+package blaze
 
 import cats.effect._
 import cats.effect.concurrent.Semaphore

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Random
 
-private final case class WaitQueueFullFailure() extends RuntimeException {
+final case class WaitQueueFullFailure() extends RuntimeException {
   @deprecated("Use `getMessage` instead", "0.20.0")
   def message: String = getMessage
 
@@ -377,5 +377,5 @@ private final class PoolManager[F[_], A <: Connection[F]](
     }
 }
 
-private final case class NoConnectionAllowedException(key: RequestKey)
+final case class NoConnectionAllowedException(key: RequestKey)
     extends IllegalArgumentException(s"No client connections allowed to $key")

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Random
 
-final case class WaitQueueFullFailure() extends RuntimeException {
+private final case class WaitQueueFullFailure() extends RuntimeException {
   @deprecated("Use `getMessage` instead", "0.20.0")
   def message: String = getMessage
 
@@ -377,5 +377,5 @@ private final class PoolManager[F[_], A <: Connection[F]](
     }
 }
 
-final case class NoConnectionAllowedException(key: RequestKey)
+private final case class NoConnectionAllowedException(key: RequestKey)
     extends IllegalArgumentException(s"No client connections allowed to $key")

--- a/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/PoolManager.scala
@@ -16,12 +16,12 @@
 
 package org.http4s
 package client
+package blaze
 
 import cats.effect._
 import cats.effect.concurrent.Semaphore
 import cats.syntax.all._
 import java.time.Instant
-import java.util.concurrent.TimeoutException
 import org.log4s.getLogger
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
@@ -34,9 +34,6 @@ final case class WaitQueueFullFailure() extends RuntimeException {
 
   override def getMessage: String = "Wait queue is full"
 }
-
-case object WaitQueueTimeoutException
-    extends TimeoutException("In wait queue for too long, timing out request.")
 
 private final class PoolManager[F[_], A <: Connection[F]](
     builder: ConnectionBuilder[F, A],

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/PoolManagerSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/PoolManagerSuite.scala
@@ -36,9 +36,9 @@ class PoolManagerSuite extends Http4sSuite with AllSyntax {
     def shutdown() = ()
   }
 
-  def mkPool(
-      maxTotal: Int = 1,
-      maxWaitQueueLimit: Int = 2,
+  private def mkPool(
+      maxTotal: Int,
+      maxWaitQueueLimit: Int,
       requestTimeout: Duration = Duration.Inf
   ) =
     ConnectionManager.pool(

--- a/blaze-client/src/test/scala/org/http4s/client/blaze/PoolManagerSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/PoolManagerSuite.scala
@@ -16,6 +16,7 @@
 
 package org.http4s
 package client
+package blaze
 
 import cats.effect._
 import com.comcast.ip4s._

--- a/client/src/main/scala/org/http4s/client/package.scala
+++ b/client/src/main/scala/org/http4s/client/package.scala
@@ -16,6 +16,7 @@
 
 package org.http4s
 
+import java.util.concurrent.TimeoutException
 import scala.concurrent.duration.DurationLong
 
 package object client extends ClientTypes {
@@ -32,3 +33,6 @@ trait ClientTypes {
 
   type Middleware[F[_]] = Client[F] => Client[F]
 }
+
+case object WaitQueueTimeoutException
+    extends TimeoutException("In wait queue for too long, timing out request.")


### PR DESCRIPTION
Resolves #4712.

The second commit in this PR might be controversial. I made all of the moved classes private, including some of the classes extending exceptions. I'd like some opinions on this.

Furthermore, I just dropped the `WaitQueueTimeoutException` class in `package.scala` under `client`. It is used by the `Retry` middleware. Not sure if it needs to be in a separate file.