### PR TITLE
Message: add pipeBodyThrough method

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/Http1ClientStageSuite.scala
@@ -132,7 +132,7 @@ class Http1ClientStageSuite extends Http4sSuite with DispatcherIOFixture {
         .evalMap(q.offer)
         .compile
         .drain).start
-      req0 = req.withBodyStream(req.body.onFinalizeWeak(d.complete(()).void))
+      req0 = req.pipeBodyThrough(_.onFinalizeWeak(d.complete(()).void))
       response <- stage.runRequest(req0, IO.never)
       result <- response.use(_.as[String])
       _ <- IO(h.stageShutdown())

--- a/client/jvm/src/main/scala/org/http4s/client/middleware/GZip.scala
+++ b/client/jvm/src/main/scala/org/http4s/client/middleware/GZip.scala
@@ -65,13 +65,13 @@ object GZip {
           _.through(Compression[F].gunzip(bufferSize)).flatMap(_.content)
         response
           .filterHeaders(nonCompressionHeader)
-          .withBodyStream(response.body.through(decompressWith(gunzip)))
+          .pipeBodyThrough(decompressWith(gunzip))
 
       case Some(header) if header.contentCoding == ContentCoding.deflate =>
         val deflate: Pipe[F, Byte, Byte] = Compression[F].deflate(DeflateParams(bufferSize))
         response
           .filterHeaders(nonCompressionHeader)
-          .withBodyStream(response.body.through(decompressWith(deflate)))
+          .pipeBodyThrough(decompressWith(deflate))
 
       case _ =>
         response

--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -204,32 +204,31 @@ object Client {
     *
     * @param app the [[HttpApp]] to respond to requests to this client
     */
-  def fromHttpApp[F[_]](app: HttpApp[F])(implicit F: Async[F]): Client[F] =
-    Client { (req: Request[F]) =>
-      Resource.suspend {
-        Ref[F].of(false).map { disposed =>
-          def go(stream: Stream[F, Byte]): Pull[F, Byte, Unit] =
-            stream.pull.uncons.flatMap {
-              case Some((chunk, stream)) =>
-                Pull.eval(disposed.get).flatMap {
-                  case true =>
-                    Pull.raiseError[F](new IOException("response was disposed"))
-                  case false =>
-                    Pull.output(chunk) >> go(stream)
-                }
-              case None =>
-                Pull.done
+  def fromHttpApp[F[_]](app: HttpApp[F])(implicit F: Async[F]): Client[F] = {
+    def until[A](disposed: Ref[F, Boolean])(source: Stream[F, A]): Stream[F, A] = {
+      def go(stream: Stream[F, A]): Pull[F, A, Unit] =
+        stream.pull.uncons.flatMap {
+          case Some((chunk, stream)) =>
+            Pull.eval(disposed.get).flatMap {
+              case true => Pull.raiseError[F](new IOException("response was disposed"))
+              case false => Pull.output(chunk) >> go(stream)
             }
-          val req0 =
-            addHostHeaderIfUriIsAbsolute(req.withBodyStream(go(req.body).stream))
-
-          Resource
-            .eval(app(req0))
-            .onFinalize(disposed.set(true))
-            .map(resp => resp.copy(body = go(resp.body).stream))
+          case None => Pull.done
         }
-      }
+      go(source).stream
     }
+
+    def runOrDispose(req: Request[F]): F[Resource[F, Response[F]]] =
+      Ref[F].of(false).map { disposed =>
+        val req0 = addHostHeaderIfUriIsAbsolute(req.pipeBodyThrough(until(disposed)))
+        Resource
+          .eval(app(req0))
+          .onFinalize(disposed.set(true))
+          .map(_.pipeBodyThrough(until(disposed)))
+      }
+
+    Client((req: Request[F]) => Resource.suspend(runOrDispose(req)))
+  }
 
   /** This method introduces an important way for the effectful backends to allow tracing. As Kleisli types
     * form the backend of tracing and these transformations are non-trivial.

--- a/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -74,7 +74,7 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
   def toHttpApp: HttpApp[F] =
     Kleisli { req =>
       F.map(run(req).allocated) { case (resp, release) =>
-        resp.withBodyStream(resp.body.onFinalizeWeak(release))
+        resp.pipeBodyThrough(_.onFinalizeWeak(release))
       }
     }
 

--- a/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -26,7 +26,9 @@ import org.http4s.internal.{Logger => InternalLogger}
 import org.log4s.getLogger
 import org.typelevel.ci.CIString
 
-/** Simple middleware for logging responses as they are processed
+/** Client middlewares that logs the HTTP responses it receives as soon as they are received locally.
+  *
+  * The "logging" is represented as an effectful action `String => F[Unit]`
   */
 object ResponseLogger {
   private[this] val logger = getLogger
@@ -73,34 +75,29 @@ object ResponseLogger {
 
   private def impl[F[_]](client: Client[F], logBody: Boolean)(
       logMessage: Response[F] => F[Unit]
-  )(implicit F: Async[F]): Client[F] =
-    Client { req =>
-      client.run(req).flatMap { response =>
-        if (!logBody)
-          Resource.eval(logMessage(response) *> F.delay(response))
-        else
-          Resource.suspend {
-            Ref[F].of(Vector.empty[Chunk[Byte]]).map { vec =>
-              Resource.make(
-                F.pure(
-                  response.copy(body =
-                    response.body
-                      // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
-                      .observe(_.chunks.flatMap(s => Stream.exec(vec.update(_ :+ s))))
-                  )
-                )
-              ) { _ =>
-                val newBody = Stream
-                  .eval(vec.get)
-                  .flatMap(v => Stream.emits(v))
-                  .flatMap(c => Stream.chunk(c))
-                logMessage(response.withBodyStream(newBody))
-                  .handleErrorWith(t => F.delay(logger.error(t)("Error logging response body")))
-              }
+  )(implicit F: Async[F]): Client[F] = {
+    def logResponse(response: Response[F]): Resource[F, Response[F]] =
+      if (!logBody)
+        Resource.eval(logMessage(response) *> F.delay(response))
+      else
+        Resource.suspend {
+          Ref[F].of(Vector.empty[Chunk[Byte]]).map { vec =>
+            val dumpChunksToVec: Pipe[F, Byte, Nothing] =
+              _.chunks.flatMap(s => Stream.exec(vec.update(_ :+ s)))
+
+            Resource.make(
+              // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended before Finalization
+              F.pure(response.pipeBodyThrough(_.observe(dumpChunksToVec)))
+            ) { _ =>
+              val newBody = Stream.eval(vec.get).flatMap(Stream.emits).unchunks
+              logMessage(response.withBodyStream(newBody))
+                .handleErrorWith(t => F.delay(logger.error(t)("Error logging response body")))
             }
           }
-      }
-    }
+        }
+
+    Client(req => client.run(req).flatMap(logResponse))
+  }
 
   def defaultResponseColor[F[_]](response: Response[F]): String =
     response.status.responseClass match {

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -29,6 +29,7 @@ import com.comcast.ip4s.Hostname
 import com.comcast.ip4s.IpAddress
 import com.comcast.ip4s.Port
 import com.comcast.ip4s.SocketAddress
+import fs2.Pipe
 import fs2.Pure
 import fs2.Stream
 import fs2.io.net.unixsocket.UnixSocketAddress
@@ -107,6 +108,9 @@ sealed trait Message[F[_]] extends Media[F] { self =>
   /** Sets the entity body without affecting headers such as `Transfer-Encoding`
     * or `Content-Length`. Most use cases are better served by [[withEntity]],
     * which uses an [[EntityEncoder]] to maintain the headers.
+    *
+    * WARNING: this method does not modify the headers of the message, and as
+    * a consequence headers may be incoherent with the body.
     */
   def withBodyStream(body: EntityBody[F]): Self =
     change(body = body)
@@ -116,6 +120,14 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     */
   def withEmptyBody: Self =
     withBodyStream(EmptyBody).transformHeaders(_.removePayloadHeaders)
+
+  /** Applies the given pipe to the entity body (byte-stream) of this message.
+    *
+    * WARNING: this method does not modify the headers of the message, and as
+    * a consequence headers may be incoherent with the body.
+    */
+  private[http4s] def pipeBodyThrough(pipe: Pipe[F, Byte, Byte]): Self =
+    withBodyStream(pipe(body))
 
   // General header methods
 

--- a/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -74,24 +74,21 @@ object GZip {
       level: DeflateParams.Level,
       resp: Response[F],
   ): Response[F] = {
-
+    val compressPipe =
+      Compression[F].gzip(
+        fileName = None,
+        modificationTime = None,
+        comment = None,
+        DeflateParams(
+          bufferSize = bufferSize,
+          level = level,
+          header = ZLibParams.Header.GZIP,
+        ),
+      )
     logger.trace("GZip middleware encoding content")
     resp
       .removeHeader[`Content-Length`]
       .putHeaders(`Content-Encoding`(ContentCoding.gzip))
-      .copy(body =
-        resp.body.through(
-          Compression[F].gzip(
-            fileName = None,
-            modificationTime = None,
-            comment = None,
-            DeflateParams(
-              bufferSize = bufferSize,
-              level = level,
-              header = ZLibParams.Header.GZIP,
-            ),
-          )
-        )
-      )
+      .pipeBodyThrough(compressPipe)
   }
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -47,5 +47,5 @@ object DefaultHead {
     apply(httpRoutes)
 
   private[this] def drainBody[G[_]: Concurrent](response: Response[G]): Response[G] =
-    response.copy(body = response.body.interruptWhen[G](Stream(true)).drain)
+    response.pipeBodyThrough(_.interruptWhen[G](Stream(true)).drain)
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -32,9 +32,7 @@ object EntityLimiter {
   def apply[F[_], G[_], B](http: Kleisli[F, Request[G], B], limit: Long = DefaultMaxEntitySize)(
       implicit G: ApplicativeThrow[G]
   ): Kleisli[F, Request[G], B] =
-    Kleisli { req =>
-      http(req.withBodyStream(req.body.through(takeLimited(limit))))
-    }
+    http.local(_.pipeBodyThrough(takeLimited(limit)))
 
   def httpRoutes[F[_]: ApplicativeThrow](
       httpRoutes: HttpRoutes[F],

--- a/server/shared/src/main/scala/org/http4s/server/middleware/PushSupport.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/PushSupport.scala
@@ -100,8 +100,7 @@ object PushSupport {
         .map { fresource =>
           val collected = collectResponse(fresource, req, verify, routes)
           resp.copy(
-            body = resp.body,
-            attributes = resp.attributes.insert(pushResponsesKey[F], collected),
+            attributes = resp.attributes.insert(pushResponsesKey[F], collected)
           )
         }
         .getOrElse(resp)

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -29,6 +29,7 @@ import cats.effect.syntax.all._
 import cats.syntax.all._
 import cats.~>
 import fs2.Chunk
+import fs2.Pipe
 import fs2.Stream
 import org.log4s.getLogger
 import org.typelevel.ci.CIString
@@ -75,36 +76,28 @@ object ResponseLogger {
       case Right(_) => true
     }
 
+    def logResponse(response: Response[F]): F[Response[F]] =
+      if (!logBody)
+        logMessage(response)
+          .as(response)
+      else
+        F.ref(Vector.empty[Chunk[Byte]]).map { vec =>
+          val newBody = Stream.eval(vec.get).flatMap(v => Stream.emits(v)).unchunks
+          // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+          val logPipe: Pipe[F, Byte, Byte] =
+            _.observe(_.chunks.flatMap(c => Stream.exec(vec.update(_ :+ c))))
+              .onFinalizeWeak(logMessage(response.withBodyStream(newBody)))
+
+          response.pipeBodyThrough(logPipe)
+        }
+
     Kleisli[G, A, Response[F]] { req =>
       http(req)
-        .flatMap { response =>
-          val out =
-            if (!logBody)
-              logMessage(response)
-                .as(response)
-            else
-              F.ref(Vector.empty[Chunk[Byte]]).map { vec =>
-                val newBody = Stream
-                  .eval(vec.get)
-                  .flatMap(v => Stream.emits(v))
-                  .flatMap(c => Stream.chunk(c))
-
-                response.copy(
-                  body = response.body
-                    // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
-                    .observe(_.chunks.flatMap(c => Stream.exec(vec.update(_ :+ c))))
-                    .onFinalizeWeak {
-                      logMessage(response.withBodyStream(newBody))
-                    }
-                )
-              }
-          fk(out)
-        }
+        .flatMap((response: Response[F]) => fk(logResponse(response)))
         .guaranteeCase {
           case Outcome.Errored(t) => fk(log(s"service raised an error: ${t.getClass}"))
           case Outcome.Canceled() => fk(log(s"service canceled response for request"))
           case Outcome.Succeeded(_) => G.unit
-
         }
     }
   }


### PR DESCRIPTION
Add an `alterBodyBy` function to `Message`, which is just to pass a function. Use it at a few places on the code base.

_Edit_ since this is a stream to stream transformation, the method is called `pipeBodyTo`.