### PR TITLE
Deprecate internal Trampoline

### DIFF
--- a/core/src/main/scala/org/http4s/internal/Trampoline.scala
+++ b/core/src/main/scala/org/http4s/internal/Trampoline.scala
@@ -21,6 +21,7 @@ import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
 
+@deprecated("Unused.  Will be removed in 1.0", "0.22.12")
 private[http4s] object Trampoline extends ExecutionContextExecutor {
   private val local = new ThreadLocal[ThreadLocalTrampoline]
 

--- a/tests/src/test/scala/org/http4s/internal/ExecutionSuite.scala
+++ b/tests/src/test/scala/org/http4s/internal/ExecutionSuite.scala
@@ -21,6 +21,7 @@ import org.http4s.testing.ErrorReporting._
 
 import scala.concurrent.ExecutionContext
 
+@deprecated("Supports an unused feature.  Will be removed in 1.0", "0.22.12")
 abstract class ExecutionSuite extends Http4sSuite {
   def ec: ExecutionContext
   def ecName: String
@@ -96,6 +97,7 @@ abstract class ExecutionSuite extends Http4sSuite {
 
 }
 
+@deprecated("Unused.  Will be removed in 1.0", "0.22.12")
 class TrampolineSuite extends ExecutionSuite {
   def ec = Trampoline
   def ecName = "trampoline"


### PR DESCRIPTION
Blaze has its own.  Scala 2.13 has parasitic.

Only keeping this in case a satellite repo was using it.