### PR TITLE
added support for comments in ServerSentEvent

### DIFF
--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -29,6 +29,7 @@ import cats.syntax.all._
 import com.comcast.ip4s
 import com.comcast.ip4s.Arbitraries._
 import fs2.{Pure, Stream}
+
 import java.nio.charset.{Charset => NioCharset}
 import java.time._
 import java.util.Locale
@@ -41,6 +42,8 @@ import org.scalacheck.Gen._
 import org.scalacheck.rng.Seed
 import org.typelevel.ci.CIString
 import org.typelevel.ci.testing.arbitraries._
+
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.util.Try
@@ -613,7 +616,7 @@ private[http4s] trait ArbitraryInstances {
         4 -> None,
         1 -> posNum[Long].map(Some.apply)
       )
-    } yield ServerSentEvent(data, event, id, retry, comment))
+    } yield ServerSentEvent(data, event, id, retry.map(FiniteDuration(_, TimeUnit.MILLISECONDS)), comment))
   }
 
   // https://tools.ietf.org/html/rfc2234#section-6

--- a/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/ArbitraryInstances.scala
@@ -592,7 +592,14 @@ private[http4s] trait ArbitraryInstances {
         !s.contains("\r") && !s.contains("\n")
       }
     Arbitrary(for {
-      data <- singleLineString
+      data <- frequency(
+        8 -> singleLineString.map(Some.apply),
+        1 -> None
+      )
+      comment <- frequency(
+        1 -> singleLineString.map(Some.apply),
+        8 -> None
+      )
       event <- frequency(
         4 -> None,
         1 -> singleLineString.map(Some.apply)
@@ -606,7 +613,7 @@ private[http4s] trait ArbitraryInstances {
         4 -> None,
         1 -> posNum[Long].map(Some.apply)
       )
-    } yield ServerSentEvent(data, event, id, retry))
+    } yield ServerSentEvent(data, event, id, retry, comment))
   }
 
   // https://tools.ietf.org/html/rfc2234#section-6

