### PR TITLE
QueryOps +? -> ++? doctest and migration guide

### DIFF
--- a/core/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/src/main/scala/org/http4s/QueryOps.scala
@@ -53,7 +53,14 @@ trait QueryOps {
   def +?[K: QueryParamKeyLike](name: K): Self =
     _withQueryParam(QueryParamKeyLike[K].getKey(name), Nil)
 
-  /** alias for withQueryParam */
+  /** alias for withQueryParam
+    *
+    * {{{
+    * scala> import org.http4s.implicits._
+    * scala> uri"www.scala.com".++?("key" -> List("value1", "value2", "value3"))
+    * res1: Uri = www.scala.com?key=value1&key=value2&key=value3
+    * }}}
+    */
   def ++?[K: QueryParamKeyLike, T: QueryParamEncoder](param: (K, collection.Seq[T])): Self =
     _withQueryParam(
       QueryParamKeyLike[K].getKey(param._1),

--- a/docs/src/main/mdoc/upgrading.md
+++ b/docs/src/main/mdoc/upgrading.md
@@ -39,6 +39,7 @@ Header names are now CIStrings which can be created by importing `org.typelevel.
 | baseUri +?? ("p", w)           | baseUri +?? ("p" -> w)          |
 | "x-ms".ci                      | ci"x-ms"                        |
 | import org.http4s.server.blaze | import org.http4s.blaze.server  |
+| baseUri.+?("k", List(v, v1))   | baseUri.++?("k" -> List(v, v1)) |
 
 
 


### PR DESCRIPTION
Just adding a doctest portion for a piece of query ops that changed and added it to the migration guide from 0.21 to 0.22