### PR TITLE
[WIP] Make dsl.impl.Path from 0.21 source compatible with Uri.Path from 0.22

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -73,6 +73,9 @@ object Path {
   def apply(list: List[String]): Path =
     list.foldLeft(Root: Path)(_ / _)
 
+  def apply(vector: Vector[String]): Path =
+    vector.foldLeft(Root: Path)(_ / _)
+
   def unapplySeq(path: Path): Some[List[String]] =
     Some(path.toList)
 

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -73,8 +73,8 @@ object Path {
   def apply(list: List[String]): Path =
     list.foldLeft(Root: Path)(_ / _)
 
-  def apply(vector: Vector[String]): Path =
-    vector.foldLeft(Root: Path)(_ / _)
+  def unsafeFromString(fromPath: String): Path =
+    apply(fromPath)
 
   def unapplySeq(path: Path): Some[List[String]] =
     Some(path.toList)


### PR DESCRIPTION
helps with https://github.com/guardrail-dev/guardrail/pull/1200

EDIT:
This actually won't work, `Uri.Path` from 0.22 needs `Segment`s, not `String`s.
I need to rework this.
