### PR TITLE
Remove multiple cookies

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -567,11 +567,11 @@ final class Response[F[_]] private (
     * cookie from the client
     */
   def removeCookie(cookie: ResponseCookie): Self =
-    putHeaders(cookie.clearCookie)
+    addCookie(cookie.clearCookie)
 
   /** Add a [[org.http4s.headers.Set-Cookie]] which will remove the specified cookie from the client */
   def removeCookie(name: String): Self =
-    putHeaders(ResponseCookie(name, "").clearCookie)
+    addCookie(ResponseCookie(name, "").clearCookie)
 
   /** Returns a list of cookies from the [[org.http4s.headers.Set-Cookie]]
     * headers. Includes expired cookies, such as those that represent cookie

--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -48,8 +48,8 @@ final case class ResponseCookie(
     writer
   }
 
-  def clearCookie: headers.`Set-Cookie` =
-    headers.`Set-Cookie`(copy(content = "", expires = Some(HttpDate.Epoch)))
+  def clearCookie: ResponseCookie =
+    copy(content = "", expires = Some(HttpDate.Epoch))
 
   private def withExpires(expires: HttpDate): ResponseCookie =
     copy(expires = Some(expires))

--- a/tests/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/tests/src/test/scala/org/http4s/ResponderSpec.scala
@@ -122,4 +122,16 @@ class ResponderSpec extends Http4sSuite {
         ResponseCookie("foo", "", expires = Option(HttpDate.Epoch))
       ))
   }
+
+  test("Responder should Remove multiple cookies") {
+    val cookie1 = ResponseCookie("foo1", "bar")
+    val cookie2 = ResponseCookie("foo2", "baz")
+    assertEquals(
+      resp.removeCookie(cookie1).removeCookie(cookie2).cookies,
+      List(
+        ResponseCookie("foo1", "", expires = Option(HttpDate.Epoch)),
+        ResponseCookie("foo2", "", expires = Option(HttpDate.Epoch))
+      )
+    )
+  }
 }


### PR DESCRIPTION
Because `putHeaders` deduplicates, calling `removeCookie` repeatedly will remove the first one.