### PR TITLE
Append, not replace, Accept header in client methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,7 @@ lazy val core = libraryProject("core")
       ip4sCore,
       literally,
       log4s,
+      munit % Test,
       scodecBits,
       slf4jApi, // residual dependency from macros
       vault,

--- a/client/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -88,7 +88,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: BracketThrow[F]) 
       d: EntityDecoder[F, A]): F[A] = {
     val r = if (d.consumes.nonEmpty) {
       val m = d.consumes.toList
-      req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
+      req.addHeader(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
     } else req
 
     run(r).use {
@@ -139,7 +139,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: BracketThrow[F]) 
       d: EntityDecoder[F, A]): F[Option[A]] = {
     val r = if (d.consumes.nonEmpty) {
       val m = d.consumes.toList
-      req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
+      req.addHeader(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
     } else req
 
     run(r).use {
@@ -164,7 +164,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: BracketThrow[F]) 
   def fetchAs[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[A] = {
     val r = if (d.consumes.nonEmpty) {
       val m = d.consumes.toList
-      req.putHeaders(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
+      req.addHeader(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
     } else req
 
     run(r).use { resp =>

--- a/client/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
+++ b/client/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
@@ -235,6 +235,28 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
       .assertEquals("Accept: text/*")
   }
 
+  test("Client should append Accept header to existing request headers on expect for requests") {
+    client
+      .expect[String](Request[IO](GET, uri"http://www.foo.com/echoheaders")
+        .putHeaders(Accept(MediaRange.`application/*`)))
+      .assertEquals("Accept: application/*, text/*")
+  }
+
+  test(
+    "Client should append Accept header to existing request headers on expectOptionOr for requests") {
+    client
+      .expectOptionOr[String](Request[IO](GET, uri"http://www.foo.com/echoheaders")
+        .putHeaders(Accept(MediaRange.`application/*`)))(_ => IO.raiseError(new Exception))
+      .assertEquals(Some("Accept: application/*, text/*"))
+  }
+
+  test("Client should append Accept header to existing request headers on fetchAs for requests") {
+    client
+      .fetchAs[String](Request[IO](GET, uri"http://www.foo.com/echoheaders")
+        .putHeaders(Accept(MediaRange.`application/*`)))
+      .assertEquals("Accept: application/*, text/*")
+  }
+
   test("Client should combine entity decoder media types correctly") {
     // This is more of an EntityDecoder spec
     val edec =

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -126,10 +126,46 @@ sealed trait Message[F[_]] extends Media[F] { self =>
   def removeHeader[A](implicit h: Header[A, _]): Self =
     removeHeader(h.name)
 
-  /** Add the provided headers to the existing headers, replacing those of the same header name
+  /** Add the provided headers to the existing headers, replacing those
+    * of the same header name
+    *
+    * {{{
+    * >>> import cats.effect.IO
+    * >>> import org.http4s.headers.Accept
+    *
+    * >>> val req = Request[IO]().putHeaders(Accept(MediaRange.`application/*`))
+    * >>> req.headers.get[Accept]
+    * Some(Accept(NonEmptyList(application/*)))
+    *
+    * >>> val req2 = req.putHeaders(Accept(MediaRange.`text/*`))
+    * >>> req2.headers.get[Accept]
+    * Some(Accept(NonEmptyList(text/*)))
+    * }}}
+    * /*/*/*/
     */
   def putHeaders(headers: Header.ToRaw*): Self =
     transformHeaders(_.put(headers: _*))
+
+  /** Add a header to these headers.  The header should be a type with a
+    * recurring `Header` instance to ensure that the new value can be
+    * appended to any existing values.
+    *
+    * {{{
+    * >>> import cats.effect.IO
+    * >>> import org.http4s.headers.Accept
+    *
+    * >>> val req = Request[IO]().addHeader(Accept(MediaRange.`application/*`))
+    * >>> req.headers.get[Accept]
+    * Some(Accept(NonEmptyList(application/*)))
+    *
+    * >>> val req2 = req.addHeader(Accept(MediaRange.`text/*`))
+    * >>> req2.headers.get[Accept]
+    * Some(Accept(NonEmptyList(application/*, text/*)))
+    * }}}
+    * /*/*/*/*/
+    */
+  def addHeader[H: Header[*, Header.Recurring]](h: H): Self =
+    transformHeaders(_.add(h))
 
   def withTrailerHeaders(trailerHeaders: F[Headers]): Self =
     withAttribute(Message.Keys.TrailerHeaders[F], trailerHeaders)

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -141,7 +141,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * >>> req2.headers.get[Accept]
     * Some(Accept(NonEmptyList(text/*)))
     * }}}
-    * /*/*/*/
+    * */*/*/*/
     */
   def putHeaders(headers: Header.ToRaw*): Self =
     transformHeaders(_.put(headers: _*))
@@ -162,7 +162,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * >>> req2.headers.get[Accept]
     * Some(Accept(NonEmptyList(application/*, text/*)))
     * }}}
-    * /*/*/*/*/
+    * */*/*/*/*/
     */
   def addHeader[H: Header[*, Header.Recurring]](h: H): Self =
     transformHeaders(_.add(h))

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -1,5 +1,6 @@
 package org.http4s.sbt
 
+import com.github.tkawachi.doctest.DoctestPlugin.autoImport._
 import com.timushev.sbt.updates.UpdatesPlugin.autoImport._ // autoImport vs. UpdateKeys necessary here for implicit
 import com.typesafe.sbt.SbtGit.git
 import com.typesafe.sbt.git.JGit
@@ -135,6 +136,8 @@ object Http4sPlugin extends AutoPlugin {
         _.revision == "0.21.10"
       )
     },
+
+    doctestTestFramework := DoctestTestFramework.Munit,
   )
 
   def extractApiVersion(version: String) = {

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -311,7 +311,7 @@ object Http4sPlugin extends AutoPlugin {
     val logback = "1.2.3"
     val log4cats = "1.3.1"
     val log4s = "1.10.0"
-    val munit = "0.7.18"
+    val munit = "0.7.27"
     val munitCatsEffect = "1.0.5"
     val munitDiscipline = "1.0.9"
     val netty = "4.1.66.Final"


### PR DESCRIPTION
Fixes #4987 

If an `Accept` header is present on the request, preserve it along with headers from the EntityDecoder.  This preserves the 0.21 behavior.

There's an argument to be made that we should only supply it if it was missing, because the user needs to customize the EntityDecoder (awkward) to get full control over the Accept header otherwise.  But that would be a breaking semantic change not surfaced by the types.

Bonus: add an `addHeader` to `Message`, because it was awkward without.

Bonus bonus: enable doctests in core.  Examples in the docs are good, and we should be doing more of this.