### PR TITLE
Update setup-node action to v2.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Setup NodeJS v16
         if: matrix.ci == 'ciNodeJS'
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v2.4.0
         with:
           node-version: 16
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ ThisBuild / githubWorkflowUseSbtThinClient := false
 ThisBuild / githubWorkflowBuildPreamble ++=
   Seq(
     WorkflowStep.Use(
-      UseRef.Public("actions", "setup-node", "v2.1.5"),
+      UseRef.Public("actions", "setup-node", "v2.4.0"),
       name = Some("Setup NodeJS v16"),
       params = Map("node-version" -> "16"),
       cond = Some("matrix.ci == 'ciNodeJS'")),


### PR DESCRIPTION
I don't think this update is critical to the [reported security vulnerability](https://github.blog/2021-09-08-github-security-update-vulnerabilities-tar-npmcli-arborist/) but can't hurt.