### PR TITLE
Replace our TestExecutionContext

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/blaze/client/ClientTimeoutSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/ClientTimeoutSuite.scala
@@ -66,7 +66,7 @@ class ClientTimeoutSuite extends Http4sSuite with DispatcherIOFixture {
   ): Option[IdleTimeoutStage[ByteBuffer]] =
     idleTimeout match {
       case d: FiniteDuration =>
-        Some(new IdleTimeoutStage[ByteBuffer](d, tickWheel, Http4sSuite.TestExecutionContext))
+        Some(new IdleTimeoutStage[ByteBuffer](d, tickWheel, munitExecutionContext))
       case _ => None
     }
 
@@ -99,7 +99,7 @@ class ClientTimeoutSuite extends Http4sSuite with DispatcherIOFixture {
       responseHeaderTimeout = responseHeaderTimeout,
       requestTimeout = requestTimeout,
       scheduler = tickWheel,
-      ec = Http4sSuite.TestExecutionContext,
+      ec = munitExecutionContext,
       retries = retries,
     )
   }
@@ -110,7 +110,7 @@ class ClientTimeoutSuite extends Http4sSuite with DispatcherIOFixture {
   ): Http1Connection[IO] =
     new Http1Connection[IO](
       requestKey = FooRequestKey,
-      executionContext = Http4sSuite.TestExecutionContext,
+      executionContext = munitExecutionContext,
       maxResponseLineSize = 4 * 1024,
       maxHeaderLength = 40 * 1024,
       maxChunkSize = Int.MaxValue,

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
@@ -42,11 +42,10 @@ import org.typelevel.vault._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import scala.annotation.nowarn
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 class Http1ServerStageSpec extends Http4sSuite {
-  implicit val ec: ExecutionContext = Http4sSuite.TestExecutionContext
+
   val fixture = ResourceFixture(Resource.make(IO.delay(new TickWheelExecutor())) { twe =>
     IO.delay(twe.shutdown())
   })

--- a/testing/js/src/test/scala/org/http4s/Http4sSuitePlatform.scala
+++ b/testing/js/src/test/scala/org/http4s/Http4sSuitePlatform.scala
@@ -16,8 +16,6 @@
 
 package org.http4s
 
-import cats.effect.unsafe.IORuntime
-
 import scala.scalajs.js
 import scala.util.Try
 
@@ -27,6 +25,4 @@ trait Http4sSuitePlatform { this: Http4sSuite =>
     Try(js.Dynamic.global.process.env.CI).toOption.filterNot(js.isUndefined).isDefined
 }
 
-trait Http4sSuiteCompanionPlatform {
-  val TestIORuntime: IORuntime = IORuntime.global
-}
+trait Http4sSuiteCompanionPlatform

--- a/testing/js/src/test/scala/org/http4s/Http4sSuitePlatform.scala
+++ b/testing/js/src/test/scala/org/http4s/Http4sSuitePlatform.scala
@@ -24,5 +24,3 @@ trait Http4sSuitePlatform { this: Http4sSuite =>
   override def munitFlakyOK =
     Try(js.Dynamic.global.process.env.CI).toOption.filterNot(js.isUndefined).isDefined
 }
-
-trait Http4sSuiteCompanionPlatform

--- a/testing/jvm/src/test/scala/org/http4s/Http4sSuitePlatform.scala
+++ b/testing/jvm/src/test/scala/org/http4s/Http4sSuitePlatform.scala
@@ -18,17 +18,11 @@ package org.http4s
 
 import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.unsafe.IORuntime
-import cats.effect.unsafe.IORuntimeConfig
-import cats.effect.unsafe.Scheduler
-import org.http4s.internal.threads.newBlockingPool
-import org.http4s.internal.threads.newDaemonPool
 import org.http4s.internal.threads.threadFactory
 
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import scala.concurrent.ExecutionContext
 
 trait Http4sSuitePlatform { this: Http4sSuite =>
 
@@ -48,22 +42,5 @@ trait Http4sSuiteCompanionPlatform {
     s.setKeepAliveTime(10L, TimeUnit.SECONDS)
     s.allowCoreThreadTimeOut(true)
     s
-  }
-
-  val TestIORuntime: IORuntime = {
-    val blockingPool = newBlockingPool("http4s-suite-blocking")
-    val computePool = newDaemonPool("http4s-suite", timeout = true)
-    val scheduledExecutor = TestScheduler
-    IORuntime.apply(
-      ExecutionContext.fromExecutor(computePool),
-      ExecutionContext.fromExecutor(blockingPool),
-      Scheduler.fromScheduledExecutor(scheduledExecutor),
-      () => {
-        blockingPool.shutdown()
-        computePool.shutdown()
-        scheduledExecutor.shutdown()
-      },
-      IORuntimeConfig(),
-    )
   }
 }

--- a/testing/jvm/src/test/scala/org/http4s/Http4sSuitePlatform.scala
+++ b/testing/jvm/src/test/scala/org/http4s/Http4sSuitePlatform.scala
@@ -18,11 +18,6 @@ package org.http4s
 
 import cats.effect.IO
 import cats.effect.Resource
-import org.http4s.internal.threads.threadFactory
-
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 
 trait Http4sSuitePlatform { this: Http4sSuite =>
 
@@ -32,15 +27,4 @@ trait Http4sSuitePlatform { this: Http4sSuite =>
 
   // allow flaky tests on ci
   override def munitFlakyOK = sys.env.contains("CI")
-}
-
-trait Http4sSuiteCompanionPlatform {
-
-  val TestScheduler: ScheduledExecutorService = {
-    val s =
-      new ScheduledThreadPoolExecutor(2, threadFactory(i => s"http4s-test-scheduler-$i", true))
-    s.setKeepAliveTime(10L, TimeUnit.SECONDS)
-    s.allowCoreThreadTimeOut(true)
-    s
-  }
 }

--- a/testing/jvm/src/test/scala/org/http4s/Http4sSuitePlatform.scala
+++ b/testing/jvm/src/test/scala/org/http4s/Http4sSuitePlatform.scala
@@ -41,8 +41,6 @@ trait Http4sSuitePlatform { this: Http4sSuite =>
 }
 
 trait Http4sSuiteCompanionPlatform {
-  val TestExecutionContext: ExecutionContext =
-    ExecutionContext.fromExecutor(newDaemonPool("http4s-suite", timeout = true))
 
   val TestScheduler: ScheduledExecutorService = {
     val s =

--- a/testing/shared/src/test/scala/org/http4s/Http4sSuite.scala
+++ b/testing/shared/src/test/scala/org/http4s/Http4sSuite.scala
@@ -18,7 +18,6 @@ package org.http4s
 
 import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import fs2._
 import fs2.text.utf8
@@ -32,8 +31,6 @@ trait Http4sSuite
     with DisciplineSuite
     with munit.ScalaCheckEffectSuite
     with Http4sSuitePlatform {
-
-  implicit val ioRuntime: IORuntime = Http4sSuite.TestIORuntime
 
   private[this] val suiteFixtures = List.newBuilder[Fixture[_]]
 
@@ -68,5 +65,4 @@ trait Http4sSuite
       .map(_.getOrElse(""))
 
 }
-
 object Http4sSuite extends Http4sSuiteCompanionPlatform

--- a/testing/shared/src/test/scala/org/http4s/Http4sSuite.scala
+++ b/testing/shared/src/test/scala/org/http4s/Http4sSuite.scala
@@ -65,4 +65,3 @@ trait Http4sSuite
       .map(_.getOrElse(""))
 
 }
-object Http4sSuite extends Http4sSuiteCompanionPlatform


### PR DESCRIPTION
Ours was written in olden times to get daemon threads.  The IORuntime.compute pool is also daemon threads, and implements a fancy work stealing algorithm.  This is the one that gets used in practice, and is a more honest test.  It also touches the ClientTimeoutSuite that's acting up.  Let's see if it helps!

Also removes our `TestIORuntime` and `TestScheduler`.  If the global is good enough for munit-cats-effect, maybe it's good enough for us.