### PR TITLE
Clean up Throwables in HTTP/2

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -146,7 +146,7 @@ private[ember] class H2Client[F[_]: Async](
             case Some("http/1.1") => Resource.pure[F, SocketType](Http1)
             case Some(other) =>
               Resource.raiseError[F, SocketType, Throwable](
-                new ProtocolException(s"Unknown protocol")
+                new ProtocolException("Unknown protocol")
               )
             case None => Resource.pure[F, SocketType](Http1)
           }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -146,7 +146,7 @@ private[ember] class H2Client[F[_]: Async](
             case Some("http/1.1") => Resource.pure[F, SocketType](Http1)
             case Some(other) =>
               Resource.raiseError[F, SocketType, Throwable](
-                new Throwable("Unknown Protocol Received")
+                new ProtocolException(s"Unknown protocol")
               )
             case None => Resource.pure[F, SocketType](Http1)
           }
@@ -233,7 +233,9 @@ private[ember] class H2Client[F[_]: Async](
                 //
                 stream <- ref.get
                   .map(_.get(i))
-                  .flatMap(_.liftTo(new Throwable("Stream Missing for push promise"))) // FOLD
+                  .flatMap(
+                    _.liftTo(new ProtocolException("Stream missing for push promise"))
+                  ) // FOLD
                 // _ <- Sync[F].delay(println(s"Push promise stream acquired for $i"))
                 req <- stream.getRequest
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -21,10 +21,9 @@ import cats.effect._
 import cats.syntax.all._
 import fs2._
 import fs2.io.net.Socket
+import fs2.io.net.SocketException
 import org.typelevel.log4cats.Logger
 import scodec.bits._
-// import cats.data._
-// import H2Frame.Settings.ConnectionSettings.{default => defaultSettings}
 
 private[h2] class H2Connection[F[_]](
     host: com.comcast.ip4s.Host,
@@ -168,7 +167,7 @@ private[h2] class H2Connection[F[_]](
               socket.isOpen.ifM(
                 socket.write(Chunk.byteVector(bv)) >>
                   chunk.traverse_(frame => logger.debug(s"$host:$port Write - $frame")),
-                new Throwable("Socket Closed when attempting to write").raiseError,
+                new SocketException("Socket closed when attempting to write").raiseError,
               )
           } else {
             val list = chunk.toList
@@ -187,7 +186,7 @@ private[h2] class H2Connection[F[_]](
             socket.isOpen.ifM(
               socket.write(Chunk.byteVector(bv)) >>
                 nonData.traverse_(frame => logger.debug(s"$host:$port Write - $frame")),
-              new Throwable("Socket Closed when attempting to write").raiseError,
+              new SocketException("Socket closed when attempting to write").raiseError,
             ) >>
               s.writeBlock.get.rethrow >>
               go(Chunk.seq(after))


### PR DESCRIPTION
Throwables that are neither Exceptions nor Errors are awkward.  Use standard types.