### PR TITLE
Don't ignore the `Part.covary` test suite in the `MultipartSuite`

### DIFF
--- a/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -199,8 +199,7 @@ I am a big moose
 
   def testPart[F[_]] = Part[F](Headers.empty, EmptyBody)
 
-  // todo compiles on dotty
-  test("Part.covary should disallow unrelated effects".ignore) {
+  test("Part.covary should disallow unrelated effects") {
     assert(
       compileErrors("testPart[Option].covary[IO]").nonEmpty
     )


### PR DESCRIPTION
It seems to work as expected now in Scala 3.