### PR TITLE
Ignore `sbt-buildinfo` updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -28,5 +28,6 @@ updates.ignore = [
   { groupId = "org.http4s", artifactId = "http4s-ember-client" },
   { groupId = "org.slf4j", artifactId = "slf4j-api" },
   { groupId = "org.eclipse.jetty" },
-  { groupId = "org.eclipse.jetty.http2" }
+  { groupId = "org.eclipse.jetty.http2" },
+  { groupId = "com.eed3si9n", artifactId = "sbt-buildinfo" }
 ]


### PR DESCRIPTION
Updates should proceed from the `0.22` branch.