### PR TITLE
Remove some outdated params in scaladocs

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
@@ -29,7 +29,6 @@ import scala.concurrent._
 
 /** Discards the body, killing it so as to clean up resources
   *
-  * @param headers ByteBuffer representation of [[Headers]] to send
   * @param pipe the blaze `TailStage`, which takes ByteBuffers which will send the data downstream
   * @param ec an ExecutionContext which will be used to complete operations
   */

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
@@ -69,27 +69,18 @@ import scala.concurrent.duration._
   *
   * Variables:
   * @param socketAddress: Socket Address the server will be mounted at
-  * @param executionContext: Execution Context the underlying blaze futures
-  *    will be executed upon.
   * @param responseHeaderTimeout: Time from when the request is made until a
   *    response line is generated before a 503 response is returned and the
   *    `HttpApp` is canceled
   * @param idleTimeout: Period of Time a connection can remain idle before the
   *    connection is timed out and disconnected.
   *    Duration.Inf disables this feature.
-  * @param isNio2: Whether or not to use NIO2 or NIO1 Socket Server Group
   * @param connectorPoolSize: Number of worker threads for the new Socket Server Group
   * @param bufferSize: Buffer size to use for IO operations
-  * @param sslBits: If defined enables secure communication to the server using the
-  *    sslContext
   * @param isHttp2Enabled: Whether or not to enable Http2 Server Features
-  * @param maxRequestLineLength: Maximum request line to parse
-  *    If exceeded returns a 400 Bad Request.
   * @param maxHeadersLen: Maximum data that composes the headers.
   *    If exceeded returns a 400 Bad Request.
   * @param chunkBufferMaxSize Size of the buffer that is used when Content-Length header is not specified.
-  * @param serviceMounts: The services that are mounted on this server to serve.
-  *    These services get assembled into a Router with the longer prefix winning.
   * @param serviceErrorHandler: The last resort to recover and generate a response
   *    this is necessary to recover totality from the error condition.
   * @param banner: Pretty log to display on server start. An empty sequence

