### PR TITLE
Specialize read timeout and header timeout exceptions in server

### DIFF
--- a/ember-core/src/main/scala/org/http4s/ember/core/EmberException.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/EmberException.scala
@@ -19,6 +19,7 @@ package org.http4s.ember.core
 import cats.syntax.all._
 import java.time.Instant
 import scala.concurrent.duration.Duration
+import scala.util.control.NoStackTrace
 
 sealed trait EmberException extends RuntimeException with Product with Serializable
 
@@ -57,7 +58,9 @@ object EmberException {
     override def getMessage: String = s"Read timeout after $duration"
   }
 
-  final case class RequestHeadersTimeout(duration: Duration) extends EmberException {
+  private[ember] final case class RequestHeadersTimeout(duration: Duration)
+      extends EmberException
+      with NoStackTrace {
     override def getMessage: String = s"Timed out waiting for request headers after $duration"
   }
 

--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -257,11 +257,8 @@ private[server] object ServerHelpers {
               }
             case Left(err) =>
               err match {
-                case EmberException.EmptyStream() =>
-                  Applicative[F].pure(None)
-                case _: EmberException.RequestHeadersTimeout =>
-                  Applicative[F].pure(None)
-                case _: EmberException.ReadTimeout =>
+                case EmberException.EmptyStream() | EmberException.RequestHeadersTimeout(_) |
+                    EmberException.ReadTimeout(_) =>
                   Applicative[F].pure(None)
                 case err =>
                   errorHandler(err)


### PR DESCRIPTION
The previous error handler was too broad in the domain of exceptions it would catch. User code can throw `TimeoutException` but those don't count as I/O timeouts that should necessarily induce a connection termination. While the old behavior was spec compliant, the new behavior makes more sense