### PR TITLE
Backport empty Origin failure from #5082

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Origin.scala
+++ b/core/src/main/scala/org/http4s/headers/Origin.scala
@@ -63,7 +63,7 @@ object Origin {
     val bracketedIpv6 = char('[') *> Uri.Parser.ipv6Address <* char(']')
     val host = List(bracketedIpv6, Uri.Parser.ipv4Address, stringHost).reduceLeft(_ orElse _)
     val port = char(':') *> digit.rep.string.map(_.toInt)
-    val nullHost = (string("null") *> `end`).orElse(`end`).as(Origin.Null)
+    val nullHost = (string("null") *> `end`).as(Origin.Null)
 
     val singleHost = ((scheme <* string("://")) ~ host ~ port.?).map { case ((sch, host), port) =>
       Origin.Host(sch, host, port)

--- a/tests/src/test/scala/org/http4s/parser/OriginHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/OriginHeaderSuite.scala
@@ -73,19 +73,18 @@ class OriginHeaderSuite extends munit.FunSuite {
     assertEquals(extracted, Some(origin))
   }
 
-  test("OriginHeader parser should Parse an empty origin") {
-    val text = ""
-    val origin = Origin.Null
-    val headers = Headers(("Origin", text))
-    val extracted = headers.get[Origin]
-    assertEquals(extracted, Some(origin))
-  }
-
   test("OriginHeader parser should Parse a 'null' origin") {
     val text = "null"
     val origin = Origin.Null
     val headers = Headers(("Origin", text))
     val extracted = headers.get[Origin]
     assertEquals(extracted, Some(origin))
+  }
+
+  test("OriginHeader should fail on an empty string") {
+    val text = ""
+    val headers = Headers(("Origin", text))
+    val extracted = headers.get[Origin]
+    assertEquals(extracted, None)
   }
 }


### PR DESCRIPTION
We can't fully backport #5082 for binary compatibility reasons, but we can fix the bug where an empty string is treated as the null origin.