### PR TITLE
Type annotations for clearness

### DIFF
--- a/docs/src/main/mdoc/client.md
+++ b/docs/src/main/mdoc/client.md
@@ -191,9 +191,9 @@ val parseFailure: Either[ParseFailure, Uri] = Uri.fromString(invalidUri)
 You can also build up a URI incrementally, e.g.:
 
 ```scala mdoc:nest
-val baseUri = uri"http://foo.com"
-val withPath = baseUri.withPath(path"/bar/baz")
-val withQuery = withPath.withQueryParam("hello", "world")
+val baseUri: Uri = uri"http://foo.com"
+val withPath: Uri = baseUri.withPath(path"/bar/baz")
+val withQuery: Uri = withPath.withQueryParam("hello", "world")
 ```
 
 ## Middleware


### PR DESCRIPTION
This just adds type annotations to the Uri creation in the docs to help when reading what types we're dealing with.  In theory it shouldn't have been a problem but from reading it I thought it was a Path because of 0.21 having `withQueryParam` on the `Path`.

If this is too noisy please just close :) 