### PR TITLE
Add module labeling to mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,19 +1,190 @@
 pull_request_rules:
+
 - name: label series/0.22 PRs
   conditions:
   - base=series/0.22
   actions:
     label:
       add: ['series/0.22']
+
 - name: label series/0.23 PRs
   conditions:
   - base=series/0.23
   actions:
     label:
       add: ['series/0.23']
+
 - name: label scala-steward's PRs
   conditions:
     - author=scala-steward
   actions:
     label:
       add: [dependencies]
+
+- name: label core PRs
+  conditions:
+    - file~=^core/
+    actions:
+      label:
+        add: ['module:core']
+
+- name: label dsl PRs
+  conditions:
+    - file~=^dsl/
+    actions:
+      label:
+        add: ['module:dsl']
+
+- name: label laws PRs
+  conditions:
+    - file~=^laws/
+    actions:
+      label:
+        add: ['module:laws']
+
+- name: label server PRs
+  conditions:
+    - file~=^server/
+    actions:
+      label:
+        add: ['module:server']
+
+- name: label client PRs
+  conditions:
+    - file~=^client/
+    actions:
+      label:
+        add: ['module:client']
+
+- name: label ember-core PRs
+  conditions:
+    - file~=^ember-core/
+    actions:
+      label:
+        add: ['module:ember-core']
+
+- name: label ember-server PRs
+  conditions:
+    - file~=^ember-server/
+    actions:
+      label:
+        add: ['module:ember-server']
+
+- name: label ember-client PRs
+  conditions:
+    - file~=^ember-client/
+    actions:
+      label:
+        add: ['module:ember-client']
+
+- name: label blaze-core PRs
+  conditions:
+    - file~=^blaze-core/
+    actions:
+      label:
+        add: ['module:blaze-core']
+
+- name: label blaze-server PRs
+  conditions:
+    - file~=^blaze-server/
+    actions:
+      label:
+        add: ['module:blaze-server']
+
+- name: label blaze-client PRs
+  conditions:
+    - file~=^blaze-client/
+    actions:
+      label:
+        add: ['module:blaze-client']
+
+- name: label servlet PRs
+  conditions:
+    - file~=^servlet/
+    actions:
+      label:
+        add: ['module:servlet']
+
+- name: label tomcat PRs
+  conditions:
+    - file~=^tomcat/
+    actions:
+      label:
+        add: ['module:tomcat']
+
+- name: label jetty-server PRs
+  conditions:
+    - file~=^jetty-server/
+    actions:
+      label:
+        add: ['module:jetty-server']
+
+- name: label jetty-client PRs
+  conditions:
+    - file~=^jetty-client/
+    actions:
+      label:
+        add: ['module:jetty-client']
+
+- name: label async-http-client PRs
+  conditions:
+    - file~=^async-http-client/
+    actions:
+      label:
+        add: ['module:async-http-client']
+
+- name: label okhttp-client PRs
+  conditions:
+    - file~=^okhttp-client/
+    actions:
+      label:
+        add: ['module:okhttp-client']
+
+- name: label jawn PRs
+  conditions:
+    - file~=^jawn/
+    actions:
+      label:
+        add: ['module:jawn']
+
+- name: label circe PRs
+  conditions:
+    - file~=^circe/
+    actions:
+      label:
+        add: ['module:circe']
+
+- name: label play-json PRs
+  conditions:
+    - file~=^play-json/
+    actions:
+      label:
+        add: ['module:play-json']
+
+- name: label scalatags PRs
+  conditions:
+    - file~=^scalatags/
+    actions:
+      label:
+        add: ['module:scalatags']
+
+- name: label twirl PRs
+  conditions:
+    - file~=^twirl/
+    actions:
+      label:
+        add: ['module:twirl']
+
+- name: label dropwizard-metrics PRs
+  conditions:
+    - file~=^dropwizard-metrics/
+    actions:
+      label:
+        add: ['module:dropwizard-metrics']
+
+- name: label prometheus-metrics PRs
+  conditions:
+    - file~=^prometheus-metrics/
+    actions:
+      label:
+        add: ['module:prometheus-metrics']

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,175 +16,175 @@ pull_request_rules:
 
 - name: label scala-steward's PRs
   conditions:
-    - author=scala-steward
+  - author=scala-steward
   actions:
     label:
       add: [dependencies]
 
 - name: label core PRs
   conditions:
-    - file~=^core/
-    actions:
-      label:
-        add: ['module:core']
+  - file~=^core/
+  actions:
+    label:
+      add: ['module:core']
 
 - name: label dsl PRs
   conditions:
-    - file~=^dsl/
-    actions:
-      label:
-        add: ['module:dsl']
+  - file~=^dsl/
+  actions:
+    label:
+      add: ['module:dsl']
 
 - name: label laws PRs
   conditions:
