### PR TITLE
Scala 3.0.0-RC3 for 0.22.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.5, 3.0.0-RC2]
+        scala: [2.12.13, 2.13.5, 3.0.0-RC3]
         java: [adopt@1.8, adopt@1.11, adopt@1.15]
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,7 +57,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
       - name: Check formatting
-        if: matrix.scala != '3.0.0-RC2'
+        if: matrix.scala != '3.0.0-RC3'
         run: sbt ++${{ matrix.scala }} scalafmtCheckAll
 
       - name: Check headers
@@ -70,7 +70,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} mimaReportBinaryIssues
 
       - name: Check unused compile dependencies
-        if: matrix.scala != '3.0.0-RC2'
+        if: matrix.scala != '3.0.0-RC3'
         run: sbt ++${{ matrix.scala }} unusedCompileDependenciesTest
 
       - name: Run tests
@@ -218,7 +218,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.5, 3.0.0-RC2]
+        scala: [2.12.13, 2.13.5, 3.0.0-RC3]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -273,12 +273,12 @@ object Http4sPlugin extends AutoPlugin {
     // reference of all the projects we depend on, and hopefully will reduce
     // error-prone merge conflicts in the dependencies below.
     val asyncHttpClient = "2.12.3"
-    val blaze = "0.15.0-M3"
+    val blaze = "0.15.0-M4"
     val boopickle = "1.3.3"
     val caseInsensitive = "1.1.3"
     val cats = "2.6.0"
     val catsEffect = "2.5.0"
-    val catsParse = "0.3.2"
+    val catsParse = "0.3.3"
     val circe = "0.14.0-M6"
     val cryptobits = "1.3"
     val disciplineCore = "1.1.4"

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -25,7 +25,7 @@ object Http4sPlugin extends AutoPlugin {
 
   val scala_213 = "2.13.5"
   val scala_212 = "2.12.13"
-  val scala_3 = "3.0.0-RC2"
+  val scala_3 = "3.0.0-RC3"
 
   override lazy val globalSettings = Seq(
     isCi := sys.env.get("CI").isDefined
@@ -279,7 +279,7 @@ object Http4sPlugin extends AutoPlugin {
     val cats = "2.6.0"
     val catsEffect = "2.5.0"
     val catsParse = "0.3.2"
-    val circe = "0.14.0-M5"
+    val circe = "0.14.0-M6"
     val cryptobits = "1.3"
     val disciplineCore = "1.1.4"
     val dropwizardMetrics = "4.1.20"
@@ -289,7 +289,7 @@ object Http4sPlugin extends AutoPlugin {
     val jawn = "1.1.2"
     val jawnFs2 = "1.1.2"
     val jetty = "9.4.40.v20210413"
-    val keypool = "0.3.3"
+    val keypool = "0.3.4"
     val literally = "1.0.1"
     val logback = "1.2.3"
     val log4cats = "1.3.0"


### PR DESCRIPTION
This won't work without cats-parse, but includes the first RC3-only dependency.