### PR TITLE
Non-deadlocking RouterInServletSuite

### DIFF
--- a/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
@@ -51,7 +51,7 @@ class BlockingHttp4sServletSuite extends Http4sSuite {
   )
 
   private def get(serverPort: Int, path: String): IO[String] =
-    IO(
+    IO.blocking(
       AutoCloseableResource.resource(
         Source
           .fromURL(new URL(s"http://127.0.0.1:$serverPort/$path"))

--- a/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
@@ -122,7 +122,7 @@ class RouterInServletSuite extends Http4sSuite {
   )(server => get(server, "context/servlet/prefix/suffix").assertEquals("suffix"))
 
   private def get(serverPort: Int, path: String): IO[String] =
-    IO.delay(
+    IO.blocking(
       AutoCloseableResource.resource(
         Source
           .fromURL(new URL(s"http://127.0.0.1:$serverPort/$path"))
@@ -137,7 +137,7 @@ class RouterInServletSuite extends Http4sSuite {
   ): Resource[IO, Int] = TestEclipseServer(servlet(routes, dispatcher), contextPath, servletPath)
 
   private def servlet(routes: HttpRoutes[IO], dispatcher: Dispatcher[IO]) =
-    new BlockingHttp4sServlet[IO](
+    new AsyncHttp4sServlet[IO](
       service = routes.orNotFound,
       servletIo = org.http4s.servlet.BlockingServletIo(4096),
       serviceErrorHandler = DefaultServiceErrorHandler,


### PR DESCRIPTION
This could be the villain in #5844.

* That `.get` in the suite should definitely be blocking
* The servlet pool is wedged, so let's use the AsyncHttp4sServlet there, too.
* I don't know if anyone has thought about what CE3 blocking means for servlets. 🤔 