### PR TITLE
Remove redundant val in the `Header.Raw` constructor

### DIFF
--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -32,7 +32,7 @@ trait Header[A, T <: Header.Type] {
 }
 
 object Header {
-  final case class Raw(val name: CIString, val value: String) {
+  final case class Raw(name: CIString, value: String) {
     override def toString: String = s"${name}: ${value}"
 
     /** True if [[name]] is a valid field-name per RFC7230.  Where it


### PR DESCRIPTION
`Header.Raw` parameters could be accessed without `val`s.