### PR TITLE
Catch DateTimeException for QueryParamDecoder failures, add codecs for remaining java.time types

### DIFF
--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -19,8 +19,9 @@ package org.http4s
 import cats.{Contravariant, Functor, Hash, MonoidK, Order, Show}
 import cats.data.{Validated, ValidatedNel}
 import cats.syntax.all._
-import java.time.{Instant, LocalDate, ZonedDateTime}
-import java.time.format.{DateTimeFormatter, DateTimeParseException}
+
+import java.time._
+import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAccessor
 
 final case class QueryParameterKey(value: String) extends AnyVal
@@ -94,30 +95,79 @@ object QueryParamCodec {
         decodeA.decode(value)
     }
 
-  def instantQueryParamCodec(formatter: DateTimeFormatter): QueryParamCodec[Instant] = {
-    import QueryParamDecoder.instantQueryParamDecoder
-    import QueryParamEncoder.instantQueryParamEncoder
+  def instantQueryParamCodec(formatter: DateTimeFormatter): QueryParamCodec[Instant] =
+    instant(formatter)
 
-    QueryParamCodec
-      .from[Instant](instantQueryParamDecoder(formatter), instantQueryParamEncoder(formatter))
-  }
+  def localDateQueryParamCodec(formatter: DateTimeFormatter): QueryParamCodec[LocalDate] =
+    localDate(formatter)
 
-  def localDateQueryParamCodec(formatter: DateTimeFormatter): QueryParamCodec[LocalDate] = {
-    import QueryParamDecoder.localDateQueryParamDecoder
-    import QueryParamEncoder.localDateQueryParamEncoder
+  def zonedDateTimeQueryParamCodec(formatter: DateTimeFormatter): QueryParamCodec[ZonedDateTime] =
+    zonedDateTime(formatter)
 
-    QueryParamCodec
-      .from[LocalDate](localDateQueryParamDecoder(formatter), localDateQueryParamEncoder(formatter))
-  }
+  def instant(formatter: DateTimeFormatter): QueryParamCodec[Instant] =
+    QueryParamCodec.from(QueryParamDecoder.instant(formatter), QueryParamEncoder.instant(formatter))
 
