### PR TITLE
Add `scalafixInternalRules` to root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1029,7 +1029,7 @@ lazy val scalafixInternalRules = project
     startYear := Some(2021),
     libraryDependencies ++= Seq(
       "ch.epfl.scala" %% "scalafix-core" % _root_.scalafix.sbt.BuildInfo.scalafixVersion
-    ).filter(_ => !tlIsScala3.value)
+    ).filter(_ => !tlIsScala3.value),
   )
 
 lazy val scalafixInternalInput = project

--- a/build.sbt
+++ b/build.sbt
@@ -635,7 +635,9 @@ lazy val blazeClient = libraryProject("blaze-client")
         Seq(
           ProblemFilters.exclude[IncompatibleResultTypeProblem](
             "org.http4s.blaze.client.ConnectionManager#NextConnection._1"
-          )
+          ),
+          ProblemFilters
+            .exclude[DirectMissingMethodProblem]("org.http4s.blaze.client.BlazeClient.makeClient"),
         )
       else Seq.empty
     },

--- a/build.sbt
+++ b/build.sbt
@@ -1026,6 +1026,7 @@ lazy val scalafixInternalRules = project
   .enablePlugins(NoPublishPlugin)
   .disablePlugins(ScalafixPlugin)
   .settings(
+    startYear := Some(2021),
     libraryDependencies ++= Seq(
       "ch.epfl.scala" %% "scalafix-core" % _root_.scalafix.sbt.BuildInfo.scalafixVersion
     ).filter(_ => !tlIsScala3.value)

--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ lazy val modules: List[ProjectReference] = List(
   examplesJetty,
   examplesTomcat,
   examplesWar,
+  scalafixInternalRules,
   scalafixInternalInput,
   scalafixInternalOutput,
   scalafixInternalTests,


### PR DESCRIPTION
`scalafixInternalRules` was omitted from the root aggregate, so CI failed to catch the header issue. Fixes https://github.com/http4s/http4s/issues/5917.