### PR TITLE
Print correct http4s version on Blaze startup

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
@@ -29,6 +29,7 @@ import java.nio.ByteBuffer
 import java.security.{KeyStore, Security}
 import java.util.concurrent.ThreadFactory
 import javax.net.ssl._
+import org.http4s.{BuildInfo => Http4sBuildInfo}
 import org.http4s.blaze.channel._
 import org.http4s.blaze.channel.nio1.NIO1SocketServerGroup
 import org.http4s.blaze.http.http2.server.ALPNServerSelector
@@ -368,7 +369,7 @@ class BlazeServerBuilder[F[_]] private (
             .foreach(logger.info(_))
 
           logger.info(
-            s"http4s v${BuildInfo.version} on blaze v${BlazeBuildInfo.version} started at ${server.baseUri}")
+            s"http4s v${Http4sBuildInfo.version} on blaze v${BlazeBuildInfo.version} started at ${server.baseUri}")
         })
 
       Resource.eval(verifyTimeoutRelations()) >>


### PR DESCRIPTION
Fixes #5074 

Explicitly reference correct BuildInfo for Http4s version.

Seems that original import got lost, so, this time I reintroduced it in a more explicit way with meaningful alias.