### PR TITLE
Fix fatal warning on ClientRouteTestBattery

### DIFF
--- a/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -147,9 +147,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
   }
 
   test("Mitigates request splitting attack in field name") {
-
     for {
-      srv <- server()
       uri <- url("/request-splitting")
       req = Request[IO](uri = uri)
         .putHeaders(Header.Raw(ci"Fine:\r\nEvil:true\r\n", "oops"))

--- a/server-testing/src/test/scala/org/http4s/server/ServerRouteTestBattery.scala
+++ b/server-testing/src/test/scala/org/http4s/server/ServerRouteTestBattery.scala
@@ -45,7 +45,7 @@ object ServerRouteTestBattery {
           if (r.headers.get(ci"Evil").isDefined) IO(Response[IO](Status.InternalServerError)).some
           else IO(Response[IO](Status.Ok)).some
         case p =>
-          GetRoutes.getPaths.get(r.uri.path.toString)
+          GetRoutes.getPaths.get(p)
       }
     }
 


### PR DESCRIPTION
We don't have fatal warnings locally, so I didn't catch this in the security release.