### PR TITLE
Add Conservative Retry For Dead Connections

### DIFF
--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -68,7 +68,7 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       additionalSocketOptions: List[SocketOptionMapping[_]] = self.additionalSocketOptions,
       userAgent: Option[`User-Agent`] = self.userAgent,
       checkEndpointIdentification: Boolean = self.checkEndpointIdentification,
-      retryPolicy: RetryPolicy[F] = self.retryPolicy,
+      retryPolicy: RetryPolicy[F] = self.retryPolicy
   ): EmberClientBuilder[F] =
     new EmberClientBuilder[F](
       blockerOpt = blockerOpt,
@@ -122,7 +122,7 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
 
   def withoutCheckEndpointAuthentication = copy(checkEndpointIdentification = false)
 
-  def withRetryPolicy(retryPolicy: RetryPolicy[F]) = 
+  def withRetryPolicy(retryPolicy: RetryPolicy[F]) =
     copy(retryPolicy = retryPolicy)
 
   def build: Resource[F, Client[F]] =

--- a/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -32,6 +32,8 @@ import fs2.io.tls._
 import scala.concurrent.duration.Duration
 import org.http4s.headers.{AgentProduct, `User-Agent`}
 import org.http4s.ember.client.internal.ClientHelpers
+import org.http4s.client.middleware.RetryPolicy
+import org.http4s.client.middleware.Retry
 
 final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     private val blockerOpt: Option[Blocker],
@@ -47,7 +49,8 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     val timeout: Duration,
     val additionalSocketOptions: List[SocketOptionMapping[_]],
     val userAgent: Option[`User-Agent`],
-    val checkEndpointIdentification: Boolean
+    val checkEndpointIdentification: Boolean,
+    val retryPolicy: RetryPolicy[F]
 ) { self =>
 
   private def copy(
@@ -64,7 +67,8 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       timeout: Duration = self.timeout,
       additionalSocketOptions: List[SocketOptionMapping[_]] = self.additionalSocketOptions,
       userAgent: Option[`User-Agent`] = self.userAgent,
-      checkEndpointIdentification: Boolean = self.checkEndpointIdentification
+      checkEndpointIdentification: Boolean = self.checkEndpointIdentification,
+      retryPolicy: RetryPolicy[F] = self.retryPolicy,
   ): EmberClientBuilder[F] =
     new EmberClientBuilder[F](
       blockerOpt = blockerOpt,
@@ -80,7 +84,8 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
       timeout = timeout,
       additionalSocketOptions = additionalSocketOptions,
       userAgent = userAgent,
-      checkEndpointIdentification = checkEndpointIdentification
+      checkEndpointIdentification = checkEndpointIdentification,
+      retryPolicy = retryPolicy
     )
 
   def withTLSContext(tlsContext: TLSContext) =
@@ -116,6 +121,9 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
     copy(checkEndpointIdentification = checkEndpointIdentification)
 
   def withoutCheckEndpointAuthentication = copy(checkEndpointIdentification = false)
+
+  def withRetryPolicy(retryPolicy: RetryPolicy[F]) = 
+    copy(retryPolicy = retryPolicy)
 
   def build: Resource[F, Client[F]] =
     for {
@@ -186,7 +194,8 @@ final class EmberClientBuilder[F[_]: Concurrent: Timer: ContextShift] private (
           }
         } yield responseResource._1
       }
-      new EmberClient[F](client, pool)
+      val stackClient = Retry(retryPolicy)(client)
+      new EmberClient[F](stackClient, pool)
     }
 }
 
@@ -207,7 +216,8 @@ object EmberClientBuilder {
       timeout = Defaults.timeout,
       additionalSocketOptions = Defaults.additionalSocketOptions,
       userAgent = Defaults.userAgent,
-      checkEndpointIdentification = true
+      checkEndpointIdentification = true,
+      retryPolicy = Defaults.retryPolicy
     )
 
   private object Defaults {
@@ -226,5 +236,7 @@ object EmberClientBuilder {
     val additionalSocketOptions = List.empty[SocketOptionMapping[_]]
     val userAgent = Some(
       `User-Agent`(AgentProduct("http4s-ember", Some(org.http4s.BuildInfo.version))))
+
+    def retryPolicy[F[_]]: RetryPolicy[F] = ClientHelpers.RetryLogic.retryUntilFresh
   }
 }

--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -134,6 +134,9 @@ private[client] object ClientHelpers {
   }.adaptError { case e @ org.http4s.ember.core.EmptyStreamError() =>
     new ClosedChannelException() {
       initCause(e)
+
+      override def getMessage(): String =
+        "Remote Disconnect: Received zero bytes after sending request"
     }
   }
 

--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -131,8 +131,8 @@ private[client] object ClientHelpers {
       processedReq <- preprocessRequest(request, userAgent)
       res <- writeRead(processedReq)
     } yield res
-  }.adaptError{
-    case e@org.http4s.ember.core.EmptyStreamError() => new ClosedChannelException(){
+  }.adaptError { case e @ org.http4s.ember.core.EmptyStreamError() =>
+    new ClosedChannelException() {
       initCause(e)
     }
   }
@@ -203,12 +203,14 @@ private[client] object ClientHelpers {
     // import org.http4s.headers.`Idempotency-Key`
 
     private val retryNow = 0.seconds.some
-    def retryUntilFresh[F[_]]: RetryPolicy[F] = {(req, result, retries) =>
+    def retryUntilFresh[F[_]]: RetryPolicy[F] = { (req, result, retries) =>
       if (emberDeadFromPoolPolicy(req, result) && retries <= 2) retryNow
       else None
     }
 
-    def emberDeadFromPoolPolicy[F[_]](req: Request[F], result: Either[Throwable, Response[F]]): Boolean =
+    def emberDeadFromPoolPolicy[F[_]](
+        req: Request[F],
+        result: Either[Throwable, Response[F]]): Boolean =
       (req.method.isIdempotent || req.headers.get("idempotency-key".ci).isDefined) &&
         isEmptyStreamError(result)
 
@@ -216,8 +218,9 @@ private[client] object ClientHelpers {
       result match {
         case Right(_) => false
         // case Left(EmberException.EmptyStream()) => true // Next version can be accessed by users
-        case Left(org.http4s.ember.core.EmptyStreamError()) => true // Note this is private in http4s in 0.21
+        case Left(org.http4s.ember.core.EmptyStreamError()) =>
+          true // Note this is private in http4s in 0.21
         case _ => false
       }
-    }
+  }
 }


### PR DESCRIPTION
Fixes #4935

Uses the conservative firefoxy strategy for retrying connections that are dead from the pool.