### PR TITLE
Make message types covariant in their effect type

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -70,7 +70,7 @@ object CirceJsonBench {
       val arraySize = (approxContentLength.toDouble /
         jsonStr.getBytes("UTF-8").length.toDouble).round.toInt
       val json = Json.arr((1 to arraySize).map(_ => obj): _*)
-      req = Request[IO]().withEntity(json)
+      req = Request().withEntity(json)
       println(
         s"Array size: $arraySize; Approx. Content-Length: $approxContentLength; Content-Length: ${req.contentLength}")
     }

--- a/bench/src/main/scala/org/http4s/ember/bench/EmberParserBench.scala
+++ b/bench/src/main/scala/org/http4s/ember/bench/EmberParserBench.scala
@@ -65,8 +65,8 @@ object EmberParserBench {
 
     @Setup(Level.Trial)
     def setup(): Unit = {
-      req = Request[IO]().withEntity("Hello Bench!")
-      resp = Response[IO]().withEntity("Hello Bench!")
+      req = Request().withEntity("Hello Bench!")
+      resp = Response().withEntity("Hello Bench!")
       reqBytes = org.http4s.ember.core.Encoder.reqToBytes(req).compile.to(Array).unsafeRunSync()
       respBytes = org.http4s.ember.core.Encoder.respToBytes(resp).compile.to(Array).unsafeRunSync()
 

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
@@ -393,7 +393,7 @@ private final class Http1Connection[F[_]](
       }
       cb(
         Right(
-          Response[F](
+          Response(
             status = status,
             httpVersion = httpVersion,
             headers = headers,

--- a/blaze-client/src/test/scala-2.13/org/http4s/client/blaze/BlazeClient213Suite.scala
+++ b/blaze-client/src/test/scala-2.13/org/http4s/client/blaze/BlazeClient213Suite.scala
@@ -41,7 +41,7 @@ class BlazeClient213Suite extends BlazeClientBase {
       .flatMap { _ =>
         builder(1, requestTimeout = 2.second).resource.use { client =>
           val submit =
-            client.status(Request[IO](uri = Uri.fromString(s"http://$name:$port/simple").yolo))
+            client.status(Request(uri = Uri.fromString(s"http://$name:$port/simple").yolo))
           submit *> IO.sleep(3.seconds) *> submit
         }
       }
@@ -156,9 +156,9 @@ class BlazeClient213Suite extends BlazeClientBase {
         }
         val s = Stream(
           Stream.eval(
-            client.expect[String](Request[IO](uri = uris(0)))
+            client.expect[String](Request(uri = uris(0)))
           )).repeat.take(10).parJoinUnbounded ++ Stream.eval(
-          client.expect[String](Request[IO](uri = uris(1))))
+          client.expect[String](Request(uri = uris(1))))
         s.compile.lastOrError
       }
       .assertEquals("simple path")

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
@@ -130,7 +130,7 @@ class BlazeClientSuite extends BlazeClientBase {
       .flatMap { reqClosed =>
         builder(1, requestTimeout = 2.seconds).resource.use { client =>
           val body = Stream(0.toByte).repeat.onFinalizeWeak(reqClosed.complete(()).void)
-          val req = Request[IO](
+          val req = Request(
             method = Method.POST,
             uri = Uri.fromString(s"http://$name:$port/respond-and-close-immediately").yolo
           ).withBodyStream(body)
@@ -153,7 +153,7 @@ class BlazeClientSuite extends BlazeClientBase {
       .flatMap { reqClosed =>
         builder(1, requestTimeout = 2.seconds).resource.use { client =>
           val body = Stream(0.toByte).repeat.onFinalizeWeak(reqClosed.complete(()).void)
-          val req = Request[IO](
+          val req = Request(
             method = Method.POST,
             uri = Uri.fromString(s"http://$name:$port/respond-and-close-immediately-no-body").yolo
           ).withBodyStream(body)
@@ -172,7 +172,7 @@ class BlazeClientSuite extends BlazeClientBase {
     builder(1, requestTimeout = 500.millis, responseHeaderTimeout = Duration.Inf).resource
       .use { client =>
         val body = Stream(0.toByte).repeat
-        val req = Request[IO](
+        val req = Request(
           method = Method.POST,
           uri = Uri.fromString(s"http://$name:$port/process-request-entity").yolo
         ).withBodyStream(body)
@@ -195,7 +195,7 @@ class BlazeClientSuite extends BlazeClientBase {
     builder(1, requestTimeout = Duration.Inf, responseHeaderTimeout = 500.millis).resource
       .use { client =>
         val body = Stream(0.toByte).repeat
-        val req = Request[IO](
+        val req = Request(
           method = Method.POST,
           uri = Uri.fromString(s"http://$name:$port/process-request-entity").yolo
         ).withBodyStream(body)
@@ -218,7 +218,7 @@ class BlazeClientSuite extends BlazeClientBase {
 
     builder(1).resource
       .use { client =>
-        val req = Request[IO](uri = uri)
+        val req = Request(uri = uri)
         client
           .run(req)
           .use { _ =>
@@ -234,7 +234,7 @@ class BlazeClientSuite extends BlazeClientBase {
   test("Blaze Http1Client should raise a ConnectionFailure when a host can't be resolved") {
     builder(1).resource
       .use { client =>
-        client.status(Request[IO](uri = uri"http://example.invalid/"))
+        client.status(Request(uri = uri"http://example.invalid/"))
       }
       .interceptMessage[ConnectionFailure](
         "Error connecting to http://example.invalid using address example.invalid:80 (unresolved: true)")
@@ -254,7 +254,7 @@ class BlazeClientSuite extends BlazeClientBase {
         done <- Deferred[IO, Unit]
         body = Stream.eval(reading.complete(())) *> (Stream.empty: EntityBody[IO]) <* Stream.eval(
           done.get)
-        req = Request[IO](Method.POST, uri = uri).withEntity(body)
+        req = Request(Method.POST, uri = uri).withEntity(body)
         _ <- client.status(req).start
         _ <- reading.get
         _ <- state.allocated.map(_.get(RequestKey.fromRequest(req))).assertEquals(Some(1))

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/ClientTimeoutSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/ClientTimeoutSuite.scala
@@ -46,7 +46,7 @@ class ClientTimeoutSuite extends Http4sSuite with DispatcherIOFixture {
   def fixture = (tickWheelFixture, dispatcher).mapN(FunFixture.map2(_, _))
 
   val www_foo_com = uri"http://www.foo.com"
-  val FooRequest = Request[IO](uri = www_foo_com)
+  val FooRequest = Request(uri = www_foo_com)
   val FooRequestKey = RequestKey.fromRequest(FooRequest)
   val resp = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndone"
 
@@ -152,7 +152,7 @@ class ClientTimeoutSuite extends Http4sSuite with DispatcherIOFixture {
         .take(n.toLong)
     }
 
-    val req = Request[IO](method = Method.POST, uri = www_foo_com, body = dataStream(4))
+    val req = Request(method = Method.POST, uri = www_foo_com, body = dataStream(4))
 
     val tail =
       mkConnection(RequestKey.fromRequest(req), tickWheel, dispatcher, idleTimeout = 10.seconds)

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
@@ -42,7 +42,7 @@ class Http1ClientStageSuite extends Http4sSuite with DispatcherIOFixture {
   val trampoline = org.http4s.blaze.util.Execution.trampoline
 
   val www_foo_test = uri"http://www.foo.test"
-  val FooRequest = Request[IO](uri = www_foo_test)
+  val FooRequest = Request(uri = www_foo_test)
   val FooRequestKey = RequestKey.fromRequest(FooRequest)
 
   val LongDuration = 30.seconds
@@ -154,7 +154,7 @@ class Http1ClientStageSuite extends Http4sSuite with DispatcherIOFixture {
   dispatcher.test("Submit a request line with a query".flaky) { dispatcher =>
     val uri = "/huh?foo=bar"
     val Right(parsed) = Uri.fromString("http://www.foo.test" + uri)
-    val req = Request[IO](uri = parsed)
+    val req = Request(uri = parsed)
 
     getSubmission(req, resp, dispatcher).map { case (request, response) =>
       val statusLine = request.split("\r\n").apply(0)
@@ -240,7 +240,7 @@ class Http1ClientStageSuite extends Http4sSuite with DispatcherIOFixture {
   dispatcher.test("Allow an HTTP/1.0 request without a Host header".ignore) { dispatcher =>
     val resp = "HTTP/1.0 200 OK\r\n\r\ndone"
 
-    val req = Request[IO](uri = www_foo_test, httpVersion = HttpVersion.`HTTP/1.0`)
+    val req = Request(uri = www_foo_test, httpVersion = HttpVersion.`HTTP/1.0`)
 
     getSubmission(req, resp, dispatcher).map { case (request, response) =>
       assert(!request.contains("Host:"))
@@ -249,7 +249,7 @@ class Http1ClientStageSuite extends Http4sSuite with DispatcherIOFixture {
   }
 
   dispatcher.test("Support flushing the prelude") { dispatcher =>
-    val req = Request[IO](uri = www_foo_test, httpVersion = HttpVersion.`HTTP/1.0`)
+    val req = Request(uri = www_foo_test, httpVersion = HttpVersion.`HTTP/1.0`)
     /*
      * We flush the prelude first to test connection liveness in pooled
      * scenarios before we consume the body.  Make sure we can handle
@@ -283,7 +283,7 @@ class Http1ClientStageSuite extends Http4sSuite with DispatcherIOFixture {
       "Foo:Bar\r\n" +
       "\r\n"
 
-    val req = Request[IO](uri = www_foo_test, httpVersion = HttpVersion.`HTTP/1.1`)
+    val req = Request(uri = www_foo_test, httpVersion = HttpVersion.`HTTP/1.1`)
 
     dispatcher.test("Support trailer headers") { dispatcher =>
       val hs: IO[Headers] = bracketResponse(req, resp, dispatcher).use { (response: Response[IO]) =>

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
@@ -441,7 +441,7 @@ object BlazeServerBuilder {
     )
 
   private def defaultApp[F[_]: Applicative]: HttpApp[F] =
-    Kleisli(_ => Response(Status.NotFound).pure[F])
+    Kleisli.pure(Response(Status.NotFound))
 
   private def defaultThreadSelectorFactory: ThreadFactory =
     threadFactory(name = n => s"blaze-selector-${n}", daemon = false)

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
@@ -441,7 +441,7 @@ object BlazeServerBuilder {
     )
 
   private def defaultApp[F[_]: Applicative]: HttpApp[F] =
-    Kleisli(_ => Response[F](Status.NotFound).pure[F])
+    Kleisli(_ => Response(Status.NotFound).pure[F])
 
   private def defaultThreadSelectorFactory: ThreadFactory =
     threadFactory(name = n => s"blaze-selector-${n}", daemon = false)

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
@@ -162,12 +162,12 @@ private[blaze] class Http1ServerStage[F[_]](
           runRequest(buff)
         catch {
           case t: BadMessage =>
-            badMessage("Error parsing status or headers in requestLoop()", t, Request[F]())
+            badMessage("Error parsing status or headers in requestLoop()", t, Request())
           case t: Throwable =>
             internalServerError(
               "error in requestLoop()",
               t,
-              Request[F](),
+              Request(),
               () => Future.successful(emptyBuffer))
         }
     }
@@ -213,7 +213,7 @@ private[blaze] class Http1ServerStage[F[_]](
           }
         })
       case Left((e, protocol)) =>
-        badMessage(e.details, new BadMessage(e.sanitized), Request[F]().withHttpVersion(protocol))
+        badMessage(e.details, new BadMessage(e.sanitized), Request().withHttpVersion(protocol))
     }
   }
 
@@ -338,7 +338,7 @@ private[blaze] class Http1ServerStage[F[_]](
       t: ParserException,
       req: Request[F]): Unit = {
     logger.debug(t)(s"Bad Request: $debugMessage")
-    val resp = Response[F](Status.BadRequest)
+    val resp = Response(Status.BadRequest)
       .withHeaders(Connection(ci"close"), `Content-Length`.zero)
     renderResponse(req, resp, () => Future.successful(emptyBuffer))
   }
@@ -350,7 +350,7 @@ private[blaze] class Http1ServerStage[F[_]](
       req: Request[F],
       bodyCleanup: () => Future[ByteBuffer]): Unit = {
     logger.error(t)(errorMsg)
-    val resp = Response[F](Status.InternalServerError)
+    val resp = Response(Status.InternalServerError)
       .withHeaders(Connection(ci"close"), `Content-Length`.zero)
     renderResponse(
       req,

--- a/boopickle/src/main/scala/org/http4s/booPickle/instances/BooPickleInstances.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/instances/BooPickleInstances.scala
@@ -52,8 +52,8 @@ trait BooPickleInstances {
 
   /** Create an `EntityEncoder` for `A` given a `Pickler[A]`
     */
-  def booEncoderOf[F[_], A: Pickler]: EntityEncoder[F, A] =
-    chunkEncoder[F]
+  def booEncoderOf[A: Pickler]: EntityEncoder.Pure[A] =
+    chunkEncoder
       .contramap[A] { v =>
         Chunk.ByteBuffer(Pickle.intoBytes(v))
       }

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSuite.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSuite.scala
@@ -77,7 +77,7 @@ class BoopickleSuite extends Http4sSuite with Http4sLawSuite {
 
   test("decode a class from a boopickle decoder") {
     val result = booOf[IO, Fruit]
-      .decode(Request[IO]().withEntity(Banana(10.0): Fruit), strict = true)
+      .decode(Request().withEntity(Banana(10.0): Fruit), strict = true)
     result.value.map(assertEquals(_, Right(Banana(10.0))))
   }
 

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSuite.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSuite.scala
@@ -51,7 +51,7 @@ class BoopickleSuite extends Http4sSuite with Http4sLawSuite {
   implicit val fruitPickler: Pickler[Fruit] =
     compositePickler[Fruit].addConcreteType[Banana].addConcreteType[Kiwi].addConcreteType[Carambola]
 
-  implicit val encoder: EntityEncoder[IO, Fruit] = booEncoderOf[IO, Fruit]
+  implicit val encoder: EntityEncoder[IO, Fruit] = booEncoderOf[Fruit]
   implicit val decoder: EntityDecoder[IO, Fruit] = booOf[IO, Fruit]
 
   implicit val fruitArbitrary: Arbitrary[Fruit] = Arbitrary {
@@ -71,7 +71,7 @@ class BoopickleSuite extends Http4sSuite with Http4sLawSuite {
 
   test("have octect-stream content type") {
     assertEquals(
-      booEncoderOf[IO, Fruit].headers.get[`Content-Type`],
+      booEncoderOf[Fruit].headers.get[`Content-Type`],
       Some(`Content-Type`(MediaType.application.`octet-stream`)))
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
       WorkflowStep.Run(
         List("cd scalafix", "sbt ci"),
         name = Some("Scalafix tests"),
-        cond = Some(s"matrix.scala == '$scala_213
+        cond = Some(s"matrix.scala == '$scala_213'")
       )
     ),
     scalas = crossScalaVersions.value.toList

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
       WorkflowStep.Run(
         List("cd scalafix", "sbt ci"),
         name = Some("Scalafix tests"),
-        cond = Some(s"matrix.scala == '$scala_213'")
+        cond = Some(s"matrix.scala == '$scala_213
       )
     ),
     scalas = crossScalaVersions.value.toList

--- a/circe/src/main/scala/org/http4s/circe/CirceEntityEncoder.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceEntityEncoder.scala
@@ -23,8 +23,8 @@ import org.http4s.EntityEncoder
   * without need to explicitly call `jsonEncoderOf`.
   */
 trait CirceEntityEncoder {
-  implicit def circeEntityEncoder[F[_], A: Encoder]: EntityEncoder[F, A] =
-    jsonEncoderOf[F, A]
+  implicit def circeEntityEncoder[A: Encoder]: EntityEncoder.Pure[A] =
+    jsonEncoderOf[A]
 }
 
 object CirceEntityEncoder extends CirceEntityEncoder

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -130,8 +130,10 @@ trait CirceInstances extends JawnInstances {
         )
     }
 
-  implicit val jsonEncoder: EntityEncoder.Pure[Json] =
-    jsonEncoderWithPrinter(defaultPrinter)
+  // mima didn't like jsonEncoder being changed to a val
+  implicit def jsonEncoder: EntityEncoder.Pure[Json] = jsonEncoderBinCompat
+  private val jsonEncoderBinCompat: EntityEncoder.Pure[Json] = jsonEncoderWithPrinter(
+    defaultPrinter)
 
   def jsonEncoderWithPrinter(printer: Printer): EntityEncoder.Pure[Json] =
     EntityEncoder[fs2.Pure, Chunk[Byte]]

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -136,7 +136,8 @@ trait CirceInstances extends JawnInstances {
     defaultPrinter)
 
   def jsonEncoderWithPrinter(printer: Printer): EntityEncoder.Pure[Json] =
-    EntityEncoder[fs2.Pure, Chunk[Byte]]
+    EntityEncoder
+      .Pure[Chunk[Byte]]
       .contramap[Json](CirceInstances.fromJsonToChunk(printer))
       .withContentType(`Content-Type`(MediaType.application.json))
 

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -130,20 +130,20 @@ trait CirceInstances extends JawnInstances {
         )
     }
 
-  implicit def jsonEncoder[F[_]]: EntityEncoder[F, Json] =
+  implicit val jsonEncoder: EntityEncoder.Pure[Json] =
     jsonEncoderWithPrinter(defaultPrinter)
 
-  def jsonEncoderWithPrinter[F[_]](printer: Printer): EntityEncoder[F, Json] =
-    EntityEncoder[F, Chunk[Byte]]
+  def jsonEncoderWithPrinter(printer: Printer): EntityEncoder.Pure[Json] =
+    EntityEncoder[fs2.Pure, Chunk[Byte]]
       .contramap[Json](CirceInstances.fromJsonToChunk(printer))
       .withContentType(`Content-Type`(MediaType.application.json))
 
-  def jsonEncoderOf[F[_], A: Encoder]: EntityEncoder[F, A] =
+  def jsonEncoderOf[A: Encoder]: EntityEncoder.Pure[A] =
     jsonEncoderWithPrinterOf(defaultPrinter)
 
-  def jsonEncoderWithPrinterOf[F[_], A](printer: Printer)(implicit
-      encoder: Encoder[A]): EntityEncoder[F, A] =
-    jsonEncoderWithPrinter[F](printer).contramap[A](encoder.apply)
+  def jsonEncoderWithPrinterOf[A](printer: Printer)(implicit
+      encoder: Encoder[A]): EntityEncoder.Pure[A] =
+    jsonEncoderWithPrinter(printer).contramap[A](encoder.apply)
 
   implicit def streamJsonArrayEncoder[F[_]]: EntityEncoder[F, Stream[F, Json]] =
     streamJsonArrayEncoderWithPrinter(defaultPrinter)

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -130,10 +130,7 @@ trait CirceInstances extends JawnInstances {
         )
     }
 
-  // mima didn't like jsonEncoder being changed to a val
-  implicit def jsonEncoder: EntityEncoder.Pure[Json] = jsonEncoderBinCompat
-  private val jsonEncoderBinCompat: EntityEncoder.Pure[Json] = jsonEncoderWithPrinter(
-    defaultPrinter)
+  implicit def jsonEncoder: EntityEncoder.Pure[Json] = jsonEncoderWithPrinter(defaultPrinter)
 
   def jsonEncoderWithPrinter(printer: Printer): EntityEncoder.Pure[Json] =
     EntityEncoder

--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -49,7 +49,7 @@ object JsonDebugErrorHandler {
             messageFailureLogger.debug(mf)(
               s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
                 .getOrElse("<unknown>")}""")
-            val firstResp = mf.toHttpResponse[G](req.httpVersion)
+            val firstResp = mf.toHttpResponse(req.httpVersion)
             Response(
               status = firstResp.status,
               httpVersion = firstResp.httpVersion,
@@ -71,8 +71,8 @@ object JsonDebugErrorHandler {
         }
     }
 
-  private final case class JsonErrorHandlerResponse[F[_]](
-      req: Request[F],
+  private final case class JsonErrorHandlerResponse(
+      req: AnyRequest,
       caught: Throwable
   )
   private object JsonErrorHandlerResponse {

--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -50,7 +50,7 @@ object JsonDebugErrorHandler {
               s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
                 .getOrElse("<unknown>")}""")
             val firstResp = mf.toHttpResponse(req.httpVersion)
-            Response(
+            Response[G](
               status = firstResp.status,
               httpVersion = firstResp.httpVersion,
               headers = firstResp.headers.redactSensitive(redactWhen)
@@ -60,7 +60,7 @@ object JsonDebugErrorHandler {
               s"""Error servicing request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
                 .getOrElse("<unknown>")}"""
             )
-            Response(
+            Response[G](
               Status.InternalServerError,
               req.httpVersion,
               Headers(

--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -39,8 +39,8 @@ object JsonDebugErrorHandler {
     Kleisli { req =>
       import cats.syntax.applicative._
       import cats.syntax.applicativeError._
-      implicit def entEnc[M[_]]: EntityEncoder.Pure[JsonErrorHandlerResponse[M]] =
-        JsonErrorHandlerResponse.entEnc[M](redactWhen)
+      implicit val entEnc: EntityEncoder.Pure[JsonErrorHandlerResponse] =
+        JsonErrorHandlerResponse.entEnc(redactWhen)
 
       service
         .run(req)
@@ -50,23 +50,23 @@ object JsonDebugErrorHandler {
               s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
                 .getOrElse("<unknown>")}""")
             val firstResp = mf.toHttpResponse[G](req.httpVersion)
-            Response[G](
+            Response(
               status = firstResp.status,
               httpVersion = firstResp.httpVersion,
               headers = firstResp.headers.redactSensitive(redactWhen)
-            ).withEntity(JsonErrorHandlerResponse[G](req, mf)).pure[F]
+            ).withEntity(JsonErrorHandlerResponse(req, mf)).pure[F]
           case t =>
             serviceErrorLogger.error(t)(
               s"""Error servicing request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
                 .getOrElse("<unknown>")}"""
             )
-            Response[G](
+            Response(
               Status.InternalServerError,
               req.httpVersion,
               Headers(
                 Connection(ci"close")
               ))
-              .withEntity(JsonErrorHandlerResponse[G](req, t))
+              .withEntity(JsonErrorHandlerResponse(req, t))
               .pure[F]
         }
     }
@@ -76,23 +76,23 @@ object JsonDebugErrorHandler {
       caught: Throwable
   )
   private object JsonErrorHandlerResponse {
-    def entEnc[F[_]](
+    def entEnc(
         redactWhen: CIString => Boolean
-    ): EntityEncoder.Pure[JsonErrorHandlerResponse[F]] =
+    ): EntityEncoder.Pure[JsonErrorHandlerResponse] =
       jsonEncoderOf(
         encoder(redactWhen)
       )
-    def encoder[F[_]](
+    def encoder(
         redactWhen: CIString => Boolean
-    ): Encoder[JsonErrorHandlerResponse[F]] =
-      (a: JsonErrorHandlerResponse[F]) =>
+    ): Encoder[JsonErrorHandlerResponse] =
+      (a: JsonErrorHandlerResponse) =>
         Json.obj(
           "request" -> encodeRequest(a.req, redactWhen),
           "throwable" -> encodeThrowable(a.caught)
         )
   }
 
-  private def encodeRequest[F[_]](req: Request[F], redactWhen: CIString => Boolean): Json =
+  private def encodeRequest(req: AnyRequest, redactWhen: CIString => Boolean): Json =
     Json
       .obj(
         "method" -> req.method.name.asJson,

--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -39,8 +39,8 @@ object JsonDebugErrorHandler {
     Kleisli { req =>
       import cats.syntax.applicative._
       import cats.syntax.applicativeError._
-      implicit def entEnc[M[_], N[_]]: EntityEncoder[M, JsonErrorHandlerResponse[N]] =
-        JsonErrorHandlerResponse.entEnc[M, N](redactWhen)
+      implicit def entEnc[M[_]]: EntityEncoder.Pure[JsonErrorHandlerResponse[M]] =
+        JsonErrorHandlerResponse.entEnc[M](redactWhen)
 
       service
         .run(req)
@@ -76,9 +76,9 @@ object JsonDebugErrorHandler {
       caught: Throwable
   )
   private object JsonErrorHandlerResponse {
-    def entEnc[F[_], G[_]](
+    def entEnc[F[_]](
         redactWhen: CIString => Boolean
-    ): EntityEncoder[F, JsonErrorHandlerResponse[G]] =
+    ): EntityEncoder.Pure[JsonErrorHandlerResponse[F]] =
       jsonEncoderOf(
         encoder(redactWhen)
       )

--- a/circe/src/test/scala/org/http4s/circe/CirceSensitiveDataEntityDecoderSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSensitiveDataEntityDecoderSpec.scala
@@ -42,7 +42,7 @@ class CirceSensitiveDataEntityDecoderSpec extends Http4sSuite {
   test(
     "should not include the JSON when failing to decode due to wrong data type of JSON key's value") {
     val json: Json = Json.obj("ssn" := 123456789)
-    val response: Response[IO] = Response[IO](status = Status.Ok).withEntity[Json](json)
+    val response: Response[IO] = Response(status = Status.Ok).withEntity(json)
     val attmptedAs: EitherT[IO, DecodeFailure, Person] = response.attemptAs[Person]
     val result: IO[Either[DecodeFailure, Person]] = attmptedAs.value
     result.map { (it: Either[DecodeFailure, Person]) =>
@@ -56,7 +56,7 @@ class CirceSensitiveDataEntityDecoderSpec extends Http4sSuite {
   }
   test("not include the JSON when failing to decode due to incorrect JSON key's name") {
     val json: Json = Json.obj("the_ssn" := "123456789")
-    val response: Response[IO] = Response[IO](status = Status.Ok).withEntity[Json](json)
+    val response: Response[IO] = Response(status = Status.Ok).withEntity(json)
     val attmptedAs: EitherT[IO, DecodeFailure, Person] = response.attemptAs[Person]
     val result: IO[Either[DecodeFailure, Person]] = attmptedAs.value
 

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -272,7 +272,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     val req = Request[IO]().withEntity(Json.fromDoubleOrNull(157))
     val body = req
       .decode { (json: Json) =>
-        Response[IO](Ok)
+        Response(Ok)
           .withEntity(json.asNumber.flatMap(_.toLong).getOrElse(0L).toString)
           .pure[IO]
       }
@@ -282,7 +282,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
 
   test("jsonOf should decode JSON from a Circe decoder") {
     val result = jsonOf[IO, Foo]
-      .decode(Request[IO]().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42))), strict = true)
+      .decode(Request().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42))), strict = true)
     result.value.assertEquals(Right(Foo(42)))
   }
 
@@ -293,7 +293,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     List("ärgerlich", """"ärgerlich"""").traverse { wort =>
       val json = Json.obj("wort" -> Json.fromString(wort))
       val result =
-        jsonOf[IO, Umlaut].decode(Request[IO]().withEntity(json), strict = true)
+        jsonOf[IO, Umlaut].decode(Request().withEntity(json), strict = true)
       result.value.assertEquals(Right(Umlaut(wort)))
     }
   }
@@ -301,14 +301,14 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   test("jsonOf should fail with custom message from a decoder") {
     val result = CirceInstancesWithCustomErrors
       .jsonOf[IO, Bar]
-      .decode(Request[IO]().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
+      .decode(Request().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
     result.value.assertEquals(Left(InvalidMessageBodyFailure(
       "Custom Could not decode JSON: {\"bar1\":42}, errors: DecodingFailure at .a: Attempt to decode value on failed cursor")))
   }
 
   test("accumulatingJsonOf should decode JSON from a Circe decoder") {
     val result = accumulatingJsonOf[IO, Foo]
-      .decode(Request[IO]().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42))), strict = true)
+      .decode(Request().withEntity(Json.obj("bar" -> Json.fromDoubleOrNull(42))), strict = true)
     result.value.assertEquals(Right(Foo(42)))
   }
 
@@ -316,7 +316,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     "accumulatingJsonOf should return an InvalidMessageBodyFailure with a list of failures on invalid JSON messages") {
     val json = Json.obj("a" -> Json.fromString("sup"), "b" -> Json.fromInt(42))
     val result = accumulatingJsonOf[IO, Bar]
-      .decode(Request[IO]().withEntity(json), strict = true)
+      .decode(Request().withEntity(json), strict = true)
     result.value.map {
       case Left(InvalidMessageBodyFailure(_, Some(DecodingFailures(NonEmptyList(_, _))))) => true
       case _ => false
@@ -326,7 +326,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   test("accumulatingJsonOf should fail with custom message from a decoder") {
     val result = CirceInstancesWithCustomErrors
       .accumulatingJsonOf[IO, Bar]
-      .decode(Request[IO]().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
+      .decode(Request().withEntity(Json.obj("bar1" -> Json.fromInt(42))), strict = true)
     result.value.assertEquals(Left(InvalidMessageBodyFailure(
       "Custom Could not decode JSON: {\"bar1\":42}, errors: DecodingFailure at .a: Attempt to decode value on failed cursor, DecodingFailure at .b: Attempt to decode value on failed cursor")))
   }

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -78,7 +78,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   val json = Json.obj("test" -> Json.fromString("CirceSupport"))
 
   test("json encoder should have json content type") {
-    val maybeHeaderT: Option[`Content-Type`] = jsonEncoder[IO].headers.get[`Content-Type`]
+    val maybeHeaderT: Option[`Content-Type`] = jsonEncoder.headers.get[`Content-Type`]
     assertEquals(maybeHeaderT, Some(`Content-Type`(MediaType.application.json)))
   }
 
@@ -101,12 +101,12 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   }
 
   test("jsonEncoderOf should have json content type") {
-    val maybeHeaderT: Option[`Content-Type`] = jsonEncoderOf[IO, Foo].headers.get[`Content-Type`]
+    val maybeHeaderT: Option[`Content-Type`] = jsonEncoderOf[Foo].headers.get[`Content-Type`]
     assertEquals(maybeHeaderT, Some(`Content-Type`(MediaType.application.json)))
   }
 
   test("jsonEncoderOf should write compact JSON") {
-    writeToString(foo)(jsonEncoderOf[IO, Foo]).assertEquals("""{"bar":42}""")
+    writeToString(foo)(jsonEncoderOf[Foo]).assertEquals("""{"bar":42}""")
   }
 
   test("jsonEncoderOf should write JSON according to custom encoders") {

--- a/circe/src/test/scala/org/http4s/circe/middleware/JsonDebugErrorHandlerSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/middleware/JsonDebugErrorHandlerSpec.scala
@@ -29,7 +29,7 @@ class JsonDebugErrorHandlerSpec extends Http4sSuite {
         Kleisli { (_: Request[IO]) =>
           IO.raiseError[Response[IO]](new Throwable("Boo!"))
         }
-      val req: Request[IO] = Request[IO](Method.GET)
+      val req: Request[IO] = Request(Method.GET)
 
       JsonDebugErrorHandler(service)
         .run(req)
@@ -44,7 +44,7 @@ class JsonDebugErrorHandlerSpec extends Http4sSuite {
         Kleisli { (_: Request[IO]) =>
           IO.raiseError[Response[IO]](MalformedMessageBodyFailure("Boo!"))
         }
-      val req: Request[IO] = Request[IO](Method.GET)
+      val req: Request[IO] = Request(Method.GET)
 
       JsonDebugErrorHandler(service)
         .run(req)

--- a/client/jvm/src/test/scala/org/http4s/client/middleware/GZipSuite.scala
+++ b/client/jvm/src/test/scala/org/http4s/client/middleware/GZipSuite.scala
@@ -47,7 +47,7 @@ class GZipSuite extends Http4sSuite {
   }
 
   test("Client Gzip should not decompress when the response body is empty") {
-    val request = Request[IO](method = Method.HEAD, uri = uri"/gziptest")
+    val request = Request(method = Method.HEAD, uri = uri"/gziptest")
     gzipClient
       .run(request)
       .use { response =>

--- a/client/jvm/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/jvm/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -47,12 +47,12 @@ class LoggerSuite extends Http4sSuite {
     ResponseLogger(true, true)(Client.fromHttpApp(testApp))
 
   test("ResponseLogger should not affect a Get") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     responseLoggerClient.status(req).assertEquals(Status.Ok)
   }
 
   test("ResponseLogger should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request(uri = uri"/post", method = POST).withBodyStream(body)
     val res = responseLoggerClient.expect[String](req)
     res.assertEquals(expectedBody)
   }
@@ -60,12 +60,12 @@ class LoggerSuite extends Http4sSuite {
   val requestLoggerClient = RequestLogger.apply(true, true)(Client.fromHttpApp(testApp))
 
   test("RequestLogger should not affect a Get") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     requestLoggerClient.status(req).assertEquals(Status.Ok)
   }
 
   test("RequestLogger should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request(uri = uri"/post", method = POST).withBodyStream(body)
     val res = requestLoggerClient.expect[String](req)
     res.assertEquals(expectedBody)
   }
@@ -74,12 +74,12 @@ class LoggerSuite extends Http4sSuite {
     Logger(true, true)(Client.fromHttpApp(testApp)).toHttpApp
 
   test("Logger should not affect a Get") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     loggerApp(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("Logger should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request(uri = uri"/post", method = POST).withBodyStream(body)
     val res = loggerApp(req)
     res.map(_.status).assertEquals(Status.Ok)
     res.flatMap(_.as[String]).assertEquals(expectedBody)

--- a/client/jvm/src/test/scala/org/http4s/client/oauth1/OAuthSuite.scala
+++ b/client/jvm/src/test/scala/org/http4s/client/oauth1/OAuthSuite.scala
@@ -117,7 +117,7 @@ class OAuthSuite extends Http4sSuite {
     val Right(uri) = Uri.fromString("http://example.com/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b")
     val Right(body) = UrlForm.decodeString(Charset.`US-ASCII`)("c2&a3=2+q")
 
-    val req = Request[IO](method = Method.POST, uri = uri).withEntity(body)
+    val req = Request(method = Method.POST, uri = uri).withEntity(body)
 
     oauth1.getUserParams(req).map { case (_, v) =>
       assert(
@@ -174,7 +174,7 @@ class OAuthSuite extends Http4sSuite {
 
     oauth1
       .signRequest(
-        req = Request[IO](Method.GET, uri),
+        req = Request(Method.GET, uri),
         oauth1.ProtocolParameter.Consumer("quack's-consumer-key", "i-heart-my-pond"),
         Some(oauth1.ProtocolParameter.Token("quack's-token", "ducks-are-the-best")),
         realm = None,

--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -219,9 +219,9 @@ object Client {
     Client { (req: Request[Kleisli[F, A, *]]) =>
       Resource.eval(Kleisli.ask[F, A]).flatMap { a =>
         client
-          .run(req.mapK(Kleisli.applyK(a)))
+          .run(req.mapK(Kleisli.applyK[F, A](a)))
           .mapK(Kleisli.liftK[F, A])
-          .map(_.mapK(Kleisli.liftK))
+          .map(_.mapK(Kleisli.liftK[F, A]))
       }
     }
 

--- a/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -226,7 +226,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
   def get[A](s: String)(f: Response[F] => F[A]): F[A] =
     Uri.fromString(s).fold(F.raiseError, uri => get(uri)(f))
 
-  private def defaultOnError(req: Request[F])(resp: Response[F])(implicit
+  private def defaultOnError(req: AnyRequest)(resp: AnyResponse)(implicit
       F: Applicative[F]): F[Throwable] =
     F.pure(UnexpectedStatus(resp.status, req.method, req.uri))
 }

--- a/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -116,14 +116,14 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
 
   def expectOr[A](uri: Uri)(onError: Response[F] => F[Throwable])(implicit
       d: EntityDecoder[F, A]): F[A] =
-    expectOr(Request[F](Method.GET, uri))(onError)
+    expectOr(Request(Method.GET, uri))(onError)
 
   /** Submits a GET request to the specified URI and decodes the response on
     * success.  On failure, the status code is returned.  The underlying HTTP
     * connection is closed at the completion of the decoding.
     */
   def expect[A](uri: Uri)(implicit d: EntityDecoder[F, A]): F[A] =
-    expectOr(uri)(defaultOnError(Request[F](uri = uri)))
+    expectOr(uri)(defaultOnError(Request(uri = uri)))
 
   def expectOr[A](s: String)(onError: Response[F] => F[Throwable])(implicit
       d: EntityDecoder[F, A]): F[A] =
@@ -134,7 +134,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
     * underlying HTTP connection is closed at the completion of the decoding.
     */
   def expect[A](s: String)(implicit d: EntityDecoder[F, A]): F[A] =
-    expectOr(s)(defaultOnError(Request[F](uri = Uri.unsafeFromString(s))))
+    expectOr(s)(defaultOnError(Request(uri = Uri.unsafeFromString(s))))
 
   def expectOptionOr[A](req: Request[F])(onError: Response[F] => F[Throwable])(implicit
       d: EntityDecoder[F, A]): F[Option[A]] = {
@@ -190,7 +190,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
 
   /** Submits a GET request to the URI and returns the response status */
   override def statusFromUri(uri: Uri): F[Status] =
-    status(Request[F](uri = uri))
+    status(Request(uri = uri))
 
   /** Submits a GET request to the URI and returns the response status */
   override def statusFromString(s: String): F[Status] =
@@ -217,7 +217,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
     * @return The result of applying f to the response to req
     */
   def get[A](uri: Uri)(f: Response[F] => F[A]): F[A] =
-    run(Request[F](Method.GET, uri)).use(f)
+    run(Request(Method.GET, uri)).use(f)
 
   /** Submits a request and decodes the response on success.  On failure, the
     * status code is returned.  The underlying HTTP connection is closed at the

--- a/client/shared/src/main/scala/org/http4s/client/Http4sClientDsl.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Http4sClientDsl.scala
@@ -37,7 +37,7 @@ trait Http4sClientDsl[F[_]] {
 class MethodOps[F[_]](private val method: Method) extends AnyVal {
 
   /** Make a [[org.http4s.Request]] using this [[Method]] */
-  final def apply(uri: Uri, headers: Header.ToRaw*): Request[F] =
+  final def apply(uri: Uri, headers: Header.ToRaw*): Request.Pure =
     Request(method, uri, headers = Headers(headers: _*))
 
   /** Make a [[org.http4s.Request]] using this Method */

--- a/client/shared/src/main/scala/org/http4s/client/RequestKey.scala
+++ b/client/shared/src/main/scala/org/http4s/client/RequestKey.scala
@@ -25,7 +25,7 @@ final case class RequestKey(scheme: Scheme, authority: Authority) {
 }
 
 object RequestKey {
-  def fromRequest[F[_]](request: Request[F]): RequestKey = {
+  def fromRequest(request: AnyRequest): RequestKey = {
     val uri = request.uri
     RequestKey(uri.scheme.getOrElse(Scheme.http), uri.authority.getOrElse(Authority()))
   }

--- a/client/shared/src/main/scala/org/http4s/client/middleware/CookieJar.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/CookieJar.scala
@@ -196,9 +196,7 @@ object CookieJar {
   private[middleware] def responseCookieToRequestCookie(r: ResponseCookie): RequestCookie =
     RequestCookie(r.name, r.content)
 
-  private[middleware] def cookieAppliesToRequest[N[_]](
-      r: Request[N],
-      c: ResponseCookie): Boolean = {
+  private[middleware] def cookieAppliesToRequest(r: AnyRequest, c: ResponseCookie): Boolean = {
     val domainApplies = c.domain.exists(s =>
       r.uri.host.forall { authority =>
         authority.renderString.contains(s)
@@ -215,8 +213,8 @@ object CookieJar {
     domainApplies && pathApplies && secureSatisfied
   }
 
-  private[middleware] def cookiesForRequest[N[_]](
-      r: Request[N],
+  private[middleware] def cookiesForRequest(
+      r: AnyRequest,
       l: List[ResponseCookie]
   ): List[RequestCookie] =
     l.foldLeft(List.empty[RequestCookie]) { case (list, cookie) =>

--- a/client/shared/src/main/scala/org/http4s/client/middleware/DestinationAttribute.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/DestinationAttribute.scala
@@ -34,7 +34,7 @@ object DestinationAttribute {
     *
     * @return the classifier function
     */
-  def getDestination[F[_]](): Request[F] => Option[String] = _.attributes.lookup(Destination)
+  val getDestination: AnyRequest => Option[String] = _.attributes.lookup(Destination)
 
   val Destination = Key.newKey[SyncIO, String].unsafeRunSync()
 

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -54,15 +54,14 @@ object Logger {
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains)(
       log: String => F[Unit])(implicit F: Async[F]): F[Unit] =
-    org.http4s.internal.Logger
-      .logMessage[F, A](message)(logHeaders, logBody, redactHeadersWhen)(log)
+    org.http4s.internal.Logger.logMessage(message)(logHeaders, logBody, redactHeadersWhen)(log)
 
   def colored[F[_]: Async](
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
       requestColor: String = RequestLogger.defaultRequestColor,
-      responseColor: Response[F] => String = ResponseLogger.defaultResponseColor[F] _,
+      responseColor: Response[F] => String = ResponseLogger.defaultResponseColor(_),
       logAction: Option[String => F[Unit]] = None
   )(client: Client[F]): Client[F] =
     ResponseLogger.colored(logHeaders, logBody, redactHeadersWhen, responseColor, logAction)(

--- a/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -54,7 +54,7 @@ object RequestLogger {
       logAction: Option[String => F[Unit]] = None
   )(client: Client[F]): Client[F] =
     impl(client, logBody = true) { request =>
-      InternalLogger.logMessageWithBodyText[F, Request[F]](request)(
+      InternalLogger.logMessageWithBodyText(request)(
         logHeaders,
         logBody,
         redactHeadersWhen
@@ -122,10 +122,10 @@ object RequestLogger {
         s"${request.httpVersion} $methodColor${request.method}$RESET$color $BOLD${request.uri}$RESET$color"
 
       val headers: String =
-        InternalLogger.defaultLogHeaders[F, Request[F]](request)(logHeaders, redactHeadersWhen)
+        InternalLogger.defaultLogHeaders(request)(logHeaders, redactHeadersWhen)
 
       val bodyText: F[String] =
-        InternalLogger.defaultLogBody[F, Request[F]](request)(logBody) match {
+        InternalLogger.defaultLogBody(request)(logBody) match {
           case Some(textF) => textF.map(text => s"""body="$text"""")
           case None => Sync[F].pure("")
         }

--- a/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -54,7 +54,7 @@ object ResponseLogger {
       logAction: Option[String => F[Unit]] = None
   )(client: Client[F]): Client[F] =
     impl(client, logBody = true) { response =>
-      InternalLogger.logMessageWithBodyText[F, Response[F]](response)(
+      InternalLogger.logMessageWithBodyText(response)(
         logHeaders,
         logBody,
         redactHeadersWhen
@@ -101,7 +101,7 @@ object ResponseLogger {
       }
     }
 
-  def defaultResponseColor[F[_]](response: Response[F]): String =
+  def defaultResponseColor(response: AnyResponse): String =
     response.status.responseClass match {
       case Status.Informational | Status.Successful | Status.Redirection => Console.GREEN
       case Status.ClientError => Console.YELLOW
@@ -119,10 +119,10 @@ object ResponseLogger {
       val prelude = s"${response.httpVersion} ${response.status}"
 
       val headers: String =
-        InternalLogger.defaultLogHeaders[F, Response[F]](response)(logHeaders, redactHeadersWhen)
+        InternalLogger.defaultLogHeaders(response)(logHeaders, redactHeadersWhen)
 
       val bodyText: F[String] =
-        InternalLogger.defaultLogBody[F, Response[F]](response)(logBody) match {
+        InternalLogger.defaultLogBody(response)(logBody) match {
           case Some(textF) => textF.map(text => s"""body="$text"""")
           case None => Sync[F].pure("")
         }

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -38,7 +38,7 @@ object Retry {
       policy: RetryPolicy[F],
       redactHeaderWhen: CIString => Boolean = Headers.SensitiveHeaders.contains)(client: Client[F])(
       implicit F: Temporal[F]): Client[F] = {
-    def showRequest(request: Request[F], redactWhen: CIString => Boolean): String = {
+    def showRequest(request: AnyRequest, redactWhen: CIString => Boolean): String = {
       val headers = request.headers.redactSensitive(redactWhen).headers.mkString(",")
       val uri = request.uri.renderString
       val method = request.method

--- a/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -112,7 +112,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
       (for {
         client <- Resource.eval(client())
         uri <- Resource.eval(url(path))
-        req = Request[IO](uri = uri)
+        req = Request(uri = uri)
         resp <- client.run(req)
       } yield resp).use(resp => expected.flatMap(checkResponse(resp, _))).assert
     }
@@ -123,7 +123,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
       uri <- url("/").map(
         _.withPath(Uri.Path(Vector(Uri.Path.Segment.encoded(
           "request-splitting HTTP/1.0\r\nEvil:true\r\nHide-Protocol-Version:")))))
-      req = Request[IO](uri = uri)
+      req = Request(uri = uri)
       c <- client()
       status <- c.status(req).handleError(_ => Status.Ok)
     } yield assertEquals(status, Status.Ok)
@@ -135,7 +135,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
       address = srv.address
       hostname = address.host.toString
       port = address.port.value
-      req = Request[IO](
+      req = Request(
         uri = Uri(
           authority = Uri
             .Authority(None, Uri.RegName(s"${hostname}\r\nEvil:true\r\n"), port = port.some)
@@ -149,7 +149,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
   test("Mitigates request splitting attack in field name") {
     for {
       uri <- url("/request-splitting")
-      req = Request[IO](uri = uri)
+      req = Request(uri = uri)
         .putHeaders(Header.Raw(ci"Fine:\r\nEvil:true\r\n", "oops"))
       c <- client()
       status <- c.status(req).handleError(_ => Status.Ok)
@@ -159,7 +159,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
   test("Mitigates request splitting attack in field value") {
     for {
       uri <- url("/request-splitting")
-      req = Request[IO](uri = uri)
+      req = Request(uri = uri)
         .putHeaders(Header.Raw(ci"X-Carrier", "\r\nEvil:true\r\n"))
       c <- client()
       status <- c.status(req).handleError(_ => Status.Ok)

--- a/client/shared/src/test/scala/org/http4s/client/ClientSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/ClientSuite.scala
@@ -28,16 +28,16 @@ import org.http4s.syntax.all._
 
 class ClientSpec extends Http4sSuite with Http4sDsl[IO] {
   private val app = HttpApp[IO] { case r =>
-    Response[IO](Ok).withEntity(r.body).pure[IO]
+    Response(Ok).withEntity(r.body).pure[IO]
   }
   val client: Client[IO] = Client.fromHttpApp(app)
 
   test("mock client should read body before dispose") {
-    client.expect[String](Request[IO](POST).withEntity("foo")).assertEquals("foo")
+    client.expect[String](Request(POST).withEntity("foo")).assertEquals("foo")
   }
 
   test("mock client should fail to read body after dispose") {
-    Request[IO](POST)
+    Request(POST)
       .withEntity("foo")
       .pure[IO]
       .flatMap { req =>
@@ -55,7 +55,7 @@ class ClientSpec extends Http4sSuite with Http4sDsl[IO] {
     })
 
     hostClient
-      .expect[String](Request[IO](GET, uri"https://http4s.org/"))
+      .expect[String](Request(GET, uri"https://http4s.org/"))
       .assertEquals("http4s.org")
   }
 
@@ -65,7 +65,7 @@ class ClientSpec extends Http4sSuite with Http4sDsl[IO] {
     })
 
     hostClient
-      .expect[String](Request[IO](GET, uri"https://http4s.org:1983/"))
+      .expect[String](Request(GET, uri"https://http4s.org:1983/"))
       .assertEquals("http4s.org:1983")
   }
 
@@ -77,7 +77,7 @@ class ClientSpec extends Http4sSuite with Http4sDsl[IO] {
     val hostClient = Client.fromHttpApp(VirtualHost(exact(routes, "http4s.org")).orNotFound)
 
     hostClient
-      .expect[String](Request[IO](GET, uri"https://http4s.org/"))
+      .expect[String](Request(GET, uri"https://http4s.org/"))
       .assertEquals("http4s.org")
   }
 
@@ -94,7 +94,7 @@ class ClientSpec extends Http4sSuite with Http4sDsl[IO] {
         Deferred[IO, Outcome[IO, Throwable, String]]
           .flatTap { outcome =>
             cancelClient
-              .expect[String](Request[IO](GET, uri"https://http4s.org/"))
+              .expect[String](Request(GET, uri"https://http4s.org/"))
               .guaranteeCase(oc => outcome.complete(oc).void)
               .start
               .flatTap(fiber =>

--- a/client/shared/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
@@ -31,15 +31,15 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
   val app = HttpRoutes
     .of[IO] {
       case r if r.method == GET && r.pathInfo == path"/" =>
-        Response[IO](Ok).withEntity("hello").pure[IO]
+        Response(Ok).withEntity("hello").pure[IO]
       case r if r.method == PUT && r.pathInfo == path"/put" =>
-        Response[IO](Created).withEntity(r.body).pure[IO]
+        Response(Created).withEntity(r.body).pure[IO]
       case r if r.method == GET && r.pathInfo == path"/echoheaders" =>
         r.headers.get[Accept].fold(IO.pure(Response[IO](BadRequest))) { m =>
-          Response[IO](Ok).withEntity(m.renderString).pure[IO]
+          Response(Ok).withEntity(m.renderString).pure[IO]
         }
       case r if r.pathInfo == path"/status/500" =>
-        Response[IO](InternalServerError).withEntity("Oops").pure[IO]
+        Response(InternalServerError).withEntity("Oops").pure[IO]
     }
     .orNotFound
 
@@ -225,19 +225,19 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
 
   test("Client should add Accept header on expect for requests") {
     client
-      .expect[String](Request[IO](GET, uri"http://www.foo.com/echoheaders"))
+      .expect[String](Request(GET, uri"http://www.foo.com/echoheaders"))
       .assertEquals("Accept: text/*")
   }
 
   test("Client should add Accept header on expect for requests") {
     client
-      .expect[String](Request[IO](GET, uri"http://www.foo.com/echoheaders"))
+      .expect[String](Request(GET, uri"http://www.foo.com/echoheaders"))
       .assertEquals("Accept: text/*")
   }
 
   test("Client should append Accept header to existing request headers on expect for requests") {
     client
-      .expect[String](Request[IO](GET, uri"http://www.foo.com/echoheaders")
+      .expect[String](Request(GET, uri"http://www.foo.com/echoheaders")
         .putHeaders(Accept(MediaRange.`application/*`)))
       .assertEquals("Accept: application/*, text/*")
   }
@@ -245,14 +245,14 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
   test(
     "Client should append Accept header to existing request headers on expectOptionOr for requests") {
     client
-      .expectOptionOr[String](Request[IO](GET, uri"http://www.foo.com/echoheaders")
+      .expectOptionOr[String](Request(GET, uri"http://www.foo.com/echoheaders")
         .putHeaders(Accept(MediaRange.`application/*`)))(_ => IO.raiseError(new Exception))
       .assertEquals(Some("Accept: application/*, text/*"))
   }
 
   test("Client should append Accept header to existing request headers on fetchAs for requests") {
     client
-      .fetchAs[String](Request[IO](GET, uri"http://www.foo.com/echoheaders")
+      .fetchAs[String](Request(GET, uri"http://www.foo.com/echoheaders")
         .putHeaders(Accept(MediaRange.`application/*`)))
       .assertEquals("Accept: application/*, text/*")
   }
@@ -262,19 +262,19 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
     val edec =
       EntityDecoder.decodeBy[IO, String](MediaType.image.jpeg)(_ => DecodeResult.successT("foo!"))
     client
-      .expect(Request[IO](GET, uri"http://www.foo.com/echoheaders"))(
+      .expect(Request(GET, uri"http://www.foo.com/echoheaders"))(
         EntityDecoder.text[IO].orElse(edec))
       .assertEquals("Accept: text/*, image/jpeg")
   }
 
   test("Client should return empty with expectOption and not found") {
     client
-      .expectOption[String](Request[IO](GET, uri"http://www.foo.com/random-not-found"))
+      .expectOption[String](Request(GET, uri"http://www.foo.com/random-not-found"))
       .assertEquals(Option.empty[String])
   }
   test("Client should return expected value with expectOption and a response") {
     client
-      .expectOption[String](Request[IO](GET, uri"http://www.foo.com/echoheaders"))
+      .expectOption[String](Request(GET, uri"http://www.foo.com/echoheaders"))
       .assertEquals(
         "Accept: text/*".some
       )

--- a/client/shared/src/test/scala/org/http4s/client/middleware/CookieJarSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/CookieJarSuite.scala
@@ -32,7 +32,7 @@ class CookieJarSuite extends Http4sSuite {
     val routes = HttpRoutes
       .of[IO] {
         case GET -> Root / "get-cookie" =>
-          val resp = Response[IO](Status.Ok).addCookie(
+          val resp = Response(Status.Ok).addCookie(
             ResponseCookie(
               name = "foo",
               content = "bar",
@@ -44,8 +44,8 @@ class CookieJarSuite extends Http4sSuite {
           req.headers
             .get[Cookie]
             .fold(
-              Response[IO](Status.InternalServerError)
-            )(_ => Response[IO](Status.Ok))
+              Response(Status.InternalServerError)
+            )(_ => Response(Status.Ok))
             .pure[IO]
       }
       .orNotFound
@@ -55,13 +55,13 @@ class CookieJarSuite extends Http4sSuite {
     for {
       jar <- CookieJar.jarImpl[IO]
       testClient = CookieJar(jar)(client)
-      _ <- testClient.successful(Request[IO](Method.GET, uri"http://google.com/get-cookie"))
-      second <- testClient.successful(Request[IO](Method.GET, uri"http://google.com/test-cookie"))
+      _ <- testClient.successful(Request(Method.GET, uri"http://google.com/get-cookie"))
+      second <- testClient.successful(Request(Method.GET, uri"http://google.com/test-cookie"))
     } yield assert(second)
   }
 
   test("cookieAppliesToRequest should apply if the given domain matches") {
-    val req = Request[IO](Method.GET, uri = uri"http://google.com")
+    val req = Request(Method.GET, uri = uri"http://google.com")
     val cookie = ResponseCookie(
       "foo",
       "bar",
@@ -71,7 +71,7 @@ class CookieJarSuite extends Http4sSuite {
   }
 
   test("cookieAppliesToRequest should not apply if not given a domain") {
-    val req = Request[IO](Method.GET, uri = uri"http://google.com")
+    val req = Request(Method.GET, uri = uri"http://google.com")
     val cookie = ResponseCookie(
       "foo",
       "bar",
@@ -81,7 +81,7 @@ class CookieJarSuite extends Http4sSuite {
   }
 
   test("cookieAppliesToRequest should apply if a subdomain") {
-    val req = Request[IO](Method.GET, uri = uri"http://api.google.com")
+    val req = Request(Method.GET, uri = uri"http://api.google.com")
     val cookie = ResponseCookie(
       "foo",
       "bar",
@@ -91,7 +91,7 @@ class CookieJarSuite extends Http4sSuite {
   }
 
   test("cookieAppliesToRequest should not apply if the wrong subdomain") {
-    val req = Request[IO](Method.GET, uri = uri"http://api.google.com")
+    val req = Request(Method.GET, uri = uri"http://api.google.com")
     val cookie = ResponseCookie(
       "foo",
       "bar",
@@ -101,7 +101,7 @@ class CookieJarSuite extends Http4sSuite {
   }
 
   test("cookieAppliesToRequest should not apply if the superdomain") {
-    val req = Request[IO](Method.GET, uri = uri"http://google.com")
+    val req = Request(Method.GET, uri = uri"http://google.com")
     val cookie = ResponseCookie(
       "foo",
       "bar",
@@ -111,7 +111,7 @@ class CookieJarSuite extends Http4sSuite {
   }
 
   test("cookieAppliesToRequest should not apply a secure cookie to an http request") {
-    val req = Request[IO](Method.GET, uri = uri"http://google.com")
+    val req = Request(Method.GET, uri = uri"http://google.com")
     val cookie = ResponseCookie(
       "foo",
       "bar",
@@ -122,7 +122,7 @@ class CookieJarSuite extends Http4sSuite {
   }
 
   test("cookieAppliesToRequest should apply a secure cookie to an https request") {
-    val req = Request[IO](Method.GET, uri = uri"https://google.com")
+    val req = Request(Method.GET, uri = uri"https://google.com")
     val cookie = ResponseCookie(
       "foo",
       "bar",

--- a/client/shared/src/test/scala/org/http4s/client/middleware/FollowRedirectSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/FollowRedirectSuite.scala
@@ -55,7 +55,7 @@ class FollowRedirectSuite extends Http4sSuite with Http4sClientDsl[IO] {
       case _ -> Root / "different-authority" =>
         TemporaryRedirect(Location(uri"http://www.example.com/ok"))
       case _ -> Root / status =>
-        Response[IO](status = Status.fromInt(status.toInt).yolo)
+        Response(status = Status.fromInt(status.toInt).yolo)
           .putHeaders(Location(uri"/ok"))
           .pure[IO]
     }
@@ -71,7 +71,7 @@ class FollowRedirectSuite extends Http4sSuite with Http4sClientDsl[IO] {
 
   test("FollowRedirect should strip payload headers when switching to GET") {
     // We could test others, and other scenarios, but this was a pain.
-    val req = Request[IO](PUT, uri"http://localhost/303").withEntity("foo")
+    val req = Request(PUT, uri"http://localhost/303").withEntity("foo")
     client
       .run(req)
       .use { case resp =>
@@ -90,7 +90,7 @@ class FollowRedirectSuite extends Http4sSuite with Http4sClientDsl[IO] {
       .orNotFound
     val client = FollowRedirect(3)(Client.fromHttpApp(statefulApp))
     client
-      .run(Request[IO](uri = uri"http://localhost/loop"))
+      .run(Request(uri = uri"http://localhost/loop"))
       .use {
         case MovedPermanently(resp) => resp.as[String].map(_.toInt)
         case _ => IO.pure(-1)
@@ -116,7 +116,7 @@ class FollowRedirectSuite extends Http4sSuite with Http4sClientDsl[IO] {
             case false => IO.raiseError(new IllegalStateException("Exhausted all connections"))
           })(_ => semaphore.release)
         val client = FollowRedirect(3)(Client(f))
-        client.status(Request[IO](uri = uri"http://localhost/loop/3"))
+        client.status(Request(uri = uri"http://localhost/loop/3"))
       }
       .assertEquals(Status.Ok)
   }
@@ -150,7 +150,7 @@ class FollowRedirectSuite extends Http4sSuite with Http4sClientDsl[IO] {
 
   test("FollowRedirect should Record the intermediate URIs") {
     client
-      .run(Request[IO](uri = uri"http://localhost/loop/0"))
+      .run(Request(uri = uri"http://localhost/loop/0"))
       .use { resp =>
         IO.pure(FollowRedirect.getRedirectUris(resp))
       }
@@ -164,7 +164,7 @@ class FollowRedirectSuite extends Http4sSuite with Http4sClientDsl[IO] {
 
   test("FollowRedirect should Not add any URIs when there are no redirects") {
     client
-      .run(Request[IO](uri = uri"http://localhost/loop/100"))
+      .run(Request(uri = uri"http://localhost/loop/100"))
       .use { case resp =>
         IO.pure(FollowRedirect.getRedirectUris(resp))
       }

--- a/client/shared/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
@@ -61,7 +61,7 @@ class RetrySuite extends Http4sSuite {
       }
     }
     val retryClient = Retry[IO](policy)(client)
-    val req = Request[IO](method, uri"http://localhost/" / status.code.toString).withEntity(body)
+    val req = Request(method, uri"http://localhost/" / status.code.toString).withEntity(body)
     retryClient
       .run(req)
       .use { _ =>
@@ -97,7 +97,7 @@ class RetrySuite extends Http4sSuite {
     val statusGen = Gen.oneOf(RetryPolicy.RetriableStatuses)
     PropF.forAllF[IO, Status, IO[Unit]](statusGen) { status =>
       IO.pure(
-        RetryPolicy.isErrorOrRetriableStatus(Response[IO](status).asRight)
+        RetryPolicy.isErrorOrRetriableStatus(Response(status).asRight)
       ).assertEquals(true)
     }
   }
@@ -106,7 +106,7 @@ class RetrySuite extends Http4sSuite {
     val statusGen = Gen.oneOf(Status.registered)
     PropF.forAllF[IO, Status, IO[Unit]](statusGen) { status =>
       IO.pure(
-        RetryPolicy.isErrorOrStatus(Response[IO](status).asRight, Set(status))
+        RetryPolicy.isErrorOrStatus(Response(status).asRight, Set(status))
       ).assertEquals(true)
     }
   }
@@ -116,7 +116,7 @@ class RetrySuite extends Http4sSuite {
     val statusGen = Gen.oneOf(Status.registered)
     PropF.forAllF[IO, Status, IO[Unit]](statusGen) { status =>
       IO.pure(
-        RetryPolicy.isErrorOrStatus(Response[IO](status).asRight, Set.empty[Status])
+        RetryPolicy.isErrorOrStatus(Response(status).asRight, Set.empty[Status])
       ).assertEquals(false)
     }
   }
@@ -130,7 +130,7 @@ class RetrySuite extends Http4sSuite {
           case false => ref.update(_ => true) *> IO.pure("")
           case true => IO.pure("OK")
         })
-        val req = Request[IO](method, uri"http://localhost/status-from-body")
+        val req = Request(method, uri"http://localhost/status-from-body")
           .withHeaders(headers)
           .withEntity(body)
         val policy = RetryPolicy[IO](
@@ -176,10 +176,10 @@ class RetrySuite extends Http4sSuite {
               else None),
             RetryPolicy.defaultRetriable[IO]))(Client[IO](_ =>
           Resource.make(semaphore.tryAcquire.flatMap {
-            case true => Response[IO](Status.InternalServerError).pure[IO]
+            case true => Response(Status.InternalServerError).pure[IO]
             case false => IO.raiseError(new IllegalStateException("Exhausted all connections"))
           })(_ => semaphore.release)))
-        client.status(Request[IO]())
+        client.status(Request())
       }
       .assertEquals(Status.InternalServerError)
   }

--- a/client/shared/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/shared/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -34,16 +34,16 @@ object GetRoutes {
 
   def getPaths(implicit F: Temporal[IO]): Map[String, IO[Response[IO]]] =
     Map(
-      SimplePath -> Response[IO](Ok).withEntity("simple path").pure[IO],
-      ChunkedPath -> Response[IO](Ok)
+      SimplePath -> Response(Ok).withEntity("simple path").pure[IO],
+      ChunkedPath -> Response(Ok)
         .withEntity(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
         .pure[IO],
       DelayedPath ->
         F.sleep(1.second) *>
-        Response[IO](Ok).withEntity("delayed path").pure[IO],
-      NoContentPath -> Response[IO](NoContent).pure[IO],
-      NotFoundPath -> Response[IO](NotFound).withEntity("not found").pure[IO],
-      EmptyNotFoundPath -> Response[IO](NotFound).pure[IO],
-      InternalServerErrorPath -> Response[IO](InternalServerError).pure[IO]
+        Response(Ok).withEntity("delayed path").pure[IO],
+      NoContentPath -> Response(NoContent).pure[IO],
+      NotFoundPath -> Response(NotFound).withEntity("not found").pure[IO],
+      EmptyNotFoundPath -> Response(NotFound).pure[IO],
+      InternalServerErrorPath -> Response(InternalServerError).pure[IO]
     )
 }

--- a/core/js/src/main/scala/org/http4s/RequestPlatform.scala
+++ b/core/js/src/main/scala/org/http4s/RequestPlatform.scala
@@ -16,4 +16,4 @@
 
 package org.http4s
 
-private[http4s] trait RequestPlatform[F[_]]
+private[http4s] trait RequestPlatform[+F[_]]

--- a/core/jvm/src/main/scala/org/http4s/RequestPlatform.scala
+++ b/core/jvm/src/main/scala/org/http4s/RequestPlatform.scala
@@ -20,9 +20,9 @@ import cats.effect.Sync
 import cats.syntax.all._
 import com.comcast.ip4s.Hostname
 
-private[http4s] trait RequestPlatform[F[_]] { self: Request[F] =>
+private[http4s] trait RequestPlatform[+F[_]] { self: Request[F] =>
 
-  def remoteHost(implicit F: Sync[F]): F[Option[Hostname]] = {
+  def remoteHost[F1[x] >: F[x]](implicit F: Sync[F1]): F1[Option[Hostname]] = {
     val inetAddress = remote.map(_.host.toInetAddress)
     F.delay(inetAddress.map(_.getHostName)).map(_.flatMap(Hostname.fromString))
   }

--- a/core/jvm/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/jvm/src/main/scala/org/http4s/StaticFile.scala
@@ -216,7 +216,7 @@ object StaticFile {
 
     List(etagMatch(req, etagCalc), notModifiedSince(req, lastModified)).combineAll
       .filter(identity)
-      .map(_ => Response[F](NotModified))
+      .map(_ => Response(NotModified))
   }
 
   private def etagMatch[F[_]](req: Option[Request[F]], etagCalc: ETag) =

--- a/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
@@ -64,6 +64,9 @@ trait EntityEncoder[+F[_], A] { self =>
 
 object EntityEncoder extends EntityEncoderCompanionPlatform {
   type Pure[A] = EntityEncoder[fs2.Pure, A]
+  object Pure {
+    def apply[A](implicit ev: EntityEncoder.Pure[A]): EntityEncoder.Pure[A] = ev
+  }
 
   private[http4s] val DefaultChunkSize = 4096
 

--- a/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
@@ -29,7 +29,7 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound(
   "Cannot convert from ${A} to an Entity, because no EntityEncoder[${F}, ${A}] instance could be found.")
-trait EntityEncoder[F[_], A] { self =>
+trait EntityEncoder[+F[_], A] { self =>
 
   /** Convert the type `A` to an [[Entity]] in the effect type `F` */
   def toEntity(a: A): Entity[F]
@@ -63,6 +63,8 @@ trait EntityEncoder[F[_], A] { self =>
 }
 
 object EntityEncoder extends EntityEncoderCompanionPlatform {
+  type Pure[A] = EntityEncoder[fs2.Pure, A]
+
   private[http4s] val DefaultChunkSize = 4096
 
   /** summon an implicit [[EntityEncoder]] */
@@ -85,23 +87,23 @@ object EntityEncoder extends EntityEncoderCompanionPlatform {
     *
     * This constructor is a helper for types that can be serialized synchronously, for example a String.
     */
-  def simple[F[_], A](hs: Header.ToRaw*)(toChunk: A => Chunk[Byte]): EntityEncoder[F, A] =
+  def simple[A](hs: Header.ToRaw*)(toChunk: A => Chunk[Byte]): EntityEncoder.Pure[A] =
     encodeBy(hs: _*) { a =>
       val c = toChunk(a)
-      Entity[F](Stream.chunk(c).covary[F], Some(c.size.toLong))
+      Entity(Stream.chunk(c), Some(c.size.toLong))
     }
 
   /** Encodes a value from its Show instance.  Too broad to be implicit, too useful to not exist. */
-  def showEncoder[F[_], A](implicit
+  def showEncoder[A](implicit
       charset: Charset = DefaultCharset,
-      show: Show[A]): EntityEncoder[F, A] = {
+      show: Show[A]): EntityEncoder.Pure[A] = {
     val hdr = `Content-Type`(MediaType.text.plain).withCharset(charset)
-    simple[F, A](hdr)(a => Chunk.array(show.show(a).getBytes(charset.nioCharset)))
+    simple[A](hdr)(a => Chunk.array(show.show(a).getBytes(charset.nioCharset)))
   }
 
-  def emptyEncoder[F[_], A]: EntityEncoder[F, A] =
-    new EntityEncoder[F, A] {
-      def toEntity(a: A): Entity[F] = Entity.empty
+  def emptyEncoder[A]: EntityEncoder.Pure[A] =
+    new EntityEncoder[fs2.Pure, A] {
+      def toEntity(a: A): Entity[fs2.Pure] = Entity.empty
       def headers: Headers = Headers.empty
     }
 
@@ -124,24 +126,24 @@ object EntityEncoder extends EntityEncoderCompanionPlatform {
         }
     }
 
-  implicit def unitEncoder[F[_]]: EntityEncoder[F, Unit] =
-    emptyEncoder[F, Unit]
+  implicit val unitEncoder: EntityEncoder.Pure[Unit] =
+    emptyEncoder[Unit]
 
-  implicit def stringEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, String] = {
+  implicit def stringEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder.Pure[String] = {
     val hdr = `Content-Type`(MediaType.text.plain).withCharset(charset)
     simple(hdr)(s => Chunk.array(s.getBytes(charset.nioCharset)))
   }
 
-  implicit def charArrayEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Array[Char]] =
-    stringEncoder[F].contramap(new String(_))
+  implicit def charArrayEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder.Pure[Array[Char]] =
+    stringEncoder.contramap(new String(_))
 
-  implicit def chunkEncoder[F[_]]: EntityEncoder[F, Chunk[Byte]] =
+  implicit val chunkEncoder: EntityEncoder.Pure[Chunk[Byte]] =
     simple(`Content-Type`(MediaType.application.`octet-stream`))(identity)
 
-  implicit def byteArrayEncoder[F[_]]: EntityEncoder[F, Array[Byte]] =
-    chunkEncoder[F].contramap(Chunk.array[Byte])
+  implicit val byteArrayEncoder: EntityEncoder.Pure[Array[Byte]] =
+    chunkEncoder.contramap(Chunk.array[Byte])
 
   /** Encodes an entity body.  Chunking of the stream is preserved.  A
     * `Transfer-Encoding: chunked` header is set, as we cannot know

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -16,12 +16,12 @@
 
 package org.http4s
 
-import cats.{Applicative, Monad, ~>}
+import cats._
 import cats.data.NonEmptyList
 import cats.effect.SyncIO
 import cats.syntax.all._
 import com.comcast.ip4s.{IpAddress, Port, SocketAddress}
-import fs2.{Pure, Stream}
+import fs2.Stream
 import fs2.text.utf8
 import java.io.File
 import org.http4s.headers._
@@ -31,12 +31,12 @@ import org.typelevel.ci.CIString
 import org.typelevel.vault._
 
 import scala.util.hashing.MurmurHash3
+import scala.annotation.nowarn
 
 /** Represents a HTTP Message. The interesting subclasses are Request and Response.
   */
-sealed trait Message[F[_]] extends Media[F] { self =>
-  type SelfF[F2[_]] <: Message[F2] { type SelfF[F3[_]] = self.SelfF[F3] }
-  type Self = SelfF[F]
+sealed trait Message[+F[_]] extends Media[F] { self =>
+  type SelfF[+F2[_]] <: Message[F2] { type SelfF[+F3[_]] = self.SelfF[F3] }
 
   def httpVersion: HttpVersion
 
@@ -46,22 +46,22 @@ sealed trait Message[F[_]] extends Media[F] { self =>
 
   def attributes: Vault
 
-  protected def change(
+  protected def change[F1[_]](
       httpVersion: HttpVersion = httpVersion,
-      body: EntityBody[F] = body,
+      body: EntityBody[F1] = body,
       headers: Headers = headers,
-      attributes: Vault = attributes): Self
+      attributes: Vault = attributes): SelfF[F1]
 
-  def withHttpVersion(httpVersion: HttpVersion): Self =
+  def withHttpVersion(httpVersion: HttpVersion): SelfF[F] =
     change(httpVersion = httpVersion)
 
-  def withHeaders(headers: Headers): Self =
+  def withHeaders(headers: Headers): SelfF[F] =
     change(headers = headers)
 
-  def withHeaders(headers: Header.ToRaw*): Self =
+  def withHeaders(headers: Header.ToRaw*): SelfF[F] =
     withHeaders(Headers(headers: _*))
 
-  def withAttributes(attributes: Vault): Self =
+  def withAttributes(attributes: Vault): SelfF[F] =
     change(attributes = attributes)
 
   // Body methods
@@ -73,7 +73,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * @tparam T type of the Body
     * @return a new message with the new body
     */
-  def withEntity[T](b: T)(implicit w: EntityEncoder[F, T]): Self = {
+  def withEntity[F1[x] >: F[x], T](b: T)(implicit w: EntityEncoder[F1, T]): SelfF[F1] = {
     val entity = w.toEntity(b)
     val hs = entity.length match {
       case Some(l) =>
@@ -95,18 +95,18 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * or `Content-Length`. Most use cases are better served by [[withEntity]],
     * which uses an [[EntityEncoder]] to maintain the headers.
     */
-  def withBodyStream(body: EntityBody[F]): Self =
+  def withBodyStream[F1[x] >: F[x]](body: EntityBody[F1]): SelfF[F1] =
     change(body = body)
 
   /** Set an empty entity body on this message, and remove all payload headers
     * that make no sense with an empty body.
     */
-  def withEmptyBody: Self =
+  def withEmptyBody: SelfF[F] =
     withBodyStream(EmptyBody).transformHeaders(_.removePayloadHeaders)
 
   // General header methods
 
-  def transformHeaders(f: Headers => Headers): Self =
+  def transformHeaders(f: Headers => Headers): SelfF[F] =
     change(headers = f(headers))
 
   /** Keep headers that satisfy the predicate
@@ -114,23 +114,22 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * @param f predicate
     * @return a new message object which has only headers that satisfy the predicate
     */
-  def filterHeaders(f: Header.Raw => Boolean): Self =
+  def filterHeaders(f: Header.Raw => Boolean): SelfF[F] =
     transformHeaders(_.transform(_.filter(f)))
 
-  def removeHeader(key: CIString): Self =
+  def removeHeader(key: CIString): SelfF[F] =
     transformHeaders(_.transform(_.filterNot(_.name == key)))
 
-  def removeHeader[A](implicit h: Header[A, _]): Self =
+  def removeHeader[A](implicit h: Header[A, _]): SelfF[F] =
     removeHeader(h.name)
 
   /** Add the provided headers to the existing headers, replacing those
     * of the same header name
     *
     * {{{
-    * >>> import cats.effect.IO
     * >>> import org.http4s.headers.Accept
     *
-    * >>> val req = Request[IO]().putHeaders(Accept(MediaRange.`application/*`))
+    * >>> val req = Request().putHeaders(Accept(MediaRange.`application/*`))
     * >>> req.headers.get[Accept]
     * Some(Accept(NonEmptyList(application/*)))
     *
@@ -140,7 +139,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * }}}
     * */*/*/*/
     */
-  def putHeaders(headers: Header.ToRaw*): Self =
+  def putHeaders(headers: Header.ToRaw*): SelfF[F] =
     transformHeaders(_.put(headers: _*))
 
   /** Add a header to these headers.  The header should be a type with a
@@ -148,10 +147,9 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * appended to any existing values.
     *
     * {{{
-    * >>> import cats.effect.IO
     * >>> import org.http4s.headers.Accept
     *
-    * >>> val req = Request[IO]().addHeader(Accept(MediaRange.`application/*`))
+    * >>> val req = Request().addHeader(Accept(MediaRange.`application/*`))
     * >>> req.headers.get[Accept]
     * Some(Accept(NonEmptyList(application/*)))
     *
@@ -161,31 +159,31 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * }}}
     * */*/*/*/*/
     */
-  def addHeader[H: Header[*, Header.Recurring]](h: H): Self =
+  def addHeader[H: Header[*, Header.Recurring]](h: H): SelfF[F] =
     transformHeaders(_.add(h))
 
-  def withTrailerHeaders(trailerHeaders: F[Headers]): Self =
-    withAttribute(Message.Keys.TrailerHeaders[F], trailerHeaders)
+  def withTrailerHeaders[F1[x] >: F[x]](trailerHeaders: F1[Headers]): SelfF[F1] =
+    withAttribute(Message.Keys.TrailerHeaders[F1], trailerHeaders)
 
-  def withoutTrailerHeaders: Self =
+  def withoutTrailerHeaders: SelfF[F] =
     withoutAttribute(Message.Keys.TrailerHeaders[F])
 
   /** The trailer headers, as specified in Section 3.6.1 of RFC 2616. The resulting
     * F might not complete until the entire body has been consumed.
     */
-  def trailerHeaders(implicit F: Applicative[F]): F[Headers] =
-    attributes.lookup(Message.Keys.TrailerHeaders[F]).getOrElse(Headers.empty.pure[F])
+  def trailerHeaders[F1[x] >: F[x]](implicit F: Applicative[F1]): F1[Headers] =
+    attributes.lookup(Message.Keys.TrailerHeaders[F1]).getOrElse(Headers.empty.pure[F1])
 
   // Specific header methods
 
-  def withContentType(contentType: `Content-Type`): Self =
+  def withContentType(contentType: `Content-Type`): SelfF[F] =
     putHeaders(contentType)
 
-  def withoutContentType: Self =
+  def withoutContentType: SelfF[F] =
     removeHeader[`Content-Type`]
 
-  def withContentTypeOption(contentTypeO: Option[`Content-Type`]): Self =
-    contentTypeO.fold(withoutContentType)(withContentType)
+  def withContentTypeOption(contentTypeO: Option[`Content-Type`]): SelfF[F] =
+    contentTypeO.fold[SelfF[F]](withoutContentType)(withContentType)
 
   def isChunked: Boolean =
     headers.get[`Transfer-Encoding`].exists(_.values.contains_(TransferCoding.chunked))
@@ -200,7 +198,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * @tparam A type of the value to store
     * @return a new message object with the key/value pair appended
     */
-  def withAttribute[A](key: Key[A], value: A): Self =
+  def withAttribute[A](key: Key[A], value: A): SelfF[F] =
     change(attributes = attributes.insert(key, value))
 
   /** Returns a new message object without the specified key in the
@@ -209,7 +207,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     * @param key [[io.chrisdavenport.vault.Key]] to remove
     * @return a new message object without the key
     */
-  def withoutAttribute(key: Key[_]): Self =
+  def withoutAttribute(key: Key[_]): SelfF[F] =
     change(attributes = attributes.delete(key))
 
   /** Lifts this Message's body to the specified effect type.
@@ -218,6 +216,18 @@ sealed trait Message[F[_]] extends Media[F] { self =>
 }
 
 object Message {
+  implicit final class InvariantOps[F[_], ThisF[f[_]] <: Message[f]](val self: ThisF[F]) {
+    import self._
+
+    def mapK[G[_]](f: F ~> G): SelfF[G] =
+      self.change(
+        httpVersion = httpVersion,
+        headers = headers,
+        body = body.translate(f),
+        attributes = attributes
+      )
+  }
+
   private[http4s] val logger = getLogger
   object Keys {
     private[this] val trailerHeaders: Key[Any] = Key.newKey[SyncIO, Any].unsafeRunSync()
@@ -237,7 +247,7 @@ object Message {
   * @param body fs2.Stream[F, Byte] defining the body of the request
   * @param attributes Immutable Map used for carrying additional information in a type safe fashion
   */
-final class Request[F[_]] private (
+final class Request[+F[_]] private (
     val method: Method,
     val uri: Uri,
     val httpVersion: HttpVersion,
@@ -250,16 +260,16 @@ final class Request[F[_]] private (
     with Serializable {
   import Request._
 
-  type SelfF[F0[_]] = Request[F0]
+  type SelfF[+F0[_]] = Request[F0]
 
-  private def copy(
+  private def copy[F1[_]](
       method: Method = this.method,
       uri: Uri = this.uri,
       httpVersion: HttpVersion = this.httpVersion,
       headers: Headers = this.headers,
-      body: EntityBody[F] = this.body,
+      body: EntityBody[F1] = this.body,
       attributes: Vault = this.attributes
-  ): Request[F] =
+  ): Request[F1] =
     Request(
       method = method,
       uri = uri,
@@ -269,28 +279,18 @@ final class Request[F[_]] private (
       attributes = attributes
     )
 
-  def mapK[G[_]](f: F ~> G): Request[G] =
-    Request[G](
-      method = method,
-      uri = uri,
-      httpVersion = httpVersion,
-      headers = headers,
-      body = body.translate(f),
-      attributes = attributes
-    )
-
   def withMethod(method: Method): Request[F] =
     copy(method = method)
 
   def withUri(uri: Uri): Request[F] =
     copy(uri = uri, attributes = attributes.delete(Request.Keys.PathInfoCaret))
 
-  override protected def change(
+  override protected def change[F1[_]](
       httpVersion: HttpVersion,
-      body: EntityBody[F],
+      body: EntityBody[F1],
       headers: Headers,
       attributes: Vault
-  ): Request[F] =
+  ): Request[F1] =
     copy(
       httpVersion = httpVersion,
       body = body,
@@ -430,21 +430,12 @@ final class Request[F[_]] private (
   def serverSoftware: ServerSoftware =
     attributes.lookup(Keys.ServerSoftware).getOrElse(ServerSoftware.Unknown)
 
-  def decodeWith[A](decoder: EntityDecoder[F, A], strict: Boolean)(f: A => F[Response[F]])(implicit
-      F: Monad[F]): F[Response[F]] =
+  def decodeWith[F1[x] >: F[x], A](decoder: EntityDecoder[F1, A], strict: Boolean)(
+      f: A => F1[Response[F1]])(implicit F: Monad[F1]): F1[Response[F1]] =
     decoder
       .decode(this, strict = strict)
-      .fold(_.toHttpResponse[F](httpVersion).pure[F], f)
+      .fold(_.toHttpResponse[F1](httpVersion).pure[F1], f)
       .flatten
-
-  /** Helper method for decoding [[Request]]s
-    *
-    * Attempt to decode the [[Request]] and, if successful, execute the continuation to get a [[Response]].
-    * If decoding fails, an `UnprocessableEntity` [[Response]] is generated.
-    */
-  def decode[A](
-      f: A => F[Response[F]])(implicit F: Monad[F], decoder: EntityDecoder[F, A]): F[Response[F]] =
-    decodeWith(decoder, strict = false)(f)
 
   /** Helper method for decoding [[Request]]s
     *
@@ -452,8 +443,9 @@ final class Request[F[_]] private (
     * If decoding fails, an `UnprocessableEntity` [[Response]] is generated. If the decoder does not support the
     * [[MediaType]] of the [[Request]], a `UnsupportedMediaType` [[Response]] is generated instead.
     */
-  def decodeStrict[A](
-      f: A => F[Response[F]])(implicit F: Monad[F], decoder: EntityDecoder[F, A]): F[Response[F]] =
+  def decodeStrict[F1[x] >: F[x], A](f: A => F1[Response[F1]])(implicit
+      F: Monad[F1],
+      decoder: EntityDecoder[F1, A]): F1[Response[F1]] =
     decodeWith(decoder, strict = true)(f)
 
   override def hashCode(): Int = MurmurHash3.productHash(this)
@@ -485,6 +477,15 @@ final class Request[F[_]] private (
 }
 
 object Request {
+  type Pure = Request[fs2.Pure]
+
+  implicit final class InvariantOps[F[_]](private val self: Request[F]) extends AnyVal {
+    import self._
+    def decode[A](f: A => F[Response[F]])(implicit
+        F: Monad[F],
+        decoder: EntityDecoder[F, A]): F[Response[F]] =
+      decodeWith(decoder, strict = false)(f)
+  }
 
   /** Representation of an incoming HTTP message
     *
@@ -506,7 +507,7 @@ object Request {
       body: EntityBody[F] = EmptyBody,
       attributes: Vault = Vault.empty
   ): Request[F] =
-    new Request[F](
+    new Request(
       method = method,
       uri = uri,
       httpVersion = httpVersion,
@@ -548,7 +549,7 @@ object Request {
   *                   parameters which may be used by the http4s backend for
   *                   additional processing such as java.io.File object
   */
-final class Response[F[_]] private (
+final class Response[+F[_]] private (
     val status: Status,
     val httpVersion: HttpVersion,
     val headers: Headers,
@@ -557,26 +558,17 @@ final class Response[F[_]] private (
     extends Message[F]
     with Product
     with Serializable {
-  type SelfF[F0[_]] = Response[F0]
-
-  def mapK[G[_]](f: F ~> G): Response[G] =
-    Response[G](
-      status = status,
-      httpVersion = httpVersion,
-      headers = headers,
-      body = body.translate(f),
-      attributes = attributes
-    )
+  type SelfF[+F0[_]] = Response[F0]
 
   def withStatus(status: Status): Response[F] =
     copy(status = status)
 
-  override protected def change(
+  override protected def change[F1[_]](
       httpVersion: HttpVersion,
-      body: EntityBody[F],
+      body: EntityBody[F1],
       headers: Headers,
       attributes: Vault
-  ): Response[F] =
+  ): Response[F1] =
     copy(
       httpVersion = httpVersion,
       body = body,
@@ -611,14 +603,14 @@ final class Response[F[_]] private (
 
   override def hashCode(): Int = MurmurHash3.productHash(this)
 
-  def copy(
+  def copy[F1[_]](
       status: Status = this.status,
       httpVersion: HttpVersion = this.httpVersion,
       headers: Headers = this.headers,
-      body: EntityBody[F] = this.body,
+      body: EntityBody[F1] = this.body,
       attributes: Vault = this.attributes
-  ): Response[F] =
-    Response[F](
+  ): Response[F1] =
+    Response(
       status = status,
       httpVersion = httpVersion,
       headers = headers,
@@ -653,6 +645,12 @@ final class Response[F[_]] private (
 }
 
 object Response extends KleisliSyntax {
+  type Pure = Response[fs2.Pure]
+
+  @nowarn("cat=unused")
+  implicit def covaryF[F[_], G[_]](fresp: F[Response[Nothing]])(implicit
+      F: Functor[F]): F[Response[G]] =
+    fresp.asInstanceOf
 
   /** Representation of the HTTP response to send back to the client
     *
@@ -676,7 +674,7 @@ object Response extends KleisliSyntax {
     Some(
       (response.status, response.httpVersion, response.headers, response.body, response.attributes))
 
-  private[this] val pureNotFound: Response[Pure] =
+  private[this] val pureNotFound: Response.Pure =
     Response(
       Status.NotFound,
       body = Stream("Not found").through(utf8.encode),
@@ -690,8 +688,8 @@ object Response extends KleisliSyntax {
 
   def notFoundFor[F[_]: Applicative](request: Request[F])(implicit
       encoder: EntityEncoder[F, String]): F[Response[F]] =
-    Response[F](Status.NotFound).withEntity(s"${request.pathInfo} not found").pure[F]
+    Response(Status.NotFound).withEntity(s"${request.pathInfo} not found").pure[F]
 
   def timeout[F[_]]: Response[F] =
-    Response[F](Status.ServiceUnavailable).withEntity("Response timed out")
+    Response(Status.ServiceUnavailable).withEntity("Response timed out")
 }

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -434,7 +434,7 @@ final class Request[+F[_]] private (
       f: A => F1[Response[F1]])(implicit F: Monad[F1]): F1[Response[F1]] =
     decoder
       .decode(this, strict = strict)
-      .fold[F1[Response[F1]]](_.toHttpResponse(httpVersion).pure[F1], f)
+      .fold(_.toHttpResponse(httpVersion).covary[F1].pure[F1], f)
       .flatten
 
   /** Helper method for decoding [[Request]]s

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -434,7 +434,7 @@ final class Request[+F[_]] private (
       f: A => F1[Response[F1]])(implicit F: Monad[F1]): F1[Response[F1]] =
     decoder
       .decode(this, strict = strict)
-      .fold(_.toHttpResponse[F1](httpVersion).pure[F1], f)
+      .fold[F1[Response[F1]]](_.toHttpResponse(httpVersion).pure[F1], f)
       .flatten
 
   /** Helper method for decoding [[Request]]s
@@ -477,6 +477,10 @@ final class Request[+F[_]] private (
 }
 
 object Request {
+
+  /** A [[Request]] that doesn't have a body requiring effectful evaluation.
+    *  A [[Request.Pure]] is always an instance of [[Request[F]]], regardless of `F`.
+    */
   type Pure = Request[fs2.Pure]
 
   implicit final class InvariantOps[F[_]](private val self: Request[F]) extends AnyVal {
@@ -645,6 +649,10 @@ final class Response[+F[_]] private (
 }
 
 object Response extends KleisliSyntax {
+
+  /** A [[Response]] that doesn't have a body requiring effectful evaluation.
+    *  A [[Response.Pure]] is always an instance of [[Response[F]]], regardless of `F`.
+    */
   type Pure = Response[fs2.Pure]
 
   @nowarn("cat=unused")

--- a/core/shared/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/shared/src/main/scala/org/http4s/MessageFailure.scala
@@ -58,7 +58,7 @@ final case class ParseFailure(sanitized: String, details: String)
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.BadRequest, httpVersion)
-      .withEntity(sanitized)(EntityEncoder.stringEncoder[F])
+      .withEntity(sanitized)(EntityEncoder.stringEncoder)
 }
 
 object ParseFailure {
@@ -107,7 +107,7 @@ final case class MalformedMessageBodyFailure(details: String, cause: Option[Thro
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.BadRequest, httpVersion)
-      .withEntity(s"The request body was malformed.")(EntityEncoder.stringEncoder[F])
+      .withEntity(s"The request body was malformed.")(EntityEncoder.stringEncoder)
 }
 
 /** Indicates a semantic error decoding the body of an HTTP [[Message]]. */
@@ -118,7 +118,7 @@ final case class InvalidMessageBodyFailure(details: String, cause: Option[Throwa
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.UnprocessableEntity, httpVersion)
-      .withEntity(s"The request body was invalid.")(EntityEncoder.stringEncoder[F])
+      .withEntity(s"The request body was invalid.")(EntityEncoder.stringEncoder)
 }
 
 /** Indicates that a [[Message]] came with no supported [[MediaType]]. */
@@ -133,7 +133,7 @@ sealed abstract class UnsupportedMediaTypeFailure extends DecodeFailure with NoS
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.UnsupportedMediaType, httpVersion)
-      .withEntity(responseMsg)(EntityEncoder.stringEncoder[F])
+      .withEntity(responseMsg)(EntityEncoder.stringEncoder)
 }
 
 /** Indicates that a [[Message]] attempting to be decoded has no [[MediaType]] and no

--- a/core/shared/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/shared/src/main/scala/org/http4s/MessageFailure.scala
@@ -58,7 +58,7 @@ final case class ParseFailure(sanitized: String, details: String)
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.BadRequest, httpVersion)
-      .withEntity(sanitized)(EntityEncoder.stringEncoder)
+      .withEntity(sanitized)
 }
 
 object ParseFailure {
@@ -107,7 +107,7 @@ final case class MalformedMessageBodyFailure(details: String, cause: Option[Thro
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.BadRequest, httpVersion)
-      .withEntity(s"The request body was malformed.")(EntityEncoder.stringEncoder)
+      .withEntity(s"The request body was malformed.")
 }
 
 /** Indicates a semantic error decoding the body of an HTTP [[Message]]. */
@@ -118,7 +118,7 @@ final case class InvalidMessageBodyFailure(details: String, cause: Option[Throwa
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.UnprocessableEntity, httpVersion)
-      .withEntity(s"The request body was invalid.")(EntityEncoder.stringEncoder)
+      .withEntity(s"The request body was invalid.")
 }
 
 /** Indicates that a [[Message]] came with no supported [[MediaType]]. */
@@ -133,7 +133,7 @@ sealed abstract class UnsupportedMediaTypeFailure extends DecodeFailure with NoS
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.UnsupportedMediaType, httpVersion)
-      .withEntity(responseMsg)(EntityEncoder.stringEncoder)
+      .withEntity(responseMsg)
 }
 
 /** Indicates that a [[Message]] attempting to be decoded has no [[MediaType]] and no

--- a/core/shared/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/shared/src/main/scala/org/http4s/MessageFailure.scala
@@ -36,7 +36,7 @@ trait MessageFailure extends RuntimeException {
   final override def getCause: Throwable = cause.orNull
 
   /** Provides a default rendering of this failure as a [[Response]]. */
-  def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F]
+  def toHttpResponse(httpVersion: HttpVersion): Response.Pure
 }
 
 /** Indicates an error parsing an HTTP [[Message]].
@@ -56,7 +56,7 @@ final case class ParseFailure(sanitized: String, details: String)
 
   def cause: Option[Throwable] = None
 
-  def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
+  def toHttpResponse(httpVersion: HttpVersion): Response.Pure =
     Response(Status.BadRequest, httpVersion)
       .withEntity(sanitized)
 }
@@ -105,7 +105,7 @@ final case class MalformedMessageBodyFailure(details: String, cause: Option[Thro
   def message: String =
     s"Malformed message body: $details"
 
-  def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
+  def toHttpResponse(httpVersion: HttpVersion): Response.Pure =
     Response(Status.BadRequest, httpVersion)
       .withEntity(s"The request body was malformed.")
 }
@@ -116,7 +116,7 @@ final case class InvalidMessageBodyFailure(details: String, cause: Option[Throwa
   def message: String =
     s"Invalid message body: $details"
 
-  def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
+  def toHttpResponse(httpVersion: HttpVersion): Response.Pure =
     Response(Status.UnprocessableEntity, httpVersion)
       .withEntity(s"The request body was invalid.")
 }
@@ -131,7 +131,7 @@ sealed abstract class UnsupportedMediaTypeFailure extends DecodeFailure with NoS
     s"Expected one of the following media ranges: ${expected.map(_.show).mkString(", ")}"
   protected def responseMsg: String = s"$sanitizedResponsePrefix. $expectedMsg"
 
-  def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
+  def toHttpResponse(httpVersion: HttpVersion): Response.Pure =
     Response(Status.UnsupportedMediaType, httpVersion)
       .withEntity(responseMsg)
 }

--- a/core/shared/src/main/scala/org/http4s/RequestPrelude.scala
+++ b/core/shared/src/main/scala/org/http4s/RequestPrelude.scala
@@ -91,7 +91,7 @@ object RequestPrelude {
       uri
     )
 
-  def fromRequest[F[_]](value: Request[F]): RequestPrelude =
+  def fromRequest(value: AnyRequest): RequestPrelude =
     RequestPreludeImpl(
       value.headers,
       value.httpVersion,

--- a/core/shared/src/main/scala/org/http4s/ResponsePrelude.scala
+++ b/core/shared/src/main/scala/org/http4s/ResponsePrelude.scala
@@ -79,7 +79,7 @@ object ResponsePrelude {
       status
     )
 
-  def fromResponse[F[_]](value: Response[F]): ResponsePrelude =
+  def fromResponse(value: AnyResponse): ResponsePrelude =
     ResponsePreludeImpl(
       value.headers,
       value.httpVersion,

--- a/core/shared/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/shared/src/main/scala/org/http4s/UrlForm.scala
@@ -97,10 +97,9 @@ object UrlForm {
   def fromChain(values: Chain[(String, String)]): UrlForm =
     apply(values.toList: _*)
 
-  implicit def entityEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, UrlForm] =
-    EntityEncoder
-      .stringEncoder[F]
+  implicit def entityEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder.Pure[UrlForm] =
+    EntityEncoder.stringEncoder
       .contramap[UrlForm](encodeString(charset))
       .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`, charset))
 

--- a/core/shared/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/Logger.scala
@@ -20,20 +20,19 @@ import cats.Monad
 import cats.effect.Concurrent
 import cats.syntax.all._
 import fs2.Stream
-import org.http4s.{Charset, Headers, MediaType, Message, Request, Response}
+import org.http4s.{AnyMessage, Charset, Headers, MediaType, Message, Request, Response}
 import org.typelevel.ci.CIString
 
 object Logger {
 
-  def defaultLogHeaders[F[_], A <: Message[F]](message: A)(
+  def defaultLogHeaders(message: AnyMessage)(
       logHeaders: Boolean,
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains): String =
     if (logHeaders)
       message.headers.redactSensitive(redactHeadersWhen).headers.mkString("Headers(", ", ", ")")
     else ""
 
-  def defaultLogBody[F[_]: Concurrent, A <: Message[F]](message: A)(
-      logBody: Boolean): Option[F[String]] =
+  def defaultLogBody[F[_]: Concurrent](message: Message[F])(logBody: Boolean): Option[F[String]] =
     if (logBody) {
       val isBinary = message.contentType.exists(_.mediaType.binary)
       val isJson = message.contentType.exists(mT =>
@@ -46,17 +45,17 @@ object Logger {
       Some(bodyStream.compile.string)
     } else None
 
-  def logMessage[F[_], A <: Message[F]](message: A)(
+  def logMessage[F[_]](message: Message[F])(
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains)(
       log: String => F[Unit])(implicit F: Concurrent[F]): F[Unit] = {
-    val logBodyText = (_: Stream[F, Byte]) => defaultLogBody[F, A](message)(logBody)
+    val logBodyText = (_: Stream[F, Byte]) => defaultLogBody[F](message)(logBody)
 
-    logMessageWithBodyText[F, A](message)(logHeaders, logBodyText, redactHeadersWhen)(log)
+    logMessageWithBodyText[F](message)(logHeaders, logBodyText, redactHeadersWhen)(log)
   }
 
-  def logMessageWithBodyText[F[_], A <: Message[F]](message: A)(
+  def logMessageWithBodyText[F[_]](message: Message[F])(
       logHeaders: Boolean,
       logBodyText: Stream[F, Byte] => Option[F[String]],
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains)(
@@ -67,7 +66,7 @@ object Logger {
         case resp: Response[_] => s"${resp.httpVersion} ${resp.status}"
       }
 
-    val headers: String = defaultLogHeaders[F, A](message)(logHeaders, redactHeadersWhen)
+    val headers: String = defaultLogHeaders(message)(logHeaders, redactHeadersWhen)
 
     val bodyText: F[String] =
       logBodyText(message.body) match {

--- a/core/shared/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/Logger.scala
@@ -39,7 +39,7 @@ object Logger {
       val isJson = message.contentType.exists(mT =>
         mT.mediaType == MediaType.application.json || mT.mediaType.subType.endsWith("+json"))
       val bodyStream = if (!isBinary || isJson) {
-        message.bodyText(implicitly, message.charset.getOrElse(Charset.`UTF-8`))
+        message.bodyText[F](implicitly, message.charset.getOrElse(Charset.`UTF-8`))
       } else {
         message.body.map(b => java.lang.Integer.toHexString(b & 0xff))
       }

--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -17,7 +17,7 @@
 package org.http4s.metrics
 
 import cats.Foldable
-import org.http4s.{Method, Request, Status}
+import org.http4s.{AnyRequest, Method, Status}
 
 /** Describes an algebra capable of writing metrics to a metrics registry
   */
@@ -97,13 +97,13 @@ object MetricsOps {
     * @param exclude For a given String, namely a path value, determine whether the value gets excluded.
     * @param excludedValue Indicates the String value to be supplied for an excluded path's field.
     * @param pathSeparator Value to use for separating the metrics fields' values
-    * @return Request[F] => Option[String]
+    * @return AnyRequest => Option[String]
     */
   def classifierFMethodWithOptionallyExcludedPath(
       exclude: String => Boolean,
       excludedValue: String = "*",
       pathSeparator: String = "_"
-  ): Request[F] => Option[String] = { (request: Request[F]) =>
+  ): AnyRequest => Option[String] = { (request: AnyRequest) =>
     val initial: String = request.method.name
 
     val pathList: List[String] =

--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -99,7 +99,7 @@ object MetricsOps {
     * @param pathSeparator Value to use for separating the metrics fields' values
     * @return Request[F] => Option[String]
     */
-  def classifierFMethodWithOptionallyExcludedPath[F[_]](
+  def classifierFMethodWithOptionallyExcludedPath(
       exclude: String => Boolean,
       excludedValue: String = "*",
       pathSeparator: String = "_"

--- a/core/shared/src/main/scala/org/http4s/package.scala
+++ b/core/shared/src/main/scala/org/http4s/package.scala
@@ -79,4 +79,6 @@ package object http4s extends http4splatform {
 
   /** A stream of server-sent events */
   type EventStream[F[_]] = Stream[F, ServerSentEvent]
+
+  type AnyF[A] = Any
 }

--- a/core/shared/src/main/scala/org/http4s/package.scala
+++ b/core/shared/src/main/scala/org/http4s/package.scala
@@ -81,4 +81,13 @@ package object http4s extends http4splatform {
   type EventStream[F[_]] = Stream[F, ServerSentEvent]
 
   type AnyF[A] = Any
+
+  /** The top type for [[Request]]. Any [[Request]] can be used where an [[AnyRequest]] is needed. */
+  type AnyRequest = Request[AnyF]
+
+  /** The top type for [[Response]]. Any [[Response]] can be used where an [[AnyResponse]] is needed. */
+  type AnyResponse = Response[AnyF]
+
+  /** The top type for [[Message]]. Any [[Message]] can be used where an [[Message]] is needed. */
+  type AnyMessage = Message[AnyF]
 }

--- a/docs/jvm/src/main/mdoc/cors.md
+++ b/docs/jvm/src/main/mdoc/cors.md
@@ -49,7 +49,7 @@ val service = HttpRoutes.of[IO] {
     Ok()
 }
 
-val request = Request[IO](Method.GET, uri"/")
+val request = Request(Method.GET, uri"/")
 
 service.orNotFound(request).unsafeRunSync()
 ```
@@ -88,9 +88,9 @@ First, we'll create some requests to use in our example. We want these requests
 have a variety of origins and methods.
 
 ```scala mdoc
-val googleGet = Request[IO](Method.GET, uri"/", headers = Headers("Origin" -> "https://google.com"))
-val yahooPut = Request[IO](Method.PUT, uri"/", headers = Headers("Origin" -> "https://yahoo.com"))
-val duckPost = Request[IO](Method.POST, uri"/", headers = Headers("Origin" -> "https://duckduckgo.com"))
+val googleGet = Request(Method.GET, uri"/", headers = Headers("Origin" -> "https://google.com"))
+val yahooPut = Request(Method.PUT, uri"/", headers = Headers("Origin" -> "https://yahoo.com"))
+val duckPost = Request(Method.POST, uri"/", headers = Headers("Origin" -> "https://duckduckgo.com"))
 ```
 
 Now, we'll create a configuration that limits the allowed methods to `GET`

--- a/docs/jvm/src/main/mdoc/csrf.md
+++ b/docs/jvm/src/main/mdoc/csrf.md
@@ -51,8 +51,8 @@ That didn't do all that much. Lets build out our CSRF Middleware by creating a `
 ```scala mdoc:silent
 val cookieName = "csrf-token"
 val key  = CSRF.generateSigningKey[IO].unsafeRunSync()
-val defaultOriginCheck: Request[IO] => Boolean =
-  CSRF.defaultOriginCheck[IO](_, "localhost", Uri.Scheme.http, None)
+val defaultOriginCheck: AnyRequest => Boolean =
+  CSRF.defaultOriginCheck(_, "localhost", Uri.Scheme.http, None)
 val csrfBuilder = CSRF[IO,IO](key, defaultOriginCheck)
 ```
 

--- a/docs/jvm/src/main/mdoc/csrf.md
+++ b/docs/jvm/src/main/mdoc/csrf.md
@@ -41,7 +41,7 @@ val service = HttpRoutes.of[IO] {
     Ok()
 } 
 
-val request = Request[IO](Method.GET, uri"/")
+val request = Request(Method.GET, uri"/")
 
 service.orNotFound(request).unsafeRunSync()
 ```
@@ -66,7 +66,7 @@ val csrf = csrfBuilder.withCookieName(cookieName).withCookieDomain(Some("localho
 Now we need to wrap this around our service! We're gonna start with a safe call
 ```scala mdoc
 val dummyRequest: Request[IO] =
-    Request[IO](method = Method.GET).putHeaders("Origin" -> "http://localhost")
+    Request(method = Method.GET).putHeaders("Origin" -> "http://localhost")
 val resp = csrf.validate()(service.orNotFound)(dummyRequest).unsafeRunSync()
 ```
 Notice how the response has the CSRF cookies added. How easy was
@@ -85,7 +85,7 @@ the browser would send this up with our request, but I needed to do it manually 
 ```scala mdoc
 val cookie = resp.cookies.head
 val dummyPostRequest: Request[IO] =
-    Request[IO](method = Method.POST).putHeaders(
+    Request(method = Method.POST).putHeaders(
       "Origin" -> "http://localhost",
       "X-Csrf-Token" -> cookie.content
     ).addCookie(RequestCookie(cookie.name,cookie.content))

--- a/docs/jvm/src/main/mdoc/dsl.md
+++ b/docs/jvm/src/main/mdoc/dsl.md
@@ -74,7 +74,7 @@ need a server to test our route.  We can construct our own request
 and experiment directly in the REPL.
 
 ```scala mdoc
-val getRoot = Request[IO](Method.GET, uri"/")
+val getRoot = Request(Method.GET, uri"/")
 
 val io = service.orNotFound.run(getRoot)
 ```

--- a/docs/jvm/src/main/mdoc/gzip.md
+++ b/docs/jvm/src/main/mdoc/gzip.md
@@ -41,7 +41,7 @@ val service = HttpRoutes.of[IO] {
     Ok("I repeat myself when I'm under stress. " * 3)
 }
 
-val request = Request[IO](Method.GET, uri"/")
+val request = Request(Method.GET, uri"/")
 
 // Do not call 'unsafeRun' in your code - see note at bottom.
 val response = service.orNotFound(request).unsafeRunSync()

--- a/docs/jvm/src/main/mdoc/hsts.md
+++ b/docs/jvm/src/main/mdoc/hsts.md
@@ -41,7 +41,7 @@ val service = HttpRoutes.of[IO] {
     Ok("ok")
 }
 
-val request = Request[IO](Method.GET, uri"/")
+val request = Request(Method.GET, uri"/")
 
 // Do not call 'unsafeRunSync' in your code
 val response = service.orNotFound(request).unsafeRunSync()

--- a/docs/jvm/src/main/mdoc/methods.md
+++ b/docs/jvm/src/main/mdoc/methods.md
@@ -24,7 +24,7 @@ def addTweet(tweet: Tweet): IO[TweetWithId] = ???
 def updateTweet(id: Int, tweet: Tweet): IO[Option[TweetWithId]] = ???
 def deleteTweet(id: Int): IO[Unit] = ???
 
-implicit val tweetWithIdEncoder = jsonEncoderOf[IO, TweetWithId]
+implicit val tweetWithIdEncoder = jsonEncoderOf[TweetWithId]
 implicit val tweetDecoder = jsonOf[IO, Tweet]
 
 val tweetService = HttpRoutes.of[IO] {

--- a/docs/jvm/src/main/mdoc/middleware.md
+++ b/docs/jvm/src/main/mdoc/middleware.md
@@ -72,8 +72,8 @@ val service = HttpRoutes.of[IO] {
     Ok()
 }
 
-val goodRequest = Request[IO](Method.GET, uri"/")
-val badRequest = Request[IO](Method.GET, uri"/bad")
+val goodRequest = Request(Method.GET, uri"/")
+val badRequest = Request(Method.GET, uri"/bad")
 
 service.orNotFound(goodRequest).unsafeRunSync()
 service.orNotFound(badRequest).unsafeRunSync()
@@ -135,7 +135,7 @@ val apiService = HttpRoutes.of[IO] {
 
 val aggregateService = apiService <+> MyMiddle(service, "SomeKey" -> "SomeValue")
 
-val apiRequest = Request[IO](Method.GET, uri"/api")
+val apiRequest = Request(Method.GET, uri"/api")
 
 aggregateService.orNotFound(goodRequest).unsafeRunSync()
 aggregateService.orNotFound(apiRequest).unsafeRunSync()

--- a/docs/jvm/src/main/mdoc/static.md
+++ b/docs/jvm/src/main/mdoc/static.md
@@ -66,7 +66,7 @@ import java.io.File
 
 val routes = HttpRoutes.of[IO] {
   case request @ GET -> Root / "index.html" =>
-    StaticFile.fromFile(new File("relative/path/to/index.html"), Some(request))
+    StaticFile.fromFile[IO](new File("relative/path/to/index.html"), Some(request))
       .getOrElseF(NotFound()) // In case the file doesn't exist
 }
 ```
@@ -85,7 +85,7 @@ only files matching a list of extensions are served. Append to the `List` as nee
 
 ```scala mdoc:nest
 def static(file: String, request: Request[IO]) =
-  StaticFile.fromResource("/" + file, Some(request)).getOrElseF(NotFound())
+  StaticFile.fromResource[IO]("/" + file, Some(request)).getOrElseF(NotFound())
 
 val routes = HttpRoutes.of[IO] {
   case request @ GET -> Root / path if List(".js", ".css", ".map", ".html", ".webm").exists(path.endsWith) =>

--- a/docs/jvm/src/main/mdoc/streaming.md
+++ b/docs/jvm/src/main/mdoc/streaming.md
@@ -120,7 +120,7 @@ class TWStream[F[_]: Async] {
    * Then we `to` them to fs2's `lines` and then to `stdout` `Sink` to print them.
    */
   val stream: Stream[F, Unit] = {
-    val req = Request[F](Method.GET, uri"https://stream.twitter.com/1.1/statuses/sample.json")
+    val req = Request(Method.GET, uri"https://stream.twitter.com/1.1/statuses/sample.json")
     val s   = jsonStream("<consumerKey>", "<consumerSecret>", "<accessToken>", "<accessSecret>")(req)
     s.map(_.spaces2).through(lines).through(utf8Encode).through(stdout)
   }

--- a/dom-core/src/main/scala/org/http4s/dom/package.scala
+++ b/dom-core/src/main/scala/org/http4s/dom/package.scala
@@ -31,7 +31,7 @@ package object dom {
 
   private[dom] def fromResponse[F[_]](response: DomResponse)(implicit F: Async[F]): F[Response[F]] =
     F.fromEither(Status.fromInt(response.status)).map { status =>
-      Response[F](
+      Response(
         status = status,
         headers = fromDomHeaders(response.headers),
         body = fromReadableStream(response.body)

--- a/dom-service-worker/src/main/scala/org/http4s/dom/FetchEventContext.scala
+++ b/dom-service-worker/src/main/scala/org/http4s/dom/FetchEventContext.scala
@@ -36,7 +36,7 @@ final class FetchEventContext[F[_]] private (
 object FetchEventContext {
   private[dom] val IOKey = Key.newKey[SyncIO, FetchEventContext[IO]].unsafeRunSync()
 
-  def apply(request: Request[IO]): IO[FetchEventContext[IO]] =
+  def apply(request: AnyRequest): IO[FetchEventContext[IO]] =
     IO.fromEither(request.attributes.lookup(IOKey).toRight(new NoSuchElementException))
 
   private[dom] def apply[F[_]](event: FetchEvent, supervisor: Supervisor[F])(implicit

--- a/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/metrics.scala
+++ b/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/metrics.scala
@@ -44,7 +44,7 @@ package object dropwizard {
       registry: MetricRegistry,
       mapper: ObjectMapper = defaultMapper): F[Response[F]] = {
     implicit val encoder: EntityEncoder.Pure[MetricRegistry] = metricRegistryEncoder(mapper)
-    Response[F](Status.Ok).withEntity(registry).pure[F]
+    Response(Status.Ok).withEntity(registry).pure[F]
   }
 
   /** Returns an OK response with a JSON dump of a MetricRegistry */

--- a/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/metrics.scala
+++ b/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/metrics.scala
@@ -32,9 +32,9 @@ package object dropwizard {
   }
 
   /** Encodes a metric registry in JSON format */
-  def metricRegistryEncoder[F[_]](
-      mapper: ObjectMapper = defaultMapper): EntityEncoder[F, MetricRegistry] =
-    EntityEncoder[F, String].contramap { metricRegistry =>
+  def metricRegistryEncoder(
+      mapper: ObjectMapper = defaultMapper): EntityEncoder.Pure[MetricRegistry] =
+    EntityEncoder.Pure[String].contramap { metricRegistry =>
       val writer = mapper.writerWithDefaultPrettyPrinter()
       writer.writeValueAsString(metricRegistry)
     }
@@ -43,8 +43,8 @@ package object dropwizard {
   def metricsResponse[F[_]: Applicative](
       registry: MetricRegistry,
       mapper: ObjectMapper = defaultMapper): F[Response[F]] = {
-    implicit val encoder: EntityEncoder[F, MetricRegistry] = metricRegistryEncoder[F](mapper)
-    Response[F](Status.Ok).withEntity[MetricRegistry](registry).pure[F]
+    implicit val encoder: EntityEncoder.Pure[MetricRegistry] = metricRegistryEncoder(mapper)
+    Response[F](Status.Ok).withEntity(registry).pure[F]
   }
 
   /** Returns an OK response with a JSON dump of a MetricRegistry */

--- a/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/metrics.scala
+++ b/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/metrics.scala
@@ -44,7 +44,7 @@ package object dropwizard {
       registry: MetricRegistry,
       mapper: ObjectMapper = defaultMapper): F[Response[F]] = {
     implicit val encoder: EntityEncoder.Pure[MetricRegistry] = metricRegistryEncoder(mapper)
-    Response(Status.Ok).withEntity(registry).pure[F]
+    Response[F](Status.Ok).withEntity(registry).pure[F]
   }
 
   /** Returns an OK response with a JSON dump of a MetricRegistry */

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSuite.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSuite.scala
@@ -131,7 +131,7 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test5")
     val meteredClient = Metrics(Dropwizard[IO](registry, "client"))(client)
 
-    meteredClient.expect[String](Request[IO](POST, uri"/ok")).attempt.map { resp =>
+    meteredClient.expect[String](Request(POST, uri"/ok")).attempt.map { resp =>
       assertEquals(resp, Right("200 OK"))
       assertEquals(count(registry, Timer("client.default.post-requests")), 1L)
       assertEquals(count(registry, Counter("client.default.active-requests")), 0L)
@@ -156,7 +156,7 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test6")
     val meteredClient = Metrics(Dropwizard[IO](registry, "client"))(client)
 
-    meteredClient.expect[String](Request[IO](PUT, uri"/ok")).attempt.map { resp =>
+    meteredClient.expect[String](Request(PUT, uri"/ok")).attempt.map { resp =>
       assertEquals(resp, Right("200 OK"))
       assertEquals(count(registry, Timer("client.default.put-requests")), 1L)
       assertEquals(count(registry, Counter("client.default.active-requests")), 0L)
@@ -181,7 +181,7 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test7")
     val meteredClient = Metrics(Dropwizard[IO](registry, "client"))(client)
 
-    meteredClient.expect[String](Request[IO](DELETE, uri"/ok")).attempt.map { resp =>
+    meteredClient.expect[String](Request(DELETE, uri"/ok")).attempt.map { resp =>
       assertEquals(resp, Right("200 OK"))
       assertEquals(count(registry, Timer("client.default.delete-requests")), 1L)
       assertEquals(count(registry, Counter("client.default.active-requests")), 0L)
@@ -263,7 +263,7 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
   val meteredClient = Metrics(Dropwizard[IO](registry, "client"))(client)
 
   val clientRunResource = meteredClient
-    .run(Request[IO](uri = Uri.unsafeFromString("/ok")))
+    .run(Request(uri = Uri.unsafeFromString("/ok")))
 
   ResourceFixture(clientRunResource).test(
     "A http client with a dropwizard metrics middleware should only record total time and decr active requests after client.run releases") {

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
@@ -31,7 +31,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test1")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](uri = uri"/ok")
+    val req = Request(uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -61,7 +61,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test2")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
 
-    val req = Request[IO](uri = uri"/bad-request")
+    val req = Request(uri = uri"/bad-request")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -90,7 +90,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test3")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](uri = uri"/internal-server-error")
+    val req = Request(uri = uri"/internal-server-error")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -119,7 +119,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test4")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = GET, uri = uri"/ok")
+    val req = Request(method = GET, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -148,7 +148,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test5")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = POST, uri = uri"/ok")
+    val req = Request(method = POST, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -177,7 +177,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test6")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = PUT, uri = uri"/ok")
+    val req = Request(method = PUT, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -206,7 +206,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test7")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = DELETE, uri = uri"/ok")
+    val req = Request(method = DELETE, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>
@@ -235,7 +235,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test8")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = GET, uri = uri"/error")
+    val req = Request(method = GET, uri = uri"/error")
 
     meteredRoutes.orNotFound(req).attempt.map { resp =>
       assert(resp.isLeft)
@@ -257,7 +257,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test9")
     val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
-    val req = Request[IO](method = GET, uri = uri"/abnormal-termination")
+    val req = Request(method = GET, uri = uri"/abnormal-termination")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.body.attempt.compile.lastOrError.map { b =>
@@ -284,7 +284,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test10")
     val meteredRoutes =
       Metrics[IO](ops = Dropwizard(registry, "server"), classifierF = classifierFunc)(testRoutes)
-    val req = Request[IO](uri = uri"/ok")
+    val req = Request(uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.as[String].map { b =>

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -36,7 +36,7 @@ import org.http4s.Uri.Path._
 import org.http4s.headers.Allow
 
 object :? {
-  def unapply[F[_]](req: Request[F]): Some[(Request[F], Map[String, collection.Seq[String]])] =
+  def unapply(req: AnyRequest): Some[(req.type, Map[String, collection.Seq[String]])] =
     Some((req, req.multiParams))
 }
 
@@ -94,7 +94,7 @@ object -> {
     *     case Method.GET -> Root / "test.json" => ...
     * }}}
     */
-  def unapply[F[_]](req: Request[F]): Some[(Method, Path)] =
+  def unapply(req: AnyRequest): Some[(Method, Path)] =
     Some((req.method, req.pathInfo))
 }
 

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -43,11 +43,11 @@ private[impl] object ResponseGenerator {
   * }}}
   */
 trait EmptyResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
-  def apply()(implicit F: Applicative[F]): F[Response[G]] = F.pure(Response[G](status))
+  def apply()(implicit F: Applicative[F]): F[Response[G]] = F.pure(Response(status))
 
   def headers(header: Header.ToRaw, _headers: Header.ToRaw*)(implicit
       F: Applicative[F]): F[Response[G]] =
-    F.pure(Response[G](status, headers = Headers(header :: _headers.toList)))
+    F.pure(Response(status, headers = Headers(header :: _headers.toList)))
 }
 
 /** Helper for the generation of a [[org.http4s.Response]] which may contain a body
@@ -64,12 +64,12 @@ trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def liftG: FunctionK[G, F]
 
   def apply()(implicit F: Applicative[F]): F[Response[G]] =
-    F.pure(Response[G](status, headers = Headers(List(`Content-Length`.zero))))
+    F.pure(Response(status, headers = Headers(List(`Content-Length`.zero))))
 
   def headers(header: Header.ToRaw, _headers: Header.ToRaw*)(implicit
       F: Applicative[F]): F[Response[G]] =
     F.pure(
-      Response[G](
+      Response(
         status,
         headers = Headers(`Content-Length`.zero) ++ Headers(header :: _headers.toList)))
 
@@ -81,7 +81,7 @@ trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers |+| Headers(headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response(status = status, headers = addEntityLength(entity, h), body = entity.body))
   }
 }
 
@@ -93,14 +93,14 @@ trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   */
 trait LocationResponseGenerator[F[_], G[_]] extends Any with EntityResponseGenerator[F, G] {
   def apply(location: Location)(implicit F: Applicative[F]): F[Response[G]] =
-    F.pure(Response[G](status = status, headers = Headers(`Content-Length`.zero, location)))
+    F.pure(Response(status = status, headers = Headers(`Content-Length`.zero, location)))
 
   def apply[A](location: Location, body: A, headers: Header.ToRaw*)(implicit
       F: Applicative[F],
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers |+| Headers(location, headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response(status = status, headers = addEntityLength(entity, h), body = entity.body))
   }
 }
 
@@ -113,15 +113,14 @@ trait LocationResponseGenerator[F[_], G[_]] extends Any with EntityResponseGener
 trait WwwAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def apply(authenticate: `WWW-Authenticate`, headers: Header.ToRaw*)(implicit
       F: Applicative[F]): F[Response[G]] =
-    F.pure(
-      Response[G](status, headers = Headers(`Content-Length`.zero, authenticate, headers.toList)))
+    F.pure(Response(status, headers = Headers(`Content-Length`.zero, authenticate, headers.toList)))
 
   def apply[A](authenticate: `WWW-Authenticate`, body: A, headers: Header.ToRaw*)(implicit
       F: Applicative[F],
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers |+| Headers(authenticate, headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response(status = status, headers = addEntityLength(entity, h), body = entity.body))
   }
 }
 
@@ -133,14 +132,14 @@ trait WwwAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGene
   */
 trait AllowResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def apply(allow: Allow, headers: Header.ToRaw*)(implicit F: Applicative[F]): F[Response[G]] =
-    F.pure(Response[G](status, headers = Headers(`Content-Length`.zero, allow, headers.toList)))
+    F.pure(Response(status, headers = Headers(`Content-Length`.zero, allow, headers.toList)))
 
   def apply[A](allow: Allow, body: A, headers: Header.ToRaw*)(implicit
       F: Applicative[F],
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers |+| Headers(allow, headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response(status = status, headers = addEntityLength(entity, h), body = entity.body))
   }
 }
 
@@ -153,14 +152,13 @@ trait AllowResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
 trait ProxyAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def apply(authenticate: `Proxy-Authenticate`, headers: Header.ToRaw*)(implicit
       F: Applicative[F]): F[Response[G]] =
-    F.pure(
-      Response[G](status, headers = Headers(`Content-Length`.zero, authenticate, headers.toList)))
+    F.pure(Response(status, headers = Headers(`Content-Length`.zero, authenticate, headers.toList)))
 
   def apply[A](authenticate: `Proxy-Authenticate`, body: A, headers: Header.ToRaw*)(implicit
       F: Applicative[F],
       w: EntityEncoder[G, A]): F[Response[G]] = {
     val h = w.headers |+| Headers(authenticate, headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response(status = status, headers = addEntityLength(entity, h), body = entity.body))
   }
 }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
@@ -208,7 +208,7 @@ object Responses {
           headers = Headers(`Content-Length`.zero) ++ Headers(header :: _headers.toList)))
 
     override def apply()(implicit F: Applicative[F]): F[Response[G]] =
-      F.pure(Response[G](ResetContent, headers = Headers(List(`Content-Length`.zero))))
+      F.pure(Response(ResetContent, headers = Headers(List(`Content-Length`.zero))))
   }
   // TODO helpers for Content-Range and multipart/byteranges
   final class PartialContentOps[F[_], G[_]](val status: PartialContent.type, val liftG: G ~> F)

--- a/dsl/src/test/scala/org/http4s/dsl/PathSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSuite.scala
@@ -17,7 +17,6 @@
 package org.http4s
 package dsl
 
-import cats.effect.IO
 import org.http4s.Uri.Path
 import org.http4s.Uri.Path.{Root, Segment}
 import org.http4s.dsl.io._
@@ -59,7 +58,7 @@ class PathSuite extends Http4sSuite with AllSyntax {
   }
 
   test("Path should -> extractor /test.json") {
-    val req = Request[IO](method = Method.GET, uri = uri"/test.json")
+    val req = Request(method = Method.GET, uri = uri"/test.json")
     assert(req match {
       case GET -> Root / "test.json" => true
       case _ => false
@@ -67,7 +66,7 @@ class PathSuite extends Http4sSuite with AllSyntax {
   }
 
   test("Path should -> extractor /foo/test.json") {
-    val req = Request[IO](method = Method.GET, uri = uri"/foo/test.json")
+    val req = Request(method = Method.GET, uri = uri"/foo/test.json")
     assert(req match {
       case GET -> Root / "foo" / "test.json" => true
       case _ => false
@@ -75,7 +74,7 @@ class PathSuite extends Http4sSuite with AllSyntax {
   }
 
   test("Path should → extractor /test.json") {
-    val req = Request[IO](method = Method.GET, uri = uri"/test.json")
+    val req = Request(method = Method.GET, uri = uri"/test.json")
     assert(req match {
       case GET → (Root / "test.json") => true
       case _ => false
@@ -83,7 +82,7 @@ class PathSuite extends Http4sSuite with AllSyntax {
   }
 
   test("Path should request path info extractor for /") {
-    val req = Request[IO](method = Method.GET, uri = uri"/")
+    val req = Request(method = Method.GET, uri = uri"/")
     assert(req match {
       case _ -> Root => true
       case _ => false

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
@@ -27,11 +27,8 @@ import org.http4s.headers.{Accept, Location, `Content-Length`, `Content-Type`}
 class ResponseGeneratorSuite extends Http4sSuite {
   test("Add the EntityEncoder headers along with a content-length header") {
     val body = "foo"
-    val resultheaders = Ok(body)(Monad[IO], EntityEncoder.stringEncoder[IO]).map(_.headers)
-    EntityEncoder
-      .stringEncoder[IO]
-      .headers
-      .headers
+    val resultheaders = Ok(body)(Monad[IO], EntityEncoder.stringEncoder).map(_.headers)
+    EntityEncoder.stringEncoder.headers.headers
       .traverse { h =>
         resultheaders.map(_.headers.exists(_ == h)).assert
       } *>
@@ -46,8 +43,8 @@ class ResponseGeneratorSuite extends Http4sSuite {
   test("Not duplicate headers when not provided") {
     val w =
       EntityEncoder.encodeBy[IO, String](
-        EntityEncoder.stringEncoder[IO].headers.put(Accept(MediaRange.`audio/*`)))(
-        EntityEncoder.stringEncoder[IO].toEntity(_)
+        EntityEncoder.stringEncoder.headers.put(Accept(MediaRange.`audio/*`)))(
+        EntityEncoder.stringEncoder.toEntity(_)
       )
 
     Ok("foo")(Monad[IO], w)
@@ -57,8 +54,8 @@ class ResponseGeneratorSuite extends Http4sSuite {
 
   test("Explicitly added headers have priority") {
     val w: EntityEncoder[IO, String] = EntityEncoder.encodeBy[IO, String](
-      EntityEncoder.stringEncoder[IO].headers.put(`Content-Type`(MediaType.text.html)))(
-      EntityEncoder.stringEncoder[IO].toEntity(_)
+      EntityEncoder.stringEncoder.headers.put(`Content-Type`(MediaType.text.html)))(
+      EntityEncoder.stringEncoder.toEntity(_)
     )
 
     val resp: IO[Response[IO]] =

--- a/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
+++ b/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
@@ -28,7 +28,7 @@ class ClientHelpersSuite extends Http4sSuite {
 
   test("Request Preprocessing should add a date header if not present") {
     ClientHelpers
-      .preprocessRequest(Request[IO](), None)
+      .preprocessRequest[IO](Request(), None)
       .map { req =>
         req.headers.get[Date].isDefined
       }
@@ -37,8 +37,8 @@ class ClientHelpersSuite extends Http4sSuite {
 
   test("Request Preprocessing should not add a date header if already present") {
     ClientHelpers
-      .preprocessRequest(
-        Request[IO](
+      .preprocessRequest[IO](
+        Request(
           headers = Headers(Date(HttpDate.Epoch))
         ),
         None)
@@ -51,7 +51,7 @@ class ClientHelpersSuite extends Http4sSuite {
   }
   test("Request Preprocessing should add a connection keep-alive header if not present") {
     ClientHelpers
-      .preprocessRequest(Request[IO](), None)
+      .preprocessRequest[IO](Request(), None)
       .map { req =>
         req.headers.get[Connection].map { case c: Connection =>
           c.hasKeepAlive
@@ -62,8 +62,8 @@ class ClientHelpersSuite extends Http4sSuite {
 
   test("Request Preprocessing should not add a connection header if already present") {
     ClientHelpers
-      .preprocessRequest(
-        Request[IO](headers = Headers(Connection(NonEmptyList.of(ci"close")))),
+      .preprocessRequest[IO](
+        Request(headers = Headers(Connection(NonEmptyList.of(ci"close")))),
         None
       )
       .map { req =>
@@ -76,7 +76,7 @@ class ClientHelpersSuite extends Http4sSuite {
 
   test("Request Preprocessing should add default user-agent") {
     ClientHelpers
-      .preprocessRequest(Request[IO](), EmberClientBuilder.default[IO].userAgent)
+      .preprocessRequest[IO](Request(), EmberClientBuilder.default[IO].userAgent)
       .map { req =>
         req.headers.get[`User-Agent`].isDefined
       }
@@ -86,8 +86,8 @@ class ClientHelpersSuite extends Http4sSuite {
   test("Request Preprocessing should not change a present user-agent") {
     val name = "foo"
     ClientHelpers
-      .preprocessRequest(
-        Request[IO](
+      .preprocessRequest[IO](
+        Request(
           headers = Headers(`User-Agent`(ProductId(name, None)))
         ),
         EmberClientBuilder.default[IO].userAgent)
@@ -106,8 +106,8 @@ class ClientHelpersSuite extends Http4sSuite {
 
       _ <- ClientHelpers
         .postProcessResponse[IO](
-          Request[IO](),
-          Response[IO](),
+          Request(),
+          Response(),
           IO.pure(Some(Array.emptyByteArray)),
           nextBytes,
           reuse
@@ -124,8 +124,8 @@ class ClientHelpersSuite extends Http4sSuite {
       reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
 
       _ <- ClientHelpers.postProcessResponse[IO](
-        Request[IO](),
-        Response[IO](),
+        Request(),
+        Response(),
         IO.pure(Some(Array[Byte](1, 2, 3))),
         nextBytes,
         reuse
@@ -140,8 +140,8 @@ class ClientHelpersSuite extends Http4sSuite {
       reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
       _ <- ClientHelpers
         .postProcessResponse[IO](
-          Request[IO](headers = Headers(Connection(NonEmptyList.of(ci"close")))),
-          Response[IO](),
+          Request(headers = Headers(Connection(NonEmptyList.of(ci"close")))),
+          Response(),
           IO.pure(Some(Array.emptyByteArray)),
           nextBytes,
           reuse
@@ -158,8 +158,8 @@ class ClientHelpersSuite extends Http4sSuite {
       reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
       _ <- ClientHelpers
         .postProcessResponse[IO](
-          Request[IO](),
-          Response[IO](headers = Headers(Connection(NonEmptyList.of(ci"close")))),
+          Request(),
+          Response(headers = Headers(Connection(NonEmptyList.of(ci"close")))),
           IO.pure(Some(Array.emptyByteArray)),
           nextBytes,
           reuse
@@ -176,8 +176,8 @@ class ClientHelpersSuite extends Http4sSuite {
       reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
       _ <- ClientHelpers
         .postProcessResponse[IO](
-          Request[IO](),
-          Response[IO](),
+          Request(),
+          Response(),
           IO.pure(None),
           nextBytes,
           reuse

--- a/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -248,7 +248,7 @@ private[ember] object Parser {
             .value) { case (_, headerP) => headerP.idx }
         ((prelude, headerP), finalBuffer) = t
 
-        baseReq = org.http4s.Request[F](
+        baseReq = org.http4s.Request(
           method = prelude.method,
           uri = prelude.uri,
           httpVersion = prelude.version,
@@ -290,7 +290,7 @@ private[ember] object Parser {
             .value) { case (_, headerP) => headerP.idx }
         ((prelude, headerP), finalBuffer) = t
 
-        baseResp = org.http4s.Response[F](
+        baseResp = org.http4s.Response(
           httpVersion = prelude.version,
           status = prelude.status,
           headers = headerP.headers

--- a/ember-core/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -45,18 +45,18 @@ class EncoderSuite extends Http4sSuite {
   }
 
   test("reqToBytes should encode a no body request correctly") {
-    val req = Request[IO](Method.GET, Uri.unsafeFromString("http://www.google.com"))
+    val req = Request(Method.GET, Uri.unsafeFromString("http://www.google.com"))
     val expected =
       """GET / HTTP/1.1
       |Host: www.google.com
       |
       |""".stripMargin
 
-    Helpers.encodeRequestRig(req).assertEquals(expected)
+    Helpers.encodeRequestRig[IO](req).assertEquals(expected)
   }
 
   test("reqToBytes should encode a request with a body correctly") {
-    val req = Request[IO](Method.POST, Uri.unsafeFromString("http://www.google.com"))
+    val req = Request(Method.POST, Uri.unsafeFromString("http://www.google.com"))
       .withEntity("Hello World!")
     val expected =
       """POST / HTTP/1.1
@@ -66,11 +66,11 @@ class EncoderSuite extends Http4sSuite {
       |
       |Hello World!""".stripMargin
 
-    Helpers.encodeRequestRig(req).assertEquals(expected)
+    Helpers.encodeRequestRig[IO](req).assertEquals(expected)
   }
 
   test("reqToBytes should encode headers correctly") {
-    val req = Request[IO](
+    val req = Request(
       Method.GET,
       Uri.unsafeFromString("http://www.google.com"),
       headers = Headers("foo" -> "bar")
@@ -81,11 +81,11 @@ class EncoderSuite extends Http4sSuite {
         |foo: bar
         |
         |""".stripMargin
-    Helpers.encodeRequestRig(req).assertEquals(expected)
+    Helpers.encodeRequestRig[IO](req).assertEquals(expected)
   }
 
   test("reqToBytes strips the fragment") {
-    val req = Request[IO](
+    val req = Request(
       Method.GET,
       Uri.unsafeFromString("https://www.example.com/path?query#fragment")
     )
@@ -94,11 +94,11 @@ class EncoderSuite extends Http4sSuite {
         |Host: www.example.com
         |
         |""".stripMargin
-    Helpers.encodeRequestRig(req).assertEquals(expected)
+    Helpers.encodeRequestRig[IO](req).assertEquals(expected)
   }
 
   test("reqToBytes respects the host header") {
-    val req = Request[IO](
+    val req = Request(
       Method.GET,
       Uri.unsafeFromString("https://www.example.com/"),
       headers = Headers(headers.Host("example.org", Some(8080)))
@@ -108,11 +108,11 @@ class EncoderSuite extends Http4sSuite {
         |Host: example.org:8080
         |
         |""".stripMargin
-    Helpers.encodeRequestRig(req).assertEquals(expected)
+    Helpers.encodeRequestRig[IO](req).assertEquals(expected)
   }
 
   test("respToBytes should encode a no body response correctly") {
-    val resp = Response[IO](Status.Ok).putHeaders(`Content-Length`.zero)
+    val resp = Response(Status.Ok).putHeaders(`Content-Length`.zero)
 
     val expected =
       """HTTP/1.1 200 OK
@@ -120,21 +120,21 @@ class EncoderSuite extends Http4sSuite {
       |
       |""".stripMargin
 
-    Helpers.encodeResponseRig(resp).assertEquals(expected)
+    Helpers.encodeResponseRig[IO](resp).assertEquals(expected)
   }
 
   test("encoder a response where entity is not allowed correctly") {
-    val resp = Response[IO](Status.NoContent)
+    val resp = Response(Status.NoContent)
     val expected =
       """HTTP/1.1 204 No Content
       |
       |""".stripMargin
 
-    Helpers.encodeResponseRig(resp).assertEquals(expected)
+    Helpers.encodeResponseRig[IO](resp).assertEquals(expected)
   }
 
   test("encode a response with a body correctly") {
-    val resp = Response[IO](Status.NotFound)
+    val resp = Response(Status.NotFound)
       .withEntity("Not Found")
 
     val expected =
@@ -144,6 +144,6 @@ class EncoderSuite extends Http4sSuite {
       |
       |Not Found""".stripMargin
 
-    Helpers.encodeResponseRig(resp).assertEquals(expected)
+    Helpers.encodeResponseRig[IO](resp).assertEquals(expected)
   }
 }

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -103,7 +103,7 @@ class ParsingSuite extends Http4sSuite {
       |Host: www.google.com
       |
       |""".stripMargin
-    val expected = Request[IO](
+    val expected = Request(
       Method.GET,
       Uri.unsafeFromString("www.google.com"),
       headers = Headers(org.http4s.headers.Host("www.google.com"))
@@ -121,7 +121,7 @@ class ParsingSuite extends Http4sSuite {
     for {
       r <- result
       a <- r.body.compile.toVector
-      b <- expected.body.compile.toVector
+      b = expected.body.toVector
     } yield assertEquals(a, b)
   }
 
@@ -132,7 +132,7 @@ class ParsingSuite extends Http4sSuite {
       |Content-Type: text/plain; charset=UTF-8
       |
       |Entity Here""".stripMargin
-    val expected = Request[IO](Method.POST, Uri.unsafeFromString("/foo"))
+    val expected = Request(Method.POST, Uri.unsafeFromString("/foo"))
       .withEntity("Entity Here")
 
     val result = Helpers.parseRequestRig[IO](raw)
@@ -147,7 +147,7 @@ class ParsingSuite extends Http4sSuite {
       _ <- result.map(_.headers).assertEquals(expected.headers)
       r <- result
       a <- r.body.through(fs2.text.utf8.decode).compile.string
-      b <- expected.body.through(fs2.text.utf8.decode).compile.string
+      b = expected.body.through(fs2.text.utf8.decode).compile.string
     } yield assertEquals(a, b)
   }
 
@@ -159,7 +159,7 @@ class ParsingSuite extends Http4sSuite {
         |Accept: */*
         |
         |""".stripMargin
-    val expected = Request[IO](Method.GET, Uri.unsafeFromString("/foo"))
+    val expected = Request(Method.GET, Uri.unsafeFromString("/foo"))
 
     val result = Helpers.parseRequestRig[IO](raw)
 

--- a/ember-core/src/test/scala/org/http4s/ember/core/RequestSplittingSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/RequestSplittingSuite.scala
@@ -41,25 +41,25 @@ class RequestSplittingSuite extends Http4sSuite {
     } yield resp
 
   test("Prevent request splitting attacks on URI path") {
-    val req = Request[IO](uri = Uri(path =
+    val req = Request(uri = Uri(path =
       Uri.Path.Root / Uri.Path.Segment.encoded(" HTTP/1.0\r\nEvil:true\r\nHide-Protocol-Version:")))
-    attack(req).intercept[IllegalArgumentException]
+    attack[IO](req).intercept[IllegalArgumentException]
   }
 
   test("Prevent request splitting attacks on URI regname") {
-    val req = Request[IO](uri = Uri(
+    val req = Request(uri = Uri(
       authority = Uri.Authority(None, Uri.RegName("example.com\r\nEvil:true\r\n")).some,
       path = Uri.Path.Root))
-    attack(req).map(_.status).assertEquals(Status.Ok)
+    attack[IO](req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("Prevent request splitting attacks on field name") {
-    val req = Request[IO]().putHeaders(Header.Raw(ci"Fine:\r\nEvil:true\r\n", "oops"))
-    attack(req).map(_.status).assertEquals(Status.Ok)
+    val req = Request().putHeaders(Header.Raw(ci"Fine:\r\nEvil:true\r\n", "oops"))
+    attack[IO](req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("Prevent request splitting attacks on field value") {
-    val req = Request[IO]().putHeaders(Header.Raw(ci"X-Carrier", "\r\nEvil:true\r\n"))
-    attack(req).map(_.status).assertEquals(Status.Ok)
+    val req = Request().putHeaders(Header.Raw(ci"X-Carrier", "\r\nEvil:true\r\n"))
+    attack[IO](req).map(_.status).assertEquals(Status.Ok)
   }
 }

--- a/ember-core/src/test/scala/org/http4s/ember/core/ResponseSplittingSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ResponseSplittingSuite.scala
@@ -37,7 +37,7 @@ class ResponseSplittingSuite extends Http4sSuite {
     val app = HttpApp[IO] { req =>
       Response(Status.NoContent.withReason(req.params("reason"))).pure[IO]
     }
-    val req = Request[IO](uri = uri"/?reason=%0D%0AEvil:true%0D%0A")
+    val req = Request(uri = uri"/?reason=%0D%0AEvil:true%0D%0A")
     attack(app, req).map { resp =>
       assertEquals(resp.headers.headers.find(_.name === ci"Evil"), None)
     }
@@ -47,7 +47,7 @@ class ResponseSplittingSuite extends Http4sSuite {
     val app = HttpApp[IO] { req =>
       Response(Status.NoContent).putHeaders(req.params("fieldName") -> "oops").pure[IO]
     }
-    val req = Request[IO](uri = uri"/?fieldName=Fine:%0D%0AEvil:true%0D%0A")
+    val req = Request(uri = uri"/?fieldName=Fine:%0D%0AEvil:true%0D%0A")
     attack(app, req).map { resp =>
       assertEquals(resp.headers.headers.find(_.name === ci"Evil"), None)
     }
@@ -59,7 +59,7 @@ class ResponseSplittingSuite extends Http4sSuite {
         .putHeaders("X-Oops" -> req.params("fieldValue"))
         .pure[IO]
     }
-    val req = Request[IO](uri = uri"/?fieldValue=%0D%0AEvil:true%0D%0A")
+    val req = Request(uri = uri"/?fieldValue=%0D%0AEvil:true%0D%0A")
     attack(app, req).map { resp =>
       assertEquals(resp.headers.headers.find(_.name === ci"Evil"), None)
     }

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -219,7 +219,7 @@ object WebSocketHelpers extends WebSocketHelpersPlatform {
     go(stream, Array.emptyByteArray).void.stream
   }
 
-  private def clientHandshake[F[_]](req: Request[F]): Either[ClientHandshakeError, String] = {
+  private def clientHandshake(req: AnyRequest): Either[ClientHandshakeError, String] = {
     val connection = req.headers.get[Connection] match {
       case Some(header) if header.hasUpgrade => Either.unit
       case _ => Left(UpgradeRequired)

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -77,7 +77,7 @@ object WebSocketHelpers extends WebSocketHelpersPlatform {
           }
           .handleErrorWith(errorHandler)
       case Left(error) =>
-        Response[F](error.status).withEntity(error.message).pure[F]
+        Response(error.status).withEntity(error.message).pure[F]
     }
 
     val handler = for {

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/client/StreamClient.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/client/StreamClient.scala
@@ -38,7 +38,7 @@ class HttpClient[F[_]](implicit F: Async[F], S: StreamUtils[F]) {
     BlazeClientBuilder[F](global).stream
       .flatMap { client =>
         val request =
-          Request[F](uri = Uri.unsafeFromString("http://localhost:8080/v1/dirs?depth=3"))
+          Request(uri = Uri.unsafeFromString("http://localhost:8080/v1/dirs?depth=3"))
         for {
           response <- client.stream(request).flatMap(_.body.chunks.through(fs2.text.utf8.decodeC))
           _ <- S.putStr(response)

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/service/GitHubService.scala
@@ -45,7 +45,7 @@ class GitHubService[F[_]: Concurrent](client: Client[F]) extends Http4sClientDsl
       .withQueryParam("scopes", "public_repo")
       .withQueryParam("state", "test_api")
 
-    client.stream(Request[F](uri = uri)).flatMap(_.body)
+    client.stream(Request(uri = uri)).flatMap(_.body)
   }
 
   def accessToken(code: String, state: String): F[String] = {
@@ -58,12 +58,12 @@ class GitHubService[F[_]: Concurrent](client: Client[F]) extends Http4sClientDsl
       .withQueryParam("state", state)
 
     client
-      .expect[AccessTokenResponse](Request[F](uri = uri))(jsonOf[F, AccessTokenResponse])
+      .expect[AccessTokenResponse](Request(uri = uri))(jsonOf[F, AccessTokenResponse])
       .map(_.access_token)
   }
 
   def userData(accessToken: String): F[String] = {
-    val request = Request[F](uri = uri"https://api.github.com/user")
+    val request = Request(uri = uri"https://api.github.com/user")
       .putHeaders("Authorization" -> s"token $accessToken")
 
     client.expect[String](request)

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
@@ -33,11 +33,11 @@ import scodec.bits.ByteVector
 
 object EmberClientSimpleExample extends IOApp {
 
-  val githubReq = Request[IO](Method.GET, uri"http://christopherdavenport.github.io/")
-  val dadJokeReq = Request[IO](Method.GET, uri"https://icanhazdadjoke.com/")
-  val googleReq = Request[IO](Method.GET, uri"https://www.google.com/")
-  val httpBinGet = Request[IO](Method.GET, uri"https://httpbin.org/get")
-  val httpBinPng = Request[IO](Method.GET, uri"https://httpbin.org/image/png")
+  val githubReq = Request(Method.GET, uri"http://christopherdavenport.github.io/")
+  val dadJokeReq = Request(Method.GET, uri"https://icanhazdadjoke.com/")
+  val googleReq = Request(Method.GET, uri"https://www.google.com/")
+  val httpBinGet = Request(Method.GET, uri"https://httpbin.org/get")
+  val httpBinPng = Request(Method.GET, uri"https://httpbin.org/image/png")
 
   val logger = Slf4jLogger.getLogger[IO]
 

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSuite.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSuite.scala
@@ -23,7 +23,7 @@ import cats.effect.IO
 trait JawnDecodeSupportSuite[J] extends Http4sSuite {
   def testJsonDecoder(decoder: EntityDecoder[IO, J]) = {
     test("return right when the entity is valid") {
-      val resp = Response[IO](Status.Ok).withEntity("""{"valid": true}""")
+      val resp = Response(Status.Ok).withEntity("""{"valid": true}""")
       decoder.decode(resp, strict = false).value.map(_.isRight).assert
     }
 
@@ -46,7 +46,7 @@ trait JawnDecodeSupportSuite[J] extends Http4sSuite {
       parseError: PartialFunction[DecodeFailure, Boolean]
   ) = {
     test("return a ParseFailure when the entity is invalid") {
-      val resp = Response[IO](Status.Ok).withEntity("""garbage""")
+      val resp = Response(Status.Ok).withEntity("""garbage""")
       decoder
         .decode(resp, strict = false)
         .value
@@ -54,7 +54,7 @@ trait JawnDecodeSupportSuite[J] extends Http4sSuite {
     }
 
     test("return a ParseFailure when the entity is empty") {
-      val resp = Response[IO](Status.Ok).withEntity("")
+      val resp = Response(Status.Ok).withEntity("")
       decoder
         .decode(resp, strict = false)
         .value

--- a/okhttp-client/src/main/scala/org/http4s/okhttp/client/OkHttpBuilder.scala
+++ b/okhttp-client/src/main/scala/org/http4s/okhttp/client/OkHttpBuilder.scala
@@ -107,7 +107,7 @@ sealed abstract class OkHttpBuilder[F[_]] private (
             Resource[F, Response[F]](
               F.pure(
                 (
-                  Response[F](
+                  Response(
                     status = s,
                     headers = getHeaders(response),
                     httpVersion = protocol,

--- a/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
@@ -54,7 +54,7 @@ class PlaySuite extends JawnDecodeSupportSuite[JsValue] {
 
   test("jsonOf should decode JSON from a Play decoder") {
     val result = jsonOf[IO, Foo]
-      .decode(Request[IO]().withEntity(Json.obj("bar" -> JsNumber(42)): JsValue), strict = true)
+      .decode(Request().withEntity(Json.obj("bar" -> JsNumber(42)): JsValue), strict = true)
     result.value.assertEquals(Right(Foo(42)))
   }
 

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
@@ -58,7 +58,7 @@ object PrometheusExportService {
         TextFormat.write004(writer, collectorRegistry.metricFamilySamples)
         writer.toString
       }
-      .map(Response[F](Status.Ok).withEntity(_))
+      .map(Response(Status.Ok).withEntity(_))
 
   def service[F[_]: Sync](collectorRegistry: CollectorRegistry): HttpRoutes[F] =
     HttpRoutes.of[F] {

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusClientMetricsSuite.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusClientMetricsSuite.scala
@@ -87,7 +87,7 @@ class PrometheusClientMetricsSuite extends Http4sSuite {
   meteredClient().test(
     "A http client with a prometheus metrics middleware should register a POST request") {
     case (registry, client) =>
-      client.expect[String](Request[IO](POST, Uri.unsafeFromString("/ok"))).attempt.map { resp =>
+      client.expect[String](Request(POST, Uri.unsafeFromString("/ok"))).attempt.map { resp =>
         assertEquals(resp, Right("200 OK"))
 
         assertEquals(count(registry, "2xx_responses", "client", "post"), 1.0)
@@ -100,7 +100,7 @@ class PrometheusClientMetricsSuite extends Http4sSuite {
   meteredClient().test(
     "A http client with a prometheus metrics middleware should register a PUT request") {
     case (registry, client) =>
-      client.expect[String](Request[IO](PUT, Uri.unsafeFromString("/ok"))).attempt.map { resp =>
+      client.expect[String](Request(PUT, Uri.unsafeFromString("/ok"))).attempt.map { resp =>
         assertEquals(resp, Right("200 OK"))
 
         assertEquals(count(registry, "2xx_responses", "client", "put"), 1.0)
@@ -113,7 +113,7 @@ class PrometheusClientMetricsSuite extends Http4sSuite {
   meteredClient().test(
     "A http client with a prometheus metrics middleware should register a DELETE request") {
     case (registry, client) =>
-      client.expect[String](Request[IO](DELETE, Uri.unsafeFromString("/ok"))).attempt.map { resp =>
+      client.expect[String](Request(DELETE, Uri.unsafeFromString("/ok"))).attempt.map { resp =>
         assertEquals(resp, Right("200 OK"))
 
         assertEquals(count(registry, "2xx_responses", "client", "delete"), 1.0)

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSuite.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSuite.scala
@@ -33,7 +33,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   meteredRoutes().test(
     "A http routes with a prometheus metrics middleware should register a 2xx response") {
     case (registry, routes) =>
-      val req = Request[IO](uri = uri"/ok")
+      val req = Request(uri = uri"/ok")
 
       val resp = routes.run(req)
       resp.flatMap { r =>
@@ -51,7 +51,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   meteredRoutes().test(
     "A http routes with a prometheus metrics middleware should register a 4xx response") {
     case (registry, routes) =>
-      val req = Request[IO](uri = uri"/bad-request")
+      val req = Request(uri = uri"/bad-request")
 
       routes.run(req).flatMap { r =>
         r.as[String].map { b =>
@@ -69,7 +69,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   meteredRoutes().test(
     "A http routes with a prometheus metrics middleware should register a 5xx response") {
     case (registry, routes) =>
-      val req = Request[IO](uri = uri"/internal-server-error")
+      val req = Request(uri = uri"/internal-server-error")
 
       routes.run(req).flatMap { r =>
         r.as[String].map { b =>
@@ -87,7 +87,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   meteredRoutes().test(
     "A http routes with a prometheus metrics middleware should register a GET request") {
     case (registry, routes) =>
-      val req = Request[IO](method = GET, uri = uri"/ok")
+      val req = Request(method = GET, uri = uri"/ok")
 
       routes.run(req).flatMap { r =>
         r.as[String].map { b =>
@@ -105,7 +105,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   meteredRoutes().test(
     "A http routes with a prometheus metrics middleware should register a POST request") {
     case (registry, routes) =>
-      val req = Request[IO](method = POST, uri = uri"/ok")
+      val req = Request(method = POST, uri = uri"/ok")
 
       routes.run(req).flatMap { r =>
         r.as[String].map { b =>
@@ -123,7 +123,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   meteredRoutes().test(
     "A http routes with a prometheus metrics middleware should register a PUT request") {
     case (registry, routes) =>
-      val req = Request[IO](method = PUT, uri = uri"/ok")
+      val req = Request(method = PUT, uri = uri"/ok")
 
       routes.run(req).flatMap { r =>
         r.as[String].map { b =>
@@ -141,7 +141,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   meteredRoutes().test(
     "A http routes with a prometheus metrics middleware should register a DELETE request") {
     case (registry, routes) =>
-      val req = Request[IO](method = DELETE, uri = uri"/ok")
+      val req = Request(method = DELETE, uri = uri"/ok")
 
       routes.run(req).flatMap { r =>
         r.as[String].map { b =>
@@ -159,7 +159,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   meteredRoutes().test(
     "A http routes with a prometheus metrics middleware should register an error") {
     case (registry, routes) =>
-      val req = Request[IO](method = GET, uri = uri"/error")
+      val req = Request(method = GET, uri = uri"/error")
 
       routes.run(req).attempt.map { r =>
         assert(r.isLeft)
@@ -174,7 +174,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   meteredRoutes().test(
     "A http routes with a prometheus metrics middleware should register an abnormal termination") {
     case (registry, routes) =>
-      val req = Request[IO](method = GET, uri = uri"/abnormal-termination")
+      val req = Request(method = GET, uri = uri"/abnormal-termination")
 
       routes.run(req).flatMap { r =>
         r.body.attempt.compile.lastOrError.map { b =>
@@ -198,7 +198,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
   val classifierFunc = (_: Request[IO]) => Some("classifier")
   meteredRoutes(classifierFunc).test("use the provided request classifier") {
     case (registry, routes) =>
-      val req = Request[IO](uri = uri"/ok")
+      val req = Request(uri = uri"/ok")
 
       routes.run(req).flatMap { r =>
         r.as[String].map { b =>
@@ -215,7 +215,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
 
   // This tests can't be easily done in munit-cats-effect as it wants to test after the Resource is freed
   meteredRoutes().test("unregister collectors".ignore) { case (cr, routes) =>
-    val req = Request[IO](uri = uri"/ok")
+    val req = Request(uri = uri"/ok")
 
     routes.run(req).as(cr).map { registry =>
       assertEquals(count(registry, "2xx_responses", "server"), 0.0)

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/util.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/util.scala
@@ -21,13 +21,13 @@ import fs2.Stream
 import io.prometheus.client.CollectorRegistry
 import java.io.IOException
 import java.util.concurrent.{TimeUnit, TimeoutException}
-import org.http4s.{Request, Response}
+import org.http4s.{AnyRequest, Response}
 import org.http4s.dsl.io._
 import org.http4s.Method.GET
 import scala.concurrent.duration.FiniteDuration
 
 object util {
-  def stub: PartialFunction[Request[IO], IO[Response[IO]]] = {
+  def stub: PartialFunction[AnyRequest, IO[Response[IO]]] = {
     case (GET | POST | PUT | DELETE) -> Root / "ok" =>
       Ok("200 OK")
     case GET -> Root / "bad-request" =>

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -31,8 +31,7 @@ trait ElemInstances {
 
   implicit def xmlEncoder[F[_]](implicit
       charset: Charset = DefaultCharset): EntityEncoder[F, Elem] =
-    EntityEncoder
-      .stringEncoder[F]
+    EntityEncoder.stringEncoder
       .contramap[Elem] { node =>
         val sw = new StringWriter
         XML.write(sw, node, charset.nioCharset.name, true, null)

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -29,8 +29,7 @@ import scala.xml.{Elem, InputSource, SAXParseException, XML}
 trait ElemInstances {
   protected def saxFactory: SAXParserFactory
 
-  implicit def xmlEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Elem] =
+  implicit def xmlEncoder(implicit charset: Charset = DefaultCharset): EntityEncoder.Pure[Elem] =
     EntityEncoder.stringEncoder
       .contramap[Elem] { node =>
         val sw = new StringWriter

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
@@ -76,8 +76,8 @@ class ScalaXmlSuite extends Http4sSuite {
 
   test("encode to UTF-8") {
     val hello = <hello name="Günther"/>
-    assertIO(
-      xmlEncoder[IO](Charset.`UTF-8`)
+    assertEquals(
+      xmlEncoder(Charset.`UTF-8`)
         .toEntity(hello)
         .body
         .through(fs2.text.utf8.decode)
@@ -91,10 +91,10 @@ class ScalaXmlSuite extends Http4sSuite {
   test("encode to UTF-16") {
     val hello = <hello name="Günther"/>
     assertIO(
-      xmlEncoder[IO](Charset.`UTF-16`)
+      xmlEncoder(Charset.`UTF-16`)
         .toEntity(hello)
         .body
-        .through(internal.decode(Charset.`UTF-16`))
+        .through(internal.decode[IO](Charset.`UTF-16`))
         .compile
         .string,
       """<?xml version='1.0' encoding='UTF-16'?>
@@ -105,10 +105,10 @@ class ScalaXmlSuite extends Http4sSuite {
   test("encode to ISO-8859-1") {
     val hello = <hello name="Günther"/>
     assertIO(
-      xmlEncoder[IO](Charset.`ISO-8859-1`)
+      xmlEncoder(Charset.`ISO-8859-1`)
         .toEntity(hello)
         .body
-        .through(internal.decode(Charset.`ISO-8859-1`))
+        .through(internal.decode[IO](Charset.`ISO-8859-1`))
         .compile
         .string,
       """<?xml version='1.0' encoding='ISO-8859-1'?>
@@ -118,7 +118,7 @@ class ScalaXmlSuite extends Http4sSuite {
 
   property("encoder sets charset of Content-Type") {
     forAll { (cs: Charset) =>
-      assertEquals(xmlEncoder[IO](cs).headers.get[`Content-Type`].flatMap(_.charset), Some(cs))
+      assertEquals(xmlEncoder(cs).headers.get[`Content-Type`].flatMap(_.charset), Some(cs))
     }
   }
 

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
@@ -38,12 +38,12 @@ class ScalaXmlSuite extends Http4sSuite {
 
   val server: Request[IO] => IO[Response[IO]] = { req =>
     req.decode { (elem: Elem) =>
-      IO.pure(Response[IO](Ok).withEntity(elem.label))
+      IO.pure(Response(Ok).withEntity(elem.label))
     }
   }
 
   test("xml should parse the XML") {
-    server(Request[IO](body = strBody("<html><h1>h1</h1></html>")))
+    server(Request(body = strBody("<html><h1>h1</h1></html>")))
       .flatMap(r => getBody(r.body))
       .assertEquals("html")
   }
@@ -61,7 +61,7 @@ class ScalaXmlSuite extends Http4sSuite {
 
   test("return 400 on parse error") {
     val body = strBody("This is not XML.")
-    val tresp = server(Request[IO](body = body))
+    val tresp = server(Request(body = body))
     tresp.map(_.status).assertEquals(Status.BadRequest)
   }
 

--- a/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
+++ b/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
@@ -27,8 +27,7 @@ trait ScalatagsInstances {
 
   private def contentEncoder[F[_], C <: Frag[_, String]](mediaType: MediaType)(implicit
       charset: Charset): EntityEncoder[F, C] =
-    EntityEncoder
-      .stringEncoder[F]
+    EntityEncoder.stringEncoder
       .contramap[C](content => content.render)
       .withContentType(`Content-Type`(mediaType, charset))
 }

--- a/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
+++ b/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
@@ -21,12 +21,12 @@ import _root_.scalatags.generic.Frag
 import org.http4s.headers.`Content-Type`
 
 trait ScalatagsInstances {
-  implicit def scalatagsEncoder[F[_], C <: Frag[_, String]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, C] =
+  implicit def scalatagsEncoder[C <: Frag[_, String]](implicit
+      charset: Charset = DefaultCharset): EntityEncoder.Pure[C] =
     contentEncoder(MediaType.text.html)
 
-  private def contentEncoder[F[_], C <: Frag[_, String]](mediaType: MediaType)(implicit
-      charset: Charset): EntityEncoder[F, C] =
+  private def contentEncoder[C <: Frag[_, String]](mediaType: MediaType)(implicit
+      charset: Charset): EntityEncoder.Pure[C] =
     EntityEncoder.stringEncoder
       .contramap[C](content => content.render)
       .withContentType(`Content-Type`(mediaType, charset))

--- a/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSuite.scala
+++ b/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSuite.scala
@@ -48,7 +48,7 @@ class ScalatagsSuite extends Http4sSuite {
 
   test("TypedTag encoder should render the body") {
     implicit val cs: Charset = Charset.`UTF-8`
-    val resp = Response[IO](Ok).withEntity(testBody())
+    val resp = Response(Ok).withEntity(testBody())
     EntityDecoder
       .text[IO]
       .decode(resp, strict = false)

--- a/server-testing/src/test/scala/org/http4s/server/ServerRouteTestBattery.scala
+++ b/server-testing/src/test/scala/org/http4s/server/ServerRouteTestBattery.scala
@@ -53,7 +53,7 @@ object ServerRouteTestBattery {
       IO(Response(body = r.body))
     }
 
-    get.orElse(post).getOrElse(IO(Response[IO](status = Status.NotFound)))
+    get.orElse(post).getOrElse(IO(Response(status = Status.NotFound)))
   }
 
 }

--- a/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -39,7 +39,7 @@ object GZip {
       http: Http[F, G],
       bufferSize: Int = 32 * 1024,
       level: DeflateParams.Level = DeflateParams.Level.DEFAULT,
-      isZippable: Response[G] => Boolean = defaultIsZippable[G](_: Response[G])
+      isZippable: Response[G] => Boolean = defaultIsZippable(_: Response[G])
   ): Http[F, G] =
     Kleisli { (req: Request[G]) =>
       req.headers.get[`Accept-Encoding`] match {
@@ -49,7 +49,7 @@ object GZip {
       }
     }
 
-  def defaultIsZippable[F[_]](resp: Response[F]): Boolean = {
+  def defaultIsZippable(resp: AnyResponse): Boolean = {
     val contentType = resp.headers.get[`Content-Type`]
     resp.headers.get[`Content-Encoding`].isEmpty &&
     resp.status.isEntityAllowed &&

--- a/server/jvm/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -137,7 +137,7 @@ object FileService {
       F: Async[F]): F[Option[Response[F]]] = {
     def nope: F[Option[Response[F]]] = F.delay(file.length()).map { size =>
       Some(
-        Response[F](
+        Response(
           status = Status.RangeNotSatisfiable,
           headers = Headers
             .apply(AcceptRangeHeader, `Content-Range`(SubRange(0, size - 1), Some(size)))))

--- a/server/jvm/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -34,7 +34,7 @@ import scala.util.{Failure, Success, Try}
 object FileService {
   private[this] val logger = getLogger
 
-  type PathCollector[F[_]] = (File, Config[F], Request[F]) => OptionT[F, Response[F]]
+  type PathCollector[F[_]] = (File, Config[F], AnyRequest) => OptionT[F, Response[F]]
 
   /** [[org.http4s.server.staticcontent.FileService]] configuration
     *
@@ -108,7 +108,7 @@ object FileService {
     }
   }
 
-  private def filesOnly[F[_]](file: File, config: Config[F], req: Request[F])(implicit
+  private def filesOnly[F[_]](file: File, config: Config[F], req: AnyRequest)(implicit
       F: Async[F]): OptionT[F, Response[F]] =
     OptionT(F.defer {
       if (file.isDirectory)
@@ -133,7 +133,7 @@ object FileService {
     })
 
   // Attempt to find a Range header and collect only the subrange of content requested
-  private def getPartialContentFile[F[_]](file: File, config: Config[F], req: Request[F])(implicit
+  private def getPartialContentFile[F[_]](file: File, config: Config[F], req: AnyRequest)(implicit
       F: Async[F]): F[Option[Response[F]]] = {
     def nope: F[Option[Response[F]]] = F.delay(file.length()).map { size =>
       Some(

--- a/server/jvm/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -157,7 +157,7 @@ object WebjarServiceBuilder {
   private def serveWebjarAsset[F[_]](
       cacheStrategy: CacheStrategy[F],
       classLoader: Option[ClassLoader],
-      request: Request[F],
+      request: AnyRequest,
       preferGzipped: Boolean)(webjarAsset: WebjarAsset)(implicit
       F: Async[F]): OptionT[F, Response[F]] =
     StaticFile
@@ -257,7 +257,7 @@ object WebjarService {
     * @param request The Request
     * @return Either the the Asset, if it exist, or Pass
     */
-  private def serveWebjarAsset[F[_]: Async](config: Config[F], request: Request[F])(
+  private def serveWebjarAsset[F[_]: Async](config: Config[F], request: AnyRequest)(
       webjarAsset: WebjarAsset): OptionT[F, Response[F]] =
     StaticFile
       .fromResource(webjarAsset.pathInJar, Some(request))

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
@@ -35,7 +35,7 @@ class GZipSuite extends Http4sSuite {
       Ok("pong")
     }
     val req =
-      Request[IO](Method.GET, uri"/").putHeaders(`Accept-Encoding`(ContentCoding.gzip))
+      Request(Method.GET, uri"/").putHeaders(`Accept-Encoding`(ContentCoding.gzip))
     routes
       .orNotFound(req)
       .map { resp =>
@@ -53,7 +53,7 @@ class GZipSuite extends Http4sSuite {
 
     val gzipRoutes: HttpRoutes[IO] = GZip(routes, isZippable = _ => true)
 
-    val req: Request[IO] = Request[IO](Method.GET, uri"/")
+    val req: Request[IO] = Request(Method.GET, uri"/")
       .putHeaders(`Accept-Encoding`(ContentCoding.gzip))
     val actual: IO[Array[Byte]] =
       gzipRoutes.orNotFound(req).flatMap(_.as[Chunk[Byte]]).map(_.toArray)
@@ -73,7 +73,7 @@ class GZipSuite extends Http4sSuite {
 
     val gzipRoutes: HttpRoutes[IO] = GZip(routes)
 
-    val req: Request[IO] = Request[IO](Method.GET, uri"/")
+    val req: Request[IO] = Request(Method.GET, uri"/")
       .putHeaders(`Accept-Encoding`(ContentCoding.gzip))
     val resp: IO[Response[IO]] = gzipRoutes.orNotFound(req)
 
@@ -86,7 +86,7 @@ class GZipSuite extends Http4sSuite {
         Ok(Stream.emits(vector).covary[IO])
       }
       val gzipRoutes: HttpRoutes[IO] = GZip(routes)
-      val req: Request[IO] = Request[IO](Method.GET, uri"/")
+      val req: Request[IO] = Request(Method.GET, uri"/")
         .putHeaders(`Accept-Encoding`(ContentCoding.gzip))
       val actual: IO[Array[Byte]] =
         gzipRoutes.orNotFound(req).flatMap(_.as[Chunk[Byte]]).map(_.toArray)

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -47,12 +47,12 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
   val respApp = ResponseLogger.httpApp(logHeaders = true, logBody = true)(testApp)
 
   test("response should not affect a Get") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     respApp(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("response should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request(uri = uri"/post", method = POST).withBodyStream(body)
     respApp(req).flatMap { res =>
       res
         .as[String]
@@ -65,12 +65,12 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
   val reqApp = RequestLogger.httpApp(logHeaders = true, logBody = true)(testApp)
 
   test("request should not affect a Get") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     reqApp(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("request should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request(uri = uri"/post", method = POST).withBodyStream(body)
     reqApp(req).flatMap { res =>
       res.as[String].map(_ === expectedBody && res.status === Status.Ok)
     }.assert
@@ -79,12 +79,12 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
   val loggerApp = Logger.httpApp(logHeaders = true, logBody = true)(testApp)
 
   test("logger should not affect a Get") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     loggerApp(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("logger should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request(uri = uri"/post", method = POST).withBodyStream(body)
     loggerApp(req).flatMap { res =>
       res.as[String].map(_ === expectedBody && res.status === Status.Ok)
     }.assert

--- a/server/jvm/src/test/scala/org/http4s/server/staticcontent/FileServiceSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/staticcontent/FileServiceSuite.scala
@@ -38,17 +38,17 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     val app = TranslateUri("/foo")(routes).orNotFound
 
     {
-      val req = Request[IO](uri = uri"/foo/testresource.txt")
+      val req = Request(uri = uri"/foo/testresource.txt")
       Stream.eval(app(req)).flatMap(_.body.chunks).compile.lastOrError.assertEquals(testResource) *>
         app(req).map(_.status).assertEquals(Status.Ok)
     } *> {
-      val req = Request[IO](uri = uri"/testresource.txt")
+      val req = Request(uri = uri"/testresource.txt")
       app(req).map(_.status).assertEquals(Status.NotFound)
     }
   }
 
   test("Return a 200 Ok file") {
-    val req = Request[IO](uri = uri"/testresource.txt")
+    val req = Request(uri = uri"/testresource.txt")
     Stream
       .eval(routes.orNotFound.run(req))
       .flatMap(_.body.chunks)
@@ -59,12 +59,12 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Return a 404 for a resource under an existing file") {
-    val req = Request[IO](uri = uri"/testresource.txt/test")
+    val req = Request(uri = uri"/testresource.txt/test")
     routes.orNotFound(req).map(_.status).assertEquals(Status.NotFound)
   }
 
   test("Decodes path segments") {
-    val req = Request[IO](uri = uri"/space+truckin%27.txt")
+    val req = Request(uri = uri"/space+truckin%27.txt")
     routes.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
@@ -77,7 +77,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
       ))
     val file = Paths.get(defaultSystemPath).resolve(relativePath).toFile
     val uri = Uri.unsafeFromString("/path-prefix/" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
@@ -88,7 +88,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     val file = systemPath.resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     val s0 = fileService(
       FileService.Config[IO](
         systemPath = systemPath.toString
@@ -102,7 +102,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultSystemPath).resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     IO(file.exists()).assert *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
@@ -113,7 +113,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultSystemPath).resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/test" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     val s0 = fileService(
       FileService.Config[IO](
         systemPath = Paths.get(defaultSystemPath).resolve("test").toString
@@ -128,7 +128,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultSystemPath).resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/prefix" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     val s0 = fileService(
       FileService.Config[IO](
         systemPath = defaultSystemPath,
@@ -143,7 +143,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     val file = absPath.toFile
 
     val uri = Uri.unsafeFromString("///" + absPath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     IO(file.exists()).assert *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
@@ -155,7 +155,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     val bytes = Chunk.array(Files.readAllBytes(path))
 
     val uri = Uri.unsafeFromString("/" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     IO(file.exists()).assert *>
       IO(Files.isSymbolicLink(Paths.get(defaultSystemPath).resolve("symlink"))).assert *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.Ok) *>
@@ -170,7 +170,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
   test("Return index.html if request points to ''") {
     val path = Paths.get(defaultSystemPath).resolve("testDir/").toAbsolutePath.toString
     val s0 = fileService(FileService.Config[IO](systemPath = path))
-    val req = Request[IO](uri = uri"")
+    val req = Request(uri = uri"")
     s0.orNotFound(req)
       .flatMap { res =>
         res.as[String].map {
@@ -183,7 +183,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
   test("Return index.html if request points to '/'") {
     val path = Paths.get(defaultSystemPath).resolve("testDir/").toAbsolutePath.toString
     val s0 = fileService(FileService.Config[IO](systemPath = path))
-    val req = Request[IO](uri = uri"/")
+    val req = Request(uri = uri"/")
     val rb = s0.orNotFound(req)
 
     rb.flatMap { res =>
@@ -192,7 +192,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Return index.html if request points to a directory") {
-    val req = Request[IO](uri = uri"/testDir/")
+    val req = Request(uri = uri"/testDir/")
     val rb = runReq(req)
 
     rb.flatMap { case (_, re) =>
@@ -202,13 +202,13 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Not find missing file") {
-    val req = Request[IO](uri = uri"/missing.txt")
+    val req = Request(uri = uri"/missing.txt")
     routes.orNotFound(req).map(_.status).assertEquals(Status.NotFound)
   }
 
   test("Return a 206 PartialContent file") {
     val range = headers.Range(4)
-    val req = Request[IO](uri = uri"/testresource.txt").withHeaders(range)
+    val req = Request(uri = uri"/testresource.txt").withHeaders(range)
     Stream
       .eval(routes.orNotFound(req))
       .flatMap(_.body.chunks)
@@ -220,7 +220,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
 
   test("Return a 206 PartialContent file") {
     val range = headers.Range(-4)
-    val req = Request[IO](uri = uri"/testresource.txt").withHeaders(range)
+    val req = Request(uri = uri"/testresource.txt").withHeaders(range)
     Stream
       .eval(routes.orNotFound(req))
       .flatMap(_.body.chunks)
@@ -232,7 +232,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
 
   test("Return a 206 PartialContent file") {
     val range = headers.Range(2, 4)
-    val req = Request[IO](uri = uri"/testresource.txt").withHeaders(range)
+    val req = Request(uri = uri"/testresource.txt").withHeaders(range)
     Stream
       .eval(routes.orNotFound(req))
       .flatMap(_.body.chunks)
@@ -252,7 +252,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
       headers.Range(-200)
     )
     val size = new File(getClass.getResource("/testresource.txt").toURI).length
-    val reqs = ranges.map(r => Request[IO](uri = uri"/testresource.txt").withHeaders(r))
+    val reqs = ranges.map(r => Request(uri = uri"/testresource.txt").withHeaders(r))
     reqs.toList.traverse { req =>
       routes.orNotFound(req).map(_.status).assertEquals(Status.RangeNotSatisfiable) *>
         routes
@@ -263,17 +263,17 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("doesn't crash on /") {
-    routes.orNotFound(Request[IO](uri = uri"/")).map(_.status).assertEquals(Status.NotFound)
+    routes.orNotFound(Request(uri = uri"/")).map(_.status).assertEquals(Status.NotFound)
   }
 
   test("handle a relative system path") {
     val s = fileService(FileService.Config[IO]("."))
     IO(Paths.get(".").resolve("build.sbt").toFile.exists()).assert *>
-      s.orNotFound(Request[IO](uri = uri"/build.sbt")).map(_.status).assertEquals(Status.Ok)
+      s.orNotFound(Request(uri = uri"/build.sbt")).map(_.status).assertEquals(Status.Ok)
   }
 
   test("404 if system path is not found") {
     val s = fileService(FileService.Config[IO]("./does-not-exist"))
-    s.orNotFound(Request[IO](uri = uri"/build.sbt")).map(_.status).assertEquals(Status.NotFound)
+    s.orNotFound(Request(uri = uri"/build.sbt")).map(_.status).assertEquals(Status.NotFound)
   }
 }

--- a/server/jvm/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSuite.scala
@@ -44,17 +44,17 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
     val app = TranslateUri("/foo")(routes).orNotFound
 
     {
-      val req = Request[IO](uri = uri"/foo/testresource.txt")
+      val req = Request(uri = uri"/foo/testresource.txt")
       Stream.eval(app(req)).flatMap(_.body.chunks).compile.lastOrError.assertEquals(testResource) *>
         app(req).map(_.status).assertEquals(Status.Ok)
     } *> {
-      val req = Request[IO](uri = uri"/testresource.txt")
+      val req = Request(uri = uri"/testresource.txt")
       app(req).map(_.status).assertEquals(Status.NotFound)
     }
   }
 
   test("Serve available content") {
-    val req = Request[IO](uri = Uri.fromString("/testresource.txt").yolo)
+    val req = Request(uri = Uri.fromString("/testresource.txt").yolo)
     val rb = routes.orNotFound(req)
 
     Stream.eval(rb).flatMap(_.body.chunks).compile.lastOrError.assertEquals(testResource) *>
@@ -62,7 +62,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Decodes path segments") {
-    val req = Request[IO](uri = uri"/space+truckin%27.txt")
+    val req = Request(uri = uri"/space+truckin%27.txt")
     routes.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
@@ -71,7 +71,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
     val s0 = builder.withPathPrefix("/path-prefix").toRoutes
     val file = Paths.get(defaultBase).resolve(relativePath).toFile
     val uri = Uri.unsafeFromString("/path-prefix/" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
@@ -82,7 +82,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
     val file = basePath.resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     val s0 = builder.withBasePath("/testDir").toRoutes
     IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
@@ -93,7 +93,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultBase).resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     IO(file.exists()).assert *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
@@ -104,7 +104,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultBase).resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/test" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     val s0 = builder.toRoutes
     IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.NotFound)
@@ -116,7 +116,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultBase).resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/test" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     val s0 = builder
       .withPathPrefix("/test")
       .toRoutes
@@ -129,14 +129,14 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
     val file = absPath.toFile
 
     val uri = Uri.unsafeFromString("///" + absPath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     val s0 = builder.toRoutes
     IO(file.exists()).assert *>
       s0.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
   test("Try to serve pre-gzipped content if asked to") {
-    val req = Request[IO](
+    val req = Request(
       uri = Uri.fromString("/testresource.txt").yolo,
       headers = Headers(`Accept-Encoding`(ContentCoding.gzip))
     )
@@ -151,7 +151,7 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Fallback to un-gzipped file if pre-gzipped version doesn't exist") {
-    val req = Request[IO](
+    val req = Request(
       uri = Uri.fromString("/testresource2.txt").yolo,
       headers = Headers(`Accept-Encoding`(ContentCoding.gzip))
     )
@@ -167,18 +167,18 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Generate non on missing content") {
-    val req = Request[IO](uri = Uri.fromString("/testresource.txtt").yolo)
+    val req = Request(uri = Uri.fromString("/testresource.txtt").yolo)
     routes.orNotFound(req).map(_.status).assertEquals(Status.NotFound)
   }
 
   test("Not send unmodified files") {
-    val req = Request[IO](uri = uri"/testresource.txt")
+    val req = Request(uri = uri"/testresource.txt")
       .putHeaders(`If-Modified-Since`(HttpDate.MaxValue))
 
     runReq(req).map(_._2.status).assertEquals(Status.NotModified)
   }
 
   test("doesn't crash on /") {
-    routes.orNotFound(Request[IO](uri = uri"/")).map(_.status).assertEquals(Status.NotFound)
+    routes.orNotFound(Request(uri = uri"/")).map(_.status).assertEquals(Status.NotFound)
   }
 }

--- a/server/jvm/src/test/scala/org/http4s/server/staticcontent/WebjarServiceFilterSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/staticcontent/WebjarServiceFilterSuite.scala
@@ -29,7 +29,7 @@ class WebjarServiceFilterSuite extends Http4sSuite with StaticContentShared {
       .toRoutes
 
   test("Return a 200 Ok file") {
-    val req = Request[IO](GET, uri"/test-lib/1.0.0/testresource.txt")
+    val req = Request(GET, uri"/test-lib/1.0.0/testresource.txt")
     val rb = runReq(req)
 
     rb.flatMap { case (b, r) =>
@@ -39,7 +39,7 @@ class WebjarServiceFilterSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Not find filtered asset") {
-    val req = Request[IO](GET, uri"/test-lib/1.0.0/sub/testresource.txt")
+    val req = Request(GET, uri"/test-lib/1.0.0/sub/testresource.txt")
     val rb = runReq(req)
 
     rb.flatMap { case (_, r) =>

--- a/server/jvm/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/staticcontent/WebjarServiceSuite.scala
@@ -46,7 +46,7 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
       .toString
 
   test("Return a 200 Ok file") {
-    val req = Request[IO](GET, uri"/test-lib/1.0.0/testresource.txt")
+    val req = Request(GET, uri"/test-lib/1.0.0/testresource.txt")
     val rb = runReq(req)
     rb.flatMap { case (b, r) =>
       assertEquals(r.status, Status.Ok)
@@ -55,7 +55,7 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Return a 200 Ok file in a subdirectory") {
-    val req = Request[IO](GET, uri"/test-lib/1.0.0/sub/testresource.txt")
+    val req = Request(GET, uri"/test-lib/1.0.0/sub/testresource.txt")
     val rb = runReq(req)
 
     rb.flatMap { case (b, r) =>
@@ -65,7 +65,7 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("Decodes path segments") {
-    val req = Request[IO](uri = uri"/deep+purple/machine+head/space+truckin%27.txt")
+    val req = Request(uri = uri"/deep+purple/machine+head/space+truckin%27.txt")
     routes.orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
@@ -74,7 +74,7 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultBase).resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     IO(file.exists()).assertEquals(true) *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
@@ -84,7 +84,7 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
     val file = Paths.get(defaultBase).resolve(relativePath).toFile
 
     val uri = Uri.unsafeFromString("/" + relativePath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     IO(file.exists()).assertEquals(true) *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
@@ -94,33 +94,33 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
     val file = absPath.toFile
 
     val uri = Uri.unsafeFromString("///" + absPath)
-    val req = Request[IO](uri = uri)
+    val req = Request(uri = uri)
     IO(file.exists()).assertEquals(true) *>
       routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
   test("Not find missing file") {
-    val req = Request[IO](uri = uri"/test-lib/1.0.0/doesnotexist.txt")
+    val req = Request(uri = uri"/test-lib/1.0.0/doesnotexist.txt")
     routes.apply(req).value.assertEquals(Option.empty[Response[IO]])
   }
 
   test("Not find missing library") {
-    val req = Request[IO](uri = uri"/1.0.0/doesnotexist.txt")
+    val req = Request(uri = uri"/1.0.0/doesnotexist.txt")
     routes.apply(req).value.assertEquals(Option.empty[Response[IO]])
   }
 
   test("Return bad request on missing version") {
-    val req = Request[IO](uri = uri"/test-lib//doesnotexist.txt")
+    val req = Request(uri = uri"/test-lib//doesnotexist.txt")
     routes.orNotFound(req).map(_.status).assertEquals(Status.BadRequest)
   }
 
   test("Not find blank asset") {
-    val req = Request[IO](uri = uri"/test-lib/1.0.0/")
+    val req = Request(uri = uri"/test-lib/1.0.0/")
     routes.apply(req).value.assertEquals(Option.empty[Response[IO]])
   }
 
   test("Not match a request with POST") {
-    val req = Request[IO](POST, uri"/test-lib/1.0.0/testresource.txt")
+    val req = Request(POST, uri"/test-lib/1.0.0/testresource.txt")
     routes.apply(req).value.assertEquals(Option.empty[Response[IO]])
   }
 
@@ -134,7 +134,7 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
       }
     }
 
-    val req = Request[IO](uri = uri"/deep+purple/machine+head/space+truckin%27.txt")
+    val req = Request(uri = uri"/deep+purple/machine+head/space+truckin%27.txt")
     routes(mockedClassLoader)
       .orNotFound(req)
       .map(resp => resp.status === Status.Ok && mockedClassLoaderCallCount === 1)
@@ -142,7 +142,7 @@ class WebjarServiceSuite extends Http4sSuite with StaticContentShared {
   }
 
   test("respect preferredGzip parameter") {
-    val req = Request[IO](
+    val req = Request(
       GET,
       uri"/test-lib/1.0.0/testresource.txt",
       headers = Headers(`Accept-Encoding`(ContentCoding.gzip)))

--- a/server/shared/src/main/scala/org/http4s/server/Router.scala
+++ b/server/shared/src/main/scala/org/http4s/server/Router.scala
@@ -43,7 +43,7 @@ object Router {
         Kleisli { req =>
           (
             if (req.pathInfo.startsWith(prefixPath))
-              routes.local(translate(prefixPath)) <+> acc
+              routes.local(translate[F](prefixPath)) <+> acc
             else
               acc
           )(req)

--- a/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -257,7 +257,7 @@ object CORS {
             }
           else {
             logger.debug(s"CORS headers were denied for ${req.method} ${req.uri}")
-            Response(status = Status.Forbidden).pure[F]
+            Response[G](status = Status.Forbidden).pure[F]
           }
         case _ =>
           // This request is out of scope for CORS

--- a/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -431,7 +431,7 @@ sealed class CORSPolicy(
           maxAgeHeader.foreach(buff.+=)
       }
       varyHeader(Method.OPTIONS)(
-        Response[G](Status.Ok, headers = Headers(buff.result().map(Header.ToRaw.rawToRaw)))).pure[F]
+        Response(Status.Ok, headers = Headers(buff.result().map(Header.ToRaw.rawToRaw)))).pure[F]
     }
 
     def nonCors(req: Request[G]) =

--- a/server/shared/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -18,8 +18,7 @@ package org.http4s
 package server
 package middleware
 
-import cats.~>
-import cats.Applicative
+import cats._
 import cats.data.{EitherT, Kleisli}
 import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
@@ -223,7 +222,7 @@ object CSRF extends CSRFSingletonPlatform {
         httpOnly = true,
         path = Some("/")),
       clock = Clock.systemUTC(),
-      onFailure = Response[G](Status.Forbidden),
+      onFailure = Response(Status.Forbidden),
       createIfNotFound = true,
       key = key,
       headerCheck = headerCheck,

--- a/server/shared/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
@@ -96,7 +96,7 @@ object HttpMethodOverrider {
         req: Request[G],
         parseResult: ParseResult[Method]): F[Response[G]] =
       parseResult match {
-        case Left(_) => F.pure(Response[G](Status.BadRequest))
+        case Left(_) => F.pure(Response(Status.BadRequest))
         case Right(om) => http(updateRequestWithMethod(req, om)).map(updateVaryHeader)
       }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/HttpsRedirect.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/HttpsRedirect.scala
@@ -47,7 +47,7 @@ object HttpsRedirect {
           val authority = Authority(host = RegName(host.value))
           val location = req.uri.copy(scheme = Some(Scheme.https), authority = Some(authority))
           val headers = Headers(Location(location), `Content-Type`(MediaType.text.xml))
-          val response = Response[G](status = MovedPermanently, headers = headers)
+          val response = Response(status = MovedPermanently, headers = headers)
           F.pure(response)
 
         case _ =>

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -57,7 +57,7 @@ object Jsonp {
             .apply(req)
         case Some(invalidCallback) =>
           logger.warn(s"Jsonp requested with invalid callback function name $invalidCallback")
-          Response[G](Status.BadRequest).withEntity(s"Not a valid callback name.").pure[F]
+          Response(Status.BadRequest).withEntity(s"Not a valid callback name.").pure[F]
         case None => http(req)
       }
     }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -57,7 +57,7 @@ object Jsonp {
             .apply(req)
         case Some(invalidCallback) =>
           logger.warn(s"Jsonp requested with invalid callback function name $invalidCallback")
-          Response(Status.BadRequest).withEntity(s"Not a valid callback name.").pure[F]
+          Response[G](Status.BadRequest).withEntity(s"Not a valid callback name.").pure[F]
         case None => http(req)
       }
     }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -94,11 +94,11 @@ object Logger {
   )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
     logBodyText(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
-  def logMessage[F[_], A <: Message[F]](message: A)(
+  def logMessage[F[_]](message: Message[F])(
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains)(
       log: String => F[Unit])(implicit F: Async[F]): F[Unit] =
     org.http4s.internal.Logger
-      .logMessage[F, A](message)(logHeaders, logBody, redactHeadersWhen)(log)
+      .logMessage[F](message)(logHeaders, logBody, redactHeadersWhen)(log)
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/MaxActiveRequests.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/MaxActiveRequests.scala
@@ -29,14 +29,14 @@ object MaxActiveRequests {
   @deprecated(message = "Please use forHttpApp instead.", since = "0.21.14")
   def httpApp[F[_]: Async](
       maxActive: Long,
-      defaultResp: Response[F] = Response[F](status = Status.ServiceUnavailable)
+      defaultResp: Response[F] = Response(status = Status.ServiceUnavailable)
   ): F[Kleisli[F, Request[F], Response[F]] => Kleisli[F, Request[F], Response[F]]] =
     forHttpApp[F](maxActive, defaultResp)
 
   @deprecated(message = "Please use forHttpApp2 instead.", since = "0.21.14")
   def inHttpApp[G[_], F[_]](
       maxActive: Long,
-      defaultResp: Response[F] = Response[F](status = Status.ServiceUnavailable)
+      defaultResp: Response[F] = Response(status = Status.ServiceUnavailable)
   )(implicit
       F: Async[F],
       G: Sync[G]): G[Kleisli[F, Request[F], Response[F]] => Kleisli[F, Request[F], Response[F]]] =
@@ -44,13 +44,13 @@ object MaxActiveRequests {
 
   def forHttpApp[F[_]: Async](
       maxActive: Long,
-      defaultResp: Response[F] = Response[F](status = Status.ServiceUnavailable)
+      defaultResp: Response[F] = Response(status = Status.ServiceUnavailable)
   ): F[Kleisli[F, Request[F], Response[F]] => Kleisli[F, Request[F], Response[F]]] =
     forHttpApp2[F, F](maxActive, defaultResp)
 
   def forHttpApp2[G[_], F[_]](
       maxActive: Long,
-      defaultResp: Response[F] = Response[F](status = Status.ServiceUnavailable)
+      defaultResp: Response[F] = Response(status = Status.ServiceUnavailable)
   )(implicit
       F: Async[F],
       G: Sync[G]): G[Kleisli[F, Request[F], Response[F]] => Kleisli[F, Request[F], Response[F]]] =
@@ -71,7 +71,7 @@ object MaxActiveRequests {
   @deprecated(message = "Please use forHttpRoutes instead.", since = "0.21.14")
   def httpRoutes[F[_]: Async](
       maxActive: Long,
-      defaultResp: Response[F] = Response[F](status = Status.ServiceUnavailable)
+      defaultResp: Response[F] = Response(status = Status.ServiceUnavailable)
   ): F[Kleisli[OptionT[F, *], Request[F], Response[F]] => Kleisli[
     OptionT[F, *],
     Request[F],
@@ -80,7 +80,7 @@ object MaxActiveRequests {
   @deprecated(message = "Please use forHttpRoutes2 instead.", since = "0.21.14")
   def inHttpRoutes[G[_], F[_]](
       maxActive: Long,
-      defaultResp: Response[F] = Response[F](status = Status.ServiceUnavailable)
+      defaultResp: Response[F] = Response(status = Status.ServiceUnavailable)
   )(implicit F: Async[F], G: Sync[G]): G[Kleisli[OptionT[F, *], Request[F], Response[F]] => Kleisli[
     OptionT[F, *],
     Request[F],
@@ -89,7 +89,7 @@ object MaxActiveRequests {
 
   def forHttpRoutes[F[_]: Async](
       maxActive: Long,
-      defaultResp: Response[F] = Response[F](status = Status.ServiceUnavailable)
+      defaultResp: Response[F] = Response(status = Status.ServiceUnavailable)
   ): F[Kleisli[OptionT[F, *], Request[F], Response[F]] => Kleisli[
     OptionT[F, *],
     Request[F],
@@ -98,7 +98,7 @@ object MaxActiveRequests {
 
   def forHttpRoutes2[G[_], F[_]](
       maxActive: Long,
-      defaultResp: Response[F] = Response[F](status = Status.ServiceUnavailable)
+      defaultResp: Response[F] = Response(status = Status.ServiceUnavailable)
   )(implicit F: Async[F], G: Sync[G]): G[Kleisli[OptionT[F, *], Request[F], Response[F]] => Kleisli[
     OptionT[F, *],
     Request[F],

--- a/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -62,10 +62,10 @@ object RequestLogger {
     def logMessage(r: Request[F]): F[Unit] =
       logBodyText match {
         case Left(bool) =>
-          Logger.logMessage[F, Request[F]](r)(logHeaders, bool, redactHeadersWhen)(log(_))
+          Logger.logMessage(r)(logHeaders, bool, redactHeadersWhen)(log(_))
         case Right(f) =>
           org.http4s.internal.Logger
-            .logMessageWithBodyText[F, Request[F]](r)(logHeaders, f, redactHeadersWhen)(log(_))
+            .logMessageWithBodyText(r)(logHeaders, f, redactHeadersWhen)(log(_))
       }
 
     val logBody: Boolean = logBodyText match {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -57,10 +57,10 @@ object ResponseLogger {
     def logMessage(resp: Response[F]): F[Unit] =
       logBodyText match {
         case Left(bool) =>
-          Logger.logMessage[F, Response[F]](resp)(logHeaders, bool, redactHeadersWhen)(log(_))
+          Logger.logMessage(resp)(logHeaders, bool, redactHeadersWhen)(log(_))
         case Right(f) =>
           org.http4s.internal.Logger
-            .logMessageWithBodyText[F, Response[F]](resp)(logHeaders, f, redactHeadersWhen)(log(_))
+            .logMessageWithBodyText(resp)(logHeaders, f, redactHeadersWhen)(log(_))
       }
 
     val logBody: Boolean = logBodyText match {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
@@ -108,7 +108,7 @@ object Throttle {
 
   def defaultResponse[F[_]](retryAfter: Option[FiniteDuration]): Response[F] = {
     val _ = retryAfter
-    Response[F](Status.TooManyRequests)
+    Response(Status.TooManyRequests)
   }
 
   /** Limits the supplied service using a provided [[TokenBucket]]

--- a/server/shared/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/UrlFormLifter.scala
@@ -54,7 +54,7 @@ object UrlFormLifter {
           for {
             decoded <- f(UrlForm.entityDecoder[G].decode(req, strictDecode).value)
             resp <- decoded.fold(
-              mf => f(mf.toHttpResponse[G](req.httpVersion).pure[G]),
+              mf => f(mf.toHttpResponse(req.httpVersion).pure[G]),
               addUrlForm
             )
           } yield resp
@@ -63,6 +63,6 @@ object UrlFormLifter {
       }
     }
 
-  private def checkRequest[F[_]](req: Request[F]): Boolean =
+  private def checkRequest(req: AnyRequest): Boolean =
     req.method == Method.POST || req.method == Method.PUT
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -78,7 +78,7 @@ object VirtualHost {
     Kleisli { req =>
       req.headers
         .get[Host]
-        .fold(F.pure(Response[G](BadRequest).withEntity("Host header required."))) { h =>
+        .fold(F.pure(Response(BadRequest).withEntity("Host header required."))) { h =>
           // Fill in the host port if possible
           val host: Host = h.port match {
             case Some(_) => h
@@ -87,7 +87,7 @@ object VirtualHost {
           }
           (first +: rest).toVector
             .collectFirst { case HostService(s, p) if p(host) => s(req) }
-            .getOrElse(F.pure(Response[G](NotFound).withEntity(s"Host '$host' not found.")))
+            .getOrElse(F.pure(Response(NotFound).withEntity(s"Host '$host' not found.")))
         }
     }
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/BasicAuth.scala
@@ -59,7 +59,7 @@ object BasicAuth {
       }
     }
 
-  private def validatePassword[F[_], A](validate: BasicAuthenticator[F, A], req: Request[F])(
+  private def validatePassword[F[_], A](validate: BasicAuthenticator[F, A], req: AnyRequest)(
       implicit F: Applicative[F]): F[Option[A]] =
     req.headers.get[Authorization] match {
       case Some(Authorization(BasicCredentials(username, password))) =>

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -89,7 +89,7 @@ object DigestAuth {
       realm: String,
       store: AuthenticationStore[F, A],
       nonceKeeper: NonceKeeper,
-      req: Request[F])(implicit F: Async[F]): F[AuthReply[A]] =
+      req: AnyRequest)(implicit F: Async[F]): F[AuthReply[A]] =
     req.headers.get[Authorization] match {
       case Some(Authorization(Credentials.AuthParams(AuthScheme.Digest, params))) =>
         checkAuthParams(realm, store, nonceKeeper, req, params)
@@ -114,7 +114,7 @@ object DigestAuth {
       realm: String,
       store: AuthenticationStore[F, A],
       nonceKeeper: NonceKeeper,
-      req: Request[F],
+      req: AnyRequest,
       paramsNel: NonEmptyList[(String, String)])(implicit F: Async[F]): F[AuthReply[A]] = {
     val params = paramsNel.toList.toMap
     if (!Set("realm", "nonce", "nc", "username", "cnonce", "qop").subsetOf(params.keySet))

--- a/server/shared/src/main/scala/org/http4s/server/package.scala
+++ b/server/shared/src/main/scala/org/http4s/server/package.scala
@@ -143,7 +143,7 @@ package object server {
         messageFailureLogger.debug(mf)(
           s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
             .getOrElse("<unknown>")}""")
-        mf.toHttpResponse(req.httpVersion).pure[F]
+        mf.toHttpResponse(req.httpVersion).covary[G].pure[F]
       case NonFatal(t) =>
         serviceErrorLogger.error(t)(
           s"""Error servicing request: ${req.method} ${req.pathInfo} from ${req.remoteAddr

--- a/server/shared/src/main/scala/org/http4s/server/package.scala
+++ b/server/shared/src/main/scala/org/http4s/server/package.scala
@@ -133,17 +133,17 @@ package object server {
   type ServiceErrorHandler[F[_]] = Request[F] => PartialFunction[Throwable, F[Response[F]]]
 
   def DefaultServiceErrorHandler[F[_]](implicit
-      F: Monad[F]): Request[F] => PartialFunction[Throwable, F[Response[F]]] =
+      F: Monad[F]): AnyRequest => PartialFunction[Throwable, F[Response[F]]] =
     inDefaultServiceErrorHandler[F, F]
 
   def inDefaultServiceErrorHandler[F[_], G[_]](implicit
-      F: Monad[F]): Request[G] => PartialFunction[Throwable, F[Response[G]]] =
+      F: Monad[F]): AnyRequest => PartialFunction[Throwable, F[Response[G]]] =
     req => {
       case mf: MessageFailure =>
         messageFailureLogger.debug(mf)(
           s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
             .getOrElse("<unknown>")}""")
-        mf.toHttpResponse[G](req.httpVersion).pure[F]
+        mf.toHttpResponse(req.httpVersion).pure[F]
       case NonFatal(t) =>
         serviceErrorLogger.error(t)(
           s"""Error servicing request: ${req.method} ${req.pathInfo} from ${req.remoteAddr

--- a/server/shared/src/main/scala/org/http4s/server/package.scala
+++ b/server/shared/src/main/scala/org/http4s/server/package.scala
@@ -102,7 +102,7 @@ package object server {
       Kleisli { (r: Request[F]) =>
         val resp = authUser(r).value.flatMap {
           case Some(authReq) =>
-            service(AuthedRequest(authReq, r)).getOrElse(Response[F](Status.NotFound))
+            service(AuthedRequest(authReq, r)).getOrElse(Response(Status.NotFound))
           case None => onAuthFailure(r)
         }
         OptionT.liftF(resp)
@@ -110,7 +110,7 @@ package object server {
     }
 
     def defaultAuthFailure[F[_]](implicit F: Applicative[F]): Request[F] => F[Response[F]] =
-      _ => F.pure(Response[F](Status.Unauthorized))
+      _ => F.pure(Response(Status.Unauthorized))
 
     def apply[F[_], Err, T](
         authUser: Kleisli[F, Request[F], Either[Err, T]],

--- a/server/shared/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/shared/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -134,9 +134,9 @@ object WebSocketBuilder {
     new WebSocketBuilder[F](
       headers = Headers.empty,
       onNonWebSocketRequest =
-        Response(Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F],
+        Response[F](Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F],
       onHandshakeFailure =
-        Response(Status.BadRequest).withEntity("WebSocket handshake failed.").pure[F],
+        Response[F](Status.BadRequest).withEntity("WebSocket handshake failed.").pure[F],
       onClose = Applicative[F].unit,
       filterPingPongs = true
     )

--- a/server/shared/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
+++ b/server/shared/src/main/scala/org/http4s/server/websocket/WebSocketBuilder.scala
@@ -134,9 +134,9 @@ object WebSocketBuilder {
     new WebSocketBuilder[F](
       headers = Headers.empty,
       onNonWebSocketRequest =
-        Response[F](Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F],
+        Response(Status.NotImplemented).withEntity("This is a WebSocket route.").pure[F],
       onHandshakeFailure =
-        Response[F](Status.BadRequest).withEntity("WebSocket handshake failed.").pure[F],
+        Response(Status.BadRequest).withEntity("WebSocket handshake failed.").pure[F],
       onClose = Applicative[F].unit,
       filterPingPongs = true
     )

--- a/server/shared/src/test/scala/org/http4s/server/ContextRouterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/ContextRouterSuite.scala
@@ -64,22 +64,22 @@ class ContextRouterSuite extends Http4sSuite {
 
   test("translate mount prefixes") {
     service
-      .orNotFound(ContextRequest((), Request[IO](GET, uri"/numbers/1")))
+      .orNotFound(ContextRequest((), Request(GET, uri"/numbers/1")))
       .flatMap(_.as[String])
       .assertEquals("one") *>
       service
-        .orNotFound(ContextRequest((), Request[IO](GET, uri"/numb/1")))
+        .orNotFound(ContextRequest((), Request(GET, uri"/numb/1")))
         .flatMap(_.as[String])
         .assertEquals("two") *>
       service
-        .orNotFound(ContextRequest((), Request[IO](GET, uri"/numbe?block")))
+        .orNotFound(ContextRequest((), Request(GET, uri"/numbe?block")))
         .map(_.status)
         .assertEquals(NotFound)
   }
 
   test("require the correct prefix") {
     service
-      .orNotFound(ContextRequest((), Request[IO](GET, uri"/letters/1")))
+      .orNotFound(ContextRequest((), Request(GET, uri"/letters/1")))
       .flatMap { resp =>
         resp.as[String].map { b =>
           b =!= "bee" && b =!= "one" && resp.status === NotFound
@@ -90,42 +90,42 @@ class ContextRouterSuite extends Http4sSuite {
 
   test("support root mappings") {
     service
-      .orNotFound(ContextRequest((), Request[IO](GET, uri"/about")))
+      .orNotFound(ContextRequest((), Request(GET, uri"/about")))
       .flatMap(_.as[String])
       .assertEquals("about")
   }
 
   test("match longer prefixes first") {
     service
-      .orNotFound(ContextRequest((), Request[IO](GET, uri"/shadow/shadowed")))
+      .orNotFound(ContextRequest((), Request(GET, uri"/shadow/shadowed")))
       .flatMap(_.as[String])
       .assertEquals("visible")
   }
 
   test("404 on unknown prefixes") {
     service
-      .orNotFound(ContextRequest((), Request[IO](GET, uri"/symbols/~")))
+      .orNotFound(ContextRequest((), Request(GET, uri"/symbols/~")))
       .map(_.status)
       .assertEquals(NotFound)
   }
 
   test("Allow passing through of routes with identical prefixes") {
     ContextRouter[IO, Unit]("" -> letters, "" -> numbers)
-      .orNotFound(ContextRequest((), Request[IO](GET, uri"/1")))
+      .orNotFound(ContextRequest((), Request(GET, uri"/1")))
       .flatMap(_.as[String])
       .assertEquals("one")
   }
 
   test("Serve custom NotFound responses") {
     ContextRouter[IO, Unit]("/foo" -> notFound)
-      .orNotFound(ContextRequest((), Request[IO](uri = uri"/foo/bar")))
+      .orNotFound(ContextRequest((), Request(uri = uri"/foo/bar")))
       .flatMap(_.as[String])
       .assertEquals("Custom NotFound")
   }
 
   test("Return the fallthrough response if no route is found") {
     val router = ContextRouter[IO, Unit]("/foo" -> notFound)
-    router(ContextRequest((), Request[IO](uri = uri"/bar"))).value
+    router(ContextRequest((), Request(uri = uri"/bar"))).value
       .map(_ == Option.empty[Response[IO]])
       .assert
   }

--- a/server/shared/src/test/scala/org/http4s/server/HttpRoutesSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/HttpRoutesSuite.scala
@@ -24,56 +24,56 @@ import org.http4s.syntax.all._
 class HttpRoutesSuite extends Http4sSuite {
   val routes1 = HttpRoutes.of[IO] {
     case req if req.pathInfo == path"/match" =>
-      Response[IO](Status.Ok).withEntity("match").pure[IO]
+      Response(Status.Ok).withEntity("match").pure[IO]
 
     case req if req.pathInfo == path"/conflict" =>
-      Response[IO](Status.Ok).withEntity("routes1conflict").pure[IO]
+      Response(Status.Ok).withEntity("routes1conflict").pure[IO]
 
     case req if req.pathInfo == path"/notfound" =>
-      Response[IO](Status.NotFound).withEntity("notfound").pure[IO]
+      Response(Status.NotFound).withEntity("notfound").pure[IO]
   }
 
   val routes2 = HttpRoutes.of[IO] {
     case req if req.pathInfo == path"/routes2" =>
-      Response[IO](Status.Ok).withEntity("routes2").pure[IO]
+      Response(Status.Ok).withEntity("routes2").pure[IO]
 
     case req if req.pathInfo == path"/conflict" =>
-      Response[IO](Status.Ok).withEntity("routes2conflict").pure[IO]
+      Response(Status.Ok).withEntity("routes2conflict").pure[IO]
   }
 
   val aggregate1 = routes1 <+> routes2
 
   test("Return a valid Response from the first service of an aggregate") {
     aggregate1
-      .orNotFound(Request[IO](uri = uri"/match"))
+      .orNotFound(Request(uri = uri"/match"))
       .flatMap(_.as[String])
       .assertEquals("match")
   }
 
   test("Return a custom NotFound from the first service of an aggregate") {
     aggregate1
-      .orNotFound(Request[IO](uri = uri"/notfound"))
+      .orNotFound(Request(uri = uri"/notfound"))
       .flatMap(_.as[String])
       .assertEquals("notfound")
   }
 
   test("Accept the first matching route in the case of overlapping paths") {
     aggregate1
-      .orNotFound(Request[IO](uri = uri"/conflict"))
+      .orNotFound(Request(uri = uri"/conflict"))
       .flatMap(_.as[String])
       .assertEquals("routes1conflict")
   }
 
   test("Fall through the first service that doesn't match to a second matching service") {
     aggregate1
-      .orNotFound(Request[IO](uri = uri"/routes2"))
+      .orNotFound(Request(uri = uri"/routes2"))
       .flatMap(_.as[String])
       .assertEquals("routes2")
   }
 
   test("Properly fall through two aggregated service if no path matches") {
     aggregate1
-      .apply(Request[IO](uri = uri"/wontMatch"))
+      .apply(Request(uri = uri"/wontMatch"))
       .value
       .map(_ == Option.empty[Response[IO]])
       .assert

--- a/server/shared/src/test/scala/org/http4s/server/MockRoute.scala
+++ b/server/shared/src/test/scala/org/http4s/server/MockRoute.scala
@@ -27,10 +27,10 @@ object MockRoute {
   def route(): HttpRoutes[IO] =
     HttpRoutes.of {
       case req if req.uri.path === path"/ping" =>
-        Response[IO](Ok).withEntity("pong").pure[IO]
+        Response(Ok).withEntity("pong").pure[IO]
 
       case req if req.method === Method.POST && req.uri.path === path"/echo" =>
-        IO.pure(Response[IO](body = req.body))
+        IO.pure(Response(body = req.body))
 
       case req if req.uri.path === path"/withslash" =>
         IO.pure(Response(Ok))

--- a/server/shared/src/test/scala/org/http4s/server/RouterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/RouterSuite.scala
@@ -63,19 +63,19 @@ class RouterSuite extends Http4sSuite {
 
   test("translate mount prefixes") {
     service
-      .orNotFound(Request[IO](GET, uri"/numbers/1"))
+      .orNotFound(Request(GET, uri"/numbers/1"))
       .flatMap(_.as[String])
       .assertEquals("one") *>
       service
-        .orNotFound(Request[IO](GET, uri"/numb/1"))
+        .orNotFound(Request(GET, uri"/numb/1"))
         .flatMap(_.as[String])
         .assertEquals("two") *>
-      service.orNotFound(Request[IO](GET, uri"/numbe?block")).map(_.status).assertEquals(NotFound)
+      service.orNotFound(Request(GET, uri"/numbe?block")).map(_.status).assertEquals(NotFound)
   }
 
   test("require the correct prefix") {
     service
-      .orNotFound(Request[IO](GET, uri"/letters/1"))
+      .orNotFound(Request(GET, uri"/letters/1"))
       .flatMap { res =>
         res.as[String].map { b =>
           b =!= "bee" && b =!= "one" && res.status === NotFound
@@ -85,30 +85,30 @@ class RouterSuite extends Http4sSuite {
   }
 
   test("support root mappings") {
-    service.orNotFound(Request[IO](GET, uri"/about")).flatMap(_.as[String]).assertEquals("about")
+    service.orNotFound(Request(GET, uri"/about")).flatMap(_.as[String]).assertEquals("about")
   }
 
   test("match longer prefixes first") {
     service
-      .orNotFound(Request[IO](GET, uri"/shadow/shadowed"))
+      .orNotFound(Request(GET, uri"/shadow/shadowed"))
       .flatMap(_.as[String])
       .assertEquals("visible")
   }
 
   test("404 on unknown prefixes") {
-    service.orNotFound(Request[IO](GET, uri"/symbols/~")).map(_.status).assertEquals(NotFound)
+    service.orNotFound(Request(GET, uri"/symbols/~")).map(_.status).assertEquals(NotFound)
   }
 
   test("Allow passing through of routes with identical prefixes") {
     Router[IO]("" -> letters, "" -> numbers)
-      .orNotFound(Request[IO](GET, uri"/1"))
+      .orNotFound(Request(GET, uri"/1"))
       .flatMap(_.as[String])
       .assertEquals("one")
   }
 
   test("Serve custom NotFound responses") {
     Router[IO]("/foo" -> notFound)
-      .orNotFound(Request[IO](uri = uri"/foo/bar"))
+      .orNotFound(Request(uri = uri"/foo/bar"))
       .flatMap {
         _.as[String]
       }
@@ -117,7 +117,7 @@ class RouterSuite extends Http4sSuite {
 
   test("Return the fallthrough response if no route is found") {
     val router = Router[IO]("/foo" -> notFound)
-    router(Request[IO](uri = uri"/bar")).value
+    router(Request(uri = uri"/bar")).value
       .map(_ == Option.empty[Response[IO]])
       .assert
   }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/AutoSlashSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/AutoSlashSuite.scala
@@ -32,30 +32,30 @@ class AutoSlashSuite extends Http4sSuite {
   }
 
   test("Auto remove a trailing slash") {
-    val req = Request[IO](uri = uri"/ping/")
+    val req = Request(uri = uri"/ping/")
     route.orNotFound(req).map(_.status).assertEquals(Status.NotFound) *>
       AutoSlash(route).orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("Match a route defined with a slash") {
     AutoSlash(route)
-      .orNotFound(Request[IO](uri = uri"/withslash"))
+      .orNotFound(Request(uri = uri"/withslash"))
       .map(_.status)
       .assertEquals(Status.Ok) *>
       AutoSlash(route)
-        .orNotFound(Request[IO](uri = uri"/withslash/"))
+        .orNotFound(Request(uri = uri"/withslash/"))
         .map(_.status)
         .assertEquals(Status.Accepted)
   }
 
   test("Respect an absent trailing slash") {
-    val req = Request[IO](uri = uri"/ping")
+    val req = Request(uri = uri"/ping")
     route.orNotFound(req).map(_.status).assertEquals(Status.Ok)
     AutoSlash(route).orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 
   test("Not crash on empty path") {
-    val req = Request[IO](uri = uri"")
+    val req = Request(uri = uri"")
     AutoSlash(route).orNotFound(req).map(_.status).assertEquals(Status.NotFound)
   }
 
@@ -63,11 +63,11 @@ class AutoSlashSuite extends Http4sSuite {
     // See https://github.com/http4s/http4s/issues/1378
     val router = Router("/public" -> AutoSlash(pingRoutes))
     router
-      .orNotFound(Request[IO](uri = uri"/public/ping"))
+      .orNotFound(Request(uri = uri"/public/ping"))
       .map(_.status)
       .assertEquals(Status.Ok) *>
       router
-        .orNotFound(Request[IO](uri = uri"/public/ping/"))
+        .orNotFound(Request(uri = uri"/public/ping/"))
         .map(_.status)
         .assertEquals(Status.Ok)
   }
@@ -76,17 +76,17 @@ class AutoSlashSuite extends Http4sSuite {
     // See https://github.com/http4s/http4s/issues/1947
     val router = AutoSlash(Router("/public" -> pingRoutes))
     router
-      .orNotFound(Request[IO](uri = uri"/public/ping"))
+      .orNotFound(Request(uri = uri"/public/ping"))
       .map(_.status)
       .assertEquals(Status.Ok) *>
       router
-        .orNotFound(Request[IO](uri = uri"/public/ping/"))
+        .orNotFound(Request(uri = uri"/public/ping/"))
         .map(_.status)
         .assertEquals(Status.Ok)
   }
 
   test("Be created via httpRoutes constructor") {
-    val req = Request[IO](uri = uri"/ping/")
+    val req = Request(uri = uri"/ping/")
     AutoSlash.httpRoutes(route).orNotFound(req).map(_.status).assertEquals(Status.Ok)
   }
 }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/BracketRequestResponseSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/BracketRequestResponseSuite.scala
@@ -40,7 +40,7 @@ final class BracketRequestResponseSuite extends Http4sSuite {
           OptionT.liftF(
             IO(Response(status = Status.Ok).withEntity(contextRequest.context.toString))))
       )
-      response <- routes.run(Request[IO]()).getOrElseF(IO(fail("Got None for response")))
+      response <- routes.run(Request()).getOrElseF(IO(fail("Got None for response")))
       acquireCount <- acquireRef.get
       responseBody <- response.as[String]
       releaseCount <- releaseRef.get
@@ -64,7 +64,7 @@ final class BracketRequestResponseSuite extends Http4sSuite {
             _ + 1L)
         }
       routes = middleware(Kleisli(Function.const(OptionT.liftF(IO.raiseError(error)))))
-      response <- routes.run(Request[IO]()).value.attempt
+      response <- routes.run(Request()).value.attempt
       acquireCount <- acquireRef.get
       releaseCount <- releaseRef.get
     } yield {
@@ -85,7 +85,7 @@ final class BracketRequestResponseSuite extends Http4sSuite {
             .update(_ + 1L)
         }
       routes = middleware(Kleisli(Function.const(OptionT.none)))
-      response <- routes.run(Request[IO]()).value
+      response <- routes.run(Request()).value
       acquireCount <- acquireRef.get
       releaseCount <- releaseRef.get
     } yield {
@@ -115,11 +115,11 @@ final class BracketRequestResponseSuite extends Http4sSuite {
       acquireCount0 <- acquireRef.get
       releaseCount0 <- releaseRef.get
       // T1
-      response1 <- routes.run(Request[IO]())
+      response1 <- routes.run(Request())
       acquireCount1 <- acquireRef.get
       releaseCount1 <- releaseRef.get
       // T2
-      response2 <- routes.run(Request[IO]())
+      response2 <- routes.run(Request())
       acquireCount2 <- acquireRef.get
       releaseCount2 <- releaseRef.get
       // T3
@@ -174,7 +174,7 @@ final class BracketRequestResponseSuite extends Http4sSuite {
               IO(Response(status = Status.Ok).withBodyStream(Stream.raiseError[IO](error)))))
         )
       ).orNotFound
-      response <- routes.run(Request[IO]())
+      response <- routes.run(Request())
       acquireCount <- acquireRef.get
       responseBody <- response.as[String].attempt
       releaseCount <- releaseRef.get
@@ -194,7 +194,7 @@ final class BracketRequestResponseSuite extends Http4sSuite {
       }
     val routes: HttpRoutes[IO] = middleware(Kleisli(Function.const(OptionT.none)))
     for {
-      response <- routes.run(Request[IO]()).value.attempt
+      response <- routes.run(Request()).value.attempt
     } yield assertEquals(response, Left(error))
   }
 
@@ -216,7 +216,7 @@ final class BracketRequestResponseSuite extends Http4sSuite {
           OptionT.liftF(
             IO(Response(status = Status.Ok).withEntity(contextRequest.context.toString))))
       ).orNotFound
-      response <- routes.run(Request[IO]())
+      response <- routes.run(Request())
       acquireCount <- acquireRef.get
       responseBody <- response.as[String].attempt
       releaseCount <- releaseRef.get

--- a/server/shared/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
@@ -30,15 +30,15 @@ import scala.concurrent.duration._
 
 class CORSSuite extends Http4sSuite {
   val routes = HttpRoutes.of[IO] {
-    case req if req.pathInfo === path"/foo" => Response[IO](Ok).withEntity("foo").pure[IO]
+    case req if req.pathInfo === path"/foo" => Response(Ok).withEntity("foo").pure[IO]
     case req if req.pathInfo === path"/vary" =>
-      Response[IO](Ok).putHeaders(Header.Raw(ci"Vary", "X-Old-Vary")).pure[IO]
+      Response(Ok).putHeaders(Header.Raw(ci"Vary", "X-Old-Vary")).pure[IO]
   }
   val app = routes.orNotFound
 
   val exampleOrigin = Origin.Host(Uri.Scheme.https, Uri.RegName("example.com"), None)
 
-  def nonCorsReq = Request[IO](uri = uri"/foo")
+  def nonCorsReq = Request(uri = uri"/foo")
   def nonPreflightReq = nonCorsReq.putHeaders(exampleOrigin: Origin)
   def preflightReq = nonPreflightReq
     .withMethod(Method.OPTIONS)
@@ -691,8 +691,8 @@ class CORSSuite extends Http4sSuite {
 @deprecated("This suite tests a deprecated feature", "0.21.27")
 class CORSDeprecatedSuite extends Http4sSuite {
   val routes = HttpRoutes.of[IO] {
-    case req if req.pathInfo === path"/foo" => Response[IO](Ok).withEntity("foo").pure[IO]
-    case req if req.pathInfo === path"/bar" => Response[IO](Unauthorized).withEntity("bar").pure[IO]
+    case req if req.pathInfo === path"/foo" => Response(Ok).withEntity("foo").pure[IO]
+    case req if req.pathInfo === path"/bar" => Response(Unauthorized).withEntity("bar").pure[IO]
   }
 
   val cors1 = CORS(routes)
@@ -713,7 +713,7 @@ class CORSDeprecatedSuite extends Http4sSuite {
     hs.get(name).fold(false)(_.exists(_.value === expected))
 
   def buildRequest(path: String, method: Method = GET) =
-    Request[IO](uri = Uri(path = Uri.Path.unsafeFromString(path)), method = method)
+    Request(uri = Uri(path = Uri.Path.unsafeFromString(path)), method = method)
       .withHeaders("Origin" -> "http://allowed.com", "Access-Control-Request-Method" -> "GET")
 
   test("Be omitted when unrequested") {
@@ -806,7 +806,7 @@ class CORSDeprecatedSuite extends Http4sSuite {
   test("Not replace vary header if already set") {
     val req = buildRequest("/")
     val service = CORS(HttpRoutes.of[IO] { case GET -> Root =>
-      Response[IO](Ok)
+      Response(Ok)
         .putHeaders("Vary" -> "Origin,Accept")
         .withEntity("foo")
         .pure[IO]

--- a/server/shared/src/test/scala/org/http4s/server/middleware/CSRFSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/CSRFSuite.scala
@@ -63,9 +63,9 @@ class CSRFSuite extends Http4sSuite {
     .orNotFound
 
   private val dummyRequest: Request[IO] =
-    Request[IO](method = Method.POST).putHeaders("Origin" -> "http://localhost")
+    Request(method = Method.POST).putHeaders("Origin" -> "http://localhost")
 
-  private val passThroughRequest: Request[IO] = Request[IO]()
+  private val passThroughRequest: Request[IO] = Request()
 
   private val csrfIO: IO[CSRF[IO, IO]] = CSRF
     .withGeneratedKey[IO, IO](defaultOriginCheck)
@@ -85,7 +85,7 @@ class CSRFSuite extends Http4sSuite {
       _.withClock(testClock)
         .withCookieName(cookieName)
         .withOnFailure(
-          Response[IO](status = Status.SeeOther, headers = Headers(Location(uri"/")))
+          Response(status = Status.SeeOther, headers = Headers(Location(uri"/")))
             .removeCookie(cookieName)
         )
         .build)
@@ -151,7 +151,7 @@ class CSRFSuite extends Http4sSuite {
     for {
       csrf <- csrfIO
       token <- csrf.generateToken[IO]
-      req = csrf.embedInRequestCookie(Request[IO](POST), token)
+      req = csrf.embedInRequestCookie(Request(POST), token)
       v <- csrf.checkCSRF(req, dummyRoutes.run(req))
     } yield assertEquals(v.status, Status.Forbidden)
   }
@@ -213,7 +213,7 @@ class CSRFSuite extends Http4sSuite {
       token <- csrf.generateToken[IO]
       res <- csrf.validate()(dummyRoutes)(
         csrf.embedInRequestCookie(
-          Request[IO](POST)
+          Request(POST)
             .putHeaders(headerName.toString -> unlift(token), Referer(uri"http://localhost/lol")),
           token)
       )
@@ -224,7 +224,7 @@ class CSRFSuite extends Http4sSuite {
     for {
       csrf <- csrfIO
       token <- csrf.generateToken[IO]
-      req = csrf.embedInRequestCookie(Request[IO](POST), token)
+      req = csrf.embedInRequestCookie(Request(POST), token)
       v <- csrf.checkCSRF(req, dummyRoutes.run(req))
     } yield assertEquals(v.status, Status.Forbidden)
   }
@@ -234,7 +234,7 @@ class CSRFSuite extends Http4sSuite {
       csrf <- csrfIO
       token <- csrf.generateToken[IO]
       res <- csrf.validate()(dummyRoutes)(
-        Request[IO](POST)
+        Request(POST)
           .putHeaders(
             headerName.toString -> unlift(token),
             "Origin" -> "http://example.com",
@@ -366,7 +366,7 @@ class CSRFSuite extends Http4sSuite {
       for {
         csrfCatchFailure <- csrfCatchFailureIO
         token <- csrfCatchFailure.generateToken[IO]
-        req = csrfCatchFailure.embedInRequestCookie(Request[IO](POST), token)
+        req = csrfCatchFailure.embedInRequestCookie(Request(POST), token)
         v <- csrfCatchFailure.checkCSRF(req, dummyRoutes.run(req))
       } yield assertEquals(v.status, Status.SeeOther)
     }
@@ -383,7 +383,7 @@ class CSRFSuite extends Http4sSuite {
         csrfCatchFailure <- csrfCatchFailureIO
         token <- csrfCatchFailure.generateToken[IO]
         res <- csrfCatchFailure.validate()(dummyRoutes)(
-          Request[IO](POST)
+          Request(POST)
             .putHeaders(
               headerName.toString -> unlift(token),
               "Origin" -> "http://example.com",

--- a/server/shared/src/test/scala/org/http4s/server/middleware/CSRFSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/CSRFSuite.scala
@@ -50,8 +50,8 @@ class CSRFSuite extends Http4sSuite {
   private val cookieName = "csrf-token"
   private val headerName = ci"X-Csrf-Token"
 
-  private val defaultOriginCheck: Request[IO] => Boolean =
-    CSRF.defaultOriginCheck[IO](_, "localhost", Uri.Scheme.http, None)
+  private val defaultOriginCheck: AnyRequest => Boolean =
+    CSRF.defaultOriginCheck(_, "localhost", Uri.Scheme.http, None)
 
   private val dummyRoutes: HttpApp[IO] = HttpRoutes
     .of[IO] {

--- a/server/shared/src/test/scala/org/http4s/server/middleware/DateSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/DateSuite.scala
@@ -25,14 +25,14 @@ import org.http4s.syntax.all._
 class DateSuite extends Http4sSuite {
 
   val service: HttpRoutes[IO] = HttpRoutes.of[IO] { case _ =>
-    Response[IO](Status.Ok).pure[IO]
+    Response(Status.Ok).pure[IO]
   }
 
   // Hack for https://github.com/typelevel/cats-effect/pull/682
   val testService = Date(service)
   val testApp = Date(service.orNotFound)
 
-  val req = Request[IO]()
+  val req = Request()
 
   test("Date should always be very shortly before the current time httpRoutes") {
     (for {
@@ -57,7 +57,7 @@ class DateSuite extends Http4sSuite {
   test("Date should not override a set date header") {
     val service = HttpRoutes
       .of[IO] { case _ =>
-        Response[IO](Status.Ok)
+        Response(Status.Ok)
           .putHeaders(HDate(HttpDate.Epoch))
           .pure[IO]
       }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
@@ -40,19 +40,19 @@ class DefaultHeadSuite extends Http4sSuite {
   val app = DefaultHead(httpRoutes).orNotFound
 
   test("honor HEAD routes") {
-    val req = Request[IO](Method.HEAD, uri = uri"/special")
+    val req = Request(Method.HEAD, uri = uri"/special")
     app(req)
       .map(_.headers.get(ci"X-Handled-By").map(_.head.value))
       .assertEquals(Some("HEAD"))
   }
 
   test("return truncated body of corresponding GET on fallthrough") {
-    val req = Request[IO](Method.HEAD, uri = uri"/hello")
+    val req = Request(Method.HEAD, uri = uri"/hello")
     app(req).flatMap(_.as[String]).assertEquals("")
   }
 
   test("retain all headers of corresponding GET on fallthrough") {
-    val get = Request[IO](Method.GET, uri = uri"/hello")
+    val get = Request(Method.GET, uri = uri"/hello")
     val head = get.withMethod(Method.HEAD)
     val getHeaders = app(get).map(_.headers)
     val headHeaders = app(head).map(_.headers)
@@ -68,14 +68,14 @@ class DefaultHeadSuite extends Http4sSuite {
         Ok(body)
       }
       app = DefaultHead(route).orNotFound
-      resp <- app(Request[IO](Method.HEAD))
+      resp <- app(Request(Method.HEAD))
       _ <- resp.body.compile.drain
       leaked <- open.get
     } yield leaked).assertEquals(false)
   }
 
   test("be created via the httpRoutes constructor") {
-    val req = Request[IO](Method.HEAD, uri = uri"/hello")
+    val req = Request(Method.HEAD, uri = uri"/hello")
     DefaultHead.httpRoutes(httpRoutes).orNotFound(req).flatMap(_.as[String]).assertEquals("")
   }
 }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
@@ -30,14 +30,14 @@ import org.http4s.server.middleware.EntityLimiter.EntityTooLarge
 
 class EntityLimiterSuite extends Http4sSuite {
   val routes = HttpRoutes.of[IO] {
-    case r if r.pathInfo == path"/echo" => r.decode[String](Response[IO](Ok).withEntity(_).pure[IO])
+    case r if r.pathInfo == path"/echo" => r.decode[String](Response(Ok).withEntity(_).pure[IO])
   }
 
   val b = chunk(Chunk.array("hello".getBytes(StandardCharsets.UTF_8)))
 
   test("Allow reasonable entities") {
     EntityLimiter(routes, 100)
-      .apply(Request[IO](POST, uri"/echo", body = b))
+      .apply(Request(POST, uri"/echo", body = b))
       .map(_ => -1)
       .value
       .assertEquals(Some(-1))
@@ -45,7 +45,7 @@ class EntityLimiterSuite extends Http4sSuite {
 
   test("Limit the maximum size of an EntityBody") {
     EntityLimiter(routes, 3)
-      .apply(Request[IO](POST, uri"/echo", body = b))
+      .apply(Request(POST, uri"/echo", body = b))
       .map(_ => -1L)
       .value
       .handleError { case EntityTooLarge(i) => Some(i) }
@@ -55,16 +55,16 @@ class EntityLimiterSuite extends Http4sSuite {
   test("Chain correctly with other HttpRoutes") {
     val routes2 = HttpRoutes.of[IO] {
       case r if r.pathInfo == path"/echo2" =>
-        r.decode[String](Response[IO](Ok).withEntity(_).pure[IO])
+        r.decode[String](Response(Ok).withEntity(_).pure[IO])
     }
 
     val st = EntityLimiter(routes, 3) <+> routes2
 
-    st.apply(Request[IO](POST, uri"/echo2", body = b))
+    st.apply(Request(POST, uri"/echo2", body = b))
       .map(_ => -1)
       .value
       .assertEquals(Some(-1)) *>
-      st.apply(Request[IO](POST, uri"/echo", body = b))
+      st.apply(Request(POST, uri"/echo", body = b))
         .map(_ => -1L)
         .value
         .handleError { case EntityTooLarge(i) => Some(i) }
@@ -74,7 +74,7 @@ class EntityLimiterSuite extends Http4sSuite {
   test("Be created via the httpRoutes constructor") {
     EntityLimiter
       .httpRoutes(routes, 3)
-      .apply(Request[IO](POST, uri"/echo", body = b))
+      .apply(Request(POST, uri"/echo", body = b))
       .map(_ => -1L)
       .value
       .handleError { case EntityTooLarge(i) => Some(i) }
@@ -86,7 +86,7 @@ class EntityLimiterSuite extends Http4sSuite {
 
     EntityLimiter
       .httpApp(app, 3L)
-      .apply(Request[IO](POST, uri"/echo", body = b))
+      .apply(Request(POST, uri"/echo", body = b))
       .map(_ => -1L)
       .handleError { case EntityTooLarge(i) => i }
       .assertEquals(3L)

--- a/server/shared/src/test/scala/org/http4s/server/middleware/ErrorActionSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/ErrorActionSuite.scala
@@ -32,7 +32,7 @@ class ErrorActionSuite extends Http4sSuite {
       IO.raiseError(error)
     }
 
-  val req = Request[IO](
+  val req = Request(
     GET,
     uri"/error",
     attributes = Vault.empty.insert(

--- a/server/shared/src/test/scala/org/http4s/server/middleware/ErrorHandlingSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/ErrorHandlingSuite.scala
@@ -27,7 +27,7 @@ class ErrorHandlingSuite extends Http4sSuite {
       IO.raiseError(t)
     }
 
-  val request = Request[IO](GET, uri"/error")
+  val request = Request(GET, uri"/error")
 
   test("Handle errors based on the default service error handler") {
     ErrorHandling(

--- a/server/shared/src/test/scala/org/http4s/server/middleware/HSTSSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/HSTSSuite.scala
@@ -30,7 +30,7 @@ class HSTSSuite extends Http4sSuite {
     Ok("pong")
   }
 
-  val req = Request[IO](Method.GET, uri"/")
+  val req = Request(Method.GET, uri"/")
 
   test("add the Strict-Transport-Security header") {
     List(

--- a/server/shared/src/test/scala/org/http4s/server/middleware/HeaderEchoSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/HeaderEchoSuite.scala
@@ -31,7 +31,7 @@ class HeaderEchoSuite extends Http4sSuite {
 
   def testSingleHeader[F[_]: Functor, G[_]](testee: Http[F, G]) = {
     val requestMatchingSingleHeaderKey =
-      Request[G](
+      Request(
         uri = uri"/request",
         headers = Headers("someheaderkey" -> "someheadervalue")
       )
@@ -53,7 +53,7 @@ class HeaderEchoSuite extends Http4sSuite {
 
   test("echo multiple headers") {
     val requestMatchingMultipleHeaderKeys =
-      Request[IO](
+      Request(
         uri = uri"/request",
         headers =
           Headers("someheaderkey" -> "someheadervalue", "anotherheaderkey" -> "anotherheadervalue"))
@@ -75,9 +75,7 @@ class HeaderEchoSuite extends Http4sSuite {
 
   test("echo only the default headers where none match the key") {
     val requestMatchingNotPresentHeaderKey =
-      Request[IO](
-        uri = uri"/request",
-        headers = Headers("someunmatchedheader" -> "someunmatchedvalue"))
+      Request(uri = uri"/request", headers = Headers("someunmatchedheader" -> "someunmatchedvalue"))
 
     val testee = HeaderEcho(_ == ci"someheaderkey")(testService)
     testee

--- a/server/shared/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSuite.scala
@@ -77,7 +77,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   }
 
   test("ignore method override if request method not in the overridable method list") {
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withMethod(GET)
       .withHeaders(overrideHeader -> "PUT")
     val app = HttpMethodOverrider(testApp, noMethodHeaderOverriderConfig)
@@ -96,7 +96,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "override request method when using header method overrider strategy if override method provided") {
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(overrideHeader -> "PUT")
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -116,7 +116,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "not override request method when using header method overrider strategy if override method not provided") {
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withMethod(DELETE)
     val app = HttpMethodOverrider(testApp, deleteHeaderOverriderConfig)
 
@@ -135,7 +135,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "override request method and store the original method when using query method overrider strategy") {
-    val req = Request[IO](uri = uri"/resources/id?_method=PUT")
+    val req = Request(uri = uri"/resources/id?_method=PUT")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -153,7 +153,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "not override request method when using query method overrider strategy if override method not provided") {
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withMethod(DELETE)
     val app = HttpMethodOverrider(testApp, deleteQueryOverriderConfig)
 
@@ -173,7 +173,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "override request method and store the original method when using form method overrider strategy") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "PUT")
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -193,7 +193,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "not override request method when using form method overrider strategy if override method not provided") {
     val urlForm = UrlForm("foo" -> "bar")
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(DELETE)
     val app = HttpMethodOverrider(testApp, deleteFormOverriderConfig)
@@ -212,7 +212,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "return 404 when using header method overrider strategy if override method provided is not recognized") {
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(overrideHeader -> "INVALID")
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -222,7 +222,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "return 404 when using query method overrider strategy if override method provided is not recognized") {
-    val req = Request[IO](uri = uri"/resources/id?_method=INVALID")
+    val req = Request(uri = uri"/resources/id?_method=INVALID")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -232,7 +232,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "return 404 when using form method overrider strategy if override method provided is not recognized") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "INVALID")
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -242,7 +242,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "return 400 when using header method overrider strategy if override method provided is duped") {
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(overrideHeader -> "")
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -252,7 +252,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "return 400 when using query method overrider strategy if override method provided is duped") {
-    val req = Request[IO](uri = uri"/resources/id?_method=")
+    val req = Request(uri = uri"/resources/id?_method=")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -262,7 +262,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "return 400 when using form method overrider strategy if override method provided is duped") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "")
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -272,7 +272,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "override request method when using header method overrider strategy and be case insensitive") {
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(overrideHeader -> "pUt")
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -293,7 +293,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "override request method when using query method overrider strategy and be case insensitive") {
-    val req = Request[IO](uri = uri"/resources/id?_method=pUt")
+    val req = Request(uri = uri"/resources/id?_method=pUt")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -312,7 +312,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "override request method when form query method overrider strategy and be case insensitive") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "pUt")
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -331,7 +331,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "updates vary header when using query method overrider strategy and vary header comes pre-populated") {
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(overrideHeader -> "PUT")
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -353,7 +353,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "set vary header when using header method overrider strategy and vary header has not been set") {
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withMethod(POST)
       .withHeaders(overrideHeader -> "DELETE")
     val app = HttpMethodOverrider(testApp, postHeaderOverriderConfig)
@@ -373,7 +373,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "not set vary header when using query method overrider strategy and vary header has not been set") {
-    val req = Request[IO](uri = uri"/resources/id?_method=DELETE")
+    val req = Request(uri = uri"/resources/id?_method=DELETE")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -393,7 +393,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   test(
     "not update vary header when using query method overrider strategy and vary header comes pre-populated") {
-    val req = Request[IO](uri = uri"/resources/id?_method=PUT")
+    val req = Request(uri = uri"/resources/id?_method=PUT")
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postQueryOverriderConfig)
 
@@ -414,7 +414,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "not set vary header when using form method overrider strategy and vary header has not been set") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "DELETE")
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)
@@ -434,7 +434,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
   test(
     "not update vary header when using form method overrider strategy and vary header comes pre-populated") {
     val urlForm = UrlForm("foo" -> "bar", overrideField -> "PUT")
-    val req = Request[IO](uri = uri"/resources/id")
+    val req = Request(uri = uri"/resources/id")
       .withEntity(urlForm)
       .withMethod(POST)
     val app = HttpMethodOverrider(testApp, postFormOverriderConfig)

--- a/server/shared/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/HttpMethodOverriderSuite.scala
@@ -56,7 +56,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
 
   private val testApp = Router("/" -> HttpRoutes.of[IO] {
     case r @ GET -> Root / "resources" / "id" =>
-      Ok(responseText[IO](msg = "resource's details", r))
+      Ok(responseText(msg = "resource's details", r))
     case r @ PUT -> Root / "resources" / "id" =>
       Ok(responseText(msg = "resource updated", r), varyHeader -> customHeader)
     case r @ DELETE -> Root / "resources" / "id" =>
@@ -71,7 +71,7 @@ class HttpMethodOverriderSuite extends Http4sSuite {
       .map(om => s"[$om ~> $reqMethod] => $msg")
       .getOrElse(s"[$reqMethod] => $msg")
 
-  private def responseText[F[_]](msg: String, req: Request[F]): String = {
+  private def responseText(msg: String, req: AnyRequest): String = {
     val overriddenMethod = req.attributes.lookup(HttpMethodOverrider.overriddenMethodAttrKey)
     mkResponseText(msg, req.method, overriddenMethod)
   }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/HttpsRedirectSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/HttpsRedirectSuite.scala
@@ -32,7 +32,7 @@ class HttpsRedirectSuite extends Http4sSuite {
   }
 
   val reqHeaders = Headers("X-Forwarded-Proto" -> "http", Host("example.com"))
-  val req = Request[IO](method = GET, uri = Uri(path = Uri.Path.Root), headers = reqHeaders)
+  val req = Request(method = GET, uri = Uri(path = Uri.Path.Root), headers = reqHeaders)
 
   test("redirect to https when 'X-Forwarded-Proto' is http") {
     List(
@@ -59,7 +59,7 @@ class HttpsRedirectSuite extends Http4sSuite {
       HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
       HttpsRedirect.httpApp(innerRoutes.orNotFound)
     ).traverse { app =>
-      val noHeadersReq = Request[IO](method = GET, uri = Uri(path = Uri.Path.Root))
+      val noHeadersReq = Request(method = GET, uri = Uri(path = Uri.Path.Root))
       app(noHeadersReq).map(_.status).assertEquals(Status.Ok) *>
         app(noHeadersReq).flatMap(_.as[String]).assertEquals("pong")
     }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/MaxActiveRequestsSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/MaxActiveRequestsSuite.scala
@@ -23,7 +23,7 @@ import org.http4s._
 import org.http4s.syntax.all._
 
 class MaxActiveRequestsSuite extends Http4sSuite {
-  val req = Request[IO]()
+  val req = Request()
 
   def routes(startedGate: Deferred[IO, Unit], deferred: Deferred[IO, Unit]) =
     Kleisli { (req: Request[IO]) =>

--- a/server/shared/src/test/scala/org/http4s/server/middleware/RequestIdSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/RequestIdSuite.scala
@@ -42,7 +42,7 @@ class RequestIdSuite extends Http4sSuite {
 
   test("propagate X-Request-ID header from request to response") {
     val req =
-      Request[IO](uri = uri"/request", headers = Headers("X-Request-ID" -> "123"))
+      Request(uri = uri"/request", headers = Headers("X-Request-ID" -> "123"))
     RequestId
       .httpRoutes(testService())
       .orNotFound(req)
@@ -54,7 +54,7 @@ class RequestIdSuite extends Http4sSuite {
   }
 
   test("generate X-Request-ID header when unset") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     RequestId
       .httpRoutes(testService())
       .orNotFound(req)
@@ -68,7 +68,7 @@ class RequestIdSuite extends Http4sSuite {
   }
 
   test("generate different request ids on subsequent requests") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     val resp = RequestId.httpRoutes(testService()).orNotFound(req)
     (resp.map(requestIdFromHeaders(_)), resp.map(requestIdFromHeaders(_)))
       .parMapN(_ =!= _)
@@ -76,7 +76,7 @@ class RequestIdSuite extends Http4sSuite {
   }
 
   test("propagate custom request id header from request to response") {
-    val req = Request[IO](
+    val req = Request(
       uri = uri"/request",
       headers = Headers("X-Request-ID" -> "123", "X-Correlation-ID" -> "abc"))
     RequestId
@@ -93,7 +93,7 @@ class RequestIdSuite extends Http4sSuite {
 
   test("generate custom request id header when unset") {
     val req =
-      Request[IO](uri = uri"/request", headers = Headers("X-Request-ID" -> "123"))
+      Request(uri = uri"/request", headers = Headers("X-Request-ID" -> "123"))
     RequestId
       .httpRoutes(ci"X-Correlation-ID")(testService(ci"X-Correlation-ID"))
       .orNotFound(req)
@@ -108,7 +108,7 @@ class RequestIdSuite extends Http4sSuite {
 
   test("generate X-Request-ID header when unset using supplied generator") {
     val uuid = UUID.fromString("00000000-0000-0000-0000-000000000000")
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     RequestId
       .httpRoutes(genReqId = IO.pure(uuid))(testService())
       .orNotFound(req)
@@ -123,7 +123,7 @@ class RequestIdSuite extends Http4sSuite {
 
   test("include requestId attribute with request and response") {
     val req =
-      Request[IO](uri = uri"/attribute", headers = Headers("X-Request-ID" -> "123"))
+      Request(uri = uri"/attribute", headers = Headers("X-Request-ID" -> "123"))
     RequestId
       .httpRoutes(testService())
       .orNotFound(req)

--- a/server/shared/src/test/scala/org/http4s/server/middleware/ResponseTimingSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/ResponseTimingSuite.scala
@@ -39,7 +39,7 @@ class ResponseTimingSuite extends Http4sSuite {
   }
 
   test("add a custom header with timing info") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     val app = ResponseTiming(thisService)
     val res = app(req)
 

--- a/server/shared/src/test/scala/org/http4s/server/middleware/StaticHeadersSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/StaticHeadersSuite.scala
@@ -31,7 +31,7 @@ class StaticHeadersSuite extends Http4sSuite {
   }
 
   test("add a no-cache header to a response") {
-    val req = Request[IO](uri = uri"/request")
+    val req = Request(uri = uri"/request")
     val resp = StaticHeaders.`no-cache`(testService).orNotFound(req)
 
     resp

--- a/server/shared/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
@@ -131,8 +131,8 @@ class ThrottleSuite extends Http4sSuite {
       override def takeToken: IO[TokenAvailability] = TokenAvailable.pure[IO]
     }
 
-    val testee = Throttle(limitNotReachedBucket, defaultResponse[IO] _)(alwaysOkApp)
-    val req = Request[IO](uri = uri"/")
+    val testee = Throttle.app(limitNotReachedBucket)(alwaysOkApp)
+    val req = Request(uri = uri"/")
 
     testee(req).map(_.status === Status.Ok).assert
   }
@@ -142,8 +142,8 @@ class ThrottleSuite extends Http4sSuite {
       override def takeToken: IO[TokenAvailability] = TokenUnavailable(None).pure[IO]
     }
 
-    val testee = Throttle(limitReachedBucket, defaultResponse[IO] _)(alwaysOkApp)
-    val req = Request[IO](uri = uri"/")
+    val testee = Throttle.app(limitReachedBucket)(alwaysOkApp)
+    val req = Request(uri = uri"/")
 
     testee(req).map(_.status === Status.TooManyRequests).assert
   }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
@@ -55,7 +55,7 @@ class TimeoutSuite extends Http4sSuite {
   }
 
   test("return the provided response if the result takes too long") {
-    val customTimeout = Response(Status.GatewayTimeout) // some people return 504 here.
+    val customTimeout = Response[IO](Status.GatewayTimeout) // some people return 504 here.
     val altTimeoutService =
       TimeoutMiddleware(1.nanosecond, OptionT.pure[IO](customTimeout))(routes)
     checkStatus(altTimeoutService.orNotFound(neverReq), customTimeout.status)

--- a/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
@@ -39,8 +39,8 @@ class TimeoutSuite extends Http4sSuite {
 
   val app = TimeoutMiddleware(5.milliseconds)(routes).orNotFound
 
-  val fastReq = Request[IO](GET, uri"/fast")
-  val neverReq = Request[IO](GET, uri"/never")
+  val fastReq = Request(GET, uri"/fast")
+  val neverReq = Request(GET, uri"/never")
 
   def checkStatus(resp: IO[Response[IO]], status: Status): IO[Unit] =
     IO.race(IO.sleep(3.seconds), resp.map(_.status)).assertEquals(Right(status))
@@ -55,7 +55,7 @@ class TimeoutSuite extends Http4sSuite {
   }
 
   test("return the provided response if the result takes too long") {
-    val customTimeout = Response[IO](Status.GatewayTimeout) // some people return 504 here.
+    val customTimeout = Response(Status.GatewayTimeout) // some people return 504 here.
     val altTimeoutService =
       TimeoutMiddleware(1.nanosecond, OptionT.pure[IO](customTimeout))(routes)
     checkStatus(altTimeoutService.orNotFound(neverReq), customTimeout.status)
@@ -67,7 +67,7 @@ class TimeoutSuite extends Http4sSuite {
       IO.never.guarantee(IO(canceled.set(true)))
     }
     val app = TimeoutMiddleware(1.millis)(routes).orNotFound
-    checkStatus(app(Request[IO]()), Status.ServiceUnavailable) *>
+    checkStatus(app(Request()), Status.ServiceUnavailable) *>
       // Give the losing response enough time to finish
       IO.sleep(100.milliseconds) *> IO(canceled.get)
   }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/TranslateUriSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/TranslateUriSuite.scala
@@ -37,28 +37,28 @@ class TranslateUriSuite extends Http4sSuite {
   val trans2 = TranslateUri("http4s")(routes).orNotFound
 
   test("match a matching request") {
-    val req = Request[IO](uri = uri"/http4s/foo")
+    val req = Request(uri = uri"/http4s/foo")
     trans1(req).map(_.status).assertEquals(Ok) *>
       trans2(req).map(_.status).assertEquals(Ok) *>
       routes.orNotFound(req).map(_.status).assertEquals(NotFound)
   }
 
   test("not match a request missing the prefix") {
-    val req = Request[IO](uri = uri"/foo")
+    val req = Request(uri = uri"/foo")
     trans1(req).map(_.status).assertEquals(NotFound) *>
       trans2(req).map(_.status).assertEquals(NotFound) *>
       routes.orNotFound(req).map(_.status).assertEquals(Ok)
   }
 
   test("not match a request with a different prefix") {
-    val req = Request[IO](uri = uri"/http5s/foo")
+    val req = Request(uri = uri"/http5s/foo")
     trans1(req).map(_.status).assertEquals(NotFound) *>
       trans2(req).map(_.status).assertEquals(NotFound) *>
       routes.orNotFound(req).map(_.status).assertEquals(NotFound)
   }
 
   test("split the Uri into scriptName and pathInfo") {
-    val req = Request[IO](uri = uri"/http4s/checkattr")
+    val req = Request(uri = uri"/http4s/checkattr")
     trans1(req)
       .map(_.status === Ok) *>
       trans1(req)
@@ -70,7 +70,7 @@ class TranslateUriSuite extends Http4sSuite {
     val emptyPrefix = TranslateUri("")(routes)
     val slashPrefix = TranslateUri("/")(routes)
 
-    val req = Request[IO](uri = uri"/foo")
+    val req = Request(uri = uri"/foo")
     emptyPrefix.orNotFound(req).map(_.status).assertEquals(Ok) *>
       slashPrefix.orNotFound(req).map(_.status).assertEquals(Ok)
   }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/UrlFormLifterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/UrlFormLifterSuite.scala
@@ -37,13 +37,13 @@ class UrlFormLifterSuite extends Http4sSuite {
   }).orNotFound
 
   test("Add application/x-www-form-urlencoded bodies to the query params") {
-    val req = Request[IO](method = POST).withEntity(urlForm).pure[IO]
+    val req = Request(method = POST).withEntity(urlForm).pure[IO]
     req.flatMap(app.run).map(_.status).assertEquals(Ok)
   }
 
   test("Add application/x-www-form-urlencoded bodies after query params") {
     val req =
-      Request[IO](method = Method.POST, uri = uri"/foo?foo=biz")
+      Request(method = Method.POST, uri = uri"/foo?foo=biz")
         .withEntity(urlForm)
         .pure[IO]
     req.flatMap(app.run).map(_.status).assertEquals(Ok) *>
@@ -51,7 +51,7 @@ class UrlFormLifterSuite extends Http4sSuite {
   }
 
   test("Ignore Requests that don't have application/x-www-form-urlencoded bodies") {
-    val req = Request[IO](method = Method.POST).withEntity("foo").pure[IO]
+    val req = Request(method = Method.POST).withEntity("foo").pure[IO]
     req.flatMap(app.run).map(_.status).assertEquals(BadRequest)
   }
 }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -27,15 +27,15 @@ import org.http4s.headers.Host
 
 class VirtualHostSuite extends Http4sSuite {
   val default = HttpRoutes.of[IO] { case _ =>
-    Response[IO](Ok).withEntity("default").pure[IO]
+    Response(Ok).withEntity("default").pure[IO]
   }
 
   val routesA = HttpRoutes.of[IO] { case _ =>
-    Response[IO](Ok).withEntity("routesA").pure[IO]
+    Response(Ok).withEntity("routesA").pure[IO]
   }
 
   val routesB = HttpRoutes.of[IO] { case _ =>
-    Response[IO](Ok).withEntity("routesB").pure[IO]
+    Response(Ok).withEntity("routesB").pure[IO]
   }
 
   val vhostExact = VirtualHost(
@@ -45,36 +45,36 @@ class VirtualHostSuite extends Http4sSuite {
   ).orNotFound
 
   test("exact should return a 400 BadRequest when no header is present on a NON HTTP/1.0 request") {
-    val req1 = Request[IO](GET, uri"/numbers/1", httpVersion = HttpVersion.`HTTP/1.1`)
-    val req2 = Request[IO](GET, uri"/numbers/1", httpVersion = HttpVersion.`HTTP/2.0`)
+    val req1 = Request(GET, uri"/numbers/1", httpVersion = HttpVersion.`HTTP/1.1`)
+    val req2 = Request(GET, uri"/numbers/1", httpVersion = HttpVersion.`HTTP/2.0`)
 
     vhostExact(req1).map(_.status).assertEquals(BadRequest) *>
       vhostExact(req2).map(_.status).assertEquals(BadRequest)
   }
 
   test("exact should honor the Host header host") {
-    val req = Request[IO](GET, uri"/numbers/1")
+    val req = Request(GET, uri"/numbers/1")
       .withHeaders(Host("routesA"))
 
     vhostExact(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
   test("exact should honor the Host header port") {
-    val req = Request[IO](GET, uri"/numbers/1")
+    val req = Request(GET, uri"/numbers/1")
       .withHeaders(Host("routesB", Some(80)))
 
     vhostExact(req).flatMap(_.as[String]).assertEquals("routesB")
   }
 
   test("exact should ignore the Host header port if not specified") {
-    val good = Request[IO](GET, uri"/numbers/1")
+    val good = Request(GET, uri"/numbers/1")
       .withHeaders(Host("routesA", Some(80)))
 
     vhostExact(good).flatMap(_.as[String]).assertEquals("routesA")
   }
 
   test("exact should result in a 404 if the hosts fail to match") {
-    val req = Request[IO](GET, uri"/numbers/1")
+    val req = Request(GET, uri"/numbers/1")
       .withHeaders(Host("routesB", Some(8000)))
 
     vhostExact(req).map(_.status).assertEquals(NotFound)
@@ -87,21 +87,21 @@ class VirtualHostSuite extends Http4sSuite {
   ).orNotFound
 
   test("wildcard match an exact route") {
-    val req = Request[IO](GET, uri"/numbers/1")
+    val req = Request(GET, uri"/numbers/1")
       .withHeaders(Host("routesa", Some(80)))
 
     vhostWildcard(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
   test("wildcard allow for a dash in the service") {
-    val req = Request[IO](GET, uri"/numbers/1")
+    val req = Request(GET, uri"/numbers/1")
       .withHeaders(Host("foo.foo-service", Some(80)))
 
     vhostWildcard(req).flatMap(_.as[String]).assertEquals("default")
   }
 
   test("wildcard match a route with a wildcard route") {
-    val req = Request[IO](GET, uri"/numbers/1")
+    val req = Request(GET, uri"/numbers/1")
     val reqs = List(
       req.withHeaders(Host("a.service", Some(80))),
       req.withHeaders(Host("A.service", Some(80))),
@@ -113,7 +113,7 @@ class VirtualHostSuite extends Http4sSuite {
   }
 
   test("wildcard not match a route with an abscent wildcard") {
-    val req = Request[IO](GET, uri"/numbers/1")
+    val req = Request(GET, uri"/numbers/1")
     val reqs =
       List(req.withHeaders(Host(".service", Some(80))), req.withHeaders(Host("service", Some(80))))
 

--- a/server/shared/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/authentication/AuthMiddlewareSuite.scala
@@ -44,7 +44,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
     val service = middleWare(authedRoutes)
 
     service
-      .orNotFound(Request[IO]())
+      .orNotFound(Request())
       .flatMap { res =>
         res.as[String].map {
           _ === "Unauthorized" && res.status === Forbidden
@@ -72,7 +72,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
     val service = middleWare(authedRoutes)
 
     service
-      .orNotFound(Request[IO]())
+      .orNotFound(Request())
       .flatMap { res =>
         res.as[String].map {
           _ === "42" && res.status === Ok
@@ -100,11 +100,11 @@ class AuthMiddlewareSuite extends Http4sSuite {
     val service = middleWare(authedRoutes)
 
     service
-      .orNotFound(Request[IO](method = Method.POST))
+      .orNotFound(Request(method = Method.POST))
       .map(_.status)
       .assertEquals(Ok) *>
       service
-        .orNotFound(Request[IO](method = Method.GET))
+        .orNotFound(Request(method = Method.GET))
         .map(_.status)
         .assertEquals(NotFound)
   }
@@ -124,7 +124,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
 
     val service = middleware(authedRoutes)
 
-    service.orNotFound(Request[IO](method = Method.POST)).map(_.status).assertEquals(Ok)
+    service.orNotFound(Request(method = Method.POST)).map(_.status).assertEquals(Ok)
   }
 
   test("return 404 for an unmatched but authenticated route") {
@@ -142,7 +142,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
 
     val service = middleware(authedRoutes)
 
-    service.orNotFound(Request[IO](method = Method.GET)).map(_.status).assertEquals(NotFound)
+    service.orNotFound(Request(method = Method.GET)).map(_.status).assertEquals(NotFound)
   }
 
   test("return 401 for a matched, but unauthenticated route") {
@@ -158,7 +158,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
 
     val service = middleware(authedRoutes)
 
-    service.orNotFound(Request[IO](method = Method.POST)).map(_.status).assertEquals(Unauthorized)
+    service.orNotFound(Request(method = Method.POST)).map(_.status).assertEquals(Unauthorized)
   }
 
   test("return 401 for an unmatched, unauthenticated route") {
@@ -174,7 +174,7 @@ class AuthMiddlewareSuite extends Http4sSuite {
 
     val service = middleware(authedRoutes)
 
-    service.orNotFound(Request[IO](method = Method.GET)).map(_.status).assertEquals(Unauthorized)
+    service.orNotFound(Request(method = Method.GET)).map(_.status).assertEquals(Unauthorized)
   }
 
   test("compose authedRoutesand not fall through") {
@@ -197,8 +197,8 @@ class AuthMiddlewareSuite extends Http4sSuite {
 
     val service = middleware(authedRoutes1 <+> authedRoutes2)
 
-    service.orNotFound(Request[IO](method = Method.GET)).map(_.status).assertEquals(Ok) *>
-      service.orNotFound(Request[IO](method = Method.POST)).map(_.status).assertEquals(Ok)
+    service.orNotFound(Request(method = Method.GET)).map(_.status).assertEquals(Ok) *>
+      service.orNotFound(Request(method = Method.POST)).map(_.status).assertEquals(Ok)
   }
 
   test("consume the entire request for an unauthenticated route for service composition") {
@@ -210,18 +210,18 @@ class AuthMiddlewareSuite extends Http4sSuite {
         Ok()
       }
 
-    val regularRoutes: HttpRoutes[IO] = HttpRoutes.pure(Response[IO](Ok))
+    val regularRoutes: HttpRoutes[IO] = HttpRoutes.pure(Response(Ok))
 
     val middleware = AuthMiddleware(authUser)
 
     val service = middleware(authedRoutes)
 
     (service <+> regularRoutes)
-      .orNotFound(Request[IO](method = Method.POST))
+      .orNotFound(Request(method = Method.POST))
       .map(_.status)
       .assertEquals(Unauthorized) *>
       (service <+> regularRoutes)
-        .orNotFound(Request[IO](method = Method.GET))
+        .orNotFound(Request(method = Method.GET))
         .map(_.status)
         .assertEquals(Unauthorized)
   }
@@ -245,17 +245,17 @@ class AuthMiddlewareSuite extends Http4sSuite {
 
     //Unauthenticated
     (service <+> regularRoutes)
-      .orNotFound(Request[IO](method = Method.POST))
+      .orNotFound(Request(method = Method.POST))
       .map(_.status)
       .assertEquals(NotFound) *>
       //Matched normally
       (service <+> regularRoutes)
-        .orNotFound(Request[IO](method = Method.GET))
+        .orNotFound(Request(method = Method.GET))
         .map(_.status)
         .assertEquals(Ok) *>
       //Unmatched
       (service <+> regularRoutes)
-        .orNotFound(Request[IO](method = Method.PUT))
+        .orNotFound(Request(method = Method.PUT))
         .map(_.status)
         .assertEquals(NotFound)
   }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -59,7 +59,7 @@ class AuthenticationSuite extends Http4sSuite {
   val basicAuthMiddleware = BasicAuth(realm, validatePassword _)
 
   test("Failure to authenticate should not run unauthorized routes") {
-    val req = Request[IO](uri = uri"/launch-the-nukes")
+    val req = Request(uri = uri"/launch-the-nukes")
     var isNuked = false
     val authedValidateNukeService = basicAuthMiddleware(nukeService {
       isNuked = true
@@ -74,7 +74,7 @@ class AuthenticationSuite extends Http4sSuite {
     val basicAuthedService = basicAuthMiddleware(service)
 
     test("BasicAuthentication should respond to a request without authentication with 401") {
-      val req = Request[IO](uri = uri"/")
+      val req = Request(uri = uri"/")
       basicAuthedService.orNotFound(req).map { res =>
         assertEquals(res.status, Unauthorized)
         assertEquals(
@@ -84,7 +84,7 @@ class AuthenticationSuite extends Http4sSuite {
     }
 
     test("BasicAuthentication should respond to a request with unknown username with 401") {
-      val req = Request[IO](
+      val req = Request(
         uri = uri"/",
         headers = Headers(Authorization(BasicCredentials("Wrong User", password))))
       basicAuthedService.orNotFound(req).map { res =>
@@ -96,7 +96,7 @@ class AuthenticationSuite extends Http4sSuite {
     }
 
     test("BasicAuthentication should respond to a request with wrong password with 401") {
-      val req = Request[IO](
+      val req = Request(
         uri = uri"/",
         headers = Headers(Authorization(BasicCredentials(username, "Wrong Password"))))
       basicAuthedService.orNotFound(req).map { res =>
@@ -108,7 +108,7 @@ class AuthenticationSuite extends Http4sSuite {
     }
 
     test("BasicAuthentication should respond to a request with correct credentials") {
-      val req = Request[IO](
+      val req = Request(
         uri = uri"/",
         headers = Headers(Authorization(BasicCredentials(username, password))))
       basicAuthedService
@@ -128,7 +128,7 @@ class AuthenticationSuite extends Http4sSuite {
 
     test("DigestAuthentication should respond to a request without authentication with 401") {
       val authedService = digestAuthMiddleware(service)
-      val req = Request[IO](uri = uri"/")
+      val req = Request(uri = uri"/")
       authedService.orNotFound(req).map { res =>
         assertEquals(res.status, Unauthorized)
         val opt = res.headers.get[`WWW-Authenticate`].map(_.value)
@@ -146,7 +146,7 @@ class AuthenticationSuite extends Http4sSuite {
     // Send a request without authorization, receive challenge.
     def doDigestAuth1(digest: HttpApp[IO]): IO[Challenge] = {
       // Get auth data
-      val req = Request[IO](uri = uri"/")
+      val req = Request(uri = uri"/")
       digest(req).map { res =>
         assertEquals(res.status, Unauthorized)
         val opt = res.headers.get[`WWW-Authenticate`].map(_.value)
@@ -185,7 +185,7 @@ class AuthenticationSuite extends Http4sSuite {
           )
           val header = Authorization(Credentials.AuthParams(ci"Digest", params))
 
-          val req2 = Request[IO](uri = uri"/", headers = Headers(header))
+          val req2 = Request(uri = uri"/", headers = Headers(header))
           digest(req2).flatMap { res2 =>
             if (withReplay) digest(req2).map(res3 => (res2, res3))
             else IO.pure((res2, null))
@@ -294,7 +294,7 @@ class AuthenticationSuite extends Http4sSuite {
             val invalidParams = params.toList.take(i) ++ params.toList.drop(i + 1)
             val header = Authorization(
               Credentials.AuthParams(ci"Digest", invalidParams.head, invalidParams.tail: _*))
-            val req = Request[IO](uri = uri"/", headers = Headers(header))
+            val req = Request(uri = uri"/", headers = Headers(header))
             digestAuthService.orNotFound(req).map(_.status)
           }
 

--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -98,7 +98,7 @@ class AsyncHttp4sServlet[F[_]](
       F.delay(logger.error(t)("Error processing request after response was committed"))
 
     case t: Throwable =>
-      val response = Response[F](Status.InternalServerError)
+      val response = Response(Status.InternalServerError)
       // We don't know what I/O mode we're in here, and we're not rendering a body
       // anyway, so we use a NullBodyWriter.
       val f = renderResponse(response, servletResponse, NullBodyWriter) *>

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -63,7 +63,7 @@ class BlockingHttp4sServlet[F[_]](
         F.unit
       } else {
         logger.error(t)("Error processing request")
-        val response = Response[F](Status.InternalServerError)
+        val response = Response(Status.InternalServerError)
         // We don't know what I/O mode we're in here, and we're not rendering a body
         // anyway, so we use a NullBodyWriter.
         renderResponse(response, servletResponse, NullBodyWriter)

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -64,7 +64,7 @@ abstract class Http4sServlet[F[_]](
       servletResponse: HttpServletResponse,
       bodyWriter: BodyWriter[F]
   ): F[Unit] = {
-    val response = Response[F](Status.BadRequest).withEntity(parseFailure.sanitized)
+    val response = Response(Status.BadRequest).withEntity(parseFailure.sanitized)
     renderResponse(response, servletResponse, bodyWriter)
   }
 

--- a/testing/shared/src/test/scala/org/http4s/testing/ErrorReporting.scala
+++ b/testing/shared/src/test/scala/org/http4s/testing/ErrorReporting.scala
@@ -41,7 +41,7 @@ object ErrorReporting extends ErrorReportingPlatform {
       F: Monad[F]): Request[F] => PartialFunction[Throwable, F[Response[G]]] =
     req => {
       case mf: MessageFailure =>
-        mf.toHttpResponse(req.httpVersion).pure[F]
+        mf.toHttpResponse(req.httpVersion).covary[G].pure[F]
       case NonFatal(_) =>
         F.pure(
           Response(

--- a/testing/shared/src/test/scala/org/http4s/testing/ErrorReporting.scala
+++ b/testing/shared/src/test/scala/org/http4s/testing/ErrorReporting.scala
@@ -41,7 +41,7 @@ object ErrorReporting extends ErrorReportingPlatform {
       F: Monad[F]): Request[F] => PartialFunction[Throwable, F[Response[G]]] =
     req => {
       case mf: MessageFailure =>
-        mf.toHttpResponse[G](req.httpVersion).pure[F]
+        mf.toHttpResponse(req.httpVersion).pure[F]
       case NonFatal(_) =>
         F.pure(
           Response(

--- a/tests/jvm/src/test/scala/org/http4s/EntityDecoderSuitePlatform.scala
+++ b/tests/jvm/src/test/scala/org/http4s/EntityDecoderSuitePlatform.scala
@@ -28,8 +28,8 @@ trait EntityDecoderSuitePlatform { self: EntityDecoderSuite =>
       .make(IO(File.createTempFile("foo", "bar")))(f => IO(f.delete()).void)
       .use { tmpFile =>
         val response = mockServe(Request()) { req =>
-          req.decodeWith(EntityDecoder.textFile(tmpFile), strict = false) { _ =>
-            Response[IO](Ok).withEntity("Hello").pure[IO]
+          req.decodeWith(EntityDecoder.textFile[IO](tmpFile), strict = false) { _ =>
+            Response(Ok).withEntity("Hello").pure[IO]
           }
         }
         response.flatMap { response =>
@@ -45,8 +45,8 @@ trait EntityDecoderSuitePlatform { self: EntityDecoderSuite =>
       .make(IO(File.createTempFile("foo", "bar")))(f => IO(f.delete()).void)
       .use { tmpFile =>
         val response = mockServe(Request()) { case req =>
-          req.decodeWith(EntityDecoder.binFile(tmpFile), strict = false) { _ =>
-            Response[IO](Ok).withEntity("Hello").pure[IO]
+          req.decodeWith(EntityDecoder.binFile[IO](tmpFile), strict = false) { _ =>
+            Response(Ok).withEntity("Hello").pure[IO]
           }
         }
 

--- a/tests/jvm/src/test/scala/org/http4s/EntityEncoderSpecPlatform.scala
+++ b/tests/jvm/src/test/scala/org/http4s/EntityEncoderSpecPlatform.scala
@@ -29,7 +29,7 @@ trait EntityEncoderSpecPlatform { self: EntityEncoderSpec =>
     val w = new FileWriter(tmpFile)
     try w.write("render files test")
     finally w.close()
-    writeToString(tmpFile)(EntityEncoder.fileEncoder)
+    writeToString(tmpFile)(EntityEncoder.fileEncoder[IO])
       .guarantee(IO.delay(tmpFile.delete()).void)
       .assertEquals("render files test")
 

--- a/tests/jvm/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/jvm/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -112,7 +112,7 @@ class StaticFileSuite extends Http4sSuite {
     val emptyFile = File.createTempFile("empty", ".tmp")
 
     val request =
-      Request[IO]().putHeaders(`If-Modified-Since`(HttpDate.MaxValue))
+      Request().putHeaders(`If-Modified-Since`(HttpDate.MaxValue))
     val response = StaticFile
       .fromFile[IO](emptyFile, Some(request))
       .value
@@ -123,7 +123,7 @@ class StaticFileSuite extends Http4sSuite {
     val emptyFile = File.createTempFile("empty", ".tmp")
 
     val request =
-      Request[IO]().putHeaders(
+      Request().putHeaders(
         `If-None-Match`(
           EntityTag(s"${emptyFile.lastModified().toHexString}-${emptyFile.length().toHexString}")))
     val response = StaticFile
@@ -136,7 +136,7 @@ class StaticFileSuite extends Http4sSuite {
     val emptyFile = File.createTempFile("empty", ".tmp")
 
     val request =
-      Request[IO]().putHeaders(
+      Request().putHeaders(
         `If-Modified-Since`(HttpDate.MaxValue),
         `If-None-Match`(
           EntityTag(s"${emptyFile.lastModified().toHexString}-${emptyFile.length().toHexString}")))
@@ -151,7 +151,7 @@ class StaticFileSuite extends Http4sSuite {
     val emptyFile = File.createTempFile("empty", ".tmp")
 
     val request =
-      Request[IO]()
+      Request()
         .putHeaders(`If-Modified-Since`(HttpDate.MaxValue), `If-None-Match`(EntityTag(s"12345")))
 
     val response = StaticFile
@@ -164,7 +164,7 @@ class StaticFileSuite extends Http4sSuite {
     val emptyFile = File.createTempFile("empty", ".tmp")
 
     val request =
-      Request[IO]()
+      Request()
         .putHeaders(
           `If-Modified-Since`(HttpDate.MinValue),
           `If-None-Match`(

--- a/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -196,7 +196,7 @@ class EntityDecoderSuite extends Http4sSuite {
     decoder
       .decode(Request(headers = Headers(`Content-Type`(MediaType.text.plain))), strict = true)
       .swap
-      .map(_.toHttpResponse[IO](HttpVersion.`HTTP/1.1`))
+      .map(_.toHttpResponse(HttpVersion.`HTTP/1.1`))
       .map(_.status)
       .value
       .assertEquals(Right(Status.UnprocessableEntity))

--- a/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -443,7 +443,7 @@ class EntityDecoderSuite extends Http4sSuite {
   // we want to return a specific kind of error when there is a MessageFailure
   sealed case class ErrorJson(value: String)
   implicit val errorJsonEntityEncoder: EntityEncoder[IO, ErrorJson] =
-    EntityEncoder.simple[IO, ErrorJson](`Content-Type`(MediaType.application.json))(json =>
+    EntityEncoder.simple[ErrorJson](`Content-Type`(MediaType.application.json))(json =>
       Chunk.array(json.value.getBytes()))
 
 // TODO: These won't work without an Eq for (Message[IO], Boolean) => DecodeResult[IO, A]

--- a/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -109,9 +109,9 @@ class EntityEncoderSpec extends Http4sSuite with EntityEncoderSpecPlatform {
       sealed case class ModelB(name: String, id: Long)
 
       implicit val w1: EntityEncoder[IO, ModelA] =
-        EntityEncoder.simple[IO, ModelA]()(_ => Chunk.array("A".getBytes))
+        EntityEncoder.simple[ModelA]()(_ => Chunk.array("A".getBytes))
       implicit val w2: EntityEncoder[IO, ModelB] =
-        EntityEncoder.simple[IO, ModelB]()(_ => Chunk.array("B".getBytes))
+        EntityEncoder.simple[ModelB]()(_ => Chunk.array("B".getBytes))
 
       assertEquals(EntityEncoder[IO, ModelA], w1)
       assertEquals(EntityEncoder[IO, ModelB], w2)

--- a/tests/shared/src/test/scala/org/http4s/MessageSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/MessageSuite.scala
@@ -181,7 +181,7 @@ class MessageSuite extends Http4sSuite {
 
   test("toString should redact an Authorization header") {
     val request =
-      Request[IO](Method.GET).putHeaders(Authorization(BasicCredentials("user", "pass")))
+      Request(Method.GET).putHeaders(Authorization(BasicCredentials("user", "pass")))
     assertEquals(
       request.toString,
       "Request(method=GET, uri=/, headers=Headers(Authorization: <REDACTED>))")
@@ -189,7 +189,7 @@ class MessageSuite extends Http4sSuite {
 
   test("toString should redact Cookie Headers") {
     val request =
-      Request[IO](Method.GET).addCookie("token", "value").addCookie("token2", "value2")
+      Request(Method.GET).addCookie("token", "value").addCookie("token2", "value2")
     assertEquals(
       request.toString,
       "Request(method=GET, uri=/, headers=Headers(Cookie: <REDACTED>))")
@@ -209,7 +209,7 @@ class MessageSuite extends Http4sSuite {
   }
 
   val uri = uri"http://localhost:1234/foo"
-  val request = Request[IO](Method.GET, uri)
+  val request = Request(Method.GET, uri)
 
   test("asCurl should build cURL representation with scheme and authority") {
     assertEquals(request.asCurl(), "curl -X GET 'http://localhost:1234/foo'")
@@ -256,15 +256,15 @@ class MessageSuite extends Http4sSuite {
   test(
     "decode should produce a UnsupportedMediaType in the event of a decode failure MediaTypeMismatch") {
     val req =
-      Request[IO](headers = Headers(`Content-Type`(MediaType.application.`octet-stream`)))
-    val resp = req.decodeWith(EntityDecoder.text, strict = true)(_ => IO.pure(Response()))
+      Request(headers = Headers(`Content-Type`(MediaType.application.`octet-stream`)))
+    val resp = req.decodeWith(EntityDecoder.text[IO], strict = true)(_ => IO.pure(Response()))
     resp.map(_.status).assertEquals(Status.UnsupportedMediaType)
   }
 
   test(
     "decode should produce a UnsupportedMediaType in the event of a decode failure MediaTypeMissing") {
-    val req = Request[IO]()
-    val resp = req.decodeWith(EntityDecoder.text, strict = true)(_ => IO.pure(Response()))
+    val req = Request()
+    val resp = req.decodeWith(EntityDecoder.text[IO], strict = true)(_ => IO.pure(Response()))
     resp.map(_.status).assertEquals(Status.UnsupportedMediaType)
   }
 
@@ -297,9 +297,9 @@ class MessageSuite extends Http4sSuite {
 
   test("withEntity should not duplicate Content-Type header") {
     // https://github.com/http4s/http4s/issues/5059
-    val hdrs = Request[IO]()
+    val hdrs = Request()
       .putHeaders(`Content-Type`(MediaType.text.html))
-      .withEntity[String]("foo")
+      .withEntity("foo")
       .headers
       .headers
       .filter(_.name === Header[`Content-Type`].name)

--- a/tests/shared/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/ResponderSpec.scala
@@ -16,16 +16,15 @@
 
 package org.http4s
 
-import cats.effect.IO
 import org.http4s.Charset._
 import org.http4s.headers._
 import org.typelevel.ci._
 
 class ResponderSpec extends Http4sSuite {
-  val resp = Response[IO](Status.Ok)
+  val resp = Response(Status.Ok)
 
   test("Responder should Change status") {
-    val resp = Response[IO](Status.Ok)
+    val resp = Response(Status.Ok)
 
     assertEquals(resp.status, Status.Ok)
 

--- a/tests/shared/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -167,13 +167,13 @@ class ServerSentEventSpec extends Http4sSuite {
     Stream.range(0, 5).map(i => ServerSentEvent(data = i.toString.some))
   test("EntityEncoder[ServerSentEvent] should set Content-Type to text/event-stream") {
     assertEquals(
-      Response[IO]().withEntity(eventStream).contentType,
+      Response().withEntity(eventStream).contentType,
       Some(`Content-Type`(MediaType.`text/event-stream`)))
   }
 
   test("EntityEncoder[ServerSentEvent] should decode to original event stream") {
     for {
-      r <- Response[IO]()
+      r <- Response()
         .withEntity(eventStream)
         .body
         .through(ServerSentEvent.decoder)

--- a/tests/shared/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -47,7 +47,7 @@ class UrlFormSpec extends Http4sSuite {
       PropF.forAllF { (urlForm: UrlForm) =>
         DecodeResult
           .success(
-            Request[IO]()
+            Request()
               .withEntity(urlForm)(UrlForm.entityEncoder(charset))
               .pure[IO])
           .flatMap { req =>

--- a/tests/shared/src/test/scala/org/http4s/headers/RefererSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/RefererSuite.scala
@@ -17,7 +17,6 @@
 package org.http4s
 package headers
 
-import cats.effect.IO
 import org.http4s.syntax.header._
 import org.http4s.laws.discipline.ArbitraryInstances._
 
@@ -47,7 +46,7 @@ class RefererSuite extends HeaderLaws {
 
   test("should be extractable") {
     val referer = Referer(getUri("http://localhost:8080"))
-    val request = Request[IO](headers = Headers(referer))
+    val request = Request(headers = Headers(referer))
 
     val extracted = request.headers.get[Referer]
     assertEquals(extracted, Some(referer))

--- a/tests/shared/src/test/scala/org/http4s/metrics/MetricsOpsSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/metrics/MetricsOpsSpec.scala
@@ -38,7 +38,7 @@ class MetricsOpsSpec extends Http4sSuite {
   {
     test("classifierFMethodWithOptionallyExcludedPath should properly exclude UUIDs") {
       Prop.forAll { (method: Method, uuid: UUID, excludedValue: String, separator: String) =>
-        val request: Request[IO] = Request[IO](
+        val request: Request[IO] = Request(
           method = method,
           uri = Uri.unsafeFromString(s"/users/$uuid/comments")
         )
@@ -75,7 +75,7 @@ class MetricsOpsSpec extends Http4sSuite {
     }
     test("classifierFMethodWithOptionallyExcludedPath should return '$method' if the path is '/'") {
       Prop.forAll { (method: Method) =>
-        val request: Request[IO] = Request[IO](
+        val request: Request[IO] = Request(
           method = method,
           uri = uri"""/"""
         )

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -108,7 +108,7 @@ Content-Type: application/pdf
         val header = Headers(
           `Content-Type`(
             MediaType.multipartType("form-data", Some("----WebKitFormBoundarycaZFo8IAKVROTEeD"))))
-        val request = Request[IO](
+        val request = Request(
           method = Method.POST,
           uri = url,
           body = Stream.emit(body).covary[IO].through(text.utf8.encode),
@@ -138,7 +138,7 @@ I am a big moose
         val header = Headers(
           `Content-Type`(
             MediaType.multipartType("form-data", Some("bQskVplbbxbC2JO8ibZ7KwmEe3AJLx_Olz"))))
-        val request = Request[IO](
+        val request = Request(
           method = Method.POST,
           uri = url,
           body = Stream.emit(body).through(text.utf8.encode),

--- a/tests/shared/src/test/scala/org/http4s/syntax/KleisliSyntaxSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/syntax/KleisliSyntaxSpec.scala
@@ -25,20 +25,20 @@ class KleisliSyntaxTests {
   // translate syntax should work on HttpRoutes
   val routes: HttpRoutes[Kleisli[IO, Int, *]] = HttpRoutes
     .of[IO] { case _ =>
-      IO(Response[IO](Status.Ok))
+      IO(Response(Status.Ok))
     }
     .translate[Kleisli[IO, Int, *]](Kleisli.liftK)(Kleisli.applyK(42))
 
   // translate syntax should work on HttpApp
   val app: HttpApp[Kleisli[IO, Int, *]] = HttpApp[IO] { case _ =>
-    IO(Response[IO](Status.Ok))
+    IO(Response(Status.Ok))
   }
     .translate[Kleisli[IO, Int, *]](Kleisli.liftK)(Kleisli.applyK(42))
 
   // translate syntax should work on AuthedRoutes
   val authedRoutes: AuthedRoutes[String, Kleisli[IO, Int, *]] = AuthedRoutes
     .of[String, IO] { case _ =>
-      IO(Response[IO](Status.Ok))
+      IO(Response(Status.Ok))
     }
     .translate[Kleisli[IO, Int, *]](Kleisli.liftK)(Kleisli.applyK(42))
 }

--- a/twirl/jvm/src/main/scala/org/http4s/twirl/TwirlInstances.scala
+++ b/twirl/jvm/src/main/scala/org/http4s/twirl/TwirlInstances.scala
@@ -22,27 +22,27 @@ import org.http4s.MediaType
 import _root_.play.twirl.api._
 
 trait TwirlInstances {
-  implicit def htmlContentEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Html] =
+  implicit def htmlContentEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder.Pure[Html] =
     contentEncoder(MediaType.text.html)
 
   /** Note: Twirl uses a media type of `text/javascript`.  This is obsolete, so we instead return
     * `application/javascript`.
     */
-  implicit def jsContentEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, JavaScript] =
+  implicit def jsContentEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder.Pure[JavaScript] =
     contentEncoder(MediaType.application.javascript)
 
-  implicit def xmlContentEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Xml] =
+  implicit def xmlContentEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder.Pure[Xml] =
     contentEncoder(MediaType.application.xml)
 
-  implicit def txtContentEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Txt] =
+  implicit def txtContentEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder.Pure[Txt] =
     contentEncoder(MediaType.text.plain)
 
-  private def contentEncoder[F[_], C <: Content](mediaType: MediaType)(implicit
-      charset: Charset): EntityEncoder[F, C] =
+  private def contentEncoder[C <: Content](mediaType: MediaType)(implicit
+      charset: Charset): EntityEncoder.Pure[C] =
     EntityEncoder.stringEncoder
       .contramap[C](content => content.body)
       .withContentType(`Content-Type`(mediaType, charset))

--- a/twirl/jvm/src/main/scala/org/http4s/twirl/TwirlInstances.scala
+++ b/twirl/jvm/src/main/scala/org/http4s/twirl/TwirlInstances.scala
@@ -43,8 +43,7 @@ trait TwirlInstances {
 
   private def contentEncoder[F[_], C <: Content](mediaType: MediaType)(implicit
       charset: Charset): EntityEncoder[F, C] =
-    EntityEncoder
-      .stringEncoder[F]
+    EntityEncoder.stringEncoder
       .contramap[C](content => content.body)
       .withContentType(`Content-Type`(mediaType, charset))
 }

--- a/twirl/jvm/src/test/scala/org/http4s/twirl/TwirlSuite.scala
+++ b/twirl/jvm/src/test/scala/org/http4s/twirl/TwirlSuite.scala
@@ -45,7 +45,7 @@ class TwirlSuite extends Http4sSuite {
 
   test("HTML encoder should render the body") {
     PropF.forAllF { implicit cs: Charset =>
-      val resp = Response[IO](Ok).withEntity(html.test())
+      val resp = Response(Ok).withEntity(html.test())
       EntityDecoder
         .text[IO]
         .decode(resp, strict = false)
@@ -65,7 +65,7 @@ class TwirlSuite extends Http4sSuite {
 
   test("JS encoder should render the body") {
     PropF.forAllF { implicit cs: Charset =>
-      val resp = Response[IO](Ok).withEntity(js.test())
+      val resp = Response(Ok).withEntity(js.test())
       EntityDecoder.text[IO].decode(resp, strict = false).value.assertEquals(Right(""""test js""""))
     }
   }
@@ -79,7 +79,7 @@ class TwirlSuite extends Http4sSuite {
 
   test("Text encoder should render the body") {
     PropF.forAllF { implicit cs: Charset =>
-      val resp = Response[IO](Ok).withEntity(txt.test())
+      val resp = Response(Ok).withEntity(txt.test())
       EntityDecoder.text[IO].decode(resp, strict = false).value.assertEquals(Right("""test text"""))
     }
   }
@@ -93,7 +93,7 @@ class TwirlSuite extends Http4sSuite {
 
   test("XML encoder should render the body") {
     PropF.forAllF { implicit cs: Charset =>
-      val resp = Response[IO](Ok).withEntity(_root_.xml.test())
+      val resp = Response(Ok).withEntity(_root_.xml.test())
       EntityDecoder
         .text[IO]
         .decode(resp, strict = false)


### PR DESCRIPTION
Depends on #5229.

It's a big diff so here's a breakdown:

- ff9dca0 is the core change. 
- b3f6010 removes no-longer-needed type arguments and annotations from production code; 
ccf9851 does the same for tests. 
- 6e1827b introduces `AnyRequest`, `AnyResponse`, `AnyMessage` as aliases for respective top types and uses them where possible. (it's debatable which of these uses are actually a good idea).
- 8d1727 and 2aa5c0e make `main` and `test`, respectively, compile on Scala 2.12. (It can seemingly handle using `Response.covaryF` for the implicit conversion from `F[Response[Nothing]]` to `F[Response[F]]` but not to `F[Response[G]]`) 