### PR TITLE
Stale connection mitigation in blaze-client

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
@@ -61,6 +61,7 @@ import scala.concurrent.duration._
   * @param asynchronousChannelGroup custom AsynchronousChannelGroup to use other than the system default
   * @param channelOptions custom socket options
   * @param customDnsResolver customDnsResolver to use other than the system default
+  * @param retries the number of times an idempotent request that fails with a `SocketException` will be retried.  This is a means to deal with connections that expired while in the pool.  Retries happen immediately.  The default is 2.  For a more sophisticated retry strategy, see the [[org.http4s.client.middleware.Retry]] middleware.
   */
 sealed abstract class BlazeClientBuilder[F[_]] private (
     val responseHeaderTimeout: Duration,
@@ -84,6 +85,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     val asynchronousChannelGroup: Option[AsynchronousChannelGroup],
     val channelOptions: ChannelOptions,
     val customDnsResolver: Option[RequestKey => Either[Throwable, InetSocketAddress]],
+    val retries: Int,
 )(implicit protected val F: ConcurrentEffect[F])
     extends BlazeBackendBuilder[Client[F]]
     with BackendBuilder[F, Client[F]] {
@@ -113,6 +115,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
       asynchronousChannelGroup: Option[AsynchronousChannelGroup] = asynchronousChannelGroup,
       channelOptions: ChannelOptions = channelOptions,
       customDnsResolver: Option[RequestKey => Either[Throwable, InetSocketAddress]] = None,
+      retries: Int = retries,
   ): BlazeClientBuilder[F] =
     new BlazeClientBuilder[F](
       responseHeaderTimeout = responseHeaderTimeout,
@@ -136,6 +139,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
       asynchronousChannelGroup = asynchronousChannelGroup,
       channelOptions = channelOptions,
       customDnsResolver = customDnsResolver,
+      retries = retries,
     ) {}
 
   def withResponseHeaderTimeout(responseHeaderTimeout: Duration): BlazeClientBuilder[F] =
@@ -181,6 +185,12 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     */
   def withDefaultSslContext: BlazeClientBuilder[F] =
     withSslContext(SSLContext.getDefault())
+
+  /** Number of times to immediately retry idempotent requests that fail
+    * with a `SocketException`.
+    */
+  def withRetries(retries: Int = retries): BlazeClientBuilder[F] =
+    copy(retries = retries)
 
   /** Use some provided `SSLContext` when making secure calls, or disable secure calls with `None` */
   @deprecated(
@@ -258,6 +268,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
         requestTimeout = requestTimeout,
         scheduler = scheduler,
         ec = executionContext,
+        retries = retries,
       )
     } yield (client, manager.state)
 
