### PR TITLE
Make charset parser case insensitive in Content-Disposition

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Content-Disposition.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Disposition.scala
@@ -47,7 +47,7 @@ object `Content-Disposition` {
     }
     val valueChars = attrChar.orElse(pctEncoded).rep
     val language = Parser.string(Rfc5234.alpha.rep) ~ (Parser.string("-") *> Rfc2616.token).rep0
-    val charset = Parser.string("UTF-8").as(StandardCharsets.UTF_8)
+    val charset = Parser.ignoreCase("UTF-8").as(StandardCharsets.UTF_8)
     val extValue = (Rfc5234.dquote *> Parser.charsWhile0(
       CharPredicate.All -- '"') <* Rfc5234.dquote) | (charset ~ (Parser.string(
       "'") *> language.? <* Parser.string("'")) ~ valueChars).map { case ((charset, _), values) =>


### PR DESCRIPTION
When we updated a service from 0.21 to 0.23 we discovered that Requests with a Content-Disposition header containing a filename attribute with "utf-8" charset were suddenly rejected.
This is because the charset parser is case sensitive.