### PR TITLE
Fix "Insert a User-Agent header" test

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
@@ -25,6 +25,7 @@ import fs2.Stream
 import fs2.concurrent.Queue
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+import org.http4s.BuildInfo
 import org.http4s.blaze.client.bits.DefaultUserAgent
 import org.http4s.blaze.pipeline.Command.EOF
 import org.http4s.blaze.pipeline.LeafBuilder
@@ -192,7 +193,7 @@ class Http1ClientStageSuite extends Http4sSuite {
     }
   }
 
-  test("Insert a User-Agent header".flaky) {
+  test("Insert a User-Agent header") {
     val resp = "HTTP/1.1 200 OK\r\n\r\ndone"
 
     getSubmission(FooRequest, resp, DefaultUserAgent).map { case (request, response) =>


### PR DESCRIPTION
I *think* this PR fixes a flaky User-Agent test.

Prior to these changes this test repeatedly failed on my system.
Weirdly, metals couldn't find the definition of `BuildInfo`, and `BuildInfo.version` was also 0.15.1 in scope of this test.
(That happens to be the [blaze version number](https://github.com/http4s/http4s/blob/83df69ae4ba56d1062bff9e55722cbc9eb0bc478/project/Http4sPlugin.scala#L286), but I can't figure that out.)

Adding the import meant the test passed each time I ran it.

I've removed the `.flaky`, perhaps that is over confident...