### PR TITLE
Addition of the Access-Control-Max-Age header

### DIFF
--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
@@ -1,7 +1,23 @@
-package org.http4s.headers
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package headers
 
 import org.http4s.parser.AdditionalRules
-import org.http4s.{Header, ParseResult}
 import org.typelevel.ci.CIStringSyntax
 
 import scala.concurrent.duration.{DurationLong, FiniteDuration}

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
@@ -7,12 +7,7 @@ import org.typelevel.ci.CIStringSyntax
 import scala.concurrent.duration.{DurationLong, FiniteDuration}
 import scala.util.Try
 
-/** Constructs an `Access-Control-Max-Age` header.
-  *
-  * The value of this field indicates how long the results of a preflight request (that is the information contained in the Access-Control-Allow-Methods and [[`Access-Control-Allow-Headers`]] headers) can be cached. A value of -1 will disable caching.
-  *
-  * @param age age of the response (in seconds)
-  */
+/** The `Access-Control-Max-Age` header. */
 trait `Access-Control-Max-Age` {
   def duration: Option[FiniteDuration]
   def unsafeDuration: FiniteDuration
@@ -20,6 +15,7 @@ trait `Access-Control-Max-Age` {
 
 object `Access-Control-Max-Age` {
 
+  /** A value of -1 of the age parameter will disable caching. */
   final case object NoCaching extends `Access-Control-Max-Age` {
     override def duration: Option[FiniteDuration] = Option.empty
 
@@ -27,6 +23,10 @@ object `Access-Control-Max-Age` {
       "It's no possible to get cache duration if caching is disable")
   }
 
+  /** The value of this field indicates how long the results of a preflight request (that is the information contained in the Access-Control-Allow-Methods and [[`Access-Control-Allow-Headers`]] headers) can be cached.
+    *
+    * @param age age of the response (in seconds)
+    */
   final case class Cache private (age: Long) extends `Access-Control-Max-Age` {
     def duration: Option[FiniteDuration] = Try(age.seconds).toOption
     def unsafeDuration: FiniteDuration = age.seconds

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
@@ -7,7 +7,6 @@ import org.typelevel.ci.CIStringSyntax
 import scala.concurrent.duration.{DurationLong, FiniteDuration}
 import scala.util.Try
 
-
 /** Constructs an `Access-Control-Max-Age` header.
   *
   * The value of this field indicates how long the results of a preflight request (that is the information contained in the Access-Control-Allow-Methods and [[`Access-Control-Allow-Headers`]] headers) can be cached. A value of -1 will disable caching.
@@ -25,7 +24,7 @@ object `Access-Control-Max-Age` {
     override def duration: Option[FiniteDuration] = Option.empty
 
     override def unsafeDuration: FiniteDuration = throw new UnsupportedOperationException(
-        "It's no possible to get cache duration if caching is disable")
+      "It's no possible to get cache duration if caching is disable")
   }
 
   final case class Cache private (age: Long) extends `Access-Control-Max-Age` {
@@ -58,7 +57,10 @@ object `Access-Control-Max-Age` {
   implicit val headerInstance: Header[`Access-Control-Max-Age`, Header.Single] =
     Header.createRendered(
       ci"Access-Control-Max-Age",
-      _.age,
+      {
+        case Cache(age) => age
+        case NoCaching => -1
+      },
       parse
     )
 }

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
@@ -1,0 +1,46 @@
+package org.http4s.headers
+
+import org.http4s.parser.AdditionalRules
+import org.http4s.{Header, ParseResult}
+import org.typelevel.ci.CIStringSyntax
+
+import scala.concurrent.duration.{DurationLong, FiniteDuration}
+import scala.util.Try
+
+object `Access-Control-Max-Age` {
+  def fromLong(age: Long): ParseResult[`Access-Control-Max-Age`] =
+    if (age >= 0)
+      ParseResult.success(apply(age))
+    else
+      ParseResult.fail("Invalid age value", s"Access-Control-Max-Age param $age must be more or equal to 0 seconds")
+
+  def unsafeFromDuration(age: FiniteDuration): `Access-Control-Max-Age` =
+    fromLong(age.toSeconds).fold(throw _, identity)
+
+  def unsafeFromLong(age: Long): `Access-Control-Max-Age` =
+    fromLong(age).fold(throw _, identity)
+
+  def parse(s: String): ParseResult[`Access-Control-Max-Age`] =
+    ParseResult.fromParser(parser, "Invalid Access-Control-Max-Age header")(s)
+
+  private[http4s] val parser = AdditionalRules.NonNegativeLong.map(unsafeFromLong)
+
+  implicit val headerInstance: Header[`Access-Control-Max-Age`, Header.Single] =
+    Header.createRendered(
+      ci"Access-Control-Max-Age",
+      _.age,
+      parse
+    )
+}
+
+/** Constructs an `Access-Control-Max-Age` header.
+  *
+  * The value of this field indicates how long the results of a preflight request (that is the information contained in the Access-Control-Allow-Methods and {@link `Access-Control-Allow-Headers`} headers) can be cached. A value of -1 will disable caching.
+  *
+  * @param age age of the response (in seconds)
+  */
+final case class `Access-Control-Max-Age` private (age: Long) {
+  def duration: Option[FiniteDuration] = Try(age.seconds).toOption
+
+  def unsafeDuration: FiniteDuration = age.seconds
+}

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
@@ -19,25 +19,16 @@ package headers
 
 import org.http4s.parser.AdditionalRules
 import org.typelevel.ci.CIStringSyntax
-
 import scala.concurrent.duration.{DurationLong, FiniteDuration}
 import scala.util.Try
 
 /** The `Access-Control-Max-Age` header. */
-trait `Access-Control-Max-Age` {
-  def duration: Option[FiniteDuration]
-  def unsafeDuration: FiniteDuration
-}
+trait `Access-Control-Max-Age`
 
 object `Access-Control-Max-Age` {
 
   /** A value of -1 of the age parameter will disable caching. */
-  final case object NoCaching extends `Access-Control-Max-Age` {
-    override def duration: Option[FiniteDuration] = Option.empty
-
-    override def unsafeDuration: FiniteDuration = throw new UnsupportedOperationException(
-      "It's no possible to get cache duration if caching is disable")
-  }
+  final case object NoCaching extends `Access-Control-Max-Age`
 
   /** The value of this field indicates how long the results of a preflight request (that is the information contained in the Access-Control-Allow-Methods and [[`Access-Control-Allow-Headers`]] headers) can be cached.
     *
@@ -68,7 +59,7 @@ object `Access-Control-Max-Age` {
   def parse(s: String): ParseResult[`Access-Control-Max-Age`] =
     ParseResult.fromParser(parser, "Invalid Access-Control-Max-Age header")(s)
 
-  private[http4s] val parser = AdditionalRules.NonNegativeLong.map(unsafeFromLong)
+  private[http4s] val parser = AdditionalRules.Long.map(unsafeFromLong)
 
   implicit val headerInstance: Header[`Access-Control-Max-Age`, Header.Single] =
     Header.createRendered(

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
@@ -7,12 +7,42 @@ import org.typelevel.ci.CIStringSyntax
 import scala.concurrent.duration.{DurationLong, FiniteDuration}
 import scala.util.Try
 
+
+/** Constructs an `Access-Control-Max-Age` header.
+  *
+  * The value of this field indicates how long the results of a preflight request (that is the information contained in the Access-Control-Allow-Methods and [[`Access-Control-Allow-Headers`]] headers) can be cached. A value of -1 will disable caching.
+  *
+  * @param age age of the response (in seconds)
+  */
+trait `Access-Control-Max-Age` {
+  def duration: Option[FiniteDuration]
+  def unsafeDuration: FiniteDuration
+}
+
 object `Access-Control-Max-Age` {
+
+  final case object NoCaching extends `Access-Control-Max-Age` {
+    override def duration: Option[FiniteDuration] = Option.empty
+
+    override def unsafeDuration: FiniteDuration = throw new UnsupportedOperationException(
+        "It's no possible to get cache duration if caching is disable")
+  }
+
+  final case class Cache private (age: Long) extends `Access-Control-Max-Age` {
+    def duration: Option[FiniteDuration] = Try(age.seconds).toOption
+    def unsafeDuration: FiniteDuration = age.seconds
+  }
+
   def fromLong(age: Long): ParseResult[`Access-Control-Max-Age`] =
     if (age >= 0)
-      ParseResult.success(apply(age))
-    else
-      ParseResult.fail("Invalid age value", s"Access-Control-Max-Age param $age must be more or equal to 0 seconds")
+      ParseResult.success(Cache.apply(age))
+    else if (age == -1) {
+      ParseResult.success(NoCaching)
+    } else {
+      ParseResult.fail(
+        "Invalid age value",
+        s"Access-Control-Max-Age param $age must be greater or equal to 0 seconds or -1")
+    }
 
   def unsafeFromDuration(age: FiniteDuration): `Access-Control-Max-Age` =
     fromLong(age.toSeconds).fold(throw _, identity)
@@ -31,16 +61,4 @@ object `Access-Control-Max-Age` {
       _.age,
       parse
     )
-}
-
-/** Constructs an `Access-Control-Max-Age` header.
-  *
-  * The value of this field indicates how long the results of a preflight request (that is the information contained in the Access-Control-Allow-Methods and [[`Access-Control-Allow-Headers`]] headers) can be cached. A value of -1 will disable caching.
-  *
-  * @param age age of the response (in seconds)
-  */
-final case class `Access-Control-Max-Age` private (age: Long) {
-  def duration: Option[FiniteDuration] = Try(age.seconds).toOption
-
-  def unsafeDuration: FiniteDuration = age.seconds
 }

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Max-Age`.scala
@@ -35,7 +35,7 @@ object `Access-Control-Max-Age` {
 
 /** Constructs an `Access-Control-Max-Age` header.
   *
-  * The value of this field indicates how long the results of a preflight request (that is the information contained in the Access-Control-Allow-Methods and {@link `Access-Control-Allow-Headers`} headers) can be cached. A value of -1 will disable caching.
+  * The value of this field indicates how long the results of a preflight request (that is the information contained in the Access-Control-Allow-Methods and [[`Access-Control-Allow-Headers`]] headers) can be cached. A value of -1 will disable caching.
   *
   * @param age age of the response (in seconds)
   */

--- a/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
+++ b/core/src/main/scala/org/http4s/parser/AdditionalRules.scala
@@ -28,4 +28,11 @@ private[http4s] object AdditionalRules {
       case _: NumberFormatException => None
     }
   }
+
+  val Long: P[Long] = Rfc7230.token.mapFilter { s =>
+    try Some(s.toLong)
+    catch {
+      case _: NumberFormatException => None
+    }
+  }
 }

--- a/tests/src/test/scala/org/http4s/headers/AccessControlMaxAgeSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/AccessControlMaxAgeSuite.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.headers
+
+import org.http4s.{Http4sSuite, ParseResult}
+import org.http4s.implicits.http4sSelectSyntaxOne
+
+class AccessControlMaxAgeSuite extends Http4sSuite {
+//  checkAll("Access-Control-MaxA-ge", headerLaws[`Access-Control-Max-Age`])
+
+  test("render should age in seconds") {
+    assertEquals(`Access-Control-Max-Age`.fromLong(120).map(_.renderString), ParseResult.success("Access-Control-Max-Age: 120"))
+  }
+
+}


### PR DESCRIPTION
Here it's the changes that introduce management of the header Access-Control-Max-Age.
I'm still missing some parsing internals, but I think it could be a good starting point.

Any feedback will be appreciated :)

The reference issue is #5010