### PR TITLE
Avoid draining body on error/cancel for Entity.Strict and Empty

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
@@ -42,8 +42,7 @@ private[http4s] trait Http1Writer[F[_]] extends EntityBodyWriter[F] {
               body.drain.compile.drain.handleError { t2 =>
                 Http1Writer.logger.error(t2)("Error draining body")
               }
-            case Entity.Strict(_) => F.unit
-            case Entity.Empty => F.unit
+            case Entity.Strict(_) | Entity.Empty => F.unit
           }
       } >> (entity match {
       case Entity.Default(body, _) =>

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
@@ -37,8 +37,13 @@ private[http4s] trait Http1Writer[F[_]] extends EntityBodyWriter[F] {
           F.unit
 
         case Outcome.Errored(_) | Outcome.Canceled() =>
-          entity.body.drain.compile.drain.handleError { t2 =>
-            Http1Writer.logger.error(t2)("Error draining body")
+          entity match {
+            case Entity.Default(body, _) =>
+              body.drain.compile.drain.handleError { t2 =>
+                Http1Writer.logger.error(t2)("Error draining body")
+              }
+            case Entity.Strict(_) => F.unit
+            case Entity.Empty => F.unit
           }
       } >> (entity match {
       case Entity.Default(body, _) =>


### PR DESCRIPTION
Together with the other PRs (#6080, #6090, #6092), this increases performance on "plaintext" from the Techempower benchmarks by around 125% (from 172k reqs/s to 392k reqs/s), and around 80% for JSON.