### PR TITLE
Deprecate internal Trampoline

### DIFF
--- a/core/shared/src/main/scala/org/http4s/internal/Trampoline.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/Trampoline.scala
@@ -21,6 +21,7 @@ import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
 
+@deprecated("Unused.  Will be removed in 1.0", "0.23.11")
 private[http4s] object Trampoline extends ExecutionContextExecutor {
   private val local = new ThreadLocal[ThreadLocalTrampoline]
 

--- a/tests/shared/src/test/scala/org/http4s/internal/ExecutionSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/internal/ExecutionSuite.scala
@@ -21,6 +21,7 @@ import org.http4s.testing.ErrorReporting._
 
 import scala.concurrent.ExecutionContext
 
+@deprecated("Supports an unused feature.  Will be removed in 1.0", "0.23.11")
 abstract class ExecutionSuite extends Http4sSuite {
   def ec: ExecutionContext
   def ecName: String
@@ -96,6 +97,7 @@ abstract class ExecutionSuite extends Http4sSuite {
 
 }
 
+@deprecated("Unused.  Will be removed in 1.0", "0.23.11")
 class TrampolineSuite extends ExecutionSuite {
   def ec = Trampoline
   def ecName = "trampoline"


### PR DESCRIPTION
#6115 didn't fly on 0.22, but when I went to remove it from main, I noticed it's not used in 0.23.