### PR TITLE
Promote http4s.js a bit

### DIFF
--- a/project/SiteConfig.scala
+++ b/project/SiteConfig.scala
@@ -56,7 +56,7 @@ object SiteConfig {
       ),
       Teaser(
         "Cross-platform",
-        "http4s cross-builds for Scala.js. Share code across browser and electron clients, serverless functions, and JVM servers."
+        "http4s cross-builds for Scala.js, enabling you to share code across browser and electron clients, serverless functions, and JVM servers."
       ),
     )
 

--- a/project/SiteConfig.scala
+++ b/project/SiteConfig.scala
@@ -54,6 +54,10 @@ object SiteConfig {
         "Streaming",
         "http4s is built on FS2, a streaming library that provides for processing and emitting large payloads in constant space and implementing websockets.",
       ),
+      Teaser(
+        "Cross-platform",
+        "http4s cross-builds for Scala.js. Share code across browser and electron clients, serverless functions, and JVM servers."
+      ),
     )
 
     val projectLinks: Seq[TextLink] = Seq(

--- a/project/SiteConfig.scala
+++ b/project/SiteConfig.scala
@@ -56,7 +56,7 @@ object SiteConfig {
       ),
       Teaser(
         "Cross-platform",
-        "http4s cross-builds for Scala.js, enabling you to share code across browser and electron clients, serverless functions, and JVM servers."
+        "http4s cross-builds for Scala.js, enabling you to share code across browsers, Node.js apps, serverless functions, and JVM servers."
       ),
     )
 

--- a/website/src/hugo/content/default.template.html
+++ b/website/src/hugo/content/default.template.html
@@ -72,7 +72,9 @@
         <li class="level2"><a href="https://http4s.org/">http4s</a></li>
         <li class="level2"><a href="https://github.com/http4s/blaze">blaze</a></li>
         <li class="level2"><a href="https://jdk-http-client.http4s.org/">http4s-jdk-http-client</a></li>
+        <li class="level2"><a href="https://http4s.github.io/http4s-dom">http4s-dom</a></li>
         <li class="level2"><a href="https://github.com/http4s/rho">rho</a></li>
+        <li class="level2"><a href="https://github.com/typelevel/feral">feral</a></li>
       </ul>
       <!-- custom end -->
       

--- a/website/src/hugo/content/versions.md
+++ b/website/src/hugo/content/versions.md
@@ -17,7 +17,7 @@
 * _I'll upgrade to Scala 3 before Cats-Effect 3:_ ${version.http4s.latest.0.22}
 * _I'm ready for Cats-Effect 3:_ ${version.http4s.latest.0.23}
 * _I'm new here, pick one:_ ${version.http4s.latest.0.23}
-* _I'm using Scala.js serverless or in the [browser](https://http4s.github.io/http4s-dom):_ ${version.http4s.latest.0.23}
+* _I'm using Scala.js [serverless](https://github.com/typelevel/feral) or in the [browser](https://http4s.github.io/http4s-dom):_ ${version.http4s.latest.0.23}
 * _I live on the bleeding edge:_ ${version.http4s.latest.1.0}
 
 

--- a/website/src/hugo/static/templates/no-page-nav.template.html
+++ b/website/src/hugo/static/templates/no-page-nav.template.html
@@ -74,6 +74,7 @@
         <li class="level2"><a href="https://jdk-http-client.http4s.org/">http4s-jdk-http-client</a></li>
         <li class="level2"><a href="https://http4s.github.io/http4s-dom">http4s-dom</a></li>
         <li class="level2"><a href="https://github.com/http4s/rho">rho</a></li>
+        <li class="level2"><a href="https://github.com/typelevel/feral">feral</a></li>
       </ul>
       <!-- custom end -->
       


### PR DESCRIPTION
Now that [feral](https://github.com/typelevel/feral) is released, we have interesting http4s.js offerings for both browser clients and serverless backends. This sneaks a couple links to feral into the site, as well as teases cross-platform capabilities on the landing page.

![Screen Shot 2021-12-21 at 3 23 34 PM](https://user-images.githubusercontent.com/3119428/146993000-805bfd95-eeea-4e53-809d-09a6ecfd9c8b.png)