### PR TITLE
Use blocking thread pool in the `JettyClient#resource`

### DIFF
--- a/jetty-client/src/main/scala/org/http4s/jetty/client/JettyClient.scala
+++ b/jetty-client/src/main/scala/org/http4s/jetty/client/JettyClient.scala
@@ -62,9 +62,10 @@ object JettyClient {
           })
         }
       )
-    val dispose = F
-      .delay(client.stop())
-      .handleErrorWith(t => F.delay(logger.error(t)("Unable to shut down Jetty client")))
+    val dispose =
+      F
+        .blocking(client.stop())
+        .handleErrorWith(t => F.delay(logger.error(t)("Unable to shut down Jetty client")))
     Resource.make(acquire)(_ => dispose)
   }
 


### PR DESCRIPTION
`org.eclipse.jetty.util.component.AbstractLifeCycle#stop` uses under the hood synchronized lock, so blocking thread pool is more desired to use.