### PR TITLE
Specify Scala.js binary version on website

### DIFF
--- a/website/jvm/src/hugo/content/versions.md
+++ b/website/jvm/src/hugo/content/versions.md
@@ -39,7 +39,7 @@ title: Versions
 	  <th class="text-center">Scala 2.12</th>
 	  <th class="text-center">Scala 2.13</th>
 	  <th class="text-center">Scala 3.0</th>
-		<th class="text-center">Scala.js</th>
+		<th class="text-center">Scala.js 1.x</th>
 	  <th>Cats</th>
 	  <th>FS2</th>
 	  <th>JDK</th>

--- a/website/jvm/src/hugo/content/versions.md
+++ b/website/jvm/src/hugo/content/versions.md
@@ -39,7 +39,7 @@ title: Versions
 	  <th class="text-center">Scala 2.12</th>
 	  <th class="text-center">Scala 2.13</th>
 	  <th class="text-center">Scala 3.0</th>
-		<th class="text-center">Scala.js 1.x</th>
+          <th class="text-center">Scala.js 1.x</th>
 	  <th>Cats</th>
 	  <th>FS2</th>
 	  <th>JDK</th>


### PR DESCRIPTION
Once upon a time many projects cross-built for Scala.js `0.6.x` and `1.x`. We most certainly will not!