### PR TITLE
Reflag flaky blaze client tests as flaky

### DIFF
--- a/blaze-client/src/test/scala-2.13/org/http4s/client/blaze/BlazeClient213Suite.scala
+++ b/blaze-client/src/test/scala-2.13/org/http4s/client/blaze/BlazeClient213Suite.scala
@@ -31,7 +31,7 @@ import scala.util.Random
 class BlazeClient213Suite extends BlazeClientBase {
   override def munitTimeout: Duration = new FiniteDuration(50, TimeUnit.SECONDS)
 
-  test("reset request timeout") {
+  test("reset request timeout".flaky) {
     val addresses = jettyServer().addresses
     val address = addresses.head
     val name = address.getHostName
@@ -104,7 +104,7 @@ class BlazeClient213Suite extends BlazeClientBase {
     }.assert
   }
 
-  test("Blaze Http1Client should behave and not deadlock on failures with parSequence") {
+  test("Blaze Http1Client should behave and not deadlock on failures with parSequence".flaky) {
     val addresses = jettyServer().addresses
     mkClient(3).use { client =>
       val failedHosts = addresses.map { address =>


### PR DESCRIPTION
These are still eating us, even at the greater timeout.