### PR TITLE
Use `assertEquals` instead of `assert`

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
@@ -138,8 +138,8 @@ class Http1ClientStageSuite extends Http4sSuite {
   test("Run a basic request".flaky) {
     getSubmission(FooRequest, resp).map { case (request, response) =>
       val statusLine = request.split("\r\n").apply(0)
-      assert(statusLine == "GET / HTTP/1.1")
-      assert(response == "done")
+      assertEquals(statusLine, "GET / HTTP/1.1")
+      assertEquals(response, "done")
     }
   }
 
@@ -150,8 +150,8 @@ class Http1ClientStageSuite extends Http4sSuite {
 
     getSubmission(req, resp).map { case (request, response) =>
       val statusLine = request.split("\r\n").apply(0)
-      assert(statusLine == "GET " + uri + " HTTP/1.1")
-      assert(response == "done")
+      assertEquals(statusLine, "GET " + uri + " HTTP/1.1")
+      assertEquals(response, "done")
     }
   }
 

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/PoolManagerSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/PoolManagerSuite.scala
@@ -88,7 +88,7 @@ class PoolManagerSuite extends Http4sSuite with AllSyntax {
           .compile
           .toList
           .attempt
-    } yield assert(att == Left(WaitQueueFullFailure()))
+    } yield assertEquals(att, Left(WaitQueueFullFailure()))
   }
 
   test("A pool manager should wake up a waiting connection on release") {
@@ -118,9 +118,9 @@ class PoolManagerSuite extends Http4sSuite with AllSyntax {
       result2 <- waiting2.join.void.attempt
       result3 <- waiting3.join.void.attempt
     } yield {
-      assert(result1 == Left(WaitQueueTimeoutException))
-      assert(result2 == Left(WaitQueueTimeoutException))
-      assert(result3.isRight)
+      assertEquals(result1, Left(WaitQueueTimeoutException))
+      assertEquals(result2, Left(WaitQueueTimeoutException))
+      assertEquals(result3, Right(()))
     }
   }
 

--- a/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
@@ -91,7 +91,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(Ping())
       p <- socket.pollOutbound(2).map(_.exists(_ == Pong()))
       _ <- socket.sendInbound(Close())
-    } yield assert(p)
+    } yield assertEquals(p, true)
   }
 
   test("Http4sWSStage should not write any more frames after close frame sent") {
@@ -102,7 +102,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       p2 <- socket.pollOutbound().map(_.contains(Close()))
       p3 <- socket.pollOutbound().map(_.isEmpty)
       _ <- socket.sendInbound(Close())
-    } yield assert(p1 && p2 && p3)
+    } yield assertEquals(p1 && p2 && p3, true)
   }
 
   test(
@@ -113,7 +113,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(Close())
       p1 <- socket.pollBatchOutputbound(2, 2).map(_ == List(Close()))
       p2 <- socket.wasCloseHookCalled().map(_ == true)
-    } yield assert(p1 && p2)
+    } yield assertEquals(p1 && p2, true)
   }
 
   test("Http4sWSStage should not send two close frames".flaky) {
@@ -123,7 +123,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(Close())
       p1 <- socket.pollBatchOutputbound(2).map(_ == List(Close()))
       p2 <- socket.wasCloseHookCalled()
-    } yield assert(p1 && p2)
+    } yield assertEquals(p1 && p2, true)
   }
 
   test("Http4sWSStage should ignore pong frames") {
@@ -132,7 +132,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(Pong())
       p <- socket.pollOutbound().map(_.isEmpty)
       _ <- socket.sendInbound(Close())
-    } yield assert(p)
+    } yield assertEquals(p, true)
   }
 
   test("Http4sWSStage should send a ping frames to backend") {
@@ -144,7 +144,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(pingWithBytes)
       p2 <- socket.pollBackendInbound().map(_.contains(pingWithBytes))
       _ <- socket.sendInbound(Close())
-    } yield assert(p1 && p2)
+    } yield assertEquals(p1 && p2, true)
   }
 
   test("Http4sWSStage should send a pong frames to backend") {
@@ -156,7 +156,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(pongWithBytes)
       p2 <- socket.pollBackendInbound().map(_.contains(pongWithBytes))
       _ <- socket.sendInbound(Close())
-    } yield assert(p1 && p2)
+    } yield assertEquals(p1 && p2, true)
   }
 
   test("Http4sWSStage should not fail on pending write request") {
@@ -173,6 +173,6 @@ class Http4sWSStageSpec extends Http4sSuite {
           .compile
           .toList
           .timeout(5.seconds)
-    } yield assert(reasonReceived == List(reasonSent))
+    } yield assertEquals(reasonReceived, List(reasonSent))
   }
 }

--- a/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/websocket/Http4sWSStageSpec.scala
@@ -91,7 +91,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(Ping())
       p <- socket.pollOutbound(2).map(_.exists(_ == Pong()))
       _ <- socket.sendInbound(Close())
