### PR TITLE
Downgrade to play-json-2.9.2

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -314,7 +314,7 @@ object Http4sPlugin extends AutoPlugin {
     val netty = "4.1.65.Final"
     val okio = "2.10.0"
     val okhttp = "4.9.1"
-    val playJson = "2.10.0-RC2"
+    val playJson = "2.9.2"
     val prometheusClient = "0.10.0"
     val reactiveStreams = "1.0.3"
     val quasiquotes = "2.1.0"


### PR DESCRIPTION
We don't want a final release on a release candidate.  

Closes #4867.  If play-json-2.10.0 appears suddenly, abandon it.