### PR TITLE
Experimental: Http1 codec reform

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/Http1DecoderBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/Http1DecoderBench.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package bench
+
+import org.openjdk.jmh.annotations._
+
+@Threads(1)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+class Http1DecoderBench {
+  @Benchmark
+  def http1Decoder: Either[ParseFailure, (Int, ResponsePrelude)] =
+    Http1DecoderBench.http1Decoder.decode(Http1DecoderBench.chunk)
+
+  @Benchmark
+  def ember: Either[Throwable, (Int, ResponsePrelude)] = {
+    import org.http4s.ember.core.Parser.Response.RespPrelude._
+    import org.http4s.ember.core.Parser._
+
+    val arr = Http1DecoderBench.chunk.toArray
+    parsePrelude[Either[Throwable, *]](arr, 1024).flatMap {
+      case Left(_) => Left(new Exception("WTF?"))
+      case Right(RespPrelude(version, status, next)) =>
+        HeaderP.parseHeaders[Either[Throwable, *]](arr, next, 1024).flatMap {
+          case Left(_) => Left(new Exception("WTF?"))
+          case Right(HeaderP(headers, _, _, i)) =>
+            Right(
+              (
+                i,
+                ResponsePrelude(
+                  httpVersion = version,
+                  status = status,
+                  headers = headers
+                )))
+        }
+    }
+  }
+}
+
+object Http1DecoderBench {
+  val resp = ResponsePrelude(
+    httpVersion = HttpVersion.`HTTP/1.1`,
+    status = Status.Ok,
+    headers = Headers(
+      "Access-Control-Allow-Credentials" -> "true",
+      "Access-Control-Allow-Origin" -> "*",
+      "Connection" -> "keep-alive",
+      "Content-Length" -> "9593",
+      "Content-Type" -> "text/html; charset=utf-8",
+      "Date" -> "Sun, 10 Oct 2021 03:34:47 GMT",
+      "Server" -> "gunicorn/19.9.0"
+    )
+  )
+  val chunk = ResponsePrelude.http1Codec.encode(resp)
+
+  val decoder = Http1Decoder
+
+  import cats.parse.{Parser => P}
+  import cats.parse.Rfc5234
+  import org.http4s.internal.parsing.Rfc7230
+  import org.typelevel.ci._
+
+  // This parser is sloppy.
+  private val parser: P[ResponsePrelude] = {
+    val statusCode: P[Status] = Rfc5234.digit.rep(3).string.mapFilter { code =>
+      Status.fromInt(code.toInt).fold(_ => None, Some(_))
+    }
+    val reasonPhrase = Rfc5234.vchar.orElse(P.charIn(" \t")).rep
+    val status: P[Status] = statusCode <* P.char(' ') <* reasonPhrase
+
+    val fieldValue = Rfc5234.vchar.rep.repSep(P.charIn(" \t")).string
+    val header = ((Rfc7230.token.string <* P.char(
+      ':') <* Rfc7230.ows) ~ (fieldValue <* Rfc7230.ows <* P.string("\r\n"))).map { case (k, v) =>
+      Header.Raw(CIString(k), v)
+    }
+    val headers = header.rep0 <* P.string("\r\n")
+
+    (HttpVersion.parser ~ (P.char(' ') *> status <* P.string("\r\n")) ~ headers).map {
+      case ((httpVersion, status), headers) =>
+        ResponsePrelude(httpVersion = httpVersion, status = status, headers = Headers(headers))
+    }
+  }
+
+  val http1Decoder: Http1Decoder[ResponsePrelude] =
+    Http1Decoder.catsParse(parser, "Invalid response prelude")
+}

--- a/bench/src/main/scala/org/http4s/bench/RenderBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/RenderBench.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package bench
+
+import cats.implicits._
+import fs2.Chunk
+import java.nio.charset.StandardCharsets
+import org.openjdk.jmh.annotations._
+import org.http4s.util._
+
+@Threads(1)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+class RenderBench {
+  import RenderBench._
+
+  @Benchmark
+  def imperativeString = {
+    val sw = new StringWriter(256)
+    sw << resp.httpVersion << " " << resp.status << "\r\n"
+    resp.headers.foreach { h =>
+      sw << h << "\r\n"
+    }
+    sw << "\r\n"
+    Chunk.array(sw.result.getBytes(StandardCharsets.US_ASCII)).toByteBuffer
+  }
+
+  @Benchmark
+  def http1Encoder = ResponsePrelude.http1Codec.encode(resp).toByteBuffer
+}
+
+object RenderBench {
+  val resp = ResponsePrelude(
+    httpVersion = HttpVersion.`HTTP/1.1`,
+    status = Status.Ok,
+    headers = Headers(
+      "Access-Control-Allow-Credentials" -> "true",
+      "Access-Control-Allow-Origin" -> "*",
+      "Connection" -> "keep-alive",
+      "Content-Length" -> "9593",
+      "Content-Type" -> "text/html; charset=utf-8",
+      "Date" -> "Sun, 10 Oct 2021 03:34:47 GMT",
+      "Server" -> "gunicorn/19.9.0"
+    )
+  )
+}

