### PR TITLE
Use blocking EC in the `BlockingServletIo`

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -57,7 +57,7 @@ final case class BlockingServletIo[F[_]: Async](chunkSize: Int) extends ServletI
     val flush = response.isChunked
     response.body.chunks
       .evalTap { chunk =>
-        Async[F].delay {
+        Async[F].blocking {
           // Avoids copying for specialized chunks
           val byteChunk = chunk.toArraySlice
           out.write(byteChunk.values, byteChunk.offset, byteChunk.length)


### PR DESCRIPTION
Previously `BlockingServletIo` used a blocker (https://github.com/http4s/http4s/pull/4175/files#diff-476d2c035d983230b75e27a4ec07fbc8a40cb2ed1ef26c75c4dbef39a4bf1c1eL58), so I opine it should use a blocking EC accordingly.