### PR TITLE
Configure mergify & release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,18 +1,86 @@
 changelog:
-  exclude:
-    labels:
-      - series/0.22
-      - series/0.23
   categories:
+
     - title: http4s-core
       labels:
-        - module:http4s-core
+        - module:core
+    - title: http4s-dsl
+      labels:
+        - module:dsl
+    - title: http4s-laws
+      labels:
+        - module:laws
+
     - title: http4s-server
       labels:
-        - module:http4s-server
+        - module:server
     - title: http4s-client
       labels:
-        - module:http4s-client
+        - module:client
+
+    - title: http4s-ember-core
+      labels:
+        - module:ember-core
+    - title: http4s-ember-server
+      labels:
+        - module:ember-server
+    - title: http4s-ember-client
+      labels:
+        - module:ember-client
+
+    - title: http4s-blaze-core
+      labels:
+        - module:blaze-core
+    - title: http4s-blaze-server
+      labels:
+        - module:blaze-server
+    - title: http4s-blaze-client
+      labels:
+        - module:blaze-client
+
+    - title: http4s-jetty-server
+      labels:
+        - module:jetty-server
+    - title: http4s-jetty-client
+      labels:
+        - module:jetty-client
+
+    - title: http4s-async-http-client
+      labels:
+        - module:async-http-client
+    - title: http4s-okhttp-client
+      labels:
+        - module:okhttp-client
+    - title: http4s-servlet
+      labels:
+        - module:servlet
+    - title: http4s-tomcat
+      labels:
+        - module:tomcat
+
+    - title: http4s-jawn
+      labels:
+        - module:jawn
+    - title: http4s-circe
+      labels:
+        - module:circe
+    - title: http4s-play-json
+      labels:
+        - module:play-json
+    - title: http4s-scalatags
+      labels:
+        - module:scalatags
+    - title: http4s-twirl
+      labels:
+        - module:twirl
+
+    - title: http4s-dropwizard-metrics
+      labels:
+        - module:dropwizard-metrics
+    - title: http4s-prometheus-metrics
+      labels:
+        - module:prometheus-metrics
+
     - title: Documentation
       labels:
         - docs

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -85,6 +85,9 @@ changelog:
       labels:
         - module:prometheus-metrics
 
+    - title: Scalafixes
+      labels:
+        - scalafix
     - title: Documentation
       labels:
         - docs

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,6 +13,9 @@ changelog:
     - title: http4s-client
       labels:
         - module:http4s-client
+    - title: Documentation
+      labels:
+        - docs
     - title: Behind the scenes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,8 @@
 changelog:
+  exclude:
+    labels:
+      # - series/0.22
+      # - series/0.23
   categories:
 
     - title: http4s-core

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -42,6 +42,12 @@ changelog:
       labels:
         - module:blaze-client
 
+    - title: http4s-servlet
+      labels:
+        - module:servlet
+    - title: http4s-tomcat
+      labels:
+        - module:tomcat
     - title: http4s-jetty-server
       labels:
         - module:jetty-server
@@ -55,12 +61,6 @@ changelog:
     - title: http4s-okhttp-client
       labels:
         - module:okhttp-client
-    - title: http4s-servlet
-      labels:
-        - module:servlet
-    - title: http4s-tomcat
-      labels:
-        - module:tomcat
 
     - title: http4s-jawn
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - series/0.22
+      - series/0.23
+  categories:
+    - title: http4s-core
+      labels:
+        - module:http4s-core
+    - title: http4s-server
+      labels:
+        - module:http4s-server
+    - title: http4s-client
+      labels:
+        - module:http4s-client
+    - title: Behind the scenes
+      labels:
+        - "*"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,20 +1,19 @@
-
 pull_request_rules:
-  - name: automatically merge scala-steward's PRs
-    conditions:
-      - author=scala-steward
-      - body~=labels:.*semver-patch.*
-      - status-success=Build and Test (ubuntu-latest, 2.12.13, adopt@1.8)
-      - status-success=Build and Test (ubuntu-latest, 2.12.13, adopt@1.11)
-      - status-success=Build and Test (ubuntu-latest, 2.12.13, adopt@1.16)
-      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.8)
-      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.11)
-      - status-success=Build and Test (ubuntu-latest, 2.13.6, adopt@1.16)
-      - status-success=Build and Test (ubuntu-latest, 3.0.0, adopt@1.8)
-      - status-success=Build and Test (ubuntu-latest, 3.0.0, adopt@1.11)
-      - status-success=Build and Test (ubuntu-latest, 3.0.0, adopt@1.16)
-      - status-success=Build website (ubuntu-latest, 2.12.13, adopt@1.8)
-      - status-success=Build docs (ubuntu-latest, 2.12.13, adopt@1.8)
-    actions:
-      merge:
-        method: merge
+- name: label series/0.22 PRs
+  conditions:
+  - base=series/0.22
+  actions:
+    label:
+      add: ['series/0.22']
+- name: label series/0.23 PRs
+  conditions:
+  - base=series/0.23
+  actions:
+    label:
+      add: ['series/0.23']
+- name: label scala-steward's PRs
+  conditions:
+    - author=scala-steward
+  actions:
+    label:
+      add: [dependencies]


### PR DESCRIPTION
Trying out some of the ideas in https://github.com/http4s/http4s/issues/5683.

1. A mergify config, to label PRs based on their target branch and also steward PRs. Seems like this is always read from the default branch, but probably won't hurt to repeat it.
2. A GH release config, which will have to be customized for every branch. I hope GH respects that.