### PR TITLE
`Access-Control-Allow-Origin` header

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Origin.scala
+++ b/core/src/main/scala/org/http4s/headers/Origin.scala
@@ -78,11 +78,14 @@ object Origin {
     }
   }
 
-  private[http4s] val parser: Parser0[Origin] = {
-    import Parser.char
+  private[http4s] val hostListParser: Parser[NonEmptyList[Origin.Host]] = {
+    import cats.parse.Rfc5234.sp
 
-    nullHostParser.orElse(singleHostParser.repSep(char(' ')).map(hosts => Origin.HostList(hosts)))
+    singleHostParser.repSep(sp)
   }
+
+  private[http4s] val parser: Parser0[Origin] =
+    nullHostParser.orElse(hostListParser.map(hosts => Origin.HostList(hosts)))
 
   def parse(s: String): ParseResult[Origin] =
     ParseResult.fromParser(parser, "Invalid Origin header")(s)

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
@@ -39,8 +39,8 @@ object `Access-Control-Allow-Origin` {
     override val toString: String = "null"
   }
 
-  case object wildcard extends `Access-Control-Allow-Origin` {
-    override val toString: String = "wildcard"
+  case object `*` extends `Access-Control-Allow-Origin` {
+    override val toString: String = "*"
   }
 
   final case class HostList(hosts: NonEmptyList[Origin.Host])
@@ -66,10 +66,10 @@ object `Access-Control-Allow-Origin` {
     import Parser.{`end`, string}
 
     val nullHost = (string(`null`.toString) *> `end`).as(`Access-Control-Allow-Origin`.`null`)
-    val wildCardHost =
-      (string(wildcard.toString) *> `end`).as(`Access-Control-Allow-Origin`.`wildcard`)
+    val wildcardHost =
+      (string(`*`.toString) *> `end`).as(`Access-Control-Allow-Origin`.`*`)
 
-    wildCardHost.orElse(nullHost).orElse(Origin.hostListParser.map(HostList))
+    wildcardHost.orElse(nullHost).orElse(Origin.hostListParser.map(HostList))
   }
 
   def parse(s: String): ParseResult[`Access-Control-Allow-Origin`] =
@@ -86,8 +86,8 @@ object `Access-Control-Allow-Origin` {
             v match {
               case `null` =>
                 writer << `null`.toString
-              case `wildcard` =>
-                writer << wildcard.toString
+              case `*` =>
+                writer << `*`.toString
               case host: HostList =>
                 writer << host
             }

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
@@ -17,6 +17,7 @@
 package org.http4s.headers
 
 import cats.Show
+import cats.data.NonEmptyList
 import cats.parse.Parser
 import cats.parse.Parser0
 import cats.syntax.show._
@@ -27,7 +28,7 @@ import org.http4s.util.Writer
 import org.typelevel.ci._
 
 /** That header indicates whether the response to a CORS request can be shared,
-  * via returning the literal value of the [[Origin.Host]] request header,
+  * via returning the literal value of the list of [[Origin.Host]] origins,
   * `null` or `*` in a response.
   *
   * @see [[https://fetch.spec.whatwg.org/#http-access-control-allow-origin CORS protocol, HTTP responses, Access-Control-Allow-Origin]].
@@ -46,19 +47,26 @@ object `Access-Control-Allow-Origin` {
       Show.show(_ => "*")
   }
 
-  final case class Host(origin: Origin.Host) extends `Access-Control-Allow-Origin` with Renderable {
-    def render(writer: Writer): writer.type =
-      origin.render(writer)
+  final case class HostList(hosts: NonEmptyList[Origin.Host])
+      extends `Access-Control-Allow-Origin`
+      with Renderable {
+    def render(writer: Writer): writer.type = {
+      writer << hosts.head
+      hosts.tail.foreach { host =>
+        writer << " "
+        writer << host
+      }
+      writer
+    }
   }
 
-  /** Based on the [[Origin.Host]] header parser. */
   private[http4s] val parser: Parser0[`Access-Control-Allow-Origin`] = {
     import Parser.{`end`, string}
 
     val nullHost = (string(Null.show) *> `end`).as(`Access-Control-Allow-Origin`.Null)
     val wildCardHost = (string(Wildcard.show) *> `end`).as(`Access-Control-Allow-Origin`.Wildcard)
 
-    wildCardHost.orElse(nullHost).orElse(Origin.singleHostParser.map(Host))
+    wildCardHost.orElse(nullHost).orElse(Origin.hostListParser.map(HostList))
   }
 
   def parse(s: String): ParseResult[`Access-Control-Allow-Origin`] =
@@ -77,7 +85,7 @@ object `Access-Control-Allow-Origin` {
                 writer << Null.show
               case Wildcard =>
                 writer << Wildcard.show
-              case host: Host =>
+              case host: HostList =>
                 writer << host
             }
         },

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
@@ -16,11 +16,9 @@
 
 package org.http4s.headers
 
-import cats.Show
 import cats.data.NonEmptyList
 import cats.parse.Parser
 import cats.parse.Parser0
-import cats.syntax.show._
 import org.http4s.Header
 import org.http4s.ParseResult
 import org.http4s.util.Renderable
@@ -37,14 +35,12 @@ sealed abstract class `Access-Control-Allow-Origin` extends Product with Seriali
 
 object `Access-Control-Allow-Origin` {
 
-  case object Null extends `Access-Control-Allow-Origin` {
-    implicit val showInstance: Show[Null.type] =
-      Show.show(_ => "null")
+  case object `null` extends `Access-Control-Allow-Origin` {
+    override val toString: String = "null"
   }
 
-  case object Wildcard extends `Access-Control-Allow-Origin` {
-    implicit val showInstance: Show[Wildcard.type] =
-      Show.show(_ => "*")
+  case object wildcard extends `Access-Control-Allow-Origin` {
+    override val toString: String = "wildcard"
   }
 
   final case class HostList(hosts: NonEmptyList[Origin.Host])
@@ -63,8 +59,9 @@ object `Access-Control-Allow-Origin` {
   private[http4s] val parser: Parser0[`Access-Control-Allow-Origin`] = {
     import Parser.{`end`, string}
 
-    val nullHost = (string(Null.show) *> `end`).as(`Access-Control-Allow-Origin`.Null)
-    val wildCardHost = (string(Wildcard.show) *> `end`).as(`Access-Control-Allow-Origin`.Wildcard)
+    val nullHost = (string(`null`.toString) *> `end`).as(`Access-Control-Allow-Origin`.`null`)
+    val wildCardHost =
+      (string(wildcard.toString) *> `end`).as(`Access-Control-Allow-Origin`.`wildcard`)
 
     wildCardHost.orElse(nullHost).orElse(Origin.hostListParser.map(HostList))
   }
@@ -81,10 +78,10 @@ object `Access-Control-Allow-Origin` {
         new Renderable {
           def render(writer: Writer): writer.type =
             v match {
-              case Null =>
-                writer << Null.show
-              case Wildcard =>
-                writer << Wildcard.show
+              case `null` =>
+                writer << `null`.toString
+              case `wildcard` =>
+                writer << wildcard.toString
               case host: HostList =>
                 writer << host
             }

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.headers
+
+import cats.parse.Parser
+import cats.parse.Parser0
+import org.http4s.Header
+import org.http4s.ParseResult
+import org.http4s.Uri
+import org.http4s.util.Renderable
+import org.http4s.util.Writer
+import org.typelevel.ci._
+
+/** That header indicates whether the response to a CORS request can be shared,
+  * via returning the literal value of the [[Origin.Host]] request header,
+  * `null` or `*` in a response.
+  *
+  * For more details, see https://fetch.spec.whatwg.org/#http-access-control-allow-origin.
+  */
+sealed abstract class `Access-Control-Allow-Origin` extends Product with Serializable
+
+object `Access-Control-Allow-Origin` {
+
+  case object Null extends `Access-Control-Allow-Origin`
+
+  case object Wildcard extends `Access-Control-Allow-Origin`
+
+  final case class Host(origin: Origin.Host) extends `Access-Control-Allow-Origin` with Renderable {
+    def toUri: Uri =
+      Uri(
+        scheme = Some(origin.scheme),
+        authority = Some(Uri.Authority(host = origin.host, port = origin.port)),
+      )
+
+    def render(writer: Writer): writer.type =
+      toUri.render(writer)
+  }
+
+  /** Based on the [[Origin.Host]] header parser. */
+  private[http4s] val parser: Parser0[`Access-Control-Allow-Origin`] = {
+    import Parser.{`end`, string}
+
+    val nullHost = (string("null") *> `end`).as(`Access-Control-Allow-Origin`.Null)
+    val wildCardHost = (string("*") *> `end`).as(`Access-Control-Allow-Origin`.Wildcard)
+
+    wildCardHost.orElse(nullHost).orElse(Origin.singleHostParser.map(Host))
+  }
+
+  def parse(s: String): ParseResult[`Access-Control-Allow-Origin`] =
+    ParseResult.fromParser(parser, "Invalid Access-Control-Allow-Origin header")(s)
+
+  val name: CIString = ci"Access-Control-Allow-Origin"
+
+  implicit val headerInstance: Header[`Access-Control-Allow-Origin`, Header.Single] =
+    Header.createRendered(
+      name,
+      v =>
+        new Renderable {
+          def render(writer: Writer): writer.type =
+            v match {
+              case `Access-Control-Allow-Origin`.Null =>
+                writer << "null"
+              case `Access-Control-Allow-Origin`.Wildcard =>
+                writer << "*"
+              case host: `Access-Control-Allow-Origin`.Host =>
+                writer << host
+            }
+        },
+      parse,
+    )
+}

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
@@ -31,7 +31,7 @@ import org.typelevel.ci._
   * via returning the literal value of the [[Origin.Host]] request header,
   * `null` or `*` in a response.
   *
-  * For more details, see https://fetch.spec.whatwg.org/#http-access-control-allow-origin.
+  * @see [[https://fetch.spec.whatwg.org/#http-access-control-allow-origin CORS protocol, HTTP responses, Access-Control-Allow-Origin]].
   */
 sealed abstract class `Access-Control-Allow-Origin` extends Product with Serializable
 

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
@@ -22,7 +22,6 @@ import cats.parse.Parser0
 import cats.syntax.show._
 import org.http4s.Header
 import org.http4s.ParseResult
-import org.http4s.Uri
 import org.http4s.util.Renderable
 import org.http4s.util.Writer
 import org.typelevel.ci._
@@ -48,14 +47,8 @@ object `Access-Control-Allow-Origin` {
   }
 
   final case class Host(origin: Origin.Host) extends `Access-Control-Allow-Origin` with Renderable {
-    def toUri: Uri =
-      Uri(
-        scheme = Some(origin.scheme),
-        authority = Some(Uri.Authority(host = origin.host, port = origin.port)),
-      )
-
     def render(writer: Writer): writer.type =
-      toUri.render(writer)
+      origin.render(writer)
   }
 
   /** Based on the [[Origin.Host]] header parser. */

--- a/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
+++ b/core/src/main/scala/org/http4s/headers/`Access-Control-Allow-Origin`.scala
@@ -56,6 +56,12 @@ object `Access-Control-Allow-Origin` {
     }
   }
 
+  def fromOrigin(origin: Origin): `Access-Control-Allow-Origin` =
+    origin match {
+      case Origin.Null => `null`
+      case Origin.HostList(hosts) => HostList(hosts)
+    }
+
   private[http4s] val parser: Parser0[`Access-Control-Allow-Origin`] = {
     import Parser.{`end`, string}
 

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -1102,10 +1102,12 @@ private[discipline] trait ArbitraryInstancesBinCompat0 extends ArbitraryInstance
     Arbitrary {
       val nullHost = Gen.const(`Access-Control-Allow-Origin`.Null)
       val wildcardHost = Gen.const(`Access-Control-Allow-Origin`.Wildcard)
-      val originHost =
-        http4sTestingArbitraryOriginHost.arbitrary.map(`Access-Control-Allow-Origin`.Host)
+      val originsHost =
+        http4sTestingArbitraryForNonEmptyList[Origin.Host].arbitrary.map(
+          `Access-Control-Allow-Origin`.HostList
+        )
 
-      Gen.oneOf(nullHost, wildcardHost, originHost)
+      Gen.oneOf(nullHost, wildcardHost, originsHost)
     }
 
   val genCustomStatusReason: Gen[String] = {

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -1100,8 +1100,8 @@ private[discipline] trait ArbitraryInstancesBinCompat0 extends ArbitraryInstance
   implicit val http4sTestingArbitraryAccessControlAllowOrigin
       : Arbitrary[`Access-Control-Allow-Origin`] =
     Arbitrary {
-      val nullHost = Gen.const(`Access-Control-Allow-Origin`.Null)
-      val wildcardHost = Gen.const(`Access-Control-Allow-Origin`.Wildcard)
+      val nullHost = Gen.const(`Access-Control-Allow-Origin`.`null`)
+      val wildcardHost = Gen.const(`Access-Control-Allow-Origin`.wildcard)
       val originsHost =
         http4sTestingArbitraryForNonEmptyList[Origin.Host].arbitrary.map(
           `Access-Control-Allow-Origin`.HostList

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -1101,7 +1101,7 @@ private[discipline] trait ArbitraryInstancesBinCompat0 extends ArbitraryInstance
       : Arbitrary[`Access-Control-Allow-Origin`] =
     Arbitrary {
       val nullHost = Gen.const(`Access-Control-Allow-Origin`.`null`)
-      val wildcardHost = Gen.const(`Access-Control-Allow-Origin`.wildcard)
+      val wildcardHost = Gen.const(`Access-Control-Allow-Origin`.`*`)
       val originsHost =
         http4sTestingArbitraryForNonEmptyList[Origin.Host].arbitrary.map(
           `Access-Control-Allow-Origin`.HostList

--- a/server/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -237,14 +237,9 @@ object CORS {
 
         varyHeader(allowCredentialsHeader(withMethodBasedHeader))
           .putHeaders(
-            // TODO model me
-            "Access-Control-Allow-Methods" -> config.allowedMethods.fold(method.renderString)(
-              _.mkString("", ", ", "")
-            ),
-            // TODO model me
-            "Access-Control-Allow-Origin" -> origin.value,
-            // TODO model me
-            "Access-Control-Max-Age" -> config.maxAge.toSeconds.toString,
+            `Access-Control-Allow-Methods`(config.allowedMethods.getOrElse(Set(method))),
+            `Access-Control-Allow-Origin`.fromOrigin(origin),
+            `Access-Control-Max-Age`.unsafeFromDuration(config.maxAge),
           )
       }
 

--- a/tests/src/test/scala/org/http4s/headers/AccessControlAllowOriginSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/AccessControlAllowOriginSuite.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.headers
+
+import org.http4s.laws.discipline.arbitrary._
+
+class AccessControlAllowOriginSuite extends HeaderLaws {
+  checkAll("Access-Control-Allow-Origin", headerLaws[`Access-Control-Allow-Origin`])
+}


### PR DESCRIPTION
In the "0.22.x" and "0.23.x" series `Origin` header still supports multiple origins, so that's why the `Access-Control-Allow-Origin` header does it as well. That behavior has been changed in the 1.0 series (https://github.com/http4s/http4s/pull/5082). And if we'll agree on this one, I port the same semantic for the `Access-Control-Allow-Origin` header for "1.0" separately. 