### PR TITLE
Expand scaladoc for Query

### DIFF
--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -33,10 +33,10 @@ import scala.collection.mutable.ListBuffer
 /** Collection representation of a query string
   *
   * It is a indexed sequence of key and maybe a value pairs which maps
-  * precisely to a query string, modulo 
-  * [[https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 percent-encoding]] 
+  * precisely to a query string, modulo
+  * [[https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 percent-encoding]]
   * and the identity of separators.
-  * 
+  *
   * The internal representation is not percent-encoded; percent-encoding is
   * applied when rendering and decoded when parsing. For example, the strings
   * "://" and "%3A%2F%2F" will both be parsed as "://" and rendered as "%3A//".

--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -34,12 +34,7 @@ import scala.collection.mutable.ListBuffer
   *
   * It is a indexed sequence of key and maybe a value pairs which maps
   * precisely to a query string, modulo
-  * [[https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 percent-encoding]]
-  * and the identity of separators.
-  *
-  * The internal representation is not percent-encoded; percent-encoding is
-  * applied when rendering and decoded when parsing. For example, the strings
-  * "://" and "%3A%2F%2F" will both be parsed as "://" and rendered as "%3A//".
+  * [[https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 percent-encoding]].
   *
   * When rendered, the resulting `String` will have the pairs separated
   * by '&' while the key is separated from the value with '='

--- a/core/src/main/scala/org/http4s/Query.scala
+++ b/core/src/main/scala/org/http4s/Query.scala
@@ -33,7 +33,13 @@ import scala.collection.mutable.ListBuffer
 /** Collection representation of a query string
   *
   * It is a indexed sequence of key and maybe a value pairs which maps
-  * precisely to a query string, modulo the identity of separators.
+  * precisely to a query string, modulo 
+  * [[https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 percent-encoding]] 
+  * and the identity of separators.
+  * 
+  * The internal representation is not percent-encoded; percent-encoding is
+  * applied when rendering and decoded when parsing. For example, the strings
+  * "://" and "%3A%2F%2F" will both be parsed as "://" and rendered as "%3A//".
   *
   * When rendered, the resulting `String` will have the pairs separated
   * by '&' while the key is separated from the value with '='


### PR DESCRIPTION
I think it would be good to have optional manual control over percent-encoding, but documenting the existing behaviour is a start.

By the way, what does "modulo the identity of separators" mean?