### PR TITLE
Mdoc warnings v23

### DIFF
--- a/docs/src/main/mdoc/dsl.md
+++ b/docs/src/main/mdoc/dsl.md
@@ -505,7 +505,10 @@ val averageTemperatureService = HttpRoutes.of[IO] {
 To support a `QueryParamDecoderMatcher[Instant]`, consider `QueryParamCodec#instantQueryParamCodec`. That
 outputs a `QueryParamCodec[Instant]`, which offers both a `QueryParamEncoder[Instant]` and `QueryParamDecoder[Instant]`.
 
-```scala mdoc:silent:warn
+```scala mdoc:silent
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
 implicit val isoInstantCodec: QueryParamCodec[Instant] =
   QueryParamCodec.instantQueryParamCodec(DateTimeFormatter.ISO_INSTANT)
 

--- a/docs/src/main/mdoc/streaming.md
+++ b/docs/src/main/mdoc/streaming.md
@@ -73,6 +73,7 @@ Putting it all together into a small app that will print the JSON objects foreve
 import org.http4s._
 import org.http4s.ember.client._
 import org.http4s.client.oauth1
+import org.http4s.client.oauth1.ProtocolParameter._
 import org.http4s.implicits._
 import cats.effect._
 import fs2.Stream
@@ -91,9 +92,16 @@ class TWStream[F[_]: Async] {
   def sign(consumerKey: String, consumerSecret: String, 
              accessToken: String, accessSecret: String)
           (req: Request[F]): F[Request[F]] = {
-    val consumer = oauth1.Consumer(consumerKey, consumerSecret)
-    val token    = oauth1.Token(accessToken, accessSecret)
-    oauth1.signRequest(req, consumer, callback = None, verifier = None, token = Some(token))
+    val consumer = Consumer(consumerKey, consumerSecret)
+    val token    = Token(accessToken, accessSecret)
+    oauth1.signRequest(
+      req,
+      consumer,
+      Some(token),
+      realm = None,
+      timestampGenerator = Timestamp.now,
+      nonceGenerator = Nonce.now,
+      )
   }
 
   /* Create a http client, sign the incoming `Request[F]`, stream the `Response[IO]`, and


### PR DESCRIPTION
This PR fixes two mdoc warnings:
- Fixes the huge text output warning about mdoc generated code in dsl.md
- Fixes the deprecation warning around oauth1 in streaming.md