### PR TITLE
Use Scala 3 cross-compatible `@nowarn`

### DIFF
--- a/ember-client/js/src/main/scala/org/http4s/ember/client/internal/ClientHelpersPlatform.scala
+++ b/ember-client/js/src/main/scala/org/http4s/ember/client/internal/ClientHelpersPlatform.scala
@@ -28,7 +28,7 @@ import scala.annotation.nowarn
 
 private[internal] trait ClientHelpersPlatform {
 
-  @nowarn // ("cat=unused"), but Scala 3 doesn't implement this category
+  @nowarn("msg=never used")
   private[internal] def mkTLSParameters(
       address: Option[SocketAddress[Host]],
       enableEndpointValidation: Boolean): TLSParameters =


### PR DESCRIPTION
Backport from https://github.com/http4s/http4s/pull/5514#discussion_r739475285. H/t @bplommer.