### PR TITLE
Proposal: Parse hosts with trailing slash in the `Origin` header

### DIFF
--- a/core/shared/src/main/scala/org/http4s/headers/Origin.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Origin.scala
@@ -51,8 +51,12 @@ object Origin {
 
     val nullP = (string("null") *> `end`).as(Origin.`null`)
 
-    val hostP = ((scheme <* string("://")) ~ host ~ (char(':') *> port).?.map(_.flatten)).map {
-      case ((sch, host), port) => Origin.Host(sch, host, port)
+    val portP = (char(':') *> port).?.map(_.flatten)
+
+    val trailingSlashP = char('/').?
+
+    val hostP = ((scheme <* string("://")) ~ host ~ portP ~ trailingSlashP).map {
+      case (((sch, host), port), _) => Origin.Host(sch, host, port)
     }
 
     nullP | hostP

--- a/tests/shared/src/test/scala/org/http4s/parser/OriginHeaderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/parser/OriginHeaderSuite.scala
@@ -22,11 +22,12 @@ import org.http4s.headers.Origin
 import org.http4s.syntax.all._
 
 class OriginHeaderSuite extends munit.FunSuite {
-  val host1 = Origin.Host(Uri.Scheme.http, Uri.RegName("www.foo.com"), Some(12345))
-  val host2 = Origin.Host(Uri.Scheme.https, Uri.Ipv4Address(ipv4"127.0.0.1"), None)
+  private val host1 = Origin.Host(Uri.Scheme.http, Uri.RegName("www.foo.com"), Some(12345))
+  private val host2 = Origin.Host(Uri.Scheme.https, Uri.Ipv4Address(ipv4"127.0.0.1"), None)
 
-  val hostString1 = "http://www.foo.com:12345"
-  val hostString2 = "https://127.0.0.1"
+  private val hostString1 = "http://www.foo.com:12345"
+  private val hostString2 = "https://127.0.0.1"
+  private val hostWithTrailingSlash = "https://127.0.0.1/"
 
   test("Origin value method should Render a host with a port number") {
     val origin: Origin = host1
@@ -53,6 +54,14 @@ class OriginHeaderSuite extends munit.FunSuite {
 
   test("OriginHeader parser should Parse a host without a port number") {
     val text = hostString2
+    val origin = host2
+    val headers = Headers(("Origin", text))
+    val extracted = headers.get[Origin]
+    assertEquals(extracted, Some(origin))
+  }
+
+  test("OriginHeader parser should parse a host with a trailing slash") {
+    val text = hostWithTrailingSlash
     val origin = host2
     val headers = Headers(("Origin", text))
     val extracted = headers.get[Origin]


### PR DESCRIPTION
This PR is mainly a proposal. The current parser of the `Origin` header is corresponding to `RFC` well. But it fails for cases of hosts with trailing slash. Also, in 0.22.x and 0.23.x series that parser works well for hosts with a trailing slash.