### PR TITLE
Support monitoring of the blaze-client pool

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientState.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientState.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.blaze.client
+
+import org.http4s.client.RequestKey
+import scala.collection.immutable
+
+trait BlazeClientState[F[_]] {
+  def isClosed: F[Boolean]
+  def allocated: F[immutable.Map[RequestKey, Int]]
+  def idleQueueDepth: F[immutable.Map[RequestKey, Int]]
+  def waitQueueDepth: F[Int]
+}

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/ConnectionManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/ConnectionManager.scala
@@ -56,6 +56,9 @@ private trait ConnectionManager[F[_], A <: Connection[F]] {
 }
 
 private object ConnectionManager {
+  trait Stateful[F[_], A <: Connection[F]] extends ConnectionManager[F, A] {
+    def state: BlazeClientState[F]
+  }
 
   /** Create a [[ConnectionManager]] that creates new connections on each request
     *
@@ -80,7 +83,7 @@ private object ConnectionManager {
       maxConnectionsPerRequestKey: RequestKey => Int,
       responseHeaderTimeout: Duration,
       requestTimeout: Duration,
-      executionContext: ExecutionContext): F[ConnectionManager[F, A]] =
+      executionContext: ExecutionContext): F[ConnectionManager.Stateful[F, A]] =
     Semaphore.uncancelable(1).map { semaphore =>
       new PoolManager[F, A](
         builder,

--- a/blaze-client/src/test/scala-2.13/org/http4s/client/blaze/BlazeClient213Suite.scala
+++ b/blaze-client/src/test/scala-2.13/org/http4s/client/blaze/BlazeClient213Suite.scala
@@ -40,7 +40,7 @@ class BlazeClient213Suite extends BlazeClientBase {
     Ref[IO]
       .of(0L)
       .flatMap { _ =>
-        mkClient(1, requestTimeout = 2.second).use { client =>
+        builder(1, requestTimeout = 2.second).resource.use { client =>
           val submit =
             client.status(Request[IO](uri = Uri.fromString(s"http://$name:$port/simple").yolo))
           submit *> munitTimer.sleep(3.seconds) *> submit
@@ -57,7 +57,7 @@ class BlazeClient213Suite extends BlazeClientBase {
       Uri.fromString(s"http://$name:$port/simple").yolo
     }
 
-    mkClient(3).use { client =>
+    builder(3).resource.use { client =>
       (1 to Runtime.getRuntime.availableProcessors * 5).toList
         .parTraverse { _ =>
           val h = hosts(Random.nextInt(hosts.length))
@@ -69,7 +69,7 @@ class BlazeClient213Suite extends BlazeClientBase {
 
   test("behave and not deadlock on failures with parTraverse") {
     val addresses = jettyServer().addresses
-    mkClient(3).use { client =>
+    builder(3).resource.use { client =>
       val failedHosts = addresses.map { address =>
         val name = address.getHostName
         val port = address.getPort
@@ -106,7 +106,7 @@ class BlazeClient213Suite extends BlazeClientBase {
 
   test("Blaze Http1Client should behave and not deadlock on failures with parSequence".flaky) {
     val addresses = jettyServer().addresses
-    mkClient(3).use { client =>
+    builder(3).resource.use { client =>
       val failedHosts = addresses.map { address =>
         val name = address.getHostName
         val port = address.getPort
@@ -142,7 +142,7 @@ class BlazeClient213Suite extends BlazeClientBase {
   test("call a second host after reusing connections on a first") {
     val addresses = jettyServer().addresses
     // https://github.com/http4s/http4s/pull/2546
-    mkClient(maxConnectionsPerRequestKey = Int.MaxValue, maxTotalConnections = 5)
+    builder(maxConnectionsPerRequestKey = Int.MaxValue, maxTotalConnections = 5).resource
       .use { client =>
         val uris = addresses.take(2).map { address =>
           val name = address.getHostName

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientBase.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientBase.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration._
 trait BlazeClientBase extends Http4sSuite {
   val tickWheel = new TickWheelExecutor(tick = 50.millis)
 
-  def mkClient(
+  def builder(
       maxConnectionsPerRequestKey: Int,
       maxTotalConnections: Int = 5,
       responseHeaderTimeout: Duration = 30.seconds,
@@ -48,11 +48,7 @@ trait BlazeClientBase extends Http4sSuite {
         .withChunkBufferMaxSize(chunkBufferMaxSize)
         .withScheduler(scheduler = tickWheel)
 
-    val builderWithMaybeSSLContext: BlazeClientBuilder[IO] =
-      sslContextOption.fold[BlazeClientBuilder[IO]](builder.withoutSslContext)(
-        builder.withSslContext)
-
-    builderWithMaybeSSLContext.resource
+    sslContextOption.fold[BlazeClientBuilder[IO]](builder.withoutSslContext)(builder.withSslContext)
   }
 
   private def testServlet =

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
@@ -35,7 +35,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val name = sslAddress.getHostName
     val port = sslAddress.getPort
     val u = Uri.fromString(s"https://$name:$port/simple").yolo
-    val resp = mkClient(0).use(_.expect[String](u).attempt)
+    val resp = builder(0).resource.use(_.expect[String](u).attempt)
     resp.assertEquals(Left(NoConnectionAllowedException(RequestKey(u.scheme.get, u.authority.get))))
   }
 
@@ -44,7 +44,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val name = sslAddress.getHostName
     val port = sslAddress.getPort
     val u = Uri.fromString(s"https://$name:$port/simple").yolo
-    val resp = mkClient(1).use(_.expect[String](u))
+    val resp = builder(1).resource.use(_.expect[String](u))
     resp.map(_.length > 0).assert
   }
 
@@ -53,7 +53,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val name = sslAddress.getHostName
     val port = sslAddress.getPort
     val u = Uri.fromString(s"https://$name:$port/simple").yolo
-    val resp = mkClient(1, sslContextOption = None)
+    val resp = builder(1, sslContextOption = None).resource
       .use(_.expect[String](u))
       .attempt
     resp.map {
@@ -68,7 +68,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val address = addresses.head
     val name = address.getHostName
     val port = address.getPort
-    mkClient(1, responseHeaderTimeout = 100.millis)
+    builder(1, responseHeaderTimeout = 100.millis).resource
       .use { client =>
         val submit = client.expect[String](Uri.fromString(s"http://$name:$port/delayed").yolo)
         submit
@@ -81,7 +81,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val address = addresses.head
     val name = address.getHostName
     val port = address.getPort
-    mkClient(1, responseHeaderTimeout = 20.seconds)
+    builder(1, responseHeaderTimeout = 20.seconds).resource
       .use { client =>
         val submit = client.expect[String](Uri.fromString(s"http://$name:$port/delayed").yolo)
         for {
@@ -99,7 +99,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val name = address.getHostName
     val port = address.getPort
 
-    val resp = mkClient(1, responseHeaderTimeout = 20.seconds)
+    val resp = builder(1, responseHeaderTimeout = 20.seconds).resource
       .use { drainTestClient =>
         drainTestClient
           .expect[String](Uri.fromString(s"http://$name:$port/delayed").yolo)
@@ -128,7 +128,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val port = address.getPort
     Deferred[IO, Unit]
       .flatMap { reqClosed =>
-        mkClient(1, requestTimeout = 2.seconds).use { client =>
+        builder(1, requestTimeout = 2.seconds).resource.use { client =>
           val body = Stream(0.toByte).repeat.onFinalizeWeak(reqClosed.complete(()))
           val req = Request[IO](
             method = Method.POST,
@@ -151,7 +151,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val port = address.getPort
     Deferred[IO, Unit]
       .flatMap { reqClosed =>
-        mkClient(1, requestTimeout = 2.seconds).use { client =>
+        builder(1, requestTimeout = 2.seconds).resource.use { client =>
           val body = Stream(0.toByte).repeat.onFinalizeWeak(reqClosed.complete(()))
           val req = Request[IO](
             method = Method.POST,
@@ -169,7 +169,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val address = addresses.head
     val name = address.getHostName
     val port = address.getPort
-    mkClient(1, requestTimeout = 500.millis, responseHeaderTimeout = Duration.Inf)
+    builder(1, requestTimeout = 500.millis, responseHeaderTimeout = Duration.Inf).resource
       .use { client =>
         val body = Stream(0.toByte).repeat
         val req = Request[IO](
@@ -192,7 +192,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val address = addresses.head
     val name = address.getHostName
     val port = address.getPort
-    mkClient(1, requestTimeout = Duration.Inf, responseHeaderTimeout = 500.millis)
+    builder(1, requestTimeout = Duration.Inf, responseHeaderTimeout = 500.millis).resource
       .use { client =>
         val body = Stream(0.toByte).repeat
         val req = Request[IO](
@@ -216,7 +216,7 @@ class BlazeClientSuite extends BlazeClientBase {
     val port = address.getPort
     val uri = Uri.fromString(s"http://$name:$port/simple").yolo
 
-    mkClient(1)
+    builder(1).resource
       .use { client =>
         val req = Request[IO](uri = uri)
         client
@@ -232,7 +232,7 @@ class BlazeClientSuite extends BlazeClientBase {
   }
 
   test("Blaze Http1Client should raise a ConnectionFailure when a host can't be resolved") {
-    mkClient(1)
+    builder(1).resource
       .use { client =>
         client.status(Request[IO](uri = uri"http://example.invalid/"))
       }
@@ -243,5 +243,28 @@ class BlazeClientSuite extends BlazeClientBase {
         case _ => false
       }
       .assert
+  }
+
+  test("Keeps stats") {
+    val addresses = jettyServer().addresses
+    val address = addresses.head
+    val name = address.getHostName
+    val port = address.getPort
+    val uri = Uri.fromString(s"http://$name:$port/simple").yolo
+    builder(1, requestTimeout = 2.seconds).resourceWithState.use { case (client, state) =>
+      for {
+        // We're not thoroughly exercising the pool stats.  We're doing a rudimentary check.
+        _ <- state.allocated.assertEquals(Map.empty[RequestKey, Int])
+        reading <- Deferred[IO, Unit]
+        done <- Deferred[IO, Unit]
+        body = Stream.eval(reading.complete(())) *> (Stream.empty: EntityBody[IO]) <* Stream.eval(
+          done.get)
+        req = Request[IO](Method.POST, uri = uri).withEntity(body)
+        _ <- client.status(req).start
+        _ <- reading.get
+        _ <- state.allocated.map(_.get(RequestKey.fromRequest(req))).assertEquals(Some(1))
+        _ <- done.complete(())
+      } yield ()
+    }
   }
 }


### PR DESCRIPTION
* Exposes some basic metrics on the client pool for monitoring.  Our use case is to see that the wait queue is backing up before it pops.
* Introduces a `ConnectionManager.Stateful`.  The only production implementation, `PoolManager`, is this. 
* Similar to `EmberClient`, though I didn't name the tuple. 
* Less similar to `AsyncHttpClientStats`, because we don't retain an underlying backend object to obtain stats separately