### PR TITLE
Implement `Request#remoteHost` via `ip4s.Dns`

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -18,9 +18,10 @@ package org.http4s
 
 import cats.{Applicative, Monad, ~>}
 import cats.data.NonEmptyList
+import cats.data.OptionT
 import cats.effect.{Sync, SyncIO}
 import cats.syntax.all._
-import com.comcast.ip4s.{Hostname, IpAddress, Port, SocketAddress}
+import com.comcast.ip4s.{Dns, Hostname, IpAddress, Port, SocketAddress}
 import fs2.{Pure, Stream}
 import fs2.text.utf8
 import java.io.File
@@ -406,10 +407,14 @@ final class Request[F[_]] private (
 
   def remoteAddr: Option[IpAddress] = remote.map(_.host)
 
-  def remoteHost(implicit F: Sync[F]): F[Option[Hostname]] = {
+  @deprecated("Use the variant requiring ip4s.Dns[F]", "0.23.7")
+  def remoteHost(F: Sync[F]): F[Option[Hostname]] = {
     val inetAddress = remote.map(_.host.toInetAddress)
-    F.blocking(inetAddress.map(_.getHostName)).map(_.flatMap(Hostname.fromString))
+    F.map(F.blocking(inetAddress.map(_.getHostName)))(_.flatMap(Hostname.fromString))
   }
+
+  def remoteHost(implicit F: Monad[F], dns: Dns[F]): F[Option[Hostname]] =
+    OptionT.fromOption(remote.map(_.host)).flatMapF(dns.reverseOption).value
 
   def remotePort: Option[Port] = remote.map(_.port)
 


### PR DESCRIPTION
Keeps source and binary compatibility with the old way, while introducing a new cross-compatible overload.