-    - file~=^laws/
-    actions:
-      label:
-        add: ['module:laws']
+  - file~=^laws/
+  actions:
+    label:
+      add: ['module:laws']
 
 - name: label server PRs
   conditions:
-    - file~=^server/
-    actions:
-      label:
-        add: ['module:server']
+  - file~=^server/
+  actions:
+    label:
+      add: ['module:server']
 
 - name: label client PRs
   conditions:
-    - file~=^client/
-    actions:
-      label:
-        add: ['module:client']
+  - file~=^client/
+  actions:
+    label:
+      add: ['module:client']
 
 - name: label ember-core PRs
   conditions:
-    - file~=^ember-core/
-    actions:
-      label:
-        add: ['module:ember-core']
+  - file~=^ember-core/
+  actions:
+    label:
+      add: ['module:ember-core']
 
 - name: label ember-server PRs
   conditions:
-    - file~=^ember-server/
-    actions:
-      label:
-        add: ['module:ember-server']
+  - file~=^ember-server/
+  actions:
+    label:
+      add: ['module:ember-server']
 
 - name: label ember-client PRs
   conditions:
-    - file~=^ember-client/
-    actions:
-      label:
-        add: ['module:ember-client']
+  - file~=^ember-client/
+  actions:
+    label:
+      add: ['module:ember-client']
 
 - name: label blaze-core PRs
   conditions:
-    - file~=^blaze-core/
-    actions:
-      label:
-        add: ['module:blaze-core']
+  - file~=^blaze-core/
+  actions:
+    label:
+      add: ['module:blaze-core']
 
 - name: label blaze-server PRs
   conditions:
-    - file~=^blaze-server/
-    actions:
-      label:
-        add: ['module:blaze-server']
+  - file~=^blaze-server/
+  actions:
+    label:
+      add: ['module:blaze-server']
 
 - name: label blaze-client PRs
   conditions:
-    - file~=^blaze-client/
-    actions:
-      label:
-        add: ['module:blaze-client']
+  - file~=^blaze-client/
+  actions:
+    label:
+      add: ['module:blaze-client']
 
 - name: label servlet PRs
   conditions:
-    - file~=^servlet/
-    actions:
-      label:
-        add: ['module:servlet']
+  - file~=^servlet/
+  actions:
+    label:
+      add: ['module:servlet']
 
 - name: label tomcat PRs
   conditions:
-    - file~=^tomcat/
-    actions:
-      label:
-        add: ['module:tomcat']
+  - file~=^tomcat/
+  actions:
+    label:
+      add: ['module:tomcat']
 
 - name: label jetty-server PRs
   conditions:
-    - file~=^jetty-server/
-    actions:
-      label:
-        add: ['module:jetty-server']
+  - file~=^jetty-server/
+  actions:
+    label:
+      add: ['module:jetty-server']
 
 - name: label jetty-client PRs
   conditions:
-    - file~=^jetty-client/
-    actions:
-      label:
-        add: ['module:jetty-client']
+  - file~=^jetty-client/
+  actions:
+    label:
+      add: ['module:jetty-client']
 
 - name: label async-http-client PRs
   conditions:
-    - file~=^async-http-client/
-    actions:
-      label:
-        add: ['module:async-http-client']
+  - file~=^async-http-client/
+  actions:
+    label:
+      add: ['module:async-http-client']
 
 - name: label okhttp-client PRs
   conditions:
-    - file~=^okhttp-client/
-    actions:
-      label:
-        add: ['module:okhttp-client']
+  - file~=^okhttp-client/
+  actions:
+    label:
+      add: ['module:okhttp-client']
 
 - name: label jawn PRs
   conditions:
-    - file~=^jawn/
-    actions:
-      label:
-        add: ['module:jawn']
+  - file~=^jawn/
+  actions:
+    label:
+      add: ['module:jawn']
 
 - name: label circe PRs
   conditions:
-    - file~=^circe/
-    actions:
-      label:
-        add: ['module:circe']
+  - file~=^circe/
+  actions:
+    label:
+      add: ['module:circe']
 
 - name: label play-json PRs
   conditions:
-    - file~=^play-json/
-    actions:
-      label:
-        add: ['module:play-json']
+  - file~=^play-json/
+  actions:
+    label:
+      add: ['module:play-json']
 
 - name: label scalatags PRs
   conditions:
-    - file~=^scalatags/
-    actions:
-      label:
-        add: ['module:scalatags']
+  - file~=^scalatags/
+  actions:
+    label:
+      add: ['module:scalatags']
 
 - name: label twirl PRs
   conditions:
-    - file~=^twirl/
-    actions:
-      label:
-        add: ['module:twirl']
+  - file~=^twirl/
+  actions:
+    label:
+      add: ['module:twirl']
 
 - name: label dropwizard-metrics PRs
   conditions:
