### PR TITLE
Reset idle timeout when request is received by blaze-server

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/IdleTimeoutStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/IdleTimeoutStage.scala
@@ -18,10 +18,11 @@ package org.http4s
 package blazecore
 
 import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.{AtomicReference}
+import java.util.concurrent.atomic.AtomicReference
 import org.http4s.blaze.pipeline.MidStage
-import org.http4s.blaze.util.{Cancelable, TickWheelExecutor}
+import org.http4s.blaze.util.{Cancelable, Execution, TickWheelExecutor}
 import org.log4s.getLogger
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
 
@@ -47,10 +48,8 @@ final private[http4s] class IdleTimeoutStage[A](
     }
   }
 
-  override def readRequest(size: Int): Future[A] = {
-    resetTimeout()
-    channelRead(size)
-  }
+  override def readRequest(size: Int): Future[A] =
+    channelRead(size).andThen { case _ => resetTimeout() }(Execution.directec)
 
   override def writeRequest(data: A): Future[Unit] = {
     resetTimeout()


### PR DESCRIPTION
This is fix for one (half) of the issues I mentioned in #4761

So it's the same application use-case, but I'll sketch the background one again to highlight the aspects that are important for this specific issue

### Background
We have an http4s-blaze-client calling an http4s-blaze-server. These normally run as separate processes on separate machines, but in the process of reproducing this issue I'm running both in one JVM. Requests sent by the client have unique identifiers. There is no retry logic. The same request is never sent twice. The server fails loud when it receives a second request with the same identifier. Detection of such case is not guaranteed but when it happens it's clean and unambiguous. The whole solution worked since years without any duplicates, until we replaced akka-remote communication with the http4s client-server communication. The server is configured with default timeouts (30s response timeout, 60s idle timeout) . The issue affects 0.21.x and probably some other version as well.

### The symptoms
From time to time the server processes the same request twice complaining about the duplicate ID.

### The issue no. 1
With help of wireshark we can see what happens on the network. This is filtered to show just one TCP (HTTP) connection. The port 10443 is the server, the port 50150 is the client.
<img width="841" alt="image" src="https://user-images.githubusercontent.com/9465998/116358303-c8102d80-a7fd-11eb-8db1-a63be613389a.png">

At 206.7 the server received a request, at 209.6 it responded with 200. This was the previous request which went fine. At 248.6 the server recieved a new request. At 269.6 the server abruptly terminated the TCP connection, while the request was still being processed. We can see that the connection was terminated ~60 seconds after the response to the previous request was sent.

Debug logs confirm that the termination of the connection is caused by IdleTimeoutStage on the server side.

One would expect that the reception of a new request at 248.6 should have reset the timeout, and that it should not occur until 308.6. But it doesn't work like that in practice. The answer as to why is in the `IdleTimeoutStage#readRequest` . The `readRequest` is called immediately after sending a response to previous request (at 209.6) and this is when the timeout is reset. When the new request is received at 248.6 the timeout is not reset.

This PR addresses this issue

### Issue no. 2 

The timeout problems don't explain why the request is processed twice. This is in my opinion an interaction of two bugs, the one that I described above and a separate on on the client side, that I haven't diagnosed yet, but I will address it in a separate PR. Nonetheless, to complete the story: When the connection is lost at 269.6, the blaze client decides to borrow another connection from the pool and resend the request though it. The server responds immediately with an error due to the duplicate ID.

### Solution to Issue no. 1
The timeout should be reset when `readRequest` completes, not when it's called, because that is (more or less) the time when actual network activity happens in the connection.

