### PR TITLE
Fix dead links to RFC

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
@@ -139,7 +139,7 @@ private[http4s] class Http4sWSStage[F[_]](
   /** The websocket input stream
     *
     * Note: On receiving a close, we MUST send a close back, as stated in section
-    * 5.5.1 of the websocket spec: https://tools.ietf.org/html/rfc6455#section-5.5.1
+    * 5.5.1 of the websocket spec: https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
     *
     * @return
     */

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
@@ -119,7 +119,7 @@ private class Http2NodeStage[F[_]](
             bytesRead += bytes.remaining()
 
             // Check length: invalid length is a stream error of type PROTOCOL_ERROR
-            // https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-8.1.2  -> 8.2.1.6
+            // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-http2-17#section-8.1.2  -> 8.2.1.6
             if (complete && maxlen > 0 && bytesRead != maxlen) {
               val msg = s"Entity too small. Expected $maxlen, received $bytesRead"
               val e = Http2Exception.PROTOCOL_ERROR.rst(streamId, msg)

--- a/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
+++ b/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala
@@ -42,7 +42,7 @@ import org.typelevel.vault._
   * - the redirect is not followed otherwise
   *
   * Whenever we follow with a GET or HEAD, an empty body is sent, and
-  * all payload headers defined in https://tools.ietf.org/html/rfc7231#section-3.3
+  * all payload headers defined in https://datatracker.ietf.org/doc/html/rfc7231#section-3.3
   * are stripped.
   *
   * If the response does not contain a valid Location header, the redirect is
@@ -62,7 +62,7 @@ object FollowRedirect {
         method: Method,
         cookies: List[ResponseCookie],
     ): Request[F] = {
-      // https://tools.ietf.org/html/rfc7231#section-7.1.
+      // https://datatracker.ietf.org/doc/html/rfc7231#section-7.1
       val nextUri = uri.copy(
         scheme = uri.scheme.orElse(req.uri.scheme),
         authority = uri.authority.orElse(req.uri.authority),

--- a/client/src/test/scala/org/http4s/client/oauth1/OAuthSuite.scala
+++ b/client/src/test/scala/org/http4s/client/oauth1/OAuthSuite.scala
@@ -32,7 +32,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 class OAuthSuite extends Http4sSuite {
   // some params taken from http://oauth.net/core/1.0/#anchor30, others from
-  // http://tools.ietf.org/html/rfc5849
+  // https://datatracker.ietf.org/doc/html/rfc5849
   implicit val timer: Timer[IO] = Http4sSuite.TestTimer
 
   val Right(uri) = Uri.fromString("http://photos.example.net/photos")

--- a/core/src/main/scala/org/http4s/EntityTag.scala
+++ b/core/src/main/scala/org/http4s/EntityTag.scala
@@ -42,7 +42,7 @@ object EntityTag {
   /*
    * entity-tag = [ weak ] opaque-tag
    *
-   * @see [[https://tools.ietf.org/html/rfc7232#section-2.3]]
+   * @see [[https://datatracker.ietf.org/doc/html/rfc7232#section-2.3]]
    */
   private[http4s] val parser: Parser[EntityTag] = {
     import Parser.{charIn, string}

--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -82,7 +82,7 @@ final class Headers(val headers: List[Header.Raw]) extends AnyVal {
   /** Removes the `Content-Length`, `Content-Range`, `Trailer`, and
     * `Transfer-Encoding` headers.
     *
-    *  https://tools.ietf.org/html/rfc7231#section-3.3
+    *  https://datatracker.ietf.org/doc/html/rfc7231#section-3.3
     */
   def removePayloadHeaders: Headers =
     transform(_.filterNot(h => Headers.PayloadHeaderKeys(h.name)))

--- a/core/src/main/scala/org/http4s/HttpDate.scala
+++ b/core/src/main/scala/org/http4s/HttpDate.scala
@@ -37,7 +37,7 @@ import scala.concurrent.duration.SECONDS
   * over java.time.Instant in the model, we assure that if two headers render
   * equally, their values are equal.
   *
-  * @see [[https://tools.ietf.org/html/rfc7231#section-7.1.1 RFC 7231, Section 7.1.1, Origination Date]]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1 RFC 7231, Section 7.1.1, Origination Date]]
   */
 class HttpDate private (val epochSecond: Long) extends Renderable with Ordered[HttpDate] {
   def compare(that: HttpDate): Int =
@@ -75,8 +75,8 @@ object HttpDate {
     *
     * The minimum year is specified by RFC5322 as 1900.
     *
-    * @see [[https://tools.ietf.org/html/rfc7231#section-7.1.1 RFC 7231, Section 7.1.1, Origination Date]]
-    * @see [[https://tools.ietf.org/html/rfc5322#section-3.3 RFC 5322, Section 3.3, Date and Time Specification]]
+    * @see [[https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1 RFC 7231, Section 7.1.1, Origination Date]]
+    * @see [[https://datatracker.ietf.org/doc/html/rfc5322#section-3.3 RFC 5322, Section 3.3, Date and Time Specification]]
     */
   val MinValue = HttpDate.unsafeFromEpochSecond(MinEpochSecond)
 
@@ -104,7 +104,7 @@ object HttpDate {
 
   /** Parses a date according to RFC7231, Section 7.1.1.1
     *
-    * @see [[https://tools.ietf.org/html/rfc7231#section-7.1.1 RFC 7231, Section 7.1.1, Origination Date]]
+    * @see [[https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1 RFC 7231, Section 7.1.1, Origination Date]]
     */
   def fromString(s: String): ParseResult[HttpDate] =
     ParseResult.fromParser(parser, "Invalid HTTP date")(s)

--- a/core/src/main/scala/org/http4s/Method.scala
+++ b/core/src/main/scala/org/http4s/Method.scala
@@ -40,7 +40,7 @@ import scala.util.hashing.MurmurHash3
   * intended effect on the server of multiple identical requests with that
   * method is the same as the effect for a single such request.
   *
-  * @see [[http://tools.ietf.org/html/rfc7231#section-4 RFC 7321, Section 4, Request Methods]]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc7231#section-4 RFC 7321, Section 4, Request Methods]]
   * @see [[http://www.iana.org/assignments/http-methods/http-methods.xhtml IANA HTTP Method Registry]]
   */
 final class Method private (val name: String, val isSafe: Boolean, val isIdempotent: Boolean)

--- a/core/src/main/scala/org/http4s/RequestCookie.scala
+++ b/core/src/main/scala/org/http4s/RequestCookie.scala
@@ -21,7 +21,7 @@ import org.http4s.internal.parsing.RelaxedCookies
 import org.http4s.util.Renderable
 import org.http4s.util.Writer
 
-// see http://tools.ietf.org/html/rfc6265
+// see https://datatracker.ietf.org/doc/html/rfc6265
 final case class RequestCookie(name: String, content: String) extends Renderable {
   override lazy val renderString: String = super.renderString
 

--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -132,7 +132,7 @@ object ResponseCookie {
 
     /* domain-av         = "Domain=" domain-value
      *
-     * But https://tools.ietf.org/html/rfc6265#section-5.2.3 mandates
+     * But https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.3 mandates
      * a leading dot, which is invalid per domain-value.
      */
     val domainAv = ignoreCase("Domain=") *> (char('.').? ~ domainValue).string.map {

--- a/core/src/main/scala/org/http4s/Status.scala
+++ b/core/src/main/scala/org/http4s/Status.scala
@@ -28,7 +28,7 @@ import org.http4s.util.Renderable
   *
   * @param code HTTP status code
   * @param reason reason for the response. eg, OK
-  * @see [[http://tools.ietf.org/html/rfc7231#section-6 RFC 7231, Section 6, Response Status Codes]]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc7231#section-6 RFC 7231, Section 6, Response Status Codes]]
   * @see [[http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml IANA Status Code Registry]]
   */
 sealed abstract case class Status private (code: Int)(

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -160,7 +160,7 @@ final case class Uri(
         writer << "/" << p
       case Uri(None, None, p, _, _) =>
         if (!p.absolute && p.segments.headOption.fold(false)(_.toString.contains(":"))) {
-          writer << "./" << p // https://tools.ietf.org/html/rfc3986#section-4.2 last paragraph
+          writer << "./" << p // https://datatracker.ietf.org/doc/html/rfc3986#section-4.2 last paragraph
         } else {
           writer << p
         }
@@ -214,7 +214,7 @@ object Uri extends UriPlatform {
     * If the scheme is defined, the URI is absolute.  If the scheme is
     * not defined, the URI is a relative reference.
     *
-    * @see [[https://tools.ietf.org/html/rfc3986#section-3.1 RFC 3986, Section 3.1, Scheme]]
+    * @see [[https://datatracker.ietf.org/doc/html/rfc3986#section-3.1 RFC 3986, Section 3.1, Scheme]]
     */
   final class Scheme private[http4s] (val value: String) extends Ordered[Scheme] {
     override def equals(o: Any) =
@@ -548,7 +548,7 @@ object Uri extends UriPlatform {
     * clear text in a URI is a security risk and deprecated by RFC
     * 3986, but preserved in this model for losslessness.
     *
-    * @see [[https://tools.ietf.org/html/rfc3986#section-3.2.1 RFC 3986, Section 3.2.1, User Information]]
+    * @see [[https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1 RFC 3986, Section 3.2.1, User Information]]
     */
   final case class UserInfo private ( // scalafix:ok Http4sGeneralLinters.nonValidatingCopyConstructor; bincompat until 1.0
       username: String,

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -465,11 +465,11 @@ object UriTemplate {
     * The default expression type is simple string expansion (Level 1), wherein a
     * single named variable is replaced by its value as a string after
     * pct-encoding any characters not in the set of unreserved URI characters
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-1.5">Section 1.5</a>).
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-1.5">Section 1.5</a>).
     *
     * Level 2 templates add the plus ("+") operator, for expansion of values that
     * are allowed to include reserved URI characters
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-1.5">Section 1.5</a>),
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-1.5">Section 1.5</a>),
     * and the crosshatch ("#") operator for expansion of fragment identifiers.
     *
     * Level 3 templates allow multiple variables per expression, each
@@ -487,7 +487,7 @@ object UriTemplate {
   final case class FragmentElm(value: String) extends FragmentDef
 
   /** Fragment expansion, crosshatch-prefixed
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-3.2.4">Section 3.2.4</a>)
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.4">Section 3.2.4</a>)
     */
   final case class SimpleFragmentExp(name: String) extends FragmentDef {
     require(name.nonEmpty, "at least one character must be set")
@@ -495,10 +495,10 @@ object UriTemplate {
   }
 
   /** Level 1 allows string expansion
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-3.2.2">Section 3.2.2</a>)
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.2">Section 3.2.2</a>)
     *
     * Level 3 allows string expansion with multiple variables
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-3.2.2">Section 3.2.2</a>)
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.2">Section 3.2.2</a>)
     */
   final case class VarExp(names: List[String]) extends PathDef {
     require(names.nonEmpty, "at least one name must be set")
@@ -509,10 +509,10 @@ object UriTemplate {
   }
 
   /** Level 2 allows reserved string expansion
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-3.2.3">Section 3.2.3</a>)
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.3">Section 3.2.3</a>)
     *
     * Level 3 allows reserved expansion with multiple variables
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-3.2.3">Section 3.2.3</a>)
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.3">Section 3.2.3</a>)
     */
   final case class ReservedExp(names: List[String]) extends PathDef {
     require(names.nonEmpty, "at least one name must be set")
@@ -523,7 +523,7 @@ object UriTemplate {
   }
 
   /** Fragment expansion with multiple variables, crosshatch-prefixed
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-3.2.4">Section 3.2.4</a>)
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.4">Section 3.2.4</a>)
     */
   final case class MultiFragmentExp(names: List[String]) extends FragmentDef {
     require(names.nonEmpty, "at least one name must be set")
@@ -534,7 +534,7 @@ object UriTemplate {
   }
 
   /** Path segments, slash-prefixed
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-3.2.6">Section 3.2.6</a>)
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.6">Section 3.2.6</a>)
     */
   final case class PathExp(names: List[String]) extends PathDef {
     require(names.nonEmpty, "at least one name must be set")
@@ -545,7 +545,7 @@ object UriTemplate {
   }
 
   /** Form-style query, ampersand-separated
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-3.2.8">Section 3.2.8</a>)
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.8">Section 3.2.8</a>)
     */
   final case class ParamExp(names: List[String]) extends QueryExp {
     require(names.nonEmpty, "at least one name must be set")
@@ -559,7 +559,7 @@ object UriTemplate {
   }
 
   /** Form-style query continuation
-    * (<a href="http://tools.ietf.org/html/rfc6570#section-3.2.9">Section 3.2.9</a>)
+    * (<a href="https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.9">Section 3.2.9</a>)
     */
   final case class ParamContExp(names: List[String]) extends QueryExp {
     require(names.nonEmpty, "at least one name must be set")

--- a/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Charset.scala
@@ -70,7 +70,7 @@ object `Accept-Charset` {
   *   This field allows user agents capable of understanding more
   * }}}
   *
-  * From [http//tools.ietf.org/html/rfc7231#section-5.3.3 RFC-7231].
+  * From [https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.3 RFC-7231].
   */
 final case class `Accept-Charset`(values: NonEmptyList[CharsetRange]) {
 

--- a/core/src/main/scala/org/http4s/headers/Accept-Language.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Language.scala
@@ -57,7 +57,7 @@ object `Accept-Language` {
 /** Request header used to indicate which natural language would be preferred for the response
   * to be translated into.
   *
-  * [[https://tools.ietf.org/html/rfc7231#section-5.3.5 RFC-7231 Section 5.3.5]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5 RFC-7231 Section 5.3.5]]
   */
 final case class `Accept-Language`(values: NonEmptyList[LanguageTag]) {
 

--- a/core/src/main/scala/org/http4s/headers/Accept-Patch.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Patch.scala
@@ -43,5 +43,5 @@ object `Accept-Patch` {
     (a, b) => `Accept-Patch`(a.values.concatNel(b.values))
 }
 
-// see https://tools.ietf.org/html/rfc5789#section-3.1
+// see https://datatracker.ietf.org/doc/html/rfc5789#section-3.1
 final case class `Accept-Patch`(values: NonEmptyList[MediaType])

--- a/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
+++ b/core/src/main/scala/org/http4s/headers/Accept-Ranges.scala
@@ -31,7 +31,7 @@ object `Accept-Ranges` {
   def parse(s: String): ParseResult[`Accept-Ranges`] =
     ParseResult.fromParser(parser, "Invalid Accept-Ranges header")(s)
 
-  /* https://tools.ietf.org/html/rfc7233#appendix-C */
+  /* https://datatracker.ietf.org/doc/html/rfc7233#appendix-C */
   val parser: P0[`Accept-Ranges`] = {
 
     val none = Parser.string("none").as(Nil)

--- a/core/src/main/scala/org/http4s/headers/Allow.scala
+++ b/core/src/main/scala/org/http4s/headers/Allow.scala
@@ -42,9 +42,9 @@ object Allow {
 }
 
 /** A Response header that lists the methods that are supported by the target resource.
-  * Must be attached to responses with status  [[https://tools.ietf.org/html/rfc7231#section-6.5.5 405 Not Allowed]],
+  * Must be attached to responses with status  [[https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.5 405 Not Allowed]],
   * though in practice not all servers honor this.
   *
-  * [[https://tools.ietf.org/html/rfc7231#section-7.4.1 RFC-7231 Section 7.4.1 Allow]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.1 RFC-7231 Section 7.4.1 Allow]]
   */
 final case class Allow(methods: Set[Method])

--- a/core/src/main/scala/org/http4s/headers/Authorization.scala
+++ b/core/src/main/scala/org/http4s/headers/Authorization.scala
@@ -21,7 +21,7 @@ import cats.parse._
 import org.typelevel.ci._
 
 object Authorization {
-  // https://tools.ietf.org/html/rfc7235#section-4.2
+  // https://datatracker.ietf.org/doc/html/rfc7235#section-4.2
   private[http4s] val parser: Parser[Authorization] = {
     import org.http4s.internal.parsing.Rfc7235.credentials
     credentials.map(Authorization(_))

--- a/core/src/main/scala/org/http4s/headers/Content-Disposition.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Disposition.scala
@@ -116,5 +116,5 @@ object `Content-Disposition` {
     )
 }
 
-// see http://tools.ietf.org/html/rfc2183
+// see https://datatracker.ietf.org/doc/html/rfc2183
 final case class `Content-Disposition`(dispositionType: String, parameters: Map[CIString, String])

--- a/core/src/main/scala/org/http4s/headers/Content-Language.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Language.scala
@@ -53,5 +53,5 @@ object `Content-Language` {
     (a, b) => `Content-Language`(a.values.concatNel(b.values))
 }
 
-//RFC - https://tools.ietf.org/html/rfc3282#page-2
+// RFC - https://datatracker.ietf.org/doc/html/rfc3282#page-2
 final case class `Content-Language`(values: NonEmptyList[LanguageTag])

--- a/core/src/main/scala/org/http4s/headers/Content-Location.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Location.scala
@@ -43,6 +43,6 @@ object `Content-Location` {
   *   as an identifier for a specific resource corresponding to the
   *   representation in this message's payload
   * }}}
-  * [[https://tools.ietf.org/html/rfc7231#section-3.1.4.2 RFC-7231 Section 3.1.4.2]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.4.2 RFC-7231 Section 3.1.4.2]]
   */
 final case class `Content-Location`(uri: Uri)

--- a/core/src/main/scala/org/http4s/headers/Content-Type.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Type.scala
@@ -74,7 +74,7 @@ object `Content-Type` {
   *   message semantics.
   * }}}
   *
-  * [[https://tools.ietf.org/html/rfc7231#section-3.1.1.5 RFC-7231]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5 RFC-7231]]
   */
 final case class `Content-Type` private (mediaType: MediaType, charset: Option[Charset]) { // scalafix:ok; private for API ergonomics, not correctness
   def withMediaType(mediaType: MediaType): `Content-Type` =

--- a/core/src/main/scala/org/http4s/headers/ETag.scala
+++ b/core/src/main/scala/org/http4s/headers/ETag.scala
@@ -37,7 +37,7 @@ object ETag {
 
   /* `ETag = entity-tag`
    *
-   * @see [[https://tools.ietf.org/html/rfc7232#section-2.3]]
+   * @see [[https://datatracker.ietf.org/doc/html/rfc7232#section-2.3]]
    */
   private[http4s] val parser: Parser[ETag] =
     entityTagParser.map(ETag.apply)

--- a/core/src/main/scala/org/http4s/headers/Expires.scala
+++ b/core/src/main/scala/org/http4s/headers/Expires.scala
@@ -54,7 +54,7 @@ object Expires {
   * However, it is a usual practice to set it to the past of far in the future
   * Thus any instant is in practice allowed
   *
-  * [[https://tools.ietf.org/html/rfc7234#section-5.3 RFC-7234 Section 5.3]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7234#section-5.3 RFC-7234 Section 5.3]]
   *
   * @param expirationDate the date of expiration. The RFC has a warning, that using large values
   * can cause problems due to integer or clock overflows.

--- a/core/src/main/scala/org/http4s/headers/Forwarded.scala
+++ b/core/src/main/scala/org/http4s/headers/Forwarded.scala
@@ -109,7 +109,7 @@ object Forwarded extends ForwardedRenderers {
       *
       * @param value obfuscated identifier with leading '_' (underscore) symbol.
       *
-      * @see [[https://tools.ietf.org/html/rfc7239#section-6.3 RFC 7239, Section 6.3, Obfuscated Identifier]]
+      * @see [[https://datatracker.ietf.org/doc/html/rfc7239#section-6.3 RFC 7239, Section 6.3, Obfuscated Identifier]]
       */
     sealed abstract case class Obfuscated private (value: String) extends Name with Port
 
@@ -133,7 +133,7 @@ object Forwarded extends ForwardedRenderers {
       }
 
     val parser: P[Node] = {
-      // https://tools.ietf.org/html/rfc7239#section-4
+      // https://datatracker.ietf.org/doc/html/rfc7239#section-4
 
       def modelNodePortFromString(str: String): Option[Node.Port] =
         Try(Integer.parseUnsignedInt(str)).toOption.flatMap(Node.Port.fromInt(_).toOption)
@@ -302,7 +302,7 @@ object Forwarded extends ForwardedRenderers {
     ParseResult.fromParser(parser, "Invalid Forwarded header")(s)
 
   private val parser: P[Forwarded] = {
-    // https://tools.ietf.org/html/rfc7239#section-4
+    // https://datatracker.ietf.org/doc/html/rfc7239#section-4
 
     // A utility so that we can decode multiple pairs and join them in a single element
     trait Pair {

--- a/core/src/main/scala/org/http4s/headers/Host.scala
+++ b/core/src/main/scala/org/http4s/headers/Host.scala
@@ -58,6 +58,6 @@ object Host extends HeaderCompanion[Host]("Host") {
   *
   * This header was mandatory in version 1.1 of the Http protocol.
   *
-  * [[https://tools.ietf.org/html/rfc7230#section-5.4 RFC-7230 Section 5.4]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7230#section-5.4 RFC-7230 Section 5.4]]
   */
 final case class Host(host: String, port: Option[Int] = None)

--- a/core/src/main/scala/org/http4s/headers/If-Match.scala
+++ b/core/src/main/scala/org/http4s/headers/If-Match.scala
@@ -57,6 +57,6 @@ object `If-Match` {
 /** Request header to make the request conditional on the current contents of the origin server
   * at the given target resource (URI).
   *
-  * [[https://tools.ietf.org/html/rfc7232#section-3.1 RFC-7232 Section 3.1]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7232#section-3.1 RFC-7232 Section 3.1]]
   */
 final case class `If-Match`(tags: Option[NonEmptyList[EntityTag]])

--- a/core/src/main/scala/org/http4s/headers/If-Modified-Since.scala
+++ b/core/src/main/scala/org/http4s/headers/If-Modified-Since.scala
@@ -43,6 +43,6 @@ object `If-Modified-Since` {
   *   being more recent than the date provided in the field-value.
   * }}
   *
-  * [[https://tools.ietf.org/html/rfc7232#section-3.3 RFC-7232]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7232#section-3.3 RFC-7232]]
   */
 final case class `If-Modified-Since`(date: HttpDate)

--- a/core/src/main/scala/org/http4s/headers/If-None-Match.scala
+++ b/core/src/main/scala/org/http4s/headers/If-None-Match.scala
@@ -31,7 +31,7 @@ import org.typelevel.ci._
   *  match any of those listed in the field-value.
   * }}}
   *
-  * From [[https://tools.ietf.org/html/rfc7232#section-3.2 RFC-7232]]
+  * From [[https://datatracker.ietf.org/doc/html/rfc7232#section-3.2 RFC-7232]]
   */
 object `If-None-Match` {
 

--- a/core/src/main/scala/org/http4s/headers/Last-Modified.scala
+++ b/core/src/main/scala/org/http4s/headers/Last-Modified.scala
@@ -32,6 +32,6 @@ object `Last-Modified` extends HeaderCompanion[`Last-Modified`]("Last-Modified")
 /** Response header that indicates the time at which the server believes the
   * entity was last modified.
   *
-  * [[https://tools.ietf.org/html/rfc7232#section-2.3 RFC-7232]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7232#section-2.3 RFC-7232]]
   */
 final case class `Last-Modified`(date: HttpDate)

--- a/core/src/main/scala/org/http4s/headers/Link.scala
+++ b/core/src/main/scala/org/http4s/headers/Link.scala
@@ -46,7 +46,7 @@ object Link {
     final case class Title(value: String) extends LinkParam
     final case class Type(value: MediaRange) extends LinkParam
 
-    // https://tools.ietf.org/html/rfc3986#section-4.1
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-4.1
     val linkValue: Parser0[LinkValue] =
       Uri.Parser.uriReference(StandardCharsets.UTF_8).map { uri =>
         headers.LinkValue(uri)

--- a/core/src/main/scala/org/http4s/headers/Max-Forwards.scala
+++ b/core/src/main/scala/org/http4s/headers/Max-Forwards.scala
@@ -23,7 +23,7 @@ import org.http4s.parser.AdditionalRules
   * that gives an upper bound on how many times the request can be
   * forwarded by a proxy before it is rejected.
   *
-  * [[https://tools.ietf.org/html/rfc7231#section-5.1.2 RFC-7231]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.2 RFC-7231]]
   */
 sealed abstract case class `Max-Forwards`(count: Long)
 

--- a/core/src/main/scala/org/http4s/headers/Origin.scala
+++ b/core/src/main/scala/org/http4s/headers/Origin.scala
@@ -34,13 +34,13 @@ object Origin {
   case object Null extends Origin
 
   // If the Origin is not "null", it is a non-empty list of Hosts:
-  // http://tools.ietf.org/html/rfc6454#section-7
+  // https://datatracker.ietf.org/doc/html/rfc6454#section-7
   final case class HostList(hosts: NonEmptyList[Host]) extends Origin
 
   // A host in an Origin header isn't a full URI.
   // It only contains a scheme, a host, and an optional port.
   // Hence we re-used parts of the Uri class here, but we don't use a whole Uri:
-  // http://tools.ietf.org/html/rfc6454#section-7
+  // https://datatracker.ietf.org/doc/html/rfc6454#section-7
   final case class Host(scheme: Uri.Scheme, host: Uri.Host, port: Option[Int] = None)
       extends Renderable {
     def toUri: Uri =

--- a/core/src/main/scala/org/http4s/headers/Proxy-Authenticate.scala
+++ b/core/src/main/scala/org/http4s/headers/Proxy-Authenticate.scala
@@ -66,6 +66,6 @@ object `Proxy-Authenticate` {
   *   challenge that indicates the authentication scheme(s) and parameters
   *   applicable to the proxy for this effective request URI...
   * }}}
-  * From [[https://tools.ietf.org/html/rfc7235#section-4.3 RFC-7235]]
+  * From [[https://datatracker.ietf.org/doc/html/rfc7235#section-4.3 RFC-7235]]
   */
 final case class `Proxy-Authenticate`(values: NonEmptyList[Challenge])

--- a/core/src/main/scala/org/http4s/headers/Proxy-Authorization.scala
+++ b/core/src/main/scala/org/http4s/headers/Proxy-Authorization.scala
@@ -25,10 +25,10 @@ import org.typelevel.ci._
   *   itself (or its user) to a proxy that requires authentication.
   * }}}
   *
-  *  From [[https://tools.ietf.org/html/rfc7235#section-4.4 RFC-7235]]
+  *  From [[https://datatracker.ietf.org/doc/html/rfc7235#section-4.4 RFC-7235]]
   */
 object `Proxy-Authorization` {
-  // https://tools.ietf.org/html/rfc7235#section-4.2
+  // https://datatracker.ietf.org/doc/html/rfc7235#section-4.2
   private[http4s] val parser: Parser[`Proxy-Authorization`] = {
     import org.http4s.internal.parsing.Rfc7235.credentials
     credentials.map(`Proxy-Authorization`(_))

--- a/core/src/main/scala/org/http4s/headers/Range.scala
+++ b/core/src/main/scala/org/http4s/headers/Range.scala
@@ -26,7 +26,7 @@ import org.http4s.util.Renderable
 import org.http4s.util.Writer
 import org.typelevel.ci._
 
-// See https://tools.ietf.org/html/rfc7233
+// See https://datatracker.ietf.org/doc/html/rfc7233
 
 object Range {
   def apply(unit: RangeUnit, r1: SubRange, rs: SubRange*): Range =
@@ -57,7 +57,7 @@ object Range {
   }
 
   val parser: P0[Range] = {
-    // https://tools.ietf.org/html/rfc7233#section-3.1
+    // https://datatracker.ietf.org/doc/html/rfc7233#section-3.1
 
     def toLong(s: String): Option[Long] =
       try Some(s.toLong)

--- a/core/src/main/scala/org/http4s/headers/Retry-After.scala
+++ b/core/src/main/scala/org/http4s/headers/Retry-After.scala
@@ -70,7 +70,7 @@ object `Retry-After` {
 /** Response header, used by the server to indicate to the user-agent how long it has to wait before
   * it can try again with a follow-up request.
   *
-  * [[https://tools.ietf.org/html/rfc7231#section-7.1.3 RFC-7231 Section 7.1.3]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3 RFC-7231 Section 7.1.3]]
   *
   * @param retry Indicates the retry time, either as a date of expiration or as a number of seconds from the current time
   * until that expiration.

--- a/core/src/main/scala/org/http4s/headers/Server.scala
+++ b/core/src/main/scala/org/http4s/headers/Server.scala
@@ -50,6 +50,6 @@ object Server extends HeaderCompanion[Server]("Server") {
 }
 
 /** Server header
-  * https://tools.ietf.org/html/rfc7231#section-7.4.2
+  * https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.2
   */
 final case class Server(product: ProductId, rest: List[ProductIdOrComment])

--- a/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
+++ b/core/src/main/scala/org/http4s/headers/Strict-Transport-Security.scala
@@ -28,7 +28,7 @@ import org.typelevel.ci._
 
 import scala.concurrent.duration.FiniteDuration
 
-/** Defined by http://tools.ietf.org/html/rfc6797
+/** Defined by https://datatracker.ietf.org/doc/html/rfc6797
   */
 object `Strict-Transport-Security` {
   private[headers] class StrictTransportSecurityImpl(

--- a/core/src/main/scala/org/http4s/headers/User-Agent.scala
+++ b/core/src/main/scala/org/http4s/headers/User-Agent.scala
@@ -67,6 +67,6 @@ object `User-Agent` {
 }
 
 /** User-Agent header
-  * [[https://tools.ietf.org/html/rfc7231#section-5.5.3 RFC-7231 Section 5.5.3]]
+  * [[https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3 RFC-7231 Section 5.5.3]]
   */
 final case class `User-Agent`(product: ProductId, rest: List[ProductIdOrComment])

--- a/core/src/main/scala/org/http4s/headers/`Idempotency-Key`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Idempotency-Key`.scala
@@ -35,6 +35,6 @@ object `Idempotency-Key` {
 
 /** Request header defines request to be idempotent used by client retry middleware.
   *
-  *  [[https://tools.ietf.org/html/draft-idempotency-header-00#section-2.1 idempotency-header]]
+  *  [[https://datatracker.ietf.org/doc/html/draft-idempotency-header-00#section-2.1 idempotency-header]]
   */
 final case class `Idempotency-Key`(key: String)

--- a/core/src/main/scala/org/http4s/internal/parsing/Cookies.scala
+++ b/core/src/main/scala/org/http4s/internal/parsing/Cookies.scala
@@ -23,7 +23,7 @@ import cats.parse.Rfc5234.dquote
 
 /** Common rules defined in RFC6265
   *
-  * @see [[https://tools.ietf.org/html/rfc6265] RFC6265, HTTP State Management Mechanism]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc6265] RFC6265, HTTP State Management Mechanism]
   */
 private[http4s] abstract class Cookies(cookieOctet: Parser[Char]) {
   /* token             = <token, defined in [RFC2616], Section 2.2> */

--- a/core/src/main/scala/org/http4s/internal/parsing/Rfc1034.scala
+++ b/core/src/main/scala/org/http4s/internal/parsing/Rfc1034.scala
@@ -23,8 +23,8 @@ import org.typelevel.ci.CIString
 
 /** Common rules defined in RFC1034, as amended by RFC1123.
   *
-  * @see [[https://tools.ietf.org/html/rfc1034] RFC1034, Domain Names: Concepts and Facilities]]
-  * @see [[https://tools.ietf.org/html/rfc1123] RFC1123, Requirements for Internet Hosts -- Application and Support]]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc1034] RFC1034, Domain Names: Concepts and Facilities]]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc1123] RFC1123, Requirements for Internet Hosts -- Application and Support]]
   */
 private[http4s] object Rfc1034 {
   def subdomain: Parser[CIString] = {

--- a/core/src/main/scala/org/http4s/internal/parsing/Rfc2234.scala
+++ b/core/src/main/scala/org/http4s/internal/parsing/Rfc2234.scala
@@ -21,7 +21,7 @@ import cats.parse.Parser.charIn
 
 /** Common rules defined in RFC2234.
   *
-  * @see [[https://tools.ietf.org/html/rfc2234] RFC2234, Augmented BNF for Syntax Specifications: ABNF]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc2234] RFC2234, Augmented BNF for Syntax Specifications: ABNF]
   */
 private[http4s] object Rfc2234 {
   /* ALPHA          =  %x41-5A / %x61-7A   ; A-Z / a-z */

--- a/core/src/main/scala/org/http4s/internal/parsing/Rfc2616.scala
+++ b/core/src/main/scala/org/http4s/internal/parsing/Rfc2616.scala
@@ -26,7 +26,7 @@ import cats.parse.Rfc5234.sp
 /** Common rules defined in RFC2616.  This RFC is now obsolete,
   * but some other active ones still refer to it.
   *
-  * @see [[https://tools.ietf.org/html/rfc2616#section-2.2] RFC2616, Basic Rules]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc2616#section-2.2] RFC2616, Basic Rules]
   */
 private[http4s] object Rfc2616 {
   /* CHAR           = <any US-ASCII character (octets 0 - 127)>

--- a/core/src/main/scala/org/http4s/internal/parsing/Rfc3986.scala
+++ b/core/src/main/scala/org/http4s/internal/parsing/Rfc3986.scala
@@ -29,7 +29,7 @@ import java.nio.ByteBuffer
 
 /** Common rules defined in Rfc3986
   *
-  * @see [[https://tools.ietf.org/html/rfc3986]]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc3986]]
   */
 private[http4s] object Rfc3986 {
   def alpha: Parser[Char] = Rfc2234.alpha

--- a/core/src/main/scala/org/http4s/internal/parsing/Rfc7230.scala
+++ b/core/src/main/scala/org/http4s/internal/parsing/Rfc7230.scala
@@ -30,7 +30,7 @@ import cats.parse.Rfc5234.vchar
 
 /** Common rules defined in RFC7230
   *
-  * @see [[https://tools.ietf.org/html/rfc7230#appendix-B]]
+  * @see [[https://datatracker.ietf.org/doc/html/rfc7230#appendix-B]]
   */
 private[http4s] object Rfc7230 {
   /* `tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
@@ -47,7 +47,7 @@ private[http4s] object Rfc7230 {
   /* `OWS = *( SP / HTAB )` */
   val ows: Parser0[Unit] = sp.orElse(htab).rep0.void
 
-  /*https://tools.ietf.org/html/rfc7230#section-3.2.3 last paragraph */
+  /*https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.3 last paragraph */
   val bws: Parser0[Unit] = ows
 
   /*   qdtext         = HTAB / SP /%x21 / %x23-5B / %x5D-7E / obs-text */

--- a/core/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/src/main/scala/org/http4s/multipart/Part.scala
@@ -43,7 +43,7 @@ object Part {
   private val ChunkSize = 8192
 
   @deprecated(
-    """Empty parts are not allowed by the multipart spec, see: https://tools.ietf.org/html/rfc7578#section-4.2
+    """Empty parts are not allowed by the multipart spec, see: https://datatracker.ietf.org/doc/html/rfc7578#section-4.2
 
 Moreover, it allows the creation of potentially incorrect multipart bodies""",
     "0.18.12",

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
@@ -78,7 +78,7 @@ class ResponseGeneratorSuite extends Http4sSuite {
   test("NoContent() does not generate Content-Length") {
     /* A server MUST NOT send a Content-Length header field in any response
      * with a status code of 1xx (Informational) or 204 (No Content).
-     * -- https://tools.ietf.org/html/rfc7230#section-3.3.2
+     * -- https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
      */
     val resp = NoContent()
     resp.map(_.contentLength).assertEquals(Option.empty[Long])
@@ -92,7 +92,7 @@ class ResponseGeneratorSuite extends Http4sSuite {
      * chunked and a message body consisting of a single chunk of zero-length;
      * or, c) close the connection immediately after sending the blank line
      * terminating the header section.
-     * -- https://tools.ietf.org/html/rfc7231#section-6.3.6
+     * -- https://datatracker.ietf.org/doc/html/rfc7231#section-6.3.6
      *
      * We choose option a.
      */
@@ -106,7 +106,7 @@ class ResponseGeneratorSuite extends Http4sSuite {
      * server MUST NOT send Content-Length in such a response unless its
      * field-value equals the decimal number of octets that would have been sent
      * in the payload body of a 200 (OK) response to the same request.
-     * -- https://tools.ietf.org/html/rfc7230#section-3.3.2
+     * -- https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
      *
      * We don't know what the proper value is in this signature, so we send
      * nothing.
@@ -120,7 +120,7 @@ class ResponseGeneratorSuite extends Http4sSuite {
     /** Aside from the cases defined above, in the absence of Transfer-Encoding,
       * an origin server SHOULD send a Content-Length header field when the
       * payload body size is known prior to sending the complete header section.
-      * -- https://tools.ietf.org/html/rfc7230#section-3.3.2
+      * -- https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
       *
       * Until someone sets a body, we have an empty body and we'll set the
       * Content-Length.

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -669,7 +669,7 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
     )
   }
 
-  // https://tools.ietf.org/html/rfc2234#section-6
+  // https://datatracker.ietf.org/doc/html/rfc2234#section-6
   val genHexDigit: Gen[Char] = oneOf(
     List('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
   )
@@ -798,7 +798,7 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
   implicit val http4sTestingCogenForPath: Cogen[Uri.Path] =
     Cogen[String].contramap(_.renderString)
 
-  /** https://tools.ietf.org/html/rfc3986 */
+  /** https://datatracker.ietf.org/doc/html/rfc3986 */
   implicit val http4sTestingArbitraryForUri: Arbitrary[Uri] = Arbitrary {
     val genPChar = oneOf(genUnreserved, genPctEncoded, genSubDelims, const(":"), const("@"))
     val genScheme = oneOf(Uri.Scheme.http, Uri.Scheme.https)

--- a/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
+++ b/scala-xml/src/test/scala/scalaxml/ScalaXmlSuite.scala
@@ -134,7 +134,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse UTF-8 charset with explicit encoding") {
-    // https://tools.ietf.org/html/rfc7303#section-8.1
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.1
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0" encoding="utf-8"?><hello name="Günther"/>""".getBytes(
@@ -147,7 +147,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse UTF-8 charset with no encoding") {
-    // https://tools.ietf.org/html/rfc7303#section-8.1
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.1
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0"?><hello name="Günther"/>""".getBytes(StandardCharsets.UTF_8)
@@ -158,7 +158,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse UTF-16 charset with explicit encoding") {
-    // https://tools.ietf.org/html/rfc7303#section-8.2
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.2
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0" encoding="utf-16"?><hello name="Günther"/>""".getBytes(
@@ -171,7 +171,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse UTF-16 charset with no encoding") {
-    // https://tools.ietf.org/html/rfc7303#section-8.2
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.2
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0"?><hello name="Günther"/>""".getBytes(StandardCharsets.UTF_16)
@@ -182,7 +182,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse omitted charset and 8-Bit MIME Entity") {
-    // https://tools.ietf.org/html/rfc7303#section-8.3
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.3
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0" encoding="iso-8859-1"?><hello name="Günther"/>""".getBytes(
@@ -195,7 +195,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse omitted charset and 16-Bit MIME Entity") {
-    // https://tools.ietf.org/html/rfc7303#section-8.4
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.4
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0" encoding="utf-16"?><hello name="Günther"/>""".getBytes(
@@ -208,7 +208,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse omitted charset, no internal encoding declaration") {
-    // https://tools.ietf.org/html/rfc7303#section-8.5
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.5
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0"?><hello name="Günther"/>""".getBytes(StandardCharsets.UTF_8)
@@ -219,7 +219,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse utf-16be charset") {
-    // https://tools.ietf.org/html/rfc7303#section-8.6
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.6
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0"?><hello name="Günther"/>""".getBytes(StandardCharsets.UTF_16BE)
@@ -230,7 +230,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse non-utf charset") {
-    // https://tools.ietf.org/html/rfc7303#section-8.7
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.7
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0" encoding="iso-2022-kr"?><hello name="문재인"/>""".getBytes(
@@ -243,7 +243,7 @@ class ScalaXmlSuite extends Http4sSuite {
   }
 
   test("parse conflicting charset and internal encoding") {
-    // https://tools.ietf.org/html/rfc7303#section-8.8
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.8
     encodingTest(
       Chunk.bytes(
         """<?xml version="1.0" encoding="utf-8"?><hello name="Günther"/>""".getBytes(

--- a/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -539,7 +539,7 @@ object CSRF {
     * any amount less than 20 bytes will throw an exception when loaded
     * into `Mac`. Any keys larger than 64 bytes are just hashed.
     *
-    * For more information, refer to: https://tools.ietf.org/html/rfc2104#section-3
+    * For more information, refer to: https://datatracker.ietf.org/doc/html/rfc2104#section-3
     *
     * Use for loading a key from a config file, after having generated
     * one safely

--- a/tests/src/test/scala/org/http4s/parser/UriParserSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/UriParserSuite.scala
@@ -31,7 +31,7 @@ class UriParserSuite extends Http4sSuite {
       }
 
     // RFC 3986 examples
-    // http://tools.ietf.org/html/rfc3986#section-1.1.2
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-1.1.2
 
     // http://www.ietf.org/rfc/rfc2396.txt
 


### PR DESCRIPTION
Most of the time a redirection of 'tools.ietf.org/html' to 'datatracker.ietf.org/doc/html' works well, but sometimes '404' happens. I've encountered '404' on those links:
http://tools.ietf.org/html/rfc3986#section-1.1.2
http://tools.ietf.org/html/rfc6265
http://tools.ietf.org/html/rfc6570#section-1.5
So I decided to migrate all links to current.