### PR TITLE
Use ember in docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1030,6 +1030,7 @@ lazy val docs = http4sProject("docs")
   )
   .settings(docsProjectSettings)
   .settings(
+    run / fork := true,
     libraryDependencies ++= Seq(
       circeGeneric,
       circeLiteral,

--- a/build.sbt
+++ b/build.sbt
@@ -1094,8 +1094,6 @@ lazy val docs = http4sProject("docs")
     client.jvm,
     core.jvm,
     theDsl.jvm,
-    blazeServer,
-    blazeClient,
     emberServer.jvm,
     emberClient.jvm,
     circe.jvm,

--- a/build.sbt
+++ b/build.sbt
@@ -1035,6 +1035,7 @@ lazy val docs = http4sProject("docs")
       circeGeneric,
       circeLiteral,
       cryptobits,
+      logbackClassic % Runtime,
     ),
     description := "Documentation for http4s",
     startYear := Some(2013),

--- a/build.sbt
+++ b/build.sbt
@@ -1095,6 +1095,8 @@ lazy val docs = http4sProject("docs")
     theDsl.jvm,
     blazeServer,
     blazeClient,
+    emberServer.jvm,
+    emberClient.jvm,
     circe.jvm,
     dropwizardMetrics,
     prometheusMetrics,

--- a/docs/src/main/mdoc/README.md
+++ b/docs/src/main/mdoc/README.md
@@ -10,7 +10,7 @@ Getting started with http4s is easy.  Let's materialize an http4s
 skeleton project from its [giter8 template]:
 
 ```sbt
-$ sbt -sbt-version 1.3.12 new http4s/http4s.g8 -b 0.23
+$ sbt new http4s/http4s.g8 --branch 0.23
 ```
 
 Follow the prompts.  For every step along the way, a default value is
@@ -60,7 +60,7 @@ $ find src/main -name '*.scala'
 ```
 `Main.scala` defines a runnable object `Main extends IOApp` with an entry point method `run` 
 which calls the `stream` method of the object `QuickstartServer` defined on `QuickstartServer.scala`.
-Starting blaze, http4s' native server backend.
+Starting ember, http4s' native server backend.
 
 `QuickStartRoutes` has two `route` definitions. The `helloWorldRoutes` containing a simple `HttpRoutes` 
 that responds to `GET/hello/$USERNAME` with a JSON greeting.  Let's try it:
@@ -74,10 +74,10 @@ download.  This is a good time to grab a beverage.  When you come
 back, you should see a line similar to this:
 
 ```
-[ioapp-compute-0] INFO  o.h.b.c.n.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:8080 
+[io-compute-1] INFO  o.h.e.s.EmberServerBuilderCompanionPlatform - Ember-Server service bound to address: [::]:8080
 ```
 
-This indicates that blaze is running our service on port 8080. Let's try out the
+This indicates that ember is running our service on port 8080. Let's try out the
 hello world service with curl:
 
 ```sh

--- a/docs/src/main/mdoc/client.md
+++ b/docs/src/main/mdoc/client.md
@@ -34,14 +34,14 @@ import org.http4s.blaze.server._
 The following is provided by an `IOApp`, but necessary if following
 along in a REPL:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```
 
 Finish setting up our server:
 
-```scala mdoc:nest
+```scala mdoc
 val app = HttpRoutes.of[IO] {
   case GET -> Root / "hello" / name =>
     Ok(s"Hello, $name.")
@@ -56,7 +56,7 @@ val server = BlazeServerBuilder[IO]
 We'll start the server in the background.  The `IO.never` keeps it
 running until we cancel the fiber.
 
-```scala mdoc:nest
+```scala mdoc
 val fiber = server.use(_ => IO.never).start.unsafeRunSync()
 ```
 
@@ -89,7 +89,7 @@ interface!
 It uses blocking IO and is less suited for production, but it is
 highly useful in a REPL:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import java.util.concurrent._
 
 val blockingPool = Executors.newFixedThreadPool(5)
@@ -148,7 +148,7 @@ the world" varies by context:
   server.
 * Here in the REPL, the last line is the end of the world.  Here we go:
 
-```scala mdoc:nest
+```scala mdoc
 val greetingsStringEffect = greetingList.map(_.mkString("\n"))
 greetingsStringEffect.unsafeRunSync()
 ```
@@ -162,7 +162,7 @@ There are a number of ways to construct a `Uri`.
 
 If you have a literal string, you can use `uri"..."`:
 
-```scala mdoc:nest
+```scala mdoc
 uri"https://my-awesome-service.com/foo/bar?wow=yeah"
 ```
 
@@ -172,7 +172,7 @@ format at compile-time.
 Otherwise, you'll need to use `Uri.fromString(...)` and handle the case where
 validation fails:
 
-```scala mdoc:nest
+```scala mdoc
 val validUri = "https://my-awesome-service.com/foo/bar?wow=yeah"
 val invalidUri = "yeah whatever"
 
@@ -183,7 +183,7 @@ val parseFailure: Either[ParseFailure, Uri] = Uri.fromString(invalidUri)
 
 You can also build up a URI incrementally, e.g.:
 
-```scala mdoc:nest
+```scala mdoc
 val baseUri: Uri = uri"http://foo.com"
 val withPath: Uri = baseUri.withPath(path"/bar/baz")
 val withQuery: Uri = withPath.withQueryParam("hello", "world")
@@ -304,7 +304,7 @@ import org.http4s.client.middleware.Metrics
 import org.http4s.metrics.dropwizard.Dropwizard
 import com.codahale.metrics.SharedMetricRegistries
 ```
-```scala mdoc:nest
+```scala mdoc
 val registry = SharedMetricRegistries.getOrCreate("default")
 val requestMethodClassifier = (r: Request[IO]) => Some(r.method.toString.toLowerCase)
 
@@ -334,14 +334,14 @@ import cats.effect.{Resource, IO}
 import org.http4s.client.middleware.Metrics
 import org.http4s.metrics.prometheus.Prometheus
 ```
-```scala mdoc:nest
-val requestMethodClassifier = (r: Request[IO]) => Some(r.method.toString.toLowerCase)
+```scala mdoc
+val classifier = (r: Request[IO]) => Some(r.method.toString.toLowerCase)
 
-val meteredClient: Resource[IO, Client[IO]] =
+val prefixedClient: Resource[IO, Client[IO]] =
   for {
     registry <- Prometheus.collectorRegistry[IO]
     metrics <- Prometheus.metricsOps[IO](registry, "prefix")
-  } yield Metrics[IO](metrics, requestMethodClassifier)(httpClient)
+  } yield Metrics[IO](metrics, classifier)(httpClient)
 ```
 
 
@@ -354,7 +354,7 @@ to add a label to every metric based on the `Request`
 
 You can send a GET by calling the `expect` method on the client, passing a `Uri`:
 
-```scala mdoc:nest
+```scala mdoc
 httpClient.expect[String](uri"https://google.com/")
 ```
 
