### PR TITLE
Initial Encoding Of ServerBuildable

### DIFF
--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -24,13 +24,14 @@ import fs2.io.tcp.SocketGroup
 import fs2.io.tcp.SocketOptionMapping
 import fs2.io.tls._
 import org.http4s._
-import org.http4s.server.Server
+import org.http4s.server._
 
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
 import _root_.org.typelevel.log4cats.Logger
 import _root_.org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.http4s.ember.server.internal.{ServerHelpers, Shutdown}
+import org.http4s.server.ServerBuildable
 
 final class EmberServerBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     val host: String,
@@ -215,4 +216,19 @@ object EmberServerBuilder {
     val shutdownTimeout: Duration = server.defaults.ShutdownTimeout
     val additionalSocketOptions = List.empty[SocketOptionMapping[_]]
   }
+
+  implicit def serverBuildableInstance[F[_]]: ServerBuildable[F, EmberServerBuilder[F]] =
+    new ServerBuildable[F, EmberServerBuilder[F]] {
+      override def resource(a: EmberServerBuilder[F]): Resource[F, Server] =
+        a.build
+
+      override def withHttpHost(a: EmberServerBuilder[F])(host: String): EmberServerBuilder[F] =
+        a.withHost(host)
+
+      override def withHttpPort(a: EmberServerBuilder[F])(port: Int): EmberServerBuilder[F] =
+        a.withPort(port)
+
+      override def withHttpApp(a: EmberServerBuilder[F])(app: HttpApp[F]): EmberServerBuilder[F] =
+        a.withHttpApp(app)
+    }
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -23,6 +23,7 @@ import org.http4s.server.{Router, Server}
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 import scala.concurrent.ExecutionContext.global
+import org.http4s.server.syntax.serverBuildable._
 
 object BlazeExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =
@@ -39,9 +40,7 @@ object BlazeExampleApp {
     for {
       blocker <- Blocker[F]
       app = httpApp[F](blocker)
-      server <- BlazeServerBuilder[F](global)
-        .bindHttp(8080)
-        .withHttpApp(app)
-        .resource
+      builder = BlazeServerBuilder[F](global)
+      server <- builder.withHttpPort(8080).withHttpApp(app).resource
     } yield server
 }

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerSimpleExample.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerSimpleExample.scala
@@ -25,6 +25,7 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.circe._
 import _root_.io.circe._
 import _root_.org.http4s.ember.server.EmberServerBuilder
