### PR TITLE
Scala 2.13.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.6, 3.0.0]
-        java: [adopt@1.8, adopt@1.11, adopt@1.15]
+        scala: [2.13.6, 2.12.13, 3.0.0]
+        java: [adopt@1.8, adopt@1.11, adopt@1.16]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -54,26 +54,26 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt --client '++${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Check formatting
         if: matrix.scala != '3.0.0'
-        run: sbt ++${{ matrix.scala }} scalafmtCheckAll
+        run: sbt --client '++${{ matrix.scala }}; scalafmtCheckAll'
 
       - name: Check headers
-        run: 'sbt ++${{ matrix.scala }} headerCheck test:headerCheck'
+        run: 'sbt --client ''++${{ matrix.scala }}; headerCheck; test:headerCheck'''
 
       - name: Compile
-        run: 'sbt ++${{ matrix.scala }} test:compile'
+        run: 'sbt --client ''++${{ matrix.scala }}; test:compile'''
 
       - name: Check binary compatibility
-        run: sbt ++${{ matrix.scala }} mimaReportBinaryIssues
+        run: sbt --client '++${{ matrix.scala }}; mimaReportBinaryIssues'
 
       - name: Run tests
-        run: sbt ++${{ matrix.scala }} test
+        run: sbt --client '++${{ matrix.scala }}; test'
 
       - name: Build docs
-        run: sbt ++${{ matrix.scala }} doc
+        run: sbt --client '++${{ matrix.scala }}; doc'
 
   publish:
     name: Publish Artifacts
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6]
+        scala: [2.12.13]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -113,13 +113,14 @@ jobs:
 
       - run: git status
 
-      - run: sbt ++${{ matrix.scala }} +publish
+      - run: sbt --client '++${{ matrix.scala }}; +publish'
 
       - if: startsWith(github.ref, 'refs/tags/v')
-        run: sbt ++${{ matrix.scala }} sonatypeBundleRelease
+        run: sbt --client '++${{ matrix.scala }}; sonatypeBundleRelease'
 
       - name: Setup Hugo
         run: |
+
           echo "$HOME/bin" > $GITHUB_PATH
           HUGO_VERSION=0.26 scripts/install-hugo
 
@@ -128,21 +129,27 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
+
           eval "$(ssh-agent -s)"
           echo "$SSH_PRIVATE_KEY" | ssh-add -
           git config --global user.name "GitHub Actions CI"
           git config --global user.email "ghactions@invalid"
           sbt ++2.12.13 website/makeSite website/ghpagesPushSite
 
+                
+
       - name: Publish docs
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
+
           eval "$(ssh-agent -s)"
           echo "$SSH_PRIVATE_KEY" | ssh-add -
           git config --global user.name "GitHub Actions CI"
           git config --global user.email "ghactions@invalid"
           sbt ++2.12.13 docs/makeSite docs/ghpagesPushSite
+
+                
 
   website:
     name: Build website
@@ -165,12 +172,13 @@ jobs:
 
       - name: Setup Hugo
         run: |
+
           echo "$HOME/bin" > $GITHUB_PATH
           HUGO_VERSION=0.26 scripts/install-hugo
 
       
       - name: Build website
-        run: sbt ++${{ matrix.scala }} website/makeSite
+        run: sbt --client '++${{ matrix.scala }}; website/makeSite'
 
   docs:
     name: Build docs
@@ -193,19 +201,20 @@ jobs:
 
       - name: Setup Hugo
         run: |
+
           echo "$HOME/bin" > $GITHUB_PATH
           HUGO_VERSION=0.26 scripts/install-hugo
 
       
       - name: Build docs
-        run: sbt ++${{ matrix.scala }} docs/makeSite
+        run: sbt --client '++${{ matrix.scala }}; docs/makeSite'
 
   scalafix:
     name: Scalafix
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.6, 3.0.0]
+        scala: [2.13.6, 2.12.13, 3.0.0]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.5, 3.0.0]
+        scala: [2.12.13, 2.13.6, 3.0.0]
         java: [adopt@1.8, adopt@1.11, adopt@1.15]
     runs-on: ${{ matrix.os }}
     steps:
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.5]
+        scala: [2.13.6]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -120,7 +120,6 @@ jobs:
 
       - name: Setup Hugo
         run: |
-
           echo "$HOME/bin" > $GITHUB_PATH
           HUGO_VERSION=0.26 scripts/install-hugo
 
