### PR TITLE
Define and link all specified HTTP versions

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
@@ -190,7 +190,7 @@ private class Http2NodeStage[F[_]](
         pseudoDone = true
         hs match {
           case h @ (HeaderNames.Connection, _) =>
-            error += s"HTTP/2.0 forbids connection specific headers: $h. "
+            error += s"HTTP/2 forbids connection specific headers: $h. "
 
           case (HeaderNames.ContentLength, v) =>
             if (contentLength < 0) try {
@@ -206,7 +206,7 @@ private class Http2NodeStage[F[_]](
 
           case (HeaderNames.TE, v) =>
             if (!v.equalsIgnoreCase("trailers"))
-              error += s"HTTP/2.0 forbids TE header values other than 'trailers'. "
+              error += s"HTTP/2 forbids TE header values other than 'trailers'. "
           // ignore otherwise
 
           case (k, v) => headers += k -> v
@@ -221,7 +221,7 @@ private class Http2NodeStage[F[_]](
     else {
       val body = if (endStream) EmptyBody else getBody(contentLength)
       val hs = Headers(headers.result())
-      val req = Request(method, path, HttpVersion.`HTTP/2.0`, hs, body, attributes())
+      val req = Request(method, path, HttpVersion.`HTTP/2`, hs, body, attributes())
       executionContext.execute(new Runnable {
         def run(): Unit = {
           val action = Sync[F]

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -30,6 +30,10 @@ import org.http4s.util._
   * version to which the sender is conformant (able to understand for
   * future communication).
   *
+  * @param major The major version, `0` to `9` inclusive
+  *
+  * @param minor The minor version, `0` to `9` inclusive
+  *
   * @see
   * [[https://httpwg.org/http-core/draft-ietf-httpbis-semantics-latest.html#protocol.version
   * HTTP Semantics, Protocol Versioning]]
@@ -37,7 +41,23 @@ import org.http4s.util._
 final case class HttpVersion private[HttpVersion] (major: Int, minor: Int)
     extends Renderable
     with Ordered[HttpVersion] {
+
+  /** Renders as an HTTP/1.1 string
+    *
+    * {{{
+    * >>> HttpVersion.`HTTP/1.1`.renderString
+    * HTTP/1.1
+    * }}}
+    */
   override def render(writer: Writer): writer.type = writer << "HTTP/" << major << '.' << minor
+
+  /** Orders by major version ascending, then minor version ascending.
+    *
+    * {{{
+    * >>> List(HttpVersion.`HTTP/1.0`, HttpVersion.`HTTP/1.1`, HttpVersion.`HTTP/0.9`).sorted
+    * List(HTTP/0.9, HTTP/1.0, HTTP/1.1)
+    * }}}
+    */
   override def compare(that: HttpVersion): Int =
     (this.major, this.minor).compare((that.major, that.minor))
 
@@ -120,6 +140,13 @@ object HttpVersion {
   private[this] val right_1_0 = Right(`HTTP/1.0`)
   private[this] val right_1_1 = Right(`HTTP/1.1`)
 
+  /** Returns an HTTP version from its HTTP/1 string representation.
+    *
+    * {{{
+    * >>> HttpVersion.fromString("HTTP/1.1")
+    * Right(HTTP/1.1)
+    * }}}
+    */
   def fromString(s: String): ParseResult[HttpVersion] =
     s match {
       case "HTTP/1.1" => right_1_1
@@ -138,6 +165,19 @@ object HttpVersion {
     }
   }
 
+  /** Returns an HTTP version from a major and minor version.
+    *
+    * {{{
+    * >>> HttpVersion.fromVersion(1, 1)
+    * Right(HTTP/1.1)
+    *
+    * >>> HttpVersion.fromVersion(1, 10)
+    * Left(org.http4s.ParseFailure: Invalid HTTP version: major must be <= 9: 10)
+    * }}}
+    *
+    * @param major The major version, `0` to `9` inclusive
+    * @param minor The minor version, `0` to `9` inclusive
+    */
   def fromVersion(major: Int, minor: Int): ParseResult[HttpVersion] =
     if (major < 0) ParseResult.fail("Invalid HTTP version", s"major must be > 0: $major")
     else if (major > 9) ParseResult.fail("Invalid HTTP version", s"major must be <= 9: $major")

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -23,9 +23,16 @@ import cats.parse.{Parser => P}
 import cats.parse.Rfc5234.digit
 import org.http4s.util._
 
-/** An HTTP version, as seen on the start line of an HTTP request or response.
+/** HTTP's version number consists of two decimal digits separated by
+  * a "." (period or decimal point). The first digit ("major version")
+  * indicates the messaging syntax, whereas the second digit ("minor
+  * version") indicates the highest minor version within that major
+  * version to which the sender is conformant (able to understand for
+  * future communication).
   *
-  * @see [[http://tools.ietf.org/html/rfc7230#section-2.6 RFC 7320, Section 2.6, Protocol Versioning]]
+  * @see
+  * [[https://httpwg.org/http-core/draft-ietf-httpbis-semantics-latest.html#protocol.version
+  * HTTP Semantics, Protocol Versioning]]
   */
 final case class HttpVersion private[HttpVersion] (major: Int, minor: Int)
     extends Renderable
@@ -40,9 +47,75 @@ final case class HttpVersion private[HttpVersion] (major: Int, minor: Int)
 }
 
 object HttpVersion {
+
+  /** HTTP/0.9 was first formalized in the HTTP/1.0 spec. `HTTP/0.9`
+    * does not literally appear in the HTTP/0.9 protocol.
+    *
+    * @see [[https://www.w3.org/Protocols/HTTP/AsImplemented.html The
+    * original HTTP as defined in 1991]]
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc1945 RFC1945,
+    * Hypertext Transfer Protocol -- HTTP/1.0]]
+    */
+  val `HTTP/0.9` = new HttpVersion(0, 9)
+
+  /** HTTP/1.0 is the first major version of HTTP.
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc1945 RFC1945,
+    * Hypertext Transfer Protocol -- HTTP/1.0]]
+    */
   val `HTTP/1.0` = new HttpVersion(1, 0)
+
+  /** HTTP/1.1 revises HTTP/1.0, and is currently defined by six RFCs.
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc208 Hypertext
+    * Transfer Protocol -- HTTP/1.1]] (obsolete)
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc2616 Hypertext
+    * Transfer Protocol -- HTTP/1.1]] (obsolete)
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc7230 Hypertext
+    * Transfer Protocol (HTTP/1.1): Message Syntax and Routing]]
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc7231 Hypertext
+    * Transfer Protocol (HTTP/1.1): Semantics and Content]]
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc7232 Hypertext
+    * Transfer Protocol (HTTP/1.1): Conditional Requests]]
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc7233 Hypertext
+    * Transfer Protocol (HTTP/1.1): Range Requests]]
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc7234 Hypertext
+    * Transfer Protocol (HTTP/1.1): Caching]]
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc7235 Hypertext
+    * Transfer Protocol (HTTP/1.1): Authentication]]
+    *
+    * @see
+    * [[https://datatracker.ietf.org/doc/draft-ietf-httpbis-messaging/
+    * HTTP/1.1]] (draft)
+    */
   val `HTTP/1.1` = new HttpVersion(1, 1)
-  val `HTTP/2.0` = new HttpVersion(2, 0)
+
+  /** HTTP/2 is the second major version of HTTP.  It defines no minor
+    * versions, so minor version `0` is implied.
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc7540 RFC7540,
+    * Hypertext Transfer Protocol Version 2 (HTTP/2)]]
+    */
+  val `HTTP/2` = new HttpVersion(2, 0)
+
+  @deprecated("Renamed to `HTTP/2`. HTTP/2 does not define minor versions.", "0.22.6")
+  def `HTTP/2.0` = `HTTP/2`
+
+  /** HTTP/3 is the third major version of HTTP.  It defines no minor
+    * versions, so minor version `0` is implied.
+    *
+    * @see [[https://quicwg.org/base-drafts/draft-ietf-quic-http.html
+    * Hypertext Transfer Protocol Version 3 (HTTP/3)]] (draft)
+    */
+  val `HTTP/3` = new HttpVersion(3, 0)
 
   private[this] val right_1_0 = Right(`HTTP/1.0`)
   private[this] val right_1_1 = Right(`HTTP/1.1`)

--- a/jetty-client/src/main/scala/org/http4s/jetty/client/JettyClient.scala
+++ b/jetty-client/src/main/scala/org/http4s/jetty/client/JettyClient.scala
@@ -85,7 +85,7 @@ object JettyClient {
       .version(
         request.httpVersion match {
           case HttpVersion.`HTTP/1.1` => JHttpVersion.HTTP_1_1
-          case HttpVersion.`HTTP/2.0` => JHttpVersion.HTTP_2
+          case HttpVersion.`HTTP/2` => JHttpVersion.HTTP_2
           case HttpVersion.`HTTP/1.0` => JHttpVersion.HTTP_1_0
           case _ => JHttpVersion.HTTP_1_1
         }

--- a/jetty-client/src/main/scala/org/http4s/jetty/client/ResponseListener.scala
+++ b/jetty-client/src/main/scala/org/http4s/jetty/client/ResponseListener.scala
@@ -69,7 +69,7 @@ private[jetty] final case class ResponseListener[F[_]](
   private def getHttpVersion(version: JHttpVersion): HttpVersion =
     version match {
       case JHttpVersion.HTTP_1_1 => HttpVersion.`HTTP/1.1`
-      case JHttpVersion.HTTP_2 => HttpVersion.`HTTP/2.0`
+      case JHttpVersion.HTTP_2 => HttpVersion.`HTTP/2`
       case JHttpVersion.HTTP_1_0 => HttpVersion.`HTTP/1.0`
       case _ => HttpVersion.`HTTP/1.1`
     }

--- a/okhttp-client/src/main/scala/org/http4s/okhttp/client/OkHttpBuilder.scala
+++ b/okhttp-client/src/main/scala/org/http4s/okhttp/client/OkHttpBuilder.scala
@@ -101,7 +101,7 @@ sealed abstract class OkHttpBuilder[F[_]] private (
 
       override def onResponse(call: Call, response: OKResponse): Unit = {
         val protocol = response.protocol() match {
-          case Protocol.HTTP_2 => HttpVersion.`HTTP/2.0`
+          case Protocol.HTTP_2 => HttpVersion.`HTTP/2`
           case Protocol.HTTP_1_1 => HttpVersion.`HTTP/1.1`
           case Protocol.HTTP_1_0 => HttpVersion.`HTTP/1.0`
           case _ => HttpVersion.`HTTP/1.1`

--- a/server/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -46,7 +46,7 @@ class VirtualHostSuite extends Http4sSuite {
 
   test("exact should return a 400 BadRequest when no header is present on a NON HTTP/1.0 request") {
     val req1 = Request[IO](GET, uri"/numbers/1", httpVersion = HttpVersion.`HTTP/1.1`)
-    val req2 = Request[IO](GET, uri"/numbers/1", httpVersion = HttpVersion.`HTTP/2.0`)
+    val req2 = Request[IO](GET, uri"/numbers/1", httpVersion = HttpVersion.`HTTP/2`)
 
     vhostExact(req1).map(_.status).assertEquals(BadRequest) *>
       vhostExact(req2).map(_.status).assertEquals(BadRequest)

--- a/tests/src/test/scala/org/http4s/HttpVersionSuite.scala
+++ b/tests/src/test/scala/org/http4s/HttpVersionSuite.scala
@@ -17,6 +17,7 @@
 package org.http4s
 
 import cats.kernel.laws.discipline.{BoundedEnumerableTests, HashTests, OrderTests}
+import cats.syntax.all._
 import org.http4s.laws.discipline.arbitrary._
 import org.scalacheck.Gen._
 import org.scalacheck.Prop._
@@ -30,17 +31,9 @@ class HttpVersionSuite extends Http4sSuite {
 
   checkAll("HttpVersion", BoundedEnumerableTests[HttpVersion].boundedEnumerable)
 
-  test("sort by descending major version") {
+  test("sorts by (major, minor)") {
     forAll { (x: HttpVersion, y: HttpVersion) =>
-      x.major > y.major ==> (x > y)
-    }
-  }
-
-  test("sort by descending minor version if major versions equal") {
-    forAll(choose(0, 9), choose(0, 9), choose(0, 9)) { (major, xMinor, yMinor) =>
-      val x = HttpVersion.fromVersion(major, xMinor).yolo
-      val y = HttpVersion.fromVersion(major, yMinor).yolo
-      (xMinor > yMinor) ==> (x > y)
+      assertEquals(x.compare(y), (x.major, x.minor).compare((y.major, y.minor)))
     }
   }
 


### PR DESCRIPTION
* Add constants for `HTTP/0.9` and `HTTP/3`
* Rename `HTTP/2.0` to `HTTP/2`, updating references. This is consistent with the specification and other backends.
* Document each version, linking to their specifications.
* Adds scaladoc and doc tests