@@ -368,6 +379,7 @@ object BlazeClientBuilder {
       asynchronousChannelGroup = None,
       channelOptions = ChannelOptions(Vector.empty),
       customDnsResolver = None,
+      retries = 2,
     ) {}
 
   def getAddress(requestKey: RequestKey): Either[Throwable, InetSocketAddress] =

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
@@ -91,6 +91,55 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
     with BackendBuilder[F, Client[F]] {
   type Self = BlazeClientBuilder[F]
 
+  @deprecated("Preserved for binary compatibility", "0.22.9")
+  private[BlazeClientBuilder] def this(
+      responseHeaderTimeout: Duration,
+      idleTimeout: Duration,
+      requestTimeout: Duration,
+      connectTimeout: Duration,
+      userAgent: Option[`User-Agent`],
+      maxTotalConnections: Int,
+      maxWaitQueueLimit: Int,
+      maxConnectionsPerRequestKey: RequestKey => Int,
+      sslContext: SSLContextOption,
+      checkEndpointIdentification: Boolean,
+      maxResponseLineSize: Int,
+      maxHeaderLength: Int,
+      maxChunkSize: Int,
+      chunkBufferMaxSize: Int,
+      parserMode: ParserMode,
+      bufferSize: Int,
+      executionContext: ExecutionContext,
+      scheduler: Resource[F, TickWheelExecutor],
+      asynchronousChannelGroup: Option[AsynchronousChannelGroup],
+      channelOptions: ChannelOptions,
+      customDnsResolver: Option[RequestKey => Either[Throwable, InetSocketAddress]],
+      F: ConcurrentEffect[F],
+  ) = this(
+    responseHeaderTimeout,
+    idleTimeout,
+    requestTimeout,
+    connectTimeout,
+    userAgent,
+    maxTotalConnections,
+    maxWaitQueueLimit,
+    maxConnectionsPerRequestKey,
+    sslContext,
+    checkEndpointIdentification,
+    maxResponseLineSize,
+    maxHeaderLength,
+    maxChunkSize,
+    chunkBufferMaxSize,
+    parserMode,
+    bufferSize,
+    executionContext,
+    scheduler,
+    asynchronousChannelGroup,
+    channelOptions,
+    customDnsResolver,
+    retries = 0,
+  )(F)
+
   protected final val logger = getLogger(this.getClass)
 
   private def copy(

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientBase.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientBase.scala
@@ -115,11 +115,6 @@ trait BlazeClientBase extends Http4sSuite {
           ()
         }
       },
-      (HttpMethod.POST, "/close-without-response") -> new Handler {
-        override def onRequestStart(ctx: ChannelHandlerContext, request: HttpRequest): Unit =
-          ctx.channel.close()
-        override def onRequestEnd(ctx: ChannelHandlerContext, request: HttpRequest): Unit = ()
-      },
     )
 
   val server = resourceSuiteFixture("http", makeScaffold(2, false))

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
@@ -20,11 +20,20 @@ package client
 
 import cats.effect._
 import cats.effect.concurrent.Deferred
+import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import fs2.Stream
 import fs2.io.tcp.SocketGroup
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpRequest
+import io.netty.handler.codec.http.HttpResponseStatus
 import org.http4s.client.ConnectionFailure
 import org.http4s.client.RequestKey
+import org.http4s.client.scaffold.Handler
+import org.http4s.client.scaffold.HandlerHelpers
+import org.http4s.client.scaffold.HandlersToNettyAdapter
+import org.http4s.client.scaffold.ServerScaffold
 import org.http4s.syntax.all._
 
 import java.net.InetSocketAddress
@@ -298,6 +307,71 @@ class BlazeClientSuite extends BlazeClientBase {
         _ <- state.allocated.map(_.get(RequestKey.fromRequest(req))).assertEquals(Some(1))
         _ <- done.complete(())
       } yield ()
