### PR TITLE
FS2 - Small related rewrites

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
@@ -118,7 +118,7 @@ class Http1ClientStageSuite extends Http4sSuite with DispatcherIOFixture {
           b
         }
         .noneTerminate
-        .through(_.evalMap(q.offer))
+        .evalMap(q.offer)
         .compile
         .drain).start
       req0 = req.withBodyStream(req.body.onFinalizeWeak(d.complete(()).void))

--- a/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
@@ -53,22 +53,15 @@ private[http4s] class Http4sWSStage[F[_]](
   def name: String = "Http4s WebSocket Stage"
 
   //////////////////////// Source and Sink generators ////////////////////////
-  def snk: Pipe[F, WebSocketFrame, Unit] =
-    _.evalMap { frame =>
-      F.delay(sentClose.get()).flatMap { wasCloseSent =>
-        if (!wasCloseSent)
-          frame match {
-            case c: Close =>
-              F.delay(sentClose.compareAndSet(false, true))
-                .flatMap(cond => if (cond) writeFrame(c, directec) else F.unit)
-            case _ =>
-              writeFrame(frame, directec)
-          }
-        else
-          //Close frame has been sent. Send no further data
-          F.unit
-      }
-    }
+  val isClosed: F[Boolean] = F.delay(sentClose.get())
+  val setClosed: F[Boolean] = F.delay(sentClose.compareAndSet(false, true))
+
+  def evalFrame(frame: WebSocketFrame): F[Unit] = frame match {
+    case c: Close => setClosed.ifM(writeFrame(c, directec), F.unit)
+    case _ => writeFrame(frame, directec)
+  }
+
+  def snkFun(frame: WebSocketFrame): F[Unit] = isClosed.ifM(F.unit, evalFrame(frame))
 
   private[this] def writeFrame(frame: WebSocketFrame, ec: ExecutionContext): F[Unit] =
     writeSemaphore.permit.use { _ =>
@@ -153,21 +146,18 @@ private[http4s] class Http4sWSStage[F[_]](
     // Effect to send a close to the other endpoint
     val sendClose: F[Unit] = F.delay(closePipeline(None))
 
-    val receiveSend: Pipe[F, WebSocketFrame, WebSocketFrame] =
+    val receiveSent: Stream[F, WebSocketFrame] =
       ws match {
         case WebSocketSeparatePipe(send, receive, _) =>
-          incoming =>
-            send.concurrently(
-              incoming.through(receive).drain
-            ) //We don't need to terminate if the send stream terminates.
+          //We don't need to terminate if the send stream terminates.
+          send.concurrently(receive(inputstream))
         case WebSocketCombinedPipe(receiveSend, _) =>
-          receiveSend
+          receiveSend(inputstream)
       }
 
     val wsStream =
-      inputstream
-        .through(receiveSend)
-        .through(snk)
+      receiveSent
+        .evalMap(snkFun)
         .drain
         .interruptWhen(deadSignal)
         .onFinalizeWeak(

--- a/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
@@ -46,7 +46,7 @@ class Http4sWSStageSpec extends Http4sSuite with DispatcherIOFixture {
       Stream
         .emits(w)
         .covary[IO]
-        .through(_.evalMap(outQ.offer))
+        .evalMap(outQ.offer)
         .compile
         .drain
 

--- a/docs/src/main/mdoc/dsl.md
+++ b/docs/src/main/mdoc/dsl.md
@@ -283,7 +283,7 @@ val drip: Stream[IO, String] =
 We can see it for ourselves in the REPL:
 
 ```scala mdoc
-val dripOutIO = drip.through(fs2.text.lines).through(_.evalMap(s => {IO{println(s); s}})).compile.drain
+val dripOutIO = drip.through(fs2.text.lines).evalMap(s => {IO{println(s); s}}).compile.drain
 dripOutIO.unsafeRunSync()
 ```
 

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -35,7 +35,7 @@ class ParsingSuite extends Http4sSuite {
     def taking[F[_]: Concurrent, A](stream: Stream[F, A]): F[F[Option[Chunk[A]]]] =
       for {
         q <- Queue.unbounded[F, Option[Chunk[A]]]
-        _ <- stream.chunks.map(Some(_)).evalMap(q.offer(_)).compile.drain.void
+        _ <- stream.chunks.map(Some(_)).evalMap(q.offer(_)).compile.drain
         _ <- q.offer(None)
       } yield q.take
 

--- a/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
@@ -33,7 +33,7 @@ class TraversalSpec extends Http4sSuite {
     def taking[F[_]: Concurrent, A](stream: Stream[F, A]): F[F[Option[Chunk[A]]]] =
       for {
         q <- Queue.unbounded[F, Option[Chunk[A]]]
-        _ <- stream.chunks.map(Some(_)).evalMap(q.offer(_)).compile.drain.void
+        _ <- stream.chunks.map(Some(_)).evalMap(q.offer(_)).compile.drain
         _ <- q.offer(None)
       } yield q.take
   }

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
@@ -48,32 +48,17 @@ private[internal] object StreamForking {
       val decrementRunning: F[Unit] = running.update(_ - 1)
       val awaitWhileRunning: F[Unit] = running.discrete.dropWhile(_ > 0).take(1).compile.drain
 
-      val stop: F[Unit] =
-        done.update {
-          case None => Some(None)
-          case x => x
-        }
-
-      val stopSignal: Signal[F, Boolean] =
-        done.map(_.nonEmpty)
-
-      def handleResult(result: Either[Throwable, Unit]): F[Unit] =
-        result match {
-          case Right(_) => F.unit
-          case Left(err) =>
-            done.update {
-              case None => Some(Some(err))
-              case x => x
-            }
-        }
+      val stop: F[Unit] = done.update(_.orElse(Some(None)))
+      val stopSignal: Signal[F, Boolean] = done.map(_.nonEmpty)
+      def stopFailed(err: Throwable): F[Unit] =
+        done.update(_.orElse(Some(Some(err))))
 
       def runInner(inner: Stream[F, O]): F[Unit] = {
         val fa = inner
           .interruptWhen(stopSignal)
           .compile
           .drain
-          .attempt
-          .flatMap(handleResult) >> available.release >> decrementRunning
+          .handleErrorWith(stopFailed) >> available.release >> decrementRunning
 
         available.acquire >> incrementRunning >> F.start(fa).void
       }
@@ -84,9 +69,7 @@ private[internal] object StreamForking {
           .interruptWhen(stopSignal)
           .compile
           .drain
-          .void
-          .attempt
-          .flatMap(handleResult) >> decrementRunning
+          .handleErrorWith(stopFailed) >> decrementRunning
 
       val signalResult: F[Unit] =
         done.get.flatMap {


### PR DESCRIPTION
- Pattern `stream.through(_.method)` is same as `stream.method`
- No need to `void` a compile-drained stream. Unlike `Stream.drain`, which returns a `Stream[F, Nothing]`, the call `stream.compile.drain` returns an `F[Unit]`
- Avoid using pipes, in favour of stream methods 