### PR TITLE
Collection micro-opts

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingChunkWriter.scala
@@ -56,7 +56,7 @@ private[http4s] class CachingChunkWriter[F[_]](
     size = 0
   }
 
-  private def toChunk: Chunk[Byte] = Chunk.concatBytes(bodyBuffer.toSeq)
+  private def toChunk: Chunk[Byte] = Chunk.concatBytes(bodyBuffer)
 
   override protected def exceptionFlush(): Future[Unit] = {
     val c = toChunk

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingStaticWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/CachingStaticWriter.scala
@@ -49,7 +49,7 @@ private[http4s] class CachingStaticWriter[F[_]](
     ()
   }
 
-  private def toChunk: Chunk[Byte] = Chunk.concatBytes(bodyBuffer.toSeq)
+  private def toChunk: Chunk[Byte] = Chunk.concatBytes(bodyBuffer)
 
   private def clear(): Unit = bodyBuffer.clear()
 

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/DumpingWriter.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/DumpingWriter.scala
@@ -41,7 +41,7 @@ class DumpingWriter(implicit protected val F: Effect[IO]) extends EntityBodyWrit
 
   def toArray: Array[Byte] =
     buffer.synchronized {
-      Chunk.concatBytes(buffer.toSeq).toArray
+      Chunk.concatBytes(buffer).toArray
     }
 
   override protected def writeEnd(chunk: Chunk[Byte]): Future[Boolean] =

--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -49,7 +49,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
       else
         Ok()
     case _ @(Method.GET -> path) =>
-      GetRoutes.getPaths.get(path.toString).getOrElse(NotFound())
+      GetRoutes.getPaths.getOrElse(path.toString, NotFound())
     case req @ (Method.POST -> _) =>
       Ok(req.body)
   }

