### PR TITLE
Remove redundant isScala3 from build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,8 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
 ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0"
 
-ThisBuild / scalafixAll / skip := isScala3.value
-ThisBuild / ScalafixConfig / skip := isScala3.value
+ThisBuild / scalafixAll / skip := isDotty.value
+ThisBuild / ScalafixConfig / skip := isDotty.value
 
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("scalafmtCheckAll", "scalafmtSbtCheck"), name = Some("Check formatting")),
@@ -814,7 +814,7 @@ lazy val scalafixInternalRules = project
   .settings(
     libraryDependencies ++= Seq(
       "ch.epfl.scala" %% "scalafix-core" % _root_.scalafix.sbt.BuildInfo.scalafixVersion
-    ).filter(_ => !isScala3.value)
+    ).filter(_ => !isDotty.value)
   )
 
 lazy val scalafixInternalInput = project
@@ -839,7 +839,7 @@ lazy val scalafixInternalTests = project
     libraryDependencies ++= Seq(
       ("ch.epfl.scala" %% "scalafix-testkit" % _root_.scalafix.sbt.BuildInfo.scalafixVersion % Test)
         .cross(CrossVersion.full)
-    ).filter(_ => !isScala3.value),
+    ).filter(_ => !isDotty.value),
     Compile / compile :=
       (Compile / compile).dependsOn(scalafixInternalInput / Compile / compile).value,
     scalafixTestkitOutputSourceDirectories :=
@@ -884,8 +884,6 @@ lazy val commonSettings = Seq(
   ).map(_ % Test),
   apiURL := Some(url(s"https://http4s.org/v${baseVersion.value}/api")),
 )
-
-val isScala3 = Def.setting(scalaVersion.value.startsWith("3"))
 
 def initCommands(additionalImports: String*) =
   initialCommands := (List(

--- a/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathInHttpRoutesSuite.scala
@@ -320,7 +320,8 @@ class PathInHttpRoutesSuite extends Http4sSuite {
   test("Path DSL within HttpService should default parameter present with incorrect format") {
     val response =
       serve(
-        Request(GET, Uri(path = path"/default", query = Query.unsafeFromString("counter=john"))))
+        Request(GET, Uri(path = path"/default", query = Query.unsafeFromString("counter=john")))
+      )
     response.map(_.status).assertEquals(NotFound)
   }
   test("Path DSL within HttpService should optional flag parameter when present") {


### PR DESCRIPTION
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 