### PR TITLE
Merge `series/0.22` into `series/0.23`

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientBase.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientBase.scala
@@ -20,10 +20,13 @@ package client
 import cats.effect._
 import cats.effect.kernel.Resource
 import cats.effect.std.Dispatcher
+import cats.implicits.catsSyntaxApplicativeId
+import fs2.Stream
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.HttpMethod
 import io.netty.handler.codec.http.HttpRequest
 import io.netty.handler.codec.http.HttpResponseStatus
+import org.http4s.Status.Ok
 import org.http4s._
 import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.client.scaffold._
@@ -62,8 +65,12 @@ trait BlazeClientBase extends Http4sSuite {
       dispatcher <- Dispatcher[IO]
       getHandler <- Resource.eval(
         RoutesToHandlerAdapter(
-          HttpRoutes.of[IO] { case _ @(Method.GET -> path) =>
-            GetRoutes.getPaths.getOrElse(path.toString, NotFound())
+          HttpRoutes.of[IO] {
+            case Method.GET -> Root / "infinite" =>
+              Response[IO](Ok).withEntity(Stream.emit[IO, String]("a" * 8 * 1024).repeat).pure[IO]
+
+            case _ @(Method.GET -> path) =>
+              GetRoutes.getPaths.getOrElse(path.toString, NotFound())
           },
           dispatcher,
         )
@@ -103,7 +110,7 @@ trait BlazeClientBase extends Http4sSuite {
       (HttpMethod.POST, "/process-request-entity") -> new Handler {
         // We wait for the entire request to arrive before sending a response. That's how servers normally behave.
         override def onRequestEnd(ctx: ChannelHandlerContext, request: HttpRequest): Unit = {
-          HandlerHelpers.sendResponse(ctx, HttpResponseStatus.OK, closeConnection = true)
+          HandlerHelpers.sendResponse(ctx, HttpResponseStatus.OK)
           ()
         }
       },

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientConnectionReuseSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientConnectionReuseSuite.scala
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.blaze
+package client
+
+import cats.effect._
+import cats.implicits._
+import fs2.Stream
+import org.http4s.Method._
+import org.http4s._
+import org.http4s.client.scaffold.TestServer
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+
+class BlazeClientConnectionReuseSuite extends BlazeClientBase {
+  override def munitTimeout: Duration = new FiniteDuration(50, TimeUnit.SECONDS)
+
+  test("BlazeClient should reuse the connection after a simple successful request".flaky) {
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(1L)
+      } yield ()
+    }
+  }
+
+  test(
+    "BlazeClient should reuse the connection after a successful request with large response".flaky
+  ) {
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "large"))
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(1L)
+      } yield ()
+    }
+  }
+
+  test(
+    "BlazeClient.status should reuse the connection after receiving a response without an entity".flaky
+  ) {
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client.status(Request[IO](GET, servers(0).uri / "no-content"))
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(1L)
+      } yield ()
+    }
+  }
+
+  // BlazeClient.status may or may not reuse the connection after receiving a response with an entity.
+  // It's up to the implementation.
+  // The connection can be reused only if the entity has been fully read from the socket.
+  // The current BlazeClient implementation will reuse the connection if it read the entire entity while reading the status line and headers.
+  // This behaviour depends on `BlazeClientBuilder.bufferSize`.
+  // In particular, responses not bigger than `bufferSize` will lead to reuse of the connection.
+
+  test(
+    "BlazeClient.status shouldn't wait for an infinite response entity and shouldn't reuse the connection"
+  ) {
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client
+          .status(Request[IO](GET, servers(0).uri / "infinite"))
+          .timeout(5.seconds) // we expect it to complete without waiting for the response body
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(2L)
+      } yield ()
+    }
+  }
+
+  test("BlazeClient should reuse connections to different servers separately".flaky) {
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(1L)
+        _ <- servers(1).establishedConnections.assertEquals(0L)
+        _ <- client.expect[String](Request[IO](GET, servers(1).uri / "simple"))
+        _ <- client.expect[String](Request[IO](GET, servers(1).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(1L)
+        _ <- servers(1).establishedConnections.assertEquals(1L)
+      } yield ()
+    }
+  }
+
+  // // Decoding failures // //
+
+  test("BlazeClient should reuse the connection after response decoding failed".flaky) {
+    // This will work regardless of whether we drain the entity or not,
+    // because the response is small and it is read in full in first read operation
+    val drainThenFail = EntityDecoder.error[IO, String](new Exception())
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client
+          .expect[String](Request[IO](GET, servers(0).uri / "simple"))(drainThenFail)
+          .attempt
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(1L)
+      } yield ()
+    }
+  }
+
+  test(
+    "BlazeClient should reuse the connection after response decoding failed and the (large) entity was drained".flaky
+  ) {
+    val drainThenFail = EntityDecoder.error[IO, String](new Exception())
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client
+          .expect[String](Request[IO](GET, servers(0).uri / "large"))(drainThenFail)
+          .attempt
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(1L)
+      } yield ()
+    }
+  }
+
+  test(
+    "BlazeClient shouldn't reuse the connection after response decoding failed and the (large) entity wasn't drained"
+  ) {
+    val failWithoutDraining = new EntityDecoder[IO, String] {
+      override def decode(m: Media[IO], strict: Boolean): DecodeResult[IO, String] =
+        DecodeResult[IO, String](IO.raiseError(new Exception()))
+      override def consumes: Set[MediaRange] = Set.empty
+    }
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client
+          .expect[String](Request[IO](GET, servers(0).uri / "large"))(failWithoutDraining)
+          .attempt
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(2L)
+      } yield ()
+    }
+  }
+
+  // // Requests with an entity // //
+
+  test("BlazeClient should reuse the connection after a request with an entity".flaky) {
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client.expect[String](
+          Request[IO](POST, servers(0).uri / "process-request-entity").withEntity("entity")
+        )
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(1L)
+      } yield ()
+    }
+  }
+
+  test(
+    "BlazeClient shouldn't wait for the request entity transfer to complete if the server closed the connection early. The closed connection shouldn't be reused."
+  ) {
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client.expect[String](
+          Request[IO](POST, servers(0).uri / "respond-and-close-immediately")
+            .withBodyStream(Stream(0.toByte).repeat)
+        )
+        _ <- client.expect[String](Request[IO](GET, servers(0).uri / "simple"))
+        _ <- servers(0).establishedConnections.assertEquals(2L)
+      } yield ()
+    }
+  }
+
+  // // Load tests // //
+
+  test(
+    "BlazeClient should keep reusing connections even when under heavy load (single client scenario)".fail.flaky
+  ) {
+    builder().resource.use { client =>
+      for {
+        servers <- makeServers()
+        _ <- client
+          .expect[String](Request[IO](GET, servers(0).uri / "simple"))
+          .replicateA(200)
+          .parReplicateA(20)
+        // There's no guarantee we'll actually manage to use 20 connections in parallel. Sharing the client means sharing the lock inside PoolManager as a contention point.
+        _ <- servers(0).establishedConnections.map(_ <= 20L).assert
+      } yield ()
+    }
+  }
+
+  test(
+    "BlazeClient should keep reusing connections even when under heavy load (multiple clients scenario)".fail.flaky
+  ) {
+    for {
+      servers <- makeServers()
+      _ <- builder().resource
+        .use { client =>
+          client.expect[String](Request[IO](GET, servers(0).uri / "simple")).replicateA(400)
+        }
+        .parReplicateA(20)
+      _ <- servers(0).establishedConnections.assertEquals(20L)
+    } yield ()
+  }
+
+  private def builder(): BlazeClientBuilder[IO] =
+    BlazeClientBuilder[IO](munitExecutionContext).withScheduler(scheduler = tickWheel)
+
+  private def makeServers(): IO[Vector[TestServer[IO]]] = {
+    val testServers = server().servers
+    testServers
+      .traverse(_.resetEstablishedConnections)
+      .as(testServers)
+  }
+}

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientConnectionReuseSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientConnectionReuseSuite.scala
@@ -223,7 +223,7 @@ class BlazeClientConnectionReuseSuite extends BlazeClientBase {
   }
 
   private def builder(): BlazeClientBuilder[IO] =
