### PR TITLE
Ember Client retry reset connection and broken pipe errors

### DIFF
--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -219,7 +219,7 @@ private[client] object ClientHelpers {
       result match {
         case Right(_) => false
         case Left(_: ClosedChannelException) => true
-        case Left(ex: IOException) => 
+        case Left(ex: IOException) =>
           val msg = ex.getMessage()
           msg == "Connection reset by peer" || msg == "Broken pipe"
         case _ => false

--- a/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -39,6 +39,7 @@ import javax.net.ssl.SNIHostName
 import org.http4s.headers.{Connection, Date, `Idempotency-Key`, `User-Agent`}
 import _root_.org.http4s.ember.core.Util._
 import java.nio.channels.ClosedChannelException
+import java.io.IOException
 
 private[client] object ClientHelpers {
 
@@ -212,12 +213,15 @@ private[client] object ClientHelpers {
         req: Request[F],
         result: Either[Throwable, Response[F]]): Boolean =
       (req.method.isIdempotent || req.headers.get[`Idempotency-Key`].isDefined) &&
-        isEmptyStreamError(result)
+        isRetryableError(result)
 
-    def isEmptyStreamError[F[_]](result: Either[Throwable, Response[F]]): Boolean =
+    def isRetryableError[F[_]](result: Either[Throwable, Response[F]]): Boolean =
       result match {
         case Right(_) => false
         case Left(_: ClosedChannelException) => true
+        case Left(ex: IOException) => 
+          val msg = ex.getMessage()
+          msg == "Connection reset by peer" || msg == "Broken pipe"
         case _ => false
       }
   }


### PR DESCRIPTION
This is a follow up for #4935 and #5286. To sum it up, there are more IO exceptions from which we can recover and retry idempotent requests.

While the particular conditions I'm trying to observe here are very well-defined within the TCP layer, the various IO syscalls and the Java IO API make it impossible to observe those conditions with any precision. I also don't want to blindly match against any `IOException` because that may catch non-retryable IO errors like connect exceptions, unresolved hosts, etc. We may be able to enumerate those out but it seems risky

So, we have to resort to match against exception messages instead. Unsurprisingly, there is precedent for doing this:
1. https://github.com/AsyncHttpClient/async-http-client/blob/master/client/src/main/java/org/asynchttpclient/netty/future/StackTraceInspector.java
2. https://github.com/reactor/reactor-netty/blob/058159592584fcc3a66c32b48a5bfe6a8fe09297/reactor-netty-core/src/main/java/reactor/netty/channel/AbortedException.java#L46

I'm pretty sure Okhttp is doing something similar but not sure where to look in their codebase. I'm also not sure how much of these condition matches we should port over, but I think it's a good start and we can expand as user reports come in.

Alternatives: some HTTP clients try reading before writing to a socket to see if the connection has closed already. This lowers the probability of getting a reset/broken pipe, but it's also not bulletproof because network shenanigans.