--- a/core/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/src/main/scala/org/http4s/ResponseCookie.scala
@@ -49,7 +49,7 @@ final case class ResponseCookie(
     domain.foreach(writer.append("; Domain=").append(_))
     path.foreach(writer.append("; Path=").append(_))
     sameSite.foreach(writer.append("; SameSite=").append(_))
-    if (secure || sameSite.exists(_ == SameSite.None)) writer.append("; Secure")
+    if (secure || sameSite.contains(SameSite.None)) writer.append("; Secure")
     if (httpOnly) writer.append("; HttpOnly")
     extension.foreach(writer.append("; ").append(_))
     writer

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -281,7 +281,7 @@ object UriTemplate {
   protected def renderFragment(f: Fragment): String = {
     val elements = new mutable.ArrayBuffer[String]()
     val expansions = new mutable.ArrayBuffer[String]()
-    f.map {
+    f.foreach {
       case FragmentElm(v) => elements.append(v)
       case SimpleFragmentExp(n) => expansions.append(n)
       case MultiFragmentExp(ns) => expansions.append(ns.mkString(","))
@@ -298,7 +298,7 @@ object UriTemplate {
 
   protected def renderFragmentIdentifier(f: Fragment): String = {
     val elements = new mutable.ArrayBuffer[String]()
-    f.map {
+    f.foreach {
       case FragmentElm(v) => elements.append(v)
       case SimpleFragmentExp(_) =>
         throw new IllegalStateException("SimpleFragmentExp cannot be converted to a Uri")

--- a/core/src/main/scala/org/http4s/UriTemplate.scala
+++ b/core/src/main/scala/org/http4s/UriTemplate.scala
@@ -314,7 +314,7 @@ object UriTemplate {
       case (elements, ParamElm(n, Nil)) => elements :+ (n -> None)
       case (elements, ParamElm(n, List(v))) => elements :+ (n -> Some(v))
       case (elements, ParamElm(n, vs)) =>
-        vs.toList.foldLeft(elements) { case (elements, v) => elements :+ (n -> Some(v)) }
+        vs.foldLeft(elements) { case (elements, v) => elements :+ (n -> Some(v)) }
       case u =>
         throw new IllegalStateException(s"${u.getClass.getName} cannot be converted to a Uri")
     }

--- a/core/src/main/scala/org/http4s/internal/parsing/Rfc3986.scala
+++ b/core/src/main/scala/org/http4s/internal/parsing/Rfc3986.scala
@@ -134,7 +134,7 @@ private[http4s] object Rfc3986 {
     }
 
     val fullIpv6WihtOptionalIpv4 = (h16Colon.repExactlyAs[List[Short]](6) ~ ls32)
-      .map { case (ls: List[Short], rs) => toIpv6(ls.toList, rs) }
+      .map { case (ls: List[Short], rs) => toIpv6(ls, rs) }
 
     val shortIpv6WithIpv4 = for {
       lefts <- h16.repSep0(0, 5, colon).with1 <* doubleColon

--- a/core/src/main/scala/org/http4s/multipart/Boundary.scala
+++ b/core/src/main/scala/org/http4s/multipart/Boundary.scala
@@ -38,7 +38,7 @@ object Boundary {
   // the boundary in the media type, which causes some implementations
   // pain.
   private val OTHER = """'()+_,-./:=""".toSeq
-  private val CHARS = (DIGIT ++ ALPHA ++ OTHER).toList
+  private val CHARS = (DIGIT ++ ALPHA ++ OTHER)
   private val nchars = CHARS.length
   private val rand = new Random()
 

--- a/core/src/main/scala/org/http4s/multipart/Boundary.scala
+++ b/core/src/main/scala/org/http4s/multipart/Boundary.scala
@@ -46,7 +46,7 @@ object Boundary {
   private def stream: CollectionCompat.LazyList[Char] =
     CollectionCompat.LazyList.continually(nextChar)
   // Don't use filterNot it works for 2.11.4 and nothing else, it will hang.
-  private def endChar: Char = stream.filter(_ != ' ').headOption.getOrElse('X')
+  private def endChar: Char = stream.find(_ != ' ').getOrElse('X')
   private def value(l: Int): String = stream.take(l).mkString
 
   def create: Boundary = Boundary(value(BoundaryLength) + endChar)

--- a/core/src/main/scala/org/http4s/multipart/Boundary.scala
+++ b/core/src/main/scala/org/http4s/multipart/Boundary.scala
@@ -38,7 +38,7 @@ object Boundary {
   // the boundary in the media type, which causes some implementations
   // pain.
   private val OTHER = """'()+_,-./:=""".toSeq
-  private val CHARS = (DIGIT ++ ALPHA ++ OTHER)
+  private val CHARS = DIGIT ++ ALPHA ++ OTHER
   private val nchars = CHARS.length
   private val rand = new Random()
 

--- a/core/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
+++ b/core/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
@@ -27,7 +27,7 @@ private[http4s] object FrameTranscoder {
     val data = new Array[Byte](in.remaining)
     in.get(data)
     if (mask != null) // We can use the charset decode
-      for (i <- 0 until data.length)
+      for (i <- data.indices)
         data(i) = (data(i) ^ mask(i & 0x3)).toByte // i mod 4 is the same as i & 0x3 but slower
     data
   }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -86,7 +86,7 @@ trait EntityResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
       F: Applicative[F],
       w: EntityEncoder[G, A],
   ): F[Response[G]] = {
-    val h = w.headers |+| Headers(headers.toList)
+    val h = w.headers |+| Headers(headers)
     val entity = w.toEntity(body)
     F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
   }
@@ -110,7 +110,7 @@ trait LocationResponseGenerator[F[_], G[_]] extends Any with EntityResponseGener
       F: Applicative[F],
       w: EntityEncoder[G, A],
   ): F[Response[G]] = {
-    val h = w.headers |+| Headers(location, headers.toList)
+    val h = w.headers |+| Headers(location, headers)
     val entity = w.toEntity(body)
     F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
   }
@@ -138,14 +138,14 @@ trait WwwAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGene
       F: Applicative[F]
   ): F[Response[G]] =
     F.pure(
-      Response[G](status, headers = Headers(`Content-Length`.zero, authenticate, headers.toList))
+      Response[G](status, headers = Headers(`Content-Length`.zero, authenticate, headers))
     )
 
   def apply[A](authenticate: `WWW-Authenticate`, body: A, headers: Header.ToRaw*)(implicit
       F: Applicative[F],
       w: EntityEncoder[G, A],
   ): F[Response[G]] = {
-    val h = w.headers |+| Headers(authenticate, headers.toList)
+    val h = w.headers |+| Headers(authenticate, headers)
     val entity = w.toEntity(body)
     F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
   }
@@ -159,13 +159,13 @@ trait WwwAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGene
   */
 trait AllowResponseGenerator[F[_], G[_]] extends Any with ResponseGenerator {
   def apply(allow: Allow, headers: Header.ToRaw*)(implicit F: Applicative[F]): F[Response[G]] =
-    F.pure(Response[G](status, headers = Headers(`Content-Length`.zero, allow, headers.toList)))
+    F.pure(Response[G](status, headers = Headers(`Content-Length`.zero, allow, headers)))
 
   def apply[A](allow: Allow, body: A, headers: Header.ToRaw*)(implicit
       F: Applicative[F],
       w: EntityEncoder[G, A],
   ): F[Response[G]] = {
-    val h = w.headers |+| Headers(allow, headers.toList)
+    val h = w.headers |+| Headers(allow, headers)
     val entity = w.toEntity(body)
     F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
   }
@@ -193,14 +193,14 @@ trait ProxyAuthenticateResponseGenerator[F[_], G[_]] extends Any with ResponseGe
       F: Applicative[F]
   ): F[Response[G]] =
     F.pure(
-      Response[G](status, headers = Headers(`Content-Length`.zero, authenticate, headers.toList))
+      Response[G](status, headers = Headers(`Content-Length`.zero, authenticate, headers))
     )
 
   def apply[A](authenticate: `Proxy-Authenticate`, body: A, headers: Header.ToRaw*)(implicit
       F: Applicative[F],
       w: EntityEncoder[G, A],
   ): F[Response[G]] = {
-    val h = w.headers |+| Headers(authenticate, headers.toList)
+    val h = w.headers |+| Headers(authenticate, headers)
     val entity = w.toEntity(body)
     F.pure(Response[G](status = status, headers = addEntityLength(entity, h), body = entity.body))
   }

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -30,7 +30,7 @@ object Http4sPlugin extends AutoPlugin {
   val scala_3 = "3.0.2"
 
   override lazy val globalSettings = Seq(
-    isCi := sys.env.get("CI").isDefined
+    isCi := sys.env.contains("CI")
   )
 
   override lazy val buildSettings = Seq(

--- a/project/MimeLoader.scala
+++ b/project/MimeLoader.scala
@@ -174,7 +174,7 @@ object MimeLoader {
       t <- Stream.emit(m.groupBy(_.mainType).toList.sortBy(_._1).map { case (t, l) =>
         toTree(t, s"${t.replaceAll("-", "_")}", mediaTypeClassName)(l)
       })
-      o <- Stream.emit(coalesce(t.toList, topLevelPackge, objectName, mediaTypeClassName))
+      o <- Stream.emit(coalesce(t, topLevelPackge, objectName, mediaTypeClassName))
       _ <- Stream.emit(treeToFile(f, o))
     } yield ()).compile.drain
 }

--- a/server/src/test/scala/org/http4s/server/middleware/HeaderEchoSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/HeaderEchoSuite.scala
@@ -41,7 +41,7 @@ class HeaderEchoSuite extends Http4sSuite {
       .map(_.headers)
       .map { responseHeaders =>
         responseHeaders.headers.exists(_.value === "someheadervalue") &&
-        responseHeaders.headers.toList.length === 3
+        responseHeaders.headers.length === 3
       }
   }
 
@@ -69,7 +69,7 @@ class HeaderEchoSuite extends Http4sSuite {
 
         responseHeaders.headers.exists(_.value === "someheadervalue") &&
         responseHeaders.headers.exists(_.value === "anotherheadervalue") &&
-        responseHeaders.headers.toList.length === 4
+        responseHeaders.headers.length === 4
       }
       .assert
   }
@@ -88,7 +88,7 @@ class HeaderEchoSuite extends Http4sSuite {
         val responseHeaders = r.headers
 
         !responseHeaders.headers.exists(_.value === "someunmatchedvalue") &&
-        responseHeaders.headers.toList.length === 2
+        responseHeaders.headers.length === 2
       }
       .assert
   }

--- a/server/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
@@ -45,7 +45,7 @@ class ThrottleSuite extends Http4sSuite {
       val takeFiveTokens: IO[List[TokenAvailability]] =
         (1 to 5).toList.traverse(_ => testee.takeToken)
       val checkTokensUpToCapacity =
-        takeFiveTokens.map(tokens => tokens.exists(_ == TokenAvailable))
+        takeFiveTokens.map(tokens => tokens.contains(TokenAvailable))
       (checkTokensUpToCapacity, testee.takeToken.map(_.isInstanceOf[TokenUnavailable]))
         .mapN(_ && _)
     }.assert

--- a/testing/src/test/scala/org/http4s/Http4sSuite.scala
+++ b/testing/src/test/scala/org/http4s/Http4sSuite.scala
@@ -54,7 +54,7 @@ trait Http4sSuite extends CatsEffectSuite with DisciplineSuite with munit.ScalaC
   val testBlocker: Blocker = Http4sSuite.TestBlocker
 
   // allow flaky tests on ci
-  override def munitFlakyOK = sys.env.get("CI").isDefined
+  override def munitFlakyOK = sys.env.contains("CI")
 
   implicit class ParseResultSyntax[A](self: ParseResult[A]) {
     def yolo: A = self.valueOr(e => sys.error(e.toString))

--- a/tests/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeadersSpec.scala
@@ -66,7 +66,7 @@ class HeadersSpec extends Http4sSuite {
     val h2 = `Set-Cookie`(ResponseCookie("foo2", "bar2"))
     val hs = Headers(clength) ++ Headers(h1, h2)
     assertEquals(hs.headers.count(_.name == `Set-Cookie`.name), 2)
-    assertEquals(hs.headers.exists(_ == clength.toRaw1), true)
+    assertEquals(hs.headers.contains(clength.toRaw1), true)
   }
 
   // TODO this isn't really "raw headers" anymore

--- a/tests/src/test/scala/org/http4s/headers/ZipkinHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/ZipkinHeaderSuite.scala
@@ -55,8 +55,8 @@ class ZipkinHeaderSuite extends Http4sSuite with HeaderLaws {
     val sampledAndDebugFlag = "5"
     val result = `X-B3-Flags`.parse(sampledAndDebugFlag)
     assert(result.isRight)
-    assert(result.valueOr(throw _).flags.exists(_ == Flag.Sampled))
-    assert(result.valueOr(throw _).flags.exists(_ == Flag.Debug))
+    assert(result.valueOr(throw _).flags.contains(Flag.Sampled))
+    assert(result.valueOr(throw _).flags.contains(Flag.Debug))
   }
 
   test("flags renders when no flags") {

--- a/tests/src/test/scala/org/http4s/websocket/WebSocketHandshakeSuite.scala
+++ b/tests/src/test/scala/org/http4s/websocket/WebSocketHandshakeSuite.scala
@@ -23,9 +23,7 @@ class WebSocketHandshakeSpec extends Http4sSuite {
   test("WebSocketHandshake should Be able to split multi value header keys") {
     val totalValue = "keep-alive, Upgrade"
     val values = List("upgrade", "Upgrade", "keep-alive", "Keep-alive")
-    assert(values.foldLeft(true) { (b, v) =>
-      b && WebSocketHandshake.valueContains(v, totalValue)
-    })
+    assert(values.forall(v => WebSocketHandshake.valueContains(v, totalValue)))
   }
 
   test("WebSocketHandshake should Do a round trip") {


### PR DESCRIPTION
This brings some micro-optimizations of using collections, such as:
* using the `contains` instead of `exists(_ == foo)`;
* using the `getOrElse(foo, bar)` instead of `get().getOrElse()`;
* using the `find` instead of `filter().headOption()`;
* removing the redundant collections conversions;
* and little others.