### PR TITLE
Core - Change Message Body definition

### DIFF
--- a/core/shared/src/main/scala/org/http4s/AuthedRequest.scala
+++ b/core/shared/src/main/scala/org/http4s/AuthedRequest.scala
@@ -20,10 +20,10 @@ import cats.Functor
 import cats.data.Kleisli
 
 object AuthedRequest {
-  def apply[F[_]: Functor, T](
-      getUser: Request[F] => F[T]): Kleisli[F, Request[F], AuthedRequest[F, T]] =
-    ContextRequest[F, T](getUser)
+  def apply[F[_]: Functor, Body, T](
+      getUser: Request[Body] => F[T]): Kleisli[F, Request[Body], AuthedRequest[Body, T]] =
+    ContextRequest[F, T, Body](getUser)
 
-  def apply[F[_], T](context: T, req: Request[F]): AuthedRequest[F, T] =
-    ContextRequest[F, T](context, req)
+  def apply[Body, T](context: T, req: Request[Body]): AuthedRequest[Body, T] =
+    ContextRequest[Body, T](context, req)
 }

--- a/core/shared/src/main/scala/org/http4s/AuthedRoutes.scala
+++ b/core/shared/src/main/scala/org/http4s/AuthedRoutes.scala
@@ -31,8 +31,10 @@ object AuthedRoutes {
     * @param run the function to lift
     * @return an [[AuthedRoutes]] that wraps `run`
     */
-  def apply[T, F[_]](run: AuthedRequest[F, T] => OptionT[F, Response[F]])(implicit
-      F: Monad[F]): AuthedRoutes[T, F] =
+  def apply[T, F[_]](
+    run: AuthedRequest[EntityBody[F], T] => OptionT[F, Response[EntityBody[F]]]
+  )(implicit F: Monad[F]
+  ): AuthedRoutes[T, F] =
     Kleisli(req => OptionT(F.unit >> run(req).value))
 
   /** Lifts a partial function into an [[AuthedRoutes]].  The application of the
@@ -44,7 +46,7 @@ object AuthedRoutes {
     * @return An [[AuthedRoutes]] that returns some [[Response]] in an `OptionT[F, *]`
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
-  def of[T, F[_]](pf: PartialFunction[AuthedRequest[F, T], F[Response[F]]])(implicit
+  def of[T, F[_]](pf: PartialFunction[AuthedRequest[EntityBody[F], T], F[Response[EntityBody[F]]]])(implicit
       FA: Monad[F]): AuthedRoutes[T, F] =
     Kleisli(req => OptionT(FA.unit >> pf.lift(req).sequence))
 

--- a/core/shared/src/main/scala/org/http4s/ContextRequest.scala
+++ b/core/shared/src/main/scala/org/http4s/ContextRequest.scala
@@ -16,37 +16,12 @@
 
 package org.http4s
 
-import cats._
-import cats.syntax.all._
-import cats.data.Kleisli
-
-final case class ContextRequest[F[_], A](context: A, req: Request[F]) {
-  def mapK[G[_]](fk: F ~> G): ContextRequest[G, A] =
+final case class ContextRequest[+ Body, A](context: A, req: Request[Body]) {
+  def mapK[Cod](fk: Body => Cod): ContextRequest[Cod, A] =
     ContextRequest(context, req.mapK(fk))
-
-  @deprecated("Use context instead", "0.21.0")
-  def authInfo: A = context
 }
 
 object ContextRequest {
-  def apply[F[_]: Functor, T](
-      getContext: Request[F] => F[T]): Kleisli[F, Request[F], ContextRequest[F, T]] =
-    Kleisli(request => getContext(request).map(ctx => ContextRequest(ctx, request)))
-
-  implicit def contextRequestInstances[F[_]]: NonEmptyTraverse[ContextRequest[F, *]] =
-    new NonEmptyTraverse[ContextRequest[F, *]] {
-      override def foldLeft[A, B](fa: ContextRequest[F, A], b: B)(f: (B, A) => B): B =
-        f(b, fa.context)
-      override def foldRight[A, B](fa: ContextRequest[F, A], lb: Eval[B])(
-          f: (A, Eval[B]) => Eval[B]): Eval[B] =
-        f(fa.context, lb)
-      override def nonEmptyTraverse[G[_]: Apply, A, B](fa: ContextRequest[F, A])(
-          f: A => G[B]): G[ContextRequest[F, B]] =
-        f(fa.context).map(b => ContextRequest(b, fa.req))
-      def reduceLeftTo[A, B](fa: ContextRequest[F, A])(f: A => B)(g: (B, A) => B): B =
-        f(fa.context)
-      def reduceRightTo[A, B](fa: ContextRequest[F, A])(f: A => B)(
-          g: (A, Eval[B]) => Eval[B]): Eval[B] =
-        Eval.later(f(fa.context))
-    }
+  def apply[T, Body](getContext: Request[Body] => T): Request[Body] => ContextRequest[Body, T] =
+    (req: Request[Body]) => ContextRequest(getContext(req), req)
 }

--- a/core/shared/src/main/scala/org/http4s/ContextResponse.scala
+++ b/core/shared/src/main/scala/org/http4s/ContextResponse.scala
@@ -18,11 +18,11 @@ package org.http4s
 
 import cats._
 
-final case class ContextResponse[F[_], A](context: A, response: Response[F]) {
-  def mapContext[B](f: A => B): ContextResponse[F, B] =
+final case class ContextResponse[Body, A](context: A, response: Response[Body]) {
+  def mapContext[B](f: A => B): ContextResponse[Body, B] =
     ContextResponse(f(context), response)
 
-  def mapK[G[_]](fk: F ~> G): ContextResponse[G, A] =
+  def mapK[Cod](fk: Body => Cod): ContextResponse[Cod, A] =
     ContextResponse(context, response.mapK(fk))
 }
 

--- a/core/shared/src/main/scala/org/http4s/ContextRoutes.scala
+++ b/core/shared/src/main/scala/org/http4s/ContextRoutes.scala
@@ -31,7 +31,7 @@ object ContextRoutes {
     * @param run the function to lift
     * @return an [[ContextRoutes]] that wraps `run`
     */
-  def apply[T, F[_]](run: ContextRequest[F, T] => OptionT[F, Response[F]])(implicit
+  def apply[T, Body, F[_]](run: ContextRequest[EntityBody[F], T] => OptionT[F, ResponseB[F]])(implicit
       F: Monad[F]): ContextRoutes[T, F] =
     Kleisli(req => OptionT(F.unit >> run(req).value))
 
@@ -44,7 +44,7 @@ object ContextRoutes {
     * @return An [[ContextRoutes]] that returns some [[Response]] in an `OptionT[F, *]`
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
-  def of[T, F[_]](pf: PartialFunction[ContextRequest[F, T], F[Response[F]]])(implicit
+  def of[T, F[_]](pf: PartialFunction[ContextRequestB[F, T], F[ResponseB[F]]])(implicit
       F: Monad[F]): ContextRoutes[T, F] =
     Kleisli(req => OptionT(Applicative[F].unit >> pf.lift(req).sequence))
 
@@ -58,7 +58,7 @@ object ContextRoutes {
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
   def strict[T, F[_]: Applicative](
-      pf: PartialFunction[ContextRequest[F, T], F[Response[F]]]): ContextRoutes[T, F] =
+      pf: PartialFunction[ContextRequest[F, T], F[ResponseB[F]]]): ContextRoutes[T, F] =
     Kleisli(req => OptionT(pf.lift(req).sequence))
 
   /** The empty service (all requests fallthrough).

--- a/core/shared/src/main/scala/org/http4s/DecodeResult.scala
+++ b/core/shared/src/main/scala/org/http4s/DecodeResult.scala
@@ -16,22 +16,13 @@
 
 package org.http4s
 
-import cats.{Applicative, Functor}
-import cats.data.EitherT
-
 object DecodeResult {
-  def apply[F[_], A](fa: F[Either[DecodeFailure, A]]): DecodeResult[F, A] =
-    EitherT(fa)
 
-  def success[F[_], A](fa: F[A])(implicit F: Functor[F]): DecodeResult[F, A] =
-    EitherT.right[DecodeFailure](fa)
+  def success(fa: F[A]): DecodeResult[F[A]] = Right(fa)
 
-  def successT[F[_], A](a: A)(implicit F: Applicative[F]): DecodeResult[F, A] =
-    EitherT.rightT[F, DecodeFailure](a)
+  def successT[A](a: A): DecodeResult[A] = Right(a)
 
-  def failure[F[_], A](fe: F[DecodeFailure])(implicit F: Functor[F]): DecodeResult[F, A] =
-    EitherT.left[A](fe)
+  def failure(fe: F[DecodeFailure]): DecodeResult[F[A]] = Left(fe)
 
-  def failureT[F[_], A](e: DecodeFailure)(implicit F: Applicative[F]): DecodeResult[F, A] =
-    EitherT.leftT[F, A](e)
+  def failureT[F[_], A](e: DecodeFailure): DecodeResult[F, A] = Left(e)
 }

--- a/core/shared/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityDecoder.scala
@@ -16,7 +16,6 @@
 
 package org.http4s
 
-import cats.{Applicative, Functor, Monad, SemigroupK}
 import cats.effect.Concurrent
 import cats.syntax.all._
 import fs2._
@@ -38,76 +37,69 @@ import cats.effect.Resource
   */
 @implicitNotFound(
   "Cannot decode into a value of type ${T}, because no EntityDecoder[${F}, ${T}] instance could be found.")
-trait EntityDecoder[F[_], T] { self =>
+trait EntityDecoder[Body, +T] { self =>
 
   /** Attempt to decode the body of the [[Message]] */
-  def decode(m: Media[F], strict: Boolean): DecodeResult[F, T]
+  def decode(m: Media[Body], strict: Boolean): DecodeResult[T]
 
   /** The [[MediaRange]]s this [[EntityDecoder]] knows how to handle */
   def consumes: Set[MediaRange]
 
   /** Make a new [[EntityDecoder]] by mapping the output result */
-  def map[T2](f: T => T2)(implicit F: Functor[F]): EntityDecoder[F, T2] =
-    new EntityDecoder[F, T2] {
+  def map[T2](f: T => T2): EntityDecoder[Body, T2] =
+    new EntityDecoder[Body, T2] {
       override def consumes: Set[MediaRange] = self.consumes
 
-      override def decode(m: Media[F], strict: Boolean): DecodeResult[F, T2] =
+      override def decode(m: Media[F], strict: Boolean): DecodeResult[T2] =
         self.decode(m, strict).map(f)
     }
 
-  def flatMapR[T2](f: T => DecodeResult[F, T2])(implicit F: Monad[F]): EntityDecoder[F, T2] =
-    new EntityDecoder[F, T2] {
-      override def decode(m: Media[F], strict: Boolean): DecodeResult[F, T2] =
+  def flatMapR[T2](f: T => DecodeResult[T2]): EntityDecoder[Body, T2] =
+    new EntityDecoder[Body, T2] {
+      override def decode(m: Media[Body], strict: Boolean): DecodeResult[T2] =
         self.decode(m, strict).flatMap(f)
 
       override def consumes: Set[MediaRange] = self.consumes
     }
 
-  def handleError(f: DecodeFailure => T)(implicit F: Functor[F]): EntityDecoder[F, T] =
+  def handleError(f: DecodeFailure => T): EntityDecoder[Body, T] =
     transform {
       case Left(e) => Right(f(e))
       case r @ Right(_) => r
     }
 
-  def handleErrorWith(f: DecodeFailure => DecodeResult[F, T])(implicit
-      F: Monad[F]): EntityDecoder[F, T] =
+  def handleErrorWith(f: DecodeFailure => DecodeResult[T]): EntityDecoder[Body, T] =
     transformWith {
       case Left(e) => f(e)
       case Right(r) => DecodeResult.successT(r)
     }
 
-  def bimap[T2](f: DecodeFailure => DecodeFailure, s: T => T2)(implicit
-      F: Functor[F]): EntityDecoder[F, T2] =
+  def bimap[T2](f: DecodeFailure => DecodeFailure, s: T => T2): EntityDecoder[Body, T2] =
     transform {
       case Left(e) => Left(f(e))
       case Right(r) => Right(s(r))
     }
 
-  def transform[T2](t: Either[DecodeFailure, T] => Either[DecodeFailure, T2])(implicit
-      F: Functor[F]): EntityDecoder[F, T2] =
+  def transform[T2](t: Either[DecodeFailure, T] => Either[DecodeFailure, T2]): EntityDecoder[Body, T2] =
     new EntityDecoder[F, T2] {
       override def consumes: Set[MediaRange] = self.consumes
 
-      override def decode(m: Media[F], strict: Boolean): DecodeResult[F, T2] =
+      override def decode(m: Media[Body], strict: Boolean): DecodeResult[T2] =
         self.decode(m, strict).transform(t)
     }
 
-  def biflatMap[T2](f: DecodeFailure => DecodeResult[F, T2], s: T => DecodeResult[F, T2])(implicit
-      F: Monad[F]): EntityDecoder[F, T2] =
+  def biflatMap[T2](f: DecodeFailure => DecodeResult[T2], s: T => DecodeResult[T2]): EntityDecoder[Body, T2] =
     transformWith {
       case Left(e) => f(e)
       case Right(r) => s(r)
     }
 
-  def transformWith[T2](f: Either[DecodeFailure, T] => DecodeResult[F, T2])(implicit
-      F: Monad[F]): EntityDecoder[F, T2] =
-    new EntityDecoder[F, T2] {
+  def transformWith[T2](f: Either[DecodeFailure, T] => DecodeResult[T2]): EntityDecoder[Body, T2] =
+    new EntityDecoder[Body, T2] {
       override def consumes: Set[MediaRange] = self.consumes
 
-      override def decode(m: Media[F], strict: Boolean): DecodeResult[F, T2] =
-        DecodeResult(
-          F.flatMap(self.decode(m, strict).value)(r => f(r).value)
-        )
+      override def decode(m: Media[Body], strict: Boolean): DecodeResult[T2] =
+        self.decode(m, strict)(r => f(r).value)
     }
 
   /** Combine two [[EntityDecoder]]'s
@@ -117,15 +109,14 @@ trait EntityDecoder[F[_], T] { self =>
     *
     * @param other backup [[EntityDecoder]]
     */
-  def orElse[T2 >: T](other: EntityDecoder[F, T2])(implicit F: Functor[F]): EntityDecoder[F, T2] =
+  def orElse[Cod <: Body, T2 >: T](other: EntityDecoder[Cod, T2]): EntityDecoder[Cod, T2] =
     widen[T2] <+> other
 
   /** true if this [[EntityDecoder]] knows how to decode the provided [[MediaType]] */
   def matchesMediaType(mediaType: MediaType): Boolean =
     consumes.exists(_.satisfiedBy(mediaType))
 
-  def widen[T2 >: T]: EntityDecoder[F, T2] =
-    this.asInstanceOf[EntityDecoder[F, T2]]
+  def widen[T2 >: T]: EntityDecoder[T2] = this
 }
 
 /** EntityDecoder is used to attempt to decode an [[EntityBody]]
@@ -139,31 +130,6 @@ object EntityDecoder {
   /** summon an implicit [[EntityDecoder]] */
   def apply[F[_], T](implicit ev: EntityDecoder[F, T]): EntityDecoder[F, T] = ev
 
-  implicit def semigroupKForEntityDecoder[F[_]: Functor]: SemigroupK[EntityDecoder[F, *]] =
-    new SemigroupK[EntityDecoder[F, *]] {
-      override def combineK[T](
-          a: EntityDecoder[F, T],
-          b: EntityDecoder[F, T]): EntityDecoder[F, T] =
-        new EntityDecoder[F, T] {
-          override def decode(m: Media[F], strict: Boolean): DecodeResult[F, T] = {
-            val mediaType = m.contentType.fold(UndefinedMediaType)(_.mediaType)
-
-            if (a.matchesMediaType(mediaType))
-              a.decode(m, strict)
-            else
-              b.decode(m, strict).leftMap {
-                case MediaTypeMismatch(actual, expected) =>
-                  MediaTypeMismatch(actual, expected ++ a.consumes)
-                case MediaTypeMissing(expected) =>
-                  MediaTypeMissing(expected ++ a.consumes)
-                case other => other
-              }
-          }
-
-          override def consumes: Set[MediaRange] = a.consumes ++ b.consumes
-        }
-    }
-
   /** Create a new [[EntityDecoder]]
     *
     * The new [[EntityDecoder]] will attempt to decode messages of type `T`
@@ -173,10 +139,10 @@ object EntityDecoder {
     * recoverable errors are returned as a [[DecodeResult#failure]], or that
     * system errors are raised in `F`.
     */
-  def decodeBy[F[_]: Applicative, T](r1: MediaRange, rs: MediaRange*)(
-      f: Media[F] => DecodeResult[F, T]): EntityDecoder[F, T] =
-    new EntityDecoder[F, T] {
-      override def decode(m: Media[F], strict: Boolean): DecodeResult[F, T] =
+  def decodeBy[Body, T](r1: MediaRange, rs: MediaRange*)(
+      f: Media[Body] => DecodeResult[T]): EntityDecoder[Body, T] =
+    new EntityDecoder[Body, T] {
+      override def decode(m: Media[Body], strict: Boolean): DecodeResult[T] =
         if (strict)
           m.contentType match {
             case Some(c) if matchesMediaType(c.mediaType) => f(m)
@@ -336,7 +302,7 @@ object EntityDecoder {
     MultipartDecoder.mixedMultipart(headerLimit, maxSizeBeforeWrite, maxParts, failOnLimit)
 
   /** An entity decoder that ignores the content and returns unit. */
-  implicit def void[F[_]: Concurrent]: EntityDecoder[F, Unit] =
+  implicit val void: EntityDecoder[Any, Unit] =
     EntityDecoder.decodeBy(MediaRange.`*/*`) { msg =>
       DecodeResult.success(msg.body.drain.compile.drain)
     }

--- a/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
@@ -156,7 +156,7 @@ object EntityEncoder {
     * `Transfer-Encoding: chunked` header is set, as we cannot know
     * the content length without running the stream.
     */
-  implicit def entityBodyEncoder[F[_]]: EntityEncoder[F, EntityBody[F]] =
+  implicit def entityBodyEncoder[F[_]]: EntityEncoder[EntityBody[F], EntityBody[F]] =
     encodeBy(`Transfer-Encoding`(TransferCoding.chunked.pure[NonEmptyList])) { body =>
       Entity(body, None)
     }
@@ -223,9 +223,9 @@ object EntityEncoder {
   implicit def multipartEncoder[F[_]]: EntityEncoder[F, Multipart[F]] =
     new MultipartEncoder[F]
 
-  implicit def entityEncoderContravariant[F[_]]: Contravariant[EntityEncoder[F, *]] =
+  implicit def entityEncoderContravariant[Body]: Contravariant[EntityEncoder[Body, *]] =
     new Contravariant[EntityEncoder[F, *]] {
-      override def contramap[A, B](r: EntityEncoder[F, A])(f: (B) => A): EntityEncoder[F, B] =
+      override def contramap[Body, B](r: EntityEncoder[Body, A])(f: (B) => A): EntityEncoder[Body, B] =
         r.contramap(f)
     }
 

--- a/core/shared/src/main/scala/org/http4s/Http.scala
+++ b/core/shared/src/main/scala/org/http4s/Http.scala
@@ -32,7 +32,7 @@ object Http {
     * @param run the function to lift
     * @return an [[Http]] that suspends `run`.
     */
-  def apply[F[_], G[_]](run: Request[G] => F[Response[G]])(implicit F: Monad[F]): Http[F, G] =
+  def apply[F[_], Body](run: Request[Body] => F[Response[Body]])(implicit F: Monad[F]): Http[F, Body] =
     Kleisli(req => F.unit >> run(req))
 
   /** Lifts an effectful [[Response]] into an [[Http]] kleisli.
@@ -42,7 +42,7 @@ object Http {
     * @param fr the effectful [[Response]] to lift
     * @return an [[Http]] that always returns `fr`
     */
-  def liftF[F[_], G[_]](fr: F[Response[G]]): Http[F, G] =
+  def liftF[F[_], Body](fr: F[Response[Body]]): Http[F, Body] =
     Kleisli.liftF(fr)
 
   /** Lifts a [[Response]] into an [[Http]] kleisli.
@@ -52,7 +52,7 @@ object Http {
     * @param r the [[Response]] to lift
     * @return an [[Http]] that always returns `r` in effect `F`
     */
-  def pure[F[_]: Applicative, G[_]](r: Response[G]): Http[F, G] =
+  def pure[F[_]: Applicative, Body](r: Response[Body]): Http[F, Body] =
     Kleisli.pure(r)
 
   /** Transforms an [[Http]] on its input.  The application of the
@@ -66,7 +66,7 @@ object Http {
     * @return An [[Http]] whose input is transformed by `f` before
     * being applied to `fa`
     */
-  def local[F[_], G[_]](f: Request[G] => Request[G])(fa: Http[F, G])(implicit
-      F: Monad[F]): Http[F, G] =
+  def local[F[_], Body](f: Request[Body] => Request[Body])(fa: Http[F, Body])(implicit
+      F: Monad[F]): Http[F, Body] =
     Kleisli(req => F.unit >> fa.run(f(req)))
 }

--- a/core/shared/src/main/scala/org/http4s/HttpApp.scala
+++ b/core/shared/src/main/scala/org/http4s/HttpApp.scala
@@ -30,7 +30,7 @@ object HttpApp {
     * @param run the function to lift
     * @return an [[HttpApp]] that wraps `run`
     */
-  def apply[F[_]: Monad](run: Request[F] => F[Response[F]]): HttpApp[F] =
+  def apply[F[_]: Monad](run: RequestB[F] => F[ResponseB[F]]): HttpApp[F] =
     Http(run)
 
   /** Lifts an effectful [[Response]] into an [[HttpApp]].
@@ -39,7 +39,7 @@ object HttpApp {
     * @param fr the effectful [[Response]] to lift
     * @return an [[HttpApp]] that always returns `fr`
     */
-  def liftF[F[_]](fr: F[Response[F]]): HttpApp[F] =
+  def liftF[F[_]](fr: F[ResponseB[F]]): HttpApp[F] =
     Kleisli.liftF(fr)
 
   /** Lifts a [[Response]] into an [[HttpApp]].
@@ -48,7 +48,7 @@ object HttpApp {
     * @param r the [[Response]] to lift
     * @return an [[Http]] that always returns `r` in effect `F`
     */
-  def pure[F[_]: Applicative](r: Response[F]): HttpApp[F] =
+  def pure[F[_]: Applicative](r: ResponseB[F]): HttpApp[F] =
     Kleisli.pure(r)
 
   /** Transforms an [[HttpApp]] on its input.  The application of the
@@ -61,7 +61,7 @@ object HttpApp {
     * @return An [[HttpApp]] whose input is transformed by `f` before
     * being applied to `fa`
     */
-  def local[F[_]](f: Request[F] => Request[F])(fa: HttpApp[F])(implicit F: Monad[F]): HttpApp[F] =
+  def local[F[_]](f: RequestB[F] => RequestB[F])(fa: HttpApp[F])(implicit F: Monad[F]): HttpApp[F] =
     Http.local(f)(fa)
 
   /** An app that always returns `404 Not Found`. */

--- a/core/shared/src/main/scala/org/http4s/HttpRoutes.scala
+++ b/core/shared/src/main/scala/org/http4s/HttpRoutes.scala
@@ -31,7 +31,7 @@ object HttpRoutes {
     * @param run the function to lift
     * @return an [[HttpRoutes]] that wraps `run`
     */
-  def apply[F[_]: Monad](run: Request[F] => OptionT[F, Response[F]]): HttpRoutes[F] =
+  def apply[F[_]: Monad](run: RequestB[F] => OptionT[F, ResponseB[F]]): HttpRoutes[F] =
     Http(run)
 
   /** Lifts an effectful [[Response]] into an [[HttpRoutes]].
@@ -40,7 +40,7 @@ object HttpRoutes {
     * @param fr the effectful [[Response]] to lift
     * @return an [[HttpRoutes]] that always returns `fr`
     */
-  def liftF[F[_]](fr: OptionT[F, Response[F]]): HttpRoutes[F] =
+  def liftF[F[_]](fr: OptionT[F, ResponseB[F]]): HttpRoutes[F] =
     Kleisli.liftF(fr)
 
   /** Lifts a [[Response]] into an [[HttpRoutes]].
@@ -49,7 +49,7 @@ object HttpRoutes {
     * @param r the [[Response]] to lift
     * @return an [[HttpRoutes]] that always returns `r` in effect `OptionT[F, *]`
     */
-  def pure[F[_]](r: Response[F])(implicit FO: Applicative[OptionT[F, *]]): HttpRoutes[F] =
+  def pure[F[_]](r: ResponseB[F])(implicit FO: Applicative[OptionT[F, *]]): HttpRoutes[F] =
     Kleisli.pure(r)
 
   /** Transforms an [[HttpRoutes]] on its input.  The application of the
@@ -62,7 +62,7 @@ object HttpRoutes {
     * @return An [[HttpRoutes]] whose input is transformed by `f` before
     * being applied to `fa`
     */
-  def local[F[_]: Monad](f: Request[F] => Request[F])(fa: HttpRoutes[F]): HttpRoutes[F] =
+  def local[F[_]: Monad](f: RequestB[F] => RequestB[F])(fa: HttpRoutes[F]): HttpRoutes[F] =
     Http.local[OptionT[F, *], F](f)(fa)
 
   /** Lifts a partial function into an [[HttpRoutes]].  The application of the
@@ -75,7 +75,7 @@ object HttpRoutes {
     * @return An [[HttpRoutes]] that returns some [[Response]] in an `OptionT[F, *]`
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
-  def of[F[_]: Monad](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] =
+  def of[F[_]: Monad](pf: PartialFunction[RequestB[F], F[ResponseB[F]]]): HttpRoutes[F] =
     Kleisli(req => OptionT(Applicative[F].unit >> pf.lift(req).sequence))
 
   /** Lifts a partial function into an [[HttpRoutes]].  The application of the
@@ -87,7 +87,7 @@ object HttpRoutes {
     * @return An [[HttpRoutes]] that returns some [[Response]] in an `OptionT[F, *]`
     * wherever `pf` is defined, an `OptionT.none` wherever it is not
     */
-  def strict[F[_]: Applicative](pf: PartialFunction[Request[F], F[Response[F]]]): HttpRoutes[F] =
+  def strict[F[_]: Applicative](pf: PartialFunction[RequestB[F], F[ResponseB[F]]]): HttpRoutes[F] =
     Kleisli(req => OptionT(pf.lift(req).sequence))
 
   /** An empty set of routes.  Always responds with `OptionT.none`.

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -174,7 +174,7 @@ sealed trait Message[+ Body] extends Media[Body] { self =>
   /** The trailer headers, as specified in Section 3.6.1 of RFC 2616. The resulting
     * F might not complete until the entire body has been consumed.
     */
-  def trailerHeaders(implicit F: Applicative[F]): F[Headers] =
+  def trailerHeaders[F[_]](implicit F: Applicative[F]): F[Headers] =
     attributes.lookup(Message.Keys.TrailerHeaders[F]).getOrElse(Headers.empty.pure[F])
 
   // Specific header methods
@@ -215,7 +215,7 @@ sealed trait Message[+ Body] extends Media[Body] { self =>
 
   /** Lifts this Message's body to the specified effect type.
     */
-  override def covary[F2[x] >: F[x]]: SelfF[F2] = this.asInstanceOf[SelfF[F2]]
+  override def covary[Cod >: Body]: SelfF[Cod] = this.asInstanceOf[SelfF[Cod]]
 }
 
 object Message {
@@ -405,7 +405,7 @@ final class Request[+ Body] private (
 
   def remoteAddr: Option[IpAddress] = remote.map(_.host)
 
-  def remoteHost(implicit F: Sync[F]): F[Option[Hostname]] = {
+  def remoteHost[F[_]](implicit F: Sync[F]): F[Option[Hostname]] = {
     val inetAddress = remote.map(_.host.toInetAddress)
     F.blocking(inetAddress.map(_.getHostName)).map(_.flatMap(Hostname.fromString))
   }

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -35,21 +35,21 @@ import scala.util.hashing.MurmurHash3
 
 /** Represents a HTTP Message. The interesting subclasses are Request and Response.
   */
-sealed trait Message[F[_]] extends Media[F] { self =>
-  type SelfF[F2[_]] <: Message[F2] { type SelfF[F3[_]] = self.SelfF[F3] }
-  type Self = SelfF[F]
+sealed trait Message[+ Body] extends Media[Body] { self =>
+  type SelfF[Cod] <: Message[Cod] { type SelfF[Dol] = self.SelfF[Dol] }
+  type Self = SelfF[Body]
 
   def httpVersion: HttpVersion
 
   def headers: Headers
 
-  def body: EntityBody[F]
+  def body: Body
 
   def attributes: Vault
 
   protected def change(
       httpVersion: HttpVersion = httpVersion,
-      body: EntityBody[F] = body,
+      body: EntityBody[Body] = body,
       headers: Headers = headers,
       attributes: Vault = attributes): Self
 
@@ -74,7 +74,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * @tparam T type of the Body
     * @return a new message with the new body
     */
-  def withEntity[T](b: T)(implicit w: EntityEncoder[F, T]): Self = {
+  def withEntity[T](b: T)(implicit w: EntityEncoder[Body, T]): Self = {
     val entity = w.toEntity(b)
     val hs = entity.length match {
       case Some(l) =>
@@ -96,7 +96,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * or `Content-Length`. Most use cases are better served by [[withEntity]],
     * which uses an [[EntityEncoder]] to maintain the headers.
     */
-  def withBodyStream(body: EntityBody[F]): Self =
+  def withBodyStream(body: Body): Self =
     change(body = body)
 
   /** Set an empty entity body on this message, and remove all payload headers
@@ -220,6 +220,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
 
 object Message {
   private[http4s] val logger = getLogger
+
   object Keys {
     private[this] val trailerHeaders: Key[Any] = Key.newKey[SyncIO, Any].unsafeRunSync()
     def TrailerHeaders[F[_]]: Key[F[Headers]] = trailerHeaders.asInstanceOf[Key[F[Headers]]]
@@ -238,28 +239,26 @@ object Message {
   * @param body fs2.Stream[F, Byte] defining the body of the request
   * @param attributes Immutable Map used for carrying additional information in a type safe fashion
   */
-final class Request[F[_]] private (
+final class Request[+ Body] private (
     val method: Method,
     val uri: Uri,
     val httpVersion: HttpVersion,
     val headers: Headers,
-    val body: EntityBody[F],
+    val body: Body,
     val attributes: Vault
-) extends Message[F]
+) extends Message[Body]
     with Product
     with Serializable {
   import Request._
 
-  type SelfF[F0[_]] = Request[F0]
-
-  private def copy(
+  private def copy[Cod](
       method: Method = this.method,
       uri: Uri = this.uri,
       httpVersion: HttpVersion = this.httpVersion,
       headers: Headers = this.headers,
-      body: EntityBody[F] = this.body,
+      body: Cod = this.body,
       attributes: Vault = this.attributes
-  ): Request[F] =
+  ): Request[Cod] =
     Request(
       method = method,
       uri = uri,
@@ -269,28 +268,28 @@ final class Request[F[_]] private (
       attributes = attributes
     )
 
-  def mapK[G[_]](f: F ~> G): Request[G] =
-    Request[G](
+  def mapK[Cod](f: Body => Cod): Request[Cod] =
+    Request[Cod](
       method = method,
       uri = uri,
       httpVersion = httpVersion,
       headers = headers,
-      body = body.translate(f),
+      body = f(body),
       attributes = attributes
     )
 
-  def withMethod(method: Method): Request[F] =
+  def withMethod(method: Method): Request[Body] =
     copy(method = method)
 
-  def withUri(uri: Uri): Request[F] =
+  def withUri(uri: Uri): Request[Body] =
     copy(uri = uri, attributes = attributes.delete(Request.Keys.PathInfoCaret))
 
   override protected def change(
       httpVersion: HttpVersion,
-      body: EntityBody[F],
+      body: B,
       headers: Headers,
       attributes: Vault
-  ): Request[F] =
+  ): Request[B] =
     copy(
       httpVersion = httpVersion,
       body = body,
@@ -305,9 +304,9 @@ final class Request[F[_]] private (
     attributes.lookup(Request.Keys.PathInfoCaret).getOrElse(-1)
 
   @deprecated(message = "Use {withPathInfo(Uri.Path)} instead", since = "0.22.0-M1")
-  def withPathInfo(pi: String): Request[F] =
+  def withPathInfo(pi: String): Request[Body] =
     withPathInfo(Uri.Path.unsafeFromString(pi))
-  def withPathInfo(pi: Uri.Path): Request[F] =
+  def withPathInfo(pi: Uri.Path): Request[Body] =
     // Don't use withUri, which clears the caret
     copy(uri = uri.withPath(scriptName.concat(pi)))
 
@@ -377,7 +376,7 @@ final class Request[F[_]] private (
     headers.get[Cookie].fold(List.empty[RequestCookie])(_.values.toList)
 
   /** Add a Cookie header for the provided [[org.http4s.headers.Cookie]] */
-  def addCookie(cookie: RequestCookie): Request[F] =
+  def addCookie(cookie: RequestCookie): Request[Body] =
     putHeaders {
       headers
         .get[Cookie]
@@ -387,7 +386,7 @@ final class Request[F[_]] private (
     }
 
   /** Add a Cookie header with the provided values */
-  def addCookie(name: String, content: String): Request[F] =
+  def addCookie(name: String, content: String): Request[Body] =
     addCookie(RequestCookie(name, content))
 
   def authType: Option[AuthScheme] =
@@ -435,12 +434,8 @@ final class Request[F[_]] private (
   def serverSoftware: ServerSoftware =
     attributes.lookup(Keys.ServerSoftware).getOrElse(ServerSoftware.Unknown)
 
-  def decodeWith[A](decoder: EntityDecoder[F, A], strict: Boolean)(f: A => F[Response[F]])(implicit
-      F: Monad[F]): F[Response[F]] =
-    decoder
-      .decode(this, strict = strict)
-      .fold(_.toHttpResponse[F](httpVersion).pure[F], f)
-      .flatten
+  def decodeWith[A](decoder: EntityDecoder[Body, A], strict: Boolean)(f: A => Response[Body]): Response[Body] =
+    decoder.decode(this, strict = strict).fold(_.toHttpResponse[Body](httpVersion), f)
 
   /** Helper method for decoding [[Request]]s
     *
@@ -448,17 +443,16 @@ final class Request[F[_]] private (
     * If decoding fails, an `UnprocessableEntity` [[Response]] is generated.
     */
   def decode[A](
-      f: A => F[Response[F]])(implicit F: Monad[F], decoder: EntityDecoder[F, A]): F[Response[F]] =
+      f: A => F[ResponseB[F]])(implicit F: Monad[F], decoder: EntityDecoder[EntityBody[F], A]): F[ResponseB[F]] =
     decodeWith(decoder, strict = false)(f)
 
-  /** Helper method for decoding [[Request]]s
+  /** Helper method for decoding [[Request]]
     *
     * Attempt to decode the [[Request]] and, if successful, execute the continuation to get a [[Response]].
     * If decoding fails, an `UnprocessableEntity` [[Response]] is generated. If the decoder does not support the
     * [[MediaType]] of the [[Request]], a `UnsupportedMediaType` [[Response]] is generated instead.
     */
-  def decodeStrict[A](
-      f: A => F[Response[F]])(implicit F: Monad[F], decoder: EntityDecoder[F, A]): F[Response[F]] =
+  def decodeStrict[A](f: A => Response[Body])(decoder: EntityDecoder[Body, A]): Response[Body] =
     decodeWith(decoder, strict = true)(f)
 
   override def hashCode(): Int = MurmurHash3.productHash(this)
@@ -503,15 +497,15 @@ object Request {
     * @param body fs2.Stream[F, Byte] defining the body of the request
     * @param attributes Immutable Map used for carrying additional information in a type safe fashion
     */
-  def apply[F[_]](
+  def apply[Body](
       method: Method = Method.GET,
       uri: Uri = Uri(path = Uri.Path.Root),
       httpVersion: HttpVersion = HttpVersion.`HTTP/1.1`,
       headers: Headers = Headers.empty,
-      body: EntityBody[F] = EmptyBody,
+      body: Body,
       attributes: Vault = Vault.empty
-  ): Request[F] =
-    new Request[F](
+  ): Request[Body] =
+    new Request[Body](
       method = method,
       uri = uri,
       httpVersion = httpVersion,
@@ -520,8 +514,7 @@ object Request {
       attributes = attributes
     )
 
-  def unapply[F[_]](
-      request: Request[F]): Option[(Method, Uri, HttpVersion, Headers, EntityBody[F], Vault)] =
+  def unapply[B](request: Request[F]): Option[(Method, Uri, HttpVersion, Headers, B, Vault)] =
     Some(
       (
         request.method,
@@ -555,19 +548,18 @@ object Request {
   *                   parameters which may be used by the http4s backend for
   *                   additional processing such as java.io.File object
   */
-final class Response[F[_]] private (
+final class Response[+ Body] private (
     val status: Status,
     val httpVersion: HttpVersion,
     val headers: Headers,
-    val body: EntityBody[F],
+    val body: Body,
     val attributes: Vault)
-    extends Message[F]
+    extends Message[Body]
     with Product
     with Serializable {
-  type SelfF[F0[_]] = Response[F0]
 
-  def mapK[G[_]](f: F ~> G): Response[G] =
-    Response[G](
+  def mapK[Cod](f: Body => Cod): Response[Cod] =
+    Response[Cod](
       status = status,
       httpVersion = httpVersion,
       headers = headers,
@@ -580,10 +572,10 @@ final class Response[F[_]] private (
 
   override protected def change(
       httpVersion: HttpVersion,
-      body: EntityBody[F],
+      body: Body,
       headers: Headers,
       attributes: Vault
-  ): Response[F] =
+  ): Response[Body] =
     copy(
       httpVersion = httpVersion,
       body = body,
@@ -592,7 +584,7 @@ final class Response[F[_]] private (
     )
 
   /** Add a Set-Cookie header for the provided [[ResponseCookie]] */
-  def addCookie(cookie: ResponseCookie): Response[F] =
+  def addCookie(cookie: ResponseCookie): Response[Body] =
     transformHeaders(_.add(`Set-Cookie`(cookie)))
 
   /** Add a [[org.http4s.headers.Set-Cookie]] header with the provided values */
@@ -618,14 +610,14 @@ final class Response[F[_]] private (
 
   override def hashCode(): Int = MurmurHash3.productHash(this)
 
-  def copy(
+  def copy[Cod](
       status: Status = this.status,
       httpVersion: HttpVersion = this.httpVersion,
       headers: Headers = this.headers,
-      body: EntityBody[F] = this.body,
+      body: Cod = this.body,
       attributes: Vault = this.attributes
-  ): Response[F] =
-    Response[F](
+  ): Response[Cod] =
+    Response[Cod](
       status = status,
       httpVersion = httpVersion,
       headers = headers,
@@ -670,35 +662,34 @@ object Response extends KleisliSyntax {
     *                   parameters which may be used by the http4s backend for
     *                   additional processing such as java.io.File object
     */
-  def apply[F[_]](
+  def apply[Body](
       status: Status = Status.Ok,
       httpVersion: HttpVersion = HttpVersion.`HTTP/1.1`,
       headers: Headers = Headers.empty,
-      body: EntityBody[F] = EmptyBody,
-      attributes: Vault = Vault.empty): Response[F] =
+      body: Body = (),
+      attributes: Vault = Vault.empty): Response[Unit] =
     new Response(status, httpVersion, headers, body, attributes)
 
-  def unapply[F[_]](
-      response: Response[F]): Option[(Status, HttpVersion, Headers, EntityBody[F], Vault)] =
+  def unapply[B](
+      response: Response[B]): Option[(Status, HttpVersion, Headers, B, Vault)] =
     Some(
       (response.status, response.httpVersion, response.headers, response.body, response.attributes))
 
-  private[this] val pureNotFound: Response[Pure] =
+  private[this] val pureNotFound: Response[String] =
     Response(
       Status.NotFound,
-      body = Stream("Not found").through(utf8.encode),
+      body = "Not found",
       headers = Headers(
         `Content-Type`(MediaType.text.plain, Charset.`UTF-8`),
         `Content-Length`.unsafeFromLong(9L)
       )
     )
 
-  def notFound[F[_]]: Response[F] = pureNotFound.covary[F].copy(body = pureNotFound.body.covary[F])
+  val notFound: Response[Unit] = pureNotFound
 
-  def notFoundFor[F[_]: Applicative](request: Request[F])(implicit
-      encoder: EntityEncoder[F, String]): F[Response[F]] =
-    Response[F](Status.NotFound).withEntity(s"${request.pathInfo} not found").pure[F]
+  def notFoundFor(request: Request[_]): Response[String] =
+    Response[String](Status.NotFound).withEntity(s"${request.pathInfo} not found")
 
-  def timeout[F[_]]: Response[F] =
-    Response[F](Status.ServiceUnavailable).withEntity("Response timed out")
+  def timeout: Response[String] =
+    Response[String](Status.ServiceUnavailable).withEntity("Response timed out")
 }

--- a/core/shared/src/main/scala/org/http4s/Status.scala
+++ b/core/shared/src/main/scala/org/http4s/Status.scala
@@ -50,7 +50,7 @@ sealed abstract case class Status private (code: Int) extends Ordered[Status] wi
     writer << code << ' ' << reason
 
   /** Helpers for for matching against a [[Response]] */
-  def unapply[F[_]](msg: Response[F]): Option[Response[F]] =
+  def unapply[B](msg: Response[B]): Option[Response[B]] =
     if (msg.status == this) Some(msg) else None
 }
 

--- a/core/shared/src/main/scala/org/http4s/multipart/Multipart.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/Multipart.scala
@@ -19,7 +19,7 @@ package multipart
 
 import org.http4s.headers._
 
-final case class Multipart[F[_]](parts: Vector[Part[F]], boundary: Boundary = Boundary.create) {
+final case class Multipart[Body](parts: Vector[Part[Body]], boundary: Boundary = Boundary.create) {
   def headers: Headers =
     Headers(
       `Transfer-Encoding`(TransferCoding.chunked),

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets
 import fs2._
 import org.http4s.internal.ChunkWriter
 
-private[http4s] class MultipartEncoder[F[_]] extends EntityEncoder[F, Multipart[F]] {
+private[http4s] class MultipartEncoder[Body] extends EntityEncoder[Body, Multipart[Body]] {
   //TODO: Refactor encoders to create headers dependent on value.
   def headers: Headers = Headers.empty
 

--- a/core/shared/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
+++ b/core/shared/src/main/scala/org/http4s/syntax/KleisliSyntax.scala
@@ -23,7 +23,7 @@ import cats.data.{Kleisli, OptionT}
 
 trait KleisliSyntax {
   implicit def http4sKleisliResponseSyntaxOptionT[F[_]: Functor, A](
-      kleisli: Kleisli[OptionT[F, *], A, Response[F]]): KleisliResponseOps[F, A] =
+      kleisli: Kleisli[OptionT[F, *], A, ResponseB[F]]): KleisliResponseOps[F, A] =
     new KleisliResponseOps[F, A](kleisli)
 
   implicit def http4sKleisliHttpRoutesSyntax[F[_]](routes: HttpRoutes[F]): KleisliHttpRoutesOps[F] =
@@ -37,8 +37,8 @@ trait KleisliSyntax {
     new KleisliAuthedRoutesOps[F, A](authedRoutes)
 }
 
-final class KleisliResponseOps[F[_]: Functor, A](self: Kleisli[OptionT[F, *], A, Response[F]]) {
-  def orNotFound: Kleisli[F, A, Response[F]] =
+final class KleisliResponseOps[F[_]: Functor, A](self: Kleisli[OptionT[F, *], A, ResponseB[F]]) {
+  def orNotFound: Kleisli[F, A, ResponseB[F]] =
     Kleisli(a => self.run(a).getOrElse(Response.notFound))
 }
 


### PR DESCRIPTION
Currently, the `Message` classes (and their subclasses `Request` and `Response`) are parameterised on an `F[_]` type, of kind `Type => Type`. The reason why these classes need a type parameter of this (higher) kind is because the entity body of requests and responses are defined as streams of bytes, `Stream[F, Byte]`, using the `Stream` class from the `fs2` library. 

IIUC, the main reason for defining  why the "Entity body" is defined as a bytestream is as
- It is a natural representation for input/output from the running clients and servers.
- It allows us to represent potentially large objects (entities) that are coming "through the wire" incrementally, which is common if transmitting video files or large PDFs...
- It serves as a common target for converting different types to/from, via entity encoders and decoders.

However, this has some downsides:
- The `Stream` data type is an intrinsically opaque type, which can represent unbounded entity bodies of unknown size. However, it could be preferable to work with finite representations (like just _arrays_ of bytes), empty representations, or specific data types. 
- It forces in the clients and servers an intermediate conversions to/from streams of bytes.
- In the definition of routes, it ties the effect on which routes run with the type 
- It exposes a low-level concern, the effect on which the clients or servers are running, into the representation of the core data structures for requests and responses. From there, it propagates through to the entity encoders/decoders, the middlewares, etc.

This Draft Pull Requests starts to consider a different alternative: decouple the core definitions of Http requests and responses from the Stream datatype from fs2, remove the `F[_]` parameter, and add a type parameter `Body` for the whole type of the body.

- Requests and responses that carry no content can be represented using the type binding `Body = Unit`. For instance, we can define a plain `NotFound` response as a `Response[Unit]`, with no `Applicative` needed. 
- Entity encoders and decoders become parameterised on the type of the `Body`, but they no longer need the HKT type parameter `F[_]`. In other words, both encoders and decoders can be defined as pure functions, without necessarilly involving any effects.  s a consequence, the `DecodeResult` is no longer an `EitherT`, but just a plain `Either`. 
- The `ContextRequest` (and its alias `AuthedRequest`) are also decoupled from the `F[_]` type.

