### PR TITLE
Add file-based multipart decoder with better resource handling

### DIFF
--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -314,7 +314,6 @@ object EntityDecoder {
     * @return A multipart/form-data encoded vector of parts with some part bodies held in
     *         temporary files.
     */
-  @deprecated("Use mixedMultipartResource", "0.23")
   def mixedMultipart[F[_]: Concurrent: Files](
       headerLimit: Int = 1024,
       maxSizeBeforeWrite: Int = 52428800,

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -288,6 +288,33 @@ object EntityDecoder {
       failOnLimit,
       chunkSize)
 
+  /** Multipart decoder that streams all parts past a threshold
+    * (anything above maxSizeBeforeWrite) into a temporary file.
+    *
+    * Note: (BIG NOTE) Using this decoder for multipart decoding is good for the sake of
+    * not holding all information in memory, as it will never have more than
+    * `maxSizeBeforeWrite` in memory before writing to a temporary file. On top of this,
+    * you can gate the # of parts to further stop the quantity of parts you can have.
+    * That said, because after a threshold it writes into a temporary file, given
+    * bincompat reasons on 0.18.x, there is no way to make a distinction about which `Part[F]`
+    * is a stream reference to a file or not. Thus, consumers using this decoder
+    * should drain all `Part[F]` bodies if they were decoded correctly. That said,
+    * this decoder gives you more control about how many part bodies it parses in the first place, thus you can have
+    * more fine-grained control about how many parts you accept.
+    *
+    * @param headerLimit the max size for the headers, in bytes. This is required as
+    *                    headers are strictly evaluated and parsed.
+    * @param maxSizeBeforeWrite the maximum size of a particular part before writing to a file is triggered
+    * @param maxParts the maximum number of parts this decoder accepts. NOTE: this also may mean that a body that doesn't
+    *                 conform perfectly to the spec (i.e isn't terminated properly) but has a lot of parts might
+    *                 be parsed correctly, despite the total body being malformed due to not conforming to the multipart
+    *                 spec. You can control this by `failOnLimit`, by setting it to true if you want to raise
+    *                 an error if sending too many parts to a particular endpoint
+    * @param failOnLimit Fail if `maxParts` is exceeded _during_ multipart parsing.
+    * @return A multipart/form-data encoded vector of parts with some part bodies held in
+    *         temporary files.
+    */
+  @deprecated("Use mixedMultipartResource", "0.23")
   def mixedMultipart[F[_]: Concurrent: Files](
       headerLimit: Int = 1024,
       maxSizeBeforeWrite: Int = 52428800,

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -314,6 +314,7 @@ object EntityDecoder {
     * @return A multipart/form-data encoded vector of parts with some part bodies held in
     *         temporary files.
     */
+  @deprecated("Use mixedMultipartResource", "0.23")
   def mixedMultipart[F[_]: Concurrent: Files](
       headerLimit: Int = 1024,
       maxSizeBeforeWrite: Int = 52428800,

--- a/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -107,6 +107,7 @@ private[http4s] object MultipartDecoder {
     * @return A multipart/form-data encoded vector of parts with some part bodies held in
     *         temporary files.
     */
+  @deprecated("Use mixedMultipartResource", "0.23")
   def mixedMultipart[F[_]: Concurrent: Files](
       headerLimit: Int = 1024,
       maxSizeBeforeWrite: Int = 52428800,

--- a/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -18,31 +18,67 @@ package org.http4s
 package multipart
 
 import cats.effect.Concurrent
+import cats.effect.Resource
+import cats.effect.std.Supervisor
 import cats.syntax.all._
-
 import fs2.io.file.Files
+import fs2.Pipe
 
 private[http4s] object MultipartDecoder {
   def decoder[F[_]: Concurrent]: EntityDecoder[F, Multipart[F]] =
-    EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
-      msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
-        case Some(boundary) =>
-          DecodeResult {
-            msg.body
-              .through(MultipartParser.parseToPartsStream[F](Boundary(boundary)))
-              .compile
-              .toVector
-              .map[Either[DecodeFailure, Multipart[F]]](parts =>
-                Right(Multipart(parts, Boundary(boundary))))
-              .handleError {
-                case e: InvalidMessageBodyFailure => Left(e)
-                case e => Left(InvalidMessageBodyFailure("Invalid multipart body", Some(e)))
-              }
-          }
-        case None =>
-          DecodeResult.failureT(
-            InvalidMessageBodyFailure("Missing boundary extension to Content-Type"))
-      }
+    makeDecoder(MultipartParser.parseToPartsStream[F](_))
+
+  /** Multipart decoder that streams all parts past a threshold
+    * (anything above `maxSizeBeforeWrite`) into a temporary file.
+    * The decoder is only valid inside the `Resource` scope; once
+    * the `Resource` is released, all the created files are deleted.
+    *
+    * Note that no files are deleted until the `Resource` is released.
+    * Thus, sharing and reusing the resulting `EntityDecoder` is not
+    * recommended, and can lead to disk space leaks.
+    *
+    * The intended way to use this is as follows:
+    *
+    * {{{
+    * mixedMultipartResource[F]()
+    *   .flatTap(request.decodeWith(_, strict = true))
+    *   .use { multipart =>
+    *     // Use the decoded entity
+    *   }
+    * }}}
+    *
+    * @param headerLimit the max size for the headers, in bytes. This is required as
+    *                    headers are strictly evaluated and parsed.
+    * @param maxSizeBeforeWrite the maximum size of a particular part before writing to a file is triggered
+    * @param maxParts the maximum number of parts this decoder accepts. NOTE: this also may mean that a body that doesn't
+    *                 conform perfectly to the spec (i.e isn't terminated properly) but has a lot of parts might
+    *                 be parsed correctly, despite the total body being malformed due to not conforming to the multipart
+    *                 spec. You can control this by `failOnLimit`, by setting it to true if you want to raise
+    *                 an error if sending too many parts to a particular endpoint
+    * @param failOnLimit Fail if `maxParts` is exceeded _during_ multipart parsing.
+    * @param chunkSize the size of chunks created when reading data from temporary files.
+    * @return A multipart/form-data encoded vector of parts with some part bodies held in
+    *         temporary files.
+    */
+  def mixedMultipartResource[F[_]: Concurrent: Files](
+      headerLimit: Int = 1024,
+      maxSizeBeforeWrite: Int = 52428800,
+      maxParts: Int = 50,
+      failOnLimit: Boolean = false,
+      chunkSize: Int = 8192
+  ): Resource[F, EntityDecoder[F, Multipart[F]]] =
+    Supervisor[F].map { supervisor =>
+      makeDecoder(
+        MultipartParser.parseToPartsSupervisedFile[F](
+          supervisor,
+          _,
+          headerLimit,
+          maxSizeBeforeWrite,
+          maxParts,
+          failOnLimit,
+          chunkSize
+        )
+      )
     }
 
   /** Multipart decoder that streams all parts past a threshold
@@ -76,18 +112,25 @@ private[http4s] object MultipartDecoder {
       maxSizeBeforeWrite: Int = 52428800,
       maxParts: Int = 50,
       failOnLimit: Boolean = false): EntityDecoder[F, Multipart[F]] =
+    makeDecoder(
+      MultipartParser.parseToPartsStreamedFile[F](
+        _,
+        headerLimit,
+        maxSizeBeforeWrite,
+        maxParts,
+        failOnLimit
+      )
+    )
+
+  private def makeDecoder[F[_]: Concurrent](
+      impl: Boundary => Pipe[F, Byte, Part[F]]
+  ): EntityDecoder[F, Multipart[F]] =
     EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
       msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
         case Some(boundary) =>
           DecodeResult {
             msg.body
-              .through(
-                MultipartParser.parseToPartsStreamedFile[F](
-                  Boundary(boundary),
-                  headerLimit,
-                  maxSizeBeforeWrite,
-                  maxParts,
-                  failOnLimit))
+              .through(impl(Boundary(boundary)))
               .compile
               .toVector
               .map[Either[DecodeFailure, Multipart[F]]](parts =>

--- a/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -107,7 +107,6 @@ private[http4s] object MultipartDecoder {
     * @return A multipart/form-data encoded vector of parts with some part bodies held in
     *         temporary files.
     */
-  @deprecated("Use mixedMultipartResource", "0.23")
   def mixedMultipart[F[_]: Concurrent: Files](
       headerLimit: Int = 1024,
       maxSizeBeforeWrite: Int = 52428800,

--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -25,6 +25,8 @@ import java.nio.file.{Path, StandardOpenOption}
 import org.typelevel.ci.CIString
 import fs2.RaiseThrowable
 import org.http4s.internal.bug
+import cats.effect.std.Supervisor
+import cats.effect.Resource
 
 /** A low-level multipart-parsing pipe.  Most end users will prefer EntityDecoder[Multipart]. */
 object MultipartParser {
@@ -46,7 +48,7 @@ object MultipartParser {
   private[this] sealed trait Event
   private[this] final case class PartStart(value: Headers) extends Event
   private[this] final case class PartChunk(value: Chunk[Byte]) extends Event
-  private[this] final case object PartEnd extends Event
+  private[this] case object PartEnd extends Event
 
   def parseStreamed[F[_]: Concurrent](
       boundary: Boundary,
@@ -590,6 +592,115 @@ object MultipartParser {
 
     go(stream, Stream.empty, 0)
   }
+
+  /////////////////////////////////////
+  // Resource-safe file-based parser //
+  /////////////////////////////////////
+
+  /** Like parseStreamedFile, but the produced parts' resources are managed by the supervisor.
+    */
+  def parseSupervisedFile[F[_]: Concurrent: Files](
+      supervisor: Supervisor[F],
+      boundary: Boundary,
+      limit: Int = 1024,
+      maxSizeBeforeWrite: Int = 52428800,
+      maxParts: Int = 20,
+      failOnLimit: Boolean = false,
+      chunkSize: Int = 8192
+  ): Pipe[F, Byte, Multipart[F]] = { st =>
+    st.through(
+      parseToPartsSupervisedFile(
+        supervisor,
+        boundary,
+        limit,
+        maxSizeBeforeWrite,
+        maxParts,
+        failOnLimit,
+        chunkSize)
+    ).fold(Vector.empty[Part[F]])(_ :+ _)
+      .map(Multipart(_, boundary))
+  }
+
+  def parseToPartsSupervisedFile[F[_]](
+      supervisor: Supervisor[F],
+      boundary: Boundary,
+      limit: Int = 1024,
+      maxSizeBeforeWrite: Int = 52428800,
+      maxParts: Int = 20,
+      failOnLimit: Boolean = false,
+      chunkSize: Int = 8192
+  )(implicit F: Concurrent[F], files: Files[F]): Pipe[F, Byte, Part[F]] = {
+    val createFile = superviseResource(supervisor, files.tempFile())
+    def append(file: Path, bytes: Stream[Pure, Byte]): F[Unit] =
+      bytes.through(files.writeAll(file, List(StandardOpenOption.APPEND))).compile.drain
+
+    final case class Acc(file: Option[Path], bytes: Stream[Pure, Byte], bytesSize: Int)
+
+    def stepPartChunk(oldAcc: Acc, chunk: Chunk[Byte]): F[Acc] = {
+      val newSize = oldAcc.bytesSize + chunk.size
+      val newBytes = oldAcc.bytes ++ Stream.chunk(chunk)
+      if (newSize > maxSizeBeforeWrite) {
+        oldAcc.file
+          .fold(createFile)(F.pure)
+          .flatTap(append(_, newBytes))
+          .map(newFile => Acc(Some(newFile), Stream.empty, 0))
+      } else F.pure(Acc(oldAcc.file, newBytes, newSize))
+    }
+
+    val stepPartEnd: Acc => F[Stream[F, Byte]] = {
+      case Acc(None, bytes, _) => F.pure(bytes)
+      case Acc(Some(file), bytes, size) =>
+        append(file, bytes)
+          .whenA(size > 0)
+          .as(
+            files.readAll(file, chunkSize = chunkSize)
+          )
+    }
+
+    val step: (Option[(Headers, Acc)], Event) => F[(Option[(Headers, Acc)], Option[Part[F]])] = {
+      case (None, PartStart(headers)) =>
+        val newAcc = Acc(None, Stream.empty, 0)
+        F.pure((Some((headers, newAcc)), None))
+      // Shouldn't happen if the `parseToEventsStream` contract holds.
+      case (None, (_: PartChunk | PartEnd)) =>
+        F.raiseError(bug("Missing PartStart"))
+      case (Some((headers, oldAcc)), PartChunk(chunk)) =>
+        stepPartChunk(oldAcc, chunk).map { newAcc =>
+          (Some((headers, newAcc)), None)
+        }
+      case (Some((headers, acc)), PartEnd) =>
+        // Part done - emit it and start over.
+        stepPartEnd(acc)
+          .map(body => (None, Some(Part(headers, body))))
+      // Shouldn't happen if the `parseToEventsStream` contract holds.
+      case (Some(_), _: PartStart) =>
+        F.raiseError(bug("Missing PartEnd"))
+    }
+
+    _.through(
+      parseEvents(boundary, limit)
+    ).through(
+      limitParts(maxParts, failOnLimit)
+    ).evalMapAccumulate(none[(Headers, Acc)])(step)
+      .mapFilter(_._2)
+  }
+
+  // Acquire the resource in a separate fiber, which will remain running until the provided
+  // supervisor sees fit to cancel it. The resulting action waits for the resource to be acquired.
+  private[this] def superviseResource[F[_], A](
+      supervisor: Supervisor[F],
+      resource: Resource[F, A]
+  )(implicit F: Concurrent[F]): F[A] =
+    F.deferred[Either[Throwable, A]].flatMap { deferred =>
+      supervisor.supervise[Nothing](
+        resource.attempt
+          .evalTap(deferred.complete)
+          // In case of an error the exception brings down the fiber.
+          .rethrow
+          // Success - keep the resource alive until the supervisor cancels this fiber.
+          .useForever
+      ) *> deferred.get.rethrow
+    }
 
   ////////////////////////////
   // Streaming event parser //

--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -599,7 +599,7 @@ object MultipartParser {
 
   /** Like parseStreamedFile, but the produced parts' resources are managed by the supervisor.
     */
-  def parseSupervisedFile[F[_]: Concurrent: Files](
+  private[multipart] def parseSupervisedFile[F[_]: Concurrent: Files](
       supervisor: Supervisor[F],
       boundary: Boundary,
       limit: Int = 1024,
@@ -621,7 +621,7 @@ object MultipartParser {
       .map(Multipart(_, boundary))
   }
 
-  def parseToPartsSupervisedFile[F[_]](
+  private[multipart] def parseToPartsSupervisedFile[F[_]](
       supervisor: Supervisor[F],
       boundary: Boundary,
       limit: Int = 1024,

--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -465,7 +465,6 @@ object MultipartParser {
   /** Same as the other streamed parsing, except
     * after a particular size, it buffers on a File.
     */
-  @deprecated("Use parseSupervisedFile", "0.23")
   def parseStreamedFile[F[_]: Concurrent: Files](
       boundary: Boundary,
       limit: Int = 1024,
@@ -478,7 +477,6 @@ object MultipartParser {
       .map(Multipart(_, boundary))
   }
 
-  @deprecated("Use parseSupervisedFile", "0.23")
   def parseToPartsStreamedFile[F[_]: Concurrent: Files](
       boundary: Boundary,
       limit: Int = 1024,

--- a/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -465,6 +465,7 @@ object MultipartParser {
   /** Same as the other streamed parsing, except
     * after a particular size, it buffers on a File.
     */
+  @deprecated("Use parseSupervisedFile", "0.23")
   def parseStreamedFile[F[_]: Concurrent: Files](
       boundary: Boundary,
       limit: Int = 1024,
@@ -477,6 +478,7 @@ object MultipartParser {
       .map(Multipart(_, boundary))
   }
 
+  @deprecated("Use parseSupervisedFile", "0.23")
   def parseToPartsStreamedFile[F[_]: Concurrent: Files](
       boundary: Boundary,
       limit: Int = 1024,

--- a/tests/src/test/scala/org/http4s/multipart/MultipartParserSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartParserSuite.scala
@@ -765,13 +765,15 @@ class MultipartParserSuite extends Http4sSuite {
     MultipartParser.parseStreamed[IO],
     MultipartParser.parseToPartsStream[IO](_))
 
-  @nowarn("cat=deprecation")
-  val _ = multipartParserTests(
-    "mixed file parser",
-    MultipartParser.parseStreamedFile[IO](_),
-    MultipartParser.parseStreamedFile[IO](_, _),
-    MultipartParser.parseToPartsStreamedFile[IO](_)
-  )
+  {
+    @nowarn("cat=deprecation")
+    val _ = multipartParserTests(
+      "mixed file parser",
+      MultipartParser.parseStreamedFile[IO](_),
+      MultipartParser.parseStreamedFile[IO](_, _),
+      MultipartParser.parseToPartsStreamedFile[IO](_)
+    )
+  }
 
   multipartParserResourceTests(
     "supervised file parser",

--- a/tests/src/test/scala/org/http4s/multipart/MultipartParserSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartParserSuite.scala
@@ -29,6 +29,7 @@ import org.typelevel.ci._
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.NoSuchFileException
+import scala.annotation.nowarn
 
 class MultipartParserSuite extends Http4sSuite {
 
@@ -764,7 +765,8 @@ class MultipartParserSuite extends Http4sSuite {
     MultipartParser.parseStreamed[IO],
     MultipartParser.parseToPartsStream[IO](_))
 
-  multipartParserTests(
+  @nowarn("cat=deprecation")
+  val _ = multipartParserTests(
     "mixed file parser",
     MultipartParser.parseStreamedFile[IO](_),
     MultipartParser.parseStreamedFile[IO](_, _),
@@ -795,6 +797,7 @@ class MultipartParserSuite extends Http4sSuite {
     val input = ruinDelims(unprocessedInput)
 
     val boundaryTest = Boundary("RU(_9F(PcJK5+JMOPCAF6Aj4iSXvpJkWy):6s)YU0")
+    @nowarn("cat=deprecation")
     val results =
       unspool(input).through(MultipartParser.parseStreamedFile[IO](boundaryTest, maxParts = 1))
 
@@ -828,6 +831,7 @@ class MultipartParserSuite extends Http4sSuite {
     val input = ruinDelims(unprocessedInput)
 
     val boundaryTest = Boundary("RU(_9F(PcJK5+JMOPCAF6Aj4iSXvpJkWy):6s)YU0")
+    @nowarn("cat=deprecation")
     val results = unspool(input).through(
       MultipartParser
         .parseStreamedFile[IO](boundaryTest, maxParts = 1, failOnLimit = true))

--- a/tests/src/test/scala/org/http4s/multipart/MultipartParserSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartParserSuite.scala
@@ -69,6 +69,19 @@ class MultipartParserSuite extends Http4sSuite {
       multipartPipe: Boundary => Pipe[IO, Byte, Multipart[IO]],
       limitedPipe: (Boundary, Int) => Pipe[IO, Byte, Multipart[IO]],
       partsPipe: Boundary => Pipe[IO, Byte, Part[IO]])(implicit loc: munit.Location): Unit = {
+    multipartParserResourceTests(
+      testName,
+      boundary => Resource.pure(multipartPipe(boundary)),
+      (boundary, limit) => Resource.pure(limitedPipe(boundary, limit)),
+      boundary => Resource.pure(partsPipe(boundary))
+    )
+  }
+
+  def multipartParserResourceTests(
+      testName: String,
+      mkMultipartPipe: Boundary => Resource[IO, Pipe[IO, Byte, Multipart[IO]]],
+      mkLimitedPipe: (Boundary, Int) => Resource[IO, Pipe[IO, Byte, Multipart[IO]]],
+      mkPartsPipe: Boundary => Resource[IO, Pipe[IO, Byte, Part[IO]]])(implicit loc: munit.Location): Unit = {
 
     val testNamePrefix = s"form streaming parsing for $testName"
 
@@ -102,23 +115,27 @@ class MultipartParserSuite extends Http4sSuite {
               |catch me if you can!
               |""".stripMargin)
 
-        val results =
-          unspool(input, chunkSize).through(multipartPipe(boundary))
+        val mkResults =
+          mkMultipartPipe(boundary).map(
+            _(unspool(input, chunkSize))
+          )
 
-        for {
-          multipartMaterialized <- results.compile.last.map(_.get)
-          headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
-          bodies = multipartMaterialized.parts
-            .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
-            .through(asciiDecode)
-            .compile
-            .foldMonoid
-          result <- bodies.attempt
-        } yield {
-          headers.headers.foreach(h => println(">> " + h))
-          expectedHeaders.headers.foreach(h => println("<< " + h))
-          assertEquals(headers, expectedHeaders)
-          assertEquals(result, Right(expected))
+        mkResults.use { results =>
+          for {
+            multipartMaterialized <- results.compile.last.map(_.get)
+            headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
+            bodies = multipartMaterialized.parts
+              .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
+              .through(asciiDecode)
+              .compile
+              .foldMonoid
+            result <- bodies.attempt
+          } yield {
+            headers.headers.foreach(h => println(">> " + h))
+            expectedHeaders.headers.foreach(h => println("<< " + h))
+            assertEquals(headers, expectedHeaders)
+            assertEquals(result, Right(expected))
+          }
         }
       }
 
@@ -138,8 +155,10 @@ class MultipartParserSuite extends Http4sSuite {
             |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI--""".stripMargin
 
       val input = ruinDelims(unprocessedInput)
-      val results =
-        unspool(input, 15).through(multipartPipe(boundary))
+      val mkResults =
+        mkMultipartPipe(boundary).map(
+          _(unspool(input, 15))
+        )
 
       val expectedHeaders = Headers(
         `Content-Disposition`(
@@ -154,19 +173,21 @@ class MultipartParserSuite extends Http4sSuite {
             |catch me if you can!
             |""".stripMargin)
 
-      for {
-        multipartMaterialized <- results.compile.last.map(_.get)
-        headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
-        bodies =
-          multipartMaterialized.parts
-            .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
-            .through(asciiDecode)
-            .compile
-            .foldMonoid
-        result <- bodies.attempt
-      } yield {
-        assertEquals(headers, expectedHeaders)
-        assertEquals(result, Right(expected))
+      mkResults.use { results =>
+        for {
+          multipartMaterialized <- results.compile.last.map(_.get)
+          headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
+          bodies =
+            multipartMaterialized.parts
+              .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
+              .through(asciiDecode)
+              .compile
+              .foldMonoid
+          result <- bodies.attempt
+        } yield {
+          assertEquals(headers, expectedHeaders)
+          assertEquals(result, Right(expected))
+        }
       }
     }
 
@@ -184,9 +205,10 @@ class MultipartParserSuite extends Http4sSuite {
             |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI--""".stripMargin
 
       val input = ruinDelims(unprocessedInput)
-      val results =
-        unspool(input, 15, StandardCharsets.UTF_8)
-          .through(multipartPipe(boundary))
+      val mkResults =
+        mkMultipartPipe(boundary).map(
+          _(unspool(input, 15, StandardCharsets.UTF_8))
+        )
 
       val expectedHeaders = Headers(
         "Content-Disposition" -> """form-data; name*="http4s很棒"; filename*="我老婆太漂亮.txt"""",
@@ -199,20 +221,22 @@ class MultipartParserSuite extends Http4sSuite {
             |catch me if you can!
             |""".stripMargin)
 
-      for {
-        multipartMaterialized <- results.compile.last.map(_.get)
-        headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
-        bodies =
-          multipartMaterialized.parts
-            .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
-            .through(asciiDecode)
-            .compile
-            .foldMonoid
-        result <- bodies.attempt
-      } yield {
+      mkResults.use { results =>
+        for {
+          multipartMaterialized <- results.compile.last.map(_.get)
+          headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
+          bodies =
+            multipartMaterialized.parts
+              .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
+              .through(asciiDecode)
+              .compile
+              .foldMonoid
+          result <- bodies.attempt
+        } yield {
 
-        assertEquals(headers, expectedHeaders)
-        assertEquals(result, Right(expected))
+          assertEquals(headers, expectedHeaders)
+          assertEquals(result, Right(expected))
+        }
       }
     }
 
@@ -230,9 +254,10 @@ class MultipartParserSuite extends Http4sSuite {
             |--_5PHqf8_Pl1FCzBuT5o_mVZg36k67UYI--""".stripMargin
 
       val input = ruinDelims(unprocessedInput)
-      val results =
-        unspool(input, 15, StandardCharsets.UTF_8)
-          .through(multipartPipe(boundary))
+      val mkResults =
+        mkMultipartPipe(boundary).map(
+          _(unspool(input, 15, StandardCharsets.UTF_8))
+        )
 
       val expectedHeaders = Headers(
         // #4513 for why this isn't a modeled header
@@ -248,19 +273,21 @@ class MultipartParserSuite extends Http4sSuite {
             |catch me if you can!
             |""".stripMargin)
 
-      for {
-        multipartMaterialized <- results.compile.last.map(_.get)
-        headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
-        bodies =
-          multipartMaterialized.parts
-            .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
-            .through(asciiDecode)
-            .compile
-            .foldMonoid
-        result <- bodies.attempt
-      } yield {
-        assertEquals(headers, expectedHeaders)
-        assertEquals(result, Right(expected))
+      mkResults.use { results =>
+        for {
+          multipartMaterialized <- results.compile.last.map(_.get)
+          headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
+          bodies =
+            multipartMaterialized.parts
+              .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
+              .through(asciiDecode)
+              .compile
+              .foldMonoid
+          result <- bodies.attempt
+        } yield {
+          assertEquals(headers, expectedHeaders)
+          assertEquals(result, Right(expected))
+        }
       }
     }
 
@@ -309,25 +336,30 @@ class MultipartParserSuite extends Http4sSuite {
           .take(10)
           .through(text.utf8Encode)
 
-      val results = (
-        preamble ++
-          crlf ++
-          unspool(input, 15) ++
-          epilogue
-      ).through(multipartPipe(boundary))
+      val mkResults =
+        mkMultipartPipe(boundary).map(
+          _(
+            preamble ++
+              crlf ++
+              unspool(input, 15) ++
+              epilogue
+          )
+        )
 
-      for {
-        multipartMaterialized <- results.compile.last.map(_.get)
-        headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
-        bodies = multipartMaterialized.parts
-          .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
-          .through(asciiDecode)
-          .compile
-          .foldMonoid
-        result <- bodies.attempt
-      } yield {
-        assertEquals(headers, expectedHeaders)
-        assertEquals(result, Right(expected))
+      mkResults.use { results =>
+        for {
+          multipartMaterialized <- results.compile.last.map(_.get)
+          headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
+          bodies = multipartMaterialized.parts
+            .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
+            .through(asciiDecode)
+            .compile
+            .foldMonoid
+          result <- bodies.attempt
+        } yield {
+          assertEquals(headers, expectedHeaders)
+          assertEquals(result, Right(expected))
+        }
       }
     }
 
@@ -355,12 +387,16 @@ class MultipartParserSuite extends Http4sSuite {
             |Content-Transfer-Encoding: binary""".stripMargin
       val maxSize = ruinDelims(headerSection).length
 
-      val results =
-        unspool(input, 15).through(limitedPipe(boundary, maxSize))
+      val mkResults =
+        mkLimitedPipe(boundary, maxSize).map(
+          _(unspool(input, 15))
+        )
 
-      results.compile.toVector
-        .interceptMessage[MalformedMessageBodyFailure](
-          s"Malformed message body: Part header was longer than $maxSize-byte limit")
+      mkResults.use { results =>
+        results.compile.toVector
+          .interceptMessage[MalformedMessageBodyFailure](
+            s"Malformed message body: Part header was longer than $maxSize-byte limit")
+      }
     }
 
     test(s"$testNamePrefix: handle a miserably large body on one line") {
@@ -391,17 +427,21 @@ class MultipartParserSuite extends Http4sSuite {
         .take(100000)
         .through(text.utf8Encode)
 
-      val results = (
-        unspool(input) ++
-          body ++
-          crlf ++
-          unspool(end)
-      ).through(multipartPipe(boundary))
+      val mkResults = mkMultipartPipe(boundary).map(
+        _(
+          unspool(input) ++
+            body ++
+            crlf ++
+            unspool(end)
+        )
+      )
 
-      results.compile.last
-        .map(_.get)
-        .map(_.parts.foldLeft(Headers.empty)(_ ++ _.headers))
-        .assertEquals(expectedHeaders)
+      mkResults.use { results =>
+        results.compile.last
+          .map(_.get)
+          .map(_.parts.foldLeft(Headers.empty)(_ ++ _.headers))
+          .assertEquals(expectedHeaders)
+      }
     }
 
     test(s"$testNamePrefix: produce the body from a single part input of one chunk") {
@@ -433,19 +473,25 @@ class MultipartParserSuite extends Http4sSuite {
             |catch me if you can!
             |""".stripMargin)
 
-      val results = unspool(input).through(multipartPipe(boundary))
-      for {
-        multipartMaterialized <- results.compile.last.map(_.get)
-        headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
-        bodies = multipartMaterialized.parts
-          .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
-          .through(asciiDecode)
-          .compile
-          .foldMonoid
-        result <- bodies.attempt
-      } yield {
-        assertEquals(headers, expectedHeaders)
-        assertEquals(result, Right(expected))
+      val mkResults =
+        mkMultipartPipe(boundary).map(
+          _(unspool(input))
+        )
+
+      mkResults.use { results =>
+        for {
+          multipartMaterialized <- results.compile.last.map(_.get)
+          headers = multipartMaterialized.parts.foldLeft(Headers.empty)(_ ++ _.headers)
+          bodies = multipartMaterialized.parts
+            .foldLeft(Stream.empty.covary[IO]: Stream[IO, Byte])(_ ++ _.body)
+            .through(asciiDecode)
+            .compile
+            .foldMonoid
+          result <- bodies.attempt
+        } yield {
+          assertEquals(headers, expectedHeaders)
+          assertEquals(result, Right(expected))
+        }
       }
     }
 
@@ -469,16 +515,22 @@ class MultipartParserSuite extends Http4sSuite {
 
       val input = ruinDelims(unprocessedInput)
 
-      val results = unspool(input).through(multipartPipe(boundary))
-      results.compile.last
-        .map(_.get)
-        .map(
-          _.parts(1).body
-            .through(asciiDecode)
-            .compile
-            .foldMonoid)
-        .flatMap(_.attempt)
-        .assertEquals(Right("bar"))
+      val mkResults =
+        mkMultipartPipe(boundary).map(
+          _(unspool(input))
+        )
+
+      mkResults.use { results =>
+        results.compile.last
+          .map(_.get)
+          .map(
+            _.parts(1).body
+              .through(asciiDecode)
+              .compile
+              .foldMonoid)
+          .flatMap(_.attempt)
+          .assertEquals(Right("bar"))
+      }
     }
 
     test(s"$testNamePrefix: parse uneven input properly") {
@@ -506,16 +558,22 @@ class MultipartParserSuite extends Http4sSuite {
           .flatMap(Stream.chunk)
           .covary[IO]
 
-      val results = unprocessed.through(multipartPipe(boundary))
-      results.compile.last
-        .map(_.get)
-        .map(
-          _.parts(1).body
-            .through(asciiDecode)
-            .compile
-            .foldMonoid)
-        .flatMap(_.attempt)
-        .assertEquals(Right("bar"))
+      val mkResults =
+        mkMultipartPipe(boundary).map(
+          _(unprocessed)
+        )
+
+      mkResults.use { results =>
+        results.compile.last
+          .map(_.get)
+          .map(
+            _.parts(1).body
+              .through(asciiDecode)
+              .compile
+              .foldMonoid)
+          .flatMap(_.attempt)
+          .assertEquals(Right("bar"))
+      }
     }
 
     def parseRandomizedChunkLength(count: Int): Unit =
@@ -539,16 +597,22 @@ class MultipartParserSuite extends Http4sSuite {
 
         val unprocessed = jumble(unprocessedInput)
 
-        val results = unprocessed.through(multipartPipe(boundary))
-        results.compile.last
-          .map(_.get)
-          .map(
-            _.parts(1).body
-              .through(asciiDecode)
-              .compile
-              .foldMonoid)
-          .flatMap(_.attempt)
-          .assertEquals(Right("bar"))
+        val mkResults =
+          mkMultipartPipe(boundary).map(
+            _(unprocessed)
+          )
+
+        mkResults.use { results =>
+          results.compile.last
+            .map(_.get)
+            .map(
+              _.parts(1).body
+                .through(asciiDecode)
+                .compile
+                .foldMonoid)
+            .flatMap(_.attempt)
+            .assertEquals(Right("bar"))
+        }
       }
 
     List.range(0, 100).foreach(parseRandomizedChunkLength)
@@ -569,22 +633,27 @@ class MultipartParserSuite extends Http4sSuite {
       val input = ruinDelims(unprocessedInput)
 
       val boundaryTest = Boundary("RU(_9F(PcJK5+JMOPCAF6Aj4iSXvpJkWy):6s)YU0")
-      val results = unspool(input).through(multipartPipe(boundaryTest))
+      val mkResults =
+        mkMultipartPipe(boundaryTest).map(
+          _(unspool(input))
+        )
 
-      results.compile.last
-        .map(_.get)
-        .map(_.parts.foldLeft(List.empty[Headers])((l, r) => l ::: List(r.headers)))
-        .assertEquals(
-          List(
-            Headers(
-              `Content-Disposition`("form-data", Map(ci"name" -> "field1")),
-              `Content-Type`(MediaType.text.plain)
-            ),
-            Headers(
-              `Content-Disposition`("form-data", Map(ci"name" -> "field2"))
+      mkResults.use { results =>
+        results.compile.last
+          .map(_.get)
+          .map(_.parts.foldLeft(List.empty[Headers])((l, r) => l ::: List(r.headers)))
+          .assertEquals(
+            List(
+              Headers(
+                `Content-Disposition`("form-data", Map(ci"name" -> "field1")),
+                `Content-Type`(MediaType.text.plain)
+              ),
+              Headers(
+                `Content-Disposition`("form-data", Map(ci"name" -> "field2"))
+              )
             )
           )
-        )
+      }
     }
 
     test(s"$testNamePrefix: parse parts lazily") {
@@ -606,26 +675,31 @@ class MultipartParserSuite extends Http4sSuite {
       val input = ruinDelims(unprocessedInput)
 
       val boundaryTest = Boundary("RU(_9F(PcJK5+JMOPCAF6Aj4iSXvpJkWy):6s)YU0")
-      val results = unspool(input).through(partsPipe(boundaryTest))
+      val mkResults =
+        mkPartsPipe(boundaryTest).map(
+          _(unspool(input))
+        )
 
-      for {
-        firstPart <- results.take(1).compile.last.map(_.get)
-        confirmedError <- results.compile.drain.attempt
-        _ <- firstPart.body
-          .through(text.utf8Decode[IO])
-          .compile
-          .foldMonoid
-      } yield {
-        assertEquals(
-          firstPart.headers,
-          Headers(
-            `Content-Disposition`("form-data", Map(ci"name" -> "field1")),
-            `Content-Type`(MediaType.text.plain)))
-        assert(confirmedError.isInstanceOf[Left[_, _]])
-        assert(
-          confirmedError.left
-            .getOrElse(throw new Exception)
-            .isInstanceOf[MalformedMessageBodyFailure])
+      mkResults.use { results =>
+        for {
+          firstPart <- results.take(1).compile.last.map(_.get)
+          confirmedError <- results.compile.drain.attempt
+          _ <- firstPart.body
+            .through(text.utf8Decode[IO])
+            .compile
+            .foldMonoid
+        } yield {
+          assertEquals(
+            firstPart.headers,
+            Headers(
+              `Content-Disposition`("form-data", Map(ci"name" -> "field1")),
+              `Content-Type`(MediaType.text.plain)))
+          assert(confirmedError.isInstanceOf[Left[_, _]])
+          assert(
+            confirmedError.left
+              .getOrElse(throw new Exception)
+              .isInstanceOf[MalformedMessageBodyFailure])
+        }
       }
     }
 
@@ -642,15 +716,17 @@ class MultipartParserSuite extends Http4sSuite {
 
         val input = ruinDelims(unprocessedInput)
 
-        for {
-          // This should be false until we drain the whole input.
-          ref <- Ref[IO].of(false)
-          trackedInput = unspool(input, chunkSize) ++ Stream.eval(ref.set(true)).drain
+        mkMultipartPipe(boundary).use { multipartPipe =>
+          for {
+            // This should be false until we drain the whole input.
+            ref <- Ref[IO].of(false)
+            trackedInput = unspool(input, chunkSize) ++ Stream.eval(ref.set(true)).drain
 
-          _ <- trackedInput.through(multipartPipe(boundary)).compile.drain
+            _ <- trackedInput.through(multipartPipe).compile.drain
 
-          reachedTheEnd <- ref.get
-        } yield assert(reachedTheEnd)
+            reachedTheEnd <- ref.get
+          } yield assert(reachedTheEnd)
+        }
       }
 
     List(1, 2, 3, 5, 8, 13, 21, 987).foreach(drainEpilogue)
@@ -668,9 +744,14 @@ class MultipartParserSuite extends Http4sSuite {
             |catch me if you can!""".stripMargin
       val input = ruinDelims(unprocessedInput)
 
-      val results = unspool(input).through(multipartPipe(boundary))
+      val mkResults =
+        mkMultipartPipe(boundary).map(
+        _(unspool(input))
+        )
 
-      results.compile.toVector.intercept[MalformedMessageBodyFailure]
+      mkResults.use { results =>
+        results.compile.toVector.intercept[MalformedMessageBodyFailure]
+      }
     }
   }
 

--- a/tests/src/test/scala/org/http4s/multipart/MultipartParserSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartParserSuite.scala
@@ -767,12 +767,13 @@ class MultipartParserSuite extends Http4sSuite {
 
   {
     @nowarn("cat=deprecation")
-    val _ = multipartParserTests(
+    val testDeprecated = multipartParserTests(
       "mixed file parser",
       MultipartParser.parseStreamedFile[IO](_),
       MultipartParser.parseStreamedFile[IO](_, _),
       MultipartParser.parseToPartsStreamedFile[IO](_)
     )
+    testDeprecated
   }
 
   multipartParserResourceTests(

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -207,7 +207,9 @@ I am a big moose
 
   {
     @nowarn("cat=deprecation")
-    val _ = multipartSpec("with mixed decoder")(Resource.pure(EntityDecoder.mixedMultipart[IO]()))
+    val testDeprecated =
+      multipartSpec("with mixed decoder")(Resource.pure(EntityDecoder.mixedMultipart[IO]()))
+    testDeprecated
   }
   multipartSpec("with mixed resource decoder")(EntityDecoder.mixedMultipartResource[IO]())
 

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -48,7 +48,9 @@ class MultipartSuite extends Http4sSuite {
       a.parts === b.parts
     }
 
-  def multipartSpec(name: String)(implicit E: EntityDecoder[IO, Multipart[IO]]) = {
+  def multipartSpec(name: String)(
+      mkDecoder: Resource[IO, EntityDecoder[IO, Multipart[IO]]]
+  ) = {
     {
       test(s"Multipart form data $name should be encoded and decoded with content types") {
         val field1 =
@@ -59,10 +61,13 @@ class MultipartSuite extends Http4sSuite {
         val body = entity.body
         val request =
           Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
-        val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value
 
-        assertIOBoolean(result.map(_ === Right(multipart)))
+        mkDecoder.use { decoder =>
+          val decoded = decoder.decode(request, true)
+          val result = decoded.value
+
+          assertIOBoolean(result.map(_ === Right(multipart)))
+        }
       }
 
       test(s"Multipart form data $name should be encoded and decoded without content types") {
@@ -73,10 +78,13 @@ class MultipartSuite extends Http4sSuite {
         val body = entity.body
         val request =
           Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
-        val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value
 
-        assertIOBoolean(result.map(_ === Right(multipart)))
+        mkDecoder.use { decoder =>
+          val decoded = decoder.decode(request, true)
+          val result = decoded.value
+
+          assertIOBoolean(result.map(_ === Right(multipart)))
+        }
       }
 
       test(s"Multipart form data $name should encoded and decoded with binary data") {
@@ -93,10 +101,12 @@ class MultipartSuite extends Http4sSuite {
         val request =
           Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
 
-        val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value
+        mkDecoder.use { decoder =>
+          val decoded = decoder.decode(request, true)
+          val result = decoded.value
 
-        assertIOBoolean(result.map(_ === Right(multipart)))
+          assertIOBoolean(result.map(_ === Right(multipart)))
+        }
       }
 
       test(s"Multipart form data $name should be decoded and encode with content types") {
@@ -127,10 +137,12 @@ Content-Type: application/pdf
           body = Stream.emit(body).covary[IO].through(text.utf8Encode),
           headers = header)
 
-        val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value.map(_.isRight)
+        mkDecoder.use { decoder =>
+          val decoded = decoder.decode(request, true)
+          val result = decoded.value.map(_.isRight)
 
-        result.assertEquals(true)
+          result.assertEquals(true)
+        }
       }
 
       test(s"Multipart form data $name should be decoded and encoded without content types") {
@@ -154,10 +166,13 @@ I am a big moose
           uri = url,
           body = Stream.emit(body).through(text.utf8Encode),
           headers = header)
-        val decoded = EntityDecoder[IO, Multipart[IO]].decode(request, true)
-        val result = decoded.value.map(_.isRight)
 
-        result.assertEquals(true)
+        mkDecoder.use { decoder =>
+          val decoded = decoder.decode(request, true)
+          val result = decoded.value.map(_.isRight)
+
+          result.assertEquals(true)
+        }
       }
 
       test(s"Multipart form data $name should extract name properly if it is present") {
@@ -187,8 +202,9 @@ I am a big moose
     }
   }
 
-  multipartSpec("with default decoder")(implicitly)
-  multipartSpec("with mixed decoder")(EntityDecoder.mixedMultipart[IO]())
+  multipartSpec("with default decoder")(Resource.pure(implicitly))
+  multipartSpec("with mixed decoder")(Resource.pure(EntityDecoder.mixedMultipart[IO]()))
+  multipartSpec("with mixed resource decoder")(EntityDecoder.mixedMultipartResource[IO]())
 
   def testPart[F[_]] = Part[F](Headers.empty, EmptyBody)
 

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -204,8 +204,11 @@ I am a big moose
   }
 
   multipartSpec("with default decoder")(Resource.pure(implicitly))
-  @nowarn("cat=deprecation")
-  val _ = multipartSpec("with mixed decoder")(Resource.pure(EntityDecoder.mixedMultipart[IO]()))
+
+  {
+    @nowarn("cat=deprecation")
+    val _ = multipartSpec("with mixed decoder")(Resource.pure(EntityDecoder.mixedMultipart[IO]()))
+  }
   multipartSpec("with mixed resource decoder")(EntityDecoder.mixedMultipartResource[IO]())
 
   def testPart[F[_]] = Part[F](Headers.empty, EmptyBody)

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -27,6 +27,7 @@ import org.http4s.headers._
 import org.http4s.syntax.literals._
 import org.http4s.EntityEncoder._
 import org.typelevel.ci._
+import scala.annotation.nowarn
 
 class MultipartSuite extends Http4sSuite {
   val url = uri"https://example.com/path/to/some/where"
@@ -203,7 +204,8 @@ I am a big moose
   }
 
   multipartSpec("with default decoder")(Resource.pure(implicitly))
-  multipartSpec("with mixed decoder")(Resource.pure(EntityDecoder.mixedMultipart[IO]()))
+  @nowarn("cat=deprecation")
+  val _ = multipartSpec("with mixed decoder")(Resource.pure(EntityDecoder.mixedMultipart[IO]()))
   multipartSpec("with mixed resource decoder")(EntityDecoder.mixedMultipartResource[IO]())
 
   def testPart[F[_]] = Part[F](Headers.empty, EmptyBody)


### PR DESCRIPTION
Fixes #2627.

The behavior and the interface should mostly match the existing mixed multipart parser. The difference is twofold:
1. The main point is that, instead of deleting files manually, this spawns a background fiber with the resource's lifecycle (as a `Resource.use`). Said fiber is managed by the provided `Supervisor`. When the `Supervisor` is closed, the fiber is canceled, at which point the file is deleted. See `superviseResource` for the implementation. This setup is not perfect (e.g. if the main stream fails, the fibers are not released, and the resources are not released until the supervisor is released), but it should be enough for the intended scenario (one-use `EntityDecoder`s).
2. A minor improvement is the addition of a separate parameter controlling chunk size when reading the file. In the existing parser the chunk size matches `maxSizeBeforeWrite`, which means the implementation creates 50MB arrays when reading the cached data.
    Admittedly, I didn't put much thought into the default chunk size (8192 bytes), so if there is a better default, I'd be happy to change the code.

Additional changes:
1. I've changed existing multipart tests a bit (wrapping parameters in `Resource`), so that I could reuse them for the new implementation.
2. I've factored out a common `EntityDecoder` implementation in `MultipartDecoder`.
3. I've added missing ScalaDoc to `EntityDecoder.mixedMultipart` (copied and pasted from the corresponding `MultipartDecoder` function).
4. ~~I've taken the liberty to deprecate the existing (unsafe) mixed multipart decoder.~~ CI sees the tests (!) using deprecated functions, and cries foul. Reverted this for now.