### PR TITLE
Upgrade to jetty-9.4.45.v20220203 on series/0.22

### DIFF
--- a/jetty-server/src/main/scala/org/http4s/jetty/server/JettyLifeCycle.scala
+++ b/jetty-server/src/main/scala/org/http4s/jetty/server/JettyLifeCycle.scala
@@ -18,7 +18,6 @@ package org.http4s.jetty.server
 
 import cats.effect._
 import cats.syntax.all._
-import org.eclipse.jetty.util.component.AbstractLifeCycle.AbstractLifeCycleListener
 import org.eclipse.jetty.util.component.Destroyable
 import org.eclipse.jetty.util.component.LifeCycle
 
@@ -58,7 +57,7 @@ private[jetty] object JettyLifeCycle {
   private[this] def stopLifeCycle[F[_]](lifeCycle: LifeCycle)(implicit F: Async[F]): F[Unit] =
     F.async[Unit] { cb =>
       lifeCycle.addLifeCycleListener(
-        new AbstractLifeCycleListener {
+        new LifeCycle.Listener {
           override def lifeCycleStopped(a: LifeCycle): Unit =
             cb(Right(()))
           override def lifeCycleFailure(a: LifeCycle, error: Throwable): Unit =
@@ -98,7 +97,7 @@ private[jetty] object JettyLifeCycle {
   private[this] def startLifeCycle[F[_]](lifeCycle: LifeCycle)(implicit F: Async[F]): F[Unit] =
     F.async[Unit] { cb =>
       lifeCycle.addLifeCycleListener(
-        new AbstractLifeCycleListener {
+        new LifeCycle.Listener {
           override def lifeCycleStarted(a: LifeCycle): Unit =
             cb(Right(()))
           override def lifeCycleFailure(a: LifeCycle, error: Throwable): Unit =

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -230,7 +230,7 @@ object Http4sPlugin extends AutoPlugin {
     val javaWebSocket = "1.5.2"
     val jawn = "1.3.2"
     val jawnFs2 = "1.2.0"
-    val jetty = "9.4.44.v20210927"
+    val jetty = "9.4.45.v20220203"
     val keypool = "0.3.5"
     val literally = "1.0.2"
     val logback = "1.2.6"


### PR DESCRIPTION
The `AbstractLifeCycleListener` was deprecated because `LifeCycle.Listener` now has default methods.

Replaces #6014.