-  def zonedDateTimeQueryParamCodec(formatter: DateTimeFormatter): QueryParamCodec[ZonedDateTime] = {
-    import QueryParamDecoder.zonedDateTimeQueryParamDecoder
-    import QueryParamEncoder.zonedDateTimeQueryParamEncoder
+  def localDate(formatter: DateTimeFormatter): QueryParamCodec[LocalDate] =
+    QueryParamCodec.from(
+      QueryParamDecoder.localDate(formatter),
+      QueryParamEncoder.localDate(formatter))
 
-    QueryParamCodec.from[ZonedDateTime](
-      zonedDateTimeQueryParamDecoder(formatter),
-      zonedDateTimeQueryParamEncoder(formatter))
-  }
+  def localTime(formatter: DateTimeFormatter): QueryParamCodec[LocalTime] =
+    QueryParamCodec.from(
+      QueryParamDecoder.localTime(formatter),
+      QueryParamEncoder.localTime(formatter))
+
+  def localDateTime(formatter: DateTimeFormatter): QueryParamCodec[LocalDateTime] =
+    QueryParamCodec.from(
+      QueryParamDecoder.localDateTime(formatter),
+      QueryParamEncoder.localDateTime(formatter))
+
+  def dayOfWeek(formatter: DateTimeFormatter): QueryParamCodec[DayOfWeek] =
+    QueryParamCodec.from(
+      QueryParamDecoder.dayOfWeek(formatter),
+      QueryParamEncoder.dayOfWeek(formatter))
+
+  def month(formatter: DateTimeFormatter): QueryParamCodec[Month] =
+    QueryParamCodec.from(QueryParamDecoder.month(formatter), QueryParamEncoder.month(formatter))
+
+  def monthDay(formatter: DateTimeFormatter): QueryParamCodec[MonthDay] =
+    QueryParamCodec.from(
+      QueryParamDecoder.monthDay(formatter),
+      QueryParamEncoder.monthDay(formatter))
+
+  def year(formatter: DateTimeFormatter): QueryParamCodec[Year] =
+    QueryParamCodec.from(QueryParamDecoder.year(formatter), QueryParamEncoder.year(formatter))
+
+  def yearMonth(formatter: DateTimeFormatter): QueryParamCodec[YearMonth] =
+    QueryParamCodec.from(
+      QueryParamDecoder.yearMonth(formatter),
+      QueryParamEncoder.yearMonth(formatter))
+
+  def zoneOffset(formatter: DateTimeFormatter): QueryParamCodec[ZoneOffset] =
+    QueryParamCodec.from(
+      QueryParamDecoder.zonedOffset(formatter),
+      QueryParamEncoder.zoneOffset(formatter))
+
+  def zonedDateTime(formatter: DateTimeFormatter): QueryParamCodec[ZonedDateTime] =
+    QueryParamCodec.from(
+      QueryParamDecoder.zonedDateTime(formatter),
+      QueryParamEncoder.zonedDateTime(formatter))
+
+  def offsetTime(formatter: DateTimeFormatter): QueryParamCodec[OffsetTime] =
+    QueryParamCodec.from(
+      QueryParamDecoder.offsetTime(formatter),
+      QueryParamEncoder.offsetTime(formatter))
+
+  def offsetDateTime(formatter: DateTimeFormatter): QueryParamCodec[OffsetDateTime] =
+    QueryParamCodec.from(
+      QueryParamDecoder.offsetDateTime(formatter),
+      QueryParamEncoder.offsetDateTime(formatter))
+
+  lazy val zoneId: QueryParamCodec[ZoneId] =
+    QueryParamCodec.from(QueryParamDecoder.zoneId, QueryParamEncoder.zoneId)
+
+  lazy val period: QueryParamCodec[Period] =
+    QueryParamCodec.from(QueryParamDecoder.period, QueryParamEncoder.period)
 }
 
 /** Type class defining how to encode a `T` as a [[QueryParameterValue]]s
@@ -148,22 +198,6 @@ object QueryParamEncoder {
         fa.contramap(f)
     }
 
-  def instantQueryParamEncoder(formatter: DateTimeFormatter): QueryParamEncoder[Instant] =
-    QueryParamEncoder[String].contramap[Instant] { (i: Instant) =>
-      formatter.format(i)
-    }
-
-  def localDateQueryParamEncoder(formatter: DateTimeFormatter): QueryParamEncoder[LocalDate] =
-    QueryParamEncoder[String].contramap[LocalDate] { (ld: LocalDate) =>
-      formatter.format(ld)
-    }
-
-  def zonedDateTimeQueryParamEncoder(
-      formatter: DateTimeFormatter): QueryParamEncoder[ZonedDateTime] =
-    QueryParamEncoder[String].contramap[ZonedDateTime] { (zdt: ZonedDateTime) =>
-      formatter.format(zdt)
-    }
-
   def fromShow[T](implicit
       sh: Show[T]
   ): QueryParamEncoder[T] =
@@ -181,8 +215,68 @@ object QueryParamEncoder {
       override def encode(value: String) =
         QueryParameterValue(value)
     }
+
   implicit lazy val uriQueryParamEncoder: QueryParamEncoder[Uri] =
     QueryParamEncoder[String].contramap(_.renderString)
+
+  def instantQueryParamEncoder(formatter: DateTimeFormatter): QueryParamEncoder[Instant] =
+    instant(formatter)
+
+  def localDateQueryParamEncoder(formatter: DateTimeFormatter): QueryParamEncoder[LocalDate] =
+    localDate(formatter)
+
+  def zonedDateTimeQueryParamEncoder(
+      formatter: DateTimeFormatter): QueryParamEncoder[ZonedDateTime] =
+    zonedDateTime(formatter)
+
+  def instant(formatter: DateTimeFormatter): QueryParamEncoder[Instant] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def localDate(formatter: DateTimeFormatter): QueryParamEncoder[LocalDate] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def localTime(formatter: DateTimeFormatter): QueryParamEncoder[LocalTime] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def localDateTime(formatter: DateTimeFormatter): QueryParamEncoder[LocalDateTime] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def dayOfWeek(formatter: DateTimeFormatter): QueryParamEncoder[DayOfWeek] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def month(formatter: DateTimeFormatter): QueryParamEncoder[Month] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def monthDay(formatter: DateTimeFormatter): QueryParamEncoder[MonthDay] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def year(formatter: DateTimeFormatter): QueryParamEncoder[Year] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def yearMonth(formatter: DateTimeFormatter): QueryParamEncoder[YearMonth] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def zoneOffset(formatter: DateTimeFormatter): QueryParamEncoder[ZoneOffset] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def zonedDateTime(formatter: DateTimeFormatter): QueryParamEncoder[ZonedDateTime] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def offsetTime(formatter: DateTimeFormatter): QueryParamEncoder[OffsetTime] =
+    javaTimeQueryParamEncoder(formatter)
+
+  def offsetDateTime(formatter: DateTimeFormatter): QueryParamEncoder[OffsetDateTime] =
+    javaTimeQueryParamEncoder(formatter)
+
+  private def javaTimeQueryParamEncoder[T <: TemporalAccessor](
+      formatter: DateTimeFormatter
+  ): QueryParamEncoder[T] =
+    QueryParamEncoder[String].contramap[T](formatter.format)
+
+  implicit lazy val zoneId: QueryParamEncoder[ZoneId] = QueryParamEncoder[String].contramap(_.getId)
+
+  implicit lazy val period: QueryParamEncoder[Period] =
+    QueryParamEncoder[String].contramap(_.toString)
 }
 
 /** Type class defining how to decode a [[QueryParameterValue]] into a `T`
@@ -232,45 +326,6 @@ object QueryParamDecoder {
           .leftMap(t => ParseFailure(s"Query decoding $typeName failed", t.getMessage))
           .toValidatedNel
     }
-
-  def instantQueryParamDecoder(formatter: DateTimeFormatter): QueryParamDecoder[Instant] =
-    new QueryParamDecoder[Instant] {
-      override def decode(value: QueryParameterValue): ValidatedNel[ParseFailure, Instant] =
-        Validated
-          .catchOnly[DateTimeParseException] {
-            val x: TemporalAccessor = formatter.parse(value.value)
-            Instant.from(x)
-          }
-          .leftMap { e =>
-            ParseFailure(s"Failed to decode value: ${value.value} as Instant", e.getMessage)
-          }
-          .toValidatedNel
-    }
-
-  def localDateQueryParamDecoder(formatter: DateTimeFormatter): QueryParamDecoder[LocalDate] =
-    (value: QueryParameterValue) =>
-      Validated
-        .catchOnly[DateTimeParseException] {
-          val x: TemporalAccessor = formatter.parse(value.value)
-          LocalDate.from(x)
-        }
-        .leftMap { e =>
-          ParseFailure(s"Failed to decode value: ${value.value} as LocalDate", e.getMessage)
-        }
-        .toValidatedNel
-
-  def zonedDateTimeQueryParamDecoder(
-      formatter: DateTimeFormatter): QueryParamDecoder[ZonedDateTime] =
-    (value: QueryParameterValue) =>
-      Validated
-        .catchOnly[DateTimeParseException] {
-          val x: TemporalAccessor = formatter.parse(value.value)
-          ZonedDateTime.from(x)
-        }
-        .leftMap { e =>
-          ParseFailure(s"Failed to decode value: ${value.value} as ZonedDateTime", e.getMessage)
-        }
-        .toValidatedNel
 
   /** QueryParamDecoder is a covariant functor. */
   implicit val FunctorQueryParamDecoder: Functor[QueryParamDecoder] =
