### PR TITLE
Fix TimeoutException: Future timed out after [30 seconds] on BlazeClient213Suite testing

### DIFF
--- a/blaze-client/src/test/scala-2.13/org/http4s/client/blaze/BlazeClient213Suite.scala
+++ b/blaze-client/src/test/scala-2.13/org/http4s/client/blaze/BlazeClient213Suite.scala
@@ -23,12 +23,15 @@ import cats.syntax.all._
 import fs2.Stream
 import org.http4s._
 import org.http4s.blaze.client.BlazeClientBase
+
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 import scala.util.Random
 
 class BlazeClient213Suite extends BlazeClientBase {
+  override def munitTimeout: Duration = new FiniteDuration(50, TimeUnit.SECONDS)
 
-  test("reset request timeout".flaky) {
+  test("reset request timeout") {
     val addresses = jettyServer().addresses
     val address = addresses.head
     val name = address.getHostName
@@ -101,7 +104,7 @@ class BlazeClient213Suite extends BlazeClientBase {
     }.assert
   }
 
-  test("Blaze Http1Client should behave and not deadlock on failures with parSequence".flaky) {
+  test("Blaze Http1Client should behave and not deadlock on failures with parSequence") {
     val addresses = jettyServer().addresses
     mkClient(3).use { client =>
       val failedHosts = addresses.map { address =>


### PR DESCRIPTION
## Fix TimeoutException: Future timed out after [30 seconds] on BlazeClient213Suite testing
I usually get the following failures when I run the tests locally.
* `BlazeClient213Suite.behave and not deadlock on failures with parTraverse`
* `BlazeClient213Suite.Blaze Http1Client should behave and not deadlock on failures with parSequence`

fail with `TimeoutException: Future timed out after [30 seconds]`, this PR may fix it.
