### PR TITLE
Remove retry from blaze client

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/BlazeClient.scala
@@ -24,7 +24,6 @@ import cats.effect.implicits._
 import cats.syntax.all._
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeoutException
-import org.http4s.blaze.pipeline.Command
 import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.blazecore.{IdleTimeoutStage, ResponseHeaderTimeoutStage}
 import org.log4s.getLogger
@@ -114,15 +113,6 @@ object BlazeClient {
                     case _ =>
                       F.delay(stageOpt.foreach(_.removeStage()))
                         .guarantee(manager.invalidate(next.connection))
-                  }
-                }
-                .recoverWith { case Command.EOF =>
-                  invalidate(next.connection).flatMap { _ =>
-                    if (next.fresh)
-                      F.raiseError(
-                        new java.net.ConnectException(s"Failed to connect to endpoint: $key"))
-                    else
-                      loop
                   }
                 }
 


### PR DESCRIPTION
This PR fixes #4809. It depends on the #4810.

blaze-client currently has a retry logic which attempts to rerun a request on a new connection if previous attempt was done on a reused connection and it failed with EOF. 

My understanding is that the intention behind that retry was to handle the scenario in which the connection as been closed while it was sitting the the connection pool, but we only learn about it once we start reading from it. #4810 proposes a better solution to that problem (by detecting that the connection is closed, before we even borrow it from the pool). 

The current retry logic is dangerous, because it either assumes that:
1. EOF in reused connection implies the connection was closed before we sent the request
2.  or that the request can be safely sent twice

Point 1. simply isn't true. The connection may be closed at any time. Including getting closed after the server received and started processing the request.

As for point 2., not all HTTP requests are idempotent. http4s doesn't know which ones can be safely retried.

Moreover the retry logic doesn't put upper bound on the number of retries. The retries are only limited by availability of reusable connections in the pool, and the `requestTimeout` (if enabled).

IMO opinion it's better to leave retry logic up to the application, which has the knowledge if the request can be safely, and what strategy of retries is desirable in given scenario (back-off period, limited number of attempts, etc.). An awesome thing about http4s (and pure FP in general) is that it composes well. For example with `cats-retry`.
