### PR TITLE
Re-enable broken ember client test

### DIFF
--- a/ember-client/shared/src/test/scala/org/http4s/ember/client/EmberClientSuite.scala
+++ b/ember-client/shared/src/test/scala/org/http4s/ember/client/EmberClientSuite.scala
@@ -27,8 +27,4 @@ class EmberClientSuite extends ClientRouteTestBattery("EmberClient") with Http4s
 
   override def clientResource: Resource[IO, Client[IO]] = EmberClientBuilder.default[IO].build
 
-  override def munitTests() =
-    // TODO https://github.com/http4s/http4s/issues/5256
-    super.munitTests().filterNot(_.name.endsWith("Execute GET /no-content") && Platform.isJvm)
-
 }


### PR DESCRIPTION
Opening for CI.

Update:
Fixes https://github.com/http4s/http4s/issues/5256.

I think the real credit for the fix goes to @RafalSumislawski in https://github.com/http4s/http4s/pull/5587.