### PR TITLE
Use unsafeFromString in Uri string literal macro

### DIFF
--- a/core/shared/src/main/scala-2/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/shared/src/main/scala-2/org/http4s/LiteralSyntaxMacros.scala
@@ -24,7 +24,7 @@ object LiteralSyntaxMacros {
     def validate(c: Context)(s: String): Either[String, c.Expr[Uri]] = {
       import c.universe._
       Uri.fromString(s) match {
-        case Right(_) => Right(c.Expr(q"org.http4s.Uri.fromString($s).toOption.get"))
+        case Right(_) => Right(c.Expr(q"org.http4s.Uri.unsafeFromString($s)"))
         case Left(parseError) => Left(s"invalid URI: ${parseError.details}")
       }
     }

--- a/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
@@ -18,7 +18,7 @@ package org.http4s
 
 import org.http4s.implicits._
 
-class LiteralSynxtaxMacrosSuite extends Http4sSuite {
+class LiteralSyntaxMacrosSuite extends Http4sSuite {
   test("'uri' macro works for valid input") {
     assertEquals(uri"a.b.c", Uri.fromString("a.b.c").toOption.get)
   }


### PR DESCRIPTION
Small quality of life change - wart remover flags this with `[wartremover:OptionPartial] Option#get is disabled - use Option#fold instead`

Currently you have to silence it locally or turn the wart off. Hopefully a fairly harmless change?