### PR TITLE
Auto-select available port for ember suites

### DIFF
--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerMtlsSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerMtlsSuite.scala
@@ -18,6 +18,7 @@ package org.http4s.ember.server
 
 import cats.effect._
 import cats.implicits._
+import com.comcast.ip4s
 import fs2.io.net.Network
 import fs2.io.net.tls.TLSContext
 import fs2.io.net.tls.TLSParameters
@@ -125,6 +126,7 @@ class EmberServerMtlsSuite extends Http4sSuite {
       tlsContext <- authTlsClientContext
       emberServer <- EmberServerBuilder
         .default[IO]
+        .withPort(ip4s.Port.fromInt(0).get)
         .withHttpApp(service[IO])
         .withTLS(
           tlsContext,

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -20,6 +20,7 @@ import cats.effect._
 import cats.effect.std.Dispatcher
 import cats.effect.std.Queue
 import cats.syntax.all._
+import com.comcast.ip4s
 import fs2.Pipe
 import fs2.Stream
 import org.http4s._
@@ -65,6 +66,7 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
   val serverResource: Resource[IO, Server] =
     EmberServerBuilder
       .default[IO]
+      .withPort(ip4s.Port.fromInt(0).get)
       .withHttpWebSocketApp(service[IO])
       .build
 

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/ConnectionSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/ConnectionSuite.scala
@@ -59,6 +59,7 @@ class ConnectionSuite extends Http4sSuite {
   ): Resource[IO, Server] =
     EmberServerBuilder
       .default[IO]
+      .withPort(ip4s.Port.fromInt(0).get)
       .withHttpApp(service)
       .withIdleTimeout(idleTimeout)
       .withRequestHeaderReceiveTimeout(headerTimeout)

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -19,6 +19,7 @@ package org.http4s.ember.server
 import cats.effect._
 import cats.syntax.all._
 import com.comcast.ip4s.Host
+import com.comcast.ip4s.Port
 import com.comcast.ip4s.SocketAddress
 import fs2.Stream
 import fs2.io.net.BindException
@@ -51,6 +52,7 @@ class EmberServerSuite extends Http4sSuite {
   val serverResource: Resource[IO, Server] =
     EmberServerBuilder
       .default[IO]
+      .withPort(Port.fromInt(0).get)
       .withHttpApp(service[IO])
       .build
 
@@ -81,8 +83,11 @@ class EmberServerSuite extends Http4sSuite {
     }
   }
 
-  server().test("server startup fails if address is already in use") { case _ =>
-    serverResource.use(_ => IO.unit).intercept[BindException]
+  server().test("server startup fails if address is already in use") { server =>
+    EmberServerBuilder
+      .default[IO]
+      .withPort(server.addressIp4s.port)
+      .build.use(_ => IO.unit).intercept[BindException]
   }
 
   fixture(receiveBufferSize = 256).test("#4731 - read socket is drained after writing") {

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -87,7 +87,9 @@ class EmberServerSuite extends Http4sSuite {
     EmberServerBuilder
       .default[IO]
       .withPort(server.addressIp4s.port)
-      .build.use(_ => IO.unit).intercept[BindException]
+      .build
+      .use(_ => IO.unit)
+      .intercept[BindException]
   }
 
   fixture(receiveBufferSize = 256).test("#4731 - read socket is drained after writing") {

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -62,6 +62,7 @@ class EmberServerSuite extends Http4sSuite {
     EmberServerBuilder
       .default[IO]
       .withHttpApp(service[IO])
+      .withPort(Port.fromInt(0).get)
       .withReceiveBufferSize(receiveBufferSize)
       .build
   )


### PR DESCRIPTION
Should fix the `BindException` reported in https://github.com/http4s/http4s/issues/5844#issuecomment-1010403086.

I tried to target this down to 0.22, but the 0 port trick doesn't work there since ember returns its address with the port number that was provided and not the port that was actually bound. Seems like that can be fixed.