### PR TITLE
Lazy header parse

### DIFF
--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -182,7 +182,7 @@ object Header {
     type Aux[A, G[_]] = Select[A] { type F[B] = G[B] }
 
     def fromRaw[A](h: Header.Raw)(implicit ev: Header[A, _]): Option[Ior[ParseFailure, A]] =
-      (h.name == Header[A].name).guard[Option].as(Header[A].parse(h.value).toIor)
+      (h.name == Header[A].name).guard[Option].map(_ => Header[A].parse(h.value).toIor)
 
     implicit def singleHeaders[A](implicit
         h: Header[A, Header.Single]): Select[A] { type F[B] = B } =


### PR DESCRIPTION
Ran into this when while trying to debug why a header parser was throwing an exception on a header it wasn't even intended for. The way it's coded right now, if we try to parse a header from its raw form, it'll parse every preceding header searched as well, even if the name doesn't match. This is definitely a performance hit when headers are queried