@@ -129,27 +128,21 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
-
           eval "$(ssh-agent -s)"
           echo "$SSH_PRIVATE_KEY" | ssh-add -
           git config --global user.name "GitHub Actions CI"
           git config --global user.email "ghactions@invalid"
           sbt ++2.12.13 website/makeSite website/ghpagesPushSite
 
-                
-
       - name: Publish docs
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
-
           eval "$(ssh-agent -s)"
           echo "$SSH_PRIVATE_KEY" | ssh-add -
           git config --global user.name "GitHub Actions CI"
           git config --global user.email "ghactions@invalid"
           sbt ++2.12.13 docs/makeSite docs/ghpagesPushSite
-
-                
 
   website:
     name: Build website
@@ -172,7 +165,6 @@ jobs:
 
       - name: Setup Hugo
         run: |
-
           echo "$HOME/bin" > $GITHUB_PATH
           HUGO_VERSION=0.26 scripts/install-hugo
 
@@ -201,7 +193,6 @@ jobs:
 
       - name: Setup Hugo
         run: |
-
           echo "$HOME/bin" > $GITHUB_PATH
           HUGO_VERSION=0.26 scripts/install-hugo
 
@@ -214,7 +205,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.5, 3.0.0]
+        scala: [2.12.13, 2.13.6, 3.0.0]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -241,7 +232,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Scalafix tests
-        if: matrix.scala == '2.13.5'
+        if: matrix.scala == '2.13.6'
         run: |
           cd scalafix
           sbt ci

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,14 +4,17 @@ pull_request_rules:
     conditions:
       - author=scala-steward
       - body~=labels:.*semver-patch.*
-      - status-success=Build and Test (ubuntu-latest, 2.13.3, adopt@1.8)
-      - status-success=Build and Test (ubuntu-latest, 2.13.3, adopt@1.11)
-      - status-success=Build and Test (ubuntu-latest, 2.13.3, adopt@1.15)
-      - status-success=Build and Test (ubuntu-latest, 2.12.12, adopt@1.8)
-      - status-success=Build and Test (ubuntu-latest, 2.12.12, adopt@1.11)
-      - status-success=Build and Test (ubuntu-latest, 2.12.12, adopt@1.15)
-      - status-success=Build website (ubuntu-latest, 2.12.12, adopt@1.8)
-      - status-success=Build docs (ubuntu-latest, 2.12.12, adopt@1.8)
+      - status-success=Build and Test (ubuntu-latest, 2.12.13, adopt@1.8)
+      - status-success=Build and Test (ubuntu-latest, 2.12.13, adopt@1.11)
+      - status-success=Build and Test (ubuntu-latest, 2.12.13, adopt@1.16)
+      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.8)
+      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.11)
+      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.16)
+      - status-success=Build and Test (ubuntu-latest, 3.0.0, adopt@1.8)
+      - status-success=Build and Test (ubuntu-latest, 3.0.0, adopt@1.11)
+      - status-success=Build and Test (ubuntu-latest, 3.0.0, adopt@1.16)
+      - status-success=Build website (ubuntu-latest, 2.12.13, adopt@1.8)
+      - status-success=Build docs (ubuntu-latest, 2.12.13, adopt@1.8)
     actions:
       merge:
         method: merge

--- a/blaze-core/src/main/scala/org/http4s/blazecore/IdleTimeoutStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/IdleTimeoutStage.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
 import org.http4s.blaze.pipeline.MidStage
 import org.http4s.blaze.util.{Cancelable, Execution, TickWheelExecutor}
