### PR TITLE
Remove most mdoc nest modifiers

### DIFF
--- a/docs/src/main/mdoc/auth.md
+++ b/docs/src/main/mdoc/auth.md
@@ -70,7 +70,7 @@ not authenticated by returning an empty response with status code 401 (Unauthori
 a kind of reconnaissance called "spidering", useful for white and black hat hackers to enumerate
 your api for possible unprotected points.
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 val spanishRoutes: AuthedRoutes[User, IO] =
     AuthedRoutes.of {
         case GET -> Root / "hola" as user => Ok(s"Hola, ${user.name}")
@@ -81,14 +81,14 @@ val frenchRoutes: HttpRoutes[IO] =
         case GET -> Root / "bonjour" => Ok(s"Bonjour")
     }
 
-val service: HttpRoutes[IO] = middleware(spanishRoutes) <+> frenchRoutes
+val serviceSpanish: HttpRoutes[IO] = middleware(spanishRoutes) <+> frenchRoutes
 ```
 
 Call to the french routes will always return 401 (Unauthorized) as they are caught by the spanish routes. To allow access to other routes you can:
 
 * Use a Router with unique route prefixes
-```scala mdoc:silent:nest
-val service = {
+```scala mdoc:silent
+val serviceRouter = {
   Router (
     "/spanish" -> middleware(spanishRoutes),
     "/french" -> frenchRoutes
@@ -97,16 +97,16 @@ val service = {
 ```
 
 * Allow fallthrough, using `AuthMiddleware.withFallThrough`.
-```scala mdoc:silent:nest
+```scala mdoc:silent
 val middlewareWithFallThrough: AuthMiddleware[IO, User] =
   AuthMiddleware.withFallThrough(authUser)
-val service: HttpRoutes[IO] = middlewareWithFallThrough(spanishRoutes) <+> frenchRoutes
+val serviceSF: HttpRoutes[IO] = middlewareWithFallThrough(spanishRoutes) <+> frenchRoutes
 ```
 
 * Reorder the routes so that authed routes compose last
-```scala mdoc:silent:nest
-val service: HttpRoutes[IO] = 
-  middlewareWithFallThrough(spanishRoutes) <+> frenchRoutes
+```scala mdoc:silent
+val serviceFS: HttpRoutes[IO] =
+  frenchRoutes <+> middlewareWithFallThrough(spanishRoutes)
 ```
 
 Alternatively, to customize the behavior on not authenticated if you do not
@@ -125,15 +125,15 @@ To allow for failure, the `authUser` function has to be adjusted to a `Request[F
 => F[Either[String,User]]`. So we'll need to handle that possibility. For advanced
 error handling, we recommend an error [ADT] instead of a `String`.
 
-```scala mdoc:silent:nest
-val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli(_ => IO(???))
+```scala mdoc:silent
+val authUserEither: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli(_ => IO(???))
 
 val onFailure: AuthedRoutes[String, IO] = 
   Kleisli(req => OptionT.liftF(Forbidden(req.context)))
 
-val middleware = AuthMiddleware(authUser, onFailure)
+val authMiddleware = AuthMiddleware(authUserEither, onFailure)
 
-val service: HttpRoutes[IO] = middleware(authedRoutes)
+val serviceKleisli: HttpRoutes[IO] = authMiddleware(authedRoutes)
 ```
 
 ## Implementing authUser
@@ -184,11 +184,11 @@ val logIn: Kleisli[IO, Request[IO], Response[IO]] = Kleisli({ request =>
 
 Now that the cookie is set, we can retrieve it again in the `authUser`.
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import org.http4s.headers.Cookie
 
 def retrieveUser: Kleisli[IO, Long, User] = Kleisli(id => IO(???))
-val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ request =>
+val authUserCookie: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ request =>
   val message = for {
     header  <- request.headers.get[Cookie]
                  .toRight("Cookie parsing error")
@@ -209,11 +209,11 @@ There is no inherent way to set the Authorization header, send the token in any
 way that your [SPA] understands. Retrieve the header value in the `authUser`
 function.
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import org.http4s.syntax.header._
 import org.http4s.headers.Authorization
 
-val authUser: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ request =>
+val authUserHeaders: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ request =>
   val message = for {
     header  <- request.headers.get[Authorization]
                  .toRight("Couldn't find an Authorization header")

--- a/docs/src/main/mdoc/cors.md
+++ b/docs/src/main/mdoc/cors.md
@@ -34,7 +34,7 @@ import org.http4s.implicits._
 
 If you're in a REPL, we also need a runtime:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```

--- a/docs/src/main/mdoc/csrf.md
+++ b/docs/src/main/mdoc/csrf.md
@@ -25,7 +25,7 @@ import org.http4s.server.middleware._
 
 If you're in a REPL, we also need a runtime:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```

--- a/docs/src/main/mdoc/dsl.md
+++ b/docs/src/main/mdoc/dsl.md
@@ -41,7 +41,7 @@ import org.http4s._, org.http4s.dsl.io._, org.http4s.implicits._
 
 If you're in a REPL, we also need a runtime:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```
@@ -74,7 +74,7 @@ and experiment directly in the REPL.
 ```scala mdoc
 val getRoot = Request[IO](Method.GET, uri"/")
 
-val io = service.orNotFound.run(getRoot)
+val serviceIO = service.orNotFound.run(getRoot)
 ```
 
 Where is our `Response[F]`?  It hasn't been created yet.  We wrapped it
@@ -89,7 +89,7 @@ run it.
 But here in the REPL, it's up to us to run it:
 
 ```scala mdoc
-val response = io.unsafeRunSync()
+val response = serviceIO.unsafeRunSync()
 ```
 
 Cool.
@@ -240,18 +240,18 @@ effectful, unless we wrap it in `IO`:
 `IO.fromFuture` requires an implicit `ContextShift`, to ensure that the
 suspended future is shifted to the correct thread pool.
 
-```scala mdoc:nest
-val io = Ok(IO.fromFuture(IO(Future {
+```scala mdoc
+val ioFuture = Ok(IO.fromFuture(IO(Future {
   println("I run when the future is constructed.")
   "Greetings from the future!"
 })))
-io.unsafeRunSync()
+ioFuture.unsafeRunSync()
 ```
 
 As good functional programmers who like to delay our side effects, we
 of course prefer to operate in `F`s:
 
-```scala mdoc:nest
+```scala mdoc
 val io = Ok(IO {
   println("I run when the IO is run.")
   "Mission accomplished!"
@@ -485,7 +485,7 @@ then parsing them as a `String` and `java.time.Year`.
 import java.time.Year
 ```
 
-```scala mdoc
+```scala mdoc:nest
 object CountryQueryParamMatcher extends QueryParamDecoderMatcher[String]("country")
 
 implicit val yearQueryParamDecoder: QueryParamDecoder[Year] =
@@ -530,7 +530,7 @@ object OptionalYearQueryParamMatcher
 def getAverageTemperatureForCurrentYear: IO[String] = ???
 def getAverageTemperatureForYear(y: Year): IO[String] = ???
 
-val routes2 = HttpRoutes.of[IO] {
+val routes = HttpRoutes.of[IO] {
   case GET -> Root / "temperature" :? OptionalYearQueryParamMatcher(maybeYear) =>
     maybeYear match {
       case None =>

--- a/docs/src/main/mdoc/entity.md
+++ b/docs/src/main/mdoc/entity.md
@@ -54,7 +54,7 @@ case class Video(body: String) extends Resp
 
 If you're in a REPL, we also need a runtime:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```

--- a/docs/src/main/mdoc/gzip.md
+++ b/docs/src/main/mdoc/gzip.md
@@ -24,7 +24,7 @@ import org.http4s.implicits._
 
 If you're in a REPL, we also need a runtime:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```
@@ -32,7 +32,7 @@ implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 Let's start by making a simple service that returns a (relatively) large string
 in its body. We'll use `as[String]` to examine the body.
 
-```scala mdoc:nest
+```scala mdoc
 val service = HttpRoutes.of[IO] {
   case _ =>
     Ok("I repeat myself when I'm under stress. " * 3)
@@ -48,27 +48,27 @@ body.length
 
 Now we can wrap the service in the `GZip` middleware.
 
-```scala mdoc:nest
+```scala mdoc
 import org.http4s.server.middleware._
-val zipService = GZip(service)
+val serviceZip = GZip(service)
 
 // Do not call 'unsafeRun' in your code - see note at bottom.
-val response = zipService.orNotFound(request).unsafeRunSync()
-val body = response.as[String].unsafeRunSync()
-body.length
+val respNormal = serviceZip.orNotFound(request).unsafeRunSync()
+val bodyNormal = respNormal.as[String].unsafeRunSync()
+bodyNormal.length
 ```
 
 So far, there was no change. That's because the caller needs to inform us that
 they will accept GZipped responses via an `Accept-Encoding` header. Acceptable
 values for the `Accept-Encoding` header are **"gzip"**, **"x-gzip"**, and **"*"**.
 
-```scala mdoc:nest
-val zipRequest = request.putHeaders("Accept-Encoding" -> "gzip")
+```scala mdoc
+val requestZip = request.putHeaders("Accept-Encoding" -> "gzip")
 
 // Do not call 'unsafeRun' in your code - see note at bottom.
-val response = zipService.orNotFound(zipRequest).unsafeRunSync()
-val body = response.as[String].unsafeRunSync()
-body.length
+val respZip = serviceZip.orNotFound(requestZip).unsafeRunSync()
+val bodyZip = respZip.as[String].unsafeRunSync()
+bodyZip.length
 ```
 
 Notice how the response no longer looks very String-like and it's shorter in

--- a/docs/src/main/mdoc/hsts.md
+++ b/docs/src/main/mdoc/hsts.md
@@ -44,8 +44,8 @@ val service = HttpRoutes.of[IO] {
 val request = Request[IO](Method.GET, uri"/")
 
 // Do not call 'unsafeRunSync' in your code
-val response = service.orNotFound(request).unsafeRunSync()
-response.headers
+val responseOk = service.orNotFound(request).unsafeRunSync()
+responseOk.headers
 ```
 
 If we were to wrap this on the `HSTS` middleware.
@@ -54,12 +54,12 @@ If we were to wrap this on the `HSTS` middleware.
 import org.http4s.server.middleware._
 ```
 
-```scala mdoc:nest
+```scala mdoc
 val hstsService = HSTS(service)
 
 // Do not call 'unsafeRunSync' in your code
-val response = hstsService.orNotFound(request).unsafeRunSync()
-response.headers
+val responseHSTS = hstsService.orNotFound(request).unsafeRunSync()
+responseHSTS.headers
 ```
 
 Now the response has the `Strict-Transport-Security` header which will mandate browsers
@@ -80,14 +80,14 @@ import org.http4s.headers._
 import scala.concurrent.duration._
 ```
 
-```scala mdoc:nest
+```scala mdoc
 val hstsHeader = `Strict-Transport-Security`
   .unsafeFromDuration(30.days, includeSubDomains = true, preload = true)
-val hstsService = HSTS(service, hstsHeader)
+val hstsServiceCustom = HSTS(service, hstsHeader)
 
 // Do not call 'unsafeRunSync' in your code
-val response = hstsService.orNotFound(request).unsafeRunSync()
-response.headers
+val responseCustom = hstsServiceCustom.orNotFound(request).unsafeRunSync()
+responseCustom.headers
 ```
 
 ## References

--- a/docs/src/main/mdoc/hsts.md
+++ b/docs/src/main/mdoc/hsts.md
@@ -28,7 +28,7 @@ import cats.effect.IO
 
 If you're in a REPL, we also need a runtime:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```

--- a/docs/src/main/mdoc/json.md
+++ b/docs/src/main/mdoc/json.md
@@ -27,7 +27,7 @@ addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.fu
 
 If you're in a REPL, we also need a runtime:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```

--- a/docs/src/main/mdoc/middleware.md
+++ b/docs/src/main/mdoc/middleware.md
@@ -208,7 +208,7 @@ import org.http4s.metrics.prometheus.{Prometheus, PrometheusExportService}
 import org.http4s.server.Router
 import org.http4s.server.middleware.Metrics
 ```
-```scala mdoc:nest
+```scala mdoc
 val meteredRouter: Resource[IO, HttpRoutes[IO]] =
   for {
     metricsSvc <- PrometheusExportService.build[IO]

--- a/docs/src/main/mdoc/middleware.md
+++ b/docs/src/main/mdoc/middleware.md
@@ -32,7 +32,7 @@ import org.http4s.implicits._
 
 If you're in a REPL, we also need a runtime:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```

--- a/docs/src/main/mdoc/service.md
+++ b/docs/src/main/mdoc/service.md
@@ -55,7 +55,7 @@ import cats.effect._, org.http4s._, org.http4s.dsl.io._
 
 If you're in a REPL, we also need a runtime.  This comes for free in `IOApp`:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```

--- a/docs/src/main/mdoc/static.md
+++ b/docs/src/main/mdoc/static.md
@@ -56,7 +56,7 @@ data over the wire again.
 
 For custom behaviour, `StaticFile.fromPath` can also be used directly in a route, to respond with a file:
 
-```scala mdoc:silent:nest
+```scala mdoc:silent
 import org.http4s._
 import org.http4s.dsl.io._
 import fs2.io.file.Path
@@ -73,20 +73,20 @@ val routes = HttpRoutes.of[IO] {
 For simple file serving, it's possible to package resources with the jar and
 deliver them from there. For example, for all resources in the classpath under `assets`:
 
-```scala mdoc:nest
-val routes = resourceServiceBuilder[IO]("/assets").toRoutes
+```scala mdoc
+val assetsRoutes = resourceServiceBuilder[IO]("/assets").toRoutes
 ```
 
 For custom behaviour, `StaticFile.fromResource` can be used. In this example,
 only files matching a list of extensions are served. Append to the `List` as needed.
 
-```scala mdoc:nest
+```scala mdoc
 def static(file: String, request: Request[IO]) =
   StaticFile.fromResource("/" + file, Some(request)).getOrElseF(NotFound())
 
 val fileTypes = List(".js", ".css", ".map", ".html", ".webm")
 
-val routes = HttpRoutes.of[IO] {
+val fileRoutes = HttpRoutes.of[IO] {
   case request @ GET -> Root / path if fileTypes.exists(path.endsWith) =>
     static(path, request)
 }


### PR DESCRIPTION
This PR removes nearly all uses of the `nest` mdoc modifier.

As discussed in https://github.com/http4s/http4s/pull/5970 the `nest` modifier can make debugging documentation difficult and it doesn't buy us a whole lot.
The "hardest" part about removing `nest` is coming up with reasonable and unique value names. :)

#### The remaining `nest`s:

I've left the `nest` modifiers in "Handling Query Parameters" section of `dsl.md` because we are creating different implicit values with the same type. So `nest` here is necessary to avoid ambiguous implicit errors.