-    } yield assertEquals(p, true)
+    } yield assert(p)
   }
 
   test("Http4sWSStage should not write any more frames after close frame sent") {
@@ -102,7 +102,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       p2 <- socket.pollOutbound().map(_.contains(Close()))
       p3 <- socket.pollOutbound().map(_.isEmpty)
       _ <- socket.sendInbound(Close())
-    } yield assertEquals(p1 && p2 && p3, true)
+    } yield assert(p1 && p2 && p3)
   }
 
   test(
@@ -113,7 +113,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(Close())
       p1 <- socket.pollBatchOutputbound(2, 2).map(_ == List(Close()))
       p2 <- socket.wasCloseHookCalled().map(_ == true)
-    } yield assertEquals(p1 && p2, true)
+    } yield assert(p1 && p2)
   }
 
   test("Http4sWSStage should not send two close frames".flaky) {
@@ -123,7 +123,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(Close())
       p1 <- socket.pollBatchOutputbound(2).map(_ == List(Close()))
       p2 <- socket.wasCloseHookCalled()
-    } yield assertEquals(p1 && p2, true)
+    } yield assert(p1 && p2)
   }
 
   test("Http4sWSStage should ignore pong frames") {
@@ -132,7 +132,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(Pong())
       p <- socket.pollOutbound().map(_.isEmpty)
       _ <- socket.sendInbound(Close())
-    } yield assertEquals(p, true)
+    } yield assert(p)
   }
 
   test("Http4sWSStage should send a ping frames to backend") {
@@ -144,7 +144,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(pingWithBytes)
       p2 <- socket.pollBackendInbound().map(_.contains(pingWithBytes))
       _ <- socket.sendInbound(Close())
-    } yield assertEquals(p1 && p2, true)
+    } yield assert(p1 && p2)
   }
 
   test("Http4sWSStage should send a pong frames to backend") {
@@ -156,7 +156,7 @@ class Http4sWSStageSpec extends Http4sSuite {
       _ <- socket.sendInbound(pongWithBytes)
       p2 <- socket.pollBackendInbound().map(_.contains(pongWithBytes))
       _ <- socket.sendInbound(Close())
-    } yield assertEquals(p1 && p2, true)
+    } yield assert(p1 && p2)
   }
 
   test("Http4sWSStage should not fail on pending write request") {

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/BlazeServerMtlsSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/BlazeServerMtlsSpec.scala
@@ -60,9 +60,9 @@ class BlazeServerMtlsSpec extends Http4sSuite {
         .lookup(ServerRequestKeys.SecureSession)
         .flatten
         .map { session =>
-          assert(session.sslSessionId != "")
-          assert(session.cipherSuite != "")
-          assert(session.keySize != 0)
+          assertNotEquals(session.sslSessionId, "")
+          assertNotEquals(session.cipherSuite, "")
+          assertNotEquals(session.keySize, 0)
 
           session.X509Certificate.head.getSubjectX500Principal.getName
         }
@@ -75,10 +75,10 @@ class BlazeServerMtlsSpec extends Http4sSuite {
         .lookup(ServerRequestKeys.SecureSession)
         .flatten
         .foreach { session =>
-          assert(session.sslSessionId != "")
-          assert(session.cipherSuite != "")
-          assert(session.keySize != 0)
-          assert(session.X509Certificate.isEmpty)
+          assertNotEquals(session.sslSessionId, "")
+          assertNotEquals(session.cipherSuite, "")
+          assertNotEquals(session.keySize, 0)
+          assertEquals(session.X509Certificate, Nil)
         }
 
       Ok("success")

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
@@ -107,7 +107,7 @@ class Http1ServerStageSpec extends Http4sSuite {
       runRequest(tickwheel, Seq(req), routes, maxReqLine = 1).result.map { buff =>
         val str = StandardCharsets.ISO_8859_1.decode(buff.duplicate()).toString
         // make sure we don't have signs of chunked encoding.
-        assertEquals(str.contains("400 Bad Request"), true)
+        assert(str.contains("400 Bad Request"))
       }
   }
 
@@ -116,7 +116,7 @@ class Http1ServerStageSpec extends Http4sSuite {
       runRequest(tickwheel, Seq(req), routes, maxHeaders = 1).result.map { buff =>
         val str = StandardCharsets.ISO_8859_1.decode(buff.duplicate()).toString
         // make sure we don't have signs of chunked encoding.
-        assertEquals(str.contains("400 Bad Request"), true)
+        assert(str.contains("400 Bad Request"))
       }
   }
 
@@ -168,7 +168,7 @@ class Http1ServerStageSpec extends Http4sSuite {
   tickWheel.test("Http1ServerStage: Errors should Deal with synchronous errors") { tw =>
     val path = "GET /sync HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
     runError(tw, path).map { case (s, c, _) =>
-      assertEquals(c, true)
+      assert(c)
       assertEquals(s, InternalServerError)
     }
   }
@@ -177,7 +177,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     tw =>
       val path = "GET /sync/422 HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
       runError(tw, path).map { case (s, c, _) =>
-        assertEquals(c, false)
+        assert(!c)
         assertEquals(s, UnprocessableEntity)
       }
   }
@@ -185,7 +185,7 @@ class Http1ServerStageSpec extends Http4sSuite {
   tickWheel.test("Http1ServerStage: Errors should Deal with asynchronous errors") { tw =>
     val path = "GET /async HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
     runError(tw, path).map { case (s, c, _) =>
-      assertEquals(c, true)
+      assert(c)
       assertEquals(s, InternalServerError)
     }
   }
@@ -194,7 +194,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     tw =>
       val path = "GET /async/422 HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
       runError(tw, path).map { case (s, c, _) =>
-        assertEquals(c, false)
+        assert(!c)
         assertEquals(s, UnprocessableEntity)
       }
   }
@@ -202,7 +202,7 @@ class Http1ServerStageSpec extends Http4sSuite {
   tickWheel.test("Http1ServerStage: Errors should Handle parse error") { tw =>
     val path = "THIS\u0000IS\u0000NOT\u0000HTTP"
     runError(tw, path).map { case (s, c, _) =>
-      assertEquals(c, true)
+      assert(c)
       assertEquals(s, BadRequest)
     }
   }
@@ -226,11 +226,11 @@ class Http1ServerStageSpec extends Http4sSuite {
     runRequest(tw, Seq(req), routes).result.map { buff =>
       val str = StandardCharsets.ISO_8859_1.decode(buff.duplicate()).toString
       // make sure we don't have signs of chunked encoding.
-      assertEquals(str.contains("0\r\n\r\n"), false)
-      assertEquals(str.contains("hello world"), true)
+      assert(!str.contains("0\r\n\r\n"))
+      assert(str.contains("hello world"))
 
       val (_, hdrs, _) = ResponseParser.apply(buff)
-      assertEquals(hdrs.exists(_.name == `Transfer-Encoding`.name), false)
+      assert(!hdrs.exists(_.name == `Transfer-Encoding`.name))
     }
   }
 
@@ -252,7 +252,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     runRequest(tw, Seq(req), routes).result.map { buf =>
       val (status, hs, body) = ResponseParser.parseBuffer(buf)
       hs.foreach { h =>
-        assertEquals(`Content-Length`.parse(h.value).isLeft, true)
+        assert(`Content-Length`.parse(h.value).isLeft)
       }
       assertEquals(body, "")
       assertEquals(status, Status.NotModified)
@@ -272,7 +272,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     runRequest(tw, Seq(req1), routes).result.map { buff =>
       // Both responses must succeed
       val (_, hdrs, _) = ResponseParser.apply(buff)
-      assertEquals(hdrs.exists(_.name == Header[Date].name), true)
+      assert(hdrs.exists(_.name == Header[Date].name))
     }
   }
 

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
@@ -107,16 +107,16 @@ class Http1ServerStageSpec extends Http4sSuite {
       runRequest(tickwheel, Seq(req), routes, maxReqLine = 1).result.map { buff =>
         val str = StandardCharsets.ISO_8859_1.decode(buff.duplicate()).toString
         // make sure we don't have signs of chunked encoding.
-        assert(str.contains("400 Bad Request"))
+        assertEquals(str.contains("400 Bad Request"), true)
       }
   }
 
   tickWheel.test("Http1ServerStage: Invalid Lengths should fail on too long of a header") {
     tickwheel =>
-      (runRequest(tickwheel, Seq(req), routes, maxHeaders = 1).result).map { buff =>
+      runRequest(tickwheel, Seq(req), routes, maxHeaders = 1).result.map { buff =>
         val str = StandardCharsets.ISO_8859_1.decode(buff.duplicate()).toString
         // make sure we don't have signs of chunked encoding.
-        assert(str.contains("400 Bad Request"))
+        assertEquals(str.contains("400 Bad Request"), true)
       }
   }
 
@@ -168,7 +168,8 @@ class Http1ServerStageSpec extends Http4sSuite {
   tickWheel.test("Http1ServerStage: Errors should Deal with synchronous errors") { tw =>
     val path = "GET /sync HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
     runError(tw, path).map { case (s, c, _) =>
-      assert(s == InternalServerError && c)
+      assertEquals(c, true)
+      assertEquals(s, InternalServerError)
     }
   }
 
@@ -176,14 +177,16 @@ class Http1ServerStageSpec extends Http4sSuite {
     tw =>
       val path = "GET /sync/422 HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
       runError(tw, path).map { case (s, c, _) =>
-        assert(s == UnprocessableEntity && !c)
+        assertEquals(c, false)
+        assertEquals(s, UnprocessableEntity)
       }
   }
 
   tickWheel.test("Http1ServerStage: Errors should Deal with asynchronous errors") { tw =>
     val path = "GET /async HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
     runError(tw, path).map { case (s, c, _) =>
-      assert(s == InternalServerError && c)
+      assertEquals(c, true)
+      assertEquals(s, InternalServerError)
     }
   }
 
@@ -191,14 +194,16 @@ class Http1ServerStageSpec extends Http4sSuite {
     tw =>
       val path = "GET /async/422 HTTP/1.1\r\nConnection:keep-alive\r\n\r\n"
       runError(tw, path).map { case (s, c, _) =>
-        assert(s == UnprocessableEntity && !c)
+        assertEquals(c, false)
+        assertEquals(s, UnprocessableEntity)
       }
   }
 
   tickWheel.test("Http1ServerStage: Errors should Handle parse error") { tw =>
     val path = "THIS\u0000IS\u0000NOT\u0000HTTP"
     runError(tw, path).map { case (s, c, _) =>
-      assert(s == BadRequest && c)
+      assertEquals(c, true)
+      assertEquals(s, BadRequest)
     }
   }
 
@@ -221,11 +226,11 @@ class Http1ServerStageSpec extends Http4sSuite {
     runRequest(tw, Seq(req), routes).result.map { buff =>
       val str = StandardCharsets.ISO_8859_1.decode(buff.duplicate()).toString
       // make sure we don't have signs of chunked encoding.
-      assert(!str.contains("0\r\n\r\n"))
-      assert(str.contains("hello world"))
+      assertEquals(str.contains("0\r\n\r\n"), false)
+      assertEquals(str.contains("hello world"), true)
 
       val (_, hdrs, _) = ResponseParser.apply(buff)
-      assert(!hdrs.exists(_.name == `Transfer-Encoding`.name))
+      assertEquals(hdrs.exists(_.name == `Transfer-Encoding`.name), false)
     }
   }
 
@@ -244,13 +249,13 @@ class Http1ServerStageSpec extends Http4sSuite {
 
     val req = "GET /foo HTTP/1.1\r\n\r\n"
 
-    (runRequest(tw, Seq(req), routes).result).map { buf =>
+    runRequest(tw, Seq(req), routes).result.map { buf =>
       val (status, hs, body) = ResponseParser.parseBuffer(buf)
       hs.foreach { h =>
-        assert(`Content-Length`.parse(h.value).isLeft)
+        assertEquals(`Content-Length`.parse(h.value).isLeft, true)
       }
-      assert(body == "")
-      assert(status == Status.NotModified)
+      assertEquals(body, "")
+      assertEquals(status, Status.NotModified)
     }
   }
 
@@ -264,10 +269,10 @@ class Http1ServerStageSpec extends Http4sSuite {
     // The first request will get split into two chunks, leaving the last byte off
     val req1 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 4\r\n\r\ndone"
 
-    (runRequest(tw, Seq(req1), routes).result).map { buff =>
+    runRequest(tw, Seq(req1), routes).result.map { buff =>
       // Both responses must succeed
       val (_, hdrs, _) = ResponseParser.apply(buff)
-      assert(hdrs.exists(_.name == Header[Date].name))
+      assertEquals(hdrs.exists(_.name == Header[Date].name), true)
     }
   }
 
@@ -282,7 +287,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     // The first request will get split into two chunks, leaving the last byte off
     val req1 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 4\r\n\r\ndone"
 
-    (runRequest(tw, Seq(req1), routes).result).map { buff =>
+    runRequest(tw, Seq(req1), routes).result.map { buff =>
       // Both responses must succeed
       val (_, hdrs, _) = ResponseParser.apply(buff)
 
@@ -304,7 +309,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     val req1 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 4\r\n\r\ndone"
     val (r11, r12) = req1.splitAt(req1.length - 1)
 
-    (runRequest(tw, Seq(r11, r12), routes).result).map { buff =>
+    runRequest(tw, Seq(r11, r12), routes).result.map { buff =>
       // Both responses must succeed
       assertEquals(
         parseAndDropDate(buff),
@@ -328,7 +333,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     val req1 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 4\r\n\r\ndone"
     val (r11, r12) = req1.splitAt(req1.length - 1)
 
-    (runRequest(tw, Seq(r11, r12), routes).result).map { buff =>
+    runRequest(tw, Seq(r11, r12), routes).result.map { buff =>
       // Both responses must succeed
       assertEquals(
         parseAndDropDate(buff),
@@ -357,7 +362,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     val req1 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 4\r\n\r\ndone"
     val req2 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 5\r\n\r\ntotal"
 
-    (runRequest(tw, Seq(req1, req2), routes).result).map { buff =>
+    runRequest(tw, Seq(req1, req2), routes).result.map { buff =>
       val hs = Set(
         H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw1,
         H.`Content-Length`.unsafeFromLong(3).toRaw1,
@@ -383,7 +388,7 @@ class Http1ServerStageSpec extends Http4sSuite {
 
     val req2 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 5\r\n\r\ntotal"
 
-    (runRequest(tw, Seq(r11, r12, req2), routes).result).map { buff =>
+    runRequest(tw, Seq(r11, r12, req2), routes).result.map { buff =>
       val hs = Set(
         H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw1,
         H.`Content-Length`.unsafeFromLong(3).toRaw1,
@@ -408,7 +413,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     val (r11, r12) = req1.splitAt(req1.length - 1)
     val req2 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 5\r\n\r\ntotal"
 
-    (runRequest(tw, Seq(r11, r12, req2), routes).result).map { buff =>
+    runRequest(tw, Seq(r11, r12, req2), routes).result.map { buff =>
       val hs = Set(
         H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw1,
         H.`Content-Length`.unsafeFromLong(3).toRaw1,
@@ -432,7 +437,7 @@ class Http1ServerStageSpec extends Http4sSuite {
       val req1 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 4\r\n\r\ndone"
       val req2 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 5\r\n\r\ntotal"
 
-      (runRequest(tw, Seq(req1 + req2), routes).result).map { buff =>
+      runRequest(tw, Seq(req1 + req2), routes).result.map { buff =>
         // Both responses must succeed
         assertEquals(
           dropDate(ResponseParser.parseBuffer(buff)),
@@ -458,7 +463,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     val req1 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 4\r\n\r\ndone"
     val req2 = "POST /sync HTTP/1.1\r\nConnection:keep-alive\r\nContent-Length: 5\r\n\r\ntotal"
 
-    (runRequest(tw, Seq(req1, req2), routes).result).map { buff =>
+    runRequest(tw, Seq(req1, req2), routes).result.map { buff =>
       // Both responses must succeed
       assertEquals(
         dropDate(ResponseParser.parseBuffer(buff)),
@@ -497,7 +502,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     .orNotFound
 
   tickWheel.test("Http1ServerStage: routes should Handle trailing headers") { tw =>
-    (runRequest(tw, Seq(req("foo")), routes2).result).map { buff =>
+    runRequest(tw, Seq(req("foo")), routes2).result.map { buff =>
       val results = dropDate(ResponseParser.parseBuffer(buff))
       assertEquals(results._1, Ok)
       assertEquals(results._3, "Foo: Bar")
@@ -507,7 +512,7 @@ class Http1ServerStageSpec extends Http4sSuite {
   tickWheel.test(
     "Http1ServerStage: routes should Fail if you use the trailers before they have resolved"
   ) { tw =>
-    (runRequest(tw, Seq(req("bar")), routes2).result).map { buff =>
+    runRequest(tw, Seq(req("bar")), routes2).result.map { buff =>
       val results = dropDate(ResponseParser.parseBuffer(buff))
       assertEquals(results._1, InternalServerError)
     }
@@ -535,7 +540,7 @@ class Http1ServerStageSpec extends Http4sSuite {
   tickWheel.test("Http1ServerStage: routes should Disconnect if we read an EOF") { tw =>
     val head = runRequest(tw, Seq.empty, Kleisli.liftF(Ok("")))
     head.result.map { _ =>
-      assert(head.closeCauses == Seq(None))
+      assertEquals(head.closeCauses, Vector(None))
     }
   }
 

--- a/client/src/test/scala/org/http4s/client/middleware/GZipSuite.scala
+++ b/client/src/test/scala/org/http4s/client/middleware/GZipSuite.scala
@@ -36,14 +36,14 @@ class GZipSuite extends Http4sSuite {
   test("Client Gzip should return data correctly") {
     gzipClient
       .get(uri"/gziptest") { response =>
-        assert(response.status == Status.Ok)
-        assert(response.headers.get[`Content-Encoding`].isEmpty)
-        assert(response.headers.get[`Content-Length`].isEmpty)
+        assertEquals(response.status, Status.Ok)
+        assertEquals(response.headers.get[`Content-Encoding`], None)
+        assertEquals(response.headers.get[`Content-Length`], None)
 
         response.as[String]
       }
       .map { body =>
-        assert(body == "Dummy response")
+        assertEquals(body, "Dummy response")
       }
   }
 
@@ -52,14 +52,14 @@ class GZipSuite extends Http4sSuite {
     gzipClient
       .run(request)
       .use { response =>
-        assert(response.status == Status.Ok)
-        assert(response.headers.get[`Content-Encoding`].isEmpty)
-        assert(response.headers.get[`Content-Length`].isEmpty)
+        assertEquals(response.status, Status.Ok)
+        assertEquals(response.headers.get[`Content-Encoding`], None)
+        assertEquals(response.headers.get[`Content-Length`], None)
 
         response.as[String]
       }
       .map { body =>
-        assert(body == "")
+        assertEquals(body, "")
       }
   }
 }

--- a/client/src/test/scala/org/http4s/client/oauth1/OAuthSuite.scala
+++ b/client/src/test/scala/org/http4s/client/oauth1/OAuthSuite.scala
@@ -29,6 +29,7 @@ import org.typelevel.ci._
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
+import scala.collection.immutable.Seq
 
 class OAuthSuite extends Http4sSuite {
   // some params taken from http://oauth.net/core/1.0/#anchor30, others from
@@ -73,7 +74,7 @@ class OAuthSuite extends Http4sSuite {
       "3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal"
 
   test("OAuth support should generate a Base String") {
-    assert(oauth1.genBaseString(Method.GET, uri, allParams) == specBaseString)
+    assertEquals(oauth1.genBaseString(Method.GET, uri, allParams), specBaseString)
   }
 
   test("OAuth support should generate a correct HMAC-SHA1 signature") {
@@ -101,7 +102,7 @@ class OAuthSuite extends Http4sSuite {
       )
       .map { auth =>
         val creds = auth.credentials
-        assert(creds.authScheme == ci"OAuth")
+        assertEquals(creds.authScheme, ci"OAuth")
       }
   }
 
@@ -115,15 +116,16 @@ class OAuthSuite extends Http4sSuite {
     val req = Request[IO](method = Method.POST, uri = uri).withEntity(body)
 
     oauth1.getUserParams(req).map { case (_, v) =>
-      assert(
-        v.sorted == Seq(
+      assertEquals(
+        v.sorted,
+        Seq(
           "b5" -> "=%3D",
           "a3" -> "a",
           "c@" -> "",
           "a2" -> "r b",
           "c2" -> "",
           "a3" -> "2 q",
-        ).sorted
+        ).sorted,
       )
     }
   }

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSuite.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardClientMetricsSuite.scala
@@ -52,13 +52,13 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
         valuesOf(registry, Timer("client.default.requests.headers"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.requests.total"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
     }
   }
@@ -77,13 +77,13 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
         valuesOf(registry, Timer("client.default.requests.headers"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.requests.total"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
     }
   }
@@ -103,13 +103,13 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
         valuesOf(registry, Timer("client.default.requests.headers"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.requests.total"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
     }
   }
@@ -128,19 +128,19 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
         valuesOf(registry, Timer("client.default.requests.headers"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.get-requests"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.2xx-responses"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
     }
   }
@@ -159,19 +159,19 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
         valuesOf(registry, Timer("client.default.requests.headers"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.post-requests"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.2xx-responses"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
     }
   }
@@ -190,19 +190,19 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
         valuesOf(registry, Timer("client.default.requests.headers"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.put-requests"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.2xx-responses"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
     }
   }
@@ -221,19 +221,19 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
         valuesOf(registry, Timer("client.default.requests.headers"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.delete-requests"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.default.2xx-responses"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
     }
   }
@@ -283,13 +283,13 @@ class DropwizardClientMetricsSuite extends Http4sSuite {
         valuesOf(registry, Timer("client.get.requests.headers"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("client.get.requests.total"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(100000000L)
+        List(100000000L),
       )
     }
   }

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
@@ -45,10 +45,11 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
         assertEquals(count(registry, Timer("server.default.2xx-responses")), 1L)
         assertEquals(count(registry, Counter("server.default.active-requests")), 0L)
         assertEquals(count(registry, Timer("server.default.requests.total")), 1L)
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.requests.headers"))
-            .map(Arrays.equals(_, (Array(50000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(50000000L),
         )
         assert(
           valuesOf(registry, Timer("server.default.get-requests"))

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
@@ -47,19 +47,19 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.default.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L)
+          List(50000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
       }
     }
@@ -83,19 +83,19 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.default.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L)
+          List(50000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.4xx-responses"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
       }
     }
@@ -118,19 +118,19 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.default.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L)
+          List(50000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.5xx-responses"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
       }
     }
@@ -153,19 +153,19 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.default.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L)
+          List(50000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
       }
     }
@@ -188,19 +188,19 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.default.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L)
+          List(50000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.post-requests"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
       }
     }
@@ -223,19 +223,19 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.default.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L)
+          List(50000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.put-requests"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
       }
     }
@@ -258,19 +258,19 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.default.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L)
+          List(50000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.delete-requests"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
       }
     }
@@ -291,13 +291,13 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
         valuesOf(registry, Timer("server.default.requests.headers"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
       assertEquals(
         valuesOf(registry, Timer("server.default.get-requests"))
           .getOrElse(Array.empty[Long])
           .toList,
-        List(50000000L)
+        List(50000000L),
       )
     }
   }
@@ -319,13 +319,13 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.default.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L)
+          List(50000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
       }
     }
@@ -350,19 +350,19 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.classifier.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L)
+          List(50000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.classifier.get-requests"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
         assertEquals(
           valuesOf(registry, Timer("server.classifier.2xx-responses"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(100000000L)
+          List(100000000L),
         )
       }
     }

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
@@ -29,8 +29,6 @@ import org.http4s.metrics.dropwizard.util._
 import org.http4s.server.middleware.Metrics
 import org.http4s.syntax.all._
 
-import java.util.Arrays
-
 class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register a 2xx response") {
     implicit val clock: Clock[IO] = FakeClock[IO]
@@ -49,17 +47,19 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
           valuesOf(registry, Timer("server.default.requests.headers"))
             .getOrElse(Array.empty[Long])
             .toList,
-          List(50000000L),
+          List(50000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
       }
     }
@@ -79,20 +79,23 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
         assertEquals(count(registry, Timer("server.default.4xx-responses")), 1L)
         assertEquals(count(registry, Counter("server.default.active-requests")), 0L)
         assertEquals(count(registry, Timer("server.default.requests.total")), 1L)
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.requests.headers"))
-            .map(Arrays.equals(_, (Array(50000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(50000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.4xx-responses"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
       }
     }
@@ -111,20 +114,23 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
         assertEquals(count(registry, Timer("server.default.5xx-responses")), 1L)
         assertEquals(count(registry, Counter("server.default.active-requests")), 0L)
         assertEquals(count(registry, Timer("server.default.requests.total")), 1L)
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.requests.headers"))
-            .map(Arrays.equals(_, (Array(50000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(50000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.5xx-responses"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
       }
     }
@@ -143,20 +149,23 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
         assertEquals(count(registry, Timer("server.default.get-requests")), 1L)
         assertEquals(count(registry, Counter("server.default.active-requests")), 0L)
         assertEquals(count(registry, Timer("server.default.requests.total")), 1L)
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.requests.headers"))
-            .map(Arrays.equals(_, (Array(50000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(50000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
       }
     }
@@ -175,20 +184,23 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
         assertEquals(count(registry, Timer("server.default.post-requests")), 1L)
         assertEquals(count(registry, Counter("server.default.active-requests")), 0L)
         assertEquals(count(registry, Timer("server.default.requests.total")), 1L)
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.requests.headers"))
-            .map(Arrays.equals(_, (Array(50000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(50000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.post-requests"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
       }
     }
@@ -207,20 +219,23 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
         assertEquals(count(registry, Timer("server.default.put-requests")), 1L)
         assertEquals(count(registry, Counter("server.default.active-requests")), 0L)
         assertEquals(count(registry, Timer("server.default.requests.total")), 1L)
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.requests.headers"))
-            .map(Arrays.equals(_, (Array(50000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(50000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.put-requests"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
       }
     }
@@ -239,20 +254,23 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
         assertEquals(count(registry, Timer("server.default.delete-requests")), 1L)
         assertEquals(count(registry, Counter("server.default.active-requests")), 0L)
         assertEquals(count(registry, Timer("server.default.requests.total")), 1L)
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.requests.headers"))
-            .map(Arrays.equals(_, (Array(50000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(50000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.delete-requests"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.2xx-responses"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
       }
     }
@@ -265,19 +283,21 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     val req = Request[IO](method = GET, uri = uri"/error")
 
     meteredRoutes.orNotFound(req).attempt.map { resp =>
-      assert(resp.isLeft)
+      val Left(_) = resp
       assertEquals(count(registry, Timer("server.default.errors")), 1L)
       assertEquals(count(registry, Counter("server.default.active-requests")), 0L)
       assertEquals(count(registry, Timer("server.default.requests.total")), 1L)
-      assert(
+      assertEquals(
         valuesOf(registry, Timer("server.default.requests.headers"))
-          .map(Arrays.equals(_, (Array(50000000L))))
-          .getOrElse(false)
+          .getOrElse(Array.empty[Long])
+          .toList,
+        List(50000000L)
       )
-      assert(
+      assertEquals(
         valuesOf(registry, Timer("server.default.get-requests"))
-          .map(Arrays.equals(_, (Array(50000000L))))
-          .getOrElse(false)
+          .getOrElse(Array.empty[Long])
+          .toList,
+        List(50000000L)
       )
     }
   }
@@ -291,19 +311,21 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     meteredRoutes.orNotFound(req).flatMap { resp =>
       resp.body.attempt.compile.lastOrError.map { b =>
         assertEquals(resp.status, Status.Ok)
-        assert(b.isLeft)
+        val Left(_) = b
         assertEquals(count(registry, Timer("server.default.abnormal-terminations")), 1L)
         assertEquals(count(registry, Counter("server.default.active-requests")), 0L)
         assertEquals(count(registry, Timer("server.default.requests.total")), 1L)
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.requests.headers"))
-            .map(Arrays.equals(_, (Array(50000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(50000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.default.get-requests"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
       }
     }
@@ -324,20 +346,23 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
         assertEquals(count(registry, Timer("server.classifier.2xx-responses")), 1L)
         assertEquals(count(registry, Counter("server.classifier.active-requests")), 0L)
         assertEquals(count(registry, Timer("server.classifier.requests.total")), 1L)
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.classifier.requests.headers"))
-            .map(Arrays.equals(_, (Array(50000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(50000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.classifier.get-requests"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
-        assert(
+        assertEquals(
           valuesOf(registry, Timer("server.classifier.2xx-responses"))
-            .map(Arrays.equals(_, (Array(100000000L))))
-            .getOrElse(false)
+            .getOrElse(Array.empty[Long])
+            .toList,
+          List(100000000L)
         )
       }
     }

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -378,10 +378,11 @@ class ParsingSuite extends Http4sSuite {
     Parser.HeaderP.parseHeaders[IO](bv, 0, 4096).map {
       case Right(headerP) =>
         assertEquals(
-          headerP.headers.headers, List(
+          headerP.headers.headers,
+          List(
             Header.Raw(ci"Content-Type", "text/plain; charset=UTF-8"),
             Header.Raw(ci"Content-Length", "11"),
-          )
+          ),
         )
         assertEquals(headerP.chunked, false)
         assertEquals(headerP.contentLength, Some(11L))

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -377,14 +377,14 @@ class ParsingSuite extends Http4sSuite {
 
     Parser.HeaderP.parseHeaders[IO](bv, 0, 4096).map {
       case Right(headerP) =>
-        assert(
-          headerP.headers.headers == List(
+        assertEquals(
+          headerP.headers.headers, List(
             Header.Raw(ci"Content-Type", "text/plain; charset=UTF-8"),
             Header.Raw(ci"Content-Length", "11"),
           )
         )
-        assert(!headerP.chunked)
-        assert(headerP.contentLength == Some(11L))
+        assertEquals(headerP.chunked, false)
+        assertEquals(headerP.contentLength, Some(11L))
       case Left(_) => fail("Headers were not right")
     }
   }
@@ -434,9 +434,9 @@ class ParsingSuite extends Http4sSuite {
 
     Parser.Request.ReqPrelude.parsePrelude[IO](bv, 4096).map {
       case Right(prelude) =>
-        assert(prelude.method == Method.GET)
-        assert(prelude.uri == uri"/")
-        assert(prelude.version == HttpVersion.`HTTP/1.1`)
+        assertEquals(prelude.method, Method.GET)
+        assertEquals(prelude.uri, uri"/")
+        assertEquals(prelude.version, HttpVersion.`HTTP/1.1`)
       case Left(_) => fail("Prelude was not right")
     }
   }
@@ -449,8 +449,8 @@ class ParsingSuite extends Http4sSuite {
     val bv = asHttp.getBytes()
     Parser.Response.RespPrelude.parsePrelude[IO](bv, 4096).map {
       case Right(prelude) =>
-        assert(prelude.version == HttpVersion.`HTTP/1.1`)
-        assert(prelude.status == Status.Ok)
+        assertEquals(prelude.version, HttpVersion.`HTTP/1.1`)
+        assertEquals(prelude.status, Status.Ok)
       case Left(_) => fail("Prelude was not right")
     }
   }

--- a/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -384,7 +384,7 @@ class ParsingSuite extends Http4sSuite {
             Header.Raw(ci"Content-Length", "11"),
           ),
         )
-        assertEquals(headerP.chunked, false)
+        assert(!headerP.chunked)
         assertEquals(headerP.contentLength, Some(11L))
       case Left(_) => fail("Headers were not right")
     }

--- a/ember-server/src/test/scala/org/http4s/ember/server/EmberServerMtlsSuite.scala
+++ b/ember-server/src/test/scala/org/http4s/ember/server/EmberServerMtlsSuite.scala
@@ -48,9 +48,9 @@ class EmberServerMtlsSuite extends Http4sSuite {
             .lookup(ServerRequestKeys.SecureSession)
             .flatten
             .map { session =>
-              assert(session.sslSessionId != "")
-              assert(session.cipherSuite != "")
-              assert(session.keySize != 0)
+              assertNotEquals(session.sslSessionId, "")
+              assertNotEquals(session.cipherSuite, "")
+              assertNotEquals(session.keySize, 0)
 
               session.X509Certificate.head.getSubjectX500Principal.getName
             }
@@ -61,10 +61,10 @@ class EmberServerMtlsSuite extends Http4sSuite {
             .lookup(ServerRequestKeys.SecureSession)
             .flatten
             .foreach { session =>
-              assert(session.sslSessionId != "")
-              assert(session.cipherSuite != "")
-              assert(session.keySize != 0)
-              assert(session.X509Certificate.isEmpty)
+              assertNotEquals(session.sslSessionId, "")
+              assertNotEquals(session.cipherSuite, "")
+              assertNotEquals(session.keySize, 0)
+              assertNotEquals(session.X509Certificate.isEmpty, true)
             }
 
           Ok("success")

--- a/ember-server/src/test/scala/org/http4s/ember/server/EmberServerMtlsSuite.scala
+++ b/ember-server/src/test/scala/org/http4s/ember/server/EmberServerMtlsSuite.scala
@@ -64,7 +64,7 @@ class EmberServerMtlsSuite extends Http4sSuite {
               assertNotEquals(session.sslSessionId, "")
               assertNotEquals(session.cipherSuite, "")
               assertNotEquals(session.keySize, 0)
-              assertNotEquals(session.X509Certificate.isEmpty, true)
+              assertEquals(session.X509Certificate.isEmpty, true)
             }
 
           Ok("success")

--- a/ember-server/src/test/scala/org/http4s/ember/server/EmberServerMtlsSuite.scala
+++ b/ember-server/src/test/scala/org/http4s/ember/server/EmberServerMtlsSuite.scala
@@ -64,7 +64,7 @@ class EmberServerMtlsSuite extends Http4sSuite {
               assertNotEquals(session.sslSessionId, "")
               assertNotEquals(session.cipherSuite, "")
               assertNotEquals(session.keySize, 0)
-              assertEquals(session.X509Certificate.isEmpty, true)
+              assert(session.X509Certificate.isEmpty)
             }
 
           Ok("success")

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSuite.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusServerMetricsSuite.scala
@@ -166,7 +166,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
     val req = Request[IO](method = GET, uri = uri"/error")
 
     routes.run(req).attempt.map { r =>
-      assert(r.isLeft)
+      val Left(_) = r
 
       assertEquals(count(registry, "errors", "server", cause = "java.io.IOException"), 1.0)
       assertEquals(count(registry, "active_requests", "server"), 0.0)
@@ -183,7 +183,7 @@ class PrometheusServerMetricsSuite extends Http4sSuite {
     routes.run(req).flatMap { r =>
       r.body.attempt.compile.lastOrError.map { b =>
         assertEquals(r.status, Status.Ok)
-        assert(b.isLeft)
+        val Left(_) = b
 
         assertEquals(
           count(registry, "abnormal_terminations", "server", cause = "java.lang.RuntimeException"),

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
@@ -55,10 +55,12 @@ class ScalaXmlSuite extends Http4sSuite {
       strBody("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?><html><h1>h1</h1></html>""")
     )
     // https://github.com/http4s/http4s/issues/1209
-    ((0 to 5).toList)
+    (0 to 5).toList
       .parTraverse(_ => server(req).flatMap(r => getBody(r.body)))
       .map { bodies =>
-        assert(bodies.forall(_ == "html"))
+        bodies.foreach { body =>
+          assertEquals(body, "html")
+        }
       }
   }
 

--- a/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSuite.scala
+++ b/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSuite.scala
@@ -40,10 +40,10 @@ class ScalatagsSuite extends Http4sSuite {
   }
 
   test("TypedTag encoder should return Content-Type text/html with proper charset") {
-    assert(testCharsets.forall { implicit cs =>
+    testCharsets.map { implicit cs =>
       val headers = EntityEncoder[IO, Text.TypedTag[String]].headers
-      headers.get[`Content-Type`].contains(`Content-Type`(MediaType.text.html, Some(cs)))
-    })
+      assertEquals(headers.get[`Content-Type`], Some(`Content-Type`(MediaType.text.html, Some(cs))))
+    }
   }
 
   test("TypedTag encoder should render the body") {

--- a/servlet/src/test/scala/org/http4s/servlet/ServletContainerSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/ServletContainerSuite.scala
@@ -21,10 +21,10 @@ class ServletContainerSuite extends Http4sSuite {
   import ServletContainer.prefixMapping
 
   test("prefixMapping should append /* when prefix does not have trailing slash") {
-    assert(prefixMapping("/foo") == "/foo/*")
+    assertEquals(prefixMapping("/foo"), "/foo/*")
   }
 
   test("prefixMapping should append * when prefix has trailing slash") {
-    assert(prefixMapping("/") == "/*")
+    assertEquals(prefixMapping("/"), "/*")
   }
 }

--- a/tests/src/test/scala/org/http4s/DecodeSpec.scala
+++ b/tests/src/test/scala/org/http4s/DecodeSpec.scala
@@ -95,20 +95,14 @@ class DecodeSpec extends Http4sSuite {
       // Not a valid first byte in UTF-8
       val source = Stream(0x80.toByte)
       val decoded = source.through(decode[Fallible](Charset.`UTF-8`)).compile.string
-      assert(decoded match {
-        case Left(_: MalformedInputException) => true
-        case _ => false
-      })
+      val Left(_: MalformedInputException) = decoded
     }
 
     test("decode should handle incomplete input") {
       // Only the first byte of a two-byte UTF-8 sequence
       val source = Stream(0xc2.toByte)
       val decoded = source.through(decode[Fallible](Charset.`UTF-8`)).compile.string
-      assert(decoded match {
-        case Left(_: MalformedInputException) => true
-        case _ => false
-      })
+      val Left(_: MalformedInputException) = decoded
     }
 
     test("decode should handle unmappable character") {
@@ -116,10 +110,7 @@ class DecodeSpec extends Http4sSuite {
       val source = Stream(0x80.toByte, 0x81.toByte)
       val decoded =
         source.through(decode[Fallible](Charset(JCharset.forName("IBM1098")))).compile.string
-      assert(decoded match {
-        case Left(_: UnmappableCharacterException) => true
-        case _ => false
-      })
+      val Left(_: UnmappableCharacterException) = decoded
     }
 
     test("decode should handle overflows") {
@@ -127,7 +118,7 @@ class DecodeSpec extends Http4sSuite {
       val source = Stream(-36.toByte)
       val decoded =
         source.through(decode[Fallible](Charset(JCharset.forName("x-ISCII91")))).compile.string
-      assert(decoded == Right("ी"))
+      assertEquals(decoded, Right("ी"))
     }
 
     test("decode should not crash in IllegalStateException") {
@@ -135,10 +126,7 @@ class DecodeSpec extends Http4sSuite {
       val source = Stream(-1.toByte)
       val decoded =
         source.through(decode[Fallible](Charset(JCharset.forName("x-IBM943")))).compile.string
-      assert(decoded match {
-        case Left(_: MalformedInputException) => true
-        case _ => false
-      })
+      val Left(_: MalformedInputException) = decoded
     }
 
     test("decode should either succeed or raise a CharacterCodingException") {

--- a/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -80,7 +80,7 @@ class EntityEncoderSpec extends Http4sSuite {
         EntityEncoder[IO, EntityBody[IO]].headers.get[`Transfer-Encoding`],
         Some(
           `Transfer-Encoding`(TransferCoding.chunked)
-        ),
+        )
       )
     }
 

--- a/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -77,9 +77,10 @@ class EntityEncoderSpec extends Http4sSuite {
 
     test("EntityEncoder should render entity bodies with chunked transfer encoding") {
       assertEquals(
-        EntityEncoder[IO, EntityBody[IO]].headers.get[`Transfer-Encoding`], Some(
+        EntityEncoder[IO, EntityBody[IO]].headers.get[`Transfer-Encoding`],
+        Some(
           `Transfer-Encoding`(TransferCoding.chunked)
-        )
+        ),
       )
     }
 

--- a/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -80,7 +80,7 @@ class EntityEncoderSpec extends Http4sSuite {
         EntityEncoder[IO, EntityBody[IO]].headers.get[`Transfer-Encoding`],
         Some(
           `Transfer-Encoding`(TransferCoding.chunked)
-        )
+        ),
       )
     }
 

--- a/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -76,8 +76,8 @@ class EntityEncoderSpec extends Http4sSuite {
     }
 
     test("EntityEncoder should render entity bodies with chunked transfer encoding") {
-      assert(
-        EntityEncoder[IO, EntityBody[IO]].headers.get[`Transfer-Encoding`] == Some(
+      assertEquals(
+        EntityEncoder[IO, EntityBody[IO]].headers.get[`Transfer-Encoding`], Some(
           `Transfer-Encoding`(TransferCoding.chunked)
         )
       )

--- a/tests/src/test/scala/org/http4s/HeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/HeaderSuite.scala
@@ -36,8 +36,8 @@ class HeaderSuite extends munit.DisciplineSuite {
     val h1 = `Content-Length`.unsafeFromLong(4)
     val h2 = `Content-Length`.unsafeFromLong(5)
 
-    assert(!(h1 == h2))
-    assert(!(h2 == h1))
+    assertNotEquals(h1, h2)
+    assertNotEquals(h2, h1)
   }
 
   /*

--- a/tests/src/test/scala/org/http4s/HttpRoutesSuite.scala
+++ b/tests/src/test/scala/org/http4s/HttpRoutesSuite.scala
@@ -24,6 +24,6 @@ class HttpRoutesSuite extends Http4sSuite {
       Response[Id](Status.Ok)
     }
     val req = Request[Id](Method.GET)
-    assert(route.run(req).map(_.status).value == Some(Status.Ok))
+    assertEquals(route.run(req).map(_.status).value, Some(Status.Ok))
   }
 }

--- a/tests/src/test/scala/org/http4s/Ipv4AddressSuite.scala
+++ b/tests/src/test/scala/org/http4s/Ipv4AddressSuite.scala
@@ -31,30 +31,30 @@ class Ipv4AddressSuite extends Http4sSuite {
   checkAll("HttpCodec[Ipv4Address]", HttpCodecTests[Ipv4Address].httpCodec)
 
   test("render should render all 4 octets") {
-    assert(renderString(Ipv4Address(ipv4"192.168.0.1")) == "192.168.0.1")
+    assertEquals(renderString(Ipv4Address(ipv4"192.168.0.1")), "192.168.0.1")
   }
 
   test("fromInet4Address should round trip with toInet4Address") {
     forAll { (ipv4: Ipv4Address) =>
-      assert(Ipv4Address.fromInet4Address(ipv4.toInet4Address) == ipv4)
+      assertEquals(Ipv4Address.fromInet4Address(ipv4.toInet4Address), ipv4)
     }
   }
 
   test("fromByteArray should round trip with toByteArray") {
     forAll { (ipv4: Ipv4Address) =>
-      assert(Ipv4Address.fromByteArray(ipv4.toByteArray) == Right(ipv4))
+      assertEquals(Ipv4Address.fromByteArray(ipv4.toByteArray), Right(ipv4))
     }
   }
 
   test("compare should be consistent with unsigned int") {
     forAll { (xs: List[Ipv4Address]) =>
-      assert(xs.sorted.map(_.address) == xs.map(_.address).sorted)
+      assertEquals(xs.sorted.map(_.address), xs.map(_.address).sorted)
     }
   }
 
   test("compare should be consistent with Ordered") {
     forAll { (a: Ipv4Address, b: Ipv4Address) =>
-      assert(math.signum(a.compareTo(b)) == math.signum(a.compare(b)))
+      assertEquals(math.signum(a.compareTo(b)), math.signum(a.compare(b)))
     }
   }
 }

--- a/tests/src/test/scala/org/http4s/Ipv6AddressSuite.scala
+++ b/tests/src/test/scala/org/http4s/Ipv6AddressSuite.scala
@@ -31,20 +31,20 @@ class Ipv6AddressSuite extends Http4sSuite {
   checkAll("HttpCodec[Ipv6Address]", HttpCodecTests[Ipv6Address].httpCodec)
 
   test("render consistently with RFC5952 should 4.1: handle leading zeroes in a 16-bit field") {
-    assert(renderString(Ipv6Address(ipv6"2001:0db8::0001")) == "2001:db8::1")
+    assertEquals(renderString(Ipv6Address(ipv6"2001:0db8::0001")), "2001:db8::1")
   }
   test("render consistently with RFC5952 should 4.2.1: shorten as much as possible") {
-    assert(renderString(Ipv6Address(ipv6"2001:db8:0:0:0:0:2:1")) == "2001:db8::2:1")
+    assertEquals(renderString(Ipv6Address(ipv6"2001:db8:0:0:0:0:2:1")), "2001:db8::2:1")
   }
   test("render consistently with RFC5952 should 4.2.2: handle one 16-bit 0 field") {
-    assert(renderString(Ipv6Address(ipv6"2001:db8:0:1:1:1:1:1")) == "2001:db8:0:1:1:1:1:1")
+    assertEquals(renderString(Ipv6Address(ipv6"2001:db8:0:1:1:1:1:1")), "2001:db8:0:1:1:1:1:1")
   }
   test("""render consistently with RFC5952 should 4.2.3: chose placement of "::"""") {
-    assert(renderString(Ipv6Address(ipv6"2001:0:0:1:0:0:0:1")) == "2001:0:0:1::1")
+    assertEquals(renderString(Ipv6Address(ipv6"2001:0:0:1:0:0:0:1")), "2001:0:0:1::1")
     renderString(Ipv6Address(ipv6"2001:db8:0:0:1:0:0:1")) == "2001:db8::1:0:0:1"
   }
   test("render consistently with RFC5952 should 4.3: lowercase") {
-    assert(renderString(Ipv6Address(ipv6"::A:B:C:D:E:F")) == "::a:b:c:d:e:f")
+    assertEquals(renderString(Ipv6Address(ipv6"::A:B:C:D:E:F")), "::a:b:c:d:e:f")
   }
 
   test("fromInet6Address should round trip with toInet6Address") {
@@ -72,9 +72,9 @@ class Ipv6AddressSuite extends Http4sSuite {
   }
 
   test("ipv6 interpolator should be consistent with fromString") {
-    assert(Right(Ipv6Address(ipv6"::1")) == Ipv6Address.fromString("::1"))
-    assert(Right(Ipv6Address(ipv6"::")) == Ipv6Address.fromString("::"))
-    assert(Right(Ipv6Address(ipv6"2001:db8::7")) == Ipv6Address.fromString("2001:db8::7"))
+    assertEquals(Ipv6Address.fromString("::1"), Right(Ipv6Address(ipv6"::1")))
+    assertEquals(Ipv6Address.fromString("::"), Right(Ipv6Address(ipv6"::")))
+    assertEquals(Ipv6Address.fromString("2001:db8::7"), Right(Ipv6Address(ipv6"2001:db8::7")))
   }
 
   test("ipv6 interpolator should reject invalid values") {

--- a/tests/src/test/scala/org/http4s/QValueSuite.scala
+++ b/tests/src/test/scala/org/http4s/QValueSuite.scala
@@ -40,22 +40,21 @@ class QValueSuite extends Http4sSuite {
   }
 
   test("fromDouble should be consistent with fromThousandths") {
-    assert((0 to 1000).forall { i =>
-      (fromDouble(i / 1000.0) == fromThousandths(i))
-    })
+    (0 to 1000).foreach { i =>
+      assertEquals(fromDouble(i / 1000.0), fromThousandths(i))
+    }
   }
 
   test("fromString should be consistent with fromThousandths") {
-    assert((0 to 1000).forall { i =>
-      (fromString((i / 1000.0).toString) == fromThousandths(i))
-    })
+    (0 to 1000).foreach { i =>
+      assertEquals(fromString((i / 1000.0).toString), fromThousandths(i))
+    }
   }
 
   test("literal syntax should be consistent with successful fromDouble") {
-    assert(Right(qValue"1.0") == fromDouble(1.0))
-    assert(Right(qValue"0.5") == fromDouble(0.5))
-    assert(Right(qValue"0.0") == fromDouble(0.0))
-
+    assertEquals(fromDouble(1.0), Right(qValue"1.0"))
+    assertEquals(fromDouble(0.5), Right(qValue"0.5"))
+    assertEquals(fromDouble(0.0), Right(qValue"0.0"))
   }
 
   test("literal syntax should reject invalid values") {

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -21,6 +21,8 @@ import org.scalacheck.Gen
 import org.scalacheck.Prop._
 import org.typelevel.ci._
 
+import scala.collection.immutable.Seq
+
 import java.nio.file.Paths
 
 // TODO: this needs some more filling out
@@ -78,7 +80,8 @@ class UriSpec extends Http4sSuite {
         test("Uri fromString should parse port correctly if there is a valid (non-negative) one") {
           forAll(Gen.choose[Int](0, Int.MaxValue)) { (nonNegative: Int) =>
             val uri = getUri(s"http://localhost:$nonNegative/")
-            (uri.port == Some(nonNegative))
+
+            assertEquals(uri.port, Some(nonNegative))
           }
         }
         test("Uri fromString should parse port correctly if there is none") {
@@ -177,7 +180,7 @@ class UriSpec extends Http4sSuite {
         Map("x" -> "abc", "y" -> "ijk"),
       )
       assertEquals(getQueryParams("http://localhost:8080/blah?"), Map("" -> ""))
-      assert(getQueryParams("http://localhost:8080/blah") == Map.empty)
+      assertEquals(getQueryParams("http://localhost:8080/blah"), Map.empty[String, String])
     }
 
     test("Uri Query decoding should Handle queries with spaces properly") {
@@ -626,7 +629,7 @@ class UriSpec extends Http4sSuite {
   {
     test("Uri.params.- should not do anything on an URI without a query") {
       val i = Uri(query = Query.empty).params - "param"
-      assert(i == Map())
+      assertEquals(i, Map.empty[String, String])
     }
     test("Uri.params.- should not reduce a map if parameter does not match") {
       val i = Uri(query = Query.unsafeFromString("param1")).params - "param2"
@@ -634,7 +637,7 @@ class UriSpec extends Http4sSuite {
     }
     test("Uri.params.- should reduce a map if matching parameter found") {
       val i = Uri(query = Query.unsafeFromString("param")).params - "param"
-      assert(i == Map())
+      assertEquals(i, Map.empty[String, String])
     }
   }
 
@@ -676,56 +679,56 @@ class UriSpec extends Http4sSuite {
           "param1=value1&param1=value2&param1=value3&param2=value4&param2=value5"
         )
       )
-      assert(
-        u.multiParams ==
+      assertEquals(
+        u.multiParams,
           Map("param1" -> Seq("value1", "value2", "value3"), "param2" -> Seq("value4", "value5"))
       )
     }
     test("Uri.multiParams should find parameter with empty key and a value") {
       val u = Uri(query = Query.unsafeFromString("param1=&=value-of-empty-key&param2=value"))
-      assert(
-        u.multiParams ==
+      assertEquals(
+        u.multiParams,
           Map("" -> Seq("value-of-empty-key"), "param1" -> Seq(""), "param2" -> Seq("value"))
       )
     }
     test("Uri.multiParams should find first value of parameter with empty key") {
-      assert(
-        Uri(query = Query.unsafeFromString("=value1&=value2")).multiParams ==
-          (Map("" -> Seq("value1", "value2")))
+      assertEquals(
+        Uri(query = Query.unsafeFromString("=value1&=value2")).multiParams,
+          Map("" -> Seq("value1", "value2"))
       )
-      assert(
-        Uri(query = Query.unsafeFromString("&=value1&=value2")).multiParams ==
-          (Map("" -> Seq("value1", "value2")))
+      assertEquals(
+        Uri(query = Query.unsafeFromString("&=value1&=value2")).multiParams,
+        Map("" -> Seq("value1", "value2"))
       )
-      assert(
-        Uri(query = Query.unsafeFromString("&&&=value1&&&=value2&=&")).multiParams ==
-          (Map("" -> Seq("value1", "value2", "")))
+      assertEquals(
+        Uri(query = Query.unsafeFromString("&&&=value1&&&=value2&=&")).multiParams,
+        Map("" -> Seq("value1", "value2", ""))
       )
     }
     test("Uri.multiParams should find parameter with empty key and without value") {
-      assert(Uri(query = Query.unsafeFromString("&")).multiParams == (Map("" -> Seq())))
-      assert(Uri(query = Query.unsafeFromString("&&")).multiParams == (Map("" -> Seq())))
-      assert(Uri(query = Query.unsafeFromString("&&&")).multiParams == (Map("" -> Seq())))
+      assertEquals(Uri(query = Query.unsafeFromString("&")).multiParams, Map("" -> Seq()))
+      assertEquals(Uri(query = Query.unsafeFromString("&&")).multiParams, Map("" -> Seq()))
+      assertEquals(Uri(query = Query.unsafeFromString("&&&")).multiParams, Map("" -> Seq()))
     }
     test("Uri.multiParams should find parameter with an empty value") {
-      assert(
-        Uri(query = Query.unsafeFromString("param1=")).multiParams == (Map("param1" -> Seq("")))
+      assertEquals(
+        Uri(query = Query.unsafeFromString("param1=")).multiParams, Map("param1" -> Seq(""))
       )
-      assert(
-        Uri(query = Query.unsafeFromString("param1=&param2=")).multiParams ==
-          (Map("param1" -> Seq(""), "param2" -> Seq("")))
+      assertEquals(
+        Uri(query = Query.unsafeFromString("param1=&param2=")).multiParams,
+          Map("param1" -> Seq(""), "param2" -> Seq(""))
       )
     }
     test("Uri.multiParams should find parameter with single value") {
-      assert(
-        Uri(query = Query.unsafeFromString("param1=value1&param2=value2")).multiParams ==
-          (Map("param1" -> Seq("value1"), "param2" -> Seq("value2")))
+      assertEquals(
+        Uri(query = Query.unsafeFromString("param1=value1&param2=value2")).multiParams,
+          Map("param1" -> Seq("value1"), "param2" -> Seq("value2"))
       )
     }
     test("Uri.multiParams should find parameter without value") {
-      assert(
-        Uri(query = Query.unsafeFromString("param1&param2&param3")).multiParams ==
-          (Map("param1" -> Seq(), "param2" -> Seq(), "param3" -> Seq()))
+      assertEquals(
+        Uri(query = Query.unsafeFromString("param1&param2&param3")).multiParams,
+          Map("param1" -> Seq(), "param2" -> Seq(), "param3" -> Seq())
       )
     }
   }
@@ -1183,7 +1186,7 @@ class UriSpec extends Http4sSuite {
   }
 
   test("Uri.equals should be false between an empty path and a trailing slash after an authority") {
-    assert(uri"http://example.com" != uri"http://example.com/")
+    assertNotEquals(uri"http://example.com", uri"http://example.com/")
   }
 
   {

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -21,9 +21,8 @@ import org.scalacheck.Gen
 import org.scalacheck.Prop._
 import org.typelevel.ci._
 
-import scala.collection.immutable.Seq
-
 import java.nio.file.Paths
+import scala.collection.immutable.Seq
 
 // TODO: this needs some more filling out
 class UriSpec extends Http4sSuite {

--- a/tests/src/test/scala/org/http4s/UriSpec.scala
+++ b/tests/src/test/scala/org/http4s/UriSpec.scala
@@ -681,28 +681,28 @@ class UriSpec extends Http4sSuite {
       )
       assertEquals(
         u.multiParams,
-          Map("param1" -> Seq("value1", "value2", "value3"), "param2" -> Seq("value4", "value5"))
+        Map("param1" -> Seq("value1", "value2", "value3"), "param2" -> Seq("value4", "value5")),
       )
     }
     test("Uri.multiParams should find parameter with empty key and a value") {
       val u = Uri(query = Query.unsafeFromString("param1=&=value-of-empty-key&param2=value"))
       assertEquals(
         u.multiParams,
-          Map("" -> Seq("value-of-empty-key"), "param1" -> Seq(""), "param2" -> Seq("value"))
+        Map("" -> Seq("value-of-empty-key"), "param1" -> Seq(""), "param2" -> Seq("value")),
       )
     }
     test("Uri.multiParams should find first value of parameter with empty key") {
       assertEquals(
         Uri(query = Query.unsafeFromString("=value1&=value2")).multiParams,
-          Map("" -> Seq("value1", "value2"))
+        Map("" -> Seq("value1", "value2")),
       )
       assertEquals(
         Uri(query = Query.unsafeFromString("&=value1&=value2")).multiParams,
-        Map("" -> Seq("value1", "value2"))
+        Map("" -> Seq("value1", "value2")),
       )
       assertEquals(
         Uri(query = Query.unsafeFromString("&&&=value1&&&=value2&=&")).multiParams,
-        Map("" -> Seq("value1", "value2", ""))
+        Map("" -> Seq("value1", "value2", "")),
       )
     }
     test("Uri.multiParams should find parameter with empty key and without value") {
@@ -712,23 +712,24 @@ class UriSpec extends Http4sSuite {
     }
     test("Uri.multiParams should find parameter with an empty value") {
       assertEquals(
-        Uri(query = Query.unsafeFromString("param1=")).multiParams, Map("param1" -> Seq(""))
+        Uri(query = Query.unsafeFromString("param1=")).multiParams,
+        Map("param1" -> Seq("")),
       )
       assertEquals(
         Uri(query = Query.unsafeFromString("param1=&param2=")).multiParams,
-          Map("param1" -> Seq(""), "param2" -> Seq(""))
+        Map("param1" -> Seq(""), "param2" -> Seq("")),
       )
     }
     test("Uri.multiParams should find parameter with single value") {
       assertEquals(
         Uri(query = Query.unsafeFromString("param1=value1&param2=value2")).multiParams,
-          Map("param1" -> Seq("value1"), "param2" -> Seq("value2"))
+        Map("param1" -> Seq("value1"), "param2" -> Seq("value2")),
       )
     }
     test("Uri.multiParams should find parameter without value") {
       assertEquals(
         Uri(query = Query.unsafeFromString("param1&param2&param3")).multiParams,
-          Map("param1" -> Seq(), "param2" -> Seq(), "param3" -> Seq())
+        Map("param1" -> Seq(), "param2" -> Seq(), "param3" -> Seq()),
       )
     }
   }

--- a/tests/src/test/scala/org/http4s/UriSuite.scala
+++ b/tests/src/test/scala/org/http4s/UriSuite.scala
@@ -38,6 +38,6 @@ class UriSuite extends Http4sSuite {
   test("Use lazy query model parsing in uri parsing") {
     val ori = "http://domain.com/path?param1=asd;fgh"
     val res = org.http4s.Uri.unsafeFromString(ori).renderString
-    assert(ori == res, s"urls don't match:\n$ori\n$res")
+    assertEquals(ori, res)
   }
 }

--- a/tests/src/test/scala/org/http4s/headers/AllowSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/AllowSuite.scala
@@ -23,14 +23,14 @@ class AllowSuite extends HeaderLaws {
   checkAll("Allow", headerLaws[Allow])
 
   test("Allow should parse an empty string") {
-    assert(Allow.parse("") == Right(Allow()))
+    assertEquals(Allow.parse(""), Right(Allow()))
   }
 
   test("Allow should parse with an ending comma") {
-    assert(Allow.parse("GET,  POST   ,") == Right(Allow(Method.GET, Method.POST)))
+    assertEquals(Allow.parse("GET,  POST   ,"), Right(Allow(Method.GET, Method.POST)))
   }
 
   test("Allow should parse with multiple commas") {
-    assert(Allow.parse("GET,,POST") == Right(Allow(Method.GET, Method.POST)))
+    assertEquals(Allow.parse("GET,,POST"), Right(Allow(Method.GET, Method.POST)))
   }
 }

--- a/tests/src/test/scala/org/http4s/headers/RetryAfterSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/RetryAfterSuite.scala
@@ -40,13 +40,11 @@ class RetryAfterSuite extends HeaderLaws {
   }
 
   test("build should build correctly for positives") {
-    assert(`Retry-After`.fromLong(0).map(_.value) match {
-      case Right("0") => true
-      case _ => false
-    })
+    val Right(result) = `Retry-After`.fromLong(0).map(_.value)
+    assertEquals(result, "0")
   }
   test("build should fail for negatives") {
-    assert(`Retry-After`.fromLong(-10).map(_.value).isLeft)
+    val Left(_) = `Retry-After`.fromLong(-10).map(_.value)
   }
   test("build should build unsafe for positives") {
     assertEquals(`Retry-After`.unsafeFromDuration(0.seconds).value, "0")

--- a/tests/src/test/scala/org/http4s/parser/AuthorizationHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/AuthorizationHeaderSuite.scala
@@ -35,7 +35,7 @@ class AuthorizationHeaderSuite extends munit.FunSuite {
     val invalidTokens = Seq("f!@", "=abc", "abc d")
     invalidTokens.foreach { token =>
       val h = Authorization(Credentials.Token(AuthScheme.Bearer, token))
-      assert(hparse(h.value).isLeft)
+      val Left(_) = hparse(h.value)
     }
   }
 

--- a/tests/src/test/scala/org/http4s/parser/ContentLocationHeaderSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/ContentLocationHeaderSpec.scala
@@ -26,7 +26,7 @@ class ContentLocationHeaderSpec extends Http4sSuite {
     val Right(uri) = Uri.fromString(s)
     val hs = Headers(("Content-Location", s))
 
-    assert(hs.get[`Content-Location`] == Some(`Content-Location`(uri)))
+    assertEquals(hs.get[`Content-Location`], Some(`Content-Location`(uri)))
   }
 
   test("ContentLocationHeader parser can Parse a simple uri with a path but no authority") {
@@ -34,7 +34,7 @@ class ContentLocationHeaderSpec extends Http4sSuite {
     val Right(uri) = Uri.fromString(s)
     val hs = Headers((("Content-Location", s)))
 
-    assert(hs.get[`Content-Location`] == Some(`Content-Location`(uri)))
+    assertEquals(hs.get[`Content-Location`], Some(`Content-Location`(uri)))
   }
 
   test("ContentLocationHeader parser can Parse a relative reference") {
@@ -42,7 +42,7 @@ class ContentLocationHeaderSpec extends Http4sSuite {
     val Right(uri) = Uri.fromString(s)
     val hs = Headers(Header.ToRaw.keyValuesToRaw(("Content-Location", s)))
 
-    assert(hs.get[`Content-Location`] == Some(`Content-Location`(uri)))
+    assertEquals(hs.get[`Content-Location`], Some(`Content-Location`(uri)))
   }
 
 }

--- a/tests/src/test/scala/org/http4s/parser/MediaRangeSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/MediaRangeSpec.scala
@@ -96,10 +96,10 @@ class MediaRangeSpec extends Http4sSuite {
     val r = `text/*`
     val t = `text/asp`
 
-    assert(r != t)
-    assert(t != r)
+    assertNotEquals[Any, Any](r, t)
+    assertNotEquals[Any, Any](t, r)
 
-    assert(r.withExtensions(ext) != t.withExtensions(ext))
-    assert(t.withExtensions(ext) != r.withExtensions(ext))
+    assertNotEquals[Any, Any](r.withExtensions(ext), t.withExtensions(ext))
+    assertNotEquals[Any, Any](t.withExtensions(ext), r.withExtensions(ext))
   }
 }

--- a/tests/src/test/scala/org/http4s/parser/UriParserSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSuite.scala
@@ -23,6 +23,8 @@ import org.http4s._
 import org.http4s.syntax.all._
 import org.typelevel.ci._
 
+import scala.collection.immutable
+
 class UriParserSuite extends Http4sSuite {
   {
     def check(items: Seq[(String, Uri)]) =
@@ -151,13 +153,16 @@ class UriParserSuite extends Http4sSuite {
       val q = Query.unsafeFromString("param1=3&param2=2&param2=foo")
       val u = Uri(query = q)
       test("Uri.requestTarget should represent query as multiParams as a Map[String,Seq[String]]") {
-        assert(u.multiParams == Map("param1" -> Seq("3"), "param2" -> Seq("2", "foo")))
+        assertEquals(
+          u.multiParams,
+          Map("param1" -> immutable.Seq("3"), "param2" -> immutable.Seq("2", "foo")),
+        )
       }
 
       test(
         "Uri.requestTarget should parse query and represent params as a Map[String,String] taking the first param"
       ) {
-        assert(u.params == Map("param1" -> "3", "param2" -> "2"))
+        assertEquals(u.params, Map("param1" -> "3", "param2" -> "2"))
       }
     }
 

--- a/tests/src/test/scala/org/http4s/websocket/WebSocketSuite.scala
+++ b/tests/src/test/scala/org/http4s/websocket/WebSocketSuite.scala
@@ -51,37 +51,37 @@ class WebSocketSuite extends Http4sSuite {
     val f3 = Text(ByteVector(0x2.toByte, 0x3.toByte), true)
     val f4 = Binary(ByteVector(0x2.toByte, 0x4.toByte), true)
 
-    assert(f1 == f1)
-    assert(f1 == f11)
-    assert(f1 != f2)
-    assert(f1 != f3)
-    assert(f1 != f4)
+    assertEquals(f1, f1)
+    assertEquals(f1, f11)
+    assertNotEquals(f1, f2)
+    assertNotEquals[Any, Any](f1, f3)
+    assertNotEquals(f1, f4)
   }
 
   test("WebSocket decoder should decode a hello world message") {
     val result = decode(helloTxtMasked, false)
-    assert(result.last == true)
-    assert(new String(result.data.toArray, UTF_8) == "Hello")
+    assertEquals(result.last, true)
+    assertEquals(new String(result.data.toArray, UTF_8), "Hello")
 
     val result2 = decode(helloTxt, true)
-    assert(result2.last == true)
-    assert(new String(result2.data.toArray, UTF_8) == "Hello")
+    assertEquals(result2.last, true)
+    assertEquals(new String(result2.data.toArray, UTF_8), "Hello")
   }
 
   test("WebSocket decoder should encode a hello world message") {
     val frame = Text(ByteVector.view("Hello".getBytes(UTF_8)), false)
     val msg = decode(encode(frame, true), false)
-    assert(msg == frame)
-    assert(msg.last == false)
-    assert(new String(msg.data.toArray, UTF_8) == "Hello")
+    assertEquals(msg, frame)
+    assertEquals(msg.last, false)
+    assertEquals(new String(msg.data.toArray, UTF_8), "Hello")
   }
 
   test("WebSocket decoder should encode a continuation message") {
     val frame = Continuation(ByteVector.view("Hello".getBytes(UTF_8)), true)
     val msg = decode(encode(frame, true), false)
-    assert(msg == frame)
-    assert(msg.last == true)
-    assert(new String(msg.data.toArray, UTF_8) == "Hello")
+    assertEquals(msg, frame)
+    assertEquals(msg.last, true)
+    assertEquals(new String(msg.data.toArray, UTF_8), "Hello")
   }
 
   test("WebSocket decoder should encode a close message") {
@@ -93,12 +93,12 @@ class WebSocketSuite extends Http4sSuite {
     forAll(choose(1000, 4999), reasonGen) { (validCloseCode: Int, validReason: String) =>
       val frame = Close(validCloseCode, validReason).valueOr(throw _)
       val msg = decode(encode(frame, true), false)
-      assert(msg == frame)
-      assert(msg.last == true)
+      assertEquals(msg, frame)
+      assertEquals(msg.last, true)
       val closeCode = msg.data.slice(0, 2)
-      assert(((closeCode(0) << 8 & 0xff00) | (closeCode(1) & 0xff)) == validCloseCode)
+      assertEquals((closeCode(0) << 8 & 0xff00) | (closeCode(1) & 0xff), validCloseCode)
       val reason = msg.data.slice(2, msg.data.length)
-      assert(new String(reason.toArray, UTF_8) == validReason)
+      assertEquals(new String(reason.toArray, UTF_8), validReason)
     }
   }
 
@@ -125,8 +125,8 @@ class WebSocketSuite extends Http4sSuite {
     val msg = decode(encode(frame, true), false)
     val msg2 = decode(encode(frame, false), true)
 
-    assert(msg == frame)
-    assert(msg == msg2)
+    assertEquals(msg, frame)
+    assertEquals(msg, msg2)
   }
 
   test("WebSocket decoder should encode and decode a message len > 0xffff") {
@@ -136,8 +136,8 @@ class WebSocketSuite extends Http4sSuite {
     val msg = decode(encode(frame, true), false)
     val msg2 = decode(encode(frame, false), true)
 
-    assert(msg == frame)
-    assert(msg == msg2)
+    assertEquals(msg, frame)
+    assertEquals(msg, msg2)
   }
 
 }

--- a/tests/src/test/scala/org/http4s/websocket/WebSocketSuite.scala
+++ b/tests/src/test/scala/org/http4s/websocket/WebSocketSuite.scala
@@ -60,11 +60,11 @@ class WebSocketSuite extends Http4sSuite {
 
   test("WebSocket decoder should decode a hello world message") {
     val result = decode(helloTxtMasked, false)
-    assertEquals(result.last, true)
+    assert(result.last)
     assertEquals(new String(result.data.toArray, UTF_8), "Hello")
 
     val result2 = decode(helloTxt, true)
-    assertEquals(result2.last, true)
+    assert(result2.last)
     assertEquals(new String(result2.data.toArray, UTF_8), "Hello")
   }
 
@@ -72,7 +72,7 @@ class WebSocketSuite extends Http4sSuite {
     val frame = Text(ByteVector.view("Hello".getBytes(UTF_8)), false)
     val msg = decode(encode(frame, true), false)
     assertEquals(msg, frame)
-    assertEquals(msg.last, false)
+    assert(!msg.last)
     assertEquals(new String(msg.data.toArray, UTF_8), "Hello")
   }
 
@@ -80,7 +80,7 @@ class WebSocketSuite extends Http4sSuite {
     val frame = Continuation(ByteVector.view("Hello".getBytes(UTF_8)), true)
     val msg = decode(encode(frame, true), false)
     assertEquals(msg, frame)
-    assertEquals(msg.last, true)
+    assert(msg.last)
     assertEquals(new String(msg.data.toArray, UTF_8), "Hello")
   }
 
@@ -94,7 +94,7 @@ class WebSocketSuite extends Http4sSuite {
       val frame = Close(validCloseCode, validReason).valueOr(throw _)
       val msg = decode(encode(frame, true), false)
       assertEquals(msg, frame)
-      assertEquals(msg.last, true)
+      assert(msg.last)
       val closeCode = msg.data.slice(0, 2)
       assertEquals((closeCode(0) << 8 & 0xff00) | (closeCode(1) & 0xff), validCloseCode)
       val reason = msg.data.slice(2, msg.data.length)


### PR DESCRIPTION
This is pretty much a minor thing. However, we are using `MUnit` currently and can get nice diffs on assertions fails for free. I'm convinced `assert(foo == bar)` is almost anti-pattern and using `assertEquals(foo, bar)` is much better. If we agree on this, I'll add this point to the contributing guide. Perhaps, Scalafix-ninja may create a rewriting rule for this.
Also, we can replace `assert(boolExpr)` with `assert(boolExpr, true)`. But one may argue that this looks odd. I made it in several test classes to give you demonstrative examples. I think that nice diffs is worth the hassle anyway.