### PR TITLE
EntityEncoder: use variance of type parameters

### DIFF
--- a/boopickle/src/main/scala/org/http4s/booPickle/instances/BooPickleInstances.scala
+++ b/boopickle/src/main/scala/org/http4s/booPickle/instances/BooPickleInstances.scala
@@ -52,8 +52,8 @@ trait BooPickleInstances {
 
   /** Create an `EntityEncoder` for `A` given a `Pickler[A]`
     */
-  def booEncoderOf[F[_], A: Pickler]: EntityEncoder[F, A] =
-    chunkEncoder[F]
+  def booEncoderOf[A: Pickler]: EntityEncoder[fs2.Pure, A] =
+    chunkEncoder
       .contramap[A] { v =>
         Chunk.ByteBuffer(Pickle.intoBytes(v))
       }

--- a/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSuite.scala
+++ b/boopickle/src/test/scala/org/http4s/booPickle/BoopickleSuite.scala
@@ -51,7 +51,7 @@ class BoopickleSuite extends Http4sSuite with Http4sLawSuite {
   implicit val fruitPickler: Pickler[Fruit] =
     compositePickler[Fruit].addConcreteType[Banana].addConcreteType[Kiwi].addConcreteType[Carambola]
 
-  implicit val encoder: EntityEncoder[IO, Fruit] = booEncoderOf[IO, Fruit]
+  implicit val encoder: EntityEncoder[IO, Fruit] = booEncoderOf[Fruit]
   implicit val decoder: EntityDecoder[IO, Fruit] = booOf[IO, Fruit]
 
   implicit val fruitArbitrary: Arbitrary[Fruit] = Arbitrary {
@@ -71,7 +71,7 @@ class BoopickleSuite extends Http4sSuite with Http4sLawSuite {
 
   test("have octect-stream content type") {
     assertEquals(
-      booEncoderOf[IO, Fruit].headers.get[`Content-Type`],
+      booEncoderOf[Fruit].headers.get[`Content-Type`],
       Some(`Content-Type`(MediaType.application.`octet-stream`)))
   }
 

--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -80,7 +80,7 @@ object JsonDebugErrorHandler {
         redactWhen: CIString => Boolean
     ): EntityEncoder[F, JsonErrorHandlerResponse[G]] =
       jsonEncoderOf(
-        encoder(redactWhen)
+        encoder[G](redactWhen)
       )
     def encoder[F[_]](
         redactWhen: CIString => Boolean

--- a/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
@@ -20,7 +20,7 @@ import cats.{Contravariant, Show}
 import cats.data.NonEmptyList
 import cats.effect.Sync
 import cats.syntax.all._
-import fs2.{Chunk, Stream}
+import fs2.{Chunk, Pure, Stream}
 import fs2.io.file.Files
 import fs2.io.readInputStream
 import java.io._
@@ -32,7 +32,7 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound(
   "Cannot convert from ${A} to an Entity, because no EntityEncoder[${F}, ${A}] instance could be found.")
-trait EntityEncoder[F[_], A] { self =>
+trait EntityEncoder[+F[_], -A] { self =>
 
   /** Convert the type `A` to an [[Entity]] in the effect type `F` */
   def toEntity(a: A): Entity[F]
@@ -88,23 +88,23 @@ object EntityEncoder {
     *
     * This constructor is a helper for types that can be serialized synchronously, for example a String.
     */
-  def simple[F[_], A](hs: Header.ToRaw*)(toChunk: A => Chunk[Byte]): EntityEncoder[F, A] =
+  def simple[A](hs: Header.ToRaw*)(toChunk: A => Chunk[Byte]): EntityEncoder[Pure, A] =
     encodeBy(hs: _*) { a =>
       val c = toChunk(a)
-      Entity[F](Stream.chunk(c).covary[F], Some(c.size.toLong))
+      Entity[Pure](Stream.chunk(c), Some(c.size.toLong))
     }
 
   /** Encodes a value from its Show instance.  Too broad to be implicit, too useful to not exist. */
-  def showEncoder[F[_], A](implicit
+  def showEncoder[A](implicit
       charset: Charset = DefaultCharset,
-      show: Show[A]): EntityEncoder[F, A] = {
+      show: Show[A]): EntityEncoder[Pure, A] = {
     val hdr = `Content-Type`(MediaType.text.plain).withCharset(charset)
-    simple[F, A](hdr)(a => Chunk.array(show.show(a).getBytes(charset.nioCharset)))
+    simple[A](hdr)(a => Chunk.array(show.show(a).getBytes(charset.nioCharset)))
   }
 
-  def emptyEncoder[F[_], A]: EntityEncoder[F, A] =
-    new EntityEncoder[F, A] {
-      def toEntity(a: A): Entity[F] = Entity.empty
+  val emptyEncoder: EntityEncoder[Pure, Any] =
+    new EntityEncoder[Pure, Any] {
+      def toEntity(a: Any): Entity[Pure] = Entity.empty
       def headers: Headers = Headers.empty
     }
 
@@ -127,24 +127,23 @@ object EntityEncoder {
         }
     }
 
-  implicit def unitEncoder[F[_]]: EntityEncoder[F, Unit] =
-    emptyEncoder[F, Unit]
+  implicit val unitEncoder: EntityEncoder[Pure, Unit] = emptyEncoder
 
-  implicit def stringEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, String] = {
+  implicit def stringEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder[Pure, String] = {
     val hdr = `Content-Type`(MediaType.text.plain).withCharset(charset)
     simple(hdr)(s => Chunk.array(s.getBytes(charset.nioCharset)))
   }
 
-  implicit def charArrayEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Array[Char]] =
-    stringEncoder[F].contramap(new String(_))
+  implicit def charArrayEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder[Pure, Array[Char]] =
+    stringEncoder.contramap(new String(_))
 
-  implicit def chunkEncoder[F[_]]: EntityEncoder[F, Chunk[Byte]] =
+  implicit val chunkEncoder: EntityEncoder[Pure, Chunk[Byte]] =
     simple(`Content-Type`(MediaType.application.`octet-stream`))(identity)
 
-  implicit def byteArrayEncoder[F[_]]: EntityEncoder[F, Array[Byte]] =
-    chunkEncoder[F].contramap(Chunk.array[Byte])
+  implicit val byteArrayEncoder: EntityEncoder[Pure, Array[Byte]] =
+    chunkEncoder.contramap(Chunk.array[Byte])
 
   /** Encodes an entity body.  Chunking of the stream is preserved.  A
     * `Transfer-Encoding: chunked` header is set, as we cannot know

--- a/core/shared/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/shared/src/main/scala/org/http4s/MessageFailure.scala
@@ -58,7 +58,7 @@ final case class ParseFailure(sanitized: String, details: String)
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.BadRequest, httpVersion)
-      .withEntity(sanitized)(EntityEncoder.stringEncoder[F])
+      .withEntity(sanitized)(EntityEncoder.stringEncoder)
 }
 
 object ParseFailure {
@@ -107,7 +107,7 @@ final case class MalformedMessageBodyFailure(details: String, cause: Option[Thro
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.BadRequest, httpVersion)
-      .withEntity(s"The request body was malformed.")(EntityEncoder.stringEncoder[F])
+      .withEntity(s"The request body was malformed.")(EntityEncoder.stringEncoder)
 }
 
 /** Indicates a semantic error decoding the body of an HTTP [[Message]]. */
@@ -118,7 +118,7 @@ final case class InvalidMessageBodyFailure(details: String, cause: Option[Throwa
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.UnprocessableEntity, httpVersion)
-      .withEntity(s"The request body was invalid.")(EntityEncoder.stringEncoder[F])
+      .withEntity(s"The request body was invalid.")(EntityEncoder.stringEncoder)
 }
 
 /** Indicates that a [[Message]] came with no supported [[MediaType]]. */
@@ -133,7 +133,7 @@ sealed abstract class UnsupportedMediaTypeFailure extends DecodeFailure with NoS
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
     Response(Status.UnsupportedMediaType, httpVersion)
-      .withEntity(responseMsg)(EntityEncoder.stringEncoder[F])
+      .withEntity(responseMsg)(EntityEncoder.stringEncoder)
 }
 
 /** Indicates that a [[Message]] attempting to be decoded has no [[MediaType]] and no

--- a/core/shared/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/shared/src/main/scala/org/http4s/UrlForm.scala
@@ -24,6 +24,7 @@ import org.http4s.headers._
 import org.http4s.internal.CollectionCompat
 import org.http4s.parser._
 import scala.io.Codec
+import fs2.Pure
 
 class UrlForm private (val values: Map[String, Chain[String]]) extends AnyVal {
   override def toString: String = values.toString()
@@ -97,10 +98,9 @@ object UrlForm {
   def fromChain(values: Chain[(String, String)]): UrlForm =
     apply(values.toList: _*)
 
-  implicit def entityEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, UrlForm] =
-    EntityEncoder
-      .stringEncoder[F]
+  implicit def entityEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder[Pure, UrlForm] =
+    EntityEncoder.stringEncoder
       .contramap[UrlForm](encodeString(charset))
       .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`, charset))
 

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
@@ -27,11 +27,8 @@ import org.http4s.headers.{Accept, Location, `Content-Length`, `Content-Type`}
 class ResponseGeneratorSuite extends Http4sSuite {
   test("Add the EntityEncoder headers along with a content-length header") {
     val body = "foo"
-    val resultheaders = Ok(body)(Monad[IO], EntityEncoder.stringEncoder[IO]).map(_.headers)
-    EntityEncoder
-      .stringEncoder[IO]
-      .headers
-      .headers
+    val resultheaders = Ok(body)(Monad[IO], EntityEncoder.stringEncoder).map(_.headers)
+    EntityEncoder.stringEncoder.headers.headers
       .traverse { h =>
         resultheaders.map(_.headers.exists(_ == h)).assert
       } *>
@@ -46,8 +43,8 @@ class ResponseGeneratorSuite extends Http4sSuite {
   test("Not duplicate headers when not provided") {
     val w =
       EntityEncoder.encodeBy[IO, String](
-        EntityEncoder.stringEncoder[IO].headers.put(Accept(MediaRange.`audio/*`)))(
-        EntityEncoder.stringEncoder[IO].toEntity(_)
+        EntityEncoder.stringEncoder.headers.put(Accept(MediaRange.`audio/*`)))(
+        EntityEncoder.stringEncoder.toEntity(_)
       )
 
     Ok("foo")(Monad[IO], w)
@@ -57,8 +54,8 @@ class ResponseGeneratorSuite extends Http4sSuite {
 
   test("Explicitly added headers have priority") {
     val w: EntityEncoder[IO, String] = EntityEncoder.encodeBy[IO, String](
-      EntityEncoder.stringEncoder[IO].headers.put(`Content-Type`(MediaType.text.html)))(
-      EntityEncoder.stringEncoder[IO].toEntity(_)
+      EntityEncoder.stringEncoder.headers.put(`Content-Type`(MediaType.text.html)))(
+      EntityEncoder.stringEncoder.toEntity(_)
     )
 
     val resp: IO[Response[IO]] =

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -29,10 +29,9 @@ import scala.xml.{Elem, InputSource, SAXParseException, XML}
 trait ElemInstances {
   protected def saxFactory: SAXParserFactory
 
-  implicit def xmlEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Elem] =
-    EntityEncoder
-      .stringEncoder[F]
+  implicit def xmlEncoder(implicit
+      charset: Charset = DefaultCharset): EntityEncoder[fs2.Pure, Elem] =
+    EntityEncoder.stringEncoder
       .contramap[Elem] { node =>
         val sw = new StringWriter
         XML.write(sw, node, charset.nioCharset.name, true, null)

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
@@ -76,8 +76,8 @@ class ScalaXmlSuite extends Http4sSuite {
 
   test("encode to UTF-8") {
     val hello = <hello name="Günther"/>
-    assertIO(
-      xmlEncoder[IO](Charset.`UTF-8`)
+    assertEquals(
+      xmlEncoder(Charset.`UTF-8`)
         .toEntity(hello)
         .body
         .through(fs2.text.utf8.decode)
@@ -91,9 +91,10 @@ class ScalaXmlSuite extends Http4sSuite {
   test("encode to UTF-16") {
     val hello = <hello name="Günther"/>
     assertIO(
-      xmlEncoder[IO](Charset.`UTF-16`)
+      xmlEncoder(Charset.`UTF-16`)
         .toEntity(hello)
         .body
+        .covary[IO]
         .through(decodeWithCharset(StandardCharsets.UTF_16))
         .compile
         .string,
@@ -105,9 +106,10 @@ class ScalaXmlSuite extends Http4sSuite {
   test("encode to ISO-8859-1") {
     val hello = <hello name="Günther"/>
     assertIO(
-      xmlEncoder[IO](Charset.`ISO-8859-1`)
+      xmlEncoder(Charset.`ISO-8859-1`)
         .toEntity(hello)
         .body
+        .covary[IO]
         .through(decodeWithCharset(StandardCharsets.ISO_8859_1))
         .compile
         .string,
@@ -118,7 +120,7 @@ class ScalaXmlSuite extends Http4sSuite {
 
   property("encoder sets charset of Content-Type") {
     forAll { (cs: Charset) =>
-      assertEquals(xmlEncoder[IO](cs).headers.get[`Content-Type`].flatMap(_.charset), Some(cs))
+      assertEquals(xmlEncoder(cs).headers.get[`Content-Type`].flatMap(_.charset), Some(cs))
     }
   }
 

--- a/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
+++ b/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
@@ -21,14 +21,13 @@ import _root_.scalatags.generic.Frag
 import org.http4s.headers.`Content-Type`
 
 trait ScalatagsInstances {
-  implicit def scalatagsEncoder[F[_], C <: Frag[_, String]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, C] =
+  implicit def scalatagsEncoder[C <: Frag[_, String]](implicit
+      charset: Charset = DefaultCharset): EntityEncoder[fs2.Pure, C] =
     contentEncoder(MediaType.text.html)
 
-  private def contentEncoder[F[_], C <: Frag[_, String]](mediaType: MediaType)(implicit
-      charset: Charset): EntityEncoder[F, C] =
-    EntityEncoder
-      .stringEncoder[F]
+  private def contentEncoder[C <: Frag[_, String]](mediaType: MediaType)(implicit
+      charset: Charset): EntityEncoder[fs2.Pure, C] =
+    EntityEncoder.stringEncoder
       .contramap[C](content => content.render)
       .withContentType(`Content-Type`(mediaType, charset))
 }

--- a/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -475,7 +475,7 @@ class EntityDecoderSuite extends Http4sSuite {
   // we want to return a specific kind of error when there is a MessageFailure
   sealed case class ErrorJson(value: String)
   implicit val errorJsonEntityEncoder: EntityEncoder[IO, ErrorJson] =
-    EntityEncoder.simple[IO, ErrorJson](`Content-Type`(MediaType.application.json))(json =>
+    EntityEncoder.simple[ErrorJson](`Content-Type`(MediaType.application.json))(json =>
       Chunk.array(json.value.getBytes()))
 
 // TODO: These won't work without an Eq for (Message[IO], Boolean) => DecodeResult[IO, A]

--- a/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -132,9 +132,9 @@ class EntityEncoderSpec extends Http4sSuite {
       sealed case class ModelB(name: String, id: Long)
 
       implicit val w1: EntityEncoder[IO, ModelA] =
-        EntityEncoder.simple[IO, ModelA]()(_ => Chunk.array("A".getBytes))
+        EntityEncoder.simple[ModelA]()(_ => Chunk.array("A".getBytes))
       implicit val w2: EntityEncoder[IO, ModelB] =
-        EntityEncoder.simple[IO, ModelB]()(_ => Chunk.array("B".getBytes))
+        EntityEncoder.simple[ModelB]()(_ => Chunk.array("B".getBytes))
 
       assertEquals(EntityEncoder[IO, ModelA], w1)
       assertEquals(EntityEncoder[IO, ModelB], w2)

--- a/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
+++ b/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
@@ -20,6 +20,7 @@ package twirl
 import org.http4s.headers.`Content-Type`
 import org.http4s.MediaType
 import _root_.play.twirl.api._
+import fs2.Pure
 
 trait TwirlInstances {
   implicit def htmlContentEncoder[F[_]](implicit
@@ -41,10 +42,9 @@ trait TwirlInstances {
       charset: Charset = DefaultCharset): EntityEncoder[F, Txt] =
     contentEncoder(MediaType.text.plain)
 
-  private def contentEncoder[F[_], C <: Content](mediaType: MediaType)(implicit
-      charset: Charset): EntityEncoder[F, C] =
-    EntityEncoder
-      .stringEncoder[F]
+  private def contentEncoder[C <: Content](mediaType: MediaType)(implicit
+      charset: Charset): EntityEncoder[Pure, C] =
+    EntityEncoder.stringEncoder
       .contramap[C](content => content.body)
       .withContentType(`Content-Type`(mediaType, charset))
 }


### PR DESCRIPTION
We modify the EntityEncoder class to make it covariant on the Stream effect type F and contravariant on the type of values A to encode. With variance, we can remove the `F[_]` type parameters from some entity encoder generators, and just reduce it to fs2.Pure (an alias of Nothing for kind F[_]); as well as reduce some  `def` to `val`.