-    BlazeClientBuilder[IO](munitExecutionContext).withScheduler(scheduler = tickWheel)
+    BlazeClientBuilder[IO].withScheduler(scheduler = tickWheel)
 
   private def makeServers(): IO[Vector[TestServer[IO]]] = {
     val testServers = server().servers

--- a/client/jvm/src/test/scala/org/http4s/client/scaffold/NettyTestServer.scala
+++ b/client/jvm/src/test/scala/org/http4s/client/scaffold/NettyTestServer.scala
@@ -33,6 +33,7 @@ import io.netty.handler.codec.http._
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.handler.ssl.SslHandler
+import org.http4s.Uri
 import org.log4s.getLogger
 
 import java.net.InetAddress
@@ -43,11 +44,14 @@ trait TestServer[F[_]] {
   def localAddress: SocketAddress[IpAddress]
   def establishedConnections: F[Long]
   def resetEstablishedConnections: F[Unit]
+  def secure: Boolean
+  def uri = Uri.unsafeFromString(s"${if (secure) "https" else "http"}://$localAddress")
 }
 
 class NettyTestServer[F[_]](
     establishedConnectionsRef: Ref[F, Long],
     val localAddress: SocketAddress[IpAddress],
+    val secure: Boolean,
 ) extends TestServer[F] {
   def establishedConnections: F[Long] = establishedConnectionsRef.get
   def resetEstablishedConnections: F[Unit] = establishedConnectionsRef.set(0L)
@@ -74,7 +78,7 @@ object NettyTestServer {
       .childHandler(new ChannelInitializer[NioSocketChannel]() {
         def initChannel(ch: NioSocketChannel): Unit = {
           logger.trace(s"Accepted new connection from [${ch.remoteAddress()}].")
-          establishedConnections.update(_ + 1)
+          dispatcher.unsafeRunSync(establishedConnections.update(_ + 1))
           sslContext.foreach { sslContext =>
             val engine = sslContext.createSSLEngine()
             engine.setUseClientMode(false)
@@ -90,7 +94,7 @@ object NettyTestServer {
     channel <- server[F](bootstrap, port)
     localInetSocketAddress = channel.localAddress().asInstanceOf[InetSocketAddress]
     localAddress <- Resource.eval(toSocketAddress(localInetSocketAddress).liftTo[F])
-  } yield new NettyTestServer(establishedConnections, localAddress)
+  } yield new NettyTestServer(establishedConnections, localAddress, secure = sslContext.isDefined)
 
   private def nioEventLoopGroup[F[_]](implicit F: Async[F]): Resource[F, NioEventLoopGroup] =
     Resource.make(F.delay(new NioEventLoopGroup()))(el => F.delay(el.shutdownGracefully()).liftToF)

--- a/client/shared/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/shared/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -26,6 +26,7 @@ import scala.concurrent.duration._
 
 object GetRoutes {
   val SimplePath = "/simple"
+  val LargePath = "/large"
   val ChunkedPath = "/chunked"
   val DelayedPath = "/delayed"
   val NoContentPath = "/no-content"
@@ -36,6 +37,9 @@ object GetRoutes {
   def getPaths(implicit F: Temporal[IO]): Map[String, IO[Response[IO]]] =
     Map(
       SimplePath -> Response[IO](Ok).withEntity("simple path").pure[IO],
+      LargePath -> Response[IO](Ok)
+        .withEntity("a" * 8 * 1024)
+        .pure[IO], // must be at least as large as the buffers used by the client
       ChunkedPath -> Response[IO](Ok)
         .withEntity(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
         .pure[IO],

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
-addSbtPlugin("org.planet42" % "laika-sbt" % "0.18.0")
+addSbtPlugin("org.planet42" % "laika-sbt" % "0.18.1")
 
 // TODO remove me after we get this transitively
 // https://github.com/djspiewak/sbt-github-actions/issues/94


### PR DESCRIPTION
It turns out that some tests in the `BlazeClientConnectionReuseSuite` ain't failed now, though it was intended by test-suite:
`BlazeClient should reuse the connection after a successful request with large response`;
`BlazeClient should reuse the connection after response decoding failed and the (large) entity was drained`
I marked them as flaky (just because I'm not sure if they are stable enough).
cc @RafalSumislawski 