### PR TITLE
Bugfix/4822

### DIFF
--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -28,6 +28,7 @@ import fs2.io.tls._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.vault.Vault
 import java.net.InetSocketAddress
+import java.util.Locale
 import org.http4s._
 import org.http4s.ember.core.Util.durationToFinite
 import org.http4s.ember.core.{Drain, EmptyStreamError, Encoder, Parser, Read}
@@ -184,7 +185,7 @@ private[server] object ServerHelpers {
     def hasConnection(expected: String): Boolean =
       headers.exists {
         case Header.Raw(name, value) =>
-          name == connectionCi && value.toLowerCase.contains(expected)
+          name == connectionCi && value.toLowerCase(Locale.ROOT).contains(expected)
         case _ => false
       }
 

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -170,23 +170,23 @@ private[server] object ServerHelpers {
       req: Request[F],
       resp: Response[F]): F[Response[F]] = {
     val connection: Connection =
-      if (isKeepAlive(req.httpVersion, req.headers, resp.headers)) keepAlive
+      if (isKeepAlive(req.httpVersion, req.headers)) keepAlive
       else close
     for {
       date <- HttpDate.current[F].map(Date(_))
     } yield resp.withHeaders(Headers.of(date, connection) ++ resp.headers)
   }
 
-  private[internal] def isKeepAlive(httpVersion: HttpVersion, requestHeaders: Headers, responseHeaders: Headers): Boolean = {
+  private[internal] def isKeepAlive(httpVersion: HttpVersion, headers: Headers): Boolean = {
     // We know this is raw because we have not parsed any headers in the underlying alg.
     // If Headers are being parsed into processed for in ParseHeaders this is incorrect.
-    val hasKeepAlive = responseHeaders.exists {
+    val hasKeepAlive = headers.exists {
       case Header.Raw(name, values) => name == connectionCi && values.contains(keepAlive.value)
       case _ => false
     }
 
     // TODO: we only need to check this if keep-alive is absent, but is there some compiler/jit optimization that infers that dependency?
-    val hasClose = requestHeaders.exists {
+    val hasClose = headers.exists {
       case Header.Raw(name, values) => name == connectionCi && values.contains(closeCi.value)
       case _ => false
     }

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -260,10 +260,8 @@ private[server] object ServerHelpers {
                 }
             }
         }
-        .takeWhile { case (req, resp) =>
-          !(req.headers
-            .get(Connection)
-            .exists(_.hasClose) || resp.headers.get(Connection).exists(_.hasClose))
+        .takeWhile { case (_, resp) =>
+          resp.headers.get(Connection).exists(_.hasKeepAlive)
         }
         .drain ++ Stream.eval_(socket.close)
     }

--- a/ember-server/src/test/scala/org/http4s/ember/server/internal/ServerHelpersSuite.scala
+++ b/ember-server/src/test/scala/org/http4s/ember/server/internal/ServerHelpersSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.ember.server.internal
+
+import munit._
+import org.http4s._
+import org.http4s.implicits._
+
+class ServerHelpersSuite extends CatsEffectSuite {
+
+  val close = Header.Raw("connection".ci, "close")
+  val keepAlive = Header.Raw("connection".ci, "keep-alive")
+
+  test("isKeepAlive - http/1.0, connection=close") {
+    assertEquals(ServerHelpers.isKeepAlive(HttpVersion.`HTTP/1.0`, Headers.of(close)), false)
+  }
+
+  test("isKeepAlive - http/1.0, connection=keep-alive") {
+    assertEquals(ServerHelpers.isKeepAlive(HttpVersion.`HTTP/1.0`, Headers.of(keepAlive)), true)
+  }
+
+  test("isKeepAlive - http/1.0, default") {
+    assertEquals(ServerHelpers.isKeepAlive(HttpVersion.`HTTP/1.0`, Headers.empty), false)
+  }
+
+  test("isKeepAlive - http/1.1, connection=close") {
+    assertEquals(ServerHelpers.isKeepAlive(HttpVersion.`HTTP/1.1`, Headers.of(close)), false)
+  }
+
+  test("isKeepAlive - http/1.1, connection=keep-alive") {
+    assertEquals(ServerHelpers.isKeepAlive(HttpVersion.`HTTP/1.1`, Headers.of(keepAlive)), true)
+  }
+
+  test("isKeepAlive - http/1.1, default") {
+    assertEquals(ServerHelpers.isKeepAlive(HttpVersion.`HTTP/1.1`, Headers.empty), true)
+  }
+}


### PR DESCRIPTION
Fixes #4822 . The issue is that AB operates on HTTP/1.0 and the absence of a connection header on HTTP/1.0 implies that the client wishes the connection to be terminated after the response is written