### PR TITLE
Avoid lock contention

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/Http1ServerStage.scala
@@ -18,8 +18,9 @@ package org.http4s
 package server
 package blaze
 
-import cats.effect.{CancelToken, ConcurrentEffect, IO, Sync, Timer}
+import cats.effect.{CancelToken, Concurrent, ConcurrentEffect, IO, Sync, Timer}
 import cats.syntax.all._
+
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeoutException
 import org.http4s.blaze.http.parser.BaseExceptions.{BadMessage, ParserException}
@@ -34,10 +35,13 @@ import org.http4s.headers.{Connection, `Content-Length`, `Transfer-Encoding`}
 import org.http4s.internal.unsafeRunAsync
 import org.http4s.syntax.string._
 import org.http4s.util.StringWriter
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.{Either, Failure, Left, Right, Success, Try}
 import io.chrisdavenport.vault._
+
+import scala.annotation.nowarn
 
 private[blaze] object Http1ServerStage {
   def apply[F[_]](
@@ -80,6 +84,7 @@ private[blaze] object Http1ServerStage {
         scheduler)
 }
 
+@nowarn("cat=unused")
 private[blaze] class Http1ServerStage[F[_]](
     httpApp: HttpApp[F],
     requestAttrs: () => Vault,
@@ -90,7 +95,9 @@ private[blaze] class Http1ServerStage[F[_]](
     serviceErrorHandler: ServiceErrorHandler[F],
     responseHeaderTimeout: Duration,
     idleTimeout: Duration,
-    scheduler: TickWheelExecutor)(implicit protected val F: ConcurrentEffect[F], timer: Timer[F])
+    scheduler: TickWheelExecutor)(implicit
+    protected val F: ConcurrentEffect[F],
+    timer: Timer[F]) // The Timer is here for binary compatibility
     extends Http1Stage[F]
     with TailStage[ByteBuffer] {
   // micro-optimization: unwrap the routes and call its .run directly
@@ -347,7 +354,11 @@ private[blaze] class Http1ServerStage[F[_]](
   private[this] val raceTimeout: Request[F] => F[Response[F]] =
     responseHeaderTimeout match {
       case finite: FiniteDuration =>
-        val timeoutResponse = timer.sleep(finite).as(Response.timeout[F])
+        val timeoutResponse = Concurrent[F].cancelable[Response[F]] { callback =>
+          val cancellable =
+            scheduler.schedule(() => callback(Right(Response.timeout[F])), executionContext, finite)
+          Sync[F].delay(cancellable.cancel())
+        }
         req => F.race(runApp(req), timeoutResponse).map(_.merge)
       case _ =>
         runApp


### PR DESCRIPTION
### Motivation

I've got a use case in which I need my HTTP server (implemented with http4s-blaze-server) to process lots of lightweight requests (small request body, small response body, cheap business logic). The thoughput in that case is determined mainly by the http4s-blaze-server.

My main observations regarding performance of http4s-blaze-server in such case are:
- http4s is the dominant consumer of CPU time (roughly 10% CPU time goes to actual application logic)
- the application is unable to fully utilise processing power of a multicore CPU. For benchmarking I'm using Ryzen 5600X - 6 cores 12 threads CPU. On that platform it's utilising only 50% of CPU, despite having 13 blaze selector threads and 12 thread in the main ExecutorContext / ContextShift.
- There's high allocation rate, with the dominant allocator being fs2, despite not really using any form of streaming. (EntityEncoder.simple converting non-streams into streams is the reason)
- from time to time a request is processed twice 

I'm able to reliably reproduce similar conditions using https://github.com/TechEmpower/FrameworkBenchmarks "plaintext" test. And that's what I'm using to get some reproducable numbers.

I'm working with `F = cats.effect.IO`.

I want to address these issues with a series of small and independent pull requests. This one is only address the CPU under-utilisation, and only partially.

### Diagnosis 

Profiling shows that the under-utilisation of CPU is caused (at least partially), buy blocking on three locks / monitors:
1. The lock inside ScheduledThreadPoolExecutor inside the Timer[IO] - it needs to be locked while sheduling or cancelling timeouts
2. The lock inside the default ExecutionContext / ContextShift provided by IOApp
3. The monitor of `Http1ServerStage.parser`

### Solution

This PR addresses 1. by using TickWheelTimer from blaze instead of Timer[IO], and it addresses 3. by creating cancelTocken before acquiring the monitor of parser, and then only acquiring it in order to modify the `cancelToken` field. The 2. I've addressed by using `ForkJoinPool` instead of the default `ThreadPoolExecutor`, but this is something that is outside of the scope of responsibility of http4s. Nontheless what could be done in http4s is reduction of thread shifts, which would reduce pressure on the scheduling mechanism of the thread pool, but this is outside of scope of this PR.

### Verifcation

The measurements are done using tfb (Techempower Frameworks Benchmark), specifically this commit https://github.com/RafalSumislawski/FrameworkBenchmarks/commit/1436a3c7227badd1e87bfb3c26e61aeec227f763 from my fork. It includes the solution to 2. And so this solution is included in the baseline measurement.

| parallel requests | Baseline (0.21.22) |          This PR |
| ------ | ------------- | ------------- |
| 256   | 207343 req/s  | 246718 req/s |
| 512    | 205574 req/s  | 276460 req/s |
| 1024 | 201791 req/s   | 275930 req/s |
| 2048 | 193030 req/s  | 269806 req/s |
| 4096 | 183165 req/s  | 266459 req/s |

This gives us a decent **33% max throughput increase**, as well as improvement in terms of dealing with large number of parallel requests (which was to be expected from a change which fixes lock contention). The difference will most likely be smaller on machines will less cores, and significantly bigger on machines with lots of cores (aka servers). 

The CPU utilisation for baseline is ~50% for this PR it's ~80%. Still not 100%. More work remains to be done in that topic...

http4s-blaze-client may need analogical changes, but I don't want to do them without setting up a benchmark for verification.