### PR TITLE
Collect entity from parser, support Entity.Strict and Empty

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
@@ -408,7 +408,7 @@ private final class Http1Connection[F[_]](
           entity = entity match {
             case Entity.Default(body, length) =>
               Entity[F](body.interruptWhen(idleTimeoutS), length)
-            case _ =>
+            case Entity.Strict(_) | Entity.Empty =>
               entity
           },
           attributes = attributes,

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerParser.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerParser.scala
@@ -46,7 +46,7 @@ private[http4s] final class Http1ServerParser[F[_]](
   def doParseContent(buff: ByteBuffer): Option[ByteBuffer] = Option(parseContent(buff))
 
   def collectMessage(
-      body: EntityBody[F],
+      entity: Entity[F],
       attrs: Vault,
   ): Either[(ParseFailure, HttpVersion), Request[F]] = {
     val h = Headers(headers.result())
@@ -73,7 +73,7 @@ private[http4s] final class Http1ServerParser[F[_]](
       .fromString(this.method)
       .flatMap { method =>
         Uri.requestTarget(this.uri).map { uri =>
-          Request(method, uri, protocol, h, Entity(body), attrsWithTrailers)
+          Request(method, uri, protocol, h, entity, attrsWithTrailers)
         }
       }
       .leftMap(_ -> protocol)

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
@@ -195,7 +195,7 @@ private[blaze] class Http1ServerStage[F[_]](
 
   // Only called while holding the monitor of `parser`
   private def runRequest(buffer: ByteBuffer): Unit = {
-    val (body, cleanup) = collectBodyFromParser(
+    val (body, cleanup) = collectEntityFromParser(
       buffer,
       () => Either.left(InvalidBodyException("Received premature EOF.")),
     )


### PR DESCRIPTION
Together with the other PRs (#6080, #6091, #6092), this increases performance on "plaintext" from the Techempower benchmarks by around 125% (from 172k reqs/s to 392k reqs/s), and around 80% for JSON.