### PR TITLE
Backport mergify config to 0.23

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,19 +1,199 @@
 pull_request_rules:
+
 - name: label series/0.22 PRs
   conditions:
   - base=series/0.22
   actions:
     label:
       add: ['series/0.22']
+
 - name: label series/0.23 PRs
   conditions:
   - base=series/0.23
   actions:
     label:
       add: ['series/0.23']
+
 - name: label scala-steward's PRs
   conditions:
-    - author=scala-steward
+  - author=scala-steward
   actions:
     label:
       add: [dependencies]
+
+- name: label core PRs
+  conditions:
+  - files~=^core/
+  actions:
+    label:
+      add: ['module:core']
+
+- name: label dsl PRs
+  conditions:
+  - files~=^dsl/
+  actions:
+    label:
+      add: ['module:dsl']
+
+- name: label laws PRs
+  conditions:
+  - files~=^laws/
+  actions:
+    label:
+      add: ['module:laws']
+
+- name: label server PRs
+  conditions:
+  - files~=^server/
+  actions:
+    label:
+      add: ['module:server']
+
+- name: label client PRs
+  conditions:
+  - files~=^client/
+  actions:
+    label:
+      add: ['module:client']
+
+- name: label ember-core PRs
+  conditions:
+  - files~=^ember-core/
+  actions:
+    label:
+      add: ['module:ember-core']
+
+- name: label ember-server PRs
+  conditions:
+  - files~=^ember-server/
+  actions:
+    label:
+      add: ['module:ember-server']
+
+- name: label ember-client PRs
+  conditions:
+  - files~=^ember-client/
+  actions:
+    label:
+      add: ['module:ember-client']
+
+- name: label blaze-core PRs
+  conditions:
+  - files~=^blaze-core/
+  actions:
+    label:
+      add: ['module:blaze-core']
+
+- name: label blaze-server PRs
+  conditions:
+  - files~=^blaze-server/
+  actions:
+    label:
+      add: ['module:blaze-server']
+
+- name: label blaze-client PRs
+  conditions:
+  - files~=^blaze-client/
+  actions:
+    label:
+      add: ['module:blaze-client']
+
+- name: label servlet PRs
+  conditions:
+  - files~=^servlet/
+  actions:
+    label:
+      add: ['module:servlet']
+
+- name: label tomcat PRs
+  conditions:
+  - files~=^tomcat/
+  actions:
+    label:
+      add: ['module:tomcat']
+
+- name: label jetty-server PRs
+  conditions:
+  - files~=^jetty-server/
+  actions:
+    label:
+      add: ['module:jetty-server']
+
+- name: label jetty-client PRs
+  conditions:
+  - files~=^jetty-client/
+  actions:
+    label:
+      add: ['module:jetty-client']
+
+- name: label async-http-client PRs
+  conditions:
+  - files~=^async-http-client/
+  actions:
+    label:
+      add: ['module:async-http-client']
+
+- name: label okhttp-client PRs
+  conditions:
+  - files~=^okhttp-client/
+  actions:
+    label:
+      add: ['module:okhttp-client']
+
+- name: label jawn PRs
+  conditions:
+  - files~=^jawn/
+  actions:
+    label:
+      add: ['module:jawn']
+
+- name: label circe PRs
+  conditions:
+  - files~=^circe/
+  actions:
+    label:
+      add: ['module:circe']
+
+- name: label play-json PRs
+  conditions:
+  - files~=^play-json/
+  actions:
+    label:
+      add: ['module:play-json']
+
+- name: label scalatags PRs
+  conditions:
+  - files~=^scalatags/
+  actions:
+    label:
+      add: ['module:scalatags']
+
+- name: label twirl PRs
+  conditions:
+  - files~=^twirl/
+  actions:
+    label:
+      add: ['module:twirl']
+
+- name: label dropwizard-metrics PRs
+  conditions:
+  - files~=^dropwizard-metrics/
+  actions:
+    label:
+      add: ['module:dropwizard-metrics']
+
+- name: label prometheus-metrics PRs
+  conditions:
+  - files~=^prometheus-metrics/
+  actions:
+    label:
+      add: ['module:prometheus-metrics']
+
+- name: label docs PRs
+  conditions:
+  - or:
+    - files~=^docs/
+    - files~=^website/
+  actions:
+    label:
+      add: ['docs']


### PR DESCRIPTION
Our mergify stuff stopped working, because mergify reads its config from the default branch which changed.