### PR TITLE
Ember Server: interrupt is socket closed.

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -170,6 +170,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
     Encoder
       .respToBytes[F](resp)
       .through(_.chunks.foreach(c => timeoutMaybe(socket.write(c), idleTimeout)))
+      .interruptWhen(Stream.repeatEval(socket.isOpen.map(x => ! x)))
       .compile
       .drain
       .attempt


### PR DESCRIPTION
Sometimes, particularly in the context of server-sent events,
we are  serving in the response an infinite stream of objects.
In those cases, it may happen that the client interrupts
the connection, so we should detect that and interrupt the stream.