### PR TITLE
Use blocking thread pool on joining Jetty's thread pool

### DIFF
--- a/jetty-server/src/main/scala/org/http4s/jetty/server/JettyThreadPools.scala
+++ b/jetty-server/src/main/scala/org/http4s/jetty/server/JettyThreadPools.scala
@@ -30,10 +30,10 @@ object JettyThreadPools {
     * Jetty [[org.eclipse.jetty.util.thread.ThreadPool]] have some rather
     * unusual properties. [[org.eclipse.jetty.util.thread.ThreadPool]] itself
     * does not implement any of the standard JVM or Jetty lifecycle systems,
-    * e.g. [[java.lang.Closeable]] or
+    * e.g. [[java.io.Closeable]] or
     * [[org.eclipse.jetty.util.component.LifeCycle]], but ''all'' the concrete
     * implementations of it provided by Jetty ''do'' implement
-    * [[[[org.eclipse.jetty.util.component.LifeCycle]]]].
+    * [[org.eclipse.jetty.util.component.LifeCycle]].
     *
     * The [[cats.effect.Resource]] implemented here will use the
     * [[org.eclipse.jetty.util.component.LifeCycle]] shutdown semantics if the
@@ -59,7 +59,7 @@ object JettyThreadPools {
 
   /** The default [[org.eclipse.jetty.util.thread.ThreadPool]] used by
     * [[JettyBuilder]]. If you require specific constraints on this (a certain
-    * number of threads, etc.) please use [[#resource]] and take a look at the
+    * number of threads, etc.) please use [[resource]] and take a look at the
     * concrete implementations of [[org.eclipse.jetty.util.thread.ThreadPool]]
     * provided by Jetty.
     */

--- a/jetty-server/src/main/scala/org/http4s/jetty/server/JettyThreadPools.scala
+++ b/jetty-server/src/main/scala/org/http4s/jetty/server/JettyThreadPools.scala
@@ -54,7 +54,7 @@ object JettyThreadPools {
       case value: ThreadPool with LifeCycle =>
         JettyLifeCycle.lifeCycleAsResource[F, ThreadPool with LifeCycle](F.pure(value))
       case value: ThreadPool =>
-        Resource.make(F.pure(value))(value => F.delay(value.join))
+        Resource.make(F.pure(value))(value => F.blocking(value.join()))
     }
 
   /** The default [[org.eclipse.jetty.util.thread.ThreadPool]] used by


### PR DESCRIPTION
Cos `org.eclipse.jetty.util.thread.ThreadPool#join` is a [blocking operation](https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/util/thread/ThreadPool.html) then it's better to run it on Cats-Effect blocking thread pool.