### PR TITLE
Send multiple chunks when testing chunked requests

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -109,7 +109,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
   test(s"$name POST a chunked body".flaky) {
     val address = jetty().addresses.head
     val uri = Uri.fromString(s"http://${address.getHostName}:${address.getPort}/echo").yolo
-    val req = POST(Stream("This is chunked.").covary[IO], uri)
+    val req = POST(Stream.emits("This is chunked.".toSeq.map(_.toString)).covary[IO], uri)
     val body = client().expect[String](req)
     body.assertEquals("This is chunked.")
   }


### PR DESCRIPTION
In it's current shape the "POST a chunked body" test sends a request with just one chunk (which may be transferred together with the head of the request). That means that the test provides poor coverage of the implementation of chunked encoding. In order to improve the coverage I changed the request body to contain multiple chunks (implemented similarly to the `/chunked` in the `GetRoutes`).