### PR TITLE
Catch Exceptions in ParseResult.fromParser, and fix Content-Type so it doesn't throw

### DIFF
--- a/core/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/src/main/scala/org/http4s/MessageFailure.scala
@@ -80,7 +80,8 @@ object ParseResult {
 
   private[http4s] def fromParser[A](parser: Parser0[A], errorMessage: => String)(
       s: String): ParseResult[A] =
-    parser.parseAll(s).leftMap(e => ParseFailure(errorMessage, e.toString))
+    try parser.parseAll(s).leftMap(e => ParseFailure(errorMessage, e.toString))
+    catch { case p: ParseFailure => p.asLeft[A] }
 
   implicit val parseResultMonad: MonadError[ParseResult, ParseFailure] =
     catsStdInstancesForEither[ParseFailure]


### PR DESCRIPTION
Fixes an issue found in https://github.com/http4s/http4s/pull/4787#issuecomment-846633626.