### PR TITLE
Update blaze to 0.14.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ If you run into any difficulties please enable partial unification in your `buil
 scalacOptions ++= Seq("-Ypartial-unification")
 ```
 
+## Requirements
+
+Running the **blaze** backend requires a modern, supported version of the JVM to build and run, as it relies on server
+APIs unavailable before JDK8u252. Any JDK newer than JDK8u252, including 9+ is supported.
+
 ## Code of Conduct
 
 http4s is proud to be a [Typelevel](https://typelevel.org/) incubator

--- a/build.sbt
+++ b/build.sbt
@@ -632,7 +632,6 @@ lazy val examples = http4sProject("examples")
   .enablePlugins(SbtTwirl)
 
 lazy val examplesBlaze = exampleProject("examples-blaze")
-  .enablePlugins(AlpnBootPlugin)
   .settings(Revolver.settings)
   .settings(
     description := "Examples of http4s server and clients on blaze",

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -306,7 +306,7 @@ object Http4sPlugin extends AutoPlugin {
     // error-prone merge conflicts in the dependencies below.
     val argonaut = "6.2.5"
     val asyncHttpClient = "2.10.5"
-    val blaze = "0.14.15"
+    val blaze = "0.14.16"
     val boopickle = "1.3.3"
     val cats = "2.6.0"
     val catsEffect = "2.5.0"


### PR DESCRIPTION
Resolves #4707.

Curl output:
```
vasil@vasil-mac ~ % curl -v -k https://localhost:8443/
*   Trying ::1...
* TCP_NODELAY set
* Connection failed
* connect to ::1 port 8443 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=NZ; ST=AK; L=Auckland; O=Home; OU=Application Development; CN=Server
*  start date: Dec 15 02:48:09 2014 GMT
*  expire date: Mar 15 02:48:09 2015 GMT
*  issuer: C=NZ; ST=AK; L=Auckland; O=Home; OU=Application Development; CN=Server
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fedd200e800)
> GET / HTTP/2
> Host: localhost:8443
> User-Agent: curl/7.64.1
> Accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
< HTTP/2 404 
< 
* Connection #0 to host localhost left intact
* Closing connection 0
```