### PR TITLE
Fix 0.23 merge

### DIFF
--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -39,8 +39,6 @@ import org.typelevel.vault.{Key, Vault}
 
 import scala.concurrent.duration._
 import scodec.bits.ByteVector
-import org.http4s.headers.Connection
-import java.nio.channels.InterruptedByTimeoutException
 import java.util.concurrent.TimeoutException
 
 private[server] object ServerHelpers {
@@ -357,8 +355,6 @@ private[server] object ServerHelpers {
                 case EmberException.EmptyStream() =>
                   Applicative[F].pure(None)
                 case _: TimeoutException =>
-                  Applicative[F].pure(None)
-                case _: InterruptedByTimeoutException =>
                   Applicative[F].pure(None)
                 case err =>
                   errorHandler(err)


### PR DESCRIPTION
Should get things green again. Also removes `InterruptedByTimeoutException` following up on https://github.com/http4s/http4s/pull/5330#discussion_r721875680 and to simplify the merge into main.