### PR TITLE
Block prometheus simpleclient-0.12

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -83,6 +83,7 @@ object Http4sPlugin extends AutoPlugin {
     dependencyUpdatesFilter -= moduleFilter(name = "vault", revision = "3.*"),
     dependencyUpdatesFilter -= moduleFilter(name = "keypool", revision = "0.4.*"),
     dependencyUpdatesFilter -= moduleFilter(organization = "co.fs2", name = "fs2-*", revision = "3.*"),
+    dependencyUpdatesFilter -= moduleFilter(organization = "io.prometheus", revision = "0.12.*"),
 
     headerSources / excludeFilter := HiddenFileFilter ||
       new FileFilter {


### PR DESCRIPTION
Follow up from #5124, in reaction to the [breaking change](https://github.com/prometheus/client_java/releases/tag/parent-0.12.0).  I think it will be safe for individual projects to upgrade if they so choose, but they should go into the breaking metrics name with eyes wide open.