### PR TITLE
Adds async timeout as param

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -39,7 +39,7 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
     *
     * Assumes non-blocking servlet IO is available, and thus requires at least Servlet 3.1.
     */
-  @deprecated("Use mountRoutes instead")
+  @deprecated("Use mountRoutes instead", "0.23.10")
   def mountService[F[_]: Async](
       name: String,
       service: HttpRoutes[F],

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -39,12 +39,21 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
     *
     * Assumes non-blocking servlet IO is available, and thus requires at least Servlet 3.1.
     */
+  @deprecated("Use mountRoutes instead")
   def mountService[F[_]: Async](
       name: String,
       service: HttpRoutes[F],
       mapping: String = "/*",
       dispatcher: Dispatcher[F],
-      asyncTimeout: Duration = defaults.ResponseTimeout
+  ): ServletRegistration.Dynamic =
+    mountHttpApp(name, service.orNotFound, mapping, dispatcher)
+
+  def mountRoutes[F[_]: Async](
+      name: String,
+      service: HttpRoutes[F],
+      mapping: String = "/*",
+      dispatcher: Dispatcher[F],
+      asyncTimeout: Duration = defaults.ResponseTimeout,
   ): ServletRegistration.Dynamic =
     mountHttpApp(name, service.orNotFound, mapping, dispatcher, asyncTimeout)
 
@@ -53,7 +62,7 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
       service: HttpApp[F],
       mapping: String = "/*",
       dispatcher: Dispatcher[F],
-      asyncTimeout: Duration = defaults.ResponseTimeout
+      asyncTimeout: Duration = defaults.ResponseTimeout,
   ): ServletRegistration.Dynamic = {
     val servlet = new AsyncHttp4sServlet(
       service = service,

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -26,6 +26,7 @@ import org.http4s.syntax.all._
 
 import javax.servlet.ServletContext
 import javax.servlet.ServletRegistration
+import scala.concurrent.duration.Duration
 
 trait ServletContextSyntax {
   implicit def ToServletContextOps(self: ServletContext): ServletContextOps =
@@ -43,18 +44,20 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
       service: HttpRoutes[F],
       mapping: String = "/*",
       dispatcher: Dispatcher[F],
+      asyncTimeout: Duration = defaults.ResponseTimeout
   ): ServletRegistration.Dynamic =
-    mountHttpApp(name, service.orNotFound, mapping, dispatcher)
+    mountHttpApp(name, service.orNotFound, mapping, dispatcher, asyncTimeout)
 
   def mountHttpApp[F[_]: Async](
       name: String,
       service: HttpApp[F],
       mapping: String = "/*",
       dispatcher: Dispatcher[F],
+      asyncTimeout: Duration = defaults.ResponseTimeout
   ): ServletRegistration.Dynamic = {
     val servlet = new AsyncHttp4sServlet(
       service = service,
-      asyncTimeout = defaults.ResponseTimeout,
+      asyncTimeout = asyncTimeout,
       servletIo = NonBlockingServletIo(DefaultChunkSize),
       serviceErrorHandler = DefaultServiceErrorHandler[F],
       dispatcher,


### PR DESCRIPTION
closes #1812 
- `mountService` method deprecated in spite of `mountRoutes` which now receives the async timeout as param