### PR TITLE
Fix Resource Leak In Jetty

### DIFF
--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -65,6 +65,7 @@ sealed class JettyBuilder[F[_]] private (
 
   private[this] val logger = getLogger
 
+  @deprecated(message = "Retained for binary compatibility", since = "0.21.23")
   private[JettyBuilder] def this(
     socketAddress: InetSocketAddress,
     threadPool: ThreadPool,

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -34,7 +34,6 @@ import org.eclipse.jetty.server.{
 }
 import org.eclipse.jetty.server.handler.StatisticsHandler
 import org.eclipse.jetty.servlet.{FilterHolder, ServletContextHandler, ServletHolder}
-import org.eclipse.jetty.util.component.{AbstractLifeCycle, LifeCycle}
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.util.thread.{QueuedThreadPool, ThreadPool}
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
@@ -47,7 +46,8 @@ import scala.concurrent.duration._
 
 sealed class JettyBuilder[F[_]] private (
     socketAddress: InetSocketAddress,
-    threadPool: ThreadPool,
+    private val threadPool: ThreadPool,
+    threadPoolResourceOption: Option[Resource[F, ThreadPool]],
     private val idleTimeout: Duration,
     private val asyncTimeout: Duration,
     shutdownTimeout: Duration,
@@ -64,6 +64,36 @@ sealed class JettyBuilder[F[_]] private (
   type Self = JettyBuilder[F]
 
   private[this] val logger = getLogger
+
+  private[JettyBuilder] def this(
+    socketAddress: InetSocketAddress,
+    threadPool: ThreadPool,
+    idleTimeout: Duration,
+    asyncTimeout: Duration,
+    shutdownTimeout: Duration,
+    servletIo: ServletIo[F],
+    sslConfig: SslConfig,
+    mounts: Vector[Mount[F]],
+    serviceErrorHandler: ServiceErrorHandler[F],
+    supportHttp2: Boolean,
+    banner: immutable.Seq[String],
+    jettyHttpConfiguration: HttpConfiguration
+  )(implicit F: ConcurrentEffect[F]) =
+    this(
+      socketAddress,
+      new UndestroyableThreadPool(threadPool),
+      None,
+      idleTimeout,
+      asyncTimeout,
+      shutdownTimeout,
+      servletIo,
+      sslConfig,
+      mounts,
+      serviceErrorHandler,
+      supportHttp2,
+      banner,
+      jettyHttpConfiguration
+    )
 
   @deprecated(message = "Retained for binary compatibility", since = "0.21.15")
   private[JettyBuilder] def this(
@@ -82,6 +112,7 @@ sealed class JettyBuilder[F[_]] private (
     this(
       socketAddress = socketAddress,
       threadPool = threadPool,
+      threadPoolResourceOption = None,
       idleTimeout = idleTimeout,
       asyncTimeout = asyncTimeout,
       shutdownTimeout = shutdownTimeout,
@@ -124,6 +155,7 @@ sealed class JettyBuilder[F[_]] private (
   private def copy(
       socketAddress: InetSocketAddress = socketAddress,
       threadPool: ThreadPool = threadPool,
+      threadPoolResourceOption: Option[Resource[F, ThreadPool]] = threadPoolResourceOption,
       idleTimeout: Duration = idleTimeout,
       asyncTimeout: Duration = asyncTimeout,
       shutdownTimeout: Duration = shutdownTimeout,
@@ -138,6 +170,7 @@ sealed class JettyBuilder[F[_]] private (
     new JettyBuilder(
       socketAddress,
       threadPool,
+      threadPoolResourceOption,
       idleTimeout,
       asyncTimeout,
       shutdownTimeout,
@@ -190,8 +223,28 @@ sealed class JettyBuilder[F[_]] private (
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
     copy(socketAddress = socketAddress)
 
+  /** Set the [[org.eclipse.jetty.util.thread.ThreadPool]] that Jetty will use.
+    *
+    * It is recommended you use [[JettyThreadPools#resource]] to build this so
+    * that it will be gracefully shutdown when/if the Jetty server is
+    * shutdown.
+    */
+  def withThreadPoolResource(threadPoolResource: Resource[F, ThreadPool]): JettyBuilder[F] =
+    copy(threadPoolResourceOption = Some(threadPoolResource))
+
+  /** Set the [[org.eclipse.jetty.util.thread.ThreadPool]] that Jetty will use.
+    *
+    * @note You should prefer [[#withThreadPoolResource]] instead of this
+    *       method. If you invoke this method the provided
+    *       [[org.eclipse.jetty.util.thread.ThreadPool]] ''will not'' be
+    *       joined, stopped, or destroyed when/if the Jetty server stops. This
+    *       is to preserve the <= 0.21.23 semantics.
+    */
+  @deprecated(
+    message = "Please use withThreadPoolResource instead and see JettyThreadPools.",
+    since = "0.21.23")
   def withThreadPool(threadPool: ThreadPool): JettyBuilder[F] =
-    copy(threadPool = threadPool)
+    copy(threadPoolResourceOption = None, threadPool = new UndestroyableThreadPool(threadPool))
 
   override def mountServlet(
       servlet: HttpServlet,
@@ -288,71 +341,75 @@ sealed class JettyBuilder[F[_]] private (
     }
   }
 
-  def resource: Resource[F, Server[F]] =
-    Resource(F.delay {
-      val jetty = new JServer(threadPool)
-
-      val context = new ServletContextHandler()
-      context.setContextPath("/")
-
-      jetty.setHandler(context)
-
-      val connector = getConnector(jetty)
-
-      connector.setHost(socketAddress.getHostString)
-      connector.setPort(socketAddress.getPort)
-      connector.setIdleTimeout(if (idleTimeout.isFinite) idleTimeout.toMillis else -1)
-      jetty.addConnector(connector)
-
-      // Jetty graceful shutdown does not work without a stats handler
-      val stats = new StatisticsHandler
-      stats.setHandler(jetty.getHandler)
-      jetty.setHandler(stats)
-
-      jetty.setStopTimeout(shutdownTimeout match {
-        case d: FiniteDuration => d.toMillis
-        case _ => 0L
-      })
-
-      for ((mount, i) <- mounts.zipWithIndex)
-        mount.f(context, i, this)
-
-      jetty.start()
-
-      val server = new Server[F] {
-        lazy val address: InetSocketAddress = {
-          val host = socketAddress.getHostString
-          val port = jetty.getConnectors()(0).asInstanceOf[ServerConnector].getLocalPort
-          new InetSocketAddress(host, port)
-        }
-
-        lazy val isSecure: Boolean = sslConfig.isSecure
-      }
-
-      banner.foreach(logger.info(_))
-      logger.info(
-        s"http4s v${BuildInfo.version} on Jetty v${JServer.getVersion} started at ${server.baseUri}")
-
-      server -> shutdown(jetty)
-    })
-
-  private def shutdown(jetty: JServer): F[Unit] =
-    F.async[Unit] { cb =>
-      jetty.addLifeCycleListener(
-        new AbstractLifeCycle.AbstractLifeCycleListener {
-          override def lifeCycleStopped(ev: LifeCycle) = cb(Right(()))
-          override def lifeCycleFailure(ev: LifeCycle, cause: Throwable) = cb(Left(cause))
-        }
+  def resource: Resource[F, Server[F]] = {
+    // If threadPoolResourceOption is None, then use the value of
+    // threadPool.
+    val threadPoolR: Resource[F, ThreadPool] =
+      threadPoolResourceOption.getOrElse(
+        Resource.pure(threadPool)
       )
-      jetty.stop()
-    }
+    val serverR: ThreadPool => Resource[F, Server[F]] = (threadPool: ThreadPool) =>
+      JettyLifeCycle
+        .lifeCycleAsResource[F, JServer](
+          F.delay {
+            val jetty = new JServer(threadPool)
+            val context = new ServletContextHandler()
+
+            context.setContextPath("/")
+
+            jetty.setHandler(context)
+
+            val connector = getConnector(jetty)
+
+            connector.setHost(socketAddress.getHostString)
+            connector.setPort(socketAddress.getPort)
+            connector.setIdleTimeout(if (idleTimeout.isFinite) idleTimeout.toMillis else -1)
+            jetty.addConnector(connector)
+
+            // Jetty graceful shutdown does not work without a stats handler
+            val stats = new StatisticsHandler
+            stats.setHandler(jetty.getHandler)
+            jetty.setHandler(stats)
+
+            jetty.setStopTimeout(shutdownTimeout match {
+              case d: FiniteDuration => d.toMillis
+              case _ => 0L
+            })
+
+            for ((mount, i) <- mounts.zipWithIndex)
+              mount.f(context, i, this)
+
+            jetty
+          }
+        )
+        .map((jetty: JServer) =>
+          new Server[F] {
+            lazy val address: InetSocketAddress = {
+              val host = socketAddress.getHostString
+              val port = jetty.getConnectors()(0).asInstanceOf[ServerConnector].getLocalPort
+              new InetSocketAddress(host, port)
+            }
+
+            lazy val isSecure: Boolean = sslConfig.isSecure
+          })
+    for {
+      threadPool <- threadPoolR
+      server <- serverR(threadPool)
+      _ <- Resource.eval(banner.traverse_(value => F.delay(logger.info(value))))
+      _ <- Resource.eval(F.delay(logger.info(
+        s"http4s v${BuildInfo.version} on Jetty v${JServer.getVersion} started at ${server.baseUri}")))
+    } yield server
+  }
 }
 
 object JettyBuilder {
   def apply[F[_]: ConcurrentEffect] =
     new JettyBuilder[F](
       socketAddress = defaults.SocketAddress,
-      threadPool = new QueuedThreadPool(),
+      threadPool = LazyThreadPool.newLazyThreadPool,
+      threadPoolResourceOption = Some(
+        JettyLifeCycle.lifeCycleAsResource[F, QueuedThreadPool](
+          Sync[F].delay(new QueuedThreadPool()))),
       idleTimeout = defaults.IdleTimeout,
       asyncTimeout = defaults.ResponseTimeout,
       shutdownTimeout = defaults.ShutdownTimeout,

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -35,7 +35,7 @@ import org.eclipse.jetty.server.{
 import org.eclipse.jetty.server.handler.StatisticsHandler
 import org.eclipse.jetty.servlet.{FilterHolder, ServletContextHandler, ServletHolder}
 import org.eclipse.jetty.util.ssl.SslContextFactory
-import org.eclipse.jetty.util.thread.{QueuedThreadPool, ThreadPool}
+import org.eclipse.jetty.util.thread.ThreadPool
 import org.http4s.server.SSLKeyStoreSupport.StoreInfo
 import org.http4s.server.jetty.JettyBuilder._
 import org.http4s.servlet.{AsyncHttp4sServlet, ServletContainer, ServletIo}
@@ -67,18 +67,18 @@ sealed class JettyBuilder[F[_]] private (
 
   @deprecated(message = "Retained for binary compatibility", since = "0.21.23")
   private[JettyBuilder] def this(
-    socketAddress: InetSocketAddress,
-    threadPool: ThreadPool,
-    idleTimeout: Duration,
-    asyncTimeout: Duration,
-    shutdownTimeout: Duration,
-    servletIo: ServletIo[F],
-    sslConfig: SslConfig,
-    mounts: Vector[Mount[F]],
-    serviceErrorHandler: ServiceErrorHandler[F],
-    supportHttp2: Boolean,
-    banner: immutable.Seq[String],
-    jettyHttpConfiguration: HttpConfiguration
+      socketAddress: InetSocketAddress,
+      threadPool: ThreadPool,
+      idleTimeout: Duration,
+      asyncTimeout: Duration,
+      shutdownTimeout: Duration,
+      servletIo: ServletIo[F],
+      sslConfig: SslConfig,
+      mounts: Vector[Mount[F]],
+      serviceErrorHandler: ServiceErrorHandler[F],
+      supportHttp2: Boolean,
+      banner: immutable.Seq[String],
+      jettyHttpConfiguration: HttpConfiguration
   )(implicit F: ConcurrentEffect[F]) =
     this(
       socketAddress,
@@ -409,8 +409,8 @@ object JettyBuilder {
       socketAddress = defaults.SocketAddress,
       threadPool = LazyThreadPool.newLazyThreadPool,
       threadPoolResourceOption = Some(
-        JettyLifeCycle.lifeCycleAsResource[F, QueuedThreadPool](
-          Sync[F].delay(new QueuedThreadPool()))),
+        JettyThreadPools.default[F]
+      ),
       idleTimeout = defaults.IdleTimeout,
       asyncTimeout = defaults.ResponseTimeout,
       shutdownTimeout = defaults.ShutdownTimeout,

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -113,7 +113,6 @@ sealed class JettyBuilder[F[_]] private (
     this(
       socketAddress = socketAddress,
       threadPool = threadPool,
-      threadPoolResourceOption = None,
       idleTimeout = idleTimeout,
       asyncTimeout = asyncTimeout,
       shutdownTimeout = shutdownTimeout,

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyLifeCycle.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyLifeCycle.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.jetty
+
+import cats.syntax.all._
+import org.eclipse.jetty.util.component.LifeCycle
+import org.eclipse.jetty.util.component.Destroyable
+import cats.effect._
+import org.eclipse.jetty.util.component.AbstractLifeCycle.AbstractLifeCycleListener
+
+private[jetty] object JettyLifeCycle {
+
+  /** Wrap a Jetty [[org.eclipse.jetty.util.component.LifeCycle]] value in a
+    * [[cats.effect.Resource]]. This calls
+    * [[org.eclipse.jetty.util.component.LifeCycle#start]] on startup and
+    * waits for the component to emit an event stating it is started, failing
+    * if it is already started (or starting). On release
+    * [[org.eclipse.jetty.util.component.LifeCycle#stop]] is called.
+    *
+    * @note If `A` is _also_ a subtype of
+    *       [[org.eclipse.jetty.util.component.Destroyable]] then
+    *       [[org.eclipse.jetty.util.component.Destroyable#destroy]] will also
+    *       be invoked.
+    */
+  def lifeCycleAsResource[F[_], A <: LifeCycle](
+      fa: F[A]
+  )(implicit F: Async[F]): Resource[F, A] =
+    Resource.make[F, A](
+      fa.flatTap(startLifeCycle[F])
+    ) {
+      case value: LifeCycle with Destroyable =>
+        stopLifeCycle[F](value) *> F.delay(value.destroy())
+      case otherwise =>
+        stopLifeCycle[F](otherwise)
+    }
+
+  /** Attempt to invoke [[org.eclipse.jetty.util.component.LifeCycle#stop]] on a
+    * [[org.eclipse.jetty.util.component.LifeCycle]]. If the
+    * [[org.eclipse.jetty.util.component.LifeCycle]] is already stopped then
+    * this method will return immediately. This can be valid in some cases
+    * where a [[org.eclipse.jetty.util.component.LifeCycle]] is stopped
+    * internally, e.g. due to some internal error occurring.
+    */
+  private[this] def stopLifeCycle[F[_]](lifeCycle: LifeCycle)(implicit F: Async[F]): F[Unit] =
+    F.async[Unit] { cb =>
+      lifeCycle.addLifeCycleListener(
+        new AbstractLifeCycleListener {
+          override def lifeCycleStopped(a: LifeCycle): Unit =
+            cb(Right(()))
+          override def lifeCycleFailure(a: LifeCycle, error: Throwable): Unit =
+            cb(Left(error))
+        }
+      )
+
+      // In the general case, it is not sufficient to merely call stop(). For
+      // example, the concrete implementation of stop() for the canonical
+      // Jetty Server instance will shortcut to a `return` call taking no
+      // action if the server is "stopping". This method _can't_ return until
+      // we are _actually stopped_, so we have to check three different states
+      // here.
+
+      if (lifeCycle.isStopped) {
+        // If the first case, we are already stopped, so our listener won't be
+        // called and we just return.
+        cb(Right(()))
+      } else if (lifeCycle.isStopping()) {
+        // If it is stopping, we need to wait for our listener to get invoked.
+        ()
+      } else {
+        // If it is neither stopped nor stopping, we need to request a stop
+        // and then wait for the event. It is imperative that we add the
+        // listener beforehand here. Otherwise we have some very annoying race
+        // conditions.
+        lifeCycle.stop()
+      }
+    }
+
+  /** Attempt to [[org.eclipse.jetty.util.component.LifeCycle#start]] on a
+    * [[org.eclipse.jetty.util.component.LifeCycle]].
+    *
+    * If the [[org.eclipse.jetty.util.component.LifeCycle]] is already started
+    * (or starting) this will fail.
+    */
+  private[this] def startLifeCycle[F[_]](lifeCycle: LifeCycle)(implicit F: Async[F]): F[Unit] =
+    F.async[Unit] { cb =>
+      lifeCycle.addLifeCycleListener(
+        new AbstractLifeCycleListener {
+          override def lifeCycleStarted(a: LifeCycle): Unit =
+            cb(Right(()))
+          override def lifeCycleFailure(a: LifeCycle, error: Throwable): Unit =
+            cb(Left(error))
+        }
+      )
+
+      // Sanity check to ensure the LifeCycle component is not already
+      // started. A couple of notes here.
+      //
+      // - There is _always_ going to be a small chance of a race condition
+      //   here in the final branch where we invoke `lifeCycle.start()` _if_
+      //   something else has a reference to the `LifeCycle`
+      //   value. Thankfully, unlike the stopLifeCycle function, this is
+      //   completely in the control of the caller. As long as the caller
+      //   doesn't leak the reference (or call .start() themselves) nothing
+      //   internally to Jetty should ever invoke .start().
+      // - Jetty components allow for reuse in many cases, unless the
+      //   .destroy() method is invoked (and the particular type implements
+      //   `Destroyable`, it's not part of `LifeCycle`). Jetty uses this for
+      //   "soft" resets of the `LifeCycle` component. Thus it is possible
+      //   that this `LifeCycle` component has been started before, though I
+      //   don't recommend this and we don't (at this time) do that in the
+      //   http4s codebase.
+      if (lifeCycle.isStarted) {
+        cb(
+          Left(new IllegalStateException(
+            "Attempting to start Jetty LifeCycle component, but it is already started.")))
+      } else if (lifeCycle.isStarting) {
+        cb(
+          Left(new IllegalStateException(
+            "Attempting to start Jetty LifeCycle component, but it is already starting.")))
+      } else {
+        lifeCycle.start()
+      }
+    }
+}

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyThreadPools.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyThreadPools.scala
@@ -49,7 +49,7 @@ object JettyThreadPools {
     *       of the [[cats.effect.Resource]] will fail.
     */
   def resource[F[_]](value: F[ThreadPool])(implicit F: Async[F]): Resource[F, ThreadPool] =
-    value match {
+    Resource.eval(value).flatMap {
       // I know, this is gross.
       case value: ThreadPool with LifeCycle =>
         JettyLifeCycle.lifeCycleAsResource[F, ThreadPool with LifeCycle](F.pure(value))

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyThreadPools.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyThreadPools.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.jetty
+
+import cats.effect._
+import org.eclipse.jetty.util.component.LifeCycle
+import org.eclipse.jetty.util.thread.ThreadPool
+import org.eclipse.jetty.util.thread.QueuedThreadPool
+
+object JettyThreadPools {
+
+  /** Create a resource for a Jetty
+    * [[org.eclipse.jetty.util.thread.ThreadPool]]. It will be "shutdown" when
+    * the resource is closed.
+    *
+    * Jetty [[org.eclipse.jetty.util.thread.ThreadPool]] have some rather
+    * unusual properties. [[org.eclipse.jetty.util.thread.ThreadPool]] itself
+    * does not implement any of the standard JVM or Jetty lifecycle systems,
+    * e.g. [[java.lang.Closeable]] or
+    * [[org.eclipse.jetty.util.component.LifeCycle]], but ''all'' the concrete
+    * implementations of it provided by Jetty ''do'' implement
+    * [[[[org.eclipse.jetty.util.component.LifeCycle]]]].
+    *
+    * The [[cats.effect.Resource]] implemented here will use the
+    * [[org.eclipse.jetty.util.component.LifeCycle]] shutdown semantics if the
+    * underlying [[org.eclipse.jetty.util.thread.ThreadPool]] implements that
+    * interface. Otherwise it will invoke
+    * [[org.eclipse.jetty.util.thread.ThreadPool#join]] on shutdown, making
+    * startup a no-op.
+    *
+    * @note It is expected and important that the
+    *       [[org.eclipse.jetty.util.thread.ThreadPool]] provided to this
+    *       function ''has not been started''. If it has and it implements
+    *       [[org.eclipse.jetty.util.component.LifeCycle]], then the creation
+    *       of the [[cats.effect.Resource]] will fail.
+    */
+  def resource[F[_]](value: F[ThreadPool])(implicit F: Async[F]): Resource[F, ThreadPool] =
+    value match {
+      // I know, this is gross.
+      case value: ThreadPool with LifeCycle =>
+        JettyLifeCycle.lifeCycleAsResource[F, ThreadPool with LifeCycle](F.pure(value))
+      case value: ThreadPool =>
+        Resource.make(F.pure(value))(value => F.delay(value.join))
+    }
+
+  /** The default [[org.eclipse.jetty.util.thread.ThreadPool]] used by
+    * [[JettyBuilder]]. If you require specific constraints on this (a certain
+    * number of threads, etc.) please use [[#resource]] and take a look at the
+    * concrete implementations of [[org.eclipse.jetty.util.thread.ThreadPool]]
+    * provided by Jetty.
+    */
+  def default[F[_]](implicit F: Async[F]): Resource[F, ThreadPool] =
+    resource[F](F.delay(new QueuedThreadPool))
+}

--- a/jetty/src/main/scala/org/http4s/server/jetty/LazyThreadPool.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/LazyThreadPool.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.jetty
+
+import cats._
+import org.eclipse.jetty.util.thread.ThreadPool
+import org.eclipse.jetty.util.thread.QueuedThreadPool
+
+/** A lazy [[org.eclipse.jetty.util.thread.ThreadPool]]. The pool will not be
+  * started until one of the methods on it is invoked.
+  *
+  * @note This is only provided to as a safety mechanism for the legacy
+  *       methods in [[JettyBuilder]] which operated directly on a
+  *       [[org.eclipse.jetty.util.thread.ThreadPool]]. If you are not using
+  *       the default [[org.eclipse.jetty.util.thread.ThreadPool]] you should
+  *       be using [[JettyThreadPools]] to build a [[cats.effect.Resource]]
+  *       for the pool.
+  */
+private[jetty] object LazyThreadPool {
+
+  def newLazyThreadPool: ThreadPool =
+    new ThreadPool {
+
+      private val value: Eval[ThreadPool] = Eval.later(new QueuedThreadPool())
+
+      override final def getIdleThreads: Int = value.value.getIdleThreads
+
+      override final def getThreads: Int = value.value.getThreads
+
+      override final def isLowOnThreads: Boolean = value.value.isLowOnThreads
+
+      override final def execute(runnable: Runnable): Unit =
+        value.value.execute(runnable)
+
+      override final def join: Unit =
+        value.value.join
+    }
+}

--- a/jetty/src/main/scala/org/http4s/server/jetty/UndestroyableThreadPool.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/UndestroyableThreadPool.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.jetty
+
+import org.eclipse.jetty.util.thread.ThreadPool
+
+/** A [[org.eclipse.jetty.util.thread.ThreadPool]] which does not implement
+  * [[[[org.eclipse.jetty.util.component.Destroyable]]]] and with a `join`
+  * method that does not do anything.
+  *
+  * We use this class to ensure that code compiled against http4s < 0.21.23
+  * will have consistent semantics. Otherwise, attempts to run
+  * [[JettyBuilder#resource]] more than once would fail as the
+  * [[org.eclipse.jetty.util.thread.ThreadPool]] would have been shut down
+  * after the first invocation completed. This is a side effect of cleaning up
+  * the resource leak by invoking `.destroy` on the Jetty Server when the
+  * resource is completed.
+  */
+private[jetty] final class UndestroyableThreadPool(value: ThreadPool) extends ThreadPool {
+  override final def getIdleThreads: Int = value.getIdleThreads
+
+  override final def getThreads: Int = value.getThreads
+
+  override final def isLowOnThreads: Boolean = value.isLowOnThreads
+
+  override final def execute(runnable: Runnable): Unit =
+    value.execute(runnable)
+
+  override final def join: Unit = ()
+}


### PR DESCRIPTION
We had a resource leak in Jetty due to us not calling `.destroy` in the `def resource` after the server terminated. Fixing this leak was a bit complicated.

By default, Jetty will terminate the provided `ThreadPool` as part of the resource cleanup in `.destroy`. Since we were sharing the `ThreadPool` in the builder, this would cause any new invocations of `def resource` to fail as the underlying `ThreadPool` will have now been terminated.

To fix this problem we now use a `Resource[F, ThreadPool]` which will ensure that we get a fresh `ThreadPool` on each invocation, as well as ensuring proper shutdown semantics. We have to keep around the old `ThreadPool` for binary compatibility. In order to avoid starting _two_ `ThreadPool` instances we introduce a `LazyThreadPool` which _should_ never actually create a `ThreadPool` (I had to leave some `ThreadPool` type here and I didn't want to use `null` or anything that would throw if it got accidentally accessed).

If someone explicitly sets the `ThreadPool` with the deprecated `withThreadPool` method, then we wrap it in `UndestroyableThreadPool` which hides the `join` method and thus preserves the old behavior allowing the `ThreadPool` to be shared across multiple invocations of `def resource` while still allowing us to cleanup all the other resources.

`JettyLifeCycle` provides utilities which lift the Jetty interfaces `LifeCycle` and `Destroyable` into a `Resource`. These are not public to keep the binary compatibility surface as small as possible. In order to allow users to customize the `ThreadPool` a subset of `JettyLifeCycle` is exposed in `JettyThreadPools`.