### PR TITLE
Remove unused ExecutionContexts in blaze-core

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
@@ -30,11 +30,9 @@ import scala.concurrent._
 /** Discards the body, killing it so as to clean up resources
   *
   * @param pipe the blaze `TailStage`, which takes ByteBuffers which will send the data downstream
-  * @param ec an ExecutionContext which will be used to complete operations
   */
 private[http4s] class BodylessWriter[F[_]](pipe: TailStage[ByteBuffer], close: Boolean)(implicit
-    protected val F: Async[F],
-    protected val ec: ExecutionContext,
+    protected val F: Async[F]
 ) extends Http1Writer[F] {
   def writeHeaders(headerWriter: StringWriter): Future[Unit] =
     pipe.channelWrite(Http1Writer.headersToByteBuffer(headerWriter.result))

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
@@ -29,9 +29,6 @@ private[http4s] trait EntityBodyWriter[F[_]] {
 
   protected val wroteHeader: Promise[Unit] = Promise[Unit]()
 
-  /** The `ExecutionContext` on which to run computations, assumed to be stack safe. */
-  implicit protected def ec: ExecutionContext
-
   /** Write a Chunk to the wire.
     *
     * @param chunk BodyChunk to write to wire

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/DumpingWriter.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/DumpingWriter.scala
@@ -21,10 +21,8 @@ package util
 import cats.effect.Async
 import cats.effect.IO
 import fs2._
-import org.http4s.blaze.util.Execution
 
 import scala.collection.mutable.Buffer
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 object DumpingWriter {
@@ -35,8 +33,6 @@ object DumpingWriter {
 }
 
 class DumpingWriter(implicit protected val F: Async[IO]) extends EntityBodyWriter[IO] {
-  override implicit protected def ec: ExecutionContext = Execution.trampoline
-
   private val buffer = Buffer[Chunk[Byte]]()
 
   def toArray: Array[Byte] =

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/FailingWriter.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/FailingWriter.scala
@@ -22,12 +22,9 @@ import cats.effect._
 import fs2._
 import org.http4s.blaze.pipeline.Command.EOF
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 class FailingWriter(implicit protected val F: Async[IO]) extends EntityBodyWriter[IO] {
-  override implicit protected val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
-
   override protected def writeEnd(chunk: Chunk[Byte]): Future[Boolean] =
     Future.failed(EOF)
 

--- a/build.sbt
+++ b/build.sbt
@@ -690,6 +690,18 @@ lazy val blazeCore = libraryProject("blaze-core")
     libraryDependencies ++= Seq(
       blazeHttp
     ),
+    mimaBinaryIssueFilters := {
+      if (tlIsScala3.value)
+        Seq(
+          ProblemFilters
+            .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.BodylessWriter.this"),
+          ProblemFilters
+            .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.BodylessWriter.ec"),
+          ProblemFilters
+            .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.EntityBodyWriter.ec"),
+        )
+      else Seq.empty
+    },
   )
   .dependsOn(core.jvm, testing.jvm % "test->test")
 
@@ -726,12 +738,6 @@ lazy val blazeServer = libraryProject("blaze-server")
         .exclude[DirectMissingMethodProblem]("org.http4s.blaze.server.BlazeServerBuilder.this"),
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.http4s.blaze.server.WebSocketDecoder.this"),
-      ProblemFilters
-        .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.BodylessWriter.this"),
-      ProblemFilters
-        .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.BodylessWriter.ec"),
-      ProblemFilters
-        .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.EntityBodyWriter.ec"),
     ) ++ {
       if (tlIsScala3.value)
         Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -726,6 +726,12 @@ lazy val blazeServer = libraryProject("blaze-server")
         .exclude[DirectMissingMethodProblem]("org.http4s.blaze.server.BlazeServerBuilder.this"),
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.http4s.blaze.server.WebSocketDecoder.this"),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.BodylessWriter.this"),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.BodylessWriter.ec"),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.EntityBodyWriter.ec"),
     ) ++ {
       if (tlIsScala3.value)
         Seq(


### PR DESCRIPTION
Discovered during #6098.