### PR TITLE
Use an instance of `Arbitrary[Year]` from ScalaCheck

### DIFF
--- a/tests/src/test/scala/org/http4s/QueryParamCodecSuite.scala
+++ b/tests/src/test/scala/org/http4s/QueryParamCodecSuite.scala
@@ -21,9 +21,8 @@ import cats.data._
 import cats.laws.discipline.{arbitrary => _, _}
 import cats.syntax.all._
 import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary.{arbYear => _, _}
+import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
-import org.scalacheck.Gen
 import org.scalacheck.Prop._
 
 import java.time._
@@ -112,10 +111,6 @@ trait QueryParamCodecInstances {
       val as = List.fill(100)(arbitrary[A].sample).flatten
       as.forall(a => x.encode(a) == y.encode(a))
     }
-
-  // TODO: Use scalacheck instance once this fix gets released https://github.com/typelevel/scalacheck/commit/2ae1be5c8e5ee1c14abea607d631e334a56796de
-  implicit final lazy val arbYear: Arbitrary[Year] =
-    Arbitrary(Gen.chooseNum(Year.MIN_VALUE + 1, Year.MAX_VALUE).map(Year.of))
 
   implicit val eqInstant: Eq[Instant] = Eq.fromUniversalEquals
 


### PR DESCRIPTION
A custom instance is not needed anymore.