### PR TITLE
Eliminate exception allocation on parser hot path

### DIFF
--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -122,8 +122,9 @@ private[client] object ClientHelpers {
           finiteDuration.fold(parse)(duration =>
             parse.timeoutTo(
               duration,
+              Concurrent[F].defer(
               ApplicativeThrow[F].raiseError(new java.util.concurrent.TimeoutException(
-                s"Timed Out on EmberClient Header Receive Timeout: $duration"))))
+                s"Timed Out on EmberClient Header Receive Timeout: $duration")))))
         }
 
     for {

--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -123,8 +123,9 @@ private[client] object ClientHelpers {
             parse.timeoutTo(
               duration,
               Concurrent[F].defer(
-              ApplicativeThrow[F].raiseError(new java.util.concurrent.TimeoutException(
-                s"Timed Out on EmberClient Header Receive Timeout: $duration")))))
+                ApplicativeThrow[F].raiseError(new java.util.concurrent.TimeoutException(
+                  s"Timed Out on EmberClient Header Receive Timeout: $duration")))
+            ))
         }
 
     for {

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -133,10 +133,11 @@ private[server] object ServerHelpers {
         parse.timeoutTo(
           duration,
           Concurrent[F].defer(
-            ApplicativeThrow[F].raiseError(new java.util.concurrent.TimeoutException(s"Timed Out on EmberServer Header Receive Timeout: $duration"))
+            ApplicativeThrow[F].raiseError(
+              new java.util.concurrent.TimeoutException(
+                s"Timed Out on EmberServer Header Receive Timeout: $duration"))
           )
-        )
-      )
+        ))
 
     for {
       tmp <- parseWithHeaderTimeout

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -132,9 +132,11 @@ private[server] object ServerHelpers {
       durationToFinite(requestHeaderReceiveTimeout).fold(parse)(duration =>
         parse.timeoutTo(
           duration,
-          ApplicativeThrow[F].raiseError(
-            new java.util.concurrent.TimeoutException(
-              s"Timed Out on EmberServer Header Receive Timeout: $duration"))))
+          Concurrent[F].defer(
+            ApplicativeThrow[F].raiseError(new java.util.concurrent.TimeoutException(s"Timed Out on EmberServer Header Receive Timeout: $duration"))
+          )
+        )
+      )
 
     for {
       tmp <- parseWithHeaderTimeout


### PR DESCRIPTION
Strictness strikes again!

I ran a performance test against Ember Server with the change (after a warmup run)
```
$ hey -n 1000000 -c 50 http://127.0.0.1:8080/
```
Before:
```
Summary:
  Total:    58.2501 secs
  Slowest:    0.1386 secs
  Fastest:    0.0003 secs
  Average:    0.0029 secs
  Requests/sec:    17167.3672

  Total data:    14000000 bytes
  Size/request:    14 bytes

Response time histogram:
  0.000 [1]    |
  0.014 [995073]    |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.028 [3517]    |
  0.042 [964]    |
  0.056 [313]    |
  0.069 [101]    |
  0.083 [19]    |
  0.097 [7]    |
  0.111 [1]    |
  0.125 [3]    |
  0.139 [1]    |
```
After:
```
Summary:
  Total:    56.8599 secs
  Slowest:    0.1795 secs
  Fastest:    0.0002 secs
  Average:    0.0028 secs
  Requests/sec:    17587.0752

  Total data:    14000000 bytes
  Size/request:    14 bytes

Response time histogram:
  0.000 [1]    |
  0.018 [996375]    |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.036 [2582]    |
  0.054 [672]    |
  0.072 [235]    |
  0.090 [86]    |
  0.108 [29]    |
  0.126 [11]    |
  0.144 [4]    |
  0.162 [4]    |
  0.179 [1]    |
```
Noticed about a ~6% CPU drop as well