### PR TITLE
Document the use of the execution context passed to the blaze builders.

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
@@ -298,6 +298,11 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
   def withBufferSize(bufferSize: Int): BlazeClientBuilder[F] =
     copy(bufferSize = bufferSize)
 
+  /** Configures the compute thread pool used to run async computations.
+    *
+    * This defaults to `cats.effect.Async[F].executionContext`. In
+    * almost all cases, it is desirable to use the default.
+    */
   def withExecutionContext(executionContext: ExecutionContext): BlazeClientBuilder[F] =
     copy(executionContextConfig = ExecutionContextConfig.ExplicitContext(executionContext))
 

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
@@ -209,6 +209,18 @@ class BlazeServerBuilder[F[_]] private (
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
     copy(socketAddress = socketAddress)
 
+
+  /** Configures the compute thread pool used to process requests
+    *
+    * This defaults to `cats.effect.Async[F].executionContext`. In
+    * almost all cases, it is desirable to use the default.
+    *
+    * The Blaze server has a single-threaded event loop receiver used
+    * for picking up tcp connections which is completely separate to
+    * this pool. Following picking up a tcp connection, Blaze shifts
+    * to this compute pool to process requests. Request processing
+    * logic is specified by the `HttpApp`.
+    */
   def withExecutionContext(executionContext: ExecutionContext): BlazeServerBuilder[F] =
     copy(executionContextConfig = ExecutionContextConfig.ExplicitContext(executionContext))
 

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
@@ -209,7 +209,7 @@ class BlazeServerBuilder[F[_]] private (
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
     copy(socketAddress = socketAddress)
 
-  /** Configures the compute thread pool used to process requests
+  /** Configures the compute thread pool used to process some async computations.
     *
     * This defaults to `cats.effect.Async[F].executionContext`. In
     * almost all cases, it is desirable to use the default.
@@ -217,8 +217,11 @@ class BlazeServerBuilder[F[_]] private (
     * The Blaze server has a single-threaded event loop receiver used
     * for picking up tcp connections which is completely separate to
     * this pool. Following picking up a tcp connection, Blaze shifts
-    * to this compute pool to process requests. Request processing
-    * logic is specified by the `HttpApp`.
+    * to a compute pool to process requests. The request processing
+    * logic specified by the `HttpApp` is executed on the
+    * `cats.effect.Async[F].executionContext`. Some of the other async
+    * computations involved in request processing are executed on this
+    * pool.
     */
   def withExecutionContext(executionContext: ExecutionContext): BlazeServerBuilder[F] =
     copy(executionContextConfig = ExecutionContextConfig.ExplicitContext(executionContext))

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
@@ -209,7 +209,6 @@ class BlazeServerBuilder[F[_]] private (
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
     copy(socketAddress = socketAddress)
 
-
   /** Configures the compute thread pool used to process requests
     *
     * This defaults to `cats.effect.Async[F].executionContext`. In


### PR DESCRIPTION
Following a [discussion on discourse](https://discord.com/channels/632277896739946517/632286375311573032/950816734288412672), I'd like to improve the docs on the custom execution context provided to the `BlazeServerBuilder` and `BlazeClientBuilder`.

Let me know what you think.

Thanks!