### PR TITLE
Add Request#isIdempotent

### DIFF
--- a/core/src/main/scala/org/http4s/Headers.scala
+++ b/core/src/main/scala/org/http4s/Headers.scala
@@ -51,6 +51,10 @@ final class Headers(val headers: List[Header.Raw]) extends AnyVal {
   ): Option[Ior[NonEmptyList[ParseFailure], ev.F[A]]] =
     ev.from(headers)
 
+  /** Returns true if there is at least one header by the specified name. */
+  def contains[A](implicit ev: Header[A, _]): Boolean =
+    headers.exists(_.name == ev.name)
+
   /** Attempt to get headers by key from this collection of headers.
     *
     * @param key name of the headers to find.

--- a/core/src/main/scala/org/http4s/Message.scala
+++ b/core/src/main/scala/org/http4s/Message.scala
@@ -440,6 +440,12 @@ final class Request[F[_]] private (
   def serverSoftware: ServerSoftware =
     attributes.lookup(Keys.ServerSoftware).getOrElse(ServerSoftware.Unknown)
 
+  /** A request is idempotent if its method is idempotent or it contains
+    * an `Idempotency-Key` header.
+    */
+  def isIdempotent: Boolean =
+    method.isIdempotent || headers.contains[`Idempotency-Key`]
+
   def decodeWith[A](decoder: EntityDecoder[F, A], strict: Boolean)(
       f: A => F[Response[F]]
   )(implicit F: Monad[F]): F[Response[F]] =

--- a/tests/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeadersSpec.scala
@@ -39,6 +39,11 @@ class HeadersSpec extends Http4sSuite {
     assertEquals(base.get(ci"raw-header"), Some(NonEmptyList.of(raw)))
   }
 
+  test("contains") {
+    assert(base.contains[`Content-Length`])
+    assert(!base.contains[`Content-Type`])
+  }
+
   test("Headers should Replaces headers") {
     val newlen = `Content-Length`.zero
     assertEquals(base.put(newlen).get[`Content-Length`], Some(newlen))

--- a/tests/src/test/scala/org/http4s/MessageSuite.scala
+++ b/tests/src/test/scala/org/http4s/MessageSuite.scala
@@ -353,4 +353,14 @@ class MessageSuite extends Http4sSuite {
     // Should preserve only the EntityEncoder's Content-Type
     assertEquals(hdrs, List(Header.Raw(ci"Content-Type", "text/plain; charset=UTF-8")))
   }
+
+  test("isIdempotent") {
+    assert(Request[IO](method = Method.GET).isIdempotent)
+    assert(Request[IO](method = Method.DELETE).isIdempotent)
+    assert(Request[IO](method = Method.PUT).isIdempotent)
+    assert(!Request[IO](method = Method.POST).isIdempotent)
+    assert(
+      Request[IO](method = Method.POST, headers = Headers("Idempotency-Key" -> "123")).isIdempotent
+    )
+  }
 }


### PR DESCRIPTION
Was trying to add default retry support to Blaze, but ran into a wall for lack of a Timer.  I'll try again in 0.23, but these were pure and already done.