### PR TITLE
Update v0.23 site with a highlight that v0.23 is a stable version now

### DIFF
--- a/website/src/hugo/themes/http4s.org/layouts/partials/nav-docs.html
+++ b/website/src/hugo/themes/http4s.org/layouts/partials/nav-docs.html
@@ -1,8 +1,8 @@
 <div class="dropdown-menu" aria-labelledby="doc-menu-item">
   <a class="dropdown-item" href="/v1.0/">v1.0 (development)</a>
-  <a class="dropdown-item" href="/v0.23/">v0.23 (development)</a>
-  <a class="dropdown-item" href="/v0.22/">v0.22 (development)</a>
-  <a class="dropdown-item" href="/v0.21/">v0.21 (stable)</a>
+  <a class="dropdown-item" href="/v0.23/">v0.23 (stable)</a>
+  <a class="dropdown-item" href="/v0.22/">v0.22 (stable)</a>
+  <a class="dropdown-item" href="/v0.21/">v0.21 (EOL)</a>
   <a class="dropdown-item" href="/v0.20/">v0.20 (EOL)</a>
   <a class="dropdown-item" href="/v0.18/">v0.18 (EOL)</a>
   <a class="dropdown-item" href="/v0.17/">v0.17 (EOL)</a>


### PR DESCRIPTION
I was reading documentation for v0.23 and got scared that v0.23 is unstable, which is actually is _not_ the case anymore. This fixes description in drop down menu.