### PR TITLE
Fix the `lint` command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -905,7 +905,6 @@ def initCommands(additionalImports: String*) =
 // This won't actually release unless on Travis.
 addCommandAlias("ci", ";clean ;release with-defaults")
 
-// OrganizeImports needs to run separately to clean up after the other rules
 addCommandAlias(
   "quicklint",
   ";scalafixAll --triggered ;scalafixAll ;scalafmtAll ;scalafmtSbt",
@@ -913,5 +912,5 @@ addCommandAlias(
 
 addCommandAlias(
   "lint",
-  ";clean ;+test:compile ;+scalafixAll --triggered ;+scalafixAll ;+scalafmtAll ;scalafmtSbt ;+mimaReportBinaryIssues",
+  ";clean ;+test:compile ;scalafixAll --triggered ;scalafixAll ;+scalafmtAll ;scalafmtSbt ;+mimaReportBinaryIssues",
 )


### PR DESCRIPTION
The `lint` command fails when running `scalafixAll` with Scala 3. We get:

> To use Scalafix on Scala 3 projects, you must unset `scalafixBinaryScalaVersion`. Rules such as ExplicitResultTypes requiring the project version to match the Scalafix version are unsupported for the moment.

I suppose It's fine to run the `scalafixAll` only for the base Scala version (which is 2).