### PR TITLE
Flush the prelude in non-blocking Servlet IO

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -71,6 +71,9 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
     // a body and a status reason.  We sacrifice the status reason.
     F.delay {
       servletResponse.setStatus(response.status.code)
+      // Transfer-Encodings are the domain of the servlet container.
+      // We don't pass them along, but the bodyWriter may key on it to
+      // flush each chunk.
       for (header <- response.headers.toList if header.isNot(`Transfer-Encoding`))
         servletResponse.addHeader(header.name.toString, header.value)
     }.attempt

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -244,30 +244,37 @@ final case class NonBlockingServletIo[F[_]: Effect](chunkSize: Int) extends Serv
         }
     }
 
+    val chunkHandler =
+      Async.shift(trampoline) *>
+        F.async[Chunk[Byte] => Unit] { cb =>
+          val blocked = Blocked(cb)
+          state.getAndSet(blocked) match {
+            case Ready if out.isReady =>
+              if (state.compareAndSet(blocked, Ready))
+                cb(writeChunk)
+            case e @ Errored(t) =>
+              if (state.compareAndSet(blocked, e))
+                cb(Left(t))
+            case _ =>
+              ()
+          }
+        }
+
+    def flushPrelude =
+      if (autoFlush)
+        chunkHandler.map(_(Chunk.empty[Byte]))
+      else
+        F.unit
+
     { (response: Response[F]) =>
       if (response.isChunked)
         autoFlush = true
-      response.body.chunks
-        .evalMap { chunk =>
-          // Shift execution to a different EC
-          Async.shift(trampoline) *>
-            F.async[Chunk[Byte] => Unit] { cb =>
-              val blocked = Blocked(cb)
-              state.getAndSet(blocked) match {
-                case Ready if out.isReady =>
-                  if (state.compareAndSet(blocked, Ready))
-                    cb(writeChunk)
-                case e @ Errored(t) =>
-                  if (state.compareAndSet(blocked, e))
-                    cb(Left(t))
-                case _ =>
-                  ()
-              }
-            }.map(_(chunk))
-        }
-        .append(awaitLastWrite)
-        .compile
-        .drain
+      flushPrelude *>
+        response.body.chunks
+          .evalMap(chunk => chunkHandler.map(_(chunk)))
+          .append(awaitLastWrite)
+          .compile
+          .drain
     }
   }
 }


### PR DESCRIPTION
We need to flush the response prelude before the first chunk when rendering a response with chunked transfer encoding.  This reaches parity with Ember and Blaze.

I thought we could just set the buffer size to zero, but this renders each byte as its own chunk.