### PR TITLE
Right align the social icons in the navbar again

### DIFF
--- a/website/jvm/src/hugo/themes/http4s.org/layouts/_default/single.html
+++ b/website/jvm/src/hugo/themes/http4s.org/layouts/_default/single.html
@@ -12,7 +12,7 @@
       </button>
 
       <div class="collapse navbar-collapse" id="navbarsExampleDefault">
-        <ul class="navbar-nav mr-auto">
+        <ul class="navbar-nav me-auto">
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="https://http4s.org/#" id="docs-menu-item" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Documentation

--- a/website/jvm/src/hugo/themes/http4s.org/layouts/partials/nav.html
+++ b/website/jvm/src/hugo/themes/http4s.org/layouts/partials/nav.html
@@ -12,7 +12,7 @@
       </a>
     </div>
     <div id="navbar" class="collapse navbar-collapse">
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="https://http4s.org/#" id="projects-menu-item" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Projects


### PR DESCRIPTION
Bootstrap 5 renamed the `mr-auto` class to `me-auto`. This class applies the `margin-right: auto` rule which has the effect of pushing the remaining elements to the right. Since we're on Bootstrap 5 now, use the new class.

| Current | Proposed |
| - | - |
| <img width="961" alt="image" src="https://user-images.githubusercontent.com/4206232/133856873-3bcaeadc-af47-44c3-90ec-20f21440e7f8.png"> | <img width="990" alt="image" src="https://user-images.githubusercontent.com/4206232/133856883-1f0f8635-98e6-4112-8d9f-c88d1868c1e7.png">