### PR TITLE
Add withMaxIdleDuration setter to BlazeClientBuilder

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
@@ -248,6 +248,13 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   def withRetries(retries: Int = retries): BlazeClientBuilder[F] =
     copy(retries = retries)
 
+  /** Time a connection can be idle and still be borrowed.  Helps deal
+    * with connections that are closed while idling in the pool for an
+    * extended period.  `Duration.Inf` means no timeout.
+    */
+  def withMaxIdleDuration(maxIdleDuration: Duration = maxIdleDuration): BlazeClientBuilder[F] =
+    copy(maxIdleDuration = maxIdleDuration)
+
   /** Use some provided `SSLContext` when making secure calls, or disable secure calls with `None` */
   @deprecated(
     message =


### PR DESCRIPTION
We missed the setter for #5899, rendering it useless until the next release.  This is what happens when we unit test without integration testing.