### PR TITLE
Use `Arbitrary[Uri]` in some tests

### DIFF
--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -32,11 +32,12 @@ import org.http4s.circe._
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
 import org.http4s.laws.discipline.EntityCodecTests
-import org.http4s.laws.discipline.arbitrary._
+import org.http4s.laws.discipline.arbitrary
 import org.scalacheck.Prop._
 import org.typelevel.jawn.ParseException
-
 import java.nio.charset.StandardCharsets
+
+import org.scalacheck.Arbitrary
 
 class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   implicit val testContext: TestContext = TestContext()
@@ -353,6 +354,8 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   }
 
   property("Uri codec round trip") {
+    implicit val arbitraryUri: Arbitrary[Uri] = arbitrary.createArbitraryUri
+
     forAll { (uri: Uri) =>
       // Uri.renderString encode special chars in the fragment
       // and after converting the Uri to Json, the fragment will be encoded

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -33,11 +33,11 @@ import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
 import org.http4s.laws.discipline.EntityCodecTests
 import org.http4s.laws.discipline.arbitrary
+import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 import org.typelevel.jawn.ParseException
-import java.nio.charset.StandardCharsets
 
-import org.scalacheck.Arbitrary
+import java.nio.charset.StandardCharsets
 
 class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   implicit val testContext: TestContext = TestContext()

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -32,7 +32,8 @@ import org.http4s.circe._
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
 import org.http4s.laws.discipline.EntityCodecTests
-import org.http4s.syntax.all._
+import org.http4s.laws.discipline.arbitrary._
+import org.scalacheck.Prop._
 import org.typelevel.jawn.ParseException
 
 import java.nio.charset.StandardCharsets
@@ -351,10 +352,13 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     )
   }
 
-  test("Uri codec round trip") {
-    // TODO would benefit from Arbitrary[Uri]
-    val uri = uri"http://www.example.com/"
-    assertEquals(uri.asJson.as[Uri], Right(uri))
+  property("Uri codec round trip") {
+    forAll { (uri: Uri) =>
+      // Uri.renderString encode special chars in the fragment
+      // and after converting the Uri to Json, the fragment will be encoded
+      val preparedUri = uri.fragment.fold(uri)(f => uri.withFragment(Uri.encode(f)))
+      assertEquals(uri.asJson.as[Uri], Right(preparedUri))
+    }
   }
 
   test("Message[F].decodeJson[A] should decode json from a message") {

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -33,7 +33,6 @@ import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
 import org.http4s.laws.discipline.EntityCodecTests
 import org.http4s.laws.discipline.arbitrary
-import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 import org.typelevel.jawn.ParseException
 
@@ -354,9 +353,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   }
 
   property("Uri codec round trip") {
-    implicit val arbitraryUri: Arbitrary[Uri] = arbitrary.createArbitraryUri
-
-    forAll { (uri: Uri) =>
+    forAll(arbitrary.createGenUri) { (uri: Uri) =>
       // Uri.renderString encode special chars in the fragment
       // and after converting the Uri to Json, the fragment will be encoded
       val preparedUri = uri.fragment.fold(uri)(f => uri.withFragment(Uri.encode(f)))

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -790,9 +790,12 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
     val genPathNoScheme = genSegmentNzNc |+| genPathAbEmpty
     val genPathAbsolute = const("/") |+| opt(genPathRootless)
 
-    oneOf(genPathAbEmpty, genPathAbsolute, genPathNoScheme, genPathRootless, genPathEmpty).map(
-      Uri.Path.unsafeFromString
-    )
+    oneOf(genPathAbEmpty, genPathAbsolute, genPathNoScheme, genPathRootless, genPathEmpty).map {
+      str =>
+        val preparedPath = if (str.startsWith("/")) str else "/" + str
+
+        Uri.Path.unsafeFromString(preparedPath)
+    }
   }
 
   implicit val http4sTestingCogenForPath: Cogen[Uri.Path] =

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -790,12 +790,9 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
     val genPathNoScheme = genSegmentNzNc |+| genPathAbEmpty
     val genPathAbsolute = const("/") |+| opt(genPathRootless)
 
-    oneOf(genPathAbEmpty, genPathAbsolute, genPathNoScheme, genPathRootless, genPathEmpty).map {
-      str =>
-        val preparedPath = if (str.startsWith("/")) str else "/" + str
-
-        Uri.Path.unsafeFromString(preparedPath)
-    }
+    oneOf(genPathAbEmpty, genPathAbsolute, genPathNoScheme, genPathRootless, genPathEmpty).map(
+      Uri.Path.unsafeFromString
+    )
   }
 
   implicit val http4sTestingCogenForPath: Cogen[Uri.Path] =

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -815,23 +815,21 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
     } yield Uri(scheme, authority, path, query, fragment)
   }
 
