### PR TITLE
ignoring error caused by client abruptly closing connection

### DIFF
--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -87,7 +87,8 @@ object WebSocketHelpers {
     } yield ()
 
     handler.handleErrorWith {
-      case BrokenPipeError() => F.unit
+      case e @ BrokenPipeError() =>
+        logger.trace(e)("WebSocket connection abruptly terminated by client")
       case e => logger.error(e)("WebSocket connection terminated with exception")
     }
   }

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -40,6 +40,8 @@ import java.nio.ByteBuffer
 import org.typelevel.log4cats.Logger
 import fs2.concurrent.SignallingRef
 
+import java.io.IOException
+
 object WebSocketHelpers {
 
   private[this] val supportedWebSocketVersion = 13L
@@ -84,8 +86,9 @@ object WebSocketHelpers {
         else F.unit
     } yield ()
 
-    handler.handleErrorWith { e =>
-      logger.error(e)("WebSocket connection terminated with exception")
+    handler.handleErrorWith {
+      case BrokenPipeError() => F.unit
+      case e => logger.error(e)("WebSocket connection terminated with exception")
     }
   }
 
@@ -275,4 +278,8 @@ object WebSocketHelpers {
       extends ClientHandshakeError(Status.BadRequest, "Sec-WebSocket-Key header not present.")
 
   final case class EndOfStreamError() extends Exception("Reached End Of Stream")
+
+  object BrokenPipeError {
+    def unapply(err: IOException): Boolean = err.getMessage == "Broken pipe"
+  }
 }


### PR DESCRIPTION
### Summary

When a client closes a web-socket connection abruptly an `IOException` is thrown by the underlying networking libraries.
The error handler in the `WebSocketHelpers` object (`ember-server`) logs an error for every error that occurs, even client errors.

This change aims to remove the noise caused by the logger.

#### Notes

- Unfortunately the error originates from a native method call and all we can do is check the error msg. 