--- a/core/shared/src/main/scala/org/http4s/internal/ChunkWriter.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/ChunkWriter.scala
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets
 import scala.collection.mutable.Buffer
 
 /** [[Writer]] that will result in a `Chunk`
-  * @param toChunk initial `Chunk`
   */
 private[http4s] class ChunkWriter(
     charset: Charset = StandardCharsets.UTF_8

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/Prometheus.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/Prometheus.scala
@@ -83,10 +83,10 @@ object Prometheus {
   def collectorRegistry[F[_]](implicit F: Sync[F]): Resource[F, CollectorRegistry] =
     Resource.make(F.delay(new CollectorRegistry()))(cr => F.delay(cr.clear()))
 
-  /** Creates a  [[MetricsOps]] that supports Prometheus metrics
-    * *
-    * * @param registry a metrics collector registry
-    * * @param prefix a prefix that will be added to all metrics
+  /** Creates a [[MetricsOps]] that supports Prometheus metrics
+    *
+    * @param registry a metrics collector registry
+    * @param prefix a prefix that will be added to all metrics
     */
   def metricsOps[F[_]: Sync](
       registry: CollectorRegistry,

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -31,7 +31,6 @@ object Timeout {
     * fires, the service's response is canceled.
     *
     * @param timeout Finite duration to wait before returning the provided response
-    * @param service [[HttpRoutes]] to transform
     */
   def apply[F[_], G[_], A](timeout: FiniteDuration, timeoutResponse: F[Response[G]])(
       http: Kleisli[F, A, Response[G]]
@@ -42,9 +41,8 @@ object Timeout {
     * duration if the service has not yet responded.  If the timeout
     * fires, the service's response is canceled.
     *
-    * @param timeout Finite duration to wait before returning a `503
-    * Service Unavailable` response
-    * @param service [[HttpRoutes]] to transform
+    * @param timeout Finite duration to wait before returning
+    * a `503 Service Unavailable` response
     */
   def apply[F[_], G[_], A](timeout: FiniteDuration)(http: Kleisli[F, A, Response[G]])(implicit
       F: Temporal[F]

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/FileService.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/FileService.scala
@@ -46,7 +46,6 @@ object FileService {
     * @param pathPrefix prefix of Uri from which content will be served
     * @param pathCollector function that performs the work of collecting the file or rendering the directory into a response.
     * @param bufferSize buffer size to use for internal read buffers
-    * @param blocker to use for blocking I/O
     * @param cacheStrategy strategy to use for caching purposes. Default to no caching.
     */
   final case class Config[F[_]](

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
@@ -34,7 +34,6 @@ import scala.util.control.NoStackTrace
 /** [[org.http4s.server.staticcontent.ResourceServiceBuilder]] builder
   *
   * @param basePath prefix of the path files will be served from
-  * @param blocker execution context to use when collecting content
   * @param pathPrefix prefix of the Uri that content will be served from
   * @param bufferSize size hint of internal buffers to use when serving resources
   * @param cacheStrategy strategy to use for caching purposes.
@@ -145,7 +144,6 @@ object ResourceService {
   /** [[org.http4s.server.staticcontent.ResourceService]] configuration
     *
     * @param basePath prefix of the path files will be served from
-    * @param blocker execution context to use when collecting content
     * @param pathPrefix prefix of the Uri that content will be served from
     * @param bufferSize size hint of internal buffers to use when serving resources
     * @param cacheStrategy strategy to use for caching purposes. Default to no caching.

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -30,8 +30,6 @@ import scala.util.control.NoStackTrace
 
 /** [[org.http4s.server.staticcontent.WebjarServiceBuilder]] builder
   *
-  * @param blocker execution context for blocking I/O
-  * @param filter To filter which assets from the webjars should be served
   * @param cacheStrategy strategy to use for caching purposes.
   * @param classLoader optional classloader for extracting the resources
   * @param preferGzipped prefer gzip compression format?
@@ -180,7 +178,6 @@ object WebjarService {
 
   /** [[org.http4s.server.staticcontent.WebjarService]] configuration
     *
-    * @param blocker execution context for blocking I/O
     * @param filter To filter which assets from the webjars should be served
     * @param cacheStrategy strategy to use for caching purposes. Default to no caching.
     */

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -26,7 +26,6 @@ import org.http4s.internal.CollectionCompat.CollectionConverters._
 
 import java.nio.file.Path
 import java.nio.file.Paths
-import scala.language.higherKinds
 import scala.util.control.NoStackTrace
 
 /** [[org.http4s.server.staticcontent.WebjarServiceBuilder]] builder

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -33,6 +33,7 @@ import scala.util.control.NoStackTrace
   * @param cacheStrategy strategy to use for caching purposes.
   * @param classLoader optional classloader for extracting the resources
   * @param preferGzipped prefer gzip compression format?
+  * @param webjarAssetFilter To filter which assets from the webjars should be served
   */
 class WebjarServiceBuilder[F[_]] private (
     webjarAssetFilter: WebjarServiceBuilder.WebjarAssetFilter,
@@ -151,9 +152,9 @@ object WebjarServiceBuilder {
 
   /** Returns an asset that matched the request if it's found in the webjar path
     *
-    * @param webjarAsset The WebjarAsset
     * @param request The Request
     * @param preferGzipped prefer gzip compression format?
+    * @param webjarAsset The WebjarAsset
     * @return Either the the Asset, if it exist, or Pass
     */
   private def serveWebjarAsset[F[_]](

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/WebjarService.scala
@@ -26,6 +26,7 @@ import org.http4s.internal.CollectionCompat.CollectionConverters._
 
 import java.nio.file.Path
 import java.nio.file.Paths
+import scala.language.higherKinds
 import scala.util.control.NoStackTrace
 
 /** [[org.http4s.server.staticcontent.WebjarServiceBuilder]] builder
@@ -152,9 +153,7 @@ object WebjarServiceBuilder {
   /** Returns an asset that matched the request if it's found in the webjar path
     *
     * @param webjarAsset The WebjarAsset
-    * @param config The configuration
     * @param request The Request
-    * @param optional class loader
     * @param preferGzipped prefer gzip compression format?
     * @return Either the the Asset, if it exist, or Pass
     */


### PR DESCRIPTION
I initially planned to fix only `blocker` but ended up checking all outdated params in scaladocs. 