### PR TITLE
Remove jvm log4cats dependency in ember client js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -386,7 +386,7 @@ lazy val client = libraryCrossProject("client")
       nettyCodecHttp % Test
     )
   )
-  .dependsOn(core, server, testing % "test->test", theDsl % "test->compile")
+  .dependsOn(core, server % "test", testing % "test->test", theDsl % "test->compile")
   .jsConfigure(_.dependsOn(nodeServerless % Test))
 
 lazy val dropwizardMetrics = libraryProject("dropwizard-metrics")
@@ -504,7 +504,6 @@ lazy val emberClient = libraryCrossProject("ember-client")
     startYear := Some(2019),
     libraryDependencies ++= Seq(
       keypool.value,
-      log4catsSlf4j,
     ),
     mimaBinaryIssueFilters := Seq(
       ProblemFilters

--- a/build.sbt
+++ b/build.sbt
@@ -383,10 +383,10 @@ lazy val client = libraryCrossProject("client")
   .jvmSettings(
     libraryDependencies ++= Seq(
       nettyBuffer % Test,
-      nettyCodecHttp % Test
+      nettyCodecHttp % Test,
     )
   )
-  .dependsOn(core, server % "test", testing % "test->test", theDsl % "test->compile")
+  .dependsOn(core, server % Test, testing % "test->test", theDsl % "test->compile")
   .jsConfigure(_.dependsOn(nodeServerless % Test))
 
 lazy val dropwizardMetrics = libraryProject("dropwizard-metrics")
@@ -503,7 +503,7 @@ lazy val emberClient = libraryCrossProject("ember-client")
     description := "ember implementation for http4s clients",
     startYear := Some(2019),
     libraryDependencies ++= Seq(
-      keypool.value,
+      keypool.value
     ),
     mimaBinaryIssueFilters := Seq(
       ProblemFilters

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -292,7 +292,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val jnrUnixSocket = "com.github.jnr" % "jnr-unixsocket" % V.jnrUnixSocket
   lazy val keypool = Def.setting("org.typelevel" %%% "keypool" % V.keypool)
   lazy val literally = Def.setting("org.typelevel" %%% "literally" % V.literally)
-  lazy val log4catsCore = "org.typelevel" %% "log4cats-core" % V.log4cats
+  lazy val log4catsCore = Def.setting("org.typelevel" %% "log4cats-core" % V.log4cats)
   lazy val log4catsNoop = Def.setting("org.typelevel" %%% "log4cats-noop" % V.log4cats)
   lazy val log4catsSlf4j = "org.typelevel" %% "log4cats-slf4j" % V.log4cats
   lazy val log4catsTesting = Def.setting("org.typelevel" %%% "log4cats-testing" % V.log4cats)

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -292,7 +292,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val jnrUnixSocket = "com.github.jnr" % "jnr-unixsocket" % V.jnrUnixSocket
   lazy val keypool = Def.setting("org.typelevel" %%% "keypool" % V.keypool)
   lazy val literally = Def.setting("org.typelevel" %%% "literally" % V.literally)
-  lazy val log4catsCore = Def.setting("org.typelevel" %% "log4cats-core" % V.log4cats)
+  lazy val log4catsCore = Def.setting("org.typelevel" %%% "log4cats-core" % V.log4cats)
   lazy val log4catsNoop = Def.setting("org.typelevel" %%% "log4cats-noop" % V.log4cats)
   lazy val log4catsSlf4j = "org.typelevel" %% "log4cats-slf4j" % V.log4cats
   lazy val log4catsTesting = Def.setting("org.typelevel" %%% "log4cats-testing" % V.log4cats)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("org.planet42" % "laika-sbt" % "0.18.1")
 // TODO remove me after we get this transitively
 // https://github.com/djspiewak/sbt-github-actions/issues/94
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.14.2")
+
+addDependencyTreePlugin


### PR DESCRIPTION
Also removes the dependency on `server` in `client`, limiting to tests only.