### PR TITLE
Enable http4s-circe.js to dead-code-eliminate Jawn

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -544,6 +544,7 @@ lazy val circe = libraryCrossProject("circe", CrossType.Pure)
     startYear := Some(2015),
     libraryDependencies ++= Seq(
       circeCore.value,
+      circeParser.value,
       circeTesting.value % Test
     )
   )
@@ -607,7 +608,7 @@ lazy val bench = http4sProject("bench")
   .settings(
     description := "Benchmarks for http4s",
     startYear := Some(2015),
-    libraryDependencies += circeParser,
+    libraryDependencies += circeParser.value,
     undeclaredCompileDependenciesTest := {},
     unusedCompileDependenciesTest := {},
   )

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -309,7 +309,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val circeJawn                        = Def.setting("io.circe"               %%% "circe-jawn"                % V.circe)
   lazy val circeJawn15                      = Def.setting("io.circe"               %%% "circe-jawn"                % V.circe15)
   lazy val circeLiteral                     =             "io.circe"               %%  "circe-literal"             % V.circe
-  lazy val circeParser                      =             "io.circe"               %%  "circe-parser"              % V.circe
+  lazy val circeParser                      = Def.setting("io.circe"               %%% "circe-parser"              % V.circe)
   lazy val circeTesting                     = Def.setting("io.circe"               %%% "circe-testing"             % V.circe)
   lazy val crypto                           = Def.setting("org.http4s"             %%% "http4s-crypto"             % V.crypto)
   lazy val cryptobits                       =             "org.reactormonk"        %%  "cryptobits"                % V.cryptobits


### PR DESCRIPTION
Some minor adjusting of the circle module to allow Jawn to be completely dead-code-eliminated on Scala.js (verified manually). Addresses https://github.com/http4s/http4s-dom/issues/10, this was not at all as involved as I thought!

It is graceful, such that the default decoder bypasses Jawn, but other Jawn-based decoders will also continue to work on Scala.js if referenced directly.

This adds a new dependency to `circe-parser`, which is a _tiny_ wrapper for Jawn on JVM and the native JSON parser on Scala.js (i.e., adds no new dependencies). However, it's only used on Scala.js (there are no changes for JVM).