### PR TITLE
Fix regression in routing dsl

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -58,7 +58,7 @@ object ~ {
 
 object / {
   def unapply(path: Path): Option[(Path, String)] =
-    if (path.endsWithSlash)
+    if (path != Root && path.endsWithSlash)
       Some(path.dropEndsWithSlash -> "")
     else
       path.segments match {

--- a/server/src/test/scala/org/http4s/server/RouterSuite.scala
+++ b/server/src/test/scala/org/http4s/server/RouterSuite.scala
@@ -123,4 +123,19 @@ class RouterSuite extends Http4sSuite {
       .map(_ == Option.empty[Response[IO]])
       .assert
   }
+
+  test("Order of variable path should not matter") {
+    val router = Router[IO]("/foo" -> HttpRoutes.of {
+      case GET -> Root / variable =>
+        val _ = variable
+        BadRequest("nope")
+      case GET -> Root =>
+        Ok("foo")
+    })
+
+    router
+      .orNotFound(Request[IO](uri = uri"/foo"))
+      .map(_.status == Status.Ok)
+      .assert
+  }
 }


### PR DESCRIPTION
Path.Root has changed to be absolute and endsWithSlash. We need to take
this into account when routing. Added a check for non-root to avoid
matching on paths we shouldn't

Fixes #5959 