### PR TITLE
- Adds the async timeout as a method param

### DIFF
--- a/examples/war/src/main/scala/com/example/http4s/war/Bootstrap.scala
+++ b/examples/war/src/main/scala/com/example/http4s/war/Bootstrap.scala
@@ -35,7 +35,7 @@ class Bootstrap extends ServletContextListener {
         .use(dispatcher =>
           IO(
             sce.getServletContext
-              .mountService("example", ExampleService[IO].routes, dispatcher = dispatcher)
+              .mountRoutes("example", ExampleService[IO].routes, dispatcher = dispatcher)
           )
         )
         .as(ExitCode.Success)

--- a/servlet/src/main/scala-2.12/org/http4s/servlet/syntax/ServletContextOpsCompanionCompat.scala
+++ b/servlet/src/main/scala-2.12/org/http4s/servlet/syntax/ServletContextOpsCompanionCompat.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package servlet
+package syntax
+
+import cats.effect._
+import cats.effect.std.Dispatcher
+import org.http4s.server.defaults
+
+import javax.servlet.ServletContext
+import javax.servlet.ServletRegistration
+
+private[syntax] trait ServletContextOpsCompanionCompat {
+
+  @deprecated("Preserved for binary compatibility", "0.23.11")
+  def `mountHttpApp$extension`[F[_]: Async](
+      servlet: ServletContext,
+      name: String,
+      service: HttpApp[F],
+      mapping: String,
+      dispatcher: Dispatcher[F],
+  ): ServletRegistration.Dynamic =
+    (new ServletContextOps(servlet)).mountHttpApp(
+      name,
+      service,
+      mapping,
+      dispatcher,
+      defaults.ResponseTimeout,
+    )
+}

--- a/servlet/src/main/scala-2.13/org/http4s/servlet/syntax/ServletContextOpsCompanionCompat.scala
+++ b/servlet/src/main/scala-2.13/org/http4s/servlet/syntax/ServletContextOpsCompanionCompat.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package servlet
+package syntax
+
+private[syntax] trait ServletContextOpsCompanionCompat

--- a/servlet/src/main/scala-3/org/http4s/servlet/syntax/ServletContextOpsCompanionCompat.scala
+++ b/servlet/src/main/scala-3/org/http4s/servlet/syntax/ServletContextOpsCompanionCompat.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package servlet
+package syntax
+
+private[syntax] trait ServletContextOpsCompanionCompat

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -40,7 +40,7 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
     * Assumes non-blocking servlet IO is available, and thus requires at least Servlet 3.1.
     */
   @deprecated("Use mountRoutes instead", "0.23.11")
-  private[servlet] def mountService[F[_]: Async](
+  def mountService[F[_]: Async](
       name: String,
       service: HttpRoutes[F],
       mapping: String = "/*",

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -88,24 +88,6 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
   }
 }
 
-object ServletContextOps {
-
-  @deprecated("Preserved for binary compatibility", "0.23.11")
-  def `mountHttpApp$extension`[F[_]: Async](
-      servlet: ServletContext,
-      name: String,
-      service: HttpApp[F],
-      mapping: String,
-      dispatcher: Dispatcher[F],
-  ): ServletRegistration.Dynamic =
-    (new ServletContextOps(servlet)).mountHttpApp(
-      name,
-      service,
-      mapping,
-      dispatcher,
-      defaults.ResponseTimeout,
-    )
-
-}
+object ServletContextOps extends ServletContextOpsCompanionCompat
 
 object servletContext extends ServletContextSyntax

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -88,4 +88,24 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
   }
 }
 
+object ServletContextOps {
+
+  @deprecated("Preserved for binary compatibility", "0.23.11")
+  def `mountHttpApp$extension`[F[_]: Async](
+      servlet: ServletContext,
+      name: String,
+      service: HttpApp[F],
+      mapping: String,
+      dispatcher: Dispatcher[F],
+  ): ServletRegistration.Dynamic =
+    (new ServletContextOps(servlet)).mountHttpApp(
+      name,
+      service,
+      mapping,
+      dispatcher,
+      defaults.ResponseTimeout,
+    )
+
+}
+
 object servletContext extends ServletContextSyntax

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -39,7 +39,7 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
     *
     * Assumes non-blocking servlet IO is available, and thus requires at least Servlet 3.1.
     */
-  @deprecated("Use mountRoutes instead", "1.0.0-M32")
+  @deprecated("Use mountRoutes instead", "0.23.11")
   private[servlet] def mountService[F[_]: Async](
       name: String,
       service: HttpRoutes[F],
@@ -57,7 +57,7 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
   ): ServletRegistration.Dynamic =
     mountHttpApp(name, service.orNotFound, mapping, dispatcher, asyncTimeout)
 
-  @deprecated("Use mountHttpApp with async timeout param instead", "1.0.0-M32")
+  @deprecated("Use mountHttpApp with async timeout param instead", "0.23.11")
   private[servlet] def mountHttpApp[F[_]: Async](
       name: String,
       service: HttpApp[F],


### PR DESCRIPTION
# Adds the async timeout as param
- closes #1812 
- Deprecates `mountService`, clients should use the new `mountRoutes` method with the timeout param
- Deprecates `mountHttpApp` without the timeout param, clients should use `mountHttpApp` with the timeout param
