### PR TITLE
Unpin `scalatags` in the Steward config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -9,6 +9,4 @@ updates.pin = [
   { groupId = "io.prometheus", version = "0.11." },
   # okio-3 has (slight) binary incompatibilities
   { groupId = "com.squareup.okio", artifactId = "okio", version = "2." },
-  # scalatags-0.11 breaks bincompat
-  { groupId = "com.lihaoyi", artifactId = "scalatags", version = "0.10." },
 ]


### PR DESCRIPTION
Closes #5654.