### PR TITLE
Add yarn to the nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -10,5 +10,6 @@ pkgs.mkShell {
     pkgs.nodejs-16_x
     pkgs.${java}
     pkgs.sbt
+    pkgs.yarn
   ];
 }


### PR DESCRIPTION
Need this to be able to run `ember-serverJS/test` from a fresh checkout.