### PR TITLE
Pin dependencies for 0.22

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,24 @@
+updates.pin = [
+  # Jetty > 9 and Tomcat > 9 are breaking changes
+  { groupId = "org.eclipse.jetty", version = "9." },
+  { groupId = "org.eclipse.jetty.http2", version = "9." },
+  { groupId = "org.apache.tomcat", version = "9." },
+  # Servlet 4 breaks Jetty 9 and Tomcat 9
+  { groupId = "javax.servlet", version = "3." },
+  # simpleclient-0.12 breaks metric names
+  { groupId = "io.prometheus", version = "0.11." },
+  # Maintain Cats-Effect 3 support
+  { groupId = "org.typelevel", artifactId = "log4cats-core", version = "1." },
+  { groupId = "org.typelevel", artifactId = "log4cats-slf4j", version = "1." },
+  { groupId = "org.typelevel", artifactId = "log4cats-testing", version = "1." },
+  { groupId = "com.comcast", artifactId = "ip4s-core", version = "2." },
+  { groupId = "com.comcast", artifactId = "ip4s-test-kit", version = "2." },
+  { groupId = "org.typelevel", artifactId = "cats-effect", version = "2." },
+  { groupId = "org.typelevel", artifactId = "cats-effect-laws", version = "2." },
+  { groupId = "org.typelevel", artifactId = "vault", version = "2." },
+  { groupId = "org.typelevel", artifactId = "keypool", version = "0.3." },
+  { groupId = "co.fs2", version = "2." },
+  # Maintain Scala 3.0 support
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.0." },
+  { groupId = "org.typelevel", artifactId = "discipline-core", version = "1.2." }
+]

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -68,24 +68,6 @@ object Http4sPlugin extends AutoPlugin {
       IO.write(dest, buildData)
     },
 
-    // servlet-4.0 is not yet supported by jetty-9 or tomcat-9, so don't accidentally depend on its new features
-    dependencyUpdatesFilter -= moduleFilter(organization = "javax.servlet", revision = "4.0.0"),
-    dependencyUpdatesFilter -= moduleFilter(organization = "javax.servlet", revision = "4.0.1"),
-    // servlet containers skipped until we figure out our Jakarta EE strategy
-    dependencyUpdatesFilter -= moduleFilter(organization = "org.eclipse.jetty*", revision = "10.0.*"),
-    dependencyUpdatesFilter -= moduleFilter(organization = "org.eclipse.jetty*", revision = "11.0.*"),
-    dependencyUpdatesFilter -= moduleFilter(organization = "org.apache.tomcat", revision = "10.0.*"),
-    // Cursed release. Calls ByteBuffer incompatibly with JDK8
-    dependencyUpdatesFilter -= moduleFilter(name = "boopickle", revision = "1.3.2"),
-    // CE3
-    dependencyUpdatesFilter -= moduleFilter(name = "log4cats-*", revision = "2.*"),
-    dependencyUpdatesFilter -= moduleFilter(name = "ip4s-*", revision = "3.*"),
-    dependencyUpdatesFilter -= moduleFilter(name = "cats-effect*", revision = "3.*"),
-    dependencyUpdatesFilter -= moduleFilter(name = "vault", revision = "3.*"),
-    dependencyUpdatesFilter -= moduleFilter(name = "keypool", revision = "0.4.*"),
-    dependencyUpdatesFilter -= moduleFilter(organization = "co.fs2", name = "fs2-*", revision = "3.*"),
-    dependencyUpdatesFilter -= moduleFilter(organization = "io.prometheus", revision = "0.12.*"),
-
     headerSources / excludeFilter := HiddenFileFilter ||
       new FileFilter {
         def accept(file: File) = {


### PR DESCRIPTION
Replaces the sbt setting, which don't give us the granularity of allowing patches and minor bumps while preventing major bumps.

Pins dependencies whose later versions are known to break compatibility with Cats Effect 2, Scala 3.0, Servlet 3.1, or themselves.

This should reduce some of the triple PR's we're getting with the new Scala Steward feature.