### PR TITLE
Tweak json.md to work on scala 2.13

### DIFF
--- a/docs/src/main/mdoc/json.md
+++ b/docs/src/main/mdoc/json.md
@@ -101,18 +101,9 @@ To transform a value of type `A` into `Json`, circe uses an
 `io.circe.Encoder[A]`.  With circe's syntax, we can convert any value
 to JSON as long as an implicit `Encoder` is in scope:
 
-```scala mdoc:silent
-import io.circe.syntax._
-```
-
-```scala mdoc:fail
-Hello("Alice").asJson
-```
-
-Oops!  We haven't told Circe how we want to encode our case class.
-Let's provide an encoder:
-
 ```scala mdoc
+import io.circe.syntax._
+
 implicit val HelloEncoder: Encoder[Hello] =
   Encoder.instance { (hello: Hello) =>
     json"""{"hello": ${hello.name}}"""


### PR DESCRIPTION
This failing mdoc example was causing trouble in https://github.com/http4s/http4s/pull/5337#issuecomment-1027252442

On Scala 2.13 this starts failing with or without the mdoc `fail` modifier

with mdoc `fail`: 
> Expected compile errors but program compiled successfully without errors 

without mdoc `fail`: 
> Cannot invoke "io.circe.Encoder.apply(Object)" because "encoder" is null

While we might be able to figure this out. I think it's worth considering if this is the best documentation example anyways.
I think it might be more useful to just show the user how to do things correctly in the first pass.

This unlocks us to move to 2.13 in `docs/mdoc` which is likely more interesting than solving this mystery.