### PR TITLE
Properly deprecate old literals

### DIFF
--- a/core/src/main/scala-2/org/http4s/MediaTypePlaform.scala
+++ b/core/src/main/scala-2/org/http4s/MediaTypePlaform.scala
@@ -18,6 +18,9 @@ package org.http4s
 
 import scala.reflect.macros.whitebox
 
+@deprecated(
+  "Misspelled, never documented, never mixed into MediaType companion, and obsolete",
+  "0.22.2")
 trait MediaTypePlaform {
 
   /** Literal syntax for MediaTypes.  Invalid or non-literal arguments are rejected
@@ -27,6 +30,7 @@ trait MediaTypePlaform {
   def mediaType(s: String): MediaType = macro MediaTypePlaform.Macros.mediaTypeLiteral
 }
 
+@deprecated("Misspelled, never documented, and obsolete", "0.22.2")
 object MediaTypePlaform {
   @deprecated(
     """MediaType literal is deprecated.  Import `org.http4s.implicits._` and use the mediaType"" string context""",

--- a/core/src/main/scala-2/org/http4s/MediaTypePlaform.scala
+++ b/core/src/main/scala-2/org/http4s/MediaTypePlaform.scala
@@ -28,6 +28,11 @@ trait MediaTypePlaform {
 }
 
 object MediaTypePlaform {
+  @deprecated(
+    """MediaType literal is deprecated.  Import `org.http4s.implicits._` and use the mediaType"" string context""",
+    "0.22.2")
+  def deprecatedLiteralImpl(s: String): MediaType =
+    MediaType.parse(s).fold(throw _, identity)
 
   private[MediaTypePlaform] class Macros(val c: whitebox.Context) {
     import c.universe._
@@ -39,8 +44,7 @@ object MediaTypePlaform {
             .parse(s)
             .fold(
               e => c.abort(c.enclosingPosition, e.details),
-              _ =>
-                q"_root_.org.http4s.MediaType.parse($s).fold(throw _, _root_.scala.Predef.identity)"
+              _ => q"_root_.org.http4s.MediaTypePlaform.deprecatedLiteralImpl($s)"
             )
         case _ =>
           c.abort(

--- a/core/src/main/scala-2/org/http4s/UriPlatform.scala
+++ b/core/src/main/scala-2/org/http4s/UriPlatform.scala
@@ -28,6 +28,12 @@ trait UriPlatform {
 }
 
 object UriPlatform {
+  @deprecated(
+    """URI literal is deprecated.  Import `org.http4s.implicits._` and use the uri"" string context""",
+    "0.22.2")
+  def deprecatedLiteralImpl(s: String): Uri =
+    Uri.unsafeFromString(s)
+
   private[UriPlatform] class Macros(val c: whitebox.Context) {
     import c.universe._
 
@@ -38,8 +44,7 @@ object UriPlatform {
             .fromString(s)
             .fold(
               e => c.abort(c.enclosingPosition, e.details),
-              _ =>
-                q"_root_.org.http4s.Uri.fromString($s).fold(throw _, _root_.scala.Predef.identity)"
+              _ => q"_root_.org.http4s.UriPlatform.deprecatedLiteralImpl($s)"
             )
         case _ =>
           c.abort(

--- a/core/src/main/scala-3/org/http4s/MediaTypePlaform.scala
+++ b/core/src/main/scala-3/org/http4s/MediaTypePlaform.scala
@@ -16,4 +16,5 @@
 
 package org.http4s
 
+@deprecated("Misspelled, never documented, and obsolete", "0.22.2")
 trait MediaTypePlaform

--- a/core/src/main/scala/org/http4s/QValue.scala
+++ b/core/src/main/scala/org/http4s/QValue.scala
@@ -123,6 +123,9 @@ object QValue extends QValuePlatform {
     ParseResult.fromParser(parser, "Invalid Q-Value")(s)
 
   /** Exists to support compile-time verified literals. Do not call directly. */
+  @deprecated(
+    """QValue literal is deprecated.  Import `org.http4s.implicits._` and use the qValue"" string context""",
+    "0.22.2")
   def ☠(thousandths: Int): QValue = new QValue(thousandths)
 
   implicit val catsInstancesForHttp4sQValue: Order[QValue]


### PR DESCRIPTION
Deprecating a macro definition doesn't generate a deprecation warning when the macro is called.  We need to deprecate the code the macro expands to.

We eliminated these entirely in 0.23, but it ate somebody at $WORK because the deprecation clock had never started.