### PR TITLE
Exclude `scalajs-dom` transitive dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,10 @@ lazy val core = libraryCrossProject("core")
       catsParse.value.exclude("org.typelevel", "cats-core_2.13"),
       crypto.value,
       fs2Core.value,
-      fs2Io.value,
+      fs2Io.value // Workaround for https://github.com/typelevel/fs2/pull/2681
+        .exclude("org.scala-js", "scalajs-dom_sjs1_2.12")
+        .exclude("org.scala-js", "scalajs-dom_sjs1_2.13")
+        .exclude("org.scala-js", "scalajs-dom_sjs1_3"),
       ip4sCore.value,
       literally.value,
       log4s.value,


### PR DESCRIPTION
So this was a very nasty surprise ... that http4s-core.js has been depending on sjs-dom v1 all along, transitively via fs2-io.js via its internal Node.js facade. This was added automatically by the facade-generating plugin without me realizing and is not used at all by fs2.io.js (nor http4s proper). Now that sjs-dom v2 is out, this lands us in a big mess in https://github.com/http4s/http4s-dom/pull/23.

There is a pending fix for it upstream in https://github.com/typelevel/fs2/pull/2681, but I'm becoming less optimistic that it will land in a non-compatibility-breaking release. So, this is the defensive maneuver.

I'd do the exclusion in http4s-dom, except users would still have problems if they tried to use http4s-circe with http4s-dom 0.2 series. So the change really needs to happen here.