--- a/bench/src/main/scala/org/http4s/bench/RenderBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/RenderBench.scala
@@ -17,7 +17,6 @@
 package org.http4s
 package bench
 
-import cats.implicits._
 import fs2.Chunk
 import java.nio.charset.StandardCharsets
 import org.openjdk.jmh.annotations._
@@ -35,6 +34,7 @@ class RenderBench {
     sw << resp.httpVersion << " " << resp.status << "\r\n"
     resp.headers.foreach { h =>
       sw << h << "\r\n"
+      ()
     }
     sw << "\r\n"
     Chunk.array(sw.result.getBytes(StandardCharsets.US_ASCII)).toByteBuffer

--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -67,6 +67,18 @@ object Header {
         writer.sanitize(_ << h.value)
       }
     }
+
+    val http1Codec: Http1Encoder[Header.Raw] = {
+      import Http1Encoder._
+      (
+        ascii.suffix(const(ascii, ": ")),
+        ascii
+      ).contramapN(h =>
+        (
+          h.name.toString,
+          h.value
+        ))
+    }
   }
 
   /** Classifies modelled headers into `Single` headers, which can only

--- a/core/src/main/scala/org/http4s/Http1Decoder.scala
+++ b/core/src/main/scala/org/http4s/Http1Decoder.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+
+import cats._
+import cats.parse.Parser0
+import java.nio.charset.StandardCharsets.US_ASCII
+import fs2.Chunk
+
+sealed trait Http1Decoder[A] { self =>
+  def decode(chunk: Chunk[Byte]): Either[ParseFailure, (Int, A)]
+
+  def product[B](fb: Http1Decoder[B]): Http1Decoder[(A, B)] =
+    new Http1Decoder[(A, B)] {
+      override def decode(chunk: Chunk[Byte]): Either[ParseFailure, (Int, (A, B))] =
+        self.decode(chunk).flatMap { case (offsetA, a) =>
+          fb.decode(chunk.drop(offsetA)).map { case (offsetB, b) =>
+            (offsetB, (a, b))
+          }
+        }
+    }
+
+  def map[B](f: A => B): Http1Decoder[B] =
+    new Http1Decoder[B] {
+      def decode(chunk: Chunk[Byte]): Either[ParseFailure, (Int, B)] =
+        self.decode(chunk).map { case (offset, a) =>
+          (offset, f(a))
+        }
+    }
+}
+
+object Http1Decoder { self =>
+  def catsParse[A](p: Parser0[A], errorMessage: => String): Http1Decoder[A] =
+    new Http1Decoder[A] {
+      def decode(chunk: Chunk[Byte]): Either[ParseFailure, (Int, A)] = {
+        val s = new String(chunk.toArray, US_ASCII)
+        try p.parse(s) match {
+          case Left(e) =>
+            Left(ParseFailure(errorMessage, e.toString))
+          case Right((leftover, a)) =>
+            Right((s.length - leftover.length, a))
+        } catch {
+          case p: ParseFailure => Left(p)
+        }
+      }
+    }
+
+  def pure[A](a: A): Http1Decoder[A] =
+    new Http1Decoder[A] {
+      def decode(chunk: Chunk[Byte]) = Right((0, a))
+    }
+
+  val unit: Http1Decoder[Unit] =
+    new Http1Decoder[Unit] {
+      def decode(chunk: Chunk[Byte]) = Right((0, ()))
+    }
+
+  implicit val catsInstancesForHttp4sHttp1Decoder: Applicative[Http1Decoder] =
+    new Applicative[Http1Decoder] {
+      override def map[A, B](fa: Http1Decoder[A])(f: A => B) =
+        fa.map(f)
+      def ap[A, B](ff: Http1Decoder[A => B])(fa: Http1Decoder[A]) =
+        ff.product(fa).map { case (f, a) => f(a) }
+      def pure[A](a: A): Http1Decoder[A] =
+        self.pure(a)
+      override def unit: Http1Decoder[Unit] = self.unit
+    }
+}

--- a/core/src/main/scala/org/http4s/Http1Encoder.scala
+++ b/core/src/main/scala/org/http4s/Http1Encoder.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+
+import cats._
+import fs2.Chunk
+
+sealed trait Http1Encoder[A] { self =>
+  import Http1Encoder.Buffer
+
+  protected def put(buf: Buffer, a: A): Unit
+
+  def encode(a: A): Chunk[Byte] = {
+    val buf = new Buffer()
+    put(buf, a)
+    buf.toChunk
+  }
+
+  def contramap[B](f: B => A) =
+    new Http1Encoder[B] {
+      override protected def put(buf: Buffer, b: B): Unit =
+        self.put(buf, f(b))
+      override def encode(b: B): Chunk[Byte] =
+        self.encode(f(b))
+    }
+
+  def product[B](fb: Http1Encoder[B]): Http1Encoder[(A, B)] =
+    new Http1Encoder[(A, B)] {
+      override protected def put(buf: Buffer, ab: (A, B)): Unit = {
+        self.put(buf, ab._1)
+        fb.put(buf, ab._2)
+      }
+    }
+
+  def prefix(fb: Http1Encoder[Unit]): Http1Encoder[A] =
+    new Http1Encoder[A] {
+      override protected def put(buf: Buffer, a: A): Unit = {
+        fb.put(buf, ())
+        self.put(buf, a)
+      }
+    }
+
+  def suffix(fb: Http1Encoder[Unit]): Http1Encoder[A] =
+    new Http1Encoder[A] {
+      override protected def put(buf: Buffer, a: A): Unit = {
+        self.put(buf, a)
+        fb.put(buf, ())
+      }
+    }
+}
+
+object Http1Encoder {
+  private[Http1Encoder] class Buffer() {
+    private[this] var capacity = 256
+    private[this] var buf = new Array[Byte](capacity)
+    private[this] var pos = 0
+
+    def +=(cs: CharSequence): Unit = {
+      val len = cs.length()
+      ensureCapacity(pos + len)
+      var i = 0
+      while (i < len) {
+        buf(pos) = cs.charAt(i).toByte
+        i += 1
+        pos += 1
+      }
+    }
+
+    def +=(b: Byte): Unit = {
+      ensureCapacity(pos + 1)
+      buf(pos) = b
+      pos += 1
+    }
+
+    private[this] def ensureCapacity(n: Int) =
+      if (buf.size < n) {
+        val newCapacity = capacity * 2
+        val newBuf = new Array[Byte](newCapacity)
+        Array.copy(buf, 0, newBuf, 0, pos)
+        buf = newBuf
+      }
+
+    def toChunk = Chunk.array(buf, 0, pos)
+  }
+
+  val ascii: Http1Encoder[CharSequence] =
+    new Http1Encoder[CharSequence] {
+      override protected def put(buf: Buffer, cs: CharSequence) =
+        buf += cs
+    }
+
+  val byte: Http1Encoder[Byte] =
+    new Http1Encoder[Byte] {
+      override protected def put(buf: Buffer, b: Byte) =
+        buf += b
+    }
+
+  val int: Http1Encoder[Int] =
+    new Http1Encoder[Int] {
+      override protected def put(buf: Buffer, i: Int) =
+        buf += i.toString
+    }
+
+  def seq[A](fa: Http1Encoder[A]): Http1Encoder[Seq[A]] =
+    new Http1Encoder[Seq[A]] {
+      override protected def put(buf: Buffer, seq: Seq[A]) =
+        seq.foreach { a =>
+          fa.put(buf, a)
+        }
+    }
+
+  def const[A](fa: Http1Encoder[A], a: A): Http1Encoder[Unit] =
+    new Http1Encoder[Unit] {
+      override protected def put(buf: Buffer, unit: Unit) = {
+        val _ = unit
+        fa.put(buf, a)
+      }
+    }
+
+  implicit val ContravariantSemigroupalHttp1Encoder: ContravariantSemigroupal[Http1Encoder] =
+    new ContravariantSemigroupal[Http1Encoder] {
+      def contramap[A, B](fa: Http1Encoder[A])(f: B => A) =
+        fa.contramap(f)
+      def product[A, B](fa: Http1Encoder[A], fb: Http1Encoder[B]) =
+        fa.product(fb)
+    }
+}

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -164,7 +164,7 @@ object HttpVersion {
         ParseResult.fromParser(parser, "HTTP version")(s)
     }
 
-  private val parser: P[HttpVersion] = {
+  private[http4s] val parser: P[HttpVersion] = {
     // HTTP-name = %x48.54.54.50 ; HTTP
     // HTTP-version = HTTP-name "/" DIGIT "." DIGIT
     val httpVersion = P.string("HTTP/") *> digit ~ (P.char('.') *> digit)
@@ -231,7 +231,7 @@ object HttpVersion {
   implicit val http1Codec: Http1Encoder[HttpVersion] = {
     import Http1Encoder._
     (
-      int.prefix(const(ascii, "HTTP/")).suffix(const(byte, '/'.toByte)),
+      int.prefix(const(ascii, "HTTP/")).suffix(const(byte, '.'.toByte)),
       int
     ).contramapN(v =>
       (
@@ -239,4 +239,7 @@ object HttpVersion {
         v.minor
       ))
   }
+
+  implicit val http1Decoder: Http1Decoder[HttpVersion] =
+    Http1Decoder.catsParse(parser, "Invalid HTTP version")
 }

--- a/core/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/src/main/scala/org/http4s/HttpVersion.scala
@@ -227,4 +227,16 @@ object HttpVersion {
     override def minBound: HttpVersion = HttpVersion(0, 0)
     override def maxBound: HttpVersion = HttpVersion(9, 9)
   }
+
+  implicit val http1Codec: Http1Encoder[HttpVersion] = {
+    import Http1Encoder._
+    (
+      int.prefix(const(ascii, "HTTP/")).suffix(const(byte, '/'.toByte)),
+      int
+    ).contramapN(v =>
+      (
+        v.major,
+        v.minor
+      ))
+  }
 }

--- a/core/src/main/scala/org/http4s/ResponsePrelude.scala
+++ b/core/src/main/scala/org/http4s/ResponsePrelude.scala
@@ -102,6 +102,9 @@ object ResponsePrelude {
   implicit val catsShowForResponsePrelude: Show[ResponsePrelude] =
     Show.fromToString
 
+  implicit def stdLibOrdering: Ordering[ResponsePrelude] =
+    catsHashAndOrderForResponsePrelude.toOrdering
+ 
   val http1Codec: Http1Encoder[ResponsePrelude] = {
     import Http1Encoder._
     (

--- a/core/src/main/scala/org/http4s/ResponsePrelude.scala
+++ b/core/src/main/scala/org/http4s/ResponsePrelude.scala
@@ -102,6 +102,19 @@ object ResponsePrelude {
   implicit val catsShowForResponsePrelude: Show[ResponsePrelude] =
     Show.fromToString
 
-  implicit def stdLibOrdering: Ordering[ResponsePrelude] =
-    catsHashAndOrderForResponsePrelude.toOrdering
+  val http1Codec: Http1Encoder[ResponsePrelude] = {
+    import Http1Encoder._
+    (
+      HttpVersion.http1Codec.suffix(const(byte, ' '.toByte)),
+      Status.http1Codec.suffix(const(ascii, "\r\n")),
+      Http1Encoder
+        .seq(Header.Raw.http1Codec.suffix(const(ascii, "\r\n")))
+        .suffix(const(ascii, "\r\n"))
+    ).contramapN(r =>
+      (
+        r.httpVersion,
+        r.status,
+        r.headers.headers
+      ))
+  }
 }

--- a/core/src/main/scala/org/http4s/Status.scala
+++ b/core/src/main/scala/org/http4s/Status.scala
@@ -17,6 +17,7 @@
 package org.http4s
 
 import cats.{Order, Show}
+import cats.syntax.all._
 import org.http4s.Status.ResponseClass
 import org.http4s.internal.CharPredicate
 import org.http4s.util.Renderable
@@ -250,4 +251,16 @@ object Status {
 
   implicit val http4sOrderForStatus: Order[Status] = Order.fromOrdering[Status]
   implicit val http4sShowForStatus: Show[Status] = Show.fromToString[Status]
+
+  val http1Codec: Http1Encoder[Status] = {
+    import Http1Encoder._
+    (
+      int.suffix(const(byte, ' '.toByte)),
+      ascii
+    ).contramapN(s =>
+      (
+        s.code,
+        s.reason
+      ))
+  }
 }

--- a/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -27,7 +27,7 @@ import scala.annotation.switch
 import scala.collection.mutable
 import cats.data.EitherT
 
-private[ember] object Parser {
+private[http4s] object Parser {
 
   object MessageP {
 


### PR DESCRIPTION
Trying to replace `Renderable` with something both more functional and performant.  It's a riff on [this gist]( https://gist.github.com/rossabaker/6a5b4be9ddd61b8ae0ca1346f61cb06e) with [twitter discussion](https://twitter.com/rossabaker/status/1443948901665546251).

Our current approach is to render to a `StringBuilder`, and then ASCII-encode that at once into an `Array[Byte]`.  This has proven more efficient than using a `CharsetEncoder` to incrementally encode small strings to a `ByteBuffer`, and much more efficient than converting small strings to concatenated `ByteVector`s or `Chunk`s.

The new approach proposed here is to create an internal byte buffer similar to `StringBuilder` that assumes one-char-per-byte and otherwise operates just like `StringBuilder`.  The array storage from this buffer is wrapped directly in a `Chunk`, eliminating a copy.  The mutable state can be wrapped in a protected method and composed via `ContravariantSemigroupal`.  Careful use of combinators like `prefix` and `suffix` eliminates nested tuples from the semigroupal and considerably improves performance.

It is named `Http1Encoder`, because HTTP/2 is stateful and I don't even begin to understand HTTP/3.