### PR TITLE
Make the output of `asCurl` more human-readable

### DIFF
--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -337,7 +337,8 @@ final class Request[F[_]] private (
 
   /** cURL representation of the request.
     *
-    * Supported cURL-Parameters are: -X, -H
+    * Supported cURL-Parameters are: --request, --url, --header.
+    * Note that `asCurl` will not print the request body.
     */
   def asCurl(redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains): String =
     CurlConverter.requestToCurlWithoutBody(this, redactHeadersWhen)

--- a/core/src/main/scala/org/http4s/internal/CurlConverter.scala
+++ b/core/src/main/scala/org/http4s/internal/CurlConverter.scala
@@ -44,7 +44,10 @@ private[http4s] object CurlConverter {
     if (preparedHeaders.isEmpty) "" else newline + preparedHeaders
   }
 
-  def requestToCurlWithoutBody[F[_]](request: Request[F], redactHeadersWhen: CIString => Boolean): String = {
+  def requestToCurlWithoutBody[F[_]](
+      request: Request[F],
+      redactHeadersWhen: CIString => Boolean,
+  ): String = {
     val params = List(
       prepareMethodName(request.method),
       prepareUri(request.uri),

--- a/core/src/main/scala/org/http4s/internal/CurlConverter.scala
+++ b/core/src/main/scala/org/http4s/internal/CurlConverter.scala
@@ -16,7 +16,10 @@
 
 package org.http4s.internal
 
-import org.http4s.{Headers, Method, Request, Uri}
+import org.http4s.Headers
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.Uri
 import org.typelevel.ci.CIString
 
 private[http4s] object CurlConverter {

--- a/core/src/main/scala/org/http4s/internal/CurlConverter.scala
+++ b/core/src/main/scala/org/http4s/internal/CurlConverter.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.internal
+
+import org.http4s.Request
+import org.typelevel.ci.CIString
+
+private[http4s] object CurlConverter {
+
+  // escapes characters that are used in the curl-command, such as '
+  private def escapeQuotationMarks(s: String) = s.replaceAll("'", """'\\''""")
+
+  def requestToCurlWithoutBody[F[_]](request: Request[F], redactHeadersWhen: CIString => Boolean): String = {
+    val elements = List(
+      s"-X ${request.method.name}",
+      s"'${escapeQuotationMarks(request.uri.renderString)}'",
+      request.headers
+        .redactSensitive(redactHeadersWhen)
+        .headers
+        .map { header =>
+          s"""-H '${escapeQuotationMarks(s"${header.name}: ${header.value}")}'"""
+        }
+        .mkString(" "),
+    )
+
+    s"curl ${elements.filter(_.nonEmpty).mkString(" ")}"
+  }
+}


### PR DESCRIPTION
This makes the output of `asCurl` verbose and adds line breakers. The result of method calls will look like this:
```
curl \
  --request GET \
  --url 'http://localhost:1234/foo' \
  --header 'Cookie: <REDACTED>' \
  --header 'Authorization: <REDACTED>'
```