### PR TITLE
Deprecate async-http-client

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
@@ -41,6 +41,7 @@ import org.http4s.internal.bug
 import org.http4s.internal.threads._
 import org.reactivestreams.Publisher
 
+@deprecated("Upstream is unmaintained. Recommend choosing another backend.", "0.22.12")
 object AsyncHttpClient {
   val defaultConfig: DefaultAsyncHttpClientConfig = new DefaultAsyncHttpClientConfig.Builder()
     .setMaxConnectionsPerHost(200)

--- a/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClientStats.scala
+++ b/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClientStats.scala
@@ -24,6 +24,7 @@ import org.asynchttpclient.HostStats
 import org.asynchttpclient.{Response => _}
 import org.http4s.internal.CollectionCompat.CollectionConverters._
 
+@deprecated("Upstream is unmaintained. Recommend choosing another backend.", "0.22.12")
 class AsyncHttpClientStats[F[_]](private val underlying: ClientStats)(implicit F: Sync[F]) {
 
   def getTotalConnectionCount: F[Long] = F.delay(underlying.getTotalConnectionCount)

--- a/async-http-client/src/test/scala/org/http4s/asynchttpclient/AsyncHttpClientSuite.scala
+++ b/async-http-client/src/test/scala/org/http4s/asynchttpclient/AsyncHttpClientSuite.scala
@@ -27,6 +27,7 @@ import org.http4s.client.ClientRouteTestBattery
 import org.http4s.client.DefaultClient
 import org.http4s.client.defaults
 
+@deprecated("Upstream client is deprecated", "0.22.12")
 class AsyncHttpClientSpec extends ClientRouteTestBattery("AsyncHttpClient") with Http4sSuite {
 
   def clientResource: Resource[IO, Client[IO]] = AsyncHttpClient.resource[IO]()


### PR DESCRIPTION
As noted on #6107, upstream has been [unmaintained for months](https://github.com/AsyncHttpClient/async-http-client/commit/c959fa0483adb4a71fbccc5be94d8b6faa4f74be).  We should start chasing people off it.