### PR TITLE
Deprecate client.Connection and client.ConnectionBuilder

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
@@ -25,7 +25,6 @@ import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.blazecore.BlazeBackendBuilder
 import org.http4s.blazecore.tickWheelResource
 import org.http4s.client.Client
-import org.http4s.client.ConnectionBuilder
 import org.http4s.client.RequestKey
 import org.http4s.client.defaults
 import org.http4s.headers.`User-Agent`

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeConnection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeConnection.scala
@@ -20,7 +20,6 @@ package client
 
 import cats.effect.Resource
 import org.http4s.blaze.pipeline.TailStage
-import org.http4s.client.Connection
 
 import java.nio.ByteBuffer
 

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Connection.scala
@@ -20,7 +20,7 @@ package client
 
 import org.http4s.client.RequestKey
 
-trait Connection[F[_]] {
+private[client] trait Connection[F[_]] {
 
   /** Determine if the connection is closed and resources have been freed */
   def isClosed: Boolean

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Connection.scala
@@ -18,22 +18,19 @@ package org.http4s
 package blaze
 package client
 
-import cats.effect._
-import cats.syntax.all._
 import org.http4s.client.RequestKey
 
-private final class BasicManager[F[_], A <: Connection[F]](builder: ConnectionBuilder[F, A])(
-    implicit F: Sync[F]
-) extends ConnectionManager[F, A] {
-  def borrow(requestKey: RequestKey): F[NextConnection] =
-    builder(requestKey).map(NextConnection(_, fresh = true))
+trait Connection[F[_]] {
 
-  override def shutdown: F[Unit] =
-    F.unit
+  /** Determine if the connection is closed and resources have been freed */
+  def isClosed: Boolean
 
-  override def invalidate(connection: A): F[Unit] =
-    F.delay(connection.shutdown())
+  /** Determine if the connection is in a state that it can be recycled for another request. */
+  def isRecyclable: Boolean
 
-  override def release(connection: A): F[Unit] =
-    invalidate(connection)
+  /** Close down the connection, freeing resources and potentially aborting a [[Response]] */
+  def shutdown(): Unit
+
+  /** The key for requests we are able to serve */
+  def requestKey: RequestKey
 }

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/ConnectionBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/ConnectionBuilder.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package org.http4s.blaze
+package org.http4s.blaze.client
 
 import org.http4s.client.RequestKey
 
-package object client {
-  type ConnectionBuilder[F[_], A <: Connection[F]] = RequestKey => F[A]
+private[client] trait ConnectionBuilder[F[_], A <: Connection[F]] {
+  def apply(key: RequestKey): F[A]
 }

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/ConnectionManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/ConnectionManager.scala
@@ -21,8 +21,6 @@ package client
 import cats.effect._
 import cats.effect.concurrent.Semaphore
 import cats.syntax.all._
-import org.http4s.client.Connection
-import org.http4s.client.ConnectionBuilder
 import org.http4s.client.RequestKey
 
 import scala.concurrent.ExecutionContext

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Client.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Client.scala
@@ -22,7 +22,6 @@ import cats.effect._
 import fs2.Stream
 import org.http4s.blaze.channel.ChannelOptions
 import org.http4s.client.Client
-import org.http4s.client.ConnectionBuilder
 import org.http4s.internal.SSLContextOption
 
 import scala.concurrent.duration.Duration

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
@@ -29,10 +29,10 @@ import org.http4s.blazecore.Http1Stage
 import org.http4s.blazecore.IdleTimeoutStage
 import org.http4s.blazecore.util.Http1Writer
 import org.http4s.client.RequestKey
-import org.http4s.headers.Connection
 import org.http4s.headers.Host
 import org.http4s.headers.`Content-Length`
 import org.http4s.headers.`User-Agent`
+import org.http4s.headers.{Connection => HConnection}
 import org.http4s.internal.CharPredicate
 import org.http4s.util.StringWriter
 import org.http4s.util.Writer
@@ -207,7 +207,7 @@ private final class Http1Connection[F[_]](
           if (userAgent.nonEmpty && req.headers.get[`User-Agent`].isEmpty)
             rr << userAgent.get << "\r\n"
 
-          val mustClose: Boolean = req.headers.get[Connection] match {
+          val mustClose: Boolean = req.headers.get[HConnection] match {
             case Some(conn) => checkCloseConnection(conn, rr)
             case None => getHttpMinor(req) == 0
           }
@@ -422,7 +422,7 @@ private final class Http1Connection[F[_]](
     }
 
   private def cleanUpAfterReceivingResponse(closeOnFinish: Boolean, headers: Headers): Unit =
-    if (closeOnFinish || headers.get[Connection].exists(_.hasClose)) {
+    if (closeOnFinish || headers.get[HConnection].exists(_.hasClose)) {
       logger.debug("Message body complete. Shutting down.")
       stageShutdown()
     } else {

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/PoolManager.scala
@@ -21,8 +21,6 @@ package client
 import cats.effect._
 import cats.effect.concurrent.Semaphore
 import cats.syntax.all._
-import org.http4s.client.Connection
-import org.http4s.client.ConnectionBuilder
 import org.http4s.client.RequestKey
 import org.http4s.internal.CollectionCompat
 import org.log4s.getLogger

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/package.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/package.scala
@@ -14,26 +14,10 @@
  * limitations under the License.
  */
 
-package org.http4s
-package blaze
-package client
+package org.http4s.blaze
 
-import cats.effect._
-import cats.syntax.all._
 import org.http4s.client.RequestKey
 
-private final class BasicManager[F[_], A <: Connection[F]](builder: ConnectionBuilder[F, A])(
-    implicit F: Sync[F]
-) extends ConnectionManager[F, A] {
-  def borrow(requestKey: RequestKey): F[NextConnection] =
-    builder(requestKey).map(NextConnection(_, fresh = true))
-
-  override def shutdown: F[Unit] =
-    F.unit
-
-  override def invalidate(connection: A): F[Unit] =
-    F.delay(connection.shutdown())
-
-  override def release(connection: A): F[Unit] =
-    invalidate(connection)
+package object client {
+  type ConnectionBuilder[F[_], A <: Connection[F]] = RequestKey => F[A]
 }

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/PoolManagerSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/PoolManagerSuite.scala
@@ -24,8 +24,6 @@ import cats.effect.concurrent.Semaphore
 import cats.implicits._
 import com.comcast.ip4s._
 import fs2.Stream
-import org.http4s.client.Connection
-import org.http4s.client.ConnectionBuilder
 import org.http4s.client.ConnectionFailure
 import org.http4s.client.RequestKey
 import org.http4s.syntax.AllSyntax

--- a/build.sbt
+++ b/build.sbt
@@ -445,6 +445,8 @@ lazy val blazeClient = libraryProject("blaze-client")
     description := "blaze implementation for http4s clients",
     startYear := Some(2014),
     mimaBinaryIssueFilters ++= Seq(
+      // These are all private to blaze-client and fallout from from
+      // the deprecation of org.http4s.client.Connection
       ProblemFilters
         .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.BasicManager.invalidate"),
       ProblemFilters
@@ -480,6 +482,14 @@ lazy val blazeClient = libraryProject("blaze-client")
         .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.PoolManager.release"),
       ProblemFilters
         .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.PoolManager.invalidate"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.BasicManager.this"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.ConnectionManager.pool"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.ConnectionManager.basic"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.PoolManager.this"),
     ),
   )
   .dependsOn(blazeCore % "compile;test->test", client % "compile;test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -444,7 +444,43 @@ lazy val blazeClient = libraryProject("blaze-client")
   .settings(
     description := "blaze implementation for http4s clients",
     startYear := Some(2014),
-    mimaBinaryIssueFilters ++= Seq(),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.BasicManager.invalidate"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.BasicManager.release"),
+      ProblemFilters.exclude[MissingTypesProblem]("org.http4s.blaze.client.BlazeConnection"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.ConnectionManager.release"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.blaze.client.ConnectionManager.invalidate"
+      ),
+      ProblemFilters
+        .exclude[ReversedMissingMethodProblem]("org.http4s.blaze.client.ConnectionManager.release"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "org.http4s.blaze.client.ConnectionManager.invalidate"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.blaze.client.ConnectionManager#NextConnection.connection"
+      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.blaze.client.ConnectionManager#NextConnection.copy"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.blaze.client.ConnectionManager#NextConnection.copy$default$1"
+      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.blaze.client.ConnectionManager#NextConnection.this"
+      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.blaze.client.ConnectionManager#NextConnection.apply"
+      ),
+      ProblemFilters.exclude[MissingTypesProblem]("org.http4s.blaze.client.Http1Connection"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.PoolManager.release"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.http4s.blaze.client.PoolManager.invalidate"),
+    ),
   )
   .dependsOn(blazeCore % "compile;test->test", client % "compile;test->test")
 

--- a/client/src/main/scala/org/http4s/client/Connection.scala
+++ b/client/src/main/scala/org/http4s/client/Connection.scala
@@ -17,6 +17,7 @@
 package org.http4s
 package client
 
+@deprecated("Is a Blaze detail.  Will be removed from public API.", "0.22.9")
 trait Connection[F[_]] {
 
   /** Determine if the connection is closed and resources have been freed */

--- a/client/src/main/scala/org/http4s/client/package.scala
+++ b/client/src/main/scala/org/http4s/client/package.scala
@@ -29,6 +29,7 @@ package object client extends ClientTypes {
 trait ClientTypes {
   import org.http4s.client._
 
+  @deprecated("Is a Blaze detail.  Will be removed from public API.", "0.22.9")
   type ConnectionBuilder[F[_], A <: Connection[F]] = RequestKey => F[A]
 
   type Middleware[F[_]] = Client[F] => Client[F]


### PR DESCRIPTION
These are blaze-specific types and clutter the Client namespace.

We keep the traits in the blaze package, because some tests use non-`BlazeConnection` implementations.

All the affected types are private, so generous MiMa exceptions are granted.  I'd rather not, but I think the alternative is an avalanche of `@nowarn`.