### PR TITLE
Revert "Exclude `scalajs-dom` transitive dependency"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,10 +155,7 @@ lazy val core = libraryCrossProject("core")
       catsParse.value.exclude("org.typelevel", "cats-core_2.13"),
       crypto.value,
       fs2Core.value,
-      fs2Io.value // Workaround for https://github.com/typelevel/fs2/pull/2681
-        .exclude("org.scala-js", "scalajs-dom_sjs1_2.12")
-        .exclude("org.scala-js", "scalajs-dom_sjs1_2.13")
-        .exclude("org.scala-js", "scalajs-dom_sjs1_3"),
+      fs2Io.value,
       ip4sCore.value,
       literally.value,
       log4s.value,


### PR DESCRIPTION
Reverts http4s/http4s#5449.

This was fixed upstream, so we no longer need it here.