### PR TITLE
cors - return Access-Control-Allow-Headers if request headers non-matching

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -332,17 +332,6 @@ sealed class CORSPolicy(
             .some
       }
 
-    val someAllowHeadersSpecificHeader =
-      allowHeaders match {
-        case AllowHeaders.All | AllowHeaders.Reflect => None
-        case AllowHeaders.In(headers) =>
-          Header
-            .Raw(
-              Header[`Access-Control-Allow-Headers`].name,
-              headers.map(_.toString).mkString(", "))
-            .some
-      }
-
     val maxAgeHeader =
       maxAge match {
         case MaxAge.Some(deltaSeconds) =>
@@ -470,10 +459,11 @@ sealed class CORSPolicy(
           else
             None
         case AllowHeaders.In(allowedHeaders) =>
-          if ((headers -- allowedHeaders).isEmpty)
-            someAllowHeadersSpecificHeader
-          else
-            None
+          Header
+            .Raw(
+              Header[`Access-Control-Allow-Headers`].name,
+              allowedHeaders.map(_.toString).mkString(", "))
+            .some
         case AllowHeaders.Reflect =>
           Header.Raw(Header[`Access-Control-Allow-Headers`].name, headers.mkString(", ")).some
       }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -360,8 +360,8 @@ sealed class CORSPolicy(
         case AllowMethods.In(_) => List(Header[`Access-Control-Request-Method`].name)
       }
       def headers = allowHeaders match {
-        case AllowHeaders.All => Nil
-        case AllowHeaders.In(_) | AllowHeaders.Reflect | AllowHeaders.Static(_) =>
+        case AllowHeaders.All | AllowHeaders.Static(_) => Nil
+        case AllowHeaders.In(_) | AllowHeaders.Reflect =>
           List(ci"Access-Control-Request-Headers")
       }
       (origin ++ methods ++ headers) match {

--- a/server/shared/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
@@ -556,7 +556,7 @@ class CORSSuite extends Http4sSuite {
       .run(preflightReq.putHeaders(
         Header.Raw(ci"Access-Control-Request-Headers", "X-Cors-Suite-1, X-Cors-Suite-3")))
       .map { resp =>
-        assertAllowHeaders(resp, Some(ci"X-Cors-Suite-1, X-Cors-Suite-2"))
+        assertAllowHeaders(resp, None)
         assertVary(
           resp,
           Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))
@@ -600,6 +600,65 @@ class CORSSuite extends Http4sSuite {
       .run(preflightReq)
       .map { resp =>
         assertAllowHeaders(resp, Some(ci"X-Cors-Suite"))
+        assertVary(
+          resp,
+          Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))
+      }
+  }
+
+  test("withAllowHeadersStatic, preflight request with non-matching origin and matching headers") {
+    CORS.policy
+      .withAllowOriginHeader(_ => false)
+      .withAllowHeadersStatic(Set(ci"X-Cors-Suite-1", ci"X-Cors-Suite-2"))
+      .apply(app)
+      .run(preflightReq)
+      .map { resp =>
+        assertAllowHeaders(resp, None)
+        assertVary(
+          resp,
+          Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))
+      }
+  }
+
+  test("withAllowHeadersStatic, preflight request with matching origin and headers") {
+    CORS.policy
+      .withAllowOriginHeader(_ => true)
+      .withAllowHeadersStatic(Set(ci"X-Cors-Suite", ci"X-Cors-Suite-2"))
+      .apply(app)
+      .run(preflightReq)
+      .map { resp =>
+        assertAllowHeaders(resp, Some(ci"X-Cors-Suite, X-Cors-Suite-2"))
+        assertVary(
+          resp,
+          Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))
+      }
+  }
+
+  test(
+    "withAllowHeadersStatic, preflight request with matching origin and some non-matching headers") {
+    CORS.policy
+      .withAllowOriginHeader(_ => true)
+      .withAllowHeadersStatic(Set(ci"X-Cors-Suite-1", ci"X-Cors-Suite-2"))
+      .apply(app)
+      .run(preflightReq.putHeaders(
+        Header.Raw(ci"Access-Control-Request-Headers", "X-Cors-Suite-1, X-Cors-Suite-3")))
+      .map { resp =>
+        assertAllowHeaders(resp, Some(ci"X-Cors-Suite-1, X-Cors-Suite-2"))
+        assertVary(
+          resp,
+          Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))
+      }
+  }
+
+  test("withAllowHeadersStatic, preflight request with matching origin and all matching headers") {
+    CORS.policy
+      .withAllowOriginHeader(_ => true)
+      .withAllowHeadersStatic(Set(ci"X-Cors-Suite-1", ci"X-Cors-Suite-2"))
+      .apply(app)
+      .run(
+        preflightReq.putHeaders(Header.Raw(ci"Access-Control-Request-Headers", "X-Cors-Suite-1")))
+      .map { resp =>
+        assertAllowHeaders(resp, Some(ci"X-Cors-Suite-1, X-Cors-Suite-2"))
         assertVary(
           resp,
           Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))

--- a/server/shared/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
@@ -614,9 +614,7 @@ class CORSSuite extends Http4sSuite {
       .run(preflightReq)
       .map { resp =>
         assertAllowHeaders(resp, None)
-        assertVary(
-          resp,
-          Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))
+        assertVary(resp, Some(ci"Origin, Access-Control-Request-Method"))
       }
   }
 
@@ -628,9 +626,7 @@ class CORSSuite extends Http4sSuite {
       .run(preflightReq)
       .map { resp =>
         assertAllowHeaders(resp, Some(ci"X-Cors-Suite, X-Cors-Suite-2"))
-        assertVary(
-          resp,
-          Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))
+        assertVary(resp, Some(ci"Origin, Access-Control-Request-Method"))
       }
   }
 
@@ -644,9 +640,7 @@ class CORSSuite extends Http4sSuite {
         Header.Raw(ci"Access-Control-Request-Headers", "X-Cors-Suite-1, X-Cors-Suite-3")))
       .map { resp =>
         assertAllowHeaders(resp, Some(ci"X-Cors-Suite-1, X-Cors-Suite-2"))
-        assertVary(
-          resp,
-          Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))
+        assertVary(resp, Some(ci"Origin, Access-Control-Request-Method"))
       }
   }
 
@@ -659,9 +653,7 @@ class CORSSuite extends Http4sSuite {
         preflightReq.putHeaders(Header.Raw(ci"Access-Control-Request-Headers", "X-Cors-Suite-1")))
       .map { resp =>
         assertAllowHeaders(resp, Some(ci"X-Cors-Suite-1, X-Cors-Suite-2"))
-        assertVary(
-          resp,
-          Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))
+        assertVary(resp, Some(ci"Origin, Access-Control-Request-Method"))
       }
   }
 

--- a/server/shared/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/CORSSuite.scala
@@ -556,7 +556,7 @@ class CORSSuite extends Http4sSuite {
       .run(preflightReq.putHeaders(
         Header.Raw(ci"Access-Control-Request-Headers", "X-Cors-Suite-1, X-Cors-Suite-3")))
       .map { resp =>
-        assertAllowHeaders(resp, None)
+        assertAllowHeaders(resp, Some(ci"X-Cors-Suite-1, X-Cors-Suite-2"))
         assertVary(
           resp,
           Some(ci"Origin, Access-Control-Request-Method, Access-Control-Request-Headers"))


### PR DESCRIPTION
Fixes #5322 - full description of issue there. Changes behaviour of `allowHeadersIn` in `CORSPolicy` to match that of `allowedHeaders` in `CORSConfig`. 