-  /** Creates an `Arbitrary[Url]` with checking that a URI is converting to String
+  /** Creates an `Gen[Url]` with checking that a URI is converting to String
     * and back to URI safely.
-    * Use this Arbitrary with cautions - it may lead to tests performance degradation.
+    * Use this Gen with cautions - it may lead to tests performance degradation.
     */
-  def createArbitraryUri: Arbitrary[Uri] =
-    Arbitrary(
-      http4sTestingArbitraryForUri.arbitrary.filter { uri =>
-        // Uri.renderString encode special chars in the fragment
-        // and after converting the Uri to Json, the fragment will be encoded
-        val convertedBackToUriWithFragment =
-          (f: Uri.Fragment) => Uri.fromString(uri.withoutFragment.toString).map(_.withFragment(f))
-        val parsedUri =
-          uri.fragment.fold(Uri.fromString(uri.toString))(convertedBackToUriWithFragment)
+  def createGenUri: Gen[Uri] =
+    http4sTestingArbitraryForUri.arbitrary.filter { uri =>
+      // Uri.renderString encode special chars in the fragment
+      // and after converting the Uri to Json, the fragment will be encoded
+      val convertedBackToUriWithFragment =
+        (f: Uri.Fragment) => Uri.fromString(uri.withoutFragment.toString).map(_.withFragment(f))
+      val parsedUri =
+        uri.fragment.fold(Uri.fromString(uri.toString))(convertedBackToUriWithFragment)
 
-        parsedUri == Right(uri)
-      }
-    )
+      parsedUri == Right(uri)
+    }
 
   implicit val http4sTestingArbitraryForLink: Arbitrary[LinkValue] = Arbitrary {
     for {

--- a/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
@@ -24,7 +24,6 @@ import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
 import org.http4s.laws.discipline.arbitrary
 import org.http4s.play._
-import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll
 
 // Originally based on CirceSpec
@@ -64,9 +63,7 @@ class PlaySuite extends JawnDecodeSupportSuite[JsValue] {
   }
 
   property("Uri codec round trip") {
-    implicit val arbitraryUri: Arbitrary[Uri] = arbitrary.createArbitraryUri
-
-    forAll { (uri: Uri) =>
+    forAll(arbitrary.createGenUri) { (uri: Uri) =>
       // Uri.renderString encode special chars in the fragment
       // and after converting the Uri to Json, the fragment will be encoded
       val preparedUri = uri.fragment.fold(uri)(f => uri.withFragment(Uri.encode(f)))

--- a/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
@@ -22,8 +22,9 @@ import cats.effect.IO
 import cats.effect.laws.util.TestContext
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
-import org.http4s.laws.discipline.arbitrary._
+import org.http4s.laws.discipline.arbitrary
 import org.http4s.play._
+import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll
 
 // Originally based on CirceSpec
@@ -63,6 +64,8 @@ class PlaySuite extends JawnDecodeSupportSuite[JsValue] {
   }
 
   property("Uri codec round trip") {
+    implicit val arbitraryUri: Arbitrary[Uri] = arbitrary.createArbitraryUri
+
     forAll { (uri: Uri) =>
       // Uri.renderString encode special chars in the fragment
       // and after converting the Uri to Json, the fragment will be encoded

--- a/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
+++ b/play-json/src/test/scala/org/http4s/play/PlaySuite.scala
@@ -22,8 +22,9 @@ import cats.effect.IO
 import cats.effect.laws.util.TestContext
 import org.http4s.headers.`Content-Type`
 import org.http4s.jawn.JawnDecodeSupportSuite
+import org.http4s.laws.discipline.arbitrary._
 import org.http4s.play._
-import org.http4s.syntax.all._
+import org.scalacheck.Prop.forAll
 
 // Originally based on CirceSpec
 class PlaySuite extends JawnDecodeSupportSuite[JsValue] {
@@ -61,11 +62,13 @@ class PlaySuite extends JawnDecodeSupportSuite[JsValue] {
     result.value.assertEquals(Right(Foo(42)))
   }
 
-  test("Uri codec should round trip") {
-    // TODO would benefit from Arbitrary[Uri]
-    val uri = uri"http://www.example.com/"
-
-    assertEquals(Json.fromJson[Uri](Json.toJson(uri)).asOpt, Some(uri))
+  property("Uri codec round trip") {
+    forAll { (uri: Uri) =>
+      // Uri.renderString encode special chars in the fragment
+      // and after converting the Uri to Json, the fragment will be encoded
+      val preparedUri = uri.fragment.fold(uri)(f => uri.withFragment(Uri.encode(f)))
+      assertEquals(Json.fromJson[Uri](Json.toJson(uri)).asOpt, Some(preparedUri))
+    }
   }
 
   test("Message[F].decodeJson[A] should decode json from a message") {


### PR DESCRIPTION
A bit richer tests of the `Uri` parsing.