### PR TITLE
Enable fatal warnings for the `lint` command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -911,7 +911,8 @@ addCommandAlias(
   ";scalafixAll --triggered ;scalafixAll ;scalafmtAll ;scalafmtSbt",
 )
 
+// Use this command for checking before submitting a PR
 addCommandAlias(
   "lint",
-  ";clean ;+test:compile ;+scalafixAll --triggered ;+scalafixAll ;+scalafmtAll ;scalafmtSbt ;+mimaReportBinaryIssues",
+  """;set ThisBuild / scalacOptions += "-Xfatal-warnings" ;clean ;+test:compile ;+scalafixAll --triggered ;+scalafixAll ;+scalafmtAll ;scalafmtSbt ;+mimaReportBinaryIssues""",
 )


### PR DESCRIPTION
I find this is not optimal to use fatal warnings in the CI and not in local development. Users should get feedback as quickly as possible. Newly, I get into that situation on my own.
Also, @ChristopherDavenport pointed about that in https://github.com/http4s/http4s/discussions/5709. Probably we should add fatal warnings for `quicklint` too? WDYT?