### PR TITLE
Improve Ember Parser Performance

### DIFF
--- a/bench/src/main/scala/org/http4s/ember/bench/EmberParserBench.scala
+++ b/bench/src/main/scala/org/http4s/ember/bench/EmberParserBench.scala
@@ -69,8 +69,8 @@ object EmberParserBench {
     def setup(): Unit = {
       req = Request[IO]().withEntity("Hello Bench!")
       resp = Response[IO]().withEntity("Hello Bench!")
-      reqBytes = org.http4s.ember.core.Encoder.reqToBytes(req).compile.to(Array).unsafeRunSync
-      respBytes = org.http4s.ember.core.Encoder.respToBytes(resp).compile.to(Array).unsafeRunSync
+      reqBytes = org.http4s.ember.core.Encoder.reqToBytes(req).compile.to(Array).unsafeRunSync()
+      respBytes = org.http4s.ember.core.Encoder.respToBytes(resp).compile.to(Array).unsafeRunSync()
 
       println(s"Content-Length: ${req.contentLength}")
     }

--- a/bench/src/main/scala/org/http4s/ember/bench/EmberParserBench.scala
+++ b/bench/src/main/scala/org/http4s/ember/bench/EmberParserBench.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.ember.bench
+
+import java.util.concurrent.TimeUnit
+
+import org.http4s._
+import cats.effect.IO
+import org.openjdk.jmh.annotations._
+import cats.effect.ContextShift
+import org.http4s.ember.core.Parser
+
+// sbt "bench/Jmh/run -i 5 -wi 5 -f 1 -t 1 org.http4s.ember.bench.EmberParserBench"
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class EmberParserBench {
+  import EmberParserBench._
+
+  @Benchmark
+  def parseRequest(in: BenchState): Request[IO] =
+    Parser.Request
+      .parser(in.maxHeaderSize)(in.reqBytes, in.read)
+      .unsafeRunSync()
+      ._1
+
+  @Benchmark
+  def parseResponse(in: BenchState): Response[IO] =
+    Parser.Response
+      .parser(in.maxHeaderSize)(in.respBytes, in.read)
+      .unsafeRunSync()
+      ._1
+}
+
+/*
+[info] EmberParserBench.parseRequest     avgt   10  1658.321 ± 74.716  ns/op
+[info] EmberParserBench.parseResponse    avgt   10  1080.508 ± 96.766  ns/op
+[info] EmberParserBench.parseRequestNew  avgt   10  1339.713 ± 147.635  ns/op
+[info] EmberParserBench.parseResponseNew avgt   10   863.105 ±  28.273  ns/op
+ */
+
+object EmberParserBench {
+
+  implicit val CS: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
+
+  @State(Scope.Benchmark)
+  class BenchState {
+    val maxHeaderSize = 256 * 1024
+    var req: Request[IO] = _
+    var resp: Response[IO] = _
+    var reqBytes: Array[Byte] = _
+    var respBytes: Array[Byte] = _
+    val read = IO.raiseError[Option[fs2.Chunk[Byte]]](new Throwable("Should Not Read in Bench"))
+
+    @Setup(Level.Trial)
+    def setup(): Unit = {
+      req = Request[IO]().withEntity("Hello Bench!")
+      resp = Response[IO]().withEntity("Hello Bench!")
+      reqBytes = org.http4s.ember.core.Encoder.reqToBytes(req).compile.to(Array).unsafeRunSync
+      respBytes = org.http4s.ember.core.Encoder.respToBytes(resp).compile.to(Array).unsafeRunSync
+
+      println(s"Content-Length: ${req.contentLength}")
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -258,7 +258,18 @@ lazy val emberCore = libraryProject("ember-core")
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.ember.core.Parser$MessageP$MessageTooLongError$"),
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.ember.core.Parser$MessageP$EndOfStreamError$"),
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.ember.core.EmptyStreamError"),
-      ProblemFilters.exclude[MissingClassProblem]("org.http4s.ember.core.Parser$MessageP$MessageTooLongError")
+      ProblemFilters.exclude[MissingClassProblem]("org.http4s.ember.core.Parser$MessageP$MessageTooLongError"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#Response#RespPrelude.parsePrelude"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#Request#ReqPrelude.parsePrelude"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#HeaderP.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#HeaderP.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#HeaderP.parseHeaders"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#HeaderP.apply"),
+      ProblemFilters.exclude[MissingClassProblem]("org.http4s.ember.core.Parser$MessageP"),
+      ProblemFilters.exclude[MissingTypesProblem]("org.http4s.ember.core.Parser$MessageP$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#MessageP.parseMessage"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#MessageP.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#MessageP.unapply")
     )
   )
   .dependsOn(core, testing % "test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -498,7 +498,7 @@ lazy val bench = http4sProject("bench")
     undeclaredCompileDependenciesTest := {},
     unusedCompileDependenciesTest := {},
   )
-  .dependsOn(core, circe)
+  .dependsOn(core, circe, emberCore)
 
 lazy val docs = http4sProject("docs")
   .enablePlugins(

--- a/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -25,37 +25,40 @@ import org.http4s._
 import org.typelevel.ci.CIString
 import scala.annotation.switch
 import scala.collection.mutable
+import cats.data.EitherT
 
 private[ember] object Parser {
 
-  final case class MessageP(bytes: Array[Byte], rest: Array[Byte])
-
   object MessageP {
 
-    private[this] val doubleCrlf: Seq[Byte] = Seq(cr, lf, cr, lf)
-
-    def parseMessage[F[_]](buffer: Array[Byte], read: Read[F], maxHeaderSize: Int)(implicit
-        F: MonadThrow[F]): F[MessageP] = {
-      val endIndex = buffer.take(maxHeaderSize).indexOfSlice(doubleCrlf)
-      if (endIndex == -1 && buffer.length > maxHeaderSize) {
-        F.raiseError(EmberException.MessageTooLong(maxHeaderSize))
-      } else if (endIndex == -1) {
-        read.flatMap {
-          case Some(chunk) =>
-            val nextBuffer = combineArrays(buffer, chunk.toArray)
-            parseMessage(nextBuffer, read, maxHeaderSize)
-          case None if buffer.length > 0 => F.raiseError(EmberException.ReachedEndOfStream())
-          case _ => F.raiseError(EmberException.EmptyStream())
-        }
-      } else {
-        val (bytes, rest) = buffer.splitAt(endIndex + 4)
-        MessageP(bytes, rest).pure[F]
+    def recurseFind[F[_], A](currentBuffer: Array[Byte], read: Read[F], maxHeaderSize: Int)(
+        f: Array[Byte] => F[Either[Unit, A]])(idx: A => Int)(implicit
+        F: MonadThrow[F]): F[(A, Array[Byte])] =
+      f(currentBuffer).flatMap {
+        case Left(_) =>
+          if (currentBuffer.length > maxHeaderSize)
+            F.raiseError(EmberException.MessageTooLong(maxHeaderSize))
+          else {
+            read.flatMap {
+              case Some(chunk) =>
+                val nextBuffer = combineArrays(currentBuffer, chunk.toArray)
+                recurseFind(nextBuffer, read, maxHeaderSize)(f)(idx)
+              case None if currentBuffer.length > 0 =>
+                F.raiseError(EmberException.ReachedEndOfStream())
+              case _ => F.raiseError(EmberException.EmptyStream())
+            }
+          }
+        case Right(out) =>
+          (out, currentBuffer.drop(idx(out))).pure[F]
       }
-    }
 
   }
 
-  final case class HeaderP(headers: Headers, chunked: Boolean, contentLength: Option[Long])
+  final case class HeaderP(
+      headers: Headers,
+      chunked: Boolean,
+      contentLength: Option[Long],
+      idx: Int)
 
   object HeaderP {
 
@@ -64,8 +67,8 @@ private[ember] object Parser {
     private[this] val transferEncodingS = "Transfer-Encoding"
     private[this] val chunkedS = "chunked"
 
-    def parseHeaders[F[_]](message: Array[Byte], initIndex: Int)(implicit
-        F: MonadThrow[F]): F[HeaderP] = {
+    def parseHeaders[F[_]](message: Array[Byte], initIndex: Int, maxHeaderSize: Int)(implicit
+        F: MonadThrow[F]): F[Either[Unit, HeaderP]] = {
       import scala.collection.mutable.ListBuffer
       var idx = initIndex
       var state = false
@@ -77,8 +80,9 @@ private[ember] object Parser {
       val headers: ListBuffer[Header.Raw] = ListBuffer()
       var name: String = null
       var start = initIndex
+      val upperBound = Math.min(message.size - 1, maxHeaderSize)
 
-      while (!complete && idx < message.size) {
+      while (!complete && idx <= upperBound) {
         if (!state) {
           val current = message(idx)
           // if current index is colon our name is complete
@@ -128,9 +132,9 @@ private[ember] object Parser {
       if (throwable != null) {
         F.raiseError(ParseHeadersError(throwable))
       } else if (!complete) {
-        F.raiseError(IncompleteHttpMessage(Headers(headers.toList)))
+        ().asLeft.pure[F]
       } else {
-        HeaderP(Headers(headers.toList), chunked, contentLength).pure[F]
+        (HeaderP(Headers(headers.toList), chunked, contentLength, idx)).asRight.pure[F]
       }
     }
 
@@ -150,7 +154,8 @@ private[ember] object Parser {
     object ReqPrelude {
 
       // Method SP URI SP HttpVersion CRLF - REST
-      def parsePrelude[F[_]](message: Array[Byte])(implicit F: MonadThrow[F]): F[ReqPrelude] = {
+      def parsePrelude[F[_]](message: Array[Byte], maxHeaderSize: Int)(implicit
+          F: MonadThrow[F]): F[Either[Unit, ReqPrelude]] = {
         var idx = 0
         var state: Byte = 0
         var complete = false
@@ -159,9 +164,10 @@ private[ember] object Parser {
         var method: Method = null
         var uri: Uri = null
         var httpVersion: HttpVersion = null
+        val upperBound = Math.min(message.size - 1, maxHeaderSize)
 
         var start = 0
-        while (!complete && idx < message.size) {
+        while (!complete && idx <= upperBound) {
           val value = message(idx)
           (state: @switch) match {
             case 0 =>
@@ -213,16 +219,9 @@ private[ember] object Parser {
               Option(httpVersion)
             ))
         else if (method == null || uri == null || httpVersion == null)
-          F.raiseError(
-            ParsePreludeError(
-              "Failed to parse HTTP request prelude",
-              Option(throwable),
-              Option(method),
-              Option(uri),
-              Option(httpVersion)
-            ))
+          ().asLeft.pure[F]
         else
-          ReqPrelude(method, uri, httpVersion, idx).pure[F]
+          (ReqPrelude(method, uri, httpVersion, idx)).asRight.pure[F]
       }
 
       final case class ParsePreludeError(
@@ -242,9 +241,13 @@ private[ember] object Parser {
         read: Read[F]
     )(implicit F: Concurrent[F]): F[(Request[F], Drain[F])] =
       for {
-        message <- MessageP.parseMessage(buffer, read, maxHeaderSize)
-        prelude <- ReqPrelude.parsePrelude(message.bytes)
-        headerP <- HeaderP.parseHeaders(message.bytes, prelude.nextIndex)
+        t <- MessageP.recurseFind(buffer, read, maxHeaderSize)(ibuffer =>
+          EitherT(ReqPrelude.parsePrelude[F](ibuffer, maxHeaderSize))
+            .flatMap(prelude =>
+              EitherT(HeaderP.parseHeaders(ibuffer, prelude.nextIndex, maxHeaderSize)).tupleLeft(
+                prelude))
+            .value) { case (_, headerP) => headerP.idx }
+        ((prelude, headerP), finalBuffer) = t
 
         baseReq = org.http4s.Request[F](
           method = prelude.method,
@@ -261,11 +264,11 @@ private[ember] object Parser {
                   baseReq
                     .withAttribute(Message.Keys.TrailerHeaders[F], trailers.get)
                     .withBodyStream(ChunkedEncoding
-                      .decode(message.rest, read, maxHeaderSize, maxHeaderSize, trailers, rest)),
+                      .decode(finalBuffer, read, maxHeaderSize, maxHeaderSize, trailers, rest)),
                   rest.get)
             }
           } else {
-            Body.parseFixedBody(headerP.contentLength.getOrElse(0L), message.rest, read).map {
+            Body.parseFixedBody(headerP.contentLength.getOrElse(0L), finalBuffer, read).map {
               case (bodyStream, drain) =>
                 (baseReq.withBodyStream(bodyStream), drain)
             }
@@ -280,9 +283,13 @@ private[ember] object Parser {
         read: Read[F]
     ): F[(Response[F], Drain[F])] =
       for {
-        message <- MessageP.parseMessage(buffer, read, maxHeaderSize)
-        prelude <- RespPrelude.parsePrelude(message.bytes)
-        headerP <- HeaderP.parseHeaders(message.bytes, prelude.nextIndex)
+        t <- MessageP.recurseFind(buffer, read, maxHeaderSize)(ibuffer =>
+          EitherT(RespPrelude.parsePrelude[F](ibuffer, maxHeaderSize))
+            .flatMap(prelude =>
+              EitherT(HeaderP.parseHeaders(ibuffer, prelude.nextIndex, maxHeaderSize)).tupleLeft(
+                prelude))
+            .value) { case (_, headerP) => headerP.idx }
+        ((prelude, headerP), finalBuffer) = t
 
         baseResp = org.http4s.Response[F](
           httpVersion = prelude.version,
@@ -297,11 +304,11 @@ private[ember] object Parser {
                 baseResp
                   .withAttribute(Message.Keys.TrailerHeaders[F], trailers.get)
                   .withBodyStream(ChunkedEncoding
-                    .decode(message.rest, read, maxHeaderSize, maxHeaderSize, trailers, rest)) ->
+                    .decode(finalBuffer, read, maxHeaderSize, maxHeaderSize, trailers, rest)) ->
                   rest.get
             }
           } else {
-            Body.parseFixedBody(headerP.contentLength.getOrElse(0L), message.rest, read).map {
+            Body.parseFixedBody(headerP.contentLength.getOrElse(0L), finalBuffer, read).map {
               case (bodyStream, drain) =>
                 baseResp.withBodyStream(bodyStream) -> drain
             }
@@ -314,7 +321,8 @@ private[ember] object Parser {
 
       // HTTP/1.1 200 OK
       // Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
-      def parsePrelude[F[_]](buffer: Array[Byte])(implicit F: MonadThrow[F]): F[RespPrelude] = {
+      def parsePrelude[F[_]](buffer: Array[Byte], maxHeaderSize: Int)(implicit
+          F: MonadThrow[F]): F[Either[Unit, RespPrelude]] = {
         var complete = false
         var idx = 0
         var throwable: Throwable = null
@@ -325,8 +333,9 @@ private[ember] object Parser {
         var status: Status = null
         var start = 0
         var state = 0 // 0 Is for HttpVersion, 1 for Status Code, 2 For Reason Phrase
+        val upperBound = Math.min(buffer.size - 1, maxHeaderSize)
 
-        while (!complete && idx < buffer.size) {
+        while (!complete && idx <= upperBound) {
           val value = buffer(idx)
           (state: @switch) match {
             case 0 =>
@@ -373,9 +382,9 @@ private[ember] object Parser {
         if (throwable != null)
           F.raiseError(RespPreludeError("Encountered Error parsing", Option(throwable)))
         else if (httpVersion == null || status == null)
-          F.raiseError(RespPreludeError("Failed to parse HTTP response prelude", None))
+          ().asLeft.pure[F]
         else
-          RespPrelude(httpVersion, status, idx).pure[F]
+          RespPrelude(httpVersion, status, idx).asRight.pure[F]
       }
 
       case class RespPreludeError(message: String, cause: Option[Throwable])

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -404,7 +404,7 @@ class ParsingSuite extends Http4sSuite {
     } yield message
 
     result
-      .map { case (req, drain) =>
+      .map { case (req, _) =>
         assertEquals(req.method, Method.POST)
         assertEquals(
           req.headers,

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -130,8 +130,8 @@ class ParsingSuite extends Http4sSuite {
   test("Parser.Request.parser should Parse a request with a body correctly") {
     val raw =
       """POST /foo HTTP/1.1
-      |Content-Type: text/plain; charset=UTF-8
       |Content-Length: 11
+      |Content-Type: text/plain; charset=UTF-8
       |
       |Entity Here""".stripMargin
     val expected = Request[IO](Method.POST, Uri.unsafeFromString("/foo"))
@@ -139,17 +139,17 @@ class ParsingSuite extends Http4sSuite {
 
     val result = Helpers.parseRequestRig[IO](raw)
 
-    result.map(_.method).assertEquals(expected.method)
-    result.map(_.uri.scheme).assertEquals(expected.uri.scheme)
-    // result.map(_.uri.authority).assertEquals(expected.uri.authority)
-    // result.map(_.uri.path).assertEquals(expected.uri.path)
-    // result.map(_.uri.query).assertEquals(expected.uri.query)
-    result.map(_.uri.fragment).assertEquals(expected.uri.fragment)
-    result.map(_.headers).assertEquals(expected.headers)
     for {
+      _ <- result.map(_.method).assertEquals(expected.method)
+      _ <- result.map(_.uri.scheme).assertEquals(expected.uri.scheme)
+      // result.map(_.uri.authority).assertEquals(expected.uri.authority)
+      // result.map(_.uri.path).assertEquals(expected.uri.path)
+      // result.map(_.uri.query).assertEquals(expected.uri.query)
+      _ <- result.map(_.uri.fragment).assertEquals(expected.uri.fragment)
+      _ <- result.map(_.headers).assertEquals(expected.headers)
       r <- result
-      a <- r.body.compile.toVector
-      b <- expected.body.compile.toVector
+      a <- r.body.through(fs2.text.utf8Decode).compile.string
+      b <- expected.body.through(fs2.text.utf8Decode).compile.string
     } yield assertEquals(a, b)
   }
 
@@ -370,14 +370,16 @@ class ParsingSuite extends Http4sSuite {
     val asHttp = Helpers.httpifyString(base)
     val bv = asHttp.getBytes()
 
-    Parser.HeaderP.parseHeaders[IO](bv, 0).map { headerP =>
-      assert(
-        headerP.headers.headers == List(
-          Header.Raw(ci"Content-Type", "text/plain; charset=UTF-8"),
-          Header.Raw(ci"Content-Length", "11"))
-      )
-      assert(!headerP.chunked)
-      assert(headerP.contentLength == Some(11L))
+    Parser.HeaderP.parseHeaders[IO](bv, 0, 4096).map {
+      case Right(headerP) =>
+        assert(
+          headerP.headers.headers == List(
+            Header.Raw(ci"Content-Type", "text/plain; charset=UTF-8"),
+            Header.Raw(ci"Content-Length", "11"))
+        )
+        assert(!headerP.chunked)
+        assert(headerP.contentLength == Some(11L))
+      case Left(_) => fail("Headers were not right")
     }
   }
 
@@ -385,6 +387,7 @@ class ParsingSuite extends Http4sSuite {
     val defaultMaxHeaderLength = 4096
     val respS =
       Stream(
+        "POST / HTTP/1.1\r\n",
         "Content-Type: text/plain\r\n",
         "Transfer-Encoding: chunked\r\n",
         "Trailer: Expires\r\n",
@@ -396,14 +399,22 @@ class ParsingSuite extends Http4sSuite {
 
     val result = for {
       take <- Helpers.taking[IO, Byte](byteStream)
-      message <- Parser.MessageP
-        .parseMessage(Array.emptyByteArray, take, defaultMaxHeaderLength)
+      message <- Parser.Request
+        .parser(defaultMaxHeaderLength)(Array.emptyByteArray, take)
     } yield message
 
     result
-      .map(_.bytes.toList)
-      .assertEquals(
-        respS.compile.string.getBytes(java.nio.charset.StandardCharsets.US_ASCII).toList)
+      .map { case (req, drain) =>
+        assertEquals(req.method, Method.POST)
+        assertEquals(
+          req.headers,
+          Headers(
+            "Content-Type" -> "text/plain",
+            "Transfer-Encoding" -> "chunked",
+            "Trailer" -> "Expires"
+          ))
+
+      }
   }
 
   test("Request Prelude should parse an expected value") {
@@ -413,10 +424,12 @@ class ParsingSuite extends Http4sSuite {
     val asHttp = Helpers.httpifyString(raw)
     val bv = asHttp.getBytes()
 
-    Parser.Request.ReqPrelude.parsePrelude[IO](bv).map { prelude =>
-      assert(prelude.method == Method.GET)
-      assert(prelude.uri == uri"/")
-      assert(prelude.version == HttpVersion.`HTTP/1.1`)
+    Parser.Request.ReqPrelude.parsePrelude[IO](bv, 4096).map {
+      case Right(prelude) =>
+        assert(prelude.method == Method.GET)
+        assert(prelude.uri == uri"/")
+        assert(prelude.version == HttpVersion.`HTTP/1.1`)
+      case Left(_) => fail("Prelude was not right")
     }
   }
 
@@ -426,9 +439,11 @@ class ParsingSuite extends Http4sSuite {
         |""".stripMargin
     val asHttp = Helpers.httpifyString(raw)
     val bv = asHttp.getBytes()
-    Parser.Response.RespPrelude.parsePrelude[IO](bv).map { prelude =>
-      assert(prelude.version == HttpVersion.`HTTP/1.1`)
-      assert(prelude.status == Status.Ok)
+    Parser.Response.RespPrelude.parsePrelude[IO](bv, 4096).map {
+      case Right(prelude) =>
+        assert(prelude.version == HttpVersion.`HTTP/1.1`)
+        assert(prelude.status == Status.Ok)
+      case Left(_) => fail("Prelude was not right")
     }
   }
 
@@ -453,6 +468,7 @@ class ParsingSuite extends Http4sSuite {
         .parser[IO](defaultMaxHeaderLength)(Array.emptyByteArray, take)
       body1 <- resp1._1.body.through(fs2.text.utf8Decode).compile.string
       drained <- resp1._2
+      _ <- IO(println(new String(drained.get)))
       resp2 <- Parser.Response
         .parser[IO](defaultMaxHeaderLength)(drained.get, take)
       body2 <- resp2._1.body.through(fs2.text.utf8Decode).compile.string
@@ -545,8 +561,8 @@ class ParsingSuite extends Http4sSuite {
       .through(text.utf8Encode)
 
     Helpers.taking[IO, Byte](byteStream).flatMap { take =>
-      Parser.MessageP
-        .parseMessage[IO](Array.emptyByteArray, take, 10)
+      Parser.Request
+        .parser[IO](10)(Array.emptyByteArray, take)
         .intercept[EmberException.MessageTooLong]
     }
   }


### PR DESCRIPTION
Looks to improve the expected case performance. 

Most servers will encode their prelude and headers within a single buffer. Presently we do a O(n) lookup for a doublecrlf to separate the header array from the body array. Then we do an O(n) parse over the prelude and body. 

Instead we give ourselves where we will repeat parsing over the buffers O(n) and iterate to do so again. If servers have odd chunking behavior there will be more reused work, but it the default case this will be much more performant. 

To make sure I was being scientific in this approach I created a bench suite to test our parsing timings only. 

```
[info] EmberParserBench.parseRequest     avgt   10  1658.321 ± 74.716  ns/op
[info] EmberParserBench.parseResponse    avgt   10  1080.508 ± 96.766  ns/op

[info] EmberParserBench.parseRequestNew  avgt   10  1339.713 ± 147.635  ns/op
[info] EmberParserBench.parseResponseNew avgt   10   863.105 ±  28.273  ns/op
```

All tests pass and we stop processing off as soon as we reach the maxHeadersSize. 
