### PR TITLE
Ember Server immediately close connection on timeout

### DIFF
--- a/ember-core/src/main/scala/org/http4s/ember/core/EmberException.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/EmberException.scala
@@ -51,4 +51,8 @@ object EmberException {
   final case class MessageTooLong(maxHeaderSize: Int) extends EmberException {
     override def getMessage: String = s"HTTP Header Section Exceeds Max Size: $maxHeaderSize Bytes"
   }
+
+  final case class ReadTimeout() extends EmberException {
+    override def getMessage: String = "Timed out while waiting on socket"
+  }
 }

--- a/ember-core/src/main/scala/org/http4s/ember/core/EmberException.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/EmberException.scala
@@ -52,7 +52,4 @@ object EmberException {
     override def getMessage: String = s"HTTP Header Section Exceeds Max Size: $maxHeaderSize Bytes"
   }
 
-  final case class ReadTimeout() extends EmberException {
-    override def getMessage: String = "Timed out while waiting on socket"
-  }
 }

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -192,8 +192,8 @@ private[server] object ServerHelpers {
     val _ = logger
     val read: Read[F] = socket
       .read(receiveBufferSize, durationToFinite(idleTimeout))
-      .adaptError {
-        case _: InterruptedByTimeoutException => EmberException.ReadTimeout()
+      .adaptError { case _: InterruptedByTimeoutException =>
+        EmberException.ReadTimeout()
       }
     Stream
       .unfoldEval[F, State, (Request[F], Response[F])](Array.emptyByteArray -> false) {

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -136,8 +136,7 @@ private[server] object ServerHelpers {
           duration,
           Concurrent[F].defer(
             ApplicativeThrow[F].raiseError(
-              new TimeoutException(
-                s"Timed out while waiting for request headers: $duration"))
+              new TimeoutException(s"Timed out while waiting for request headers: $duration"))
           )
         ))
 


### PR DESCRIPTION
Today, Ember Server returns a 500 Internal Server Error and closes a connection after any server-related timeout occurs (socket read timeout, idle timeout, write timeout, request header receive timeout). This means that a downstream client who writes a request after the timeout response is returned will immediately see a 500 response. This is inconsistent with several widely used HTTP servers (AWS ALB/ELB, nginx, blaze-server).

This behavior means that a retry needs to be instrumented against a 500 in userspace by downstream users. I think this is poor out-of-the-box experience. We should close the connection immediately without writing any sort of response; most mature clients (blaze, okhttp, jetty) are coded to retry immediately against a closed or reset connection. The client will either observe the connection to be closed before writing their next request, or receive a RST packet after writing their request, and retry accordingly. Ember Client actually does neither and instead raises a `Connection reset by peer` error, but I'm going to open a followup to fix that. 

I would write a test for this but it's kind of difficult with any well-behaved client, so I offer this screenshot instead:
<img width="504" alt="Screen Shot 2021-09-28 at 8 16 24 PM" src="https://user-images.githubusercontent.com/2617549/135186480-92ec53a4-4371-4eb5-a0fb-a2219af440c3.png">
:
