### PR TITLE
Fix ember client cancellation bug

### DIFF
--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -273,7 +273,8 @@ final class EmberClientBuilder[F[_]: Async] private (
               )
             }
           )
-          responseResource <- Resource.makeCase(
+          responseResource <- Resource.makeCaseFull(
+            (poll: Poll[F]) => poll(
             ClientHelpers
               .request[F](
                 request,
@@ -284,6 +285,7 @@ final class EmberClientBuilder[F[_]: Async] private (
                 timeout,
                 userAgent,
               )
+            )
           ) { case ((response, drain), exitCase) =>
             exitCase match {
               case Resource.ExitCase.Succeeded =>
@@ -335,7 +337,7 @@ final class EmberClientBuilder[F[_]: Async] private (
             unixSocketClient(request, address)
           }
       }
-      val stackClient = Retry.create(retryPolicy, logRetries = false)(client)
+      val stackClient = Retry.create(retryPolicy, logRetries = true)(client)
       val iClient = new EmberClient[F](stackClient, pool)
 
       optH2.fold(iClient) { h2 =>

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -273,18 +273,18 @@ final class EmberClientBuilder[F[_]: Async] private (
               )
             }
           )
-          responseResource <- Resource.makeCaseFull(
-            (poll: Poll[F]) => poll(
-            ClientHelpers
-              .request[F](
-                request,
-                managed.value,
-                chunkSize,
-                maxResponseHeaderSize,
-                idleConnectionTime,
-                timeout,
-                userAgent,
-              )
+          responseResource <- Resource.makeCaseFull((poll: Poll[F]) =>
+            poll(
+              ClientHelpers
+                .request[F](
+                  request,
+                  managed.value,
+                  chunkSize,
+                  maxResponseHeaderSize,
+                  idleConnectionTime,
+                  timeout,
+                  userAgent,
+                )
             )
           ) { case ((response, drain), exitCase) =>
             exitCase match {
@@ -337,7 +337,7 @@ final class EmberClientBuilder[F[_]: Async] private (
             unixSocketClient(request, address)
           }
       }
-      val stackClient = Retry.create(retryPolicy, logRetries = true)(client)
+      val stackClient = Retry.create(retryPolicy, logRetries = false)(client)
       val iClient = new EmberClient[F](stackClient, pool)
 
       optH2.fold(iClient) { h2 =>


### PR DESCRIPTION
Fixes #6058

makeCase surpresses cancellation. makeCaseFull does not. We could probably specify better what spaces are cancelable and get some better semantics, but this fixes the critical issue of all cancellation being suppressed.

Big Bug need to fix ASAP