-    - file~=^dropwizard-metrics/
-    actions:
-      label:
-        add: ['module:dropwizard-metrics']
+  - file~=^dropwizard-metrics/
+  actions:
+    label:
+      add: ['module:dropwizard-metrics']
 
 - name: label prometheus-metrics PRs
   conditions:
-    - file~=^prometheus-metrics/
-    actions:
-      label:
-        add: ['module:prometheus-metrics']
+  - file~=^prometheus-metrics/
+  actions:
+    label:
+      add: ['module:prometheus-metrics']

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,168 +23,168 @@ pull_request_rules:
 
 - name: label core PRs
   conditions:
-  - file~=^core/
+  - files~=^core/
   actions:
     label:
       add: ['module:core']
 
 - name: label dsl PRs
   conditions:
-  - file~=^dsl/
+  - files~=^dsl/
   actions:
     label:
       add: ['module:dsl']
 
 - name: label laws PRs
   conditions:
-  - file~=^laws/
+  - files~=^laws/
   actions:
     label:
       add: ['module:laws']
 
 - name: label server PRs
   conditions:
-  - file~=^server/
+  - files~=^server/
   actions:
     label:
       add: ['module:server']
 
 - name: label client PRs
   conditions:
-  - file~=^client/
+  - files~=^client/
   actions:
     label:
       add: ['module:client']
 
 - name: label ember-core PRs
   conditions:
-  - file~=^ember-core/
+  - files~=^ember-core/
   actions:
     label:
       add: ['module:ember-core']
 
 - name: label ember-server PRs
   conditions:
-  - file~=^ember-server/
+  - files~=^ember-server/
   actions:
     label:
       add: ['module:ember-server']
 
 - name: label ember-client PRs
   conditions:
-  - file~=^ember-client/
+  - files~=^ember-client/
   actions:
     label:
       add: ['module:ember-client']
 
 - name: label blaze-core PRs
   conditions:
-  - file~=^blaze-core/
+  - files~=^blaze-core/
   actions:
     label:
       add: ['module:blaze-core']
 
 - name: label blaze-server PRs
   conditions:
-  - file~=^blaze-server/
+  - files~=^blaze-server/
   actions:
     label:
       add: ['module:blaze-server']
 
 - name: label blaze-client PRs
   conditions:
-  - file~=^blaze-client/
+  - files~=^blaze-client/
   actions:
     label:
       add: ['module:blaze-client']
 
 - name: label servlet PRs
   conditions:
-  - file~=^servlet/
+  - files~=^servlet/
   actions:
     label:
       add: ['module:servlet']
 
 - name: label tomcat PRs
   conditions:
-  - file~=^tomcat/
+  - files~=^tomcat/
   actions:
     label:
       add: ['module:tomcat']
 
 - name: label jetty-server PRs
   conditions:
-  - file~=^jetty-server/
+  - files~=^jetty-server/
   actions:
     label:
       add: ['module:jetty-server']
 
 - name: label jetty-client PRs
   conditions:
-  - file~=^jetty-client/
+  - files~=^jetty-client/
   actions:
     label:
       add: ['module:jetty-client']
 
 - name: label async-http-client PRs
   conditions:
-  - file~=^async-http-client/
+  - files~=^async-http-client/
   actions:
     label:
       add: ['module:async-http-client']
 
 - name: label okhttp-client PRs
   conditions:
-  - file~=^okhttp-client/
+  - files~=^okhttp-client/
   actions:
     label:
       add: ['module:okhttp-client']
 
 - name: label jawn PRs
   conditions:
-  - file~=^jawn/
+  - files~=^jawn/
   actions:
     label:
       add: ['module:jawn']
 
 - name: label circe PRs
   conditions:
-  - file~=^circe/
+  - files~=^circe/
   actions:
     label:
       add: ['module:circe']
 
 - name: label play-json PRs
   conditions:
-  - file~=^play-json/
+  - files~=^play-json/
   actions:
     label:
       add: ['module:play-json']
 
 - name: label scalatags PRs
   conditions:
-  - file~=^scalatags/
+  - files~=^scalatags/
   actions:
     label:
       add: ['module:scalatags']
 
 - name: label twirl PRs
   conditions:
-  - file~=^twirl/
+  - files~=^twirl/
   actions:
     label:
       add: ['module:twirl']
 
 - name: label dropwizard-metrics PRs
   conditions:
-  - file~=^dropwizard-metrics/
+  - files~=^dropwizard-metrics/
   actions:
     label:
       add: ['module:dropwizard-metrics']
 
 - name: label prometheus-metrics PRs
   conditions:
-  - file~=^prometheus-metrics/
+  - files~=^prometheus-metrics/
   actions:
     label:
       add: ['module:prometheus-metrics']


### PR DESCRIPTION
Part of https://github.com/http4s/http4s/pull/5940#issuecomment-1019702909. Targeting main because that's where mergify reads the config from.

Getting auto-labeling for dependencies will be a little trickier.