### PR TITLE
Fix inverted logic in ClientRouteTestBattery

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -46,9 +46,9 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
           case "/request-splitting" =>
             val status =
               if (exchange.getRequestHeaders.containsKey("Evil"))
-                200
+                Status.InternalServerError.code
               else
-                500
+                Status.Ok.code
             IO.blocking {
               exchange.sendResponseHeaders(status, -1L)
               exchange.close()


### PR DESCRIPTION
We released the security patches privately, without CI.  I panicked because the tests were failing, but it was due to an inversion in the logic that was ported to the HttpExchange server in 0.23.

I ran the tests locally when releasing, so I'm not sure how this slipped through.  Manual releases are bad.