### PR TITLE
Remove custom status reason phrases

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
@@ -36,7 +36,6 @@ import org.http4s.websocket.WebSocketContext
 import org.http4s.{headers => H}
 import org.typelevel.ci._
 import org.typelevel.vault._
-import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -534,21 +533,6 @@ class Http1ServerStageSpec extends Http4sSuite {
     val head = runRequest(tw, Seq.empty, Kleisli.liftF(Ok("")))
     head.result.map { _ =>
       assert(head.closeCauses == Seq(None))
-    }
-  }
-
-  fixture.test("Prevent response splitting attacks on status reason phrase") { tw =>
-    val rawReq = "GET /?reason=%0D%0AEvil:true%0D%0A HTTP/1.0\r\n\r\n"
-    @nowarn("cat=deprecation")
-    val head = runRequest(
-      tw,
-      List(rawReq),
-      HttpApp { req =>
-        Response[IO](Status.NoContent.withReason(req.params("reason"))).pure[IO]
-      })
-    head.result.map { buff =>
-      val (_, headers, _) = ResponseParser.parseBuffer(buff)
-      assertEquals(headers.find(_.name === ci"Evil"), None)
     }
   }
 

--- a/core/shared/src/main/scala/org/http4s/Status.scala
+++ b/core/shared/src/main/scala/org/http4s/Status.scala
@@ -18,9 +18,7 @@ package org.http4s
 
 import cats.{Order, Show}
 import org.http4s.Status.ResponseClass
-import org.http4s.internal.CharPredicate
 import org.http4s.util.Renderable
-import scala.annotation.nowarn
 
 /** Representation of the HTTP response code and reason
   *
@@ -31,11 +29,11 @@ import scala.annotation.nowarn
   * @see [[http://tools.ietf.org/html/rfc7231#section-6 RFC 7231, Section 6, Response Status Codes]]
   * @see [[http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml IANA Status Code Registry]]
   */
