### PR TITLE
Replace existing headers in withEntity

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -91,7 +91,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
 
       case None => w.headers
     }
-    change(body = entity.body, headers = headers.transform(_ ++ hs.headers))
+    change(body = entity.body, headers = headers ++ hs)
   }
 
   /** Sets the entity body without affecting headers such as `Transfer-Encoding`


### PR DESCRIPTION
Fixes #5059.

With the global header registry, we used to be able to append two sets of headers and detect which were single and which were recurring from their names.  In the type class model of 0.22, this is no longer possible.  We need to merge the headers from the `EntityEncoder` with the headers already on the message.

Usually the headers are `Content-Type` and `Content-Length`, both of which are single.  Using a merge operation that replaces existing headers fits well here.  We get a change in behavior if the message already has any recurring headers that the `EntityEncoder` tries to add, but it's fair to say anything the `EntityEncoder` cared to specify, it should control.