### PR TITLE
Add `apply`-builder for `Http4sClientDsl`

### DIFF
--- a/client/src/main/scala/org/http4s/client/dsl/Http4sClientDsl.scala
+++ b/client/src/main/scala/org/http4s/client/dsl/Http4sClientDsl.scala
@@ -36,6 +36,10 @@ trait Http4sClientDsl[F[_]] {
   }
 }
 
+object Http4sClientDsl {
+  def apply[F[_]]: Http4sClientDsl[F] = new Http4sClientDsl[F[_]] {}
+}
+
 class MethodOps[F[_]](private val method: Method) extends AnyVal {
 
   /** Make a [[org.http4s.Request]] using this [[Method]] */


### PR DESCRIPTION
Adds an `apply`-builder for convenience. Also moves the file to match the package location.