### PR TITLE
Make Use Of IPv4 Or IPv6 In Defaults Explicit

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/server/blaze/BlazeServerBuilder.scala
@@ -467,7 +467,7 @@ object BlazeServerBuilder {
       F: ConcurrentEffect[F],
       timer: Timer[F]): BlazeServerBuilder[F] =
     new BlazeServerBuilder(
-      socketAddress = defaults.SocketAddress,
+      socketAddress = defaults.IPv4SocketAddress,
       executionContext = executionContext,
       responseHeaderTimeout = defaults.ResponseTimeout,
       idleTimeout = defaults.IdleTimeout,

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -185,7 +185,7 @@ object EmberServerBuilder {
     )
 
   private object Defaults {
-    val host: String = server.defaults.Host
+    val host: String = server.defaults.IPv4Host
     val port: Int = server.defaults.HttpPort
 
     def httpApp[F[_]: Applicative]: HttpApp[F] = HttpApp.notFound[F]

--- a/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
+++ b/jetty/src/main/scala/org/http4s/server/jetty/JettyBuilder.scala
@@ -351,7 +351,7 @@ sealed class JettyBuilder[F[_]] private (
 object JettyBuilder {
   def apply[F[_]: ConcurrentEffect] =
     new JettyBuilder[F](
-      socketAddress = defaults.SocketAddress,
+      socketAddress = defaults.IPv4SocketAddress,
       threadPool = new QueuedThreadPool(),
       idleTimeout = defaults.IdleTimeout,
       asyncTimeout = defaults.ResponseTimeout,

--- a/server/src/main/scala/org/http4s/server/ServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuilder.scala
@@ -35,12 +35,12 @@ trait ServerBuilder[F[_]] extends BackendBuilder[F, Server[F]] {
 
   def bindSocketAddress(socketAddress: InetSocketAddress): Self
 
-  final def bindHttp(port: Int = defaults.HttpPort, host: String = defaults.Host): Self =
+  final def bindHttp(port: Int = defaults.HttpPort, host: String = defaults.IPv4Host): Self =
     bindSocketAddress(InetSocketAddress.createUnresolved(host, port))
 
-  final def bindLocal(port: Int): Self = bindHttp(port, defaults.Host)
+  final def bindLocal(port: Int): Self = bindHttp(port, defaults.IPv4Host)
 
-  final def bindAny(host: String = defaults.Host): Self = bindHttp(0, host)
+  final def bindAny(host: String = defaults.IPv4Host): Self = bindHttp(0, host)
 
   /** Sets the handler for errors thrown invoking the service.  Is not
     * guaranteed to be invoked on errors on the server backend, such as

--- a/server/src/main/scala/org/http4s/server/package.scala
+++ b/server/src/main/scala/org/http4s/server/package.scala
@@ -37,8 +37,29 @@ package object server {
          | |_||_\__|\__| .__/ |_|/__/
          |             |_|""".stripMargin.split("\n").toList
 
+    val IPv4Host: String =
+      InetAddress.getByAddress("localhost", Array[Byte](127, 0, 0, 1)).getHostAddress
+    val IPv6Host: String =
+      InetAddress
+        .getByAddress("localhost", Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
+        .getHostAddress
+
+    @deprecated(
+      message =
+        "Please use IPv4Host or IPv6Host. This value can change depending on Platform specific settings and can be either the canonical IPv4 or IPv6 address. If you require this behavior please call `InetAddress.getLoopbackAddress` directly.",
+      since = "0.21.23")
     val Host = InetAddress.getLoopbackAddress.getHostAddress
     val HttpPort = 8080
+
+    val IPv4SocketAddress: InetSocketAddress =
+      InetSocketAddress.createUnresolved(IPv4Host, HttpPort)
+    val IPv6SocketAddress: InetSocketAddress =
+      InetSocketAddress.createUnresolved(IPv6Host, HttpPort)
+
+    @deprecated(
+      message =
+        "Please use IPv4SocketAddress or IPv6SocketAddress. This value can change depending on Platform specific settings and can be either the canonical IPv4 or IPv6 address. If you require this behavior please call `InetAddress.getLoopbackAddress` directly.",
+      since = "0.21.23")
     val SocketAddress = InetSocketAddress.createUnresolved(Host, HttpPort)
 
     @deprecated("Renamed to ResponseTimeout", "0.21.0-M3")

--- a/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
+++ b/tomcat/src/main/scala/org/http4s/server/tomcat/TomcatBuilder.scala
@@ -243,7 +243,7 @@ sealed class TomcatBuilder[F[_]] private (
 object TomcatBuilder {
   def apply[F[_]: ConcurrentEffect]: TomcatBuilder[F] =
     new TomcatBuilder[F](
-      socketAddress = defaults.SocketAddress,
+      socketAddress = defaults.IPv4SocketAddress,
       externalExecutor = None,
       idleTimeout = defaults.IdleTimeout,
       asyncTimeout = defaults.ResponseTimeout,


### PR DESCRIPTION
The implementation for our default `Host` was the following,

```scala
val Host = InetAddress.getLoopbackAddress.getHostAddress
```

Whether the result of this invocation is the canonical IPv4 or IPv6 loopback address is the result of this code in the JRE.

```java
class InetAddressImplFactory {

    static InetAddressImpl create() {
        return InetAddress.loadImpl(isIPv6Supported() ?
                                    "Inet6AddressImpl" : "Inet4AddressImpl");
    }

    static native boolean isIPv6Supported();
}
```

Where `isIPv6Supported` is some native method.

On standard JREs, this is governed by a set of system properties including `java.net.preferIPv6Addresses`. For example,

```shell
> scala
Welcome to Scala 2.13.4-20201218-225751-unknown (OpenJDK 64-Bit Server VM, Java 16).
Type in expressions for evaluation. Or try :help.

scala> java.net.InetAddress.getLoopbackAddress
java.net.InetAddress.getLoopbackAddress
val res0: java.net.InetAddress = localhost/127.0.0.1

scala> :q
:q
> scala -Djava.net.preferIPv6Addresses=true
Welcome to Scala 2.13.4-20201218-225751-unknown (OpenJDK 64-Bit Server VM, Java 16).
Type in expressions for evaluation. Or try :help.

scala> java.net.InetAddress.getLoopbackAddress
java.net.InetAddress.getLoopbackAddress
val res0: java.net.InetAddress = localhost/0:0:0:0:0:0:0:1
```

And honestly if they are running on a more exotic JRE I've no idea which one they'd get by default. Most systems these days (e.g. Linux, Windows, Web Browsers) will prefer the IPv6 Address if the system has a ipv6 address and the target has an IPv6 address, so I wouldn't be surprised if some systems used similar heuristics to give IPv6 precedence (which is of course great, IPv6 is great!).

However, I expect the dynamic and quasi-defined behavior would be surprising to most users.

This commit deprecates the default `Host` and `SocketAddress` and adds new IPv4/IPv6 specific replacements so that the behavior is unambiguous. It changes the various http4s internal uses of `Host` to use the IPv4 based defaults as that is likely what they are already doing in 99% of cases and should be the least surprising on our users.