-import org.log4s.getLogger
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
@@ -31,7 +30,6 @@ final private[http4s] class IdleTimeoutStage[A](
     exec: TickWheelExecutor,
     ec: ExecutionContext)
     extends MidStage[A, A] { stage =>
-  private[this] val logger = getLogger
 
   @volatile private var cb: Callback[TimeoutException] = null
 

--- a/blaze-core/src/main/scala/org/http4s/blazecore/ResponseHeaderTimeoutStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/ResponseHeaderTimeoutStage.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.{AtomicReference}
 import org.http4s.blaze.pipeline.MidStage
 import org.http4s.blaze.util.{Cancelable, TickWheelExecutor}
-import org.log4s.getLogger
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
@@ -31,7 +30,6 @@ final private[http4s] class ResponseHeaderTimeoutStage[A](
     exec: TickWheelExecutor,
     ec: ExecutionContext)
     extends MidStage[A, A] { stage =>
-  private[this] val logger = getLogger
   @volatile private[this] var cb: Callback[TimeoutException] = null
 
   private val timeoutState = new AtomicReference[Cancelable](NoOpCancelable)

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import org.http4s.sbt.ScaladocApiMapping
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 // Global settings
-ThisBuild / crossScalaVersions := Seq(scala_212, scala_213, scala_3)
+ThisBuild / crossScalaVersions := Seq(scala_213, scala_212, scala_3)
 ThisBuild / scalaVersion := (ThisBuild / crossScalaVersions).value.filter(_.startsWith("2.")).last
 ThisBuild / baseVersion := "0.22"
 ThisBuild / publishGithubUser := "rossabaker"
@@ -43,8 +43,6 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
 enablePlugins(SonatypeCiReleasePlugin)
 
 versionIntroduced := Map(
-  // There is, and will hopefully not be, an 0.22.0. But this hushes
-  // MiMa for now while we bootstrap Dotty support.
   scala_3 -> "0.22.0",
 )
 

--- a/core/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/src/main/scala/org/http4s/multipart/Part.scala
@@ -40,8 +40,8 @@ object Part {
 
   @deprecated(
     """Empty parts are not allowed by the multipart spec, see: https://tools.ietf.org/html/rfc7578#section-4.2
-       Moreover, it allows the creation of potentially incorrect multipart bodies
-    """.stripMargin,
+
+Moreover, it allows the creation of potentially incorrect multipart bodies""",
     "0.18.12"
   )
   def empty[F[_]]: Part[F] =

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -1,6 +1,5 @@
 package org.http4s.sbt
 
-import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import com.timushev.sbt.updates.UpdatesPlugin.autoImport._ // autoImport vs. UpdateKeys necessary here for implicit
 import com.typesafe.sbt.SbtGit.git
 import com.typesafe.sbt.git.JGit

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -24,7 +24,7 @@ object Http4sPlugin extends AutoPlugin {
 
   override def requires = Http4sOrgPlugin
 
-  val scala_213 = "2.13.5"
+  val scala_213 = "2.13.6"
   val scala_212 = "2.12.13"
   val scala_3 = "3.0.0"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,13 +3,12 @@ libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 // https://github.com/coursier/coursier/issues/450
 classpathTypes += "maven-plugin"
 
-addSbtPlugin("ch.epfl.lamp"               %  "sbt-dotty"                 % "0.5.5")
 addSbtPlugin("ch.epfl.scala"              %  "sbt-scalafix"              % "0.9.28")
 addSbtPlugin("com.earldouglas"            %  "xsbt-web-plugin"           % "4.2.2")
 addSbtPlugin("com.eed3si9n"               %  "sbt-buildinfo"             % "0.10.0")
 addSbtPlugin("com.eed3si9n"               %  "sbt-unidoc"                % "0.4.3")
 addSbtPlugin("com.github.tkawachi"        %  "sbt-doctest"               % "0.9.9")
-addSbtPlugin("org.http4s"                 %  "sbt-http4s-org"            % "0.7.5")
+addSbtPlugin("org.http4s"                 %  "sbt-http4s-org"            % "0.8.0")
 addSbtPlugin("com.timushev.sbt"           %  "sbt-updates"               % "0.5.3")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-ghpages"               % "0.6.3")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-site"                  % "1.4.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.earldouglas"            %  "xsbt-web-plugin"           % "4.2.
 addSbtPlugin("com.eed3si9n"               %  "sbt-buildinfo"             % "0.10.0")
 addSbtPlugin("com.eed3si9n"               %  "sbt-unidoc"                % "0.4.3")
 addSbtPlugin("com.github.tkawachi"        %  "sbt-doctest"               % "0.9.9")
-addSbtPlugin("org.http4s"                 %  "sbt-http4s-org"            % "0.8.0")
+addSbtPlugin("org.http4s"                 %  "sbt-http4s-org"            % "0.8.1")
 addSbtPlugin("com.timushev.sbt"           %  "sbt-updates"               % "0.5.3")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-ghpages"               % "0.6.3")
 addSbtPlugin("com.typesafe.sbt"           %  "sbt-site"                  % "1.4.1")


### PR DESCRIPTION
Bumps `kind-projector` via `sbt-spiewak` via `sbt-http4s-org` which allows us to upgrade scala to 2.13.6.

Also allows us to drop `sbt-dotty`

Closes #4839