### PR TITLE
Don't force npm onto ember.js users

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -532,7 +532,20 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
     },
   )
   .jsSettings(
-    jsVersionIntroduced("0.23.5")
+    jsVersionIntroduced("0.23.5"),
+    mimaBinaryIssueFilters := {
+      if (tlIsScala3)
+        Seq(
+          ProblemFilters.exclude[IncompatibleTemplateDefProblem](
+            "org.http4s.ember.core.h2.facade.Compressor"
+          ),
+          ProblemFilters.exclude[IncompatibleTemplateDefProblem](
+            "org.http4s.ember.core.h2.facade.Decompressor"
+          ),
+        )
+      else
+        Seq.empty
+    },
   )
   .jvmSettings(
     libraryDependencies += "com.twitter" % "hpack" % "1.0.2"

--- a/build.sbt
+++ b/build.sbt
@@ -534,7 +534,7 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
   .jsSettings(
     jsVersionIntroduced("0.23.5"),
     mimaBinaryIssueFilters := {
-      if (tlIsScala3)
+      if (tlIsScala3.value)
         Seq(
           ProblemFilters.exclude[IncompatibleTemplateDefProblem](
             "org.http4s.ember.core.h2.facade.Compressor"

--- a/ember-core/js/src/main/scala/org/http4s/ember/core/h2/HpackPlatform.scala
+++ b/ember-core/js/src/main/scala/org/http4s/ember/core/h2/HpackPlatform.scala
@@ -26,8 +26,8 @@ import scala.scalajs.js.JSConverters._
 private[h2] trait HpackPlatform {
 
   def create[F[_]](implicit F: Async[F]): F[Hpack[F]] = F.delay {
-    val compressor = new facade.Compressor(facade.HpackOptions(4096))
-    val decompressor = new facade.Decompressor(facade.HpackOptions(4096))
+    val compressor = facade.Compressor(facade.HpackOptions(4096))
+    val decompressor = facade.Decompressor(facade.HpackOptions(4096))
     new Hpack[F] {
       def encodeHeaders(headers: NonEmptyList[(String, String, Boolean)]): F[ByteVector] = {
         val jsHeaders = headers

--- a/ember-core/js/src/main/scala/org/http4s/ember/core/h2/facade/Decompressor.scala
+++ b/ember-core/js/src/main/scala/org/http4s/ember/core/h2/facade/Decompressor.scala
@@ -18,13 +18,16 @@ package org.http4s.ember.core.h2.facade
 
 import scala.annotation.nowarn
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSImport
 
 @js.native
-@JSImport("hpack.js", "decompressor")
 @nowarn
-private[h2] class Decompressor(options: HpackOptions) extends js.Object {
+private[h2] trait Decompressor extends js.Object {
   def write(raw: js.typedarray.Uint8Array): Unit = js.native
   def execute(): Unit = js.native
   def read(): Header = js.native
+}
+
+private[h2] object Decompressor {
+  def apply(options: HpackOptions): Decompressor =
+    hpackjs.decompressor.create(options).asInstanceOf[Decompressor]
 }

--- a/ember-core/js/src/main/scala/org/http4s/ember/core/h2/facade/package.scala
+++ b/ember-core/js/src/main/scala/org/http4s/ember/core/h2/facade/package.scala
@@ -14,19 +14,10 @@
  * limitations under the License.
  */
 
-package org.http4s.ember.core.h2.facade
+package org.http4s.ember.core.h2
 
-import scala.annotation.nowarn
 import scala.scalajs.js
 
-@js.native
-@nowarn
-private[h2] trait Compressor extends js.Object {
-  def write(headers: js.Array[Header]): Unit = js.native
-  def read(): js.typedarray.Uint8Array = js.native
-}
-
-private[h2] object Compressor {
-  def apply(options: HpackOptions): Compressor =
-    hpackjs.compressor.create(options).asInstanceOf[Compressor]
+package object facade {
+  private[facade] lazy val hpackjs = js.Dynamic.global.require("hpack.js")
 }


### PR DESCRIPTION
The ember h2 support on Scala.js requires an npm package [hpack.js](https://www.npmjs.com/package/hpack.js).

Previously, this was expressed as a global `@JSImport` annotation, which forced _all_ users of ember.js to reckon with npm and/or Scala.js bundler even if they are not enabling h2. This manifests as a breaking change for existing users.

This PR changes it to a "lazy" `require`, so the npm package is only loaded if h2 support is enabled.

The long term solution is still to replace the npm package with a pure Scala implementation. This will let us remove npm from our own build.