### PR TITLE
Fix HTTP/2 warnings and restore compiler settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -478,11 +478,6 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
       log4catsCore.value,
       log4catsTesting.value % Test,
     ),
-    scalacOptions --= Seq(
-      "-Ywarn-numeric-widen",
-      "-Werror",
-      "-Xfatal-warnings",
-    ),
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Encoder.reqToBytes"),

--- a/ember-core/js/src/main/scala/org/http4s/ember/core/h2/facade/Compressor.scala
+++ b/ember-core/js/src/main/scala/org/http4s/ember/core/h2/facade/Compressor.scala
@@ -16,11 +16,13 @@
 
 package org.http4s.ember.core.h2.facade
 
+import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
 @js.native
 @JSImport("hpack.js", "compressor")
+@nowarn
 private[h2] class Compressor(options: HpackOptions) extends js.Object {
   def write(headers: js.Array[Header]): Unit = js.native
   def read(): js.typedarray.Uint8Array = js.native

--- a/ember-core/js/src/main/scala/org/http4s/ember/core/h2/facade/Decompressor.scala
+++ b/ember-core/js/src/main/scala/org/http4s/ember/core/h2/facade/Decompressor.scala
@@ -16,11 +16,13 @@
 
 package org.http4s.ember.core.h2.facade
 
+import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
 @js.native
 @JSImport("hpack.js", "decompressor")
+@nowarn
 private[h2] class Decompressor(options: HpackOptions) extends js.Object {
   def write(raw: js.typedarray.Uint8Array): Unit = js.native
   def execute(): Unit = js.native

--- a/ember-core/jvm/src/main/scala/org/http4s/ember/core/h2/H2TLSPlatform.scala
+++ b/ember-core/jvm/src/main/scala/org/http4s/ember/core/h2/H2TLSPlatform.scala
@@ -19,6 +19,8 @@ package org.http4s.ember.core.h2
 import cats.syntax.all._
 import fs2.io.net.tls.TLSParameters
 
+import javax.net.ssl.SSLEngine
+
 private[h2] abstract class H2TLSPlatform {
 
   def transform(params: TLSParameters): TLSParameters =
@@ -35,7 +37,7 @@ private[h2] abstract class H2TLSPlatform {
       useCipherSuitesOrder = params.useCipherSuitesOrder,
       needClientAuth = params.needClientAuth,
       wantClientAuth = params.wantClientAuth,
-      handshakeApplicationProtocolSelector = { (t: javax.net.ssl.SSLEngine, l: List[String]) =>
+      handshakeApplicationProtocolSelector = { (_: SSLEngine, l: List[String]) =>
         l.find(_ === "h2").getOrElse("http/1.1")
       }.some,
     )

--- a/ember-core/jvm/src/main/scala/org/http4s/ember/core/h2/HpackPlatform.scala
+++ b/ember-core/jvm/src/main/scala/org/http4s/ember/core/h2/HpackPlatform.scala
@@ -53,16 +53,18 @@ trait HpackPlatform {
       tDecoder: com.twitter.hpack.Decoder,
       bv: ByteVector,
   ): F[NonEmptyList[(String, String)]] = Sync[F].delay {
-    var buffer = new ListBuffer[(String, String)]
+    val buffer = new ListBuffer[(String, String)]
     val is = new ByteArrayInputStream(bv.toArray)
     val listener = new HeaderListener {
-      def addHeader(name: Array[Byte], value: Array[Byte], sensitive: Boolean): Unit =
+      def addHeader(name: Array[Byte], value: Array[Byte], sensitive: Boolean): Unit = {
         buffer.+=(
           new String(name, StandardCharsets.ISO_8859_1) -> new String(
             value,
             StandardCharsets.ISO_8859_1,
           )
         )
+        ()
+      }
     }
 
     tDecoder.decode(is, listener)

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -118,7 +118,7 @@ private[ember] class H2Client[F[_]: Async](
   ): Resource[F, H2Connection[F]] =
     createSocket(key, useTLS, priorKnowledge).flatMap {
       case (socket, Http2) => fromSocket(ByteVector.empty, socket, key)
-      case (socket, Http1) => Resource.eval(InvalidSocketType().raiseError)
+      case (_, Http1) => Resource.eval(InvalidSocketType().raiseError)
     }
 
   // This is currently how we create http2 only sockets, will need to actually handle which
@@ -144,7 +144,7 @@ private[ember] class H2Client[F[_]: Async](
           socketType <- protocol match {
             case Some("h2") => Resource.pure[F, SocketType](Http2)
             case Some("http/1.1") => Resource.pure[F, SocketType](Http1)
-            case Some(other) =>
+            case Some(_) =>
               Resource.raiseError[F, SocketType, Throwable](
                 new Throwable("Unknown Protocol Received")
               )
@@ -211,8 +211,8 @@ private[ember] class H2Client[F[_]: Async](
         socket,
         logger,
       )
-      bgRead <- h2.readLoop.compile.drain.background
-      bgWrite <- h2.writeLoop.compile.drain.background
+      _ <- h2.readLoop.compile.drain.background
+      _ <- h2.writeLoop.compile.drain.background
       _ <-
         Stream
           .fromQueueUnterminated(closed)
@@ -224,7 +224,7 @@ private[ember] class H2Client[F[_]: Async](
           .compile
           .drain
           .background
-      created <-
+      _ <-
         Stream
           .fromQueueUnterminated(created)
           .parEvalMap(10) { i =>
@@ -243,7 +243,7 @@ private[ember] class H2Client[F[_]: Async](
                 // _ <- Sync[F].delay(println(s"Push promise request acquired for $i"))
                 outE <- onPushPromise(req, resp).flatMap {
                   case Outcome.Canceled() => stream.rstStream(H2Error.RefusedStream)
-                  case Outcome.Errored(e) => stream.rstStream(H2Error.RefusedStream)
+                  case Outcome.Errored(_) => stream.rstStream(H2Error.RefusedStream)
                   case Outcome.Succeeded(f) => f
                 }.attempt
                 _ <- ref.update(_ - i)

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -256,7 +256,7 @@ private[h2] class H2Connection[F[_]](
                 streamCreateAndHeaders.use(_ =>
                   for {
                     stream <- initiateRemoteStreamById(id)
-                    enqueue <- createdStreams.offer(id)
+                    _ <- createdStreams.offer(id)
                     _ <- stream.receiveHeaders(h, cs ::: c :: Nil: _*)
                   } yield ()
                 )
@@ -278,7 +278,7 @@ private[h2] class H2Connection[F[_]](
                 streamCreateAndHeaders.use(_ =>
                   for {
                     stream <- initiateRemoteStreamById(id)
-                    enqueue <- createdStreams.offer(id)
+                    _ <- createdStreams.offer(id)
                     _ <- stream.receivePushPromise(p, cs ::: c :: Nil: _*)
 
                   } yield ()
@@ -309,7 +309,7 @@ private[h2] class H2Connection[F[_]](
           logger.warn("Invalid Continuation - Protocol Error - Issuing GoAway") >>
             goAway(H2Error.ProtocolError)
         }
-      case (f, H2Connection.State(_, _, _, _, _, _, _, Some((h, cs)), None)) =>
+      case (f, H2Connection.State(_, _, _, _, _, _, _, Some(_), None)) =>
         // Only Continuation Frames Are Valid While there is a value
         logger.warn(
           s"Continuation for headers in process, retrieved unexpected frame $f -  Protocol Error - Issuing GoAway"
@@ -347,7 +347,7 @@ private[h2] class H2Connection[F[_]](
                 streamCreateAndHeaders.use(_ =>
                   for {
                     stream <- initiateRemoteStreamById(i)
-                    enqueue <- createdStreams.offer(i)
+                    _ <- createdStreams.offer(i)
                     _ <- stream.receiveHeaders(h)
 
                   } yield ()
@@ -362,7 +362,7 @@ private[h2] class H2Connection[F[_]](
         else {
           state.update(s => s.copy(headersInProgress = Some((h, List.empty))))
         }
-      case (h @ H2Frame.PushPromise(attachedTo, true, i, headerBlock, _), s) =>
+      case (h @ H2Frame.PushPromise(_, true, i, headerBlock, _), s) =>
         val size = headerBlock.size.toInt
         if (connectionType == H2Connection.ConnectionType.Server) {
           logger.warn(
@@ -387,24 +387,24 @@ private[h2] class H2Connection[F[_]](
                 streamCreateAndHeaders.use(_ =>
                   for {
                     stream <- initiateRemoteStreamById(i)
-                    enqueue <- createdStreams.offer(i)
+                    _ <- createdStreams.offer(i)
                     _ <- stream.receivePushPromise(h)
                   } yield ()
                 )
               }
           }
         }
-      case (h @ H2Frame.PushPromise(i, false, _, headerBlock, _), s) =>
+      case (h @ H2Frame.PushPromise(_, false, _, headerBlock, _), s) =>
         val size = headerBlock.size.toInt
         if (size > s.remoteSettings.maxFrameSize.frameSize) goAway(H2Error.FrameSizeError)
         else {
           state.update(s => s.copy(pushPromiseInProgress = Some((h, List.empty))))
         }
 
-      case (H2Frame.Continuation(_, _, _), s) =>
+      case (H2Frame.Continuation(_, _, _), _) =>
         goAway(H2Error.ProtocolError)
 
-      case (settings @ H2Frame.Settings(0, false, _), s) =>
+      case (settings @ H2Frame.Settings(0, false, _), _) =>
         for {
           newWriteBlock <- Deferred[F, Either[Throwable, Unit]]
           t <- state.modify { s =>
@@ -431,26 +431,26 @@ private[h2] class H2Connection[F[_]](
           _ <- settingsAck.complete(Either.right(settings)).void
 
         } yield ()
-      case (H2Frame.Settings(0, true, _), s) => Applicative[F].unit
-      case (H2Frame.Settings(_, _, _), s) =>
+      case (H2Frame.Settings(0, true, _), _) => Applicative[F].unit
+      case (H2Frame.Settings(_, _, _), _) =>
         logger.warn("Received Settings Not Oriented at Identifier 0 - Issuing goAway") >>
           goAway(H2Error.ProtocolError)
-      case (g @ H2Frame.GoAway(0, _, _, bv), s) =>
+      case (g @ H2Frame.GoAway(0, _, _, _), _) =>
         mapRef.get.flatMap { m =>
           m.values.toList.traverse_(connection => connection.receiveGoAway(g))
         } >> outgoing.offer(Chunk.singleton(H2Frame.Ping.ack))
       case (_: H2Frame.GoAway, _) =>
         goAway(H2Error.ProtocolError)
-      case (H2Frame.Ping(0, false, bv), s) =>
+      case (H2Frame.Ping(0, false, bv), _) =>
         outgoing.offer(Chunk.singleton(H2Frame.Ping.ack.copy(data = bv)))
-      case (H2Frame.Ping(0, true, _), s) => Applicative[F].unit
-      case (H2Frame.Ping(x, _, _), s) =>
+      case (H2Frame.Ping(0, true, _), _) => Applicative[F].unit
+      case (H2Frame.Ping(_, _, _), _) =>
         goAway(H2Error.ProtocolError)
 
-      case (w @ H2Frame.WindowUpdate(_, 0), _) =>
+      case (H2Frame.WindowUpdate(_, 0), _) =>
         logger.warn("Encountered 0 Sized Window Update - Procol Error - Issuing GoAway") >>
           goAway(H2Error.ProtocolError)
-      case (w @ H2Frame.WindowUpdate(i, size), s) =>
+      case (w @ H2Frame.WindowUpdate(i, size), _) =>
         i match {
           case 0 =>
             for {
@@ -481,7 +481,7 @@ private[h2] class H2Connection[F[_]](
             }
         }
 
-      case (d @ H2Frame.Data(i, data, _, _), st) =>
+      case (d @ H2Frame.Data(i, data, _, _), _) =>
         val size = data.size.toInt
         if (size > localSettings.maxFrameSize.frameSize) {
           logger.warn(
@@ -523,7 +523,7 @@ private[h2] class H2Connection[F[_]](
           }
         }
 
-      case (rst @ H2Frame.RstStream(i, _), s) =>
+      case (rst @ H2Frame.RstStream(i, _), _) =>
         mapRef.get.map(_.get(i)).flatMap {
           case Some(s) =>
             s.receiveRstStream(rst)
@@ -533,7 +533,7 @@ private[h2] class H2Connection[F[_]](
             ) >>
               goAway(H2Error.ProtocolError)
         }
-      case (H2Frame.Priority(i, _, i2, _), s) =>
+      case (H2Frame.Priority(i, _, i2, _), _) =>
         if (i == i2) goAway(H2Error.ProtocolError) // Can't depend on yourself
         else Applicative[F].unit // We Do Nothing with these presently
       case (H2Frame.Unknown(_), _) => Applicative[F].unit // Ignore Unknown Frames

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Frame.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Frame.scala
@@ -19,7 +19,11 @@ package org.http4s.ember.core.h2
 import cats.syntax.all._
 import scodec.bits._
 
+import scala.annotation.nowarn
+
 private[ember] sealed trait H2Frame
+
+@nowarn("msg=implicit numeric widening")
 private[ember] object H2Frame {
   /*
   All frames begin with a fixed 9-octet header followed by a variable-
@@ -197,7 +201,7 @@ private[ember] object H2Frame {
         )
         .getOrElse(data.data)
       val flags: Byte = {
-        var init: Int = 0x0
+        val init: Int = 0x0
         val endStreamBitSet: Int = if (data.endStream) (init | (1 << 0)) else init
         val paddedSet: Int = if (data.pad.isDefined) endStreamBitSet | (1 << 3) else endStreamBitSet
         paddedSet.toByte
@@ -575,13 +579,13 @@ private[ember] object H2Frame {
           value.toInt match {
             case 1 => SettingsEnablePush(true).asRight
             case 0 => SettingsEnablePush(false).asRight
-            case other => H2Error.ProtocolError.asLeft
+            case _ => H2Error.ProtocolError.asLeft
           }
         case 0x3 => SettingsMaxConcurrentStreams(value).asRight
         case 0x4 => SettingsInitialWindowSize.fromInt(value)
         case 0x5 => SettingsMaxFrameSize.fromInt(value)
         case 0x6 => SettingsMaxHeaderListSize(value).asRight
-        case other => Unknown(identifier, value).asRight
+        case _ => Unknown(identifier, value).asRight
       }
     }
     // The initial value is 4,096 octets

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
@@ -152,7 +152,7 @@ private[h2] object PseudoHeaders {
 
   def findWithNoDuplicates[A](l: List[A])(bool: A => Boolean): Option[A] =
     l.foldLeft(Either.right[Unit, Option[A]](None)) {
-      case (Left(e), a) => Left(e)
+      case (Left(e), _) => Left(e)
       case (Right(Some(a)), next) =>
         if (bool(next)) Left(())
         else Right(Some(a))


### PR DESCRIPTION
Cleans up a few vars that could have been vals.

Tolerates numeric widening in two classes.  I think they were all `Int => Long`, which is a safe conversion.  Fixing them wouldn't be that hard, but would be an ongoing chore.  As long as there's no floating point lurking within, it's fine.

Most of this is unused variable names, including a few that were shadowed.  I think the net effect is good, but we lost some descriptive names of discarded effects.  I don't miss them, but if anyone does, I would extract the generators into descriptively named inner methods.



