### PR TITLE
Remove redundant draining of request/response body

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/BodylessWriter.scala
@@ -46,7 +46,7 @@ private[http4s] class BodylessWriter[F[_]](pipe: TailStage[ByteBuffer], close: B
     * @return the F which, when run, will send the headers and kill the entity body
     */
   override def writeEntityBody(p: EntityBody[F]): F[Boolean] =
-    p.drain.compile.drain.map(_ => close)
+    p.compile.drain.as(close)
 
   override protected def writeEnd(chunk: Chunk[Byte]): Future[Boolean] =
     Future.successful(close)

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala
@@ -36,7 +36,7 @@ private[http4s] trait Http1Writer[F[_]] extends EntityBodyWriter[F] {
           F.unit
 
         case ExitCase.Error(_) | ExitCase.Canceled =>
-          body.drain.compile.drain.handleError { t2 =>
+          body.compile.drain.handleError { t2 =>
             Http1Writer.logger.error(t2)("Error draining body")
           }
       } >> writeEntityBody(body)

--- a/core/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/src/main/scala/org/http4s/EntityDecoder.scala
@@ -288,6 +288,6 @@ object EntityDecoder {
   /** An entity decoder that ignores the content and returns unit. */
   implicit def void[F[_]: Sync]: EntityDecoder[F, Unit] =
     EntityDecoder.decodeBy(MediaRange.`*/*`) { msg =>
-      DecodeResult.success(msg.body.drain.compile.drain)
+      DecodeResult.success(msg.body.compile.drain)
     }
 }

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -103,7 +103,7 @@ abstract class Http4sServlet[F[_]](service: HttpApp[F], servletIo: ServletIo[F])
       .flatMap {
         case Right(()) => bodyWriter(response)
         case Left(t) =>
-          response.body.drain.compile.drain.handleError { t2 =>
+          response.body.compile.drain.handleError { t2 =>
             logger.error(t2)("Error draining body")
           } *> F.raiseError(t)
       }
@@ -210,7 +210,7 @@ object Http4sServlet {
     }) {
       case Right(()) => bodyWriter(response)
       case Left(t) =>
-        response.body.drain.compile.drain.handleError { case t2 =>
+        response.body.compile.drain.handleError { t2 =>
           logger.error(t2)("Error draining body")
         } *> F.raiseError(t)
     }


### PR DESCRIPTION
A tiny refactoring as a follow-up from https://github.com/http4s/http4s/pull/6116#discussion_r825437891