### PR TITLE
Make `Http*` syntax available without an import

### DIFF
--- a/client/src/main/scala/org/http4s/client/Client.scala
+++ b/client/src/main/scala/org/http4s/client/Client.scala
@@ -25,7 +25,6 @@ import cats.syntax.all._
 import fs2._
 import java.io.IOException
 import org.http4s.headers.Host
-import org.http4s.syntax.kleisli._
 import scala.util.control.NoStackTrace
 
 /** A [[Client]] submits [[Request]]s to a server and processes the [[Response]]. */

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -25,6 +25,7 @@ import fs2.{Pure, Stream}
 import fs2.text.utf8Encode
 import java.io.File
 import org.http4s.headers._
+import org.http4s.syntax.{KleisliSyntax, KleisliSyntaxBinCompat0, KleisliSyntaxBinCompat1}
 import org.log4s.getLogger
 import org.typelevel.ci.CIString
 import org.typelevel.vault._
@@ -663,7 +664,7 @@ final class Response[F[_]] private (
     s"""Response(status=${status.code}, headers=${headers.redactSensitive()})"""
 }
 
-object Response {
+object Response extends KleisliSyntax with KleisliSyntaxBinCompat0 with KleisliSyntaxBinCompat1 {
 
   /** Representation of the HTTP response to send back to the client
     *

--- a/core/src/main/scala/org/http4s/syntax/package.scala
+++ b/core/src/main/scala/org/http4s/syntax/package.scala
@@ -18,6 +18,7 @@ package org.http4s
 
 package object syntax {
   object all extends AllSyntaxBinCompat
+  @deprecated("import is no longer needed", "0.22.3")
   object kleisli extends KleisliSyntax with KleisliSyntaxBinCompat0 with KleisliSyntaxBinCompat1
   object literals extends LiteralsSyntax
   object string extends StringSyntax

--- a/docs/src/main/mdoc/static.md
+++ b/docs/src/main/mdoc/static.md
@@ -23,7 +23,6 @@ import cats.effect._
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.Server
 import org.http4s.server.staticcontent._
-import org.http4s.syntax.kleisli._
 import scala.concurrent.ExecutionContext.global
 
 object SimpleHttpServer extends IOApp {

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeExample.scala
@@ -21,7 +21,6 @@ import com.example.http4s.ExampleService
 import org.http4s.HttpApp
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.{Router, Server}
-import org.http4s.syntax.kleisli._
 import scala.concurrent.ExecutionContext.global
 
 object BlazeExample extends IOApp {

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/Server.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/Server.scala
@@ -22,7 +22,6 @@ import org.http4s.HttpApp
 import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.Router
-import org.http4s.syntax.kleisli._
 import scala.concurrent.ExecutionContext.global
 
 object Server extends IOApp {

--- a/examples/docker/src/main/scala/com/example/http4s/Example.scala
+++ b/examples/docker/src/main/scala/com/example/http4s/Example.scala
@@ -21,7 +21,6 @@ import fs2.Stream
 import org.http4s._
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.dsl.Http4sDsl
-import org.http4s.syntax.kleisli._
 import scala.concurrent.ExecutionContext.global
 
 object Main extends IOApp {

--- a/server/src/test/scala/org/http4s/server/middleware/BracketRequestResponseSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/BracketRequestResponseSuite.scala
@@ -21,7 +21,6 @@ import cats.data._
 import cats.effect._
 import cats.effect.concurrent._
 import org.http4s._
-import org.http4s.syntax.kleisli._
 import org.http4s.server._
 
 final class BracketRequestResponseSuite extends Http4sSuite {

--- a/server/src/test/scala/org/http4s/server/middleware/DateSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/DateSuite.scala
@@ -20,7 +20,6 @@ import cats.data.OptionT
 import cats.syntax.all._
 import cats.effect._
 import org.http4s._
-import org.http4s.syntax.kleisli._
 import org.http4s.headers.{Date => HDate}
 
 class DateSuite extends Http4sSuite {

--- a/tests/src/test/scala/org/http4s/syntax/KleisliSyntaxSpec.scala
+++ b/tests/src/test/scala/org/http4s/syntax/KleisliSyntaxSpec.scala
@@ -41,5 +41,4 @@ class KleisliSyntaxTests {
       IO(Response[IO](Status.Ok))
     }
     .translate[Kleisli[IO, Int, *]](Kleisli.liftK)(Kleisli.applyK(42))
-
 }

--- a/tests/src/test/scala/org/http4s/syntax/KleisliSyntaxSpec.scala
+++ b/tests/src/test/scala/org/http4s/syntax/KleisliSyntaxSpec.scala
@@ -36,7 +36,7 @@ class KleisliSyntaxTests {
     .translate[Kleisli[IO, Int, *]](Kleisli.liftK)(Kleisli.applyK(42))
 
   // translate syntax should work on AuthedRoutes
-  val authedRoutes: AuthedRoutes[String, IO] = AuthedRoutes
+  val authedRoutes: AuthedRoutes[String, Kleisli[IO, Int, *]] = AuthedRoutes
     .of[String, IO] { case _ =>
       IO(Response[IO](Status.Ok))
     }

--- a/tests/src/test/scala/org/http4s/syntax/KleisliSyntaxSpec.scala
+++ b/tests/src/test/scala/org/http4s/syntax/KleisliSyntaxSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+
+import cats.data.Kleisli
+import cats.effect.IO
+
+class KleisliSyntaxTests {
+  // We're not testing any runtime behaviour here, just that the syntax compiles without imports.
+
+  // translate syntax should work on HttpRoutes
+  val routes: HttpRoutes[Kleisli[IO, Int, *]] = HttpRoutes
+    .of[IO] { case _ =>
+      IO(Response[IO](Status.Ok))
+    }
+    .translate[Kleisli[IO, Int, *]](Kleisli.liftK)(Kleisli.applyK(42))
+
+  // translate syntax should work on HttpApp
+  val app: HttpApp[Kleisli[IO, Int, *]] = HttpApp[IO] { case _ =>
+    IO(Response[IO](Status.Ok))
+  }
+    .translate[Kleisli[IO, Int, *]](Kleisli.liftK)(Kleisli.applyK(42))
+
+  // translate syntax should work on AuthedRoutes
+  val authedRoutes: AuthedRoutes[String, IO] = AuthedRoutes
+    .of[String, IO] { case _ =>
+      IO(Response[IO](Status.Ok))
+    }
+    .translate[Kleisli[IO, Int, *]](Kleisli.liftK)(Kleisli.applyK(42))
+
+}


### PR DESCRIPTION
As discussed in #5062 - by adding these implicits to the companion of one of the type parameters, we remove the need for an import.