### PR TITLE
Add unidocs project to root aggregate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,7 @@ lazy val modules: List[ProjectReference] = List(
   twirl,
   scalatags,
   bench,
+  unidocs,
   examples,
   examplesBlaze,
   examplesDocker,

--- a/build.sbt
+++ b/build.sbt
@@ -916,6 +916,7 @@ lazy val docs = http4sProject("site")
     mdocIn := (Compile / sourceDirectory).value / "mdoc",
     tlFatalWarningsInCi := false,
     fork := false,
+    tlSiteApiUrl := Some(url("https://http4s.org/v0.22/api/")),
   )
   .dependsOn(
     client,


### PR DESCRIPTION
Arghh, this one is frustrating. I forgot to add the unidoc artifact to the root aggregate, so of course it didn't publish with the rest of v0.22.12 ...

Monkey patching it until the next release by pointing to the current API docs on the site.