### PR TITLE
EPUB download of the docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -662,6 +662,8 @@ lazy val docs = http4sProject("docs")
       includeLandingPage = false
     ),
     laikaDescribe := "<disabled>",
+    laikaIncludeEPUB := true,
+    laikaIncludePDF := false,
     Laika / sourceDirectories := Seq(mdocOut.value),
     ghpagesPrivateMappings := (laikaSite / mappings).value ++ {
       val docsPrefix = extractDocsPrefix(version.value)

--- a/build.sbt
+++ b/build.sbt
@@ -656,7 +656,7 @@ lazy val docs = http4sProject("docs")
     laikaExtensions := SiteConfig.extensions,
     laikaConfig := SiteConfig.config(versioned = true).value,
     laikaTheme := SiteConfig.theme(
-      currentVersion = SiteConfig.versions.v1_0,
+      currentVersion = SiteConfig.versions.current,
       SiteConfig.variables.value,
       SiteConfig.homeURL.value,
       includeLandingPage = false
@@ -704,7 +704,7 @@ lazy val website = http4sProject("website")
     laikaExtensions := SiteConfig.extensions,
     laikaConfig := SiteConfig.config(versioned = false).value,
     laikaTheme := SiteConfig.theme(
-      currentVersion = SiteConfig.versions.v1_0,
+      currentVersion = SiteConfig.versions.current,
       SiteConfig.variables.value,
       SiteConfig.homeURL.value,
       includeLandingPage = true

--- a/project/SiteConfig.scala
+++ b/project/SiteConfig.scala
@@ -144,6 +144,7 @@ object SiteConfig {
       configBuilder = config
         .withValue(LaikaKeys.versioned, versioned)
         .withValue(LinkConfig(excludeFromValidation = Seq(Root / "api")))
+        .withValue(LaikaKeys.artifactBaseName, s"http4s-${versions.v1_0.displayValue}")
     )
   }
 

--- a/project/SiteConfig.scala
+++ b/project/SiteConfig.scala
@@ -86,6 +86,8 @@ object SiteConfig {
 
     val all: Seq[Version] = Seq(v1_0, v0_23, v0_22, v0_21, choose)
 
+    val current: Version = v1_0
+
     def config(current: Version): Versions = Versions(
       currentVersion = current,
       olderVersions = all.dropWhile(_ != current).drop(1),
@@ -103,7 +105,7 @@ object SiteConfig {
     val downloadPageDesc: Option[String] = Some(
       "The e-book contains the same documentation as the website.")
     val downloadDocURL =
-      s"http://localhost:4242/${versions.v1_0.pathSegment}/downloads/"
+      s"http://localhost:4242/${versions.current.pathSegment}/downloads/"
     val epubMetadataDesc: Option[String] = Some("A minimal, idiomatic Scala interface for HTTP.")
   }
 
@@ -144,7 +146,7 @@ object SiteConfig {
       configBuilder = config
         .withValue(LaikaKeys.versioned, versioned)
         .withValue(LinkConfig(excludeFromValidation = Seq(Root / "api")))
-        .withValue(LaikaKeys.artifactBaseName, s"http4s-${versions.v1_0.displayValue}")
+        .withValue(LaikaKeys.artifactBaseName, s"http4s-${versions.current.displayValue}")
     )
   }
 
@@ -245,7 +247,7 @@ object SiteConfig {
       .metadata(
         title = Some("http4s"),
         description = epub.epubMetadataDesc,
-        version = Some(versions.v1_0.displayValue),
+        version = Some(versions.current.displayValue),
         language = Some("en")
       )
       .epub

--- a/project/SiteConfig.scala
+++ b/project/SiteConfig.scala
@@ -8,6 +8,7 @@ import laika.config.{ConfigBuilder, LaikaKeys}
 import laika.helium.Helium
 import laika.helium.config.{HeliumIcon, IconLink, ImageLink, ReleaseInfo, Teaser, TextLink}
 import laika.rewrite.link.LinkConfig
+import laika.rewrite.nav.CoverImage
 import laika.rewrite.{Version, Versions}
 import laika.sbt.LaikaConfig
 import laika.theme.ThemeProvider
@@ -62,7 +63,9 @@ object SiteConfig {
       TextLink.internal(Root / "contributing" / "README.md", "Contributing"),
       TextLink.internal(Root / "adopters" / "README.md", "Adopters"),
       TextLink.internal(Root / "code-of-conduct" / "README.md", "Code of Conduct"),
-      TextLink.internal(Root / "further-reading" / "README.md", "Further Reading")
+      TextLink.internal(Root / "further-reading" / "README.md", "Further Reading"),
+      // TODO: the internal reference is not resolving for now
+      TextLink.external(epub.downloadDocURL, "Download (EPUB)")
     )
   }
 
@@ -94,6 +97,14 @@ object SiteConfig {
     } ++ all.map { v =>
       Root / v.pathSegment / "index.html"
     }
+  }
+
+  object epub {
+    val downloadPageDesc: Option[String] = Some(
+      "The e-book contains the same documentation as the website.")
+    val downloadDocURL =
+      s"http://localhost:4242/${versions.v1_0.pathSegment}/downloads/"
+    val epubMetadataDesc: Option[String] = Some("A minimal, idiomatic Scala interface for HTTP.")
   }
 
   // This kind of variable generator used to live in Http4sPlugin, but it's not used by anything other than Laika.
@@ -128,6 +139,7 @@ object SiteConfig {
     val config = variables.value.foldLeft(ConfigBuilder.empty) { case (builder, (key, value)) =>
       builder.withValue(key, value)
     }
+
     LaikaConfig(
       configBuilder = config
         .withValue(LaikaKeys.versioned, versioned)
@@ -214,11 +226,31 @@ object SiteConfig {
             HeliumIcon.github,
             options = Styles("svg-link")),
           IconLink.external("https://discord.gg/XF3CXcMzqD", HeliumIcon.chat),
-          IconLink.external("https://twitter.com/http4s", HeliumIcon.twitter)
+          IconLink.external("https://twitter.com/http4s", HeliumIcon.twitter),
+          // TODO: the internal reference is not resolving for now
+          IconLink.external(epub.downloadDocURL, HeliumIcon.download)
         )
       )
       .site
       .versions(versions.config(currentVersion))
+      .site
+      .downloadPage(
+        title = "Documentation Downloads",
+        description = epub.downloadPageDesc,
+        includeEPUB = true,
+        includePDF = false
+      )
+      .epub
+      .metadata(
+        title = Some("http4s"),
+        description = epub.epubMetadataDesc,
+        version = Some(versions.v1_0.displayValue),
+        language = Some("en")
+      )
+      .epub
+      .coverImages(CoverImage(Root / "images" / "http4s-logo-text-dark-2.svg"))
+      .epub
+      .tableOfContent("Table of Content", 3)
       .build
 
     HeliumExtensions.applyTo(fullTheme, variables, versions.paths)

--- a/project/SiteConfig.scala
+++ b/project/SiteConfig.scala
@@ -105,7 +105,7 @@ object SiteConfig {
     val downloadPageDesc: Option[String] = Some(
       "The e-book contains the same documentation as the website.")
     val downloadDocURL =
-      s"http://localhost:4242/${versions.current.pathSegment}/downloads/"
+      s"https://http4s.org/${versions.current.pathSegment}/downloads/"
     val epubMetadataDesc: Option[String] = Some("A minimal, idiomatic Scala interface for HTTP.")
   }
 


### PR DESCRIPTION
Closes #5452. Do we want a backport for 0.22/0.23?

How will looks the landing page: https://www.dropbox.com/s/4d46p7nsbb7mcwj/Screenshot%20from%202021-12-02%2012-56-22.png?dl=0

How will looks the download page in the docs: https://www.dropbox.com/s/65e5jdhh6bx9j0o/Screenshot%20from%202021-12-02%2012-59-47.png?dl=0

The Generated EPUB: https://www.dropbox.com/s/dg5sq5anwb54c0h/http4s-1.0.epub?dl=0