### PR TITLE
Scala-steward exclusions in `main`

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -6,3 +6,16 @@ updates.pin = [
   # Servlet 4 breaks Jetty 9 and Tomcat 9
   { groupId = "javax.servlet", version = "3." },
 ]
+
+updates.ignore = [
+  # These will be merged forward from series/0.23
+  { groupId = "com.github.jnr", artifactId = "jnr-unixsocket" },
+  { groupId = "org.typelevel", artifactId = "jawn-fs2" },
+  { groupId = "org.typelevel", artifactId = "jawn-parser" },
+  { groupId = "org.typelevel", artifactId = "cats-effect" },
+  { groupId = "org.typelevel", artifactId = "cats-effect-laws" },
+  { groupId = "org.typelevel", artifactId = "cats-effect-std" },
+  { groupId = "org.typelevel", artifactId = "cats-effect-testkit" },
+  { groupId = "co.fs2" },
+  { groupId = "io.netty" }
+]


### PR DESCRIPTION
This is a non-comprehensive collection of dependencies that scala-steward shouldn't update on `main` because the updates will be merged forward from 0.23.