@@ -365,10 +365,9 @@ can build up a request object and pass that to `expect`:
 import org.http4s.client.dsl.io._
 import org.http4s.headers._
 import org.http4s.MediaType
-import org.http4s.Method._
 ```
 
-```scala mdoc:nest
+```scala mdoc
 val request = GET(
   uri"https://my-lovely-api.com/",
   Authorization(Credentials.Token(AuthScheme.Bearer, "open sesame")),
@@ -380,7 +379,7 @@ httpClient.expect[String](request)
 
 ### Post a form, decoding the JSON response to a case class
 
-```scala mdoc:nest
+```scala mdoc
 import org.http4s.circe._
 import io.circe.generic.auto._
 
@@ -401,7 +400,7 @@ val postRequest = POST(
 httpClient.expect[AuthResponse](postRequest)
 ```
 
-```scala mdoc:nest:invisible
+```scala mdoc:invisible
 fiber.cancel.unsafeRunSync()
 ```
 
@@ -440,7 +439,7 @@ Passing it to a `EntityDecoder` is safe.
 client.get[T]("some-url")(response => jsonOf(response.body))
 ```
 
-```scala mdoc:nest:invisible
+```scala mdoc:invisible
 blockingPool.shutdown()
 ```
 

--- a/docs/src/main/mdoc/client.md
+++ b/docs/src/main/mdoc/client.md
@@ -60,12 +60,10 @@ val server = EmberServerBuilder
   .build
 ```
 
-We'll start the server in the background.  The `IO.never` keeps it
-running until we cancel the fiber.
+We'll start the server in the background.
 
 ```scala mdoc
-val startAndSleep = server.use(_ => IO.never).start <* IO.sleep(2.seconds)
-val fiber = startAndSleep.unsafeRunSync()
+val shutdown = server.allocated.unsafeRunSync()._2
 ```
 
 
@@ -409,7 +407,7 @@ httpClient.expect[AuthResponse](postRequest)
 ```
 
 ```scala mdoc:invisible
