### PR TITLE
Exposing callable parameters for DigestAuth.challenge

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -102,8 +102,12 @@ object DigestAuth {
   /** Side-effect of running the returned task: If req contains a valid
     * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
     */
-  private[authentication] def challenge[F[_], A](realm: String, store: AuthenticationStore[F, A], nonceKeeper: NonceKeeper)(
-      implicit F: Sync[F]
+  private[authentication] def challenge[F[_], A](
+      realm: String,
+      store: AuthenticationStore[F, A],
+      nonceKeeper: NonceKeeper,
+  )(implicit
+      F: Sync[F]
   ): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =
     Kleisli { req =>
       def paramsToChallenge(params: Map[String, String]) =

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -30,6 +30,7 @@ import org.http4s.headers._
 
 import java.math.BigInteger
 import java.util.Date
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 
 /** Provides Digest Authentication from RFC 2617.
@@ -62,6 +63,7 @@ object DigestAuth {
     *                       purposes anymore).
     * @param nonceBits The number of random bits a nonce should consist of.
     */
+  @nowarn
   def apply[F[_]: Sync, A](
       realm: String,
       store: AuthenticationStore[F, A],
@@ -87,6 +89,7 @@ object DigestAuth {
     *                       purposes anymore).
     * @param nonceBits The number of random bits a nonce should consist of.
     */
+  @nowarn
   def challenge[F[_], A](
       realm: String,
       store: AuthenticationStore[F, A],
@@ -102,7 +105,11 @@ object DigestAuth {
   /** Side-effect of running the returned task: If req contains a valid
     * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
     */
-  private[authentication] def challenge[F[_], A](
+  @deprecated(
+    "Calling challenge is side-effecting, please use the F[_]-suspended variant",
+    "0.22.11",
+  )
+  def challenge[F[_], A](
       realm: String,
       store: AuthenticationStore[F, A],
       nonceKeeper: NonceKeeper,

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -81,11 +81,13 @@ object DigestAuth {
       nonceCleanupInterval: Duration = 1.hour,
       nonceStaleTime: Duration = 1.hour,
       nonceBits: Int = 160,
-  )(implicit F: Async[F]): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] = {
-    val nonceKeeper =
-      new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits)
-    challenge[F, A](realm, store, nonceKeeper)
-  }
+  )(implicit F: Sync[F]): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =
+    Kleisli { req =>
+      F.delay(new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits))
+        .flatMap { nonceKeeper =>
+          challenge[F, A](realm, store, nonceKeeper).apply(req)
+        }
+    }
 
   @deprecated("Maintaining for ABI compatibility", "0.22.12")
   def challenge[F[_], A](realm: String, store: AuthenticationStore[F, A], nonceKeeper: NonceKeeper)(

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -87,7 +87,7 @@ object DigestAuth {
     challenge[F, A](realm, store, nonceKeeper)
   }
 
-  @deprecated("Maintaining for ABI compatibility", "0.23.10")
+  @deprecated("Maintaining for ABI compatibility", "0.22.12")
   def challenge[F[_], A](realm: String, store: AuthenticationStore[F, A], nonceKeeper: NonceKeeper)(
       implicit F: Sync[F]
   ): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -102,7 +102,7 @@ object DigestAuth {
   /** Side-effect of running the returned task: If req contains a valid
     * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
     */
-  private def challenge[F[_], A](realm: String, store: AuthenticationStore[F, A], nonceKeeper: NonceKeeper)(
+  private[authentication] def challenge[F[_], A](realm: String, store: AuthenticationStore[F, A], nonceKeeper: NonceKeeper)(
       implicit F: Sync[F]
   ): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =
     Kleisli { req =>


### PR DESCRIPTION
NonceKeeper is package-private, so there's no way to construct one,
meaning there's no way to call `challenge`.

Mirror the same parameters from `apply`, and maintain the previous
`challenge` method for bincompat.

I'm happy to make changes if desired.

Thank you