### PR TITLE
Add migration docs start for 0.21 to 0.22

### DIFF
--- a/docs/jvm/src/main/mdoc/upgrading.md
+++ b/docs/jvm/src/main/mdoc/upgrading.md
@@ -24,6 +24,24 @@ The compiler errors should help you in showing what's left to upgrade.
 
 For further information about the changes since 0.21, check the [changelog](https://http4s.org/changelog/)
 
+
+## Http4s 0.21 -> 0.22 Migration Guide
+
+General Changes:  
+
+Header names are now CIStrings which can be created by importing `org.typelevel.ci._` and using the `ci` string interpolator.
+
+| 0.21                           | 0.22                            |
+| -----------------------------  | -----------------------------   |
+| headers.get(\`If-Match\`)      | headers.get[\`If-Match\`]       |
+| Headers.of(                    | Headers(                        |
+| Header("x-ms", "1")            | Header(ci"x-ms", "1")           |
+| baseUri +?? ("p", w)           | baseUri +?? ("p" -> w)          |
+| "x-ms".ci                      | ci"x-ms"                        |
+| import org.http4s.server.blaze | import org.http4s.blaze.server  |
+
+
+
 ## Help us help you!
 
 If you see recurring patterns that could benefit from a scalafix, please [report them for consideration](https://github.com/http4s/http4s/issues/4858).  For general upgrade tips, please consider a [pull request to this document](https://github.com/http4s/http4s/edit/series/0.22/docs/src/main/mdoc/upgrading.md).


### PR DESCRIPTION
Adds a small table for 0.21 to 0.22 migration guide gotchas that we ran into while upgrading.  