+    }
+  }
+
+  test("retries idempotent requests") {
+    Ref.of[IO, Int](0).flatMap { attempts =>
+      val handlers = Map((HttpMethod.GET, "/close-without-response") -> new Handler {
+        override def onRequestStart(ctx: ChannelHandlerContext, request: HttpRequest): Unit = {
+          attempts.update(_ + 1).unsafeRunSync()
+          ctx.channel.close()
+        }
+        override def onRequestEnd(ctx: ChannelHandlerContext, request: HttpRequest): Unit = ()
+      })
+      ServerScaffold[IO](1, false, HandlersToNettyAdapter[IO](handlers)).use { server =>
+        val address = server.addresses.head
+        val name = address.host
+        val port = address.port
+        val uri = Uri.fromString(s"http://$name:$port/close-without-response").yolo
+        val req = Request[IO](method = Method.GET, uri = uri)
+        builder(1, retries = 3).resource
+          .use(client => client.status(req).attempt *> attempts.get.assertEquals(4))
+      }
+    }
+  }
+
+  test("does not retry non-idempotent requests") {
+    Ref.of[IO, Int](0).flatMap { attempts =>
+      val handlers = Map((HttpMethod.POST, "/close-without-response") -> new Handler {
+        override def onRequestStart(ctx: ChannelHandlerContext, request: HttpRequest): Unit = {
+          attempts.update(_ + 1).unsafeRunSync()
+          ctx.channel.close()
+        }
+        override def onRequestEnd(ctx: ChannelHandlerContext, request: HttpRequest): Unit = ()
+      })
+      ServerScaffold[IO](1, false, HandlersToNettyAdapter[IO](handlers)).use { server =>
+        val address = server.addresses.head
+        val name = address.host
+        val port = address.port
+        val uri = Uri.fromString(s"http://$name:$port/close-without-response").yolo
+        val req = Request[IO](method = Method.POST, uri = uri)
+        builder(1, retries = 3).resource
+          .use(client => client.status(req).attempt *> attempts.get.assertEquals(1))
+      }
+    }
+  }
+
+  test("does not retry requests that fail without a SocketException") {
+    Ref.of[IO, Int](0).flatMap { attempts =>
+      val handlers = Map((HttpMethod.GET, "/500") -> new Handler {
+        override def onRequestStart(ctx: ChannelHandlerContext, request: HttpRequest): Unit = {
+          attempts.update(_ + 1).unsafeRunSync()
+          HandlerHelpers
+            .sendResponse(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, closeConnection = true)
+          ()
+        }
+        override def onRequestEnd(ctx: ChannelHandlerContext, request: HttpRequest): Unit = ()
+      })
+      ServerScaffold[IO](1, false, HandlersToNettyAdapter[IO](handlers)).use { server =>
+        val address = server.addresses.head
+        val name = address.host
+        val port = address.port
+        val uri = Uri.fromString(s"http://$name:$port/500").yolo
+        val req = Request[IO](method = Method.GET, uri = uri)
+        builder(1, retries = 3).resource
+          .use(client => client.status(req).attempt *> attempts.get.assertEquals(1))
+      }
     }
   }
 }

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
@@ -316,6 +316,7 @@ class BlazeClientSuite extends BlazeClientBase {
         override def onRequestStart(ctx: ChannelHandlerContext, request: HttpRequest): Unit = {
           attempts.update(_ + 1).unsafeRunSync()
           ctx.channel.close()
+          ()
         }
         override def onRequestEnd(ctx: ChannelHandlerContext, request: HttpRequest): Unit = ()
       })
@@ -337,6 +338,7 @@ class BlazeClientSuite extends BlazeClientBase {
         override def onRequestStart(ctx: ChannelHandlerContext, request: HttpRequest): Unit = {
           attempts.update(_ + 1).unsafeRunSync()
           ctx.channel.close()
+          ()
         }
         override def onRequestEnd(ctx: ChannelHandlerContext, request: HttpRequest): Unit = ()
       })

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/ClientTimeoutSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/ClientTimeoutSuite.scala
@@ -75,6 +75,7 @@ class ClientTimeoutSuite extends Http4sSuite {
       responseHeaderTimeout: Duration = Duration.Inf,
       requestTimeout: Duration = Duration.Inf,
       idleTimeout: Duration = Duration.Inf,
+      retries: Int = 0,
   ): Client[IO] = {
     val manager = ConnectionManager.basic[IO, Http1Connection[IO]]((_: RequestKey) =>
       IO {
@@ -93,6 +94,7 @@ class ClientTimeoutSuite extends Http4sSuite {
       requestTimeout = requestTimeout,
       scheduler = tickWheel,
       ec = Http4sSuite.TestExecutionContext,
+      retries = retries,
     )
   }
 
@@ -217,6 +219,7 @@ class ClientTimeoutSuite extends Http4sSuite {
       requestTimeout = 50.millis,
       scheduler = tickWheel,
       ec = munitExecutionContext,
+      retries = 0,
     )
 
     // if the unsafeRunTimed timeout is hit, it's a NoSuchElementException,


### PR DESCRIPTION
Adds an automated retry policy to blaze-client to account for connections that closed while idling in the pool.

This is less flexible than Ember's, mainly because we don't have access to a `Timer`.  Then again, this is the bare minimum suggested by HTTP specs, and we don't need all that power.  Like Ember's, this is a conservative default that only retries idempotent requests.

This, like Ember's default strategy, may interact surprisingly with an explicit retry middleware as the retry policies compose.
