### PR TITLE
Merge branch `series/0.22` into `series/0.23`

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.1.1
+version = 3.2.0
 
 style = default
 

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/BlazeServerSuite.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/BlazeServerSuite.scala
@@ -29,6 +29,7 @@ import org.http4s.dsl.io._
 import org.http4s.internal.threads._
 import org.http4s.multipart.Multipart
 import org.http4s.server.Server
+import org.http4s.testing.ClosableResource
 
 import java.net.HttpURLConnection
 import java.net.URL
@@ -72,11 +73,11 @@ class BlazeServerSuite extends Http4sSuite {
 
   override def afterAll(): Unit = munitIoRuntime.shutdown()
 
-  def builder =
+  private def builder =
     BlazeServerBuilder[IO]
       .withResponseHeaderTimeout(1.second)
 
-  val service: HttpApp[IO] = HttpApp {
+  private val service: HttpApp[IO] = HttpApp {
     case GET -> Root / "thread" / "routing" =>
       val thread = Thread.currentThread.getName
       Ok(thread)
@@ -98,27 +99,27 @@ class BlazeServerSuite extends Http4sSuite {
     case _ => NotFound()
   }
 
-  val serverR =
+  private val serverR =
     builder
       .bindAny()
       .withHttpApp(service)
       .resource
 
-  val blazeServer =
+  private val blazeServer =
     ResourceFixture[Server](
       serverR,
       (_: TestOptions, _: Server) => IO.unit,
       (_: Server) => IO.sleep(100.milliseconds) *> IO.unit,
     )
 
-  def get(server: Server, path: String): IO[String] = IO.blocking {
-    Source
-      .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-      .getLines()
-      .mkString
+  private def get(server: Server, path: String): IO[String] = IO.blocking {
+    ClosableResource.resource(
+      Source
+        .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
+    )(_.getLines().mkString)(_.close())
   }
 
-  def getStatus(server: Server, path: String): IO[Status] = {
+  private def getStatus(server: Server, path: String): IO[Status] = {
     val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
     for {
       conn <- IO.blocking(url.openConnection().asInstanceOf[HttpURLConnection])
@@ -129,7 +130,7 @@ class BlazeServerSuite extends Http4sSuite {
     } yield status
   }
 
-  def post(server: Server, path: String, body: String): IO[String] = IO.blocking {
+  private def post(server: Server, path: String, body: String): IO[String] = IO.blocking {
     val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
     val conn = url.openConnection().asInstanceOf[HttpURLConnection]
     val bytes = body.getBytes(StandardCharsets.UTF_8)
@@ -137,10 +138,13 @@ class BlazeServerSuite extends Http4sSuite {
     conn.setRequestProperty("Content-Length", bytes.size.toString)
     conn.setDoOutput(true)
     conn.getOutputStream.write(bytes)
-    Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines().mkString
-  }
 
-  def postChunkedMultipart(
+    ClosableResource.resource(
+      Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
+    )(_.getLines().mkString)(_.close())
+  }
+  
+  private def postChunkedMultipart(
       server: Server,
       path: String,
       boundary: String,
@@ -155,7 +159,10 @@ class BlazeServerSuite extends Http4sSuite {
       conn.setRequestProperty("Content-Type", s"""multipart/form-data; boundary="$boundary"""")
       conn.setDoOutput(true)
       conn.getOutputStream.write(bytes)
-      Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines().mkString
+
+      ClosableResource.resource(
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
+      )(_.getLines().mkString)(_.close())
     }
 
   blazeServer.test("route requests on the service executor".flaky) { server =>

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/BlazeServerSuite.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/BlazeServerSuite.scala
@@ -29,7 +29,7 @@ import org.http4s.dsl.io._
 import org.http4s.internal.threads._
 import org.http4s.multipart.Multipart
 import org.http4s.server.Server
-import org.http4s.testing.ClosableResource
+import org.http4s.testing.AutoCloseableResource
 
 import java.net.HttpURLConnection
 import java.net.URL
@@ -113,10 +113,10 @@ class BlazeServerSuite extends Http4sSuite {
     )
 
   private def get(server: Server, path: String): IO[String] = IO.blocking {
-    ClosableResource.resource(
+    AutoCloseableResource.resource(
       Source
         .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-    )(_.getLines().mkString)(_.close())
+    )(_.getLines().mkString)
   }
 
   private def getStatus(server: Server, path: String): IO[Status] = {
@@ -139,9 +139,9 @@ class BlazeServerSuite extends Http4sSuite {
     conn.setDoOutput(true)
     conn.getOutputStream.write(bytes)
 
-    ClosableResource.resource(
+    AutoCloseableResource.resource(
       Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
-    )(_.getLines().mkString)(_.close())
+    )(_.getLines().mkString)
   }
 
   private def postChunkedMultipart(
@@ -160,9 +160,9 @@ class BlazeServerSuite extends Http4sSuite {
       conn.setDoOutput(true)
       conn.getOutputStream.write(bytes)
 
-      ClosableResource.resource(
+      AutoCloseableResource.resource(
         Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
-      )(_.getLines().mkString)(_.close())
+      )(_.getLines().mkString)
     }
 
   blazeServer.test("route requests on the service executor".flaky) { server =>

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/BlazeServerSuite.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/BlazeServerSuite.scala
@@ -143,7 +143,7 @@ class BlazeServerSuite extends Http4sSuite {
       Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
     )(_.getLines().mkString)(_.close())
   }
-  
+
   private def postChunkedMultipart(
       server: Server,
       path: String,

--- a/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -79,12 +79,4 @@ class LoggerSuite extends Http4sSuite {
     res.map(_.status).assertEquals(Status.Ok)
     res.flatMap(_.as[String]).assertEquals(expectedBody)
   }
-
-  private def loggerColoredCompiles(): Unit = {
-    val _ = Logger.colored[IO](
-      logHeaders = true,
-      logBody = false,
-      logAction = Some(s => IO(println(s))),
-    ) _
-  }
 }

--- a/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -25,7 +25,7 @@ import org.http4s.syntax.all._
 /** Common Tests for Logger, RequestLogger, and ResponseLogger
   */
 class LoggerSuite extends Http4sSuite {
-  val testApp = HttpApp[IO] {
+  private val testApp = HttpApp[IO] {
     case req @ POST -> Root / "post" =>
       Ok(req.body)
     case GET -> Root / "request" =>
@@ -34,11 +34,11 @@ class LoggerSuite extends Http4sSuite {
       NotFound()
   }
 
-  def body: EntityBody[IO] = fs2.Stream.emits("This is a test resource.".getBytes()).covary
+  private def body: EntityBody[IO] = fs2.Stream.emits("This is a test resource.".getBytes()).covary
 
-  val expectedBody: String = "This is a test resource."
+  private val expectedBody: String = "This is a test resource."
 
-  val responseLoggerClient =
+  private val responseLoggerClient =
     ResponseLogger(true, true)(Client.fromHttpApp(testApp))
 
   test("ResponseLogger should not affect a Get") {
@@ -80,7 +80,7 @@ class LoggerSuite extends Http4sSuite {
     res.flatMap(_.as[String]).assertEquals(expectedBody)
   }
 
-  def loggerColoredCompiles(): Unit = {
+  private def loggerColoredCompiles(): Unit = {
     val _ = Logger.colored[IO](
       logHeaders = true,
       logBody = false,

--- a/jetty-server/src/test/scala/org/http4s/jetty/server/JettyServerSuite.scala
+++ b/jetty-server/src/test/scala/org/http4s/jetty/server/JettyServerSuite.scala
@@ -23,6 +23,7 @@ import cats.effect.Temporal
 import cats.syntax.all._
 import org.http4s.dsl.io._
 import org.http4s.server.Server
+import org.http4s.testing.ClosableResource
 
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -33,9 +34,9 @@ import scala.io.Source
 
 class JettyServerSuite extends Http4sSuite {
 
-  def builder = JettyBuilder[IO]
+  private def builder = JettyBuilder[IO]
 
-  val serverR =
+  private val serverR =
     builder
       .bindAny()
       .withAsyncTimeout(3.seconds)
@@ -61,17 +62,17 @@ class JettyServerSuite extends Http4sSuite {
       )
       .resource
 
-  val jettyServer = ResourceFixture[Server](serverR)
+  private val jettyServer = ResourceFixture[Server](serverR)
 
-  def get(server: Server, path: String): IO[String] =
+  private def get(server: Server, path: String): IO[String] =
     IO.blocking(
-      Source
-        .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-        .getLines()
-        .mkString
+      ClosableResource.resource(
+        Source
+          .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
+      )(_.getLines().mkString)(_.close())
     )
 
-  def post(server: Server, path: String, body: String): IO[String] =
+  private def post(server: Server, path: String, body: String): IO[String] =
     IO.blocking {
       val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
       val conn = url.openConnection().asInstanceOf[HttpURLConnection]
@@ -80,7 +81,10 @@ class JettyServerSuite extends Http4sSuite {
       conn.setRequestProperty("Content-Length", bytes.size.toString)
       conn.setDoOutput(true)
       conn.getOutputStream.write(bytes)
-      Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name).getLines().mkString
+
+      ClosableResource.resource(
+        Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
+      )(_.getLines().mkString)(_.close())
     }
 
   jettyServer.test("ChannelOptions should route requests on the service executor") { server =>

--- a/jetty-server/src/test/scala/org/http4s/jetty/server/JettyServerSuite.scala
+++ b/jetty-server/src/test/scala/org/http4s/jetty/server/JettyServerSuite.scala
@@ -23,7 +23,7 @@ import cats.effect.Temporal
 import cats.syntax.all._
 import org.http4s.dsl.io._
 import org.http4s.server.Server
-import org.http4s.testing.ClosableResource
+import org.http4s.testing.AutoCloseableResource
 
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -66,10 +66,10 @@ class JettyServerSuite extends Http4sSuite {
 
   private def get(server: Server, path: String): IO[String] =
     IO.blocking(
-      ClosableResource.resource(
+      AutoCloseableResource.resource(
         Source
           .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-      )(_.getLines().mkString)(_.close())
+      )(_.getLines().mkString)
     )
 
   private def post(server: Server, path: String, body: String): IO[String] =
@@ -82,9 +82,9 @@ class JettyServerSuite extends Http4sSuite {
       conn.setDoOutput(true)
       conn.getOutputStream.write(bytes)
 
-      ClosableResource.resource(
+      AutoCloseableResource.resource(
         Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
-      )(_.getLines().mkString)(_.close())
+      )(_.getLines().mkString)
     }
 
   jettyServer.test("ChannelOptions should route requests on the service executor") { server =>

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -200,7 +200,7 @@ object Http4sPlugin extends AutoPlugin {
     val blaze = "0.15.2"
     val boopickle = "1.4.0"
     val caseInsensitive = "1.2.0"
-    val cats = "2.6.1"
+    val cats = "2.7.0"
     val catsEffect = "3.3.0"
     val catsParse = "0.3.6"
     val circe = "0.14.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.7"
 // https://github.com/coursier/coursier/issues/450
 classpathTypes += "maven-plugin"
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.32")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.33")
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.2.4")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += Resolver.sonatypeRepo("releases")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.32")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.33")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -23,13 +23,14 @@ import cats.syntax.all._
 import fs2.io.readInputStream
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
+import org.http4s.testing.AutoCloseableResource
 
 import scala.io.Source
 
 /** Common Tests for Logger, RequestLogger, and ResponseLogger
   */
 class LoggerSuite extends Http4sSuite {
-  val testApp = HttpApp[IO] {
+  private val testApp = HttpApp[IO] {
     case GET -> Root / "request" =>
       Ok("request response")
     case req @ POST -> Root / "post" =>
@@ -38,14 +39,15 @@ class LoggerSuite extends Http4sSuite {
       Ok()
   }
 
-  def testResource = getClass.getResourceAsStream("/testresource.txt")
+  private def testResource = getClass.getResourceAsStream("/testresource.txt")
 
-  def body: EntityBody[IO] =
+  private def body: EntityBody[IO] =
     readInputStream[IO](IO.pure(testResource), 4096)
 
-  val expectedBody: String = Source.fromInputStream(testResource).mkString
+  private val expectedBody: String =
+    AutoCloseableResource.resource(Source.fromInputStream(testResource))(_.mkString)
 
-  val respApp = ResponseLogger.httpApp(logHeaders = true, logBody = true)(testApp)
+  private val respApp = ResponseLogger.httpApp(logHeaders = true, logBody = true)(testApp)
 
   test("response should not affect a Get") {
     val req = Request[IO](uri = uri"/request")
@@ -63,7 +65,7 @@ class LoggerSuite extends Http4sSuite {
     }.assert
   }
 
-  val reqApp = RequestLogger.httpApp(logHeaders = true, logBody = true)(testApp)
+  private val reqApp = RequestLogger.httpApp(logHeaders = true, logBody = true)(testApp)
 
   test("request should not affect a Get") {
     val req = Request[IO](uri = uri"/request")
@@ -77,7 +79,7 @@ class LoggerSuite extends Http4sSuite {
     }.assert
   }
 
-  val loggerApp = Logger.httpApp(logHeaders = true, logBody = true)(testApp)
+  private val loggerApp = Logger.httpApp(logHeaders = true, logBody = true)(testApp)
 
   test("logger should not affect a Get") {
     val req = Request[IO](uri = uri"/request")

--- a/server/jvm/src/test/scala/org/http4s/server/staticcontent/StaticContentShared.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/staticcontent/StaticContentShared.scala
@@ -21,6 +21,7 @@ package staticcontent
 import cats.effect.IO
 import fs2._
 import org.http4s.syntax.all._
+import org.http4s.testing.AutoCloseableResource
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -32,10 +33,14 @@ private[staticcontent] trait StaticContentShared { this: Http4sSuite =>
   lazy val testResource: Chunk[Byte] = {
     val s = getClass.getResourceAsStream("/testresource.txt")
     require(s != null, "Couldn't acquire resource!")
-    val bytes = scala.io.Source
-      .fromInputStream(s)
-      .mkString
-      .getBytes(StandardCharsets.UTF_8)
+    val bytes =
+      AutoCloseableResource.resource(
+        scala.io.Source
+          .fromInputStream(s)
+      )(
+        _.mkString
+          .getBytes(StandardCharsets.UTF_8)
+      )
 
     Chunk.array(bytes)
   }
@@ -54,11 +59,13 @@ private[staticcontent] trait StaticContentShared { this: Http4sSuite =>
     require(s != null, "Couldn't acquire resource!")
 
     Chunk.array(
-      scala.io.Source
-        .fromInputStream(s)
-        .mkString
-        .getBytes(StandardCharsets.UTF_8)
-    )
+      AutoCloseableResource.resource(
+        scala.io.Source
+          .fromInputStream(s)
+      )(
+        _.mkString
+          .getBytes(StandardCharsets.UTF_8)
+      ))
   }
 
   lazy val testWebjarResourceGzipped: Chunk[Byte] = {
@@ -77,11 +84,13 @@ private[staticcontent] trait StaticContentShared { this: Http4sSuite =>
     require(s != null, "Couldn't acquire resource!")
 
     Chunk.array(
-      scala.io.Source
-        .fromInputStream(s)
-        .mkString
-        .getBytes(StandardCharsets.UTF_8)
-    )
+      AutoCloseableResource.resource(
+        scala.io.Source
+          .fromInputStream(s)
+      )(
+        _.mkString
+          .getBytes(StandardCharsets.UTF_8)
+      ))
   }
 
   def runReq(

--- a/server/jvm/src/test/scala/org/http4s/server/staticcontent/StaticContentShared.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/staticcontent/StaticContentShared.scala
@@ -65,7 +65,8 @@ private[staticcontent] trait StaticContentShared { this: Http4sSuite =>
       )(
         _.mkString
           .getBytes(StandardCharsets.UTF_8)
-      ))
+      )
+    )
   }
 
   lazy val testWebjarResourceGzipped: Chunk[Byte] = {
@@ -90,7 +91,8 @@ private[staticcontent] trait StaticContentShared { this: Http4sSuite =>
       )(
         _.mkString
           .getBytes(StandardCharsets.UTF_8)
-      ))
+      )
+    )
   }
 
   def runReq(

--- a/servlet/src/test/scala/org/http4s/servlet/AsyncHttp4sServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/AsyncHttp4sServletSuite.scala
@@ -30,7 +30,7 @@ import org.eclipse.jetty.servlet.ServletHolder
 import org.http4s.dsl.io._
 import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.syntax.all._
-import org.http4s.testing.ClosableResource
+import org.http4s.testing.AutoCloseableResource
 
 import java.net.URL
 import scala.concurrent.duration._
@@ -54,10 +54,10 @@ class AsyncHttp4sServletSuite extends Http4sSuite {
 
   private def get(serverPort: Int, path: String): IO[String] =
     IO.blocking[String](
-      ClosableResource.resource(
+      AutoCloseableResource.resource(
         Source
           .fromURL(new URL(s"http://127.0.0.1:$serverPort/$path"))
-      )(_.getLines().mkString)(_.close())
+      )(_.getLines().mkString)
     )
 
   servletServer.test("AsyncHttp4sServlet handle GET requests") { server =>

--- a/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
@@ -31,7 +31,7 @@ import org.eclipse.jetty.servlet.ServletHolder
 import org.http4s.dsl.io._
 import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.syntax.all._
-import org.http4s.testing.ClosableResource
+import org.http4s.testing.AutoCloseableResource
 
 import java.net.HttpURLConnection
 import java.net.URL
@@ -58,10 +58,10 @@ class BlockingHttp4sServletSuite extends Http4sSuite {
 
   private def get(serverPort: Int, path: String): IO[String] =
     IO(
-      ClosableResource.resource(
+      AutoCloseableResource.resource(
         Source
           .fromURL(new URL(s"http://127.0.0.1:$serverPort/$path"))
-      )(_.getLines().mkString)(_.close())
+      )(_.getLines().mkString)
     )
 
   private def post(serverPort: Int, path: String, body: String): IO[String] =
@@ -74,9 +74,9 @@ class BlockingHttp4sServletSuite extends Http4sSuite {
       conn.setDoOutput(true)
       conn.getOutputStream.write(bytes)
 
-      ClosableResource.resource(
+      AutoCloseableResource.resource(
         Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
-      )(_.getLines().mkString)(_.close())
+      )(_.getLines().mkString)
     }
 
   servletServer.test("Http4sBlockingServlet handle GET requests") { server =>

--- a/testing/shared/src/test/scala/org/http4s/testing/AutoCloseableResource.scala
+++ b/testing/shared/src/test/scala/org/http4s/testing/AutoCloseableResource.scala
@@ -16,7 +16,7 @@
 
 package org.http4s.testing
 
-object AutoCloseableResource {
+private[http4s] object AutoCloseableResource {
 
   /** Performs an operation using a resource, and then releases the resource,
     * even if the operation throws an exception. This method behaves similarly
@@ -30,7 +30,7 @@ object AutoCloseableResource {
     * @return the result of the operation, if neither the operation nor
     *         releasing the resource throws
     */
-  def resource[R <: AutoCloseable, A](resource: R)(body: R => A): A = {
+  private[http4s] def resource[R <: AutoCloseable, A](resource: R)(body: R => A): A = {
     if (resource == null) throw new NullPointerException("null resource")
 
     var toThrow: Throwable = null

--- a/testing/shared/src/test/scala/org/http4s/testing/AutoCloseableResource.scala
+++ b/testing/shared/src/test/scala/org/http4s/testing/AutoCloseableResource.scala
@@ -18,6 +18,7 @@ package org.http4s.testing
 
 private[http4s] object AutoCloseableResource {
 
+  // TODO: Consider using [[munit.CatsEffectFixtures]] or [[cats.effect.Resource.fromAutoCloseable]] instead
   /** Performs an operation using a resource, and then releases the resource,
     * even if the operation throws an exception. This method behaves similarly
     * to Java's try-with-resources.

--- a/testing/shared/src/test/scala/org/http4s/testing/ClosableResource.scala
+++ b/testing/shared/src/test/scala/org/http4s/testing/ClosableResource.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.testing
+
+object ClosableResource {
+
+  /** Performs an operation using a resource, and then releases the resource,
+    * even if the operation throws an exception. This method behaves similarly
+    * to Java's try-with-resources.
+    * Ported from the Scala's 2.13 [[scala.util.Using.resource]].
+    *
+    * @param resource the resource
+    * @param body     the operation to perform with the resource
+    * @param release  the operation to perform on the finally case
+    * @tparam R the type of the resource
+    * @tparam A the return type of the operation
+    * @return the result of the operation, if neither the operation nor
+    *         releasing the resource throws
+    */
+  def resource[R, A](resource: R)(body: R => A)(release: R => Unit): A = {
+    if (resource == null) throw new NullPointerException("null resource")
+
+    var toThrow: Throwable = null
+
+    try body(resource)
+    catch {
+      case t: Throwable =>
+        toThrow = t
+        null.asInstanceOf[A]
+    } finally if (toThrow eq null) release(resource)
+    else {
+      try release(resource)
+      finally throw toThrow
+    }
+  }
+}

--- a/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -24,6 +24,7 @@ import fs2.io.file.Files
 import fs2.io.file.Path
 import org.http4s.Status._
 import org.http4s.headers._
+import org.http4s.testing.ClosableResource
 
 import java.net.URL
 import java.net.UnknownHostException
@@ -297,7 +298,8 @@ class StaticFileSuite extends Http4sSuite {
   if (Platform.isJvm)
     test("Read from a URL") {
       val url = getClass.getResource("/lorem-ipsum.txt")
-      val expected = scala.io.Source.fromURL(url, "utf-8").mkString
+      val expected =
+        ClosableResource.resource(scala.io.Source.fromURL(url, "utf-8"))(_.mkString)(_.close())
       val s = StaticFile
         .fromURL[IO](getClass.getResource("/lorem-ipsum.txt"))
         .value

--- a/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -24,7 +24,7 @@ import fs2.io.file.Files
 import fs2.io.file.Path
 import org.http4s.Status._
 import org.http4s.headers._
-import org.http4s.testing.ClosableResource
+import org.http4s.testing.AutoCloseableResource
 
 import java.net.URL
 import java.net.UnknownHostException
@@ -299,7 +299,7 @@ class StaticFileSuite extends Http4sSuite {
     test("Read from a URL") {
       val url = getClass.getResource("/lorem-ipsum.txt")
       val expected =
-        ClosableResource.resource(scala.io.Source.fromURL(url, "utf-8"))(_.mkString)(_.close())
+        AutoCloseableResource.resource(scala.io.Source.fromURL(url, "utf-8"))(_.mkString)
       val s = StaticFile
         .fromURL[IO](getClass.getResource("/lorem-ipsum.txt"))
         .value

--- a/tomcat-server/src/test/scala/org/http4s/tomcat/server/TomcatServerSuite.scala
+++ b/tomcat-server/src/test/scala/org/http4s/tomcat/server/TomcatServerSuite.scala
@@ -22,7 +22,7 @@ import cats.effect.IO
 import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory
 import org.http4s.dsl.io._
 import org.http4s.server.Server
-import org.http4s.testing.ClosableResource
+import org.http4s.testing.AutoCloseableResource
 
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -74,10 +74,10 @@ class TomcatServerSuite extends Http4sSuite {
 
   private def get(server: Server, path: String): IO[String] =
     IO.blocking(
-      ClosableResource.resource(
+      AutoCloseableResource.resource(
         Source
           .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-      )(_.getLines().mkString)(_.close())
+      )(_.getLines().mkString)
     )
 
   private def post(server: Server, path: String, body: String): IO[String] =
@@ -90,10 +90,10 @@ class TomcatServerSuite extends Http4sSuite {
       conn.setDoOutput(true)
       conn.getOutputStream.write(bytes)
 
-      ClosableResource.resource(
+      AutoCloseableResource.resource(
         Source
           .fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
-      )(_.getLines().mkString)(_.close())
+      )(_.getLines().mkString)
     }
 
   tomcatServer.test("server should route requests on the service executor".flaky) { server =>

--- a/tomcat-server/src/test/scala/org/http4s/tomcat/server/TomcatServerSuite.scala
+++ b/tomcat-server/src/test/scala/org/http4s/tomcat/server/TomcatServerSuite.scala
@@ -22,6 +22,7 @@ import cats.effect.IO
 import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory
 import org.http4s.dsl.io._
 import org.http4s.server.Server
+import org.http4s.testing.ClosableResource
 
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -41,9 +42,9 @@ class TomcatServerSuite extends Http4sSuite {
     LogManager.getLogManager().reset()
   }
 
-  val builder = TomcatBuilder[IO]
+  private val builder = TomcatBuilder[IO]
 
-  val serverR: cats.effect.Resource[IO, Server] =
+  private val serverR: cats.effect.Resource[IO, Server] =
     builder
       .bindAny()
       .withAsyncTimeout(3.seconds)
@@ -69,17 +70,17 @@ class TomcatServerSuite extends Http4sSuite {
       )
       .resource
 
-  val tomcatServer = ResourceFixture[Server](serverR)
+  private val tomcatServer = ResourceFixture[Server](serverR)
 
-  def get(server: Server, path: String): IO[String] =
+  private def get(server: Server, path: String): IO[String] =
     IO.blocking(
-      Source
-        .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
-        .getLines()
-        .mkString
+      ClosableResource.resource(
+        Source
+          .fromURL(new URL(s"http://127.0.0.1:${server.address.getPort}$path"))
+      )(_.getLines().mkString)(_.close())
     )
 
-  def post(server: Server, path: String, body: String): IO[String] =
+  private def post(server: Server, path: String, body: String): IO[String] =
     IO.blocking {
       val url = new URL(s"http://127.0.0.1:${server.address.getPort}$path")
       val conn = url.openConnection().asInstanceOf[HttpURLConnection]
@@ -88,10 +89,11 @@ class TomcatServerSuite extends Http4sSuite {
       conn.setRequestProperty("Content-Length", bytes.size.toString)
       conn.setDoOutput(true)
       conn.getOutputStream.write(bytes)
-      Source
-        .fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
-        .getLines()
-        .mkString
+
+      ClosableResource.resource(
+        Source
+          .fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name)
+      )(_.getLines().mkString)(_.close())
     }
 
   tomcatServer.test("server should route requests on the service executor".flaky) { server =>


### PR DESCRIPTION
Previously, I was about to move the `AutoCloseableResource` to the JVM module. And accidentally found out that there is the `StaticFileSuite` in the shared module, which works well on JS with it. `ScalaJS` now can work with the `AutoCloseable`, or am I missing something? Anyways, tests passed locally. Let's see what'll happen on the CI.

**UPD**: that test suite contains `Platform.isJvm`, so that's why it works on JS (or accurately, not work on JS at all) 😄 