### PR TITLE
Ignore Jetty HTTP/2 updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -26,3 +26,8 @@ updates.pin = [
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.0." },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = "3.0." }
 ]
+
+updates.ignore = [
+  # On same release cycle as org.eclipse.jetty
+  { groupId = "org.eclipse.jetty.http2" }
+]


### PR DESCRIPTION
This is on the same release cycle as main Jetty, so no need to generate duplicate PRs.