### PR TITLE
Forbidding space in URI path was overzealous

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/client/blaze/Http1Connection.scala
@@ -471,5 +471,5 @@ private object Http1Connection {
     } else writer
   }
 
-  private val ForbiddenUriCharacters = CharPredicate(0x0.toChar, ' ', '\r', '\n')
+  private val ForbiddenUriCharacters = CharPredicate(0x0.toChar, '\r', '\n')
 }

--- a/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -147,5 +147,5 @@ private[ember] object Encoder {
     }
   }
 
-  private val ForbiddenUriCharacters = CharPredicate(0x0.toChar, ' ', '\r', '\n')
+  private val ForbiddenUriCharacters = CharPredicate(0x0.toChar, '\r', '\n')
 }


### PR DESCRIPTION
A user was passing an untrimmed string to `Uri.withPath`.  In 0.22, this will be properly encoded.  In 0.21, it was silently tolerated through 0.21.29 and [GHSA-5vcm-3xc3-w7x3](https://github.com/http4s/http4s/security/advisories/GHSA-5vcm-3xc3-w7x3).

We must prohibit carriage return, newline, and null.  But there's no reason space is worse than other unencoded characters not in the URI alphabet that the weak 0.21 `Uri.withPath` model accepts.  This should not have been a breaking change to users just trying to get patched.