--- a/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -24,6 +24,9 @@ import org.http4s.headers._
 import org.http4s.laws.discipline.ArbitraryInstances._
 import org.scalacheck.effect._
 
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+
 class ServerSentEventSpec extends Http4sSuite {
   import ServerSentEvent._
 
@@ -141,7 +144,7 @@ class ServerSentEventSpec extends Http4sSuite {
 
   test("encode should handle leading spaces") {
     // This is a pathological case uncovered by scalacheck
-    val sse = ServerSentEvent(" a".some, Some(" b"), Some(EventId(" c")), Some(1L))
+    val sse = ServerSentEvent(" a".some, Some(" b"), Some(EventId(" c")), Some(FiniteDuration(1, TimeUnit.MILLISECONDS)))
     Stream
       .emit(sse)
       .covary[IO]

--- a/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -17,7 +17,8 @@
 package org.http4s
 
 import cats.effect.IO
-import fs2.Stream
+import cats.implicits.catsSyntaxOptionId
+import fs2.{Pure, Stream}
 import fs2.text.utf8Encode
 import org.http4s.headers._
 import org.http4s.laws.discipline.ArbitraryInstances._
@@ -26,8 +27,10 @@ import org.scalacheck.effect._
 class ServerSentEventSpec extends Http4sSuite {
   import ServerSentEvent._
 
-  def toStream(s: String): Stream[IO, Byte] =
-    Stream.emit(s).through(utf8Encode)
+  def toStream(s: String): Stream[IO, Byte] = {
+    val scrubbed = s.dropWhile(_.isWhitespace)
+    Stream.emit(scrubbed).through(utf8Encode)
+  }
 
   test("decode should decode multi-line messages") {
     val stream = toStream("""
@@ -41,7 +44,21 @@ class ServerSentEventSpec extends Http4sSuite {
       .toVector
       .assertEquals(
         Vector(
-          ServerSentEvent(data = "YHOO\n+2\n10")
+          ServerSentEvent(data = "YHOO\n+2\n10".some)
+        ))
+  }
+
+  test("a lone comment is a valid event") {
+    val stream = toStream("""
+      |: hello
+      |""".stripMargin('|'))
+    stream
+      .through(ServerSentEvent.decoder)
+      .compile
+      .toVector
+      .assertEquals(
+        Vector(
+          ServerSentEvent(comments = "hello".some)
         ))
   }
 
@@ -62,9 +79,9 @@ class ServerSentEventSpec extends Http4sSuite {
       .compile
       .toVector
       .assertEquals(Vector(
-        ServerSentEvent(data = "first event", id = Some(EventId("1"))),
-        ServerSentEvent(data = "second event", id = Some(EventId.reset)),
-        ServerSentEvent(data = " third event", id = None)
+        ServerSentEvent(data = "first event".some, id = Some(EventId("1")), comments = Some("test stream")),
+        ServerSentEvent(data = "second event".some, id = Some(EventId.reset)),
+        ServerSentEvent(data = " third event".some, id = None)
       ))
   }
 
@@ -84,9 +101,9 @@ class ServerSentEventSpec extends Http4sSuite {
       .toVector
       .assertEquals(
         Vector(
-          ServerSentEvent(data = ""),
-          ServerSentEvent(data = "\n"),
-          ServerSentEvent(data = "")
+          ServerSentEvent(data = "".some),
+          ServerSentEvent(data = "\n".some),
+          ServerSentEvent(data = "".some)
         ))
   }
 
@@ -103,8 +120,8 @@ class ServerSentEventSpec extends Http4sSuite {
       .toVector
       .assertEquals(
         Vector(
-          ServerSentEvent(data = "test"),
-          ServerSentEvent(data = "test")
+          ServerSentEvent(data = "test".some),
+          ServerSentEvent(data = "test".some)
         ))
   }
 
@@ -115,6 +132,7 @@ class ServerSentEventSpec extends Http4sSuite {
         .covary[IO]
         .through(ServerSentEvent.encoder)
         .through(ServerSentEvent.decoder)
+        .dropLast
         .compile
         .toVector
       roundTrip.assertEquals(sses)
@@ -123,19 +141,20 @@ class ServerSentEventSpec extends Http4sSuite {
 
   test("encode should handle leading spaces") {
     // This is a pathological case uncovered by scalacheck
-    val sse = ServerSentEvent(" a", Some(" b"), Some(EventId(" c")), Some(1L))
+    val sse = ServerSentEvent(" a".some, Some(" b"), Some(EventId(" c")), Some(1L))
     Stream
       .emit(sse)
       .covary[IO]
       .through(ServerSentEvent.encoder)
       .through(ServerSentEvent.decoder)
+      .dropLast
       .compile
       .last
       .assertEquals(Some(sse))
   }
 
   val eventStream: Stream[IO, ServerSentEvent] =
-    Stream.range(0, 5).map(i => ServerSentEvent(data = i.toString))
+    Stream.range(0, 5).map(i => ServerSentEvent(data = i.toString.some))
   test("EntityEncoder[ServerSentEvent] should set Content-Type to text/event-stream") {
     assertEquals(
       Response[IO]().withEntity(eventStream).contentType,
@@ -148,6 +167,7 @@ class ServerSentEventSpec extends Http4sSuite {
         .withEntity(eventStream)
         .body
         .through(ServerSentEvent.decoder)
+        .dropLast
         .compile
         .toVector
       e <- eventStream.compile.toVector

--- a/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/tests/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -18,7 +18,7 @@ package org.http4s
 
 import cats.effect.IO
 import cats.implicits.catsSyntaxOptionId
-import fs2.{Pure, Stream}
+import fs2.Stream
 import fs2.text.utf8Encode
 import org.http4s.headers._
 import org.http4s.laws.discipline.ArbitraryInstances._
@@ -58,7 +58,7 @@ class ServerSentEventSpec extends Http4sSuite {
       .toVector
       .assertEquals(
         Vector(
-          ServerSentEvent(comments = "hello".some)
+          ServerSentEvent(comment = "hello".some)
         ))
   }
 
@@ -79,7 +79,7 @@ class ServerSentEventSpec extends Http4sSuite {
       .compile
       .toVector
       .assertEquals(Vector(
-        ServerSentEvent(data = "first event".some, id = Some(EventId("1")), comments = Some("test stream")),
+        ServerSentEvent(data = "first event".some, id = Some(EventId("1")), comment = Some("test stream")),
         ServerSentEvent(data = "second event".some, id = Some(EventId.reset)),
         ServerSentEvent(data = " third event".some, id = None)
       ))


### PR DESCRIPTION
A few notes.  

* unit tests had dropLast added because fs2.text.lines sees "\n" as two lines so decode sees it as two events when in fact it is one.  There is an fs2.text conversation happening now over an alternative linesWithEndings that would provide a cleaner path
* note one alternative to dropLast is we always add an extra empty event (maybe cleaner and safer since we could be dropping a non-empty buggy event)
* @rossabaker I will save the cleaner version of decode for now, it just didn't perform as well and I ran out of time for today as discussed the big thing is getting ServerSentEvents with the correct fields
* slight tweak to use an internal LineBuffer performance is on par with StringBuilder albeit a bit more memory consumed again could tweak this with something that accumulates in a StringBuilder and notes if any lines at all have been added (performance is from very informal testing)
* noting in real world I doubt the performance of this will be a gating factor
