### PR TITLE
Optimize Http1Writer for cases when the entity is Empty or Strict

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
@@ -206,7 +206,7 @@ private final class Http1Connection[F[_]](
           }
 
           val writeRequest: F[Boolean] = getChunkEncoder(req, mustClose, rr)
-            .write(rr, req.body)
+            .write(rr, req.entity)
             .onError {
               case EOF => F.delay(shutdownWithError(EOF))
               case t =>

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
@@ -296,7 +296,7 @@ private[blaze] class Http1ServerStage[F[_]](
 
     // TODO: pool shifting: https://github.com/http4s/http4s/blob/main/core/src/main/scala/org/http4s/internal/package.scala#L45
     val fa = bodyEncoder
-      .write(rr, resp.body)
+      .write(rr, resp.entity)
       .recover { case EOF => true }
       .attempt
       .flatMap {


### PR DESCRIPTION
The "encode" counterpart to https://github.com/http4s/http4s/pull/5813, perhaps.

Gives a significant performance improvement in some cases.

In techempower benchmarks, plaintext goes from 172k req/s to 267k req/s. JSON serialization goes from 146k req/s to 201k req/s (with an `EntityEncoder` that uses `EntityEncoder.simple` but also changing to jsoniter-scala, so not quite a direct comparison).

For another example, similar to plaintext:
example1 (strict): Requests/sec: 286024.12
example2 (non-strict): Requests/sec: 229754.28

Results from `docker run --network=host techempower/tfb.wrk wrk -H 'Host: localhost' -H 'Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7' -H 'Connection: keep-alive' --latency -d 15 -c 4096 --timeout 8 -t 16 http://127.0.0.1:9111/example2 -s pipeline.lua -- 16`

```scala
object Main extends IOApp.Simple with Http4sDsl[IO] {
  private val message = "strict vs non-strict benchmark"
  private val service = HttpRoutes.of[IO] {
    case GET -> Root / "example1" =>
      IO.pure(Response[IO](entity = Entity.strict(Chunk.array(message.getBytes(Charset.`UTF-8`.nioCharset)))))
    case GET -> Root / "example2" =>
      Ok(message)
  }
  override val run: IO[Unit] = {
    BlazeServerBuilder[IO]
      .bindHttp(9111, "0.0.0.0")
      .withHttpApp(service.orNotFound)
      .withSocketKeepAlive(true)
      .resource
      .use(_ => IO.never)
  }
}
```
