### PR TITLE
Fixes issue CORS.toHttpRoutes and CORS.toHttpApp are unconfigurable (Added config parameter)

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -215,10 +215,10 @@ object CORS {
     }
 
   def httpRoutes[F[_]: Monad](httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
-    httpRoutes(httpRoutes, CORSConfig.default)
+    apply(httpRoutes, CORSConfig.default)
 
   def httpApp[F[_]: Applicative](httpApp: HttpApp[F]): HttpApp[F] =
-    httpApp(httpApp, CORSConfig.default)
+    apply(httpApp, CORSConfig.default)
 
   def httpRoutes[F[_]: Monad](
       httpRoutes: HttpRoutes[F],


### PR DESCRIPTION
This PR fixes issue #5096 

Updated CORS.scala, Added functions `httpRoutes` and `httpApp` with `config` parameters and made the old `httpRoutes` and `httpApp` (at lines 217 and 220 respectively) call the new `httpRoutes` and `httpApp` functions respectively ,  made the new `httpRoutes` and `httpApp` functions call the apply function with `CORSConfig` parameter, fixes the issue "CORS.toHttpRoutes and CORS.toHttpApp are unconfigurable #5096

- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