+import org.http4s.server.syntax.serverBuildable._
 
 object EmberServerSimpleExample extends IOApp {
 
@@ -36,8 +37,8 @@ object EmberServerSimpleExample extends IOApp {
       server <-
         EmberServerBuilder
           .default[IO]
-          .withHost(host)
-          .withPort(port)
+          .withHttpHost(host)
+          .withHttpPort(port)
           .withHttpApp(service[IO])
           .build
     } yield server

--- a/play-json/src/main/scala/org/http4s/play/Parser.scala
+++ b/play-json/src/main/scala/org/http4s/play/Parser.scala
@@ -1,7 +1,17 @@
 /*
- * Based on https://github.com/typelevel/jawn/blob/v1.0.3/support/play/src/main/scala/Parser.scala
- * Copyright Erik Osheim, 2012-2020
- * See licenses/LICENSE_jawn
+ * Copyright 2018 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.http4s.play

--- a/server/src/main/scala/org/http4s/server/ServerBuildable.scala
+++ b/server/src/main/scala/org/http4s/server/ServerBuildable.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package server
+
+import cats.effect.concurrent._
+import cats.effect._
+import cats.syntax.all._
+import fs2._
+import fs2.concurrent._
+
+/** A pseudo-typeclass for something which can build a server.
+  *
+  * There are primary three motivations for this class.
+  *
+  * - Provide an ad-hoc polymorphic way approach to configure a server, as
+  *   opposed to the [[ServerBuilder]] subtyping approach. This is generally
+  *   more consistent with the current design idioms in use in FP Scala code
+  *   and (subjectively) is cleaner, e.g. no dealing with `Self` typing, etc.
+  * - Provide a minimal definition for what you need to provide if you are
+  *   implementing a server backend. [[ServerBuilder]] already does this to a
+  *   degree, but due to the current design of that class, not all of our
+  *   servers implement that, e.g. Ember.
+  *
+  * This class does not and ''can not'' replace backend specific
+  * builders. Those must always exist as the precise feature set of a given
+  * backend will likely never be totally shared with any other backend.
+  */
+trait ServerBuildable[F[_], A] {
+
+  /** Returns the backend as a resource.  Resource acquire waits
+    * until the backend is ready to process requests.
+    */
+  def resource(a: A): Resource[F, Server]
+
+  // Abstract Settings
+
+  /** Set the http host for the server. */
+  def withHttpHost(a: A)(host: String): A
+
+  /** Set the http port for the server. */
+  def withHttpPort(a: A)(port: Int): A
+
+  /** Set the [[HttpApp]] to serve on this server. */
+  def withHttpApp(a: A)(app: HttpApp[F]): A
+
+  // final
+
+  /** Returns the backend as a single-element stream.  The stream
+    * does not emit until the backend is ready to process requests.
+    * The backend is shut down when the stream is finalized.
+    */
+  final def stream(a: A): Stream[F, Server] = Stream.resource(resource(a))
+
+  /** Returns an effect that allocates a backend and an `F[Unit]` to
+    * release it.  The returned `F` waits until the backend is ready
+    * to process requests.  The second element of the tuple shuts
+    * down the backend when run.
+    *
+    * Unlike [[resource]] and [[stream]], there is no automatic
+    * release of the backend.  This function is intended for REPL
+    * sessions, tests, and other situations where composing a
+    * [[cats.effect.Resource]] or [[fs2.Stream]] is not tenable.
+    * [[resource]] or [[stream]] is recommended wherever possible.
+    */
+  final def allocated(a: A)(implicit F: Bracket[F, Throwable]): F[(Server, F[Unit])] = resource(a).allocated
+
+  /** Bind the server to a given port and host. */
+  final def bindHttp(a: A)(port: Int = defaults.HttpPort, host: String = defaults.Host): A =
+    withHttpPort(withHttpHost(a)(host))(port)
+
+  /** Bind the server to localhost */
+  final def bindLocal(a: A)(port: Int): A = bindHttp(a)(port, defaults.Host)
+
+  /** Bind the server to localhost, on some dynamically determined free port. */
+  final def bindAny(a: A)(host: String = defaults.Host): A = bindHttp(a)(0, host)
+
+  /** Runs the server as a Stream that emits only when the terminated signal becomes true.
+    * Useful for servers with associated lifetime behaviors.
+    */
+  final def serveWhile(a: A)(
+      terminateWhenTrue: Signal[F, Boolean],
+      exitWith: Ref[F, ExitCode]): Stream[F, ExitCode] =
+    Stream.resource(resource(a)) *> (terminateWhenTrue.discrete
+      .takeWhile(_ === false)
+      .drain ++ Stream.eval(exitWith.get))
+
+  /** Runs the server as a process that never emits.  Useful for a server
+    * that runs for the rest of the JVM's life.
+    */
+  final def serve(a: A)(implicit F: Concurrent[F]): Stream[F, ExitCode] =
+    for {
+      signal <- Stream.eval(SignallingRef[F, Boolean](false))
+      exitCode <- Stream.eval(Ref[F].of(ExitCode.Success))
+      serve <- serveWhile(a)(signal, exitCode)
+    } yield serve
+}
+
+object ServerBuildable {
+
+  // TODO: Generate syntax with simulacrum? It's a two parameter class so I'm
+  // not certain that is viable.
+
+  def apply[F[_], A](implicit instance: ServerBuildable[F, A]): ServerBuildable[F, A] = instance
+
+  trait Ops[F[_], A] extends Serializable {
+    def typeClassInstance: ServerBuildable[F, A]
+    def resource: Resource[F, Server]
+    def withHttpHost(host: String): A
+    def withHttpPort(port: Int): A
+    def withHttpApp(app: HttpApp[F]): A
+  }
+
+  trait ToServerBuildableOps extends Serializable {
+    implicit def toServerBuildableOps[F[_], A](target: A)(implicit tc: ServerBuildable[F, A]): Ops[F, A] =
+      new Ops[F, A] {
+        override val typeClassInstance: ServerBuildable[F, A] = tc
+        override def resource: Resource[F, Server] =
+          tc.resource(target)
+        override def withHttpHost(host: String): A = tc.withHttpHost(target)(host)
+        override def withHttpPort(port: Int): A = tc.withHttpPort(target)(port)
+        override def withHttpApp(app: HttpApp[F]): A = tc.withHttpApp(target)(app)
+      }
+  }
+}

--- a/server/src/main/scala/org/http4s/server/syntax/package.scala
+++ b/server/src/main/scala/org/http4s/server/syntax/package.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server
+
+package object syntax {
+  object serverBuildable extends ServerBuildable.ToServerBuildableOps
+}


### PR DESCRIPTION
This commit provides an initial encoding a of `ServerBuildable` a pseudo typeclass alternative to `ServerBuilder`.

The intent here is to provide a clean minimal ad-hoc polymorphic way to define an interface for things which can configure and run servers.

Prior to this, the code required to build a server varied a great deal between the different backends. `ServerBuilder` provides somewhat of a common interface, but lacks even some very basic items, e.g. there is no way to pass in an `HttpApp` to `ServerBuilder`.

This leads to confusion among users about exactly how to configure and start a specific server, and discourages trying different http backends as users have to learn the idioms of each underlying system again. To an extent, that is unavoidable. Certain aspects of configuration will _always_ be specific a given backend, however it need not be quite a bespoke as it is.

Currently `ServerBuildable` implements 1 fundamental operation for serving a server,

```scala
  /** Returns the backend as a resource.  Resource acquire waits
    * until the backend is ready to process requests.
    */
  def resource(a: A): Resource[F, Server]
```

And 3 fundamental operations for configuring a server builder,

```scala
  /** Set the http host for the server. */
  def withHttpHost(a: A)(host: String): A

  /** Set the http port for the server. */
  def withHttpPort(a: A)(port: Int): A

  /** Set the [[HttpApp]] to serve on this server. */
  def withHttpApp(a: A)(app: HttpApp[F]): A
```

I've some thoughts on how to make this encoding a bit more bin compat friendly as well, and I'm not sold on it at all, but I thought I'd make a draft PR now so people can provide feedback. 

Currently this is targeting 0.22.x, but given the scope of this change, _if_ it gets merged 1.x.x is probably more likely.