### PR TITLE
Uri Path Segment Encoder

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -446,7 +446,7 @@ object Uri extends UriPlatform {
     }
 
     object SegmentEncoder {
-      implicit def apply[A](implicit segmentEncoder: SegmentEncoder[A]): SegmentEncoder[A] =
+      def apply[A](implicit segmentEncoder: SegmentEncoder[A]): SegmentEncoder[A] =
         segmentEncoder
 
       def instance[A](f: A => Segment): SegmentEncoder[A] = f.apply

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -444,6 +444,7 @@ object Uri extends UriPlatform {
       final def contramap[B](f: B => A): SegmentEncoder[B] =
         b => this.toSegment(f(b))
     }
+
     object SegmentEncoder {
       implicit def apply[A](implicit segmentEncoder: SegmentEncoder[A]): SegmentEncoder[A] =
         segmentEncoder

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -457,25 +457,22 @@ object Uri extends UriPlatform {
 
       implicit val segmentSegmentEncoder: SegmentEncoder[Segment] = identity
 
-      implicit val charSegmentEncoder: SegmentEncoder[Char] = v => Segment(v.toString())
+      implicit val charSegmentEncoder: SegmentEncoder[Char] = fromToString
       implicit val stringSegmentEncoder: SegmentEncoder[String] = Segment.apply
 
-      implicit val booleanSegmentEncoder: SegmentEncoder[Boolean] = v => Segment(v.toString())
+      implicit val booleanSegmentEncoder: SegmentEncoder[Boolean] = fromToString
 
-      implicit val byteSegmentEncoder: SegmentEncoder[Byte] = v => Segment(v.toString())
-      implicit val shortSegmentEncoder: SegmentEncoder[Short] = v => Segment(v.toString())
-      implicit val intSegmentEncoder: SegmentEncoder[Int] = v => Segment(v.toString())
-      implicit val longSegmentEncoder: SegmentEncoder[Long] = v => Segment(v.toString())
-      implicit val bigIntSegmentEncoder: SegmentEncoder[BigInt] = v => Segment(v.toString())
+      implicit val byteSegmentEncoder: SegmentEncoder[Byte] = fromToString
+      implicit val shortSegmentEncoder: SegmentEncoder[Short] = fromToString
+      implicit val intSegmentEncoder: SegmentEncoder[Int] = fromToString
+      implicit val longSegmentEncoder: SegmentEncoder[Long] = fromToString
+      implicit val bigIntSegmentEncoder: SegmentEncoder[BigInt] = fromToString
 
-      implicit val floatSegmentEncoder: SegmentEncoder[Float] = v => Segment(v.toString())
-      implicit val doubleSegmentEncoder: SegmentEncoder[Double] = v => Segment(v.toString())
-      implicit val bigDecimalSegmentEncoder: SegmentEncoder[BigDecimal] = v => Segment(v.toString())
+      implicit val floatSegmentEncoder: SegmentEncoder[Float] = fromToString
+      implicit val doubleSegmentEncoder: SegmentEncoder[Double] = fromToString
+      implicit val bigDecimalSegmentEncoder: SegmentEncoder[BigDecimal] = fromToString
 
-      implicit val uuidSegmentEncoder: SegmentEncoder[java.util.UUID] = v => Segment(v.toString())
-
-      implicit val durationSegmentEncoder: SegmentEncoder[scala.concurrent.duration.Duration] =
-        v => Segment(v.toString())
+      implicit val uuidSegmentEncoder: SegmentEncoder[java.util.UUID] = fromToString
 
       implicit val contravariantInstance: Contravariant[SegmentEncoder] =
         new Contravariant[SegmentEncoder] {

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -453,8 +453,21 @@ object Uri extends UriPlatform {
       def fromShow[A](implicit show: Show[A]): SegmentEncoder[A] =
         instance(a => Segment(show.show(a)))
 
-      implicit val stringSegmentEncoder: SegmentEncoder[String] = Segment.apply
       implicit val segmentSegmentEncoder: SegmentEncoder[Segment] = identity
+      implicit val stringSegmentEncoder: SegmentEncoder[String] = Segment.apply
+
+      implicit val booleanSegmentEncoder: SegmentEncoder[Boolean] = v => Segment(v.toString())
+
+      implicit val byteSegmentEncoder: SegmentEncoder[Byte] = v => Segment(v.toString())
+      implicit val intSegmentEncoder: SegmentEncoder[Int] = v => Segment(v.toString())
+      implicit val longSegmentEncoder: SegmentEncoder[Long] = v => Segment(v.toString())
+      implicit val bigIntSegmentEncoder: SegmentEncoder[BigInt] = v => Segment(v.toString())
+
+      implicit val floatSegmentEncoder: SegmentEncoder[Float] = v => Segment(v.toString())
+      implicit val doubleSegmentEncoder: SegmentEncoder[Double] = v => Segment(v.toString())
+      implicit val bigDecimalSegmentEncoder: SegmentEncoder[BigDecimal] = v => Segment(v.toString())
+
+      implicit val uuidSegmentEncoder: SegmentEncoder[java.util.UUID] = v => Segment(v.toString())
 
       implicit val contravariantInstance: Contravariant[SegmentEncoder] =
         new Contravariant[SegmentEncoder] {

--- a/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
+++ b/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
@@ -23,6 +23,7 @@ import org.http4s.Uri.Path.SegmentEncoder
 import org.http4s.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
+
 import scala.annotation.nowarn
 
 final class SegmentEncoderSuite extends Http4sSuite {

--- a/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
+++ b/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
@@ -23,6 +23,7 @@ import org.http4s.Uri.Path.SegmentEncoder
 import org.http4s.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
+import scala.annotation.nowarn
 
 final class SegmentEncoderSuite extends Http4sSuite {
   private val equalityCheckCount: Int = 16
@@ -31,6 +32,7 @@ final class SegmentEncoderSuite extends Http4sSuite {
     Arbitrary.arbitrary[A => Segment].map(SegmentEncoder.instance)
   )
 
+  @nowarn("cat=deprecation")
   implicit private def eqSegmentEncoder[A](implicit A: Arbitrary[A]): Eq[SegmentEncoder[A]] =
     Eq.instance { (e1, e2) =>
       Stream

--- a/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
+++ b/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
@@ -27,11 +27,11 @@ import org.scalacheck.Arbitrary
 class SegmentEncoderSuite extends Http4sSuite {
   private def equalityCheckCount: Int = 16
 
-  private implicit def arbitrarySegmentEncoder[A: Cogen]: Arbitrary[SegmentEncoder[A]] = Arbitrary(
+  implicit private def arbitrarySegmentEncoder[A: Cogen]: Arbitrary[SegmentEncoder[A]] = Arbitrary(
     Arbitrary.arbitrary[A => Segment].map(SegmentEncoder.instance)
   )
 
-  private implicit def eqSegmentEncoder[A](implicit A: Arbitrary[A]): Eq[SegmentEncoder[A]] =
+  implicit private def eqSegmentEncoder[A](implicit A: Arbitrary[A]): Eq[SegmentEncoder[A]] =
     Eq.instance { (e1, e2) =>
       Stream
         .continually(A.arbitrary.sample)
@@ -42,5 +42,6 @@ class SegmentEncoderSuite extends Http4sSuite {
 
   checkAll(
     "Contravariant[SegmentEncoder]",
-    ContravariantTests[SegmentEncoder].contravariant[Long, Int, Char])
+    ContravariantTests[SegmentEncoder].contravariant[Long, Int, Char],
+  )
 }

--- a/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
+++ b/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
@@ -27,7 +27,7 @@ import org.scalacheck.Cogen
 import scala.annotation.nowarn
 
 final class SegmentEncoderSuite extends Http4sSuite {
-  private val equalityCheckCount: Int = 16
+  private val equalityCheckCount: Int = 100
 
   implicit private def arbitrarySegmentEncoder[A: Cogen]: Arbitrary[SegmentEncoder[A]] = Arbitrary(
     Arbitrary.arbitrary[A => Segment].map(SegmentEncoder.instance)

--- a/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
+++ b/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+
+import cats._
+import cats.laws.discipline.ContravariantTests
+import org.http4s.Uri.Path.Segment
+import org.http4s.Uri.Path.SegmentEncoder
+import org.http4s.laws.discipline.arbitrary._
+import org.scalacheck.Cogen
+import org.scalacheck.Arbitrary
+
+class SegmentEncoderSuite extends Http4sSuite {
+  private def equalityCheckCount: Int = 16
+
+  private implicit def arbitrarySegmentEncoder[A: Cogen]: Arbitrary[SegmentEncoder[A]] = Arbitrary(
+    Arbitrary.arbitrary[A => Segment].map(SegmentEncoder.instance)
+  )
+
+  private implicit def eqSegmentEncoder[A](implicit A: Arbitrary[A]): Eq[SegmentEncoder[A]] =
+    Eq.instance { (e1, e2) =>
+      Stream
+        .continually(A.arbitrary.sample)
+        .flatten
+        .take(equalityCheckCount)
+        .forall(a => Eq[Segment].eqv(e1.toSegment(a), e2.toSegment(a)))
+    }
+
+  checkAll(
+    "Contravariant[SegmentEncoder]",
+    ContravariantTests[SegmentEncoder].contravariant[Long, Int, Char])
+}

--- a/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
+++ b/tests/src/test/scala/org/http4s/SegmentEncoderSuite.scala
@@ -21,11 +21,11 @@ import cats.laws.discipline.ContravariantTests
 import org.http4s.Uri.Path.Segment
 import org.http4s.Uri.Path.SegmentEncoder
 import org.http4s.laws.discipline.arbitrary._
-import org.scalacheck.Cogen
 import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
 
-class SegmentEncoderSuite extends Http4sSuite {
-  private def equalityCheckCount: Int = 16
+final class SegmentEncoderSuite extends Http4sSuite {
+  private val equalityCheckCount: Int = 16
 
   implicit private def arbitrarySegmentEncoder[A: Cogen]: Arbitrary[SegmentEncoder[A]] = Arbitrary(
     Arbitrary.arbitrary[A => Segment].map(SegmentEncoder.instance)


### PR DESCRIPTION
## Description
Adding a `SegmentEncoder` typeclass that works similar to a `QueryParamEncoder` but for `Uri.Path.Segment`

This would make working with newtypes/anyvals and urls a bit easier.

## Example

### Preamble 
```
case class Foo(value: Long) extends AnyVal
val foo: Foo = ???
val myInt: Int = ???
```

### Before
```
myBaseUrl / "bar" / foo.value.toString / myInt.toString
```

### After
```
myBaseUrl / "bar" / foo / myInt
```

## Possible TODOs

- [ ] Probably some more unit tests.
- [x] Some default Encoders for base types?
  - Int, Long, Float, Double, Byte, Boolean?
- [ ] Moving `SegmentEncoder` to it's own file?  