@@ -334,4 +389,80 @@ object QueryParamDecoder {
       def decode(value: QueryParameterValue): ValidatedNel[ParseFailure, Uri] =
         Uri.fromString(value.value).toValidatedNel
     }
+
+  def instantQueryParamDecoder(formatter: DateTimeFormatter): QueryParamDecoder[Instant] =
+    instant(formatter)
+
+  def localDateQueryParamDecoder(formatter: DateTimeFormatter): QueryParamDecoder[LocalDate] =
+    localDate(formatter)
+
+  def zonedDateTimeQueryParamDecoder(
+      formatter: DateTimeFormatter): QueryParamDecoder[ZonedDateTime] =
+    zonedDateTime(formatter)
+
+  def instant(formatter: DateTimeFormatter): QueryParamDecoder[Instant] =
+    javaTimeQueryParamDecoder(formatter, Instant.from, "Instant")
+
+  def localDate(formatter: DateTimeFormatter): QueryParamDecoder[LocalDate] =
+    javaTimeQueryParamDecoder(formatter, LocalDate.from, "LocalDate")
+
+  def localTime(formatter: DateTimeFormatter): QueryParamDecoder[LocalTime] =
+    javaTimeQueryParamDecoder(formatter, LocalTime.from, "LocalTime")
+
+  def localDateTime(formatter: DateTimeFormatter): QueryParamDecoder[LocalDateTime] =
+    javaTimeQueryParamDecoder(formatter, LocalDateTime.from, "LocalDateTime")
+
+  def dayOfWeek(formatter: DateTimeFormatter): QueryParamDecoder[DayOfWeek] =
+    javaTimeQueryParamDecoder(formatter, DayOfWeek.from, "DayOfWeek")
+
+  def month(formatter: DateTimeFormatter): QueryParamDecoder[Month] =
+    javaTimeQueryParamDecoder(formatter, Month.from, "Month")
+
+  def monthDay(formatter: DateTimeFormatter): QueryParamDecoder[MonthDay] =
+    javaTimeQueryParamDecoder(formatter, MonthDay.from, "MonthDay")
+
+  def year(formatter: DateTimeFormatter): QueryParamDecoder[Year] =
+    javaTimeQueryParamDecoder(formatter, Year.from, "Year")
+
+  def yearMonth(formatter: DateTimeFormatter): QueryParamDecoder[YearMonth] =
+    javaTimeQueryParamDecoder(formatter, YearMonth.from, "YearMonth")
+
+  def zonedOffset(formatter: DateTimeFormatter): QueryParamDecoder[ZoneOffset] =
+    javaTimeQueryParamDecoder(formatter, ZoneOffset.from, "ZoneOffset")
+
+  def zonedDateTime(formatter: DateTimeFormatter): QueryParamDecoder[ZonedDateTime] =
+    javaTimeQueryParamDecoder(formatter, ZonedDateTime.from, "ZonedDateTime")
+
+  def offsetTime(formatter: DateTimeFormatter): QueryParamDecoder[OffsetTime] =
+    javaTimeQueryParamDecoder(formatter, OffsetTime.from, "OffsetTime")
+
+  def offsetDateTime(formatter: DateTimeFormatter): QueryParamDecoder[OffsetDateTime] =
+    javaTimeQueryParamDecoder(formatter, OffsetDateTime.from, "OffsetDateTime")
+
+  private def javaTimeQueryParamDecoder[T](
+      formatter: DateTimeFormatter,
+      fromTemporalAccessor: TemporalAccessor => T,
+      displayName: String
+  ): QueryParamDecoder[T] =
+    (value: QueryParameterValue) =>
+      Validated
+        .catchNonFatal(fromTemporalAccessor(formatter.parse(value.value)))
+        .leftMap(e =>
+          ParseFailure(s"Failed to decode value ${value.value} as $displayName", e.getMessage))
+        .toValidatedNel
+
+  implicit lazy val zoneId: QueryParamDecoder[ZoneId] =
+    javaTimeQueryParamDecoderFromString(ZoneId.of, "ZoneId")
+
+  implicit lazy val period: QueryParamDecoder[Period] =
+    javaTimeQueryParamDecoderFromString(Period.parse, "Period")
+
+  private def javaTimeQueryParamDecoderFromString[T](
+      parse: String => T,
+      displayName: String
+  ): QueryParamDecoder[T] = QueryParamDecoder[String].emap(s =>
+    Either
+      .catchNonFatal(parse(s))
+      .leftMap(e => ParseFailure(s"Failed to decode value $s as $displayName", e.getMessage)))
+
 }