-fiber.cancel.unsafeRunSync()
+shutdown.unsafeRunSync()
 ```
 
 ## Calls to a JSON API

--- a/docs/src/main/mdoc/json.md
+++ b/docs/src/main/mdoc/json.md
@@ -254,9 +254,12 @@ val server = EmberServerBuilder
   .withPort(port"8080")
   .withHttpApp(jsonApp)
   .build
+```
 
-val startAndSleep = server.use(_ => IO.never).start <* IO.sleep(2.seconds)
-val fiber = startAndSleep.unsafeRunSync()
+We start a server resource in the background.
+
+```scala mdoc
+val shutdown = server.allocated.unsafeRunSync()._2
 ```
 
 ## A Hello World Client
@@ -293,7 +296,7 @@ helloAlice.compile.last.unsafeRunSync()
 Finally, shut down our example server.
 
 ```scala mdoc:silent
-fiber.cancel.unsafeRunSync()
+shutdown.unsafeRunSync()
 ```
 
 [circe-generic]: https://github.com/travisbrown/circe#codec-derivation

--- a/docs/src/main/mdoc/json.md
+++ b/docs/src/main/mdoc/json.md
@@ -219,14 +219,18 @@ import cats.effect.unsafe.implicits.global
 ```scala mdoc:silent
 import cats.effect._
 
+import com.comcast.ip4s._
+
 import io.circe.generic.auto._
 import io.circe.syntax._
 
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.io._
-import org.http4s.blaze.server._
+import org.http4s.ember.server._
 import org.http4s.implicits._
+
+import scala.concurrent.duration._
 
 case class User(name: String)
 case class Hello(greeting: String)
@@ -243,12 +247,16 @@ val jsonApp = HttpRoutes.of[IO] {
     } yield (resp)
 }.orNotFound
 
-val server = BlazeServerBuilder[IO]
-  .bindHttp(8080)
-  .withHttpApp(jsonApp)
-  .resource
 
-val fiber = server.use(_ => IO.never).start.unsafeRunSync()
+val server = EmberServerBuilder
+  .default[IO]
+  .withHost(ipv4"0.0.0.0")
+  .withPort(port"8080")
+  .withHttpApp(jsonApp)
+  .build
+
+val startAndSleep = server.use(_ => IO.never).start <* IO.sleep(2.seconds)
+val fiber = startAndSleep.unsafeRunSync()
 ```
 
 ## A Hello World Client
@@ -257,7 +265,7 @@ Now let's make a client for the service above:
 
 ```scala mdoc:silent
 import org.http4s.client.dsl.io._
-import org.http4s.blaze.client._
+import org.http4s.ember.client._
 import cats.effect.IO
 import io.circe.generic.auto._
 import fs2.Stream
@@ -267,7 +275,7 @@ def helloClient(name: String): Stream[IO, Hello] = {
   // Encode a User request
   val req = POST(User(name).asJson, uri"http://localhost:8080/hello")
   // Create a client
-  BlazeClientBuilder[IO].stream.flatMap { httpClient =>
+  Stream.resource(EmberClientBuilder.default[IO].build).flatMap { httpClient =>
     // Decode a Hello response
     Stream.eval(httpClient.expect(req)(jsonOf[IO, Hello]))
   }

--- a/docs/src/main/mdoc/service.md
+++ b/docs/src/main/mdoc/service.md
@@ -140,11 +140,10 @@ val server = EmberServerBuilder
 
 The `withHttpApp` call associates the specified routes with this http server instance.
 
-We start a server resource in the background.  The server will run until we cancel the fiber:
+We start a server resource in the background.
 
 ```scala mdoc
-val startAndSleep = server.use(_ => IO.never).start <* IO.sleep(2.seconds)
-val fiber = startAndSleep.unsafeRunSync()
+val shutdown = server.allocated.unsafeRunSync()._2
 ```
 
 Use curl, or your favorite HTTP client, to see your service in action:
@@ -158,7 +157,7 @@ $ curl http://localhost:8080/hello/Pete
 We can shut down the server by canceling its fiber.
 
 ```scala mdoc
-fiber.cancel.unsafeRunSync()
+shutdown.unsafeRunSync()
 ```
 
 ### Running Your Service as an `App`

--- a/docs/src/main/mdoc/service.md
+++ b/docs/src/main/mdoc/service.md
@@ -7,7 +7,7 @@ and calling it with http4s' client.
 Create a new directory, with the following build.sbt in the root:
 
 ```scala
-scalaVersion := "2.13.6" // Also supports 2.12.x and 3.x
+scalaVersion := "2.13.8" // Also supports 2.12.x and 3.x
 
 val http4sVersion = "@{version.http4s.doc}"
 
