### PR TITLE
Path info index fix

### DIFF
--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -389,19 +389,20 @@ object Uri extends UriPlatform {
         segments: Vector[Path.Segment] = segments,
         absolute: Boolean = absolute,
         endsWithSlash: Boolean = endsWithSlash,
-    ) = Path(segments, absolute, endsWithSlash)
+    ): Path = Path(segments, absolute, endsWithSlash)
 
-    def dropEndsWithSlash = copy(endsWithSlash = false)
-    def addEndsWithSlash = copy(endsWithSlash = true)
+    def dropEndsWithSlash: Path = copy(endsWithSlash = false)
+    def addEndsWithSlash: Path = copy(endsWithSlash = true)
 
-    def toAbsolute = copy(absolute = true)
-    def toRelative = copy(absolute = false)
+    def toAbsolute: Path = copy(absolute = true)
+    def toRelative: Path = copy(absolute = false)
   }
 
   object Path {
-    val empty = new Path(Vector.empty, absolute = false, endsWithSlash = false)
-    val Root = new Path(Vector.empty, absolute = true, endsWithSlash = false)
-    lazy val Asterisk = new Path(Vector(Segment("*")), absolute = false, endsWithSlash = false)
+    val empty: Path = new Path(Vector.empty, absolute = false, endsWithSlash = false)
+    val Root: Path = new Path(Vector.empty, absolute = true, endsWithSlash = false)
+    lazy val Asterisk: Path =
+      new Path(Vector(Segment("*")), absolute = false, endsWithSlash = false)
 
     final class Segment private (val encoded: String) {
       def isEmpty = encoded.isEmpty

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -400,9 +400,9 @@ object Uri extends UriPlatform {
   }
 
   object Path {
-    val empty = Path(Vector.empty)
-    val Root = Path(Vector.empty, absolute = true)
-    lazy val Asterisk = Path(Vector(Segment("*")), absolute = false, endsWithSlash = false)
+    val empty = new Path(Vector.empty, absolute = false, endsWithSlash = false)
+    val Root = new Path(Vector.empty, absolute = true, endsWithSlash = false)
+    lazy val Asterisk = new Path(Vector(Segment("*")), absolute = false, endsWithSlash = false)
 
     final class Segment private (val encoded: String) {
       def isEmpty = encoded.isEmpty
@@ -493,7 +493,9 @@ object Uri extends UriPlatform {
         absolute: Boolean = false,
         endsWithSlash: Boolean = false,
     ): Path =
-      new Path(segments, absolute, endsWithSlash)
+      // make sure that we never end up with Path(Vector(), true, true) or Path(Vector(), false, true)
+      if (segments.isEmpty && (absolute || endsWithSlash)) Root
+      else new Path(segments, absolute, endsWithSlash)
 
     // def unapply(path: Path): Some[(Vector[Segment], Boolean, Boolean)] =
     //   Some((path.segments, path.absolute, path.endsWithSlash))

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -375,8 +375,7 @@ object Uri extends UriPlatform {
     def indexOfString(path: String): Option[Int] = findSplit(Path.unsafeFromString(path))
 
     def findSplit(prefix: Path): Option[Int] =
-      if (prefix.isEmpty) None
-      else if (startsWith(prefix)) Some(prefix.segments.size)
+      if (startsWith(prefix)) Some(prefix.segments.size)
       else None
     def findSplitOfString(path: String): Option[Int] = findSplit(Path.unsafeFromString(path))
 

--- a/core/src/main/scala/org/http4s/Uri.scala
+++ b/core/src/main/scala/org/http4s/Uri.scala
@@ -389,8 +389,7 @@ object Uri extends UriPlatform {
         segments: Vector[Path.Segment] = segments,
         absolute: Boolean = absolute,
         endsWithSlash: Boolean = endsWithSlash,
-    ) =
-      new Path(segments, absolute, endsWithSlash)
+    ) = Path(segments, absolute, endsWithSlash)
 
     def dropEndsWithSlash = copy(endsWithSlash = false)
     def addEndsWithSlash = copy(endsWithSlash = true)

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -104,7 +104,7 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
       headers = toHeaders(req),
       body = servletIo.reader(req),
       attributes = Vault.empty
-        .insert(Request.Keys.PathInfoCaret, getPathInfoIndex(req, uri))
+        .insert(Request.Keys.PathInfoCaret, getPathInfoIndex(req, uri).get)
         .insert(
           Request.Keys.ConnectionInfo,
           Request.Connection(
@@ -137,14 +137,13 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
         ),
     )
 
-  private def getPathInfoIndex(req: HttpServletRequest, uri: Uri) = {
-    val pathInfo =
+  private def getPathInfoIndex(req: HttpServletRequest, uri: Uri): Option[Int] = {
+    val prefix =
       Uri.Path
         .unsafeFromString(req.getContextPath)
         .concat(Uri.Path.unsafeFromString(req.getServletPath))
-    uri.path
-      .findSplit(pathInfo)
-      .getOrElse(-1)
+
+    uri.path.findSplit(prefix)
   }
 
   protected def toHeaders(req: HttpServletRequest): Headers = {

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -97,53 +97,64 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
           .getOrElse(req.getRequestURI)
       )
       version <- HttpVersion.fromString(req.getProtocol)
+      pathInfoIndex <- getPathInfoIndex(req, uri)
+      attributes <- ParseResult.fromTryCatchNonFatal("")(
+        Vault.empty
+          .insert(Request.Keys.PathInfoCaret, pathInfoIndex)
+          .insert(
+            Request.Keys.ConnectionInfo,
+            Request.Connection(
+              local = SocketAddress(
+                IpAddress.fromString(stripBracketsFromAddr(req.getLocalAddr)).get,
+                Port.fromInt(req.getLocalPort).get,
+              ),
+              remote = SocketAddress(
+                IpAddress.fromString(stripBracketsFromAddr(req.getRemoteAddr)).get,
+                Port.fromInt(req.getRemotePort).get,
+              ),
+              secure = req.isSecure,
+            ),
+          )
+          .insert(Request.Keys.ServerSoftware, serverSoftware)
+          .insert(ServletRequestKeys.HttpSession, Option(req.getSession(false)))
+          .insert(
+            ServerRequestKeys.SecureSession,
+            (
+              Option(req.getAttribute("javax.servlet.request.ssl_session_id").asInstanceOf[String]),
+              Option(req.getAttribute("javax.servlet.request.cipher_suite").asInstanceOf[String]),
+              Option(req.getAttribute("javax.servlet.request.key_size").asInstanceOf[Int]),
+              Option(
+                req
+                  .getAttribute("javax.servlet.request.X509Certificate")
+                  .asInstanceOf[Array[X509Certificate]]
+              ),
+            )
+              .mapN(SecureSession.apply),
+          )
+      )
     } yield Request(
       method = method,
       uri = uri,
       httpVersion = version,
       headers = toHeaders(req),
       body = servletIo.reader(req),
-      attributes = Vault.empty
-        .insert(Request.Keys.PathInfoCaret, getPathInfoIndex(req, uri).get)
-        .insert(
-          Request.Keys.ConnectionInfo,
-          Request.Connection(
-            local = SocketAddress(
-              IpAddress.fromString(stripBracketsFromAddr(req.getLocalAddr)).get,
-              Port.fromInt(req.getLocalPort).get,
-            ),
-            remote = SocketAddress(
-              IpAddress.fromString(stripBracketsFromAddr(req.getRemoteAddr)).get,
-              Port.fromInt(req.getRemotePort).get,
-            ),
-            secure = req.isSecure,
-          ),
-        )
-        .insert(Request.Keys.ServerSoftware, serverSoftware)
-        .insert(ServletRequestKeys.HttpSession, Option(req.getSession(false)))
-        .insert(
-          ServerRequestKeys.SecureSession,
-          (
-            Option(req.getAttribute("javax.servlet.request.ssl_session_id").asInstanceOf[String]),
-            Option(req.getAttribute("javax.servlet.request.cipher_suite").asInstanceOf[String]),
-            Option(req.getAttribute("javax.servlet.request.key_size").asInstanceOf[Int]),
-            Option(
-              req
-                .getAttribute("javax.servlet.request.X509Certificate")
-                .asInstanceOf[Array[X509Certificate]]
-            ),
-          )
-            .mapN(SecureSession.apply),
-        ),
+      attributes = attributes,
     )
 
-  private def getPathInfoIndex(req: HttpServletRequest, uri: Uri): Option[Int] = {
+  private def getPathInfoIndex(req: HttpServletRequest, uri: Uri): ParseResult[Int] = {
     val prefix =
       Uri.Path
         .unsafeFromString(req.getContextPath)
         .concat(Uri.Path.unsafeFromString(req.getServletPath))
 
-    uri.path.findSplit(prefix)
+    uri.path
+      .findSplit(prefix)
+      .toRight(
+        ParseFailure(
+          uri.path.renderString,
+          s"Couldn't find pathInfoIndex given the contextPath='${req.getContextPath}' and servletPath='${req.getServletPath}'.",
+        )
+      )
   }
 
   protected def toHeaders(req: HttpServletRequest): Headers = {

--- a/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
@@ -18,15 +18,8 @@ package org.http4s
 package servlet
 
 import cats.effect.IO
-import cats.effect.Resource
 import cats.effect.Timer
 import cats.syntax.all._
-import org.eclipse.jetty.server.HttpConfiguration
-import org.eclipse.jetty.server.HttpConnectionFactory
-import org.eclipse.jetty.server.ServerConnector
-import org.eclipse.jetty.server.{Server => EclipseServer}
-import org.eclipse.jetty.servlet.ServletContextHandler
-import org.eclipse.jetty.servlet.ServletHolder
 import org.http4s.dsl.io._
 import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.syntax.all._
@@ -53,7 +46,7 @@ class BlockingHttp4sServletSuite extends Http4sSuite {
     }
     .orNotFound
 
-  private val servletServer = ResourceFixture[Int](serverPortR)
+  private val servletServer = ResourceFixture[Int](TestEclipseServer(servlet))
 
   private def get(serverPort: Int, path: String): IO[String] =
     testBlocker.delay[IO, String](
@@ -95,23 +88,4 @@ class BlockingHttp4sServletSuite extends Http4sSuite {
     servletIo = org.http4s.servlet.BlockingServletIo(4096, testBlocker),
     serviceErrorHandler = DefaultServiceErrorHandler,
   )
-
-  private lazy val serverPortR = Resource
-    .make(IO(new EclipseServer))(server => IO(server.stop()))
-    .evalMap { server =>
-      IO {
-        val connector =
-          new ServerConnector(server, new HttpConnectionFactory(new HttpConfiguration()))
-
-        val context = new ServletContextHandler
-        context.addServlet(new ServletHolder(servlet), "/*")
-
-        server.addConnector(connector)
-        server.setHandler(context)
-
-        server.start()
-
-        connector.getLocalPort
-      }
-    }
 }

--- a/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.servlet
+
+import cats.effect.IO
+import cats.effect.Resource
+import org.http4s.Http4sSuite
+import org.http4s.HttpRoutes
+import org.http4s.dsl.io._
+import org.http4s.server.DefaultServiceErrorHandler
+import org.http4s.server.Router
+import org.http4s.testing.AutoCloseableResource
+
+import java.net.URL
+import scala.io.Source
+
+// Regression tests for #5362 / #5100
+class RouterInServletSuite extends Http4sSuite {
+
+  private val mainRoutes = HttpRoutes.of[IO] {
+    case GET -> Root => Ok("root")
+    case GET -> Root / "suffix" => Ok("suffix")
+  }
+
+  private val alternativeRoutes = HttpRoutes.of[IO] { case GET -> Root =>
+    Ok("alternative root")
+  }
+
+  private val router = Router(
+    "prefix" -> mainRoutes,
+    "" -> alternativeRoutes,
+  )
+
+  private val serverWithoutRouter =
+    ResourceFixture[Int](mkServer(mainRoutes))
+  private val server =
+    ResourceFixture[Int](mkServer(router))
+  private val serverWithContextPath =
+    ResourceFixture[Int](mkServer(router, contextPath = "/context"))
+  private val serverWithServletPath =
+    ResourceFixture[Int](mkServer(router, servletPath = "/servlet/*"))
+  private val serverWithContextAndServletPath =
+    ResourceFixture[Int](mkServer(router, contextPath = "/context", servletPath = "/servlet/*"))
+
+  serverWithoutRouter.test(
+    "Http4s servlet without router should handle root request"
+  )(server => get(server, "").assertEquals("root"))
+
+  serverWithoutRouter.test(
+    "Http4s servlet without router should handle suffix request"
+  )(server => get(server, "suffix").assertEquals("suffix"))
+
+  server.test(
+    "Http4s servlet should handle alternative-root request"
+  )(server => get(server, "").assertEquals("alternative root"))
+
+  server.test(
+    "Http4s servlet should handle root request"
+  )(server => get(server, "prefix").assertEquals("root"))
+
+  server.test(
+    "Http4s servlet should handle suffix request"
+  )(server => get(server, "prefix/suffix").assertEquals("suffix"))
+
+  serverWithContextPath.test(
+    "Http4s servlet with non-empty context path should handle alternative-root request"
+  )(server => get(server, "context").assertEquals("alternative root"))
+
+  serverWithContextPath.test(
+    "Http4s servlet with non-empty context path should handle root request"
+  )(server => get(server, "context/prefix").assertEquals("root"))
+
+  serverWithContextPath.test(
+    "Http4s servlet with non-empty context path should handle suffix request"
+  )(server => get(server, "context/prefix/suffix").assertEquals("suffix"))
+
+  serverWithServletPath.test(
+    "Http4s servlet with non-empty servlet path should handle alternative-root request"
+  )(server => get(server, "servlet").assertEquals("alternative root"))
+
+  serverWithServletPath.test(
+    "Http4s servlet with non-empty servlet path should handle root request"
+  )(server => get(server, "servlet/prefix").assertEquals("root"))
+
+  serverWithServletPath.test(
+    "Http4s servlet with non-empty servlet path should handle suffix request"
+  )(server => get(server, "servlet/prefix/suffix").assertEquals("suffix"))
+
+  serverWithContextAndServletPath.test(
+    "Http4s servlet with non-empty context & servlet path should handle alternative-root request"
+  )(server => get(server, "context/servlet").assertEquals("alternative root"))
+
+  serverWithContextAndServletPath.test(
+    "Http4s servlet with non-empty context & servlet path should handle root request"
+  )(server => get(server, "context/servlet/prefix").assertEquals("root"))
+
+  serverWithContextAndServletPath.test(
+    "Http4s servlet with non-empty context & servlet path should handle suffix request"
+  )(server => get(server, "context/servlet/prefix/suffix").assertEquals("suffix"))
+
+  private def get(serverPort: Int, path: String): IO[String] =
+    testBlocker.delay[IO, String](
+      AutoCloseableResource.resource(
+        Source
+          .fromURL(new URL(s"http://127.0.0.1:$serverPort/$path"))
+      )(_.getLines().mkString)
+    )
+
+  private def mkServer(
+      routes: HttpRoutes[IO],
+      contextPath: String = "/",
+      servletPath: String = "/*",
+  ): Resource[IO, Int] = TestEclipseServer(servlet(routes), contextPath, servletPath)
+
+  private def servlet(routes: HttpRoutes[IO]) = new BlockingHttp4sServlet[IO](
+    service = routes.orNotFound,
+    servletIo = org.http4s.servlet.BlockingServletIo(4096, testBlocker),
+    serviceErrorHandler = DefaultServiceErrorHandler,
+  )
+
+}

--- a/servlet/src/test/scala/org/http4s/servlet/TestEclipseServer.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/TestEclipseServer.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.servlet
+
+import cats.effect.IO
+import cats.effect.Resource
+import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.server.{Server => EclipseServer}
+import org.eclipse.jetty.servlet.ServletContextHandler
+import org.eclipse.jetty.servlet.ServletHolder
+
+import javax.servlet.Servlet
+
+object TestEclipseServer {
+
+  def apply(
+      servlet: Servlet,
+      contextPath: String = "/",
+      servletPath: String = "/*",
+  ): Resource[IO, Int /* port */ ] =
+    Resource
+      .make(IO(new EclipseServer))(server => IO(server.stop()))
+      .evalMap { server =>
+        IO {
+          val connector =
+            new ServerConnector(server, new HttpConnectionFactory(new HttpConfiguration()))
+
+          val context = new ServletContextHandler
+          context.addServlet(new ServletHolder(servlet), servletPath)
+          context.setContextPath(contextPath)
+
+          server.addConnector(connector)
+          server.setHandler(context)
+
+          server.start()
+
+          connector.getLocalPort
+        }
+      }
+
+}


### PR DESCRIPTION
This is a fix for the #5362 (a regression introduced most likely in #3221). A fix for this issue has already been proposed by @fthomas in #5100 but it got stuck. I followed Franks findings, and @hamnis's suggestion to have a deeper look in order to find the root cause of the issue. So in this PR I propose an alternative way of solving the problem which (at least according to my understanding) deals with the issue at it's origin. 

This PR:
- a320e1f61b57f7fd862649151e191e98d7db5bf9: Adds a test suite verifying behaviour and interactions between `Routes`, `Router` and `contextPath` and `servletPath`.
- 5ae3db5b6d1c7f4102cc8b0d86adb530f1baf630: Removes the fallback to `-1` in case of failure to find split. IMO using the value of `-1` as a fallback is an anti-pattern, that in this case lead to performing integer arithmetic on the special-value leading to unexpected results.
- e38c3f8c688782f12d728ce6fcf60eac4c5360b0: Removes the special case for empty prefixes in `findSplit` which lead to not-finding a split, where otherwise the default logic would calculate a valid result of `0`. This fixes all but one introduced tests.
- 6c3c7f664f0c62dcf68a24cfea084e8d2564c2ef: Fixes the remaining "Http4s servlet with non-empty context path should handle alternative-root request", by enforcing use of `Root = new Path(Vector.empty, absolute = true, endsWithSlash = false)` to represent empty paths with a slash. Before that change `path"/a/".splitAt(1)._2` would result in `Path(Vector.empty, true, true)` which was rendered as `//` and in my opinion doesn't make sense.

~After spending 8+ hours trying to figure out if `Uri` behaves correctly (by inventing some laws), I can now say with confidence that I have no idea how it **should** behave. That is exactly why this PR (which is effectively a PR to `Uri`) defines the expected bahaviour in terms or `Servlet` and `Router`.~ (see #5794 for a more complete rework of `concat` and `splitAt`)