### PR TITLE
Avoid sleeping 1 second in tests which don't use the /delay path.

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientBase.scala
+++ b/blaze-client/src/test/scala/org/http4s/client/blaze/BlazeClientBase.scala
@@ -52,7 +52,8 @@ trait BlazeClientBase extends Http4sSuite {
     new HttpServlet {
       override def doGet(req: HttpServletRequest, srv: HttpServletResponse): Unit =
         GetRoutes.getPaths.get(req.getRequestURI) match {
-          case Some(resp) =>
+          case Some(response) =>
+            val resp = response.unsafeRunSync()
             srv.setStatus(resp.status.code)
             resp.headers.foreach { h =>
               srv.addHeader(h.name.toString, h.value)

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -38,7 +38,8 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
     new HttpServlet {
       override def doGet(req: HttpServletRequest, srv: HttpServletResponse): Unit =
         GetRoutes.getPaths.get(req.getRequestURI) match {
-          case Some(r) => renderResponse(srv, r).unsafeRunSync() // We are outside the IO world
+          case Some(r) =>
+            renderResponse(srv, r.unsafeRunSync()).unsafeRunSync() // We are outside the IO world
           case None => srv.sendError(404)
         }
 
@@ -114,7 +115,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
       val req = Request[IO](uri = Uri.fromString(s"http://$name:$port$path").yolo)
       client()
         .run(req)
-        .use(resp => checkResponse(resp, expected))
+        .use(resp => expected.flatMap(expectedResponse => checkResponse(resp, expectedResponse)))
         .assert
     }
   }

--- a/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -21,7 +21,6 @@ import cats.effect._
 import cats.syntax.all._
 import fs2._
 import org.http4s.Status._
-import org.http4s.internal.CollectionCompat
 import scala.concurrent.duration._
 
 object GetRoutes {
@@ -33,19 +32,18 @@ object GetRoutes {
   val EmptyNotFoundPath = "/empty-not-found"
   val InternalServerErrorPath = "/internal-server-error"
 
-  def getPaths(implicit timer: Timer[IO]): Map[String, Response[IO]] =
-    CollectionCompat.mapValues(
-      Map(
-        SimplePath -> Response[IO](Ok).withEntity("simple path").pure[IO],
-        ChunkedPath -> Response[IO](Ok)
-          .withEntity(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
-          .pure[IO],
-        DelayedPath ->
-          timer.sleep(1.second) *>
-          Response[IO](Ok).withEntity("delayed path").pure[IO],
-        NoContentPath -> Response[IO](NoContent).pure[IO],
-        NotFoundPath -> Response[IO](NotFound).withEntity("not found").pure[IO],
-        EmptyNotFoundPath -> Response[IO](NotFound).pure[IO],
-        InternalServerErrorPath -> Response[IO](InternalServerError).pure[IO]
-      ))(_.unsafeRunSync())
+  def getPaths(implicit timer: Timer[IO]): Map[String, IO[Response[IO]]] =
+    Map(
+      SimplePath -> Response[IO](Ok).withEntity("simple path").pure[IO],
+      ChunkedPath -> Response[IO](Ok)
+        .withEntity(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
+        .pure[IO],
+      DelayedPath ->
+        timer.sleep(1.second) *>
+        Response[IO](Ok).withEntity("delayed path").pure[IO],
+      NoContentPath -> Response[IO](NoContent).pure[IO],
+      NotFoundPath -> Response[IO](NotFound).withEntity("not found").pure[IO],
+      EmptyNotFoundPath -> Response[IO](NotFound).pure[IO],
+      InternalServerErrorPath -> Response[IO](InternalServerError).pure[IO]
+    )
 }


### PR DESCRIPTION
The `GetRoutes.getPaths` used to block for 1 second due to `unsafeRunSync` waiting for `timer.sleep(1.second)`. This PR fixes it which should make some tests faster. The difference is most noticeable in `BlazeClient213Suite`.