### PR TITLE
Minimal slice from #4509 (Entity rethinking)

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
@@ -140,7 +140,7 @@ object AsyncHttpClient {
               .flatMap(part => chunk(Chunk.array(part.getBodyPartBytes)))
               .mergeHaltBoth(Stream.eval(deferredThrowable.get.flatMap(F.raiseError[Byte])))
 
-          responseWithBody = response.copy(body = body)
+          responseWithBody = response.copy(entity = Entity(body))
 
           _ <-
             invokeCallbackF[F](cb(Right(responseWithBody -> (dispose >> bodyDisposal.get.flatten))))

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
@@ -418,7 +418,7 @@ private final class Http1Connection[F[_]](
             status = status,
             httpVersion = httpVersion,
             headers = headers,
-            body = body.interruptWhen(idleTimeoutS),
+            entity = Entity(body.interruptWhen(idleTimeoutS)),
             attributes = attributes,
           )
         )

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/ClientTimeoutSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/ClientTimeoutSuite.scala
@@ -139,7 +139,7 @@ class ClientTimeoutSuite extends Http4sSuite with DispatcherIOFixture {
           .map(_ => "1".toByte)
           .take(4)
           .onFinalizeWeak[IO](d.complete(()).void)
-      req = Request(method = Method.POST, uri = www_foo_com, body = body)
+      req = Request(method = Method.POST, uri = www_foo_com, entity = Entity(body))
       tail = mkConnection(
         RequestKey.fromRequest(req),
         tickWheel,
@@ -165,7 +165,7 @@ class ClientTimeoutSuite extends Http4sSuite with DispatcherIOFixture {
           .take(n.toLong)
       }
 
-      val req = Request[IO](method = Method.POST, uri = www_foo_com, body = dataStream(4))
+      val req = Request[IO](method = Method.POST, uri = www_foo_com, entity = Entity(dataStream(4)))
 
       val tail =
         mkConnection(RequestKey.fromRequest(req), tickWheel, dispatcher, idleTimeout = 10.seconds)

--- a/blaze-core/src/main/scala/org/http4s/blazecore/IdleTimeoutStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/IdleTimeoutStage.scala
@@ -147,9 +147,7 @@ object IdleTimeoutStage {
 
   sealed trait State
   case object Disabled extends State
-  // scalafix:off Http4sGeneralLinters; bincompat until 1.0
   final case class Enabled(timeoutTask: Runnable, cancel: Cancelable) extends State
-  // scalafix:on
   case object ShutDown extends State
 
 }

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerParser.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerParser.scala
@@ -73,7 +73,7 @@ private[http4s] final class Http1ServerParser[F[_]](
       .fromString(this.method)
       .flatMap { method =>
         Uri.requestTarget(this.uri).map { uri =>
-          Request(method, uri, protocol, h, body, attrsWithTrailers)
+          Request(method, uri, protocol, h, Entity(body), attrsWithTrailers)
         }
       }
       .leftMap(_ -> protocol)

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
@@ -234,7 +234,7 @@ private class Http2NodeStage[F[_]](
     else {
       val body = if (endStream) EmptyBody else getBody(contentLength)
       val hs = Headers(headers.result())
-      val req = Request(method, path, HttpVersion.`HTTP/2`, hs, body, attributes())
+      val req = Request(method, path, HttpVersion.`HTTP/2`, hs, Entity(body), attributes())
       executionContext.execute(new Runnable {
         def run(): Unit = {
           val action = F

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
@@ -278,7 +278,7 @@ class Http1ServerStageSpec extends Http4sSuite {
   fixture.test("Http1ServerStage: routes should Add a date header") { tw =>
     val routes = HttpRoutes
       .of[IO] { case req =>
-        IO.pure(Response(body = req.body))
+        IO.pure(Response(entity = req.entity))
       }
       .orNotFound
 
@@ -296,7 +296,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     val dateHeader = Date(HttpDate.Epoch)
     val routes = HttpRoutes
       .of[IO] { case req =>
-        IO.pure(Response(body = req.body).withHeaders(dateHeader))
+        IO.pure(Response(entity = req.entity).withHeaders(dateHeader))
       }
       .orNotFound
 
@@ -317,7 +317,7 @@ class Http1ServerStageSpec extends Http4sSuite {
   ) { tw =>
     val routes = HttpRoutes
       .of[IO] { case req =>
-        IO.pure(Response(body = req.body))
+        IO.pure(Response(entity = req.entity))
       }
       .orNotFound
 
@@ -445,7 +445,7 @@ class Http1ServerStageSpec extends Http4sSuite {
     tw =>
       val routes = HttpRoutes
         .of[IO] { case req =>
-          IO.pure(Response(body = req.body))
+          IO.pure(Response(entity = req.entity))
         }
         .orNotFound
 
@@ -471,7 +471,7 @@ class Http1ServerStageSpec extends Http4sSuite {
   ) { tw =>
     val routes = HttpRoutes
       .of[IO] { case req =>
-        IO.pure(Response(body = req.body))
+        IO.pure(Response(entity = req.entity))
       }
       .orNotFound
 

--- a/build.sbt
+++ b/build.sbt
@@ -388,7 +388,7 @@ lazy val client = libraryCrossProject("client")
   .jvmSettings(
     libraryDependencies ++= Seq(
       nettyBuffer % Test,
-      nettyCodecHttp % Test
+      nettyCodecHttp % Test,
     )
   )
   .dependsOn(core, server, testing % "test->test", theDsl % "test->compile")

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -206,9 +206,11 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     (for {
       stream <- streamJsonArrayDecoder[IO].decode(
         Media(
-          Stream.fromIterator[IO](
-            """[{"test1":"CirceSupport"},{"test2":"CirceSupport"}]""".getBytes.iterator,
-            128,
+          Entity(
+            Stream.fromIterator[IO](
+              """[{"test1":"CirceSupport"},{"test2":"CirceSupport"}]""".getBytes.iterator,
+              128,
+            )
           ),
           Headers("content-type" -> "application/json"),
         ),
@@ -232,9 +234,11 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   ) {
     val result = streamJsonArrayDecoder[IO].decode(
       Media(
-        Stream.fromIterator[IO](
-          """[{"test1":"CirceSupport"},{"test2":"CirceSupport"}]""".getBytes.iterator,
-          128,
+        Entity(
+          Stream.fromIterator[IO](
+            """[{"test1":"CirceSupport"},{"test2":"CirceSupport"}]""".getBytes.iterator,
+            128,
+          )
         ),
         Headers.empty,
       ),
@@ -246,9 +250,11 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   test("stream json array decoder should not fail on improper JSON") {
     val result = streamJsonArrayDecoder[IO].decode(
       Media(
-        Stream.fromIterator[IO](
-          """[{"test1":"CirceSupport"},{"test2":CirceSupport"}]""".getBytes.iterator,
-          128,
+        Entity(
+          Stream.fromIterator[IO](
+            """[{"test1":"CirceSupport"},{"test2":CirceSupport"}]""".getBytes.iterator,
+            128,
+          )
         ),
         Headers("content-type" -> "application/json"),
       ),
@@ -261,9 +267,11 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     (for {
       stream <- streamJsonArrayDecoder[IO].decode(
         Media(
-          Stream.fromIterator[IO](
-            """[{"test1":"CirceSupport"},{"test2":CirceSupport"}]""".getBytes.iterator,
-            128,
+          Entity(
+            Stream.fromIterator[IO](
+              """[{"test1":"CirceSupport"},{"test2":CirceSupport"}]""".getBytes.iterator,
+              128,
+            )
           ),
           Headers("content-type" -> "application/json"),
         ),

--- a/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
+++ b/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
@@ -152,7 +152,7 @@ sealed abstract class JavaNetClientBuilder[F[_]] private (
             .toList
         )
       )
-    } yield Response(status = status, headers = headers, body = readBody(conn))
+    } yield Response(status = status, headers = headers, entity = Entity(readBody(conn)))
 
   private def timeoutMillis(d: Duration): Int =
     d match {

--- a/client/jvm/src/test/scala/org/http4s/client/scaffold/RoutesToNettyAdapter.scala
+++ b/client/jvm/src/test/scala/org/http4s/client/scaffold/RoutesToNettyAdapter.scala
@@ -29,6 +29,7 @@ import io.netty.channel.ChannelInboundHandler
 import io.netty.handler.codec.http.HttpResponseStatus._
 import io.netty.handler.codec.http._
 import org.http4s
+import org.http4s.Entity
 import org.http4s.Headers
 import org.http4s.HttpRoutes
 import org.http4s.Method
@@ -74,7 +75,7 @@ class RoutesToHandlerAdapter[F[_]](
         bodyQueue <- Queue.unbounded[F, Option[Chunk[Byte]]]
         _ <- requestBodyQueue.set(bodyQueue)
         body = fs2.Stream.fromQueueNoneTerminatedChunk(bodyQueue)
-        http4sRequest = http4s.Request(method, uri, headers = headers, body = body)
+        http4sRequest = http4s.Request(method, uri, headers = headers, entity = Entity(body))
         _ <- processRequest(ctx, http4sRequest).start
       } yield ()
     )

--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -225,7 +225,7 @@ object Client {
           Resource
             .eval(app(req0))
             .flatTap(_ => Resource.make(F.unit)(_ => disposed.set(true)))
-            .map(resp => resp.copy(body = go(resp.body).stream))
+            .map(resp => resp.copy(entity = Entity(go(resp.body).stream)))
         }
       }
     }

--- a/client/shared/src/main/scala/org/http4s/client/Http4sClientDsl.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Http4sClientDsl.scala
@@ -53,6 +53,6 @@ class MethodOps[F[_]](private val method: Method) extends AnyVal {
         `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
       }
       .getOrElse(h)
-    Request(method = method, uri = uri, headers = newHeaders, body = entity.body)
+    Request(method = method, uri = uri, headers = newHeaders, entity = entity)
   }
 }

--- a/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -83,10 +83,12 @@ object ResponseLogger {
             Ref[F].of(Vector.empty[Chunk[Byte]]).map { vec =>
               Resource.make(
                 F.pure(
-                  response.copy(body =
-                    response.body
-                      // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
-                      .observe(_.chunks.flatMap(s => Stream.exec(vec.update(_ :+ s))))
+                  response.copy(entity =
+                    Entity(
+                      response.body
+                        // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+                        .observe(_.chunks.flatMap(s => Stream.exec(vec.update(_ :+ s))))
+                    )
                   )
                 )
               ) { _ =>

--- a/core/shared/src/main/scala/org/http4s/Entity.scala
+++ b/core/shared/src/main/scala/org/http4s/Entity.scala
@@ -20,14 +20,11 @@ import cats.Monoid
 import cats.syntax.all._
 import cats.~>
 
-final case class Entity[+F[_]](body: EntityBody[F], length: Option[Long] = None)
+final case class Entity[+F[_]](body: EntityBody[F], length: Option[Long] = None) {
+  def translate[F1[x] >: F[x], G[_]](fk: F1 ~> G): Entity[G] = Entity(body.translate(fk), length)
+}
 
 object Entity {
-  implicit class InvariantOps[F[_]](private val self: Entity[F]) extends AnyVal {
-    import self._
-
-    def translate[G[_]](fk: F ~> G): Entity[G] = Entity(body.translate(fk), length)
-  }
 
   implicit def http4sMonoidForEntity[F[_]]: Monoid[Entity[F]] =
     new Monoid[Entity[F]] {

--- a/core/shared/src/main/scala/org/http4s/Entity.scala
+++ b/core/shared/src/main/scala/org/http4s/Entity.scala
@@ -18,10 +18,17 @@ package org.http4s
 
 import cats.Monoid
 import cats.syntax.all._
+import cats.~>
 
 final case class Entity[+F[_]](body: EntityBody[F], length: Option[Long] = None)
 
 object Entity {
+  implicit class InvariantOps[F[_]](private val self: Entity[F]) extends AnyVal {
+    import self._
+
+    def translate[G[_]](fk: F ~> G): Entity[G] = Entity(body.translate(fk), length)
+  }
+
   implicit def http4sMonoidForEntity[F[_]]: Monoid[Entity[F]] =
     new Monoid[Entity[F]] {
       def combine(a1: Entity[F], a2: Entity[F]): Entity[F] =

--- a/core/shared/src/main/scala/org/http4s/Media.scala
+++ b/core/shared/src/main/scala/org/http4s/Media.scala
@@ -24,7 +24,9 @@ import org.http4s.Charset.`UTF-8`
 import org.http4s.headers._
 
 trait Media[F[_]] {
-  def body: EntityBody[F]
+
+  def entity: Entity[F]
+  final def body: EntityBody[F] = entity.body
   def headers: Headers
   def covary[F2[x] >: F[x]]: Media[F2]
 
@@ -69,9 +71,9 @@ trait Media[F[_]] {
 }
 
 object Media {
-  def apply[F[_]](b: EntityBody[F], h: Headers): Media[F] =
+  def apply[F[_]](e: Entity[F], h: Headers): Media[F] =
     new Media[F] {
-      def body = b
+      def entity = e
 
       def headers: Headers = h
 

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -49,12 +49,6 @@ sealed trait Message[F[_]] extends Media[F] { self =>
 
   def httpVersion: HttpVersion
 
-  def headers: Headers
-
-  def entity: Entity[F]
-
-  final def body: EntityBody[F] = entity.body
-
   def attributes: Vault
 
   protected def change(

--- a/core/shared/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/shared/src/main/scala/org/http4s/StaticFile.scala
@@ -123,7 +123,7 @@ object StaticFile {
                 Some(
                   Response(
                     headers = headers,
-                    body = readInputStream[F](F.pure(inputStream), DefaultBufferSize),
+                    entity = Entity(readInputStream[F](F.pure(inputStream), DefaultBufferSize)),
                   )
                 )
               },
@@ -211,7 +211,7 @@ object StaticFile {
 
                   val r = Response(
                     headers = hs,
-                    body = body,
+                    entity = Entity(body),
                     attributes = Vault.empty.insert(staticPathKey, f),
                   )
 

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -88,7 +88,7 @@ trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   ): F[Response[G]] = {
     val h = w.headers |+| Headers(headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), entity = entity))
   }
 }
 
@@ -108,7 +108,7 @@ trait LocationResponseGenerator[F[_], G[_]] extends Any with EntityResponseGener
   ): F[Response[G]] = {
     val h = w.headers |+| Headers(location, headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), entity = entity))
   }
 }
 
@@ -132,7 +132,7 @@ trait WwwAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGene
   ): F[Response[G]] = {
     val h = w.headers |+| Headers(authenticate, headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), entity = entity))
   }
 }
 
@@ -152,7 +152,7 @@ trait AllowResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   ): F[Response[G]] = {
     val h = w.headers |+| Headers(allow, headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), entity = entity))
   }
 }
 
@@ -176,6 +176,6 @@ trait ProxyAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGe
   ): F[Response[G]] = {
     val h = w.headers |+| Headers(authenticate, headers.toList)
     val entity = w.toEntity(body)
-    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
+    F.pure(Response[G](status = status, headers = addEntityLength(entity, h), entity = entity))
   }
 }

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
@@ -73,7 +73,7 @@ object EmberClientSimpleExample extends IOApp {
       .use(resp =>
         resp.body.compile
           .to(ByteVector)
-          .map(bv => resp.copy(body = Stream.chunk(Chunk.byteVector(bv))))
+          .map(bv => resp.copy(entity = Entity(Stream.chunk(Chunk.byteVector(bv)))))
       )
 
   def logTimed[F[_]: Temporal, A](logger: Logger[F], name: String, fa: F[A]): F[A] =

--- a/jetty-client/src/main/scala/org/http4s/jetty/client/ResponseListener.scala
+++ b/jetty-client/src/main/scala/org/http4s/jetty/client/ResponseListener.scala
@@ -56,14 +56,14 @@ private[jetty] final case class ResponseListener[F[_]](
             status = s,
             httpVersion = getHttpVersion(response.getVersion),
             headers = getHeaders(response.getHeaders),
-            body = Stream.fromQueueNoneTerminated(queue).repeatPull {
+            entity = Entity(Stream.fromQueueNoneTerminated(queue).repeatPull {
               _.uncons1.flatMap {
                 case None => Pull.pure(None)
                 case Some((Item.Done, _)) => Pull.pure(None)
                 case Some((Item.Buf(b), tl)) => Pull.output(Chunk.byteBuffer(b)).as(Some(tl))
                 case Some((Item.Raise(t), _)) => Pull.raiseError[F](t)
               }
-            },
+            }),
           )
         )
       }

--- a/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
+++ b/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
@@ -29,7 +29,7 @@ trait EntityCodecLaws[F[_], A] extends EntityEncoderLaws[F, A] {
   def entityCodecRoundTrip(a: A): IsEq[F[Either[DecodeFailure, A]]] =
     (for {
       entity <- F.pure(encoder.toEntity(a))
-      message = Request(body = entity.body, headers = encoder.headers)
+      message = Request(entity = entity, headers = encoder.headers)
       a0 <- decoder.decode(message, strict = true).value
     } yield a0) <-> F.pure(Right(a))
 }

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -973,7 +973,7 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
         httpVersion <- getArbitrary[HttpVersion]
         headers <- getArbitrary[Headers]
         body <- http4sTestingGenForPureByteStream
-      } yield try Request(method, uri, httpVersion, headers, body)
+      } yield try Request(method, uri, httpVersion, headers, Entity(body))
       catch {
         case t: Throwable => t.printStackTrace(); throw t
       }
@@ -999,7 +999,7 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
         httpVersion <- getArbitrary[HttpVersion]
         headers <- getArbitrary[Headers]
         body <- http4sTestingGenForPureByteStream
-      } yield Response(status, httpVersion, headers, body)
+      } yield Response(status, httpVersion, headers, Entity(body))
     }
 
   implicit val http4sTestingArbitraryForSegment: Arbitrary[Uri.Path.Segment] =

--- a/node-serverless/src/main/scala/org/http4s/node/serverless/ServerlessApp.scala
+++ b/node-serverless/src/main/scala/org/http4s/node/serverless/ServerlessApp.scala
@@ -73,7 +73,7 @@ object ServerlessApp {
       uri <- F.fromEither(Uri.fromString(req.url))
       headers = Headers(req.headers.toList)
       body = Stream.resource(io.suspendReadableAndRead()(req)).flatMap(_._2)
-      request = Request(method, uri, headers = headers, body = body)
+      request = Request(method, uri, headers = headers, entity = Entity(body))
       response <- app.run(request)
       _ <- F.delay {
         val headers = response.headers.headers

--- a/okhttp-client/src/main/scala/org/http4s/okhttp/client/OkHttpBuilder.scala
+++ b/okhttp-client/src/main/scala/org/http4s/okhttp/client/OkHttpBuilder.scala
@@ -112,7 +112,7 @@ sealed abstract class OkHttpBuilder[F[_]] private (
                     status = s,
                     headers = getHeaders(response),
                     httpVersion = protocol,
-                    body = body,
+                    entity = Entity(body),
                   ),
                   dispose,
                 )

--- a/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -79,17 +79,19 @@ object GZip {
     resp
       .removeHeader[`Content-Length`]
       .putHeaders(`Content-Encoding`(ContentCoding.gzip))
-      .copy(body =
-        resp.body.through(
-          Compression[F].gzip(
-            fileName = None,
-            modificationTime = None,
-            comment = None,
-            DeflateParams(
-              bufferSize = bufferSize,
-              level = level,
-              header = ZLibParams.Header.GZIP,
-            ),
+      .copy(entity =
+        Entity(
+          resp.body.through(
+            Compression[F].gzip(
+              fileName = None,
+              modificationTime = None,
+              comment = None,
+              DeflateParams(
+                bufferSize = bufferSize,
+                level = level,
+                header = ZLibParams.Header.GZIP,
+              ),
+            )
           )
         )
       )

--- a/server/shared/src/main/scala/org/http4s/server/middleware/BracketRequestResponse.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/BracketRequestResponse.scala
@@ -125,9 +125,10 @@ object BracketRequestResponse {
             bracketRoutes(contextRequest)
               .foldF(release(contextRequest.context, None, Outcome.succeeded(F.unit)) *> F.pure(
                 None: Option[Response[F]]))(contextResponse =>
-                F.pure(Some(contextResponse.response.copy(body =
+                F.pure(Some(contextResponse.response.copy(entity = Entity(
                   contextResponse.response.body.onFinalizeCaseWeak(ec =>
                     release(contextRequest.context, Some(contextResponse.context), exitCaseToOutcome(ec)))))))
+                )
               .guaranteeCase {
                   case Outcome.Succeeded(_) =>
                     F.unit
@@ -185,8 +186,10 @@ object BracketRequestResponse {
           contextService
             .run(ContextRequest(a, request))
             .map(response =>
-              response.copy(body =
-                response.body.onFinalizeCaseWeak(ec => release(a, exitCaseToOutcome(ec)))
+              response.copy(entity =
+                Entity(
+                  response.body.onFinalizeCaseWeak(ec => release(a, exitCaseToOutcome(ec)))
+                )
               )
             )
             .guaranteeCase {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -47,5 +47,5 @@ object DefaultHead {
     apply(httpRoutes)
 
   private[this] def drainBody[G[_]: Concurrent](response: Response[G]): Response[G] =
-    response.copy(body = response.body.interruptWhen[G](Stream(true)).drain)
+    response.copy(entity = Entity(response.body.interruptWhen[G](Stream(true)).drain))
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -71,7 +71,7 @@ object Jsonp {
       old.modify(_ + begin.size + end.size)
     }
     resp
-      .copy(body = jsonpBody)
+      .copy(entity = Entity(jsonpBody))
       .transformHeaders(_ ++ Headers(newLengthHeaderOption))
       .withContentType(`Content-Type`(MediaType.application.javascript))
   }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/PushSupport.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/PushSupport.scala
@@ -50,7 +50,7 @@ object PushSupport {
         .getOrElse(Vector(PushLocation(newUrl, cascade)))
 
       response.copy(
-        body = response.body,
+        entity = response.entity,
         attributes = response.attributes.insert(PushSupport.pushLocationKey, newPushResouces),
       )
     }
@@ -100,8 +100,7 @@ object PushSupport {
         .map { fresource =>
           val collected = collectResponse(fresource, req, verify, routes)
           resp.copy(
-            body = resp.body,
-            attributes = resp.attributes.insert(pushResponsesKey[F], collected),
+            attributes = resp.attributes.insert(pushResponsesKey[F], collected)
           )
         }
         .getOrElse(resp)

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -90,12 +90,14 @@ object ResponseLogger {
                   .flatMap(c => Stream.chunk(c).covary[F])
 
                 response.copy(
-                  body = response.body
-                    // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
-                    .observe(_.chunks.flatMap(c => Stream.exec(vec.update(_ :+ c))))
-                    .onFinalizeWeak {
-                      logMessage(response.withBodyStream(newBody))
-                    }
+                  entity = Entity(
+                    response.body
+                      // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+                      .observe(_.chunks.flatMap(c => Stream.exec(vec.update(_ :+ c))))
+                      .onFinalizeWeak {
+                        logMessage(response.withBodyStream(newBody))
+                      }
+                  )
                 )
               }
           fk(out)

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/MemoryCache.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/MemoryCache.scala
@@ -58,7 +58,7 @@ class MemoryCache[F[_]] extends CacheStrategy[F] {
     resp
       .as[Chunk[Byte]]
       .map { chunk =>
-        val newResponse: Response[F] = resp.copy(body = Stream.chunk(chunk).covary[F])
+        val newResponse: Response[F] = resp.copy(entity = Entity(Stream.chunk(chunk)))
         cacheMap.put(path, newResponse)
         newResponse
       }

--- a/server/shared/src/test/scala/org/http4s/server/MockRoute.scala
+++ b/server/shared/src/test/scala/org/http4s/server/MockRoute.scala
@@ -31,7 +31,7 @@ object MockRoute {
         Response[IO](Ok).withEntity("pong").pure[IO]
 
       case req if req.method === Method.POST && req.uri.path === path"/echo" =>
-        IO.pure(Response[IO](body = req.body))
+        IO.pure(Response[IO](entity = req.entity))
 
       case req if req.uri.path === path"/withslash" =>
         IO.pure(Response(Ok))

--- a/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
@@ -22,6 +22,7 @@ import cats.effect._
 import cats.implicits._
 import fs2.Stream._
 import fs2._
+import org.http4s.Entity
 import org.http4s.Method._
 import org.http4s.Status._
 import org.http4s.server.middleware.EntityLimiter.EntityTooLarge
@@ -34,11 +35,11 @@ class EntityLimiterSuite extends Http4sSuite {
     case r if r.pathInfo == path"/echo" => r.decode[String](Response[IO](Ok).withEntity(_).pure[IO])
   }
 
-  val b = chunk(Chunk.array("hello".getBytes(StandardCharsets.UTF_8)))
+  val e = Entity(chunk(Chunk.array("hello".getBytes(StandardCharsets.UTF_8))))
 
   test("Allow reasonable entities") {
     EntityLimiter(routes, 100)
-      .apply(Request[IO](POST, uri"/echo", body = b))
+      .apply(Request[IO](POST, uri"/echo", entity = e))
       .map(_ => -1)
       .value
       .assertEquals(Some(-1))
@@ -46,7 +47,7 @@ class EntityLimiterSuite extends Http4sSuite {
 
   test("Limit the maximum size of an EntityBody") {
     EntityLimiter(routes, 3)
-      .apply(Request[IO](POST, uri"/echo", body = b))
+      .apply(Request[IO](POST, uri"/echo", entity = e))
       .map(_ => -1L)
       .value
       .handleError { case EntityTooLarge(i) => Some(i) }
@@ -61,11 +62,11 @@ class EntityLimiterSuite extends Http4sSuite {
 
     val st = EntityLimiter(routes, 3) <+> routes2
 
-    st.apply(Request[IO](POST, uri"/echo2", body = b))
+    st.apply(Request[IO](POST, uri"/echo2", entity = e))
       .map(_ => -1)
       .value
       .assertEquals(Some(-1)) *>
-      st.apply(Request[IO](POST, uri"/echo", body = b))
+      st.apply(Request[IO](POST, uri"/echo", entity = e))
         .map(_ => -1L)
         .value
         .handleError { case EntityTooLarge(i) => Some(i) }
@@ -75,7 +76,7 @@ class EntityLimiterSuite extends Http4sSuite {
   test("Be created via the httpRoutes constructor") {
     EntityLimiter
       .httpRoutes(routes, 3)
-      .apply(Request[IO](POST, uri"/echo", body = b))
+      .apply(Request[IO](POST, uri"/echo", entity = e))
       .map(_ => -1L)
       .value
       .handleError { case EntityTooLarge(i) => Some(i) }
@@ -87,7 +88,7 @@ class EntityLimiterSuite extends Http4sSuite {
 
     EntityLimiter
       .httpApp(app, 3L)
-      .apply(Request[IO](POST, uri"/echo", body = b))
+      .apply(Request[IO](POST, uri"/echo", entity = e))
       .map(_ => -1L)
       .handleError { case EntityTooLarge(i) => i }
       .assertEquals(3L)

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -109,7 +109,7 @@ abstract class Http4sServlet[F[_]](
       uri = uri,
       httpVersion = version,
       headers = toHeaders(req),
-      body = servletIo.reader(req),
+      entity = Entity(servletIo.reader(req)),
       attributes = Vault.empty
         .insert(Request.Keys.PathInfoCaret, getPathInfoIndex(req, uri))
         .insert(

--- a/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -455,7 +455,7 @@ class EntityDecoderSuite extends Http4sSuite {
   test("binary EntityDecoder should concat Chunks") {
     val d1 = Array[Byte](1, 2, 3); val d2 = Array[Byte](4, 5, 6)
     val body = chunk(Chunk.array(d1)) ++ chunk(Chunk.array(d2))
-    val msg = Request[IO](body = body)
+    val msg = Request[IO](entity = Entity(body))
     val expected = Chunk.array(Array[Byte](1, 2, 3, 4, 5, 6))
     EntityDecoder.binary[IO].decode(msg, strict = false).value.assertEquals(Right(expected))
   }

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -181,7 +181,7 @@ I am a big moose
     test(s"Multipart form data $name should extract name properly if it is present") {
       val part = Part(
         Headers(`Content-Disposition`("form-data", Map(ci"name" -> "Rich Homie Quan"))),
-        Stream.empty.covary[IO],
+        Entity.empty,
       )
       assertEquals(part.name, Some("Rich Homie Quan"))
     }
@@ -191,7 +191,7 @@ I am a big moose
         Headers(
           `Content-Disposition`("form-data", Map(ci"name" -> "file", ci"filename" -> "file.txt"))
         ),
-        Stream.empty.covary[IO],
+        Entity.empty,
       )
       assertEquals(part.filename, Some("file.txt"))
     }
@@ -215,7 +215,7 @@ I am a big moose
   }
   multipartSpec("with mixed resource decoder")(EntityDecoder.mixedMultipartResource[IO]())
 
-  def testPart[F[_]] = Part[F](Headers.empty, EmptyBody)
+  def testPart[F[_]] = Part[F](Headers.empty, Entity.empty)
 
   test("Part.covary should disallow unrelated effects") {
     assert(

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -58,9 +58,8 @@ class MultipartSuite extends Http4sSuite {
       val field2 = Part.formData[IO]("field2", "Text_Field_2")
       val multipart = Multipart(Vector(field1, field2))
       val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
-      val body = entity.body
       val request =
-        Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
+        Request(method = Method.POST, uri = url, entity = entity, headers = multipart.headers)
 
       mkDecoder.use { decoder =>
         val decoded = decoder.decode(request, true)
@@ -75,9 +74,8 @@ class MultipartSuite extends Http4sSuite {
       val multipart = Multipart[IO](Vector(field1))
 
       val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
-      val body = entity.body
       val request =
-        Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
+        Request(method = Method.POST, uri = url, entity = entity, headers = multipart.headers)
 
       mkDecoder.use { decoder =>
         val decoded = decoder.decode(request, true)
@@ -97,9 +95,8 @@ class MultipartSuite extends Http4sSuite {
       val multipart = Multipart[IO](Vector(field1, field2))
 
       val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
-      val body = entity.body
       val request =
-        Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
+        Request(method = Method.POST, uri = url, entity = entity, headers = multipart.headers)
 
       mkDecoder.use { decoder =>
         val decoded = decoder.decode(request, true)
@@ -136,7 +133,7 @@ Content-Type: application/pdf
       val request = Request[IO](
         method = Method.POST,
         uri = url,
-        body = Stream.emit(body).covary[IO].through(text.utf8.encode),
+        entity = Entity(Stream.emit(body).covary[IO].through(text.utf8.encode)),
         headers = header,
       )
 
@@ -169,7 +166,7 @@ I am a big moose
       val request = Request[IO](
         method = Method.POST,
         uri = url,
-        body = Stream.emit(body).through(text.utf8.encode),
+        entity = Entity(Stream.emit(body).through(text.utf8.encode)),
         headers = header,
       )
 


### PR DESCRIPTION
I've taken the liberty of slicing part of #4509 into a standalone PR to try and get the ball rolling again. This slice just changes `Message` to use `Entity` instead of `EntityBody` without actually making `Entity` more opinionated - so it doesn't yet provide any benefits, but it's a more manageable diff that lays groundwork for converting `Entity` to an ADT in subsequent slices. 