### PR TITLE
relax Client.translate bound on G[_] to MonadCancelThrow

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -169,7 +169,7 @@ trait Client[F[_]] {
     */
   def get[A](s: String)(f: Response[F] => F[A]): F[A]
 
-  @deprecated("use public method with MonadCancelThrow instead", since = "2021-Dec")
+  @deprecated("use public method with MonadCancelThrow instead", since = "0.23.7")
   private[client] def translate[G[_]: Async](
       fk: F ~> G
   )(gK: G ~> F)(implicit F: MonadCancelThrow[F]): Client[G] = translateImpl(fk)(gK)

--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -170,18 +170,21 @@ trait Client[F[_]] {
   def get[A](s: String)(f: Response[F] => F[A]): F[A]
 
   @deprecated("use public method with MonadCancelThrow instead", since = "2021-Dec")
-  private[client] def translate[G[_]: Async](fk: F ~> G)(gK: G ~> F)(implicit
-      F: MonadCancelThrow[F]): Client[G] =
+  private[client] def translate[G[_]: Async](
+      fk: F ~> G
+  )(gK: G ~> F)(implicit F: MonadCancelThrow[F]): Client[G] =
     Client((req: Request[G]) =>
       run(
         req.mapK(gK)
       ).mapK(fk)
-        .map(_.mapK(fk)))
+        .map(_.mapK(fk))
+    )
 
   /** Translates the effect type of this client from F to G
     */
-  def translate[G[_]: MonadCancelThrow](fk: F ~> G)(gK: G ~> F)(implicit
-      F: MonadCancelThrow[F]): Client[G] =
+  def translate[G[_]: MonadCancelThrow](
+      fk: F ~> G
+  )(gK: G ~> F)(implicit F: MonadCancelThrow[F]): Client[G] =
     Client((req: Request[G]) =>
       run(
         req.mapK(gK)

--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -171,9 +171,8 @@ trait Client[F[_]] {
 
   /** Translates the effect type of this client from F to G
     */
-  def translate[G[_]: Async](
-      fk: F ~> G
-  )(gK: G ~> F)(implicit F: MonadCancel[F, Throwable]): Client[G] =
+  def translate[G[_]: MonadCancelThrow](fk: F ~> G)(gK: G ~> F)(implicit
+      F: MonadCancelThrow[F]): Client[G] =
     Client((req: Request[G]) =>
       run(
         req.mapK(gK)

--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -172,17 +172,15 @@ trait Client[F[_]] {
   @deprecated("use public method with MonadCancelThrow instead", since = "2021-Dec")
   private[client] def translate[G[_]: Async](
       fk: F ~> G
-  )(gK: G ~> F)(implicit F: MonadCancelThrow[F]): Client[G] =
-    Client((req: Request[G]) =>
-      run(
-        req.mapK(gK)
-      ).mapK(fk)
-        .map(_.mapK(fk))
-    )
+  )(gK: G ~> F)(implicit F: MonadCancelThrow[F]): Client[G] = translateImpl(fk)(gK)
 
   /** Translates the effect type of this client from F to G
     */
   def translate[G[_]: MonadCancelThrow](
+      fk: F ~> G
+  )(gK: G ~> F)(implicit F: MonadCancelThrow[F]): Client[G] = translateImpl(fk)(gK)
+
+  private[client] def translateImpl[G[_]: MonadCancelThrow](
       fk: F ~> G
   )(gK: G ~> F)(implicit F: MonadCancelThrow[F]): Client[G] =
     Client((req: Request[G]) =>

--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -169,6 +169,15 @@ trait Client[F[_]] {
     */
   def get[A](s: String)(f: Response[F] => F[A]): F[A]
 
+  @deprecated("use public method with MonadCancelThrow instead", since = "2021-Dec")
+  private[client] def translate[G[_]: Async](fk: F ~> G)(gK: G ~> F)(implicit
+      F: MonadCancelThrow[F]): Client[G] =
+    Client((req: Request[G]) =>
+      run(
+        req.mapK(gK)
+      ).mapK(fk)
+        .map(_.mapK(fk)))
+
   /** Translates the effect type of this client from F to G
     */
   def translate[G[_]: MonadCancelThrow](fk: F ~> G)(gK: G ~> F)(implicit


### PR DESCRIPTION
MiMa flags this change, so I assume it needs to target 1.x?