### PR TITLE
Make it possible to extract Path from Request.pathInfo

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -71,6 +71,15 @@ object / {
           Some(Path(allButLast, absolute = path.absolute) -> last.decoded())
         case _ => None
       }
+
+  /** Path extractor:
+    * {{{
+    *   request match {
+    *     case Root / "test.json" => must handle methods here...
+    * }}}
+    */
+  def unapply[F[_]](req: Request[F]): Option[(Path, String)] =
+    unapply(req.pathInfo)
 }
 
 object -> {


### PR DESCRIPTION
Sometimes it's useful to extract the Path directly from the request and work on that.

When using http4s-directives, we never want to handle Methods using pattern matching, since we care about correct HTTP response codes.

This makes foot-shooting possible, but that was possible anyway.