### PR TITLE
Use more idiomatic `Network[F]`

### DIFF
--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -107,11 +107,9 @@ final class EmberClientBuilder[F[_]: Async] private (
 
   def build: Resource[F, Client[F]] =
     for {
-      sg <- sgOpt.fold(Network.forAsync.socketGroup())(_.pure[Resource[F, *]])
+      sg <- Resource.pure(sgOpt.getOrElse(Network[F]))
       tlsContextOptWithDefault <- Resource.eval(
-        tlsContextOpt
-          .fold(TLSContext.Builder.forAsync.system.attempt.map(_.toOption))(_.some.pure[F])
-      )
+        tlsContextOpt.fold(Network[F].tlsContext.system.attempt.map(_.toOption))(_.some.pure[F]))
       builder =
         KeyPoolBuilder
           .apply[F, RequestKey, EmberConnection[F]](

--- a/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -123,7 +123,7 @@ final class EmberServerBuilder[F[_]: Async] private (
 
   def build: Resource[F, Server] =
     for {
-      sg <- sgOpt.getOrElse(Network.forAsync[F]).pure[Resource[F, *]]
+      sg <- sgOpt.getOrElse(Network[F]).pure[Resource[F, *]]
       ready <- Resource.eval(Deferred[F, Either[Throwable, InetSocketAddress]])
       shutdown <- Resource.eval(Shutdown[F](shutdownTimeout))
       _ <- Concurrent[F].background(


### PR DESCRIPTION
Use `Network[F]` over `forAsync` and use the default `Network[F]` socket group as default for ember client.