### PR TITLE
Allow optional spaces when separating cookie value from directives

### DIFF
--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -78,7 +78,7 @@ final case class ResponseCookie(
 
 object ResponseCookie {
   private[http4s] val parser: Parser[ResponseCookie] = {
-    import Parser.{char, charIn, failWith, ignoreCase, pure, string}
+    import Parser.{char, charIn, failWith, ignoreCase, pure}
     import Rfc2616.Rfc1123Date
     import Rfc5234.digit
     import Rfc6265.{cookieName, cookieValue}

--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -201,7 +201,7 @@ object ResponseCookie {
       .orElse(extensionAv)
 
     /* set-cookie-string = cookie-pair *( ";" SP cookie-av ) */
-    (cookiePair ~ (string(";") *> string(" ").? *> cookieAv).rep0).map {
+    (cookiePair ~ (char(';') *> char(' ').rep0 *> cookieAv).rep0).map {
       case ((name, value), avs) =>
         avs.foldLeft(ResponseCookie(name, value))((p, f) => f(p))
     }

--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -201,8 +201,9 @@ object ResponseCookie {
       .orElse(extensionAv)
 
     /* set-cookie-string = cookie-pair *( ";" SP cookie-av ) */
-    (cookiePair ~ (string("; ") *> cookieAv).rep0).map { case ((name, value), avs) =>
-      avs.foldLeft(ResponseCookie(name, value))((p, f) => f(p))
+    (cookiePair ~ (string(";") *> string(" ").? *> cookieAv).rep0).map {
+      case ((name, value), avs) =>
+        avs.foldLeft(ResponseCookie(name, value))((p, f) => f(p))
     }
   }
 }

--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -201,9 +201,8 @@ object ResponseCookie {
       .orElse(extensionAv)
 
     /* set-cookie-string = cookie-pair *( ";" SP cookie-av ) */
-    (cookiePair ~ (char(';') *> char(' ').rep0 *> cookieAv).rep0).map {
-      case ((name, value), avs) =>
-        avs.foldLeft(ResponseCookie(name, value))((p, f) => f(p))
+    (cookiePair ~ (char(';') *> char(' ').rep0 *> cookieAv).rep0).map { case ((name, value), avs) =>
+      avs.foldLeft(ResponseCookie(name, value))((p, f) => f(p))
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/headers/SetCookieHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/headers/SetCookieHeaderSpec.scala
@@ -56,6 +56,20 @@ class SetCookieHeaderSpec extends Http4sSuite {
     assertEquals(c.httpOnly, true)
   }
 
+  test("Set-Cookie parser should parse a set cookie without spaces") {
+    val cookiestr =
+      "myname=\"foo\";Domain=example.com;Max-Age=1;Path=value;SameSite=Strict;Secure;HttpOnly"
+    val c = parse(cookiestr).cookie
+    assertEquals(c.name, "myname")
+    assertEquals(c.domain, Some("example.com"))
+    assertEquals(c.content, """"foo"""")
+    assertEquals(c.maxAge, Some(1L))
+    assertEquals(c.path, Some("value"))
+    assertEquals(c.sameSite, Some(SameSite.Strict))
+    assertEquals(c.secure, true)
+    assertEquals(c.httpOnly, true)
+  }
+
   test("Set-Cookie parser should parse with a domain with a leading dot") {
     val cookiestr = "myname=\"foo\"; Domain=.example.com"
     val c = parse(cookiestr).cookie


### PR DESCRIPTION
# What has been done here?

Allow optional spaces when separating cookie value from directives

# Why?

According to [rfc-6265](https://datatracker.ietf.org/doc/html/rfc6265#section-2.2) spaces after `;` separating a `set-cookie` directives are optional:

> This specification uses the Augmented Backus-Naur Form (ABNF)
>    notation of [RFC5234].
> 
>    The following core rules are included by reference, as defined in
>    [RFC5234], Appendix B.1: ALPHA (letters), CR (carriage return), CRLF
>    (CR LF), CTLs (controls), DIGIT (decimal 0-9), DQUOTE (double quote),
>    HEXDIG (hexadecimal 0-9/A-F/a-f), LF (line feed), NUL (null octet),
>    OCTET (any 8-bit sequence of data except NUL), SP (space), HTAB
>    (horizontal tab), CHAR (any [USASCII] character), VCHAR (any visible
>    [USASCII] character), and WSP (whitespace).
> 
>    The OWS (optional whitespace) rule is used where zero or more linear
>    whitespace characters MAY appear:
> 
>    OWS            = *( [ obs-fold ] WSP )
>                     ; "optional" whitespace
>    obs-fold       = CRLF
> 
>    OWS SHOULD either not be produced or be produced as a single SP
>    character.

After the changes introduced in the `ResponseCookie` parser before releasing `0.22.x` version, reading cookies that aren't using spaces is broken.

You can test this behavior quickly in a worksheet:

```scala
import cats.effect.IO
import org.http4s._
import org.http4s.headers.`Set-Cookie`
import org.typelevel.ci._

val cookie = Header.Raw(ci"set-cookie", "Key=value;Path=/;Secure;HTTPOnly")

implicitly[Header.Select[`Set-Cookie`]].from(List(cookie))
```

☝🏼 That doesn't work

👇🏼 While this does

```scala
import cats.effect.IO
import org.http4s._
import org.http4s.headers.`Set-Cookie`
import org.typelevel.ci._

val cookie = Header.Raw(ci"set-cookie", "Key=value; Path=/; Secure; HTTPOnly")

implicitly[Header.Select[`Set-Cookie`]].from(List(cookie))
```

Thanks to @ChristopherDavenport for pointing me to the solution 😸.