### PR TITLE
docs: use mdoc instead of laika for variable substitutions in code blocks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -906,12 +906,13 @@ lazy val docs = http4sProject("docs")
         scalafixInternalTests,
       ),
     mdocIn := (Compile / sourceDirectory).value / "mdoc",
+    mdocVariables := SiteConfig.mdocVariables.value,
     tlFatalWarningsInCi := false,
     laikaExtensions := SiteConfig.extensions,
     laikaConfig := SiteConfig.config(versioned = true).value,
     laikaTheme := SiteConfig.theme(
       currentVersion = SiteConfig.versions.current,
-      SiteConfig.variables.value,
+      SiteConfig.laikaVariables.value,
       SiteConfig.homeURL.value,
       includeLandingPage = false,
     ),
@@ -959,7 +960,7 @@ lazy val website = http4sProject("website")
     laikaConfig := SiteConfig.config(versioned = false).value,
     laikaTheme := SiteConfig.theme(
       currentVersion = SiteConfig.versions.current,
-      SiteConfig.variables.value,
+      SiteConfig.laikaVariables.value,
       SiteConfig.homeURL.value,
       includeLandingPage = false,
     ),

--- a/docs/src/main/mdoc/auth.md
+++ b/docs/src/main/mdoc/auth.md
@@ -148,7 +148,7 @@ We'll use a small library for the signing/validation of the cookies, which
 basically contains the code used by the Play framework for this specific task.
 
 ```scala
-libraryDependencies += "org.reactormonk" %% "cryptobits" % "@{version.cryptobits}"
+libraryDependencies += "org.reactormonk" %% "cryptobits" % "@version_cryptobits@"
 ```
 
 First, we'll need to set the cookie. For the crypto instance, we'll need to

--- a/docs/src/main/mdoc/client.md
+++ b/docs/src/main/mdoc/client.md
@@ -9,7 +9,7 @@ A recap of the dependencies for this example, in case you skipped the [service] 
 ```scala
 scalaVersion := "2.13.4" // Also supports 2.11.x and 2.12.x
 
-val http4sVersion = "@{version.http4s.doc}"
+val http4sVersion = "@version_http4s_doc@"
 
 // Only necessary for SNAPSHOT releases
 resolvers += Resolver.sonatypeRepo("snapshots")

--- a/docs/src/main/mdoc/json.md
+++ b/docs/src/main/mdoc/json.md
@@ -12,14 +12,14 @@ The http4s team recommends circe.  Only http4s-circe is required for
 basic interop with circe, but to follow this tutorial, install all three:
 
 ```scala
-val http4sVersion = "@{version.http4s.doc}"
+val http4sVersion = "@version_http4s_doc@"
 
 libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-circe" % http4sVersion,
   // Optional for auto-derivation of JSON codecs
-  "io.circe" %% "circe-generic" % "@{version.circe}",
+  "io.circe" %% "circe-generic" % "@version_circe@",
   // Optional for string interpolation to JSON model
-  "io.circe" %% "circe-literal" % "@{version.circe}"
+  "io.circe" %% "circe-literal" % "@version_circe@"
 )
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/docs/src/main/mdoc/service.md
+++ b/docs/src/main/mdoc/service.md
@@ -9,7 +9,7 @@ Create a new directory, with the following build.sbt in the root:
 ```scala
 scalaVersion := "2.13.6" // Also supports 2.12.x and 3.x
 
-val http4sVersion = "@{version.http4s.doc}"
+val http4sVersion = "@version_http4s_doc@"
 
 // Only necessary for SNAPSHOT releases
 resolvers += Resolver.sonatypeRepo("snapshots")

--- a/docs/src/main/mdoc/streaming.md
+++ b/docs/src/main/mdoc/streaming.md
@@ -59,8 +59,8 @@ First, let's assume we want to use [Circe] for JSON support. Please see [json] f
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-circe" % "@{version.http4s.doc}",
-  "io.circe" %% "circe-generic" % "@{version.circe}"
+  "org.http4s" %% "http4s-circe" % "@version_http4s_doc@",
+  "io.circe" %% "circe-generic" % "@version_circe@"
 )
 ```
 

--- a/project/SiteConfig.scala
+++ b/project/SiteConfig.scala
@@ -110,7 +110,7 @@ object SiteConfig {
   }
 
   // This kind of variable generator used to live in Http4sPlugin, but it's not used by anything other than Laika.
-  lazy val variables: Initialize[Map[String, String]] = setting {
+  lazy val laikaVariables: Initialize[Map[String, String]] = setting {
     val (major, minor) =
       version.value match { // cannot use the existing http4sApiVersion as it is somehow defined as a task, not a setting
         case VersionNumber(Seq(major, minor, _*), _, _) => (major.toInt, minor.toInt)
@@ -125,6 +125,12 @@ object SiteConfig {
       "version.cryptobits" -> cryptobits.revision,
     ) ++ latestInSeries
   }
+  
+  lazy val mdocVariables: Initialize[Map[String, String]] = setting { 
+    laikaVariables.value.map {
+      case (key, value) => (key.replace('.','_'), value)
+    }
+  }
 
   val homeURL: Initialize[String] = setting {
     if (isCi.value) "https://http4s.org"
@@ -138,7 +144,7 @@ object SiteConfig {
   )
 
   def config(versioned: Boolean): sbt.Def.Initialize[LaikaConfig] = sbt.Def.setting {
-    val config = variables.value.foldLeft(ConfigBuilder.empty) { case (builder, (key, value)) =>
+    val config = laikaVariables.value.foldLeft(ConfigBuilder.empty) { case (builder, (key, value)) =>
       builder.withValue(key, value)
     }
 

--- a/project/SiteConfig.scala
+++ b/project/SiteConfig.scala
@@ -125,10 +125,10 @@ object SiteConfig {
       "version.cryptobits" -> cryptobits.revision,
     ) ++ latestInSeries
   }
-  
-  lazy val mdocVariables: Initialize[Map[String, String]] = setting { 
-    laikaVariables.value.map {
-      case (key, value) => (key.replace('.','_'), value)
+
+  lazy val mdocVariables: Initialize[Map[String, String]] = setting {
+    laikaVariables.value.map { case (key, value) =>
+      (key.replace('.', '_'), value)
     }
   }
 
@@ -144,8 +144,9 @@ object SiteConfig {
   )
 
   def config(versioned: Boolean): sbt.Def.Initialize[LaikaConfig] = sbt.Def.setting {
-    val config = laikaVariables.value.foldLeft(ConfigBuilder.empty) { case (builder, (key, value)) =>
-      builder.withValue(key, value)
+    val config = laikaVariables.value.foldLeft(ConfigBuilder.empty) {
+      case (builder, (key, value)) =>
+        builder.withValue(key, value)
     }
 
     LaikaConfig(


### PR DESCRIPTION
As discussed some time ago, this PR switches from Laika to mdoc for variable substitutions in code blocks.

Using Laika for this purpose had limitations (e.g. they could only be used inside string literals) and won't be supported in a more complete form in the near future. mdoc has built-in support for this functionality without any limitations.

Changes in this PR:
* `build.sbt`: feed the variable map to both, Laika and mdoc, so that Laika can perform substitutions in text markup and mdoc in code blocks.
* `HeliumExtensions`: remove the old workaround for the limited support of this feature.
* Markdown files in the `docs` project: adjust the syntax for the existing variable substitutions to the one required for mdoc.

As probably expected, the syntax for substitutions is different:
* For mdoc the syntax is `@version_circe@`.
* For Laika the syntax is `${version.circe}`.

