### PR TITLE
Support parsing response bodies without Content-Length in ember

### DIFF
--- a/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -295,7 +295,13 @@ private[ember] object Parser {
     def parser[F[_]: Concurrent](maxHeaderSize: Int)(
         buffer: Array[Byte],
         read: Read[F],
-    ): F[(Response[F], Drain[F])] =
+    ): F[(Response[F], Drain[F])] = {
+      // per https://httpwg.org/specs/rfc7230.html#rfc.section.3.3.3
+      def expectNoBody(status: Status): Boolean =
+        status == Status.NoContent ||
+          status == Status.NotModified ||
+          status.responseClass == Status.Informational
+
       for {
         t <- MessageP.recurseFind(buffer, read, maxHeaderSize)(ibuffer =>
           EitherT(RespPrelude.parsePrelude[F](ibuffer, maxHeaderSize))
@@ -325,13 +331,19 @@ private[ember] object Parser {
                   ) ->
                   rest.get
             }
+          } else if (expectNoBody(prelude.status)) {
+            (baseResp -> (Some(finalBuffer): Option[Array[Byte]]).pure[F]).pure[F]
           } else {
-            Body.parseFixedBody(headerP.contentLength.getOrElse(0L), finalBuffer, read).map {
-              case (bodyStream, drain) =>
+            headerP.contentLength
+              .fold(Body.parseUnknownBody(finalBuffer, read))(
+                Body.parseFixedBody(_, finalBuffer, read)
+              )
+              .map { case (bodyStream, drain) =>
                 baseResp.withBodyStream(bodyStream) -> drain
-            }
+              }
           }
       } yield resp
+    }
 
     object RespPrelude {
 
@@ -440,6 +452,30 @@ private[ember] object Parser {
         }
       } else {
         (EmptyBody.covary[F], (Some(buffer): Option[Array[Byte]]).pure[F]).pure[F]
+      }
+
+    def parseUnknownBody[F[_]: Concurrent](
+        buffer: Array[Byte],
+        read: Read[F],
+    ): F[(EntityBody[F], Drain[F])] =
+      Ref[F].of(false).map { consumed =>
+        lazy val readAll: Pull[F, Byte, Unit] =
+          Pull.eval(read).flatMap {
+            case Some(c) => Pull.output(c) >> readAll
+            case None => Pull.eval(consumed.set(true)).void
+          }
+
+        val body =
+          Stream
+            .eval(consumed.get)
+            .ifM(
+              ifTrue = Stream.raiseError(BodyAlreadyConsumedError()),
+              ifFalse = Stream.chunk(Chunk.array(buffer)) ++ readAll.stream,
+            )
+
+        val drain: Drain[F] = (None: Option[Array[Byte]]).pure[F]
+
+        (body, drain)
       }
 
     final case class BodyAlreadyConsumedError()


### PR DESCRIPTION
Adds support for parsing response bodies without a `Content-Length` header to `ember`.

Fixes #5865 