### PR TITLE
Deprecate `DefaultCharset`, use `UTF-8` directly

### DIFF
--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -26,6 +26,7 @@ import cats.effect.Sync
 import cats.syntax.all._
 import fs2._
 import fs2.io.file.writeAll
+import org.http4s.Charset.`UTF-8`
 import org.http4s.multipart.Multipart
 import org.http4s.multipart.MultipartDecoder
 import scodec.bits.ByteVector
@@ -205,7 +206,7 @@ object EntityDecoder {
 
   /** Decodes a message to a String */
   def decodeText[F[_]](
-      m: Media[F])(implicit F: Sync[F], defaultCharset: Charset = DefaultCharset): F[String] =
+      m: Media[F])(implicit F: Sync[F], defaultCharset: Charset = `UTF-8`): F[String] =
     m.bodyText.compile.string
 
   /////////////////// Instances //////////////////////////////////////////////
@@ -233,7 +234,7 @@ object EntityDecoder {
 
   implicit def text[F[_]](implicit
       F: Sync[F],
-      defaultCharset: Charset = DefaultCharset): EntityDecoder[F, String] =
+      defaultCharset: Charset = `UTF-8`): EntityDecoder[F, String] =
     EntityDecoder.decodeBy(MediaRange.`text/*`)(msg =>
       collectBinary(msg).map(chunk =>
         new String(chunk.toArray, msg.charset.getOrElse(defaultCharset).nioCharset)))

--- a/core/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/src/main/scala/org/http4s/EntityEncoder.scala
@@ -27,6 +27,7 @@ import fs2.Chunk
 import fs2.Stream
 import fs2.io.file.readAll
 import fs2.io.readInputStream
+import org.http4s.Charset.`UTF-8`
 import org.http4s.headers._
 import org.http4s.multipart.Multipart
 import org.http4s.multipart.MultipartEncoder
@@ -102,7 +103,7 @@ object EntityEncoder {
 
   /** Encodes a value from its Show instance.  Too broad to be implicit, too useful to not exist. */
   def showEncoder[F[_], A](implicit
-      charset: Charset = DefaultCharset,
+      charset: Charset = `UTF-8`,
       show: Show[A]): EntityEncoder[F, A] = {
     val hdr = `Content-Type`(MediaType.text.plain).withCharset(charset)
     simple[F, A](hdr)(a => Chunk.bytes(show.show(a).getBytes(charset.nioCharset)))
@@ -137,13 +138,13 @@ object EntityEncoder {
     emptyEncoder[F, Unit]
 
   implicit def stringEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, String] = {
+      charset: Charset = `UTF-8`): EntityEncoder[F, String] = {
     val hdr = `Content-Type`(MediaType.text.plain).withCharset(charset)
     simple(hdr)(s => Chunk.bytes(s.getBytes(charset.nioCharset)))
   }
 
   implicit def charArrayEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Array[Char]] =
+      charset: Charset = `UTF-8`): EntityEncoder[F, Array[Char]] =
     stringEncoder[F].contramap(new String(_))
 
   implicit def chunkEncoder[F[_]]: EntityEncoder[F, Chunk[Byte]] =
