### PR TITLE
Add Function To Creat Host From ip4s.IpAddress

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -542,6 +542,20 @@ object Uri extends UriPlatform {
 
   object Host {
 
+    /** Create a [[Host]] value from an [[com.comcast.ip4s.IpAddress]].
+      *
+      * This is a convenience method for creating the correct host based on
+      * the underlying IP protocol version of the given address, either IPv4
+      * or IPv6.
+      */
+    def fromIpAddress(value: ip4s.IpAddress): Host =
+      value match {
+        case value: ip4s.Ipv4Address =>
+          Ipv4Address(value)
+        case value: ip4s.Ipv6Address =>
+          Ipv6Address(value)
+      }
+
     implicit val catsInstancesForHttp4sUriHost: Hash[Host] with Order[Host] with Show[Host] =
       new Hash[Host] with Order[Host] with Show[Host] {
         override def hash(x: Host): Int =


### PR DESCRIPTION
This commit adds a method on the companion object of `Host` to create an instance of `Host` from an `ip4s.IpAddress`. It's just a short hand for not having to introspect the underlying ADT constructor.