### PR TITLE
Update discipline to 1.4.0

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -24,6 +24,5 @@ updates.pin = [
   { groupId = "co.fs2", version = "2." },
   # Maintain Scala 3.0 support
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.0." },
-  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = "3.0." },
-  { groupId = "org.typelevel", artifactId = "discipline-core", version = "1.2." }
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = "3.0." }
 ]

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -252,7 +252,7 @@ object Http4sPlugin extends AutoPlugin {
     val circe = "0.14.1"
     val crypto = "0.1.0"
     val cryptobits = "1.3"
-    val disciplineCore = "1.2.0"
+    val disciplineCore = "1.4.0"
     val dropwizardMetrics = "4.2.4"
     val fs2 = "2.5.10"
     val ip4s = "2.0.4"


### PR DESCRIPTION
It's back on Scala 3, so we can start it on 0.22.