### PR TITLE
Mark the failing tests as flaky because they sometimes pass

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientConnectionReuseSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientConnectionReuseSuite.scala
@@ -193,7 +193,7 @@ class BlazeClientConnectionReuseSuite extends BlazeClientBase {
   // // Load tests // //
 
   test(
-    "BlazeClient should keep reusing connections even when under heavy load (single client scenario)".fail
+    "BlazeClient should keep reusing connections even when under heavy load (single client scenario)".fail.flaky
   ) {
     builder().resource.use { client =>
       for {
@@ -209,7 +209,7 @@ class BlazeClientConnectionReuseSuite extends BlazeClientBase {
   }
 
   test(
-    "BlazeClient should keep reusing connections even when under heavy load (multiple clients scenario)".fail
+    "BlazeClient should keep reusing connections even when under heavy load (multiple clients scenario)".fail.flaky
   ) {
     for {
       servers <- makeServers()


### PR DESCRIPTION
It turns out these tests I marked with `fail` sometimes pass on CI, leading to build failure.
(https://github.com/http4s/http4s/runs/4498932845?check_suite_focus=true)