@@ -184,7 +185,7 @@ object EntityEncoder {
   implicit def readerEncoder[F[_], R <: Reader](blocker: Blocker)(implicit
       F: Sync[F],
       cs: ContextShift[F],
-      charset: Charset = DefaultCharset): EntityEncoder[F, F[R]] =
+      charset: Charset = `UTF-8`): EntityEncoder[F, F[R]] =
     entityBodyEncoder[F].contramap { (fr: F[R]) =>
       // Shared buffer
       val charBuffer = CharBuffer.allocate(DefaultChunkSize)

--- a/core/src/main/scala/org/http4s/Media.scala
+++ b/core/src/main/scala/org/http4s/Media.scala
@@ -20,6 +20,7 @@ import cats.MonadThrow
 import fs2.RaiseThrowable
 import fs2.Stream
 import fs2.text.utf8Decode
+import org.http4s.Charset.`UTF-8`
 import org.http4s.headers._
 
 trait Media[F[_]] {
@@ -29,7 +30,7 @@ trait Media[F[_]] {
 
   final def bodyText(implicit
       RT: RaiseThrowable[F],
-      defaultCharset: Charset = DefaultCharset): Stream[F, String] =
+      defaultCharset: Charset = `UTF-8`): Stream[F, String] =
     charset.getOrElse(defaultCharset) match {
       case Charset.`UTF-8` =>
         // suspect this one is more efficient, though this is superstition

--- a/core/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/src/main/scala/org/http4s/UrlForm.scala
@@ -21,6 +21,7 @@ import cats.Monoid
 import cats.data.Chain
 import cats.effect.Sync
 import cats.syntax.all._
+import org.http4s.Charset.`UTF-8`
 import org.http4s.headers._
 import org.http4s.internal.CollectionCompat
 import org.http4s.parser._
@@ -99,8 +100,7 @@ object UrlForm {
   def fromChain(values: Chain[(String, String)]): UrlForm =
     apply(values.toList: _*)
 
-  implicit def entityEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, UrlForm] =
+  implicit def entityEncoder[F[_]](implicit charset: Charset = `UTF-8`): EntityEncoder[F, UrlForm] =
     EntityEncoder
       .stringEncoder[F]
       .contramap[UrlForm](encodeString(charset))
@@ -108,7 +108,7 @@ object UrlForm {
 
   implicit def entityDecoder[F[_]](implicit
       F: Sync[F],
-      defaultCharset: Charset = DefaultCharset): EntityDecoder[F, UrlForm] =
+      defaultCharset: Charset = `UTF-8`): EntityDecoder[F, UrlForm] =
     EntityDecoder.decodeBy(MediaType.application.`x-www-form-urlencoded`) { m =>
       DecodeResult(
         EntityDecoder

--- a/core/src/main/scala/org/http4s/package.scala
+++ b/core/src/main/scala/org/http4s/package.scala
@@ -34,6 +34,7 @@ package object http4s {
 
   type ParseResult[+A] = Either[ParseFailure, A]
 
+  @deprecated("Use Charset.`UTF-8` directly", "0.22.8")
   val DefaultCharset = Charset.`UTF-8`
 
   /** A kleisli with a [[Request]] input and a [[Response]] output.  This type

--- a/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/scalaxml/ElemInstances.scala
@@ -20,6 +20,7 @@ package scalaxml
 import cats.data.EitherT
 import cats.effect.Sync
 import cats.syntax.all._
+import org.http4s.Charset.`UTF-8`
 import org.http4s.headers.`Content-Type`
 
 import java.io.ByteArrayInputStream
@@ -34,8 +35,7 @@ import scala.xml.XML
 trait ElemInstances {
   protected def saxFactory: SAXParserFactory
 
-  implicit def xmlEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Elem] =
+  implicit def xmlEncoder[F[_]](implicit charset: Charset = `UTF-8`): EntityEncoder[F, Elem] =
     EntityEncoder
       .stringEncoder[F]
       .contramap[Elem] { node =>

--- a/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
+++ b/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
@@ -18,11 +18,12 @@ package org.http4s
 package scalatags
 
 import _root_.scalatags.generic.Frag
+import org.http4s.Charset.`UTF-8`
 import org.http4s.headers.`Content-Type`
 
 trait ScalatagsInstances {
   implicit def scalatagsEncoder[F[_], C <: Frag[_, String]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, C] =
+      charset: Charset = `UTF-8`): EntityEncoder[F, C] =
     contentEncoder(MediaType.text.html)
 
   private def contentEncoder[F[_], C <: Frag[_, String]](mediaType: MediaType)(implicit

--- a/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
+++ b/twirl/src/main/scala/org/http4s/twirl/TwirlInstances.scala
@@ -18,27 +18,26 @@ package org.http4s
 package twirl
 
 import _root_.play.twirl.api._
+import org.http4s.Charset.`UTF-8`
 import org.http4s.MediaType
 import org.http4s.headers.`Content-Type`
 
 trait TwirlInstances {
   implicit def htmlContentEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Html] =
+      charset: Charset = `UTF-8`): EntityEncoder[F, Html] =
     contentEncoder(MediaType.text.html)
 
   /** Note: Twirl uses a media type of `text/javascript`.  This is obsolete, so we instead return
     * `application/javascript`.
     */
   implicit def jsContentEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, JavaScript] =
+      charset: Charset = `UTF-8`): EntityEncoder[F, JavaScript] =
     contentEncoder(MediaType.application.javascript)
 
-  implicit def xmlContentEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Xml] =
+  implicit def xmlContentEncoder[F[_]](implicit charset: Charset = `UTF-8`): EntityEncoder[F, Xml] =
     contentEncoder(MediaType.application.xml)
 
-  implicit def txtContentEncoder[F[_]](implicit
-      charset: Charset = DefaultCharset): EntityEncoder[F, Txt] =
+  implicit def txtContentEncoder[F[_]](implicit charset: Charset = `UTF-8`): EntityEncoder[F, Txt] =
     contentEncoder(MediaType.text.plain)
 
   private def contentEncoder[F[_], C <: Content](mediaType: MediaType)(implicit


### PR DESCRIPTION
The `DefaultCharset` alias served a purpose when it was introduced 6 years ago, but in 2021 anybody who has to think about charsets knows that UTF-8 is the universal default. By inlining it we remove the cognitive burden of needing to know that `DefaultCharset` is a global alias for UTF-8.