### PR TITLE
Check for allowed entity in GZip server middleware

### DIFF
--- a/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -52,9 +52,9 @@ object GZip {
   def defaultIsZippable[F[_]](resp: Response[F]): Boolean = {
     val contentType = resp.headers.get[`Content-Type`]
     resp.headers.get[`Content-Encoding`].isEmpty &&
-      resp.status.isEntityAllowed &&
-      (contentType.isEmpty || contentType.get.mediaType.compressible ||
-        (contentType.get.mediaType eq MediaType.application.`octet-stream`))
+    resp.status.isEntityAllowed &&
+    (contentType.isEmpty || contentType.get.mediaType.compressible ||
+      (contentType.get.mediaType eq MediaType.application.`octet-stream`))
   }
 
   private def satisfiedByGzip(acceptEncoding: `Accept-Encoding`) =

--- a/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -52,8 +52,9 @@ object GZip {
   def defaultIsZippable[F[_]](resp: Response[F]): Boolean = {
     val contentType = resp.headers.get[`Content-Type`]
     resp.headers.get[`Content-Encoding`].isEmpty &&
-    (contentType.isEmpty || contentType.get.mediaType.compressible ||
-      (contentType.get.mediaType eq MediaType.application.`octet-stream`))
+      resp.status.isEntityAllowed &&
+      (contentType.isEmpty || contentType.get.mediaType.compressible ||
+        (contentType.get.mediaType eq MediaType.application.`octet-stream`))
   }
 
   private def satisfiedByGzip(acceptEncoding: `Accept-Encoding`) =


### PR DESCRIPTION
If a response has a status that doesn't allow any entity, the GZip server middleware should not handle it because the injected Content-Encoding header is semantically questionable and not handled well by all clients.