-sealed abstract case class Status private (code: Int)(
-    val reason: String,
-    val isEntityAllowed: Boolean)
-    extends Ordered[Status]
-    with Renderable {
+sealed abstract case class Status private (code: Int) extends Ordered[Status] with Renderable {
+
+  def reason: String
+
+  def isEntityAllowed: Boolean
 
   val responseClass: ResponseClass =
     if (code < 200) Status.Informational
@@ -48,18 +46,8 @@ sealed abstract case class Status private (code: Int)(
 
   def isSuccess: Boolean = responseClass.isSuccess
 
-  @deprecated(
-    "Custom status phrases will be removed in 1.0. They are an optional feature, pose a security risk, and already unsupported on some backends.",
-    "0.22.6")
-  def withReason(reason: String): Status = Status(code, reason, isEntityAllowed)
-
-  /** A sanitized [[reason]] phrase. Blank if reason is invalid per
-    * RFC7230, otherwise equivalent to reason.
-    */
-  def sanitizedReason: String = ""
-
   override def render(writer: org.http4s.util.Writer): writer.type =
-    writer << code << ' ' << sanitizedReason
+    writer << code << ' ' << reason
 
   /** Helpers for for matching against a [[Response]] */
   def unapply[F[_]](msg: Response[F]): Option[Response[F]] =
@@ -69,30 +57,17 @@ sealed abstract case class Status private (code: Int)(
 object Status {
   import Registry._
 
-  private val ReasonPhrasePredicate =
-    CharPredicate("\t ") ++ CharPredicate(0x21.toChar to 0x7e.toChar) ++ CharPredicate(
-      0x80.toChar to Char.MaxValue)
-
-  @deprecated(
-    "Use apply(Int). Custom status phrases will be removed in 1.0. They are an optional feature, pose a security risk, and already unsupported on some backends. For simplicity, we'll now assume that entities are allowed on all custom status codes.",
-    "0.22.6")
-  def apply(code: Int, reason: String = "", isEntityAllowed: Boolean = true): Status =
-    new Status(code)(reason, isEntityAllowed) {
-      override lazy val sanitizedReason =
-        if (reason.forall(ReasonPhrasePredicate))
-          reason
-        else
-          ""
-    }
-
-  @nowarn("cat=deprecation")
   def apply(code: Int): Status =
-    apply(code, "", true)
+    trust(code, "", true)
 
-  private def trust(code: Int, reason: String, isEntityAllowed: Boolean = true): Status =
-    new Status(code)(reason, isEntityAllowed) {
-      override val sanitizedReason = reason
+  private def trust(code: Int, reason: String, isEntityAllowed: Boolean = true): Status = {
+    val reason0 = reason
+    val isEntityAllowed0 = isEntityAllowed
+    new Status(code) {
+      def reason = reason0
+      def isEntityAllowed = isEntityAllowed0
     }
+  }
 
   sealed trait ResponseClass {
     def isSuccess: Boolean
@@ -119,17 +94,6 @@ object Status {
       lookup(code) match {
         case right: Right[_, _] => right
         case _ => ParseResult.success(trust(code, ""))
-      }
-    }
-
-  @deprecated(
-    "Use fromInt. Custom status phrases will be removed in 1.0. They are an optional feature, pose a security risk, and already unsupported on some backends.",
-    "0.22.6")
-  def fromIntAndReason(code: Int, reason: String): ParseResult[Status] =
-    withRangeCheck(code) {
-      lookup(code, reason) match {
-        case right: Right[_, _] => right
-        case _ => ParseResult.success(Status(code, reason))
       }
     }
 

--- a/ember-core/src/test/scala/org/http4s/ember/core/ResponseSplittingSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ResponseSplittingSuite.scala
@@ -21,7 +21,6 @@ import cats.effect.{Concurrent, IO}
 import cats.implicits._
 import org.http4s.implicits._
 import org.typelevel.ci._
-import scala.annotation.nowarn
 
 class ResponseSplittingSuite extends Http4sSuite {
   def attack[F[_]](app: HttpApp[F], req: Request[F])(implicit F: Concurrent[F]): F[Response[F]] =
@@ -33,17 +32,6 @@ class ResponseSplittingSuite extends Http4sSuite {
         .to(Array)
       result <- Parser.Response.parser[F](1024)(respBytes, F.pure(None))
     } yield (result._1)
-
-  test("Prevent response splitting attacks on status reason phrase") {
-    @nowarn("cat=deprecation")
-    val app = HttpApp[IO] { req =>
-      Response(Status.NoContent.withReason(req.params("reason"))).pure[IO]
-    }
-    val req = Request[IO](uri = uri"/?reason=%0D%0AEvil:true%0D%0A")
-    attack(app, req).map { resp =>
-      assertEquals(resp.headers.headers.find(_.name === ci"Evil"), None)
-    }
-  }
 
   test("Prevent response splitting attacks on field name") {
     val app = HttpApp[IO] { req =>

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -43,7 +43,6 @@ import org.typelevel.ci.CIString
 import org.typelevel.ci.testing.arbitraries._
 
 import java.util.concurrent.TimeUnit
-import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.util.Try
@@ -162,20 +161,12 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
   val genStandardStatus =
     oneOf(Status.registered)
 
-  @deprecated(
-    "Custom status phrases will be removed in 1.0. They are an optional feature, pose a security risk, and already unsupported on some backends.",
-    "0.22.6")
-  val genCustomStatus = for {
-    code <- genValidStatusCode
-    reason <- genCustomStatusReason
-  } yield Status.fromInt(code).yolo.withReason(reason)
-
-  @nowarn("cat=deprecation")
   implicit val http4sTestingArbitraryForStatus: Arbitrary[Status] = Arbitrary(
-    frequency(
-      4 -> genStandardStatus,
-      1 -> genCustomStatus
+    oneOf(
+      genValidStatusCode.map(Status(_)),
+      genStandardStatus
     ))
+
   implicit val http4sTestingCogenForStatus: Cogen[Status] =
     Cogen[Int].contramap(_.code)
 

--- a/tests/shared/src/test/scala/org/http4s/StatusSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/StatusSpec.scala
@@ -22,9 +22,8 @@ import java.nio.charset.StandardCharsets
 import org.http4s.Status._
 import org.scalacheck.Gen
 import org.scalacheck.Prop.{forAll, propBoolean}
-import scala.annotation.nowarn
 
-class StatusSpec extends StatusDeprecatedSpec {
+class StatusSpec extends Http4sSuite {
   checkAll("Status", OrderTests[Status].order)
 
   test("Statuses should not be equal if their codes are not") {
@@ -35,8 +34,8 @@ class StatusSpec extends StatusDeprecatedSpec {
 
   test("Statuses should be equal if their codes are") {
     forAll(genValidStatusCode) { i =>
-      val s1: Status = getStatus(i, "a reason")
-      val s2: Status = getStatus(i, "another reason")
+      val s1: Status = getStatus(i)
+      val s2: Status = getStatus(i)
       s1 == s2
     }
   }
@@ -92,22 +91,6 @@ class StatusSpec extends StatusDeprecatedSpec {
     assertEquals(getStatus(NotFound.code).reason, "Not Found")
   }
 
-  test(
-    "Finding a status by code and reason should succeed if the code is in the valid range, but not a standard code") {
-    val s1 = getStatus(371, "some reason")
-    assertEquals(s1.code, 371)
-    assertEquals(s1.reason, "some reason")
-  }
-
-  test(
-    "Finding a status by code and reason should succeed for a standard code and nonstandard reason, without replacing the default reason") {
-    assertEquals(
-      getStatus(NotFound.code, "My dog ate my homework").reason,
-      "My dog ate my homework")
-
-    assertEquals(getStatus(NotFound.code).reason, "Not Found")
-  }
-
   test("all known status have a reason") {
     Status.registered.foreach { status =>
       assert(status.renderString.drop(4).nonEmpty, status.renderString)
@@ -124,23 +107,6 @@ class StatusSpec extends StatusDeprecatedSpec {
 
   private def getStatus(code: Int) =
     fromInt(code) match {
-      case Right(s) => s
-      case Left(t) => throw t
-    }
-}
-
-@nowarn("cat=deprecation")
-class StatusDeprecatedSpec extends Http4sSuite {
-  test("Finding a status by code and reason should fail if the code is not in the valid range") {
-    assert(fromIntAndReason(17, "a reason").isLeft)
-  }
-
-  test("Finding a status by code and reason should succeed for a standard code and reason") {
-    assertEquals(getStatus(NotFound.code, "Not Found").reason, "Not Found")
-  }
-
-  protected def getStatus(code: Int, reason: String) =
-    fromIntAndReason(code, reason) match {
       case Right(s) => s
       case Left(t) => throw t
     }


### PR DESCRIPTION
Follows up on the deprecations initiated in 0.22.6.

Also ports the encoding away from the weird case class with a second parameter list.  It's an exotic Scala feature that we don't need.