### PR TITLE
Fix readable stream cancellation bug for Firefox

### DIFF
--- a/dom-core/src/main/scala/org/http4s/dom/package.scala
+++ b/dom-core/src/main/scala/org/http4s/dom/package.scala
@@ -61,7 +61,14 @@ package object dom {
 
   private[dom] def closeReadableStream[F[_], A](rs: ReadableStream[A], exitCase: Resource.ExitCase)(
       implicit F: Async[F]): F[Unit] = exitCase match {
-    case Resource.ExitCase.Succeeded => F.fromPromise(F.delay(rs.cancel(null))).void
+    case Resource.ExitCase.Succeeded =>
+      F.fromPromise {
+        F.delay {
+          // Best guess: Firefox internally locks a ReadableStream after it is "drained"
+          // This checks if the stream is locked before canceling it to avoid an error
+          if (!rs.locked) rs.cancel(null) else scalajs.js.Promise.resolve[Unit](())
+        }
+      }.void
     case Resource.ExitCase.Errored(ex) =>
       F.fromPromise(F.delay(rs.cancel(ex.getMessage()))).void
     case Resource.ExitCase.Canceled =>


### PR DESCRIPTION
This addresses the bug identified in #5090, although the Firefox CI question remains at large.

Explanation is in a code comment.

