### PR TITLE
blaze-0.14.18

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -318,7 +318,7 @@ object Http4sPlugin extends AutoPlugin {
     // error-prone merge conflicts in the dependencies below.
     val argonaut = "6.2.5"
     val asyncHttpClient = "2.10.5"
-    val blaze = "0.14.17"
+    val blaze = "0.14.18"
     val boopickle = "1.3.3"
     val cats = "2.6.1"
     val catsEffect = "2.5.1"


### PR DESCRIPTION
Gets us the monotonic TickWheelExecutor.  This didn't cause #5116, but it theoretically could.