### PR TITLE
Use loopback address for Netty scaffold

### DIFF
--- a/client/src/test/scala/org/http4s/client/scaffold/NettyTestServer.scala
+++ b/client/src/test/scala/org/http4s/client/scaffold/NettyTestServer.scala
@@ -106,7 +106,7 @@ object NettyTestServer {
       F: Async[F]
   ): Resource[F, Channel] =
     Resource.make[F, Channel](
-      F.delay(bootstrap.bind(InetAddress.getLocalHost(), port)).liftToFWithChannel
+      F.delay(bootstrap.bind(InetAddress.getLoopbackAddress(), port)).liftToFWithChannel
     )(channel => F.delay(channel.close(new DefaultChannelPromise(channel))).liftToF)
 
   private def toSocketAddress(


### PR DESCRIPTION
Pretty sure this should fix the `BindException`s that are proliferating.