### PR TITLE
Replace Sync and Concurrent constraints with fs2.Compiler.Target

### DIFF
--- a/core/shared/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/shared/src/main/scala/org/http4s/UrlForm.scala
@@ -18,7 +18,7 @@ package org.http4s
 
 import cats.{Eq, Monoid}
 import cats.data.Chain
-import cats.effect.Concurrent
+import fs2.Compiler.Target
 import cats.syntax.all._
 import org.http4s.headers._
 import org.http4s.internal.CollectionCompat
@@ -105,7 +105,7 @@ object UrlForm {
       .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`, charset))
 
   implicit def entityDecoder[F[_]](implicit
-      F: Concurrent[F],
+      F: Target[F],
       defaultCharset: Charset = DefaultCharset): EntityDecoder[F, UrlForm] =
     EntityDecoder.decodeBy(MediaType.application.`x-www-form-urlencoded`) { m =>
       DecodeResult(

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -17,15 +17,15 @@
 package org.http4s
 package multipart
 
-import cats.effect.Concurrent
+import fs2.Compiler.Target
 import cats.syntax.all._
 import fs2.Pipe
 
 private[http4s] object MultipartDecoder extends MultipartDecoderPlatform {
-  def decoder[F[_]: Concurrent]: EntityDecoder[F, Multipart[F]] =
+  def decoder[F[_]: Target]: EntityDecoder[F, Multipart[F]] =
     makeDecoder(MultipartParser.parseToPartsStream[F](_))
 
-  private[multipart] def makeDecoder[F[_]: Concurrent](
+  private[multipart] def makeDecoder[F[_]: Target](
       impl: Boundary => Pipe[F, Byte, Part[F]]
   ): EntityDecoder[F, Multipart[F]] =
     EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -21,7 +21,7 @@ package middleware
 import cats.arrow.FunctionK
 import cats.{FlatMap, ~>}
 import cats.data.{Kleisli, NonEmptyList, OptionT}
-import cats.effect.Sync
+import fs2.Compiler.Target
 import cats.syntax.all._
 import fs2._
 import org.http4s.headers._
@@ -29,7 +29,7 @@ import org.typelevel.ci._
 import scala.collection.mutable.ListBuffer
 
 object ChunkAggregator {
-  def apply[F[_]: FlatMap, G[_]: Sync, A](f: G ~> F)(
+  def apply[F[_]: FlatMap, G[_]: Target, A](f: G ~> F)(
       http: Kleisli[F, A, Response[G]]): Kleisli[F, A, Response[G]] =
     http.flatMapF { response =>
       f(
@@ -42,10 +42,10 @@ object ChunkAggregator {
           })
     }
 
-  def httpRoutes[F[_]: Sync](httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
+  def httpRoutes[F[_]: Target](httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
     apply(OptionT.liftK[F])(httpRoutes)
 
-  def httpApp[F[_]: Sync](httpApp: HttpApp[F]): HttpApp[F] =
+  def httpApp[F[_]: Target](httpApp: HttpApp[F]): HttpApp[F] =
     apply(FunctionK.id[F])(httpApp)
 
   /* removes the `TransferCoding.chunked` value from the `Transfer-Encoding` header,


### PR DESCRIPTION
There's a lot of places that need `Target` but have a context bound of `Concurrent` or `Sync` - either of which derives `Target` but neither of which implies the other. That makes the API less flexible, and client code ends up needing both and using an `Async` bound. The `Concurrent` bound also prevents use of datatypes such as `SyncIO` and `StateT` that have `Sync` but not `Concurrent` instances.

I have a more comprehensive version of this PR stashed away, but this is enough to convey the idea.