@@ -16,8 +16,8 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-dsl" % http4sVersion,
-  "org.http4s" %% "http4s-blaze-server" % http4sVersion,
-  "org.http4s" %% "http4s-blaze-client" % http4sVersion
+  "org.http4s" %% "http4s-ember-server" % http4sVersion,
+  "org.http4s" %% "http4s-ember-client" % http4sVersion
 )
 
 // Uncomment if you're using Scala 2.12.x
@@ -105,12 +105,12 @@ val tweetService = HttpRoutes.of[IO] {
 ### Running Your Service
 
 http4s supports multiple server backends.  In this example, we'll use
-[blaze], the native backend supported by http4s.
+[ember], the native backend supported by http4s.
 
-We start from a `BlazeServerBuilder`, and then mount the `helloWorldService` under
+We start from a `EmberServerBuilder`, and then mount the `helloWorldService` under
 the base path of `/` and the remainder of the services under the base
 path of `/api`. The services can be mounted in any order as the request will be
-matched against the longest base paths first. The `BlazeServerBuilder` is immutable
+matched against the longest base paths first. The `EmberServerBuilder` is immutable
 with chained methods, each returning a new builder.
 
 Multiple `HttpRoutes` can be combined with the `combineK` method (or its alias
@@ -120,27 +120,31 @@ Multiple `HttpRoutes` can be combined with the `combineK` method (or its alias
 
 ```scala mdoc:silent
 import cats.syntax.all._
-import org.http4s.blaze.server._
+import com.comcast.ip4s._
+import org.http4s.ember.server._
 import org.http4s.implicits._
 import org.http4s.server.Router
+import scala.concurrent.duration._
 ```
 
 ```scala mdoc
 val services = tweetService <+> helloWorldService
 val httpApp = Router("/" -> helloWorldService, "/api" -> services).orNotFound
-val serverBuilder = BlazeServerBuilder[IO]
-  .bindHttp(8080, "localhost")
+val server = EmberServerBuilder
+  .default[IO]
+  .withHost(ipv4"0.0.0.0")
+  .withPort(port"8080")
   .withHttpApp(httpApp)
+  .build
 ```
 
-The `bindHttp` call isn't strictly necessary as the server will be set to run
-using defaults of port 8080 and the loopback address. The `withHttpApp` call
-associates the specified routes with this http server instance.
+The `withHttpApp` call associates the specified routes with this http server instance.
 
 We start a server resource in the background.  The server will run until we cancel the fiber:
 
 ```scala mdoc
-val fiber = serverBuilder.resource.use(_ => IO.never).start.unsafeRunSync()
+val startAndSleep = server.use(_ => IO.never).start <* IO.sleep(2.seconds)
+val fiber = startAndSleep.unsafeRunSync()
 ```
 
 Use curl, or your favorite HTTP client, to see your service in action:
@@ -159,12 +163,6 @@ fiber.cancel.unsafeRunSync()
 
 ### Running Your Service as an `App`
 
-Every `ServerBuilder[F]` has a `.serve` method that returns a
-`Stream[F, ExitCode]`.  This stream runs forever without emitting
-any output.  When this process is run with `.unsafeRunSync` on the
-main thread, it blocks forever, keeping the JVM (and your server)
-alive until the JVM is killed.
-
 As a convenience, cats-effect provides an `cats.effect.IOApp` trait
 with an abstract `run` method that returns a `IO[ExitCode]`.  An
 `IOApp` runs the process and adds a JVM shutdown hook to interrupt
@@ -173,10 +171,11 @@ SIGTERM is received.
 
 ```scala mdoc:silent:reset
 import cats.effect._
+import com.comcast.ip4s._
 import org.http4s.HttpRoutes
 import org.http4s.dsl.io._
 import org.http4s.implicits._
-import org.http4s.blaze.server._
+import org.http4s.ember.server._
 ```
 
 ```scala mdoc:silent
@@ -188,32 +187,18 @@ object Main extends IOApp {
   }.orNotFound
 
   def run(args: List[String]): IO[ExitCode] =
-    BlazeServerBuilder[IO]
-      .bindHttp(8080, "localhost")
+    EmberServerBuilder
+      .default[IO]
+      .withHost(ipv4"0.0.0.0")
+      .withPort(port"8080")
       .withHttpApp(helloWorldService)
-      .serve
-      .compile
-      .drain
-      .as(ExitCode.Success)
-}
-```
-
-You may also create the server within an `IOApp` using resource:
-
-```scala mdoc:silent
-object MainWithResource extends IOApp {
-
-  def run(args: List[String]): IO[ExitCode] =
-    BlazeServerBuilder[IO]
-      .bindHttp(8080, "localhost")
-      .withHttpApp(Main.helloWorldService)
-      .resource
+      .build
       .use(_ => IO.never)
       .as(ExitCode.Success)
 }
 ```
 
-[blaze]: https://github.com/http4s/blaze
+[ember]: https://github.com/http4s/http4s
 [mdoc]: https://scalameta.org/mdoc/
 [Cats Kleisli Datatype]: https://typelevel.org/cats/datatypes/kleisli.html
 [cats-effect: The IO Monad for Scala]: https://typelevel.org/cats-effect/

--- a/docs/src/main/mdoc/static.md
+++ b/docs/src/main/mdoc/static.md
@@ -17,7 +17,8 @@ being served.
 
 ```scala mdoc
 import cats.effect._
-import org.http4s.blaze.server.BlazeServerBuilder
+import com.comcast.ip4s._
+import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Server
 import org.http4s.server.staticcontent._
 
@@ -27,10 +28,12 @@ object SimpleHttpServer extends IOApp {
 
   val app: Resource[IO, Server] =
     for {
-      server <- BlazeServerBuilder[IO]
-        .bindHttp(8080)
+      server <- EmberServerBuilder
+        .default[IO]
+        .withHost(ipv4"0.0.0.0")
+        .withPort(port"8080")
         .withHttpApp(fileService[IO](FileService.Config(".")).orNotFound)
-        .resource
+        .build
     } yield server
 }
 ```

--- a/docs/src/main/mdoc/streaming.md
+++ b/docs/src/main/mdoc/streaming.md
@@ -71,7 +71,7 @@ Putting it all together into a small app that will print the JSON objects foreve
 
 ```scala mdoc:reset:silent
 import org.http4s._
-import org.http4s.blaze.client._
+import org.http4s.ember.client._
 import org.http4s.client.oauth1
 import org.http4s.implicits._
 import cats.effect._
@@ -104,7 +104,7 @@ class TWStream[F[_]: Async] {
                    accessToken: String, accessSecret: String)
                   (req: Request[F]): Stream[F, Json] =
     for {
-      client <- BlazeClientBuilder[F].stream
+      client <- Stream.resource(EmberClientBuilder.default[F].build)
       sr  <- Stream.eval(sign(consumerKey, consumerSecret, accessToken, accessSecret)(req))
       res <- client.stream(sr).flatMap(_.body.chunks.parseJsonStream)
     } yield res

--- a/docs/src/main/resources/logback.xml
+++ b/docs/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- On Windows machines setting withJansi to true enables ANSI
+         color code interpretation by the Jansi library. This requires
+         org.fusesource.jansi:jansi:1.8 on the class path.  Note that
+         Unix-based operating systems such as Linux and Mac OS X
+         support ANSI color codes by default. -->
+    <withJansi>true</withJansi>
+    <encoder>
+      <pattern>[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
This PR updates all the mdoc checked docs to use ember instead of blaze.

This is a continuation of https://github.com/http4s/http4s/pull/4932 and https://github.com/http4s/http4s/pull/4279.
Everything is rebased on latest `series/0.23`, but I can change the target branch if desired.

I have introduced three changes that are worth calling out as they may be controversial.

### Sleeping after ember server start
Starting the ember server in mdoc now looks like:
```scala
val startAndSleep = server.use(_ => IO.never).start <* IO.sleep(2.seconds)
val fiber = startAndSleep.unsafeRunSync()
```
Without an `IO.sleep`, any attempt to connect to the ember server would fail with a `java.net.ConnectException: Connection refused` as the request would be attempted before the ember server was actually bound to the address.

### Adding logback to docs/mdoc
This was absolutely crucial for me to figure out what was going on with the connect refusal error above.
With logging enable I could see the `ConnectException` and then a second later the ember server log:
```
[info] [io-compute-15] INFO  o.h.e.s.EmberServerBuilderCompanionPlatform - Ember-Server service bound to address: [::]:8080
```
I think having the logs is worthwhile if someone is running `mdoc`, it gives us slightly more visibility into what is going on.
I stole the [`logback.xml` from the gitter8 template](https://github.com/http4s/http4s.g8/blob/0.23/src/main/g8/src/main/resources/logback.xml).

### Forking mdoc
This is really just the workaround described in https://github.com/scalameta/mdoc/issues/613 to avoid terminating sbt when mdoc fails.

### Ditching `nest` mdoc modifier
I've removed `nest` mdoc modifiers in client.md because I found they only added confusion.
I've held off removing `nest` from the other docs as it turned out to not be necessary, but I feel like it's still worthwhile.
I don't think it buys us much.