### PR TITLE
Fix edit button links and positioning

### DIFF
--- a/website/jvm/src/hugo/layouts/partials/edit-button.html
+++ b/website/jvm/src/hugo/layouts/partials/edit-button.html
@@ -1,3 +1,3 @@
-<a href="https://github.com/http4s/http4s/edit/main/website/src/hugo/content/{{ .File.Path }}" class="btn btn-secondary btn-sm">
+<a href="https://github.com/http4s/http4s/edit/main/website/jvm/src/hugo/content/{{ .File.Path }}" class="btn btn-secondary btn-sm">
   <i class="fa fa-edit"></i>
 </a>

--- a/website/jvm/src/hugo/themes/http4s.org/layouts/_default/single.html
+++ b/website/jvm/src/hugo/themes/http4s.org/layouts/_default/single.html
@@ -50,7 +50,7 @@
       <div class="row row-offcanvas row-offcanvas-right">
 
         <div class="col-12 col-md-9 order-1">
-          <span class="float-right">
+          <span class="float-end">
           {{ partial "edit-button.html" . }}
           <span class="d-md-none">
             <button type="button" class="btn btn-secondary btn-sm" data-toggle="offcanvas">


### PR DESCRIPTION
There are some floating edit and navigation offcanvas buttons that have stopped floating due to Bootstrap 5 renaming some classes, so I've fixed that. I also rolled in a change that fixes the website edit links. The docs edit links are fine, though.

I also considered updating [this file](https://github.com/http4s/http4s/blob/66e322e1650f424ddd5ffd49ca211b6d9540ba8b/website/jvm/src/hugo/layouts/partials/edit-link.html) but it seems to be unused from what I can tell. Maybe ripping out all of this unused stuff can be its own issue? Or maybe it's not actually unused? (Related: https://github.com/http4s/http4s/pull/5208#issuecomment-922099474)

| Current | Proposed |
| - | - |
| <img width="1017" alt="image" src="https://user-images.githubusercontent.com/4206232/133869844-9d6db379-0cbe-4140-a4c1-203decbb1a1c.png"> | <img width="1011" alt="image" src="https://user-images.githubusercontent.com/4206232/133869852-e071c672-ca6d-4452-9dfb-741524b0d100.png">