--- a/core/src/main/scala/org/http4s/QueryParam.scala
+++ b/core/src/main/scala/org/http4s/QueryParam.scala
@@ -145,7 +145,7 @@ object QueryParamCodec {
 
   def zoneOffset(formatter: DateTimeFormatter): QueryParamCodec[ZoneOffset] =
     QueryParamCodec.from(
-      QueryParamDecoder.zonedOffset(formatter),
+      QueryParamDecoder.zoneOffset(formatter),
       QueryParamEncoder.zoneOffset(formatter))
 
   def zonedDateTime(formatter: DateTimeFormatter): QueryParamCodec[ZonedDateTime] =
@@ -427,7 +427,7 @@ object QueryParamDecoder {
   def yearMonth(formatter: DateTimeFormatter): QueryParamDecoder[YearMonth] =
     javaTimeQueryParamDecoder(formatter, YearMonth.from, "YearMonth")
 
-  def zonedOffset(formatter: DateTimeFormatter): QueryParamDecoder[ZoneOffset] =
+  def zoneOffset(formatter: DateTimeFormatter): QueryParamDecoder[ZoneOffset] =
     javaTimeQueryParamDecoder(formatter, ZoneOffset.from, "ZoneOffset")
 
   def zonedDateTime(formatter: DateTimeFormatter): QueryParamDecoder[ZonedDateTime] =

--- a/tests/src/test/scala/org/http4s/QueryParamCodecSuite.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSuite.scala
@@ -181,7 +181,7 @@ trait QueryParamCodecInstances {
       .toFormatter)
 
   implicit val zoneOffsetQueryParamCodec: QueryParamCodec[ZoneOffset] =
-    QueryParamCodec.zoneOffset(DateTimeFormatter.ofPattern("xxxxx"))
+    QueryParamCodec.zoneOffset(DateTimeFormatter.ofPattern("XXXXX"))
 
   implicit val zonedDateTimeQueryParamCodec: QueryParamCodec[ZonedDateTime] =
     QueryParamCodec.zonedDateTime(DateTimeFormatter.ISO_ZONED_DATE_TIME)

--- a/tests/src/test/scala/org/http4s/QueryParamCodecSuite.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSuite.scala
@@ -18,16 +18,15 @@ package org.http4s
 
 import cats._
 import cats.data._
-import cats.syntax.all._
 import cats.laws.discipline.{arbitrary => _, _}
-
-import java.time.format.DateTimeFormatter
-import java.time.{Instant, LocalDate, ZoneId, ZonedDateTime}
-
-import org.http4s.internal.CollectionCompat.CollectionConverters._
-import org.scalacheck.{Arbitrary, Cogen, Gen}
-import org.scalacheck.Arbitrary.{arbInstant => _, arbLocalDate => _, arbZonedDateTime => _, _}
+import cats.syntax.all._
+import org.scalacheck.Arbitrary.{arbYear => _, _}
 import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Cogen, Gen}
+
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, SignStyle}
+import java.time._
+import java.time.temporal.ChronoField.{MONTH_OF_YEAR, YEAR}
 
 class QueryParamCodecSuite extends Http4sSuite with QueryParamCodecInstances {
   checkAll("Boolean QueryParamCodec", QueryParamCodecLaws[Boolean])
@@ -39,12 +38,35 @@ class QueryParamCodecSuite extends Http4sSuite with QueryParamCodecInstances {
   checkAll("String QueryParamCodec", QueryParamCodecLaws[String])
   checkAll("Instant QueryParamCodec", QueryParamCodecLaws[Instant])
   checkAll("LocalDate QueryParamCodec", QueryParamCodecLaws[LocalDate])
+  checkAll("LocalTime QueryParamCodec", QueryParamCodecLaws[LocalTime])
+  checkAll("LocalDateTime QueryParamCodec", QueryParamCodecLaws[LocalDateTime])
+  checkAll("DayOfWeek QueryParamCodec", QueryParamCodecLaws[DayOfWeek])
+  checkAll("Month QueryParamCodec", QueryParamCodecLaws[Month])
+  checkAll("MonthDay QueryParamCodec", QueryParamCodecLaws[MonthDay])
+  checkAll("Year QueryParamCodec", QueryParamCodecLaws[Year])
+  checkAll("YearMonth QueryParamCodec", QueryParamCodecLaws[YearMonth])
+  checkAll("ZoneOffset QueryParamCodec", QueryParamCodecLaws[ZoneOffset])
+  checkAll("ZoneId QueryParamCodec", QueryParamCodecLaws[ZoneId])
+  checkAll("Period QueryParamCodec", QueryParamCodecLaws[Period])
 
   if (!sys.props.get("java.specification.version").contains("1.8")) {
     // skipping this property due to bug in JDK8
     // where round trip conversion fails for region-based zone id & daylight saving time
     // see https://bugs.openjdk.java.net/browse/JDK-8183553 and https://bugs.openjdk.java.net/browse/JDK-8066982
     checkAll("ZonedDateTime QueryParamCodec", QueryParamCodecLaws[ZonedDateTime])
+    checkAll("OffsetTime QueryParamCodec", QueryParamCodecLaws[OffsetTime])
+    checkAll("OffsetDateTime QueryParamCodec", QueryParamCodecLaws[OffsetDateTime])
+
+    test("QueryParamCodec[ZonedDateTime] handles DateTimeException") {
+      implicit val zonedDateTimeQueryParamCodec: QueryParamCodec[ZonedDateTime] =
+        QueryParamCodec.zonedDateTimeQueryParamCodec(DateTimeFormatter.ISO_INSTANT)
+      forAll { instant: Instant =>
+        QueryParamDecoder[ZonedDateTime].decode(QueryParameterValue(instant.toString)) match {
+          case Validated.Invalid(NonEmptyList(ParseFailure(_, _), _)) => ()
+          case Validated.Valid(zdt) => fail(s"Parsing incorrectly succeeded with $zdt")
+        }
+      }
+    }
   }
 
   // Law checks for instances.
@@ -84,11 +106,39 @@ trait QueryParamCodecInstances {
       as.forall(a => x.encode(a) == y.encode(a))
     }
 
-  implicit val eqInstant: Eq[Instant] = Eq.fromUniversalEquals[Instant]
+  // TODO: Use scalacheck instance once this fix gets released https://github.com/typelevel/scalacheck/commit/2ae1be5c8e5ee1c14abea607d631e334a56796de
+  implicit final lazy val arbYear: Arbitrary[Year] =
+    Arbitrary(Gen.chooseNum(Year.MIN_VALUE + 1, Year.MAX_VALUE).map(Year.of))
 
-  implicit val eqLocalDate: Eq[LocalDate] = Eq.fromUniversalEquals[LocalDate]
+  implicit val eqInstant: Eq[Instant] = Eq.fromUniversalEquals
 
-  implicit val eqZonedDateTime: Eq[ZonedDateTime] = Eq.fromUniversalEquals[ZonedDateTime]
+  implicit val eqLocalDate: Eq[LocalDate] = Eq.fromUniversalEquals
+
+  implicit val eqLocalTime: Eq[LocalTime] = Eq.fromUniversalEquals
+
+  implicit val eqLocalDateTime: Eq[LocalDateTime] = Eq.fromUniversalEquals
+
+  implicit val eqDayOfWeek: Eq[DayOfWeek] = Eq.fromUniversalEquals
+
+  implicit val eqMonth: Eq[Month] = Eq.fromUniversalEquals
+
+  implicit val eqMonthDay: Eq[MonthDay] = Eq.fromUniversalEquals
+
+  implicit val eqYear: Eq[Year] = Eq.fromUniversalEquals
+
+  implicit val eqYearWeek: Eq[YearMonth] = Eq.fromUniversalEquals
+
+  implicit val eqZoneOffset: Eq[ZoneOffset] = Eq.fromUniversalEquals
+
+  implicit val eqZonedDateTime: Eq[ZonedDateTime] = Eq.fromUniversalEquals
+
+  implicit val eqOffsetTime: Eq[OffsetTime] = Eq.fromUniversalEquals
+
+  implicit val eqOffsetDateTime: Eq[OffsetDateTime] = Eq.fromUniversalEquals
+
+  implicit val eqZoneId: Eq[ZoneId] = Eq.fromUniversalEquals
+
+  implicit val eqPeriod: Eq[Period] = Eq.fromUniversalEquals
 
   implicit def ArbQueryParamDecoder[A: Arbitrary]: Arbitrary[QueryParamDecoder[A]] =
     Arbitrary(arbitrary[String => A].map(QueryParamDecoder[String].map))
@@ -103,41 +153,47 @@ trait QueryParamCodecInstances {
     QueryParamCodec.instantQueryParamCodec(DateTimeFormatter.ISO_INSTANT)
 
   implicit val localDateQueryParamCodec: QueryParamCodec[LocalDate] =
-    QueryParamCodec.localDateQueryParamCodec(DateTimeFormatter.ISO_LOCAL_DATE)
+    QueryParamCodec.localDate(DateTimeFormatter.ISO_LOCAL_DATE)
+
+  implicit val localTimeQueryParamCodec: QueryParamCodec[LocalTime] =
+    QueryParamCodec.localTime(DateTimeFormatter.ISO_LOCAL_TIME)
+
+  implicit val localDateTimeQueryParamCodec: QueryParamCodec[LocalDateTime] =
+    QueryParamCodec.localDateTime(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+
+  implicit val dayOfWeekQueryParamCodec: QueryParamCodec[DayOfWeek] =
+    QueryParamCodec.dayOfWeek(DateTimeFormatter.ofPattern("E"))
+
+  implicit val monthQueryParamCodec: QueryParamCodec[Month] =
+    QueryParamCodec.month(DateTimeFormatter.ofPattern("MM"))
+
+  implicit val monthDayQueryParamCodec: QueryParamCodec[MonthDay] =
+    QueryParamCodec.monthDay(DateTimeFormatter.ofPattern("--MM-dd"))
+
+  implicit val yearQueryParamCodec: QueryParamCodec[Year] = QueryParamCodec.year(
+    new DateTimeFormatterBuilder().appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD).toFormatter)
+
+  implicit val yearMonthQueryParamCodec: QueryParamCodec[YearMonth] = QueryParamCodec.yearMonth(
+    new DateTimeFormatterBuilder()
+      .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+      .appendLiteral('-')
+      .appendValue(MONTH_OF_YEAR, 2)
+      .toFormatter)
+
+  implicit val zoneOffsetQueryParamCodec: QueryParamCodec[ZoneOffset] =
+    QueryParamCodec.zoneOffset(DateTimeFormatter.ofPattern("xxxxx"))
 
   implicit val zonedDateTimeQueryParamCodec: QueryParamCodec[ZonedDateTime] =
-    QueryParamCodec.zonedDateTimeQueryParamCodec(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+    QueryParamCodec.zonedDateTime(DateTimeFormatter.ISO_ZONED_DATE_TIME)
 
-  implicit val ArbitraryInstant: Arbitrary[Instant] =
-    Arbitrary(
-      Gen
-        .choose[Long](Instant.MIN.getEpochSecond, Instant.MAX.getEpochSecond)
-        .map(Instant.ofEpochSecond))
+  implicit val offsetTimeQueryParamCodec: QueryParamCodec[OffsetTime] =
+    QueryParamCodec.offsetTime(DateTimeFormatter.ISO_OFFSET_TIME)
 
-  implicit val ArbitraryLocalDate: Arbitrary[LocalDate] =
-    Arbitrary(
-      Gen
-        .choose[Long](LocalDate.MIN.toEpochDay, LocalDate.MAX.toEpochDay)
-        .map(LocalDate.ofEpochDay))
+  implicit val offsetDateTimeQueryParamCodec: QueryParamCodec[OffsetDateTime] =
+    QueryParamCodec.offsetDateTime(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
-  implicit val ArbitraryZonedDateTime: Arbitrary[ZonedDateTime] = {
-    val zoneIds = {
-      val zoneIdIter = ZoneId.getAvailableZoneIds.asScala.iterator
-      // Workaround for a bug in Java 1.8:
-      //   - https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8138664
-      // See also the original issue:
-      //   - https://github.com/http4s/http4s/issues/3664
-      if (sys.props.get("java.specification.version").contains("1.8"))
-        zoneIdIter.filterNot(_ == "GMT0")
-      else
-        zoneIdIter
-    }.toSeq
+  implicit val zoneIdQueryParamCodec: QueryParamCodec[ZoneId] = QueryParamCodec.zoneId
 
-    Arbitrary(
-      for {
-        instant <- Arbitrary.arbitrary[Instant] // re-use `Gen` from `Arbitrary[Instant]` here
-        zoneId <- Gen.oneOf(zoneIds)
-      } yield ZonedDateTime.ofInstant(instant, ZoneId.of(zoneId))
-    )
-  }
+  implicit val periodQueryParamCodec: QueryParamCodec[Period] = QueryParamCodec.period
+
 }


### PR DESCRIPTION
I had an issue where http4s was producing a 5xx with no information for an invalid `ZonedDateTime`, rather than a 400 / `Validated.Invalid`. It was due to handling a `DateTimeParseException` but not its supertype `DateTimeException` in the `QueryParamDecoder` (can be thrown when the formatter doesn't quite match up). Any objections to using `Validated.catchNonFatal`? Also added a test to reproduce the specific issue / prove it's fixed.

Other than that:
1. Added codecs for the other `java.time` types while in the area - personally there has been a need for e.g. `QueryParamDecoder[OffsetDateTime]` in the past. Tried to minimise duplication as they mostly follow a similar pattern.
2. One weirdness in the codec tests is that scalacheck's `Arbitrary[Year]` instance was incorrect so I've defined a new one - fixed in https://github.com/typelevel/scalacheck/commit/2ae1be5c8e5ee1c14abea607d631e334a56796de and TODO added to use that once released.
3. Removed the custom `Arbitrary` instances to use those in scalacheck instead. I'm hoping that zone related JDK8 bug will be protected by the if clause in the tests? Can always revert back if it breaks the CI though 😃