### PR TITLE
Enable fatal warnings in `lint`/`quicklint` commands

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1080,7 +1080,6 @@ def initCommands(additionalImports: String*) =
 // This won't actually release unless on Travis.
 addCommandAlias("ci", ";clean ;release with-defaults")
 
-// OrganizeImports needs to run separately to clean up after the other rules
 addCommandAlias(
   "quicklint",
   ";scalafixAll --triggered ;scalafixAll ;scalafmtAll ;scalafmtSbt",
@@ -1088,5 +1087,5 @@ addCommandAlias(
 
 addCommandAlias(
   "lint",
-  ";clean ;+test:compile ;+scalafixAll --triggered ;+scalafixAll ;+scalafmtAll ;scalafmtSbt ;+mimaReportBinaryIssues",
+  ";clean ;+test:compile ;scalafixAll --triggered ;scalafixAll ;+scalafmtAll ;scalafmtSbt ;+mimaReportBinaryIssues",
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1080,22 +1080,29 @@ def initCommands(additionalImports: String*) =
 // This won't actually release unless on Travis.
 addCommandAlias("ci", ";clean ;release with-defaults")
 
-lazy val setFatalWarnings: String =
+lazy val enableFatalWarnings: String =
   """set ThisBuild / scalacOptions += "-Xfatal-warnings""""
 
-lazy val unsetFatalWarnings: String =
+lazy val disableFatalWarnings: String =
   """set ThisBuild / scalacOptions -= "-Xfatal-warnings""""
 
 addCommandAlias(
   "quicklint",
-  ";scalafixAll --triggered ;scalafixAll ;scalafmtAll ;scalafmtSbt",
+  List(
+    enableFatalWarnings,
+    "scalafixAll --triggered",
+    "scalafixAll",
+    "scalafmtAll",
+    "scalafmtSbt",
+    disableFatalWarnings,
+  ).mkString(" ;"),
 )
 
 // Use this command for checking before submitting a PR
 addCommandAlias(
   "lint",
   List(
-    setFatalWarnings,
+    enableFatalWarnings,
     "clean",
     "+test:compile",
     "scalafixAll --triggered",
@@ -1103,6 +1110,6 @@ addCommandAlias(
     "+scalafmtAll",
     "scalafmtSbt",
     "+mimaReportBinaryIssues",
-    unsetFatalWarnings,
+    disableFatalWarnings,
   ).mkString(" ;"),
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1080,12 +1080,29 @@ def initCommands(additionalImports: String*) =
 // This won't actually release unless on Travis.
 addCommandAlias("ci", ";clean ;release with-defaults")
 
+lazy val setFatalWarnings: String =
+  """set ThisBuild / scalacOptions += "-Xfatal-warnings""""
+
+lazy val unsetFatalWarnings: String =
+  """set ThisBuild / scalacOptions -= "-Xfatal-warnings""""
+
 addCommandAlias(
   "quicklint",
   ";scalafixAll --triggered ;scalafixAll ;scalafmtAll ;scalafmtSbt",
 )
 
+// Use this command for checking before submitting a PR
 addCommandAlias(
   "lint",
-  ";clean ;+test:compile ;scalafixAll --triggered ;scalafixAll ;+scalafmtAll ;scalafmtSbt ;+mimaReportBinaryIssues",
+  List(
+    setFatalWarnings,
+    "clean",
+    "+test:compile",
+    "scalafixAll --triggered",
+    "scalafixAll",
+    "+scalafmtAll",
+    "scalafmtSbt",
+    "+mimaReportBinaryIssues",
+    unsetFatalWarnings,
+  ).mkString(" ;"),
 )


### PR DESCRIPTION
I find this is not optimal to use fatal warnings in the CI and not in local development. Users should get feedback as quickly as possible. Newly, I get into that situation on my own.
Also, @ChristopherDavenport pointed about that in #5709.
That is for the `series/0.23` (and not `series/0.22`) for the reason I described in https://github.com/http4s/http4s/pull/5841#issuecomment-1008708190.