### PR TITLE
Update `cats-effect` version to 3.3.0

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -201,7 +201,7 @@ object Http4sPlugin extends AutoPlugin {
     val boopickle = "1.4.0"
     val caseInsensitive = "1.2.0"
     val cats = "2.6.1"
-    val catsEffect = "3.2.9"
+    val catsEffect = "3.3.0"
     val catsParse = "0.3.6"
     val circe = "0.14.1"
     val circe15 = "0.15.0-M1"

--- a/server/shared/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
@@ -62,7 +62,7 @@ class ThrottleSuite extends Http4sSuite {
 
     takeTokenAfterRefill
       .map { result =>
-        ctx.tick(101.milliseconds)
+        ctx.advanceAndTick(101.milliseconds)
         result
       }
       .assertEquals(TokenAvailable)
@@ -83,7 +83,7 @@ class ThrottleSuite extends Http4sSuite {
 
     takeExtraToken
       .map { result =>
-        ctx.tick(300.milliseconds)
+        ctx.advanceAndTick(300.milliseconds)
         result
       }
       .map(_.isInstanceOf[TokenUnavailable])
@@ -121,7 +121,7 @@ class ThrottleSuite extends Http4sSuite {
     }
 
     takeTwoTokens.map { result =>
-      ctx.tick(75.milliseconds)
+      ctx.advanceAndTick(75.milliseconds)
       result match {
         case TokenUnavailable(t) => t.exists(_ <= 25.milliseconds)
         case _ => false


### PR DESCRIPTION
Steward is a bit late for now, so here is CE 3.3.0 (though it doesn't migrate changes of `TestContext` https://github.com/typelevel/fs2/runs/4344942116?check_suite_focus=true).