### PR TITLE
Add Message.normalize and use in clients

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
@@ -63,7 +63,10 @@ object AsyncHttpClient {
         Resource(F.async[(Response[F], F[Unit])] { cb =>
           F.delay(
             httpClient
-              .executeRequest(toAsyncRequest(req, dispatcher), asyncHandler(cb, dispatcher))
+              .executeRequest(
+                toAsyncRequest(req.normalize, dispatcher),
+                asyncHandler(cb, dispatcher),
+              )
           ).as(None)
         })
       }

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClient.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClient.scala
@@ -83,7 +83,8 @@ private class BlazeClient[F[_], A <: BlazeConnection[F]](
 )(implicit F: Async[F])
     extends DefaultClient[F] {
 
-  override def run(req: Request[F]): Resource[F, Response[F]] = {
+  override def run(request: Request[F]): Resource[F, Response[F]] = {
+    val req = request.normalize
     val key = RequestKey.fromRequest(req)
     for {
       requestTimeoutF <- scheduleRequestTimeout(key)

--- a/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
+++ b/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
@@ -109,7 +109,8 @@ sealed abstract class JavaNetClientBuilder[F[_]] private (
     * The shutdown of this client is a no-op. $WHYNOSHUTDOWN
     */
   def create: Client[F] =
-    Client { (req: Request[F]) =>
+    Client { (request: Request[F]) =>
+      val req = request.normalize
       def respond(conn: HttpURLConnection): F[Response[F]] =
         for {
           _ <- configureSsl(conn)

--- a/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -129,6 +129,22 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
     }
   }
 
+  GetRoutes.getPaths.get(GetRoutes.SimplePath).foreach { expected =>
+    val path = GetRoutes.SimplePath
+
+    test(s"$name Execute GET withEntity $path") {
+      serverClient().flatMap { case (server, client) =>
+        val address = server().addresses.head
+        val req =
+          Request[IO](uri = Uri.fromString(s"http://$address$path").yolo).withEntity("entity")
+        client()
+          .run(req)
+          .use(resp => expected.flatMap(checkResponse(resp, _)))
+          .assert
+      }
+    }
+  }
+
   test("Mitigates request splitting attack in URI path") {
     serverClient().flatMap { case (server, client) =>
       val address = server().addresses.head

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -53,6 +53,8 @@ sealed trait Message[F[_]] extends Media[F] { self =>
 
   def attributes: Vault
 
+  def normalize: Self
+
   protected def change(
       httpVersion: HttpVersion = httpVersion,
       entity: Entity[F] = entity,
@@ -297,6 +299,12 @@ final class Request[F[_]] private (
       entity = entity.translate(f),
       attributes = attributes,
     )
+
+  def normalize: Request[F] =
+    if (method === Method.GET || method === Method.HEAD) {
+      change(entity = Entity.empty).removeHeader[`Content-Length`]
+    } else
+      this
 
   def withMethod(method: Method): Request[F] =
     copy(method = method)
@@ -581,6 +589,8 @@ final class Response[F[_]] private (
     with Product
     with Serializable {
   type SelfF[F0[_]] = Response[F0]
+
+  def normalize: Response[F] = this
 
   def mapK[G[_]](f: F ~> G): Response[G] =
     Response[G](

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -335,7 +335,8 @@ final class EmberClientBuilder[F[_]: Async] private (
                 .map(_._1)
             )
           )
-      val client = Client[F] { request =>
+      val client = Client[F] { req =>
+        val request = req.normalize
         request.attributes
           .lookup(Request.Keys.UnixSocketAddress)
           .fold(webClient(request)) { (address: UnixSocketAddress) =>

--- a/jetty-client/src/main/scala/org/http4s/jetty/client/JettyClient.scala
+++ b/jetty-client/src/main/scala/org/http4s/jetty/client/JettyClient.scala
@@ -48,7 +48,7 @@ object JettyClient {
           Resource.suspend(F.async[Resource[F, Response[F]]] { cb =>
             F.bracket(StreamRequestContentProvider()) { dcp =>
               (for {
-                jReq <- F.catchNonFatal(toJettyRequest(client, req, dcp))
+                jReq <- F.catchNonFatal(toJettyRequest(client, req.normalize, dcp))
                 rl <- ResponseListener(cb)
                 _ <- F.delay(jReq.send(rl))
                 _ <- dcp.write(req)

--- a/okhttp-client/src/main/scala/org/http4s/okhttp/client/OkHttpBuilder.scala
+++ b/okhttp-client/src/main/scala/org/http4s/okhttp/client/OkHttpBuilder.scala
@@ -79,7 +79,9 @@ sealed abstract class OkHttpBuilder[F[_]] private (
 
   private def run(dispatcher: Dispatcher[F])(req: Request[F]) =
     Resource.suspend(F.async_[Resource[F, Response[F]]] { cb =>
-      okHttpClient.newCall(toOkHttpRequest(req, dispatcher)).enqueue(handler(cb, dispatcher))
+      okHttpClient
+        .newCall(toOkHttpRequest(req.normalize, dispatcher))
+        .enqueue(handler(cb, dispatcher))
     })
 
   private def handler(cb: Result[F] => Unit, dispatcher: Dispatcher[F])(implicit


### PR DESCRIPTION
Resolves #6108 

I was just thinking about an alternative way to solve #6108. The advantage of this approach is that there's a central place to clean up requests, so no need to deal with internally inconsistent requests in every client.

E.g. as opposed to #6111 this approach fixes JavaNetClient automatically too. I also imagine this approach could be used to solve #6106 and #6107

This is still WIP by the way. If it's useful to have this for `Response` I can call `normalize` for responses too. 
If not, I can move `normalize` from `Message` to `Request` or even somewhere less public so that is not exposed to users of http4s.