### PR TITLE
Re-enable Firefox CI, only for DOM modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,15 @@ jobs:
         os: [ubuntu-latest]
         scala: [2.13.6, 2.12.14, 3.0.1]
         java: [adopt@1.8, adopt@1.11, adopt@1.16]
-        ci: [ciJVM, ciNodeJS, ciChrome]
+        ci: [ciJVM, ciNodeJS, ciFirefox, ciChrome]
         exclude:
           - ci: ciNodeJS
             java: adopt@1.11
           - ci: ciNodeJS
+            java: adopt@1.16
+          - ci: ciFirefox
+            java: adopt@1.11
+          - ci: ciFirefox
             java: adopt@1.16
           - ci: ciChrome
             java: adopt@1.11

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ ThisBuild / githubWorkflowBuild := Seq(
     cond = Some("matrix.ci == 'ciJVM'"))
 )
 
-val ciVariants = List("ciJVM", "ciNodeJS", /*"ciFirefox",*/ "ciChrome")
+val ciVariants = List("ciJVM", "ciNodeJS", "ciFirefox", "ciChrome")
 val jsCiVariants = ciVariants.tail
 ThisBuild / githubWorkflowBuildMatrixAdditions += "ci" -> ciVariants
 
@@ -135,10 +135,12 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
 
 addCommandAlias("ciJVM", "; project rootJVM")
 addCommandAlias("ciNodeJS", "; set parallelExecution := false; project rootNodeJS")
-def browserCiCommand(browser: JSEnv) =
-  s"; set parallelExecution := false; set Global / useJSEnv := JSEnv.$browser; project rootBrowser"
-addCommandAlias("ciFirefox", browserCiCommand(Firefox))
-addCommandAlias("ciChrome", browserCiCommand(Chrome))
+addCommandAlias(
+  "ciFirefox",
+  "; set parallelExecution := false; set Global / useJSEnv := JSEnv.Firefox; project rootDom")
+addCommandAlias(
+  "ciChrome",
+  "; set parallelExecution := false; set Global / useJSEnv := JSEnv.Chrome; project rootBrowser")
 
 enablePlugins(SonatypeCiReleasePlugin)
 
@@ -238,6 +240,15 @@ lazy val rootBrowser = project
     boopickle.js,
     jawn.js,
     circe.js,
+    domCore.js,
+    domFetchClient.js,
+    domServiceWorker.js,
+    domServiceWorkerTests.js
+  )
+
+lazy val rootDom = project
+  .enablePlugins(NoPublishPlugin)
+  .aggregate(
     domCore.js,
     domFetchClient.js,
     domServiceWorker.js,


### PR DESCRIPTION
An attempt to solve the Firefox testing problem reported in #5090 while avoiding flakiness by only testing the DOM modules, which are deeply intertwined with browser APIs.