### PR TITLE
Don't block on cancellation in Http1ServerStage

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
@@ -25,7 +25,7 @@ import cats.effect.kernel.Deferred
 import cats.effect.std.Dispatcher
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
-import org.http4s.blaze.pipeline.Command.Connected
+import org.http4s.blaze.pipeline.Command.{Connected, Disconnected}
 import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.blazecore.{ResponseParser, SeqTestHead}
 import org.http4s.dsl.io._
@@ -533,5 +533,37 @@ class Http1ServerStageSpec extends Http4sSuite {
     head.result.map { _ =>
       assert(head.closeCauses == Seq(None))
     }
+  }
+
+  fixture.test("Http1ServerStage: don't deadlock TickWheelExecutor with uncancelable request") {
+    tw =>
+      val reqUncancelable = List("GET /uncancelable HTTP/1.0\r\n\r\n")
+      val reqCancelable = List("GET /cancelable HTTP/1.0\r\n\r\n")
+
+      (for {
+        uncancelableStarted <- Deferred[IO, Unit]
+        uncancelableCanceled <- Deferred[IO, Unit]
+        cancelableStarted <- Deferred[IO, Unit]
+        cancelableCanceled <- Deferred[IO, Unit]
+        app = HttpApp[IO] {
+          case req if req.pathInfo === path"/uncancelable" =>
+            uncancelableStarted.complete(()) *>
+              IO.uncancelable { poll =>
+                poll(uncancelableCanceled.complete(())) *>
+                  cancelableCanceled.get
+              }.as(Response[IO]())
+          case _ =>
+            cancelableStarted.complete(()) *> IO.never.guarantee(
+              cancelableCanceled.complete(()).void)
+        }
+        head <- IO(runRequest(tw, reqUncancelable, app))
+        _ <- uncancelableStarted.get
+        _ <- uncancelableCanceled.get
+        _ <- IO(head.sendInboundCommand(Disconnected))
+        head2 <- IO(runRequest(tw, reqCancelable, app))
+        _ <- cancelableStarted.get
+        _ <- IO(head2.sendInboundCommand(Disconnected))
+        _ <- cancelableCanceled.get.timeout(5.seconds)
+      } yield ()).assert
   }
 }

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
@@ -563,7 +563,7 @@ class Http1ServerStageSpec extends Http4sSuite {
         head2 <- IO(runRequest(tw, reqCancelable, app))
         _ <- cancelableStarted.get
         _ <- IO(head2.sendInboundCommand(Disconnected))
-        _ <- cancelableCanceled.get.timeout(5.seconds)
+        _ <- cancelableCanceled.get
       } yield ()).assert
   }
 }


### PR DESCRIPTION
In Cats-Effect 3, cancellation applies backpressure on completion of the finalizer.  If a response can't be canceled, the cancellation task does not complete.  Beginning in http4s-0.23, we started running this cancellation token synchronously in `Http1ServerStage`.  The result is that an uncancelable response can lock up the `TickWheelExecutor`'s scheduler thread.  Unhandled scheduled events may continue to pile up until OOM.

This runs cancellation asynchronously, as was done before http4s-0.23.  The test demonstrates that scheduling continues even after the cancellation of an uncancelable request.

Fixes #5116.