### PR TITLE
(scalajs linking) StaticFile: make staticFileKey a lazy val

### DIFF
--- a/core/shared/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/shared/src/main/scala/org/http4s/StaticFile.scala
@@ -347,6 +347,6 @@ object StaticFile {
   private[http4s] val staticPathKey = Key.newKey[SyncIO, Path].unsafeRunSync()
 
   @deprecated("Use staticPathKey", since = "0.23.5")
-  private[http4s] val staticFileKey: Key[File] =
+  private[http4s] lazy val staticFileKey: Key[File] =
     staticPathKey.imap(_.toNioPath.toFile)(f => Path.fromNioPath(f.toPath))
 }


### PR DESCRIPTION
This is a small tweak for fixing scalajs linking when using `StaticFile` (when using the `1.0.0` series).

Targeting this PR to series/0.23 so the changes can be synchronized with other branches more easily. 

### The problem: 
Because `staticFileKey` is not lazy, scalajs linker will fail to link a project if `StaticFiles` is referenced: 
```
[error] Referring to non-existent class java.io.File
[error]   called from constructor org.http4s.StaticFile$.<init>()void
```

### The solution:
Making it a `lazy val` fixes the linking :) (as long as `fromFile` / `fromResource` / `fromURL` are not called)

