### PR TITLE
Add DefaultQueryParamDecoderMatcher class

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/RequestDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/RequestDsl.scala
@@ -44,7 +44,7 @@ trait RequestDsl extends Methods with Auth {
   type QueryParamDecoderMatcher[T] = impl.QueryParamDecoderMatcher[T]
   type QueryParamMatcher[T] = impl.QueryParamMatcher[T]
   type OptionalQueryParamDecoderMatcher[T] = impl.OptionalQueryParamDecoderMatcher[T]
-  type DefaultQueryParamDecoderMatcher[T] = impl.DefaultQueryParamDecoderMatcher[T]
+  type QueryParamDecoderMatcherWithDefault[T] = impl.QueryParamDecoderMatcherWithDefault[T]
   type OptionalMultiQueryParamDecoderMatcher[T] = impl.OptionalMultiQueryParamDecoderMatcher[T]
   type OptionalQueryParamMatcher[T] = impl.OptionalQueryParamMatcher[T]
   type ValidatingQueryParamDecoderMatcher[T] = impl.ValidatingQueryParamDecoderMatcher[T]

--- a/dsl/src/main/scala/org/http4s/dsl/RequestDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/RequestDsl.scala
@@ -44,6 +44,7 @@ trait RequestDsl extends Methods with Auth {
   type QueryParamDecoderMatcher[T] = impl.QueryParamDecoderMatcher[T]
   type QueryParamMatcher[T] = impl.QueryParamMatcher[T]
   type OptionalQueryParamDecoderMatcher[T] = impl.OptionalQueryParamDecoderMatcher[T]
+  type DefaultQueryParamDecoderMatcher[T] = impl.DefaultQueryParamDecoderMatcher[T]
   type OptionalMultiQueryParamDecoderMatcher[T] = impl.OptionalMultiQueryParamDecoderMatcher[T]
   type OptionalQueryParamMatcher[T] = impl.OptionalQueryParamMatcher[T]
   type ValidatingQueryParamDecoderMatcher[T] = impl.ValidatingQueryParamDecoderMatcher[T]

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -326,6 +326,9 @@ abstract class OptionalQueryParamDecoderMatcher[T: QueryParamDecoder](name: Stri
       .toOption
 }
 
+/** A param extractor with a default value. If the query param is not present, the default value is returned
+  * If the query param is present but incorrectly formatted, will return `None`
+  */
 abstract class QueryParamDecoderMatcherWithDefault[T: QueryParamDecoder](name: String, default: T) {
   def unapply(params: Map[String, collection.Seq[String]]): Option[T] =
     params

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -326,7 +326,7 @@ abstract class OptionalQueryParamDecoderMatcher[T: QueryParamDecoder](name: Stri
       .toOption
 }
 
-abstract class DefaultQueryParamDecoderMatcher[T: QueryParamDecoder](name: String, default: T) {
+abstract class QueryParamDecoderMatcherWithDefault[T: QueryParamDecoder](name: String, default: T) {
   def unapply(params: Map[String, collection.Seq[String]]): Option[T] =
     params
       .get(name)
@@ -336,8 +336,8 @@ abstract class DefaultQueryParamDecoderMatcher[T: QueryParamDecoder](name: Strin
       .map(_.getOrElse(default))
 }
 
-abstract class DefaultQueryParamMatcher[T: QueryParamDecoder: QueryParam](default: T)
-    extends DefaultQueryParamDecoderMatcher[T](QueryParam[T].key.value, default)
+abstract class QueryParamMatcherWithDefault[T: QueryParamDecoder: QueryParam](default: T)
+    extends QueryParamDecoderMatcherWithDefault[T](QueryParam[T].key.value, default)
 
 /** Flag (value-less) query param extractor
   */

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -326,6 +326,19 @@ abstract class OptionalQueryParamDecoderMatcher[T: QueryParamDecoder](name: Stri
       .toOption
 }
 
+abstract class DefaultQueryParamDecoderMatcher[T: QueryParamDecoder](name: String, default: T) {
+  def unapply(params: Map[String, collection.Seq[String]]): Option[T] =
+    params
+      .get(name)
+      .flatMap(_.headOption)
+      .traverse(s => QueryParamDecoder[T].decode(QueryParameterValue(s)))
+      .toOption
+      .map(_.getOrElse(default))
+}
+
+abstract class DefaultQueryParamMatcher[T: QueryParamDecoder: QueryParam](default: T)
+    extends DefaultQueryParamDecoderMatcher[T](QueryParam[T].key.value, default)
+
 /** Flag (value-less) query param extractor
   */
 abstract class FlagQueryParamMatcher(name: String) {

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSuite.scala
@@ -49,6 +49,8 @@ class PathInHttpRoutesSuite extends Http4sSuite {
 
   object MultiOptCounter extends OptionalMultiQueryParamDecoderMatcher[Int]("counter")
 
+  object DefaultCounter extends DefaultQueryParamDecoderMatcher[Int]("counter", 0)
+
   object Flag extends FlagQueryParamMatcher("flag")
 
   val app: HttpApp[IO] = HttpApp {
@@ -87,6 +89,8 @@ class PathInHttpRoutesSuite extends Http4sSuite {
         case Valid(Nil) => Ok("absent")
         case Invalid(errors) => BadRequest(errors.toList.map(_.details).mkString("\n"))
       }
+    case GET -> Root / "default" :? DefaultCounter(c) =>
+      Ok(s"counter: $c")
     case GET -> Root / "flagparam" :? Flag(flag) =>
       if (flag) Ok("flag present")
       else Ok("flag not present")
@@ -281,6 +285,24 @@ class PathInHttpRoutesSuite extends Http4sSuite {
             """For input string: "foo"""",
             """For input string: "bar""""
           ))
+  }
+  test("Path DSL within HttpService should default parameter present") {
+    val response =
+      serve(Request(GET, Uri(path = path"/default", query = Query.unsafeFromString("counter=3"))))
+    response.map(_.status).assertEquals(Ok) *>
+      response.flatMap(_.as[String]).assertEquals("counter: 3")
+  }
+  test("Path DSL within HttpService should default parameter absent") {
+    val response =
+      serve(Request(GET, Uri(path = path"/default", query = Query.unsafeFromString("other=john"))))
+    response.map(_.status).assertEquals(Ok) *>
+      response.flatMap(_.as[String]).assertEquals("counter: 0")
+  }
+  test("Path DSL within HttpService should default parameter present with incorrect format") {
+    val response =
+      serve(
+        Request(GET, Uri(path = path"/default", query = Query.unsafeFromString("counter=john"))))
+    response.map(_.status).assertEquals(NotFound)
   }
   test("Path DSL within HttpService should optional flag parameter when present") {
     val response =

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSuite.scala
@@ -49,7 +49,7 @@ class PathInHttpRoutesSuite extends Http4sSuite {
 
   object MultiOptCounter extends OptionalMultiQueryParamDecoderMatcher[Int]("counter")
 
-  object DefaultCounter extends DefaultQueryParamDecoderMatcher[Int]("counter", 0)
+  object DefaultCounter extends QueryParamDecoderMatcherWithDefault[Int]("counter", 0)
 
   object Flag extends FlagQueryParamMatcher("flag")
 


### PR DESCRIPTION
Hello! First-time contributor here. This PR adds a `DefaultQueryParamDecoderMatcher`, which, as the name suggests, accepts a default value for a query parameter. I followed the pattern for the other matchers. Let me know if there's anything I missed!