### PR TITLE
Render continually between response prelude and body

### DIFF
--- a/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -240,7 +240,7 @@ private[server] object ServerHelpers {
                 requestVault)
             }
 
-            result.attempt.flatMap {
+            result.continual {
               case Right((req, resp, drain)) =>
                 send(socket)(Some(req), resp, idleTimeout, onWriteFailure) >>
                   drain.map {

--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -87,6 +87,14 @@ class AsyncHttp4sServlet[F[_]](
       F.race(timeout, response).flatMap(r => renderResponse(r.merge, servletResponse, bodyWriter))
     }
 
+  override protected def renderResponse(
+      response: Response[F],
+      servletResponse: HttpServletResponse,
+      bodyWriter: BodyWriter[F]
+  ): F[Unit] =
+    // The supertype hopes that we are a ConcurrentEffect.  We know we're one.
+    Http4sServlet.renderResponseContinually(response, servletResponse, bodyWriter)
+
   private def errorHandler(
       servletRequest: ServletRequest,
       servletResponse: HttpServletResponse): PartialFunction[Throwable, Unit] = {

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -67,8 +67,24 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
       servletResponse: HttpServletResponse,
       bodyWriter: BodyWriter[F]
   ): F[Unit] =
+    // Binary compatibility hack
+    F match {
+      case ce: ConcurrentEffect[F] =>
+        renderResponseContinually(response, servletResponse, bodyWriter)(ce)
+      case _ => renderResponseDiscontinually(response, servletResponse, bodyWriter)
+    }
+
+  private def renderResponseDiscontinually(
+      response: Response[F],
+      servletResponse: HttpServletResponse,
+      bodyWriter: BodyWriter[F]
+  ): F[Unit] =
     // Note: the servlet API gives us no undeprecated method to both set
     // a body and a status reason.  We sacrifice the status reason.
+    //
+    // This F.attempt.flatMap can be interrupted, which prevents the body from
+    // running, which prevents the response from finalizing.  Woe betide you if
+    // your effect isn't Concurrent.
     F.delay {
       servletResponse.setStatus(response.status.code)
       for (header <- response.headers.toList if header.isNot(`Transfer-Encoding`))
@@ -81,6 +97,28 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
             logger.error(t2)("Error draining body")
           } *> F.raiseError(t)
       }
+
+  private def renderResponseContinually(
+      response: Response[F],
+      servletResponse: HttpServletResponse,
+      bodyWriter: BodyWriter[F]
+  )(implicit F: ConcurrentEffect[F]): F[Unit] =
+    // Note: the servlet API gives us no undeprecated method to both set
+    // a body and a status reason.  We sacrifice the status reason.
+    F.continual(F.delay {
+      servletResponse.setStatus(response.status.code)
+      // Transfer-Encodings are the domain of the servlet container.
+      // We don't pass them along, but the bodyWriter may key on it to
+      // flush each chunk.
+      for (header <- response.headers.toList if header.isNot(`Transfer-Encoding`))
+        servletResponse.addHeader(header.name.toString, header.value)
+    }) {
+      case Right(()) => bodyWriter(response)
+      case Left(t) =>
+        response.body.drain.compile.drain.handleError { case t2 =>
+          logger.error(t2)("Error draining body")
+        } *> F.raiseError(t)
+    }
 
   protected def toRequest(req: HttpServletRequest): ParseResult[Request[F]] =
     for {

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -70,7 +70,7 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
     // Binary compatibility hack
     F match {
       case ce: ConcurrentEffect[F] =>
-        renderResponseContinually(response, servletResponse, bodyWriter)(ce)
+        Http4sServlet.renderResponseContinually(response, servletResponse, bodyWriter)(ce)
       case _ => renderResponseDiscontinually(response, servletResponse, bodyWriter)
     }
 
@@ -97,28 +97,6 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
             logger.error(t2)("Error draining body")
           } *> F.raiseError(t)
       }
-
-  private def renderResponseContinually(
-      response: Response[F],
-      servletResponse: HttpServletResponse,
-      bodyWriter: BodyWriter[F]
-  )(implicit F: ConcurrentEffect[F]): F[Unit] =
-    // Note: the servlet API gives us no undeprecated method to both set
-    // a body and a status reason.  We sacrifice the status reason.
-    F.continual(F.delay {
-      servletResponse.setStatus(response.status.code)
-      // Transfer-Encodings are the domain of the servlet container.
-      // We don't pass them along, but the bodyWriter may key on it to
-      // flush each chunk.
-      for (header <- response.headers.toList if header.isNot(`Transfer-Encoding`))
-        servletResponse.addHeader(header.name.toString, header.value)
-    }) {
-      case Right(()) => bodyWriter(response)
-      case Left(t) =>
-        response.body.drain.compile.drain.handleError { case t2 =>
-          logger.error(t2)("Error draining body")
-        } *> F.raiseError(t)
-    }
 
   protected def toRequest(req: HttpServletRequest): ParseResult[Request[F]] =
     for {
@@ -169,4 +147,30 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
     } yield Header(name, value)
     Headers(headers.toList)
   }
+}
+
+object Http4sServlet {
+  private[this] val logger = getLogger
+
+  private[servlet] def renderResponseContinually[F[_]](
+      response: Response[F],
+      servletResponse: HttpServletResponse,
+      bodyWriter: BodyWriter[F]
+  )(implicit F: ConcurrentEffect[F]): F[Unit] =
+    // Note: the servlet API gives us no undeprecated method to both set
+    // a body and a status reason.  We sacrifice the status reason.
+    F.continual(F.delay {
+      servletResponse.setStatus(response.status.code)
+      // Transfer-Encodings are the domain of the servlet container.
+      // We don't pass them along, but the bodyWriter may key on it to
+      // flush each chunk.
+      for (header <- response.headers.toList if header.isNot(`Transfer-Encoding`))
+        servletResponse.addHeader(header.name.toString, header.value)
+    }) {
+      case Right(()) => bodyWriter(response)
+      case Left(t) =>
+        response.body.drain.compile.drain.handleError { case t2 =>
+          logger.error(t2)("Error draining body")
+        } *> F.raiseError(t)
+    }
 }


### PR DESCRIPTION
When we acquire a `Response`, it is the server's responsibility to ensure that its body's finalizer runs.  Lacking a resourceful model of a response (#2663), the `.attempt.flatMap` can be interrupted and cause a leak.

We can't fix this in general, because `Http4sServlet` only requires an `Effect`.  We do a best effort by pattern matching the instance.  In `AsyncHttp4sServlet`, we can guarantee the better behavior.

Bonus: plug the same leak in blaze-server and ember-server