### PR TITLE
Steward exclusions in 0.23 for dependencies merged forward from 0.22

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -12,3 +12,14 @@ updates.pin = [
   # scalatags-0.11 breaks bincompat
   { groupId = "com.lihaoyi", artifactId = "scalatags", version = "0.10." }
 ]
+
+updates.ignore = [
+  # These will be merged forward from series/0.22
+  { groupId = "io.netty" },
+  { groupId = "org.typelevel", artifactId = "jawn-parser" },
+  { groupId = "io.dropwizard.metrics" },
+  { groupId = "ch.qos.logback", artifactId = "logback-classic" },
+  { groupId = "ch.epfl.scala", artifactId = "sbt-scalafix" },
+  { groupId = "org.planet42", artifactId = "laika-sbt" },
+  { groupId = "org.scala-sbt" }
+]


### PR DESCRIPTION
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 