### PR TITLE
Resolve #6068 digestauth challenge redux

### DIFF
--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -102,7 +102,7 @@ object DigestAuth {
   /** Side-effect of running the returned task: If req contains a valid
     * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
     */
-  private def challenge[F[_], A](
+  private[authentication] def challenge[F[_], A](
       realm: String,
       store: AuthenticationStore[F, A],
       nonceKeeper: NonceKeeper,

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -66,6 +66,13 @@ object DigestAuth {
   object Md5HashedAuthStore {
     def apply[F[_], A](func: String => F[Option[(A, String)]]): AuthStore[F, A] =
       new Md5HashedAuthStore(func)
+
+    def precomputeHash[F[_]: Monad: Hash](
+        username: String,
+        realm: String,
+        password: String,
+    ): F[String] =
+      DigestUtil.computeHa1(username, realm, password)
   }
   final class Md5HashedAuthStore[F[_], A](val func: String => F[Option[(A, String)]])
       extends AuthStore[F, A]

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -27,11 +27,8 @@ import cats.effect.Sync
 import cats.effect.Timer
 import cats.syntax.all._
 import org.http4s.crypto.Hash
-import org.http4s.crypto.unsafe.SecureRandom
 import org.http4s.headers._
 
-import java.math.BigInteger
-import java.util.Date
 import scala.concurrent.duration._
 
 /** Provides Digest Authentication from RFC 2617.
@@ -194,14 +191,4 @@ object DigestAuth {
       }
     }
   }
-}
-
-private[authentication] class Nonce(val created: Date, var nc: Int, val data: String)
-
-private[authentication] object Nonce {
-  val random = new SecureRandom()
-
-  private def getRandomData(bits: Int): String = new BigInteger(bits, random).toString(16)
-
-  def gen(bits: Int): Nonce = new Nonce(new Date(), 0, getRandomData(bits))
 }

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -66,7 +66,7 @@ object DigestAuth {
   private case object NoCredentials extends AuthReply[Nothing]
   private case object NoAuthorizationHeader extends AuthReply[Nothing]
 
-  @deprecated("Calling apply is side-effecting, please use applyF", "0.22.11")
+  @deprecated("Calling apply is side-effecting, please use applyF", "0.22.13")
   def apply[F[_]: Sync, A](
       realm: String,
       store: String => F[Option[(A, String)]],

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -233,7 +233,6 @@ object DigestAuth {
       F.pure(BadParameters)
     } else {
       val method = req.method.toString
-      val uri = req.uri.toString
 
       if (!params.get("realm").contains(realm)) {
         F.pure(BadParameters)
@@ -255,7 +254,7 @@ object DigestAuth {
                         params("username"),
                         realm,
                         password,
-                        uri,
+                        req.uri,
                         nonce,
                         nc,
                         params("cnonce"),
@@ -274,7 +273,7 @@ object DigestAuth {
                       .computeHashedResponse(
                         method,
                         ha1Hash,
-                        uri,
+                        req.uri,
                         nonce,
                         nc,
                         params("cnonce"),

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -68,15 +68,26 @@ object DigestAuth {
       nonceCleanupInterval: Duration = 1.hour,
       nonceStaleTime: Duration = 1.hour,
       nonceBits: Int = 160,
-  ): AuthMiddleware[F, A] = {
-    val nonceKeeper =
-      new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits)
-    challenged(challenge(realm, store, nonceKeeper))
-  }
+  ): AuthMiddleware[F, A] =
+    challenged(challenge(realm, store, nonceCleanupInterval, nonceStaleTime, nonceBits))
 
   /** Side-effect of running the returned task: If req contains a valid
     * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
     */
+  @annotation.nowarn("msg=Maintaining for ABI compatibility")
+  def challenge[F[_], A](
+      realm: String,
+      store: AuthenticationStore[F, A],
+      nonceCleanupInterval: Duration = 1.hour,
+      nonceStaleTime: Duration = 1.hour,
+      nonceBits: Int = 160,
+  )(implicit F: Sync[F]): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] = {
+    val nonceKeeper =
+      new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits)
+    challenge[F, A](realm, store, nonceKeeper)
+  }
+
+  @deprecated("Maintaining for ABI compatibility", "0.23.10")
   def challenge[F[_], A](realm: String, store: AuthenticationStore[F, A], nonceKeeper: NonceKeeper)(
       implicit F: Sync[F]
   ): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -68,30 +68,46 @@ object DigestAuth {
       nonceCleanupInterval: Duration = 1.hour,
       nonceStaleTime: Duration = 1.hour,
       nonceBits: Int = 160,
-  ): AuthMiddleware[F, A] =
-    challenged(challenge(realm, store, nonceCleanupInterval, nonceStaleTime, nonceBits))
+  ): AuthMiddleware[F, A] = {
+    val nonceKeeper =
+      new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits)
+    challenged(challenge(realm, store, nonceKeeper))
+  }
 
-  /** Side-effect of running the returned task: If req contains a valid
-    * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
+  /** Similar to [[apply]], but exposing the underlying [[challenge]]
+    * [[cats.data.Kleisli]] instead of an entire [[AuthMiddleware]]
+    *
+    * @param realm The realm used for authentication purposes.
+    * @param store A partial function mapping (realm, user) to the
+    *              appropriate password.
+    * @param nonceCleanupInterval Interval (in milliseconds) at which stale
+    *                             nonces should be cleaned up.
+    * @param nonceStaleTime Amount of time (in milliseconds) after which a nonce
+    *                       is considered stale (i.e. not used for authentication
+    *                       purposes anymore).
+    * @param nonceBits The number of random bits a nonce should consist of.
     */
-  @annotation.nowarn("msg=Maintaining for ABI compatibility")
   def challenge[F[_], A](
       realm: String,
       store: AuthenticationStore[F, A],
       nonceCleanupInterval: Duration = 1.hour,
       nonceStaleTime: Duration = 1.hour,
       nonceBits: Int = 160,
-  )(implicit F: Sync[F]): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =
-    Kleisli { req =>
-      F.delay(new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits))
-        .flatMap { nonceKeeper =>
-          challenge[F, A](realm, store, nonceKeeper).apply(req)
-        }
-    }
+  )(implicit F: Sync[F]): F[Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]]] =
+    F.delay(new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits))
+      .map { nonceKeeper =>
+        challenge[F, A](realm, store, nonceKeeper)
+      }
 
-  @deprecated("Maintaining for ABI compatibility", "0.22.12")
-  def challenge[F[_], A](realm: String, store: AuthenticationStore[F, A], nonceKeeper: NonceKeeper)(
-      implicit F: Sync[F]
+  /** Side-effect of running the returned task: If req contains a valid
+    * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
+    */
+  private def challenge[F[_], A](
+      realm: String,
+      store: AuthenticationStore[F, A],
+      nonceKeeper: NonceKeeper,
+  )(implicit
+      F: Sync[F]
   ): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =
     Kleisli { req =>
       def paramsToChallenge(params: Map[String, String]) =

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -87,7 +87,7 @@ object DigestAuth {
     challenge[F, A](realm, store, nonceKeeper)
   }
 
-  @deprecated("Maintaining for ABI compatibility", "0.23.10")
+  @deprecated("Maintaining for ABI compatibility", "0.22.12")
   def challenge[F[_], A](realm: String, store: AuthenticationStore[F, A], nonceKeeper: NonceKeeper)(
       implicit F: Sync[F]
   ): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -164,7 +164,7 @@ object DigestAuth {
       nonceStaleTime: Duration = 1.hour,
       nonceBits: Int = 160,
   )(implicit F: Concurrent[F]): F[Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]]] =
-    NonceKeeperF[F](nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits)
+    NonceKeeperF[F](nonceStaleTime, nonceCleanupInterval, nonceBits)
       .map { nonceKeeper =>
         challengeInterop[F, A](realm, store, nonceKeeper.newNonce(), nonceKeeper.receiveNonce _)
       }

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
@@ -43,13 +43,13 @@ private[authentication] object DigestUtil {
   def computeHashedResponse[F[_]: Monad: Hash](
       method: String,
       ha1: String,
-      uri: String,
+      uri: Uri,
       nonce: String,
       nc: String,
       cnonce: String,
       qop: String,
   ): F[String] = for {
-    ha2str <- (method + ":" + uri).pure[F]
+    ha2str <- (method + ":" + uri.toString()).pure[F]
     ha2 <- md5(ha2str)
     respstr = ha1 + ":" + nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2
     result <- md5(respstr)
@@ -84,7 +84,7 @@ private[authentication] object DigestUtil {
       username: String,
       realm: String,
       password: String,
-      uri: String,
+      uri: Uri,
       nonce: String,
       nc: String,
       cnonce: String,

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
@@ -30,6 +30,24 @@ private[authentication] object DigestUtil {
   private def md5[F[_]: Monad: Hash](str: String): F[String] =
     Hash[F].digest(HashAlgorithm.MD5, ByteVector.view(str.getBytes())).map(_.toHex)
 
+  def computeHashedResponse[F[_]: Monad: Hash](
+      method: String,
+      ha1: String,
+      uri: Uri,
+      nonce: String,
+      nc: String,
+      cnonce: String,
+      qop: String,
+  ): F[String] = computeHashedResponse[F](
+    method,
+    ha1,
+    uri.toString(),
+    nonce,
+    nc,
+    cnonce,
+    qop,
+  )
+
   /** Computes the response value used in Digest Authentication.
     * @param method
     * @param ha1
@@ -43,13 +61,13 @@ private[authentication] object DigestUtil {
   def computeHashedResponse[F[_]: Monad: Hash](
       method: String,
       ha1: String,
-      uri: Uri,
+      uri: String,
       nonce: String,
       nc: String,
       cnonce: String,
       qop: String,
   ): F[String] = for {
-    ha2str <- (method + ":" + uri.toString()).pure[F]
+    ha2str <- (method + ":" + uri).pure[F]
     ha2 <- md5(ha2str)
     respstr = ha1 + ":" + nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2
     result <- md5(respstr)
@@ -66,6 +84,28 @@ private[authentication] object DigestUtil {
       ha1str <- (username + ":" + realm + ":" + password).pure[F]
       ha1 <- md5(ha1str)
     } yield ha1
+
+  def computeResponse[F[_]: Monad: Hash](
+      method: String,
+      username: String,
+      realm: String,
+      password: String,
+      uri: Uri,
+      nonce: String,
+      nc: String,
+      cnonce: String,
+      qop: String,
+  ): F[String] = computeResponse[F](
+    method,
+    username,
+    realm,
+    password,
+    uri.toString(),
+    nonce,
+    nc,
+    cnonce,
+    qop,
+  )
 
   /** Computes the response value used in Digest Authentication.
     * @param method
@@ -84,7 +124,7 @@ private[authentication] object DigestUtil {
       username: String,
       realm: String,
       password: String,
-      uri: Uri,
+      uri: String,
       nonce: String,
       nc: String,
       cnonce: String,

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
@@ -55,6 +55,18 @@ private[authentication] object DigestUtil {
     result <- md5(respstr)
   } yield result
 
+  /** Computes the ha1 component of the Digest Authentication scheme
+    * @param username
+    * @param realm
+    * @param password
+    * @return The hash of the supplied fields when concatenated together
+    */
+  def computeHa1[F[_]: Monad: Hash](username: String, realm: String, password: String): F[String] =
+    for {
+      ha1str <- (username + ":" + realm + ":" + password).pure[F]
+      ha1 <- md5(ha1str)
+    } yield ha1
+
   /** Computes the response value used in Digest Authentication.
     * @param method
     * @param username
@@ -78,8 +90,7 @@ private[authentication] object DigestUtil {
       cnonce: String,
       qop: String,
   ): F[String] = for {
-    ha1str <- (username + ":" + realm + ":" + password).pure[F]
-    ha1 <- md5(ha1str)
+    ha1 <- computeHa1(username, realm, password)
     result <- computeHashedResponse(method, ha1, uri, nonce, nc, cnonce, qop)
   } yield result
 }

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.middleware.authentication
+
+import org.http4s.crypto.unsafe.SecureRandom
+
+import java.math.BigInteger
+import java.util.Date
+
+private[authentication] class Nonce(val created: Date, var nc: Int, val data: String)
+
+private[authentication] object Nonce {
+  val random = new SecureRandom()
+
+  private def getRandomData(bits: Int): String = new BigInteger(bits, random).toString(16)
+
+  def gen(bits: Int): Nonce = new Nonce(new Date(), 0, getRandomData(bits))
+}

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
@@ -26,7 +26,11 @@ import org.http4s.crypto.unsafe.SecureRandom
 import java.math.BigInteger
 import scala.concurrent.duration.MILLISECONDS
 
-private[authentication] class NonceF[F[_]](val createdMillis: Long, val nc: Ref[F, Int], val data: String)
+private[authentication] class NonceF[F[_]](
+    val createdMillis: Long,
+    val nc: Ref[F, Int],
+    val data: String,
+)
 
 private[authentication] object NonceF {
   val random = new SecureRandom()

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
@@ -24,9 +24,9 @@ import cats.syntax.all._
 import org.http4s.crypto.unsafe.SecureRandom
 
 import java.math.BigInteger
-import java.time.Instant
+import scala.concurrent.duration.MILLISECONDS
 
-private[authentication] class NonceF[F[_]](val created: Instant, val nc: Ref[F, Int], val data: String)
+private[authentication] class NonceF[F[_]](val createdMillis: Long, val nc: Ref[F, Int], val data: String)
 
 private[authentication] object NonceF {
   val random = new SecureRandom()
@@ -37,6 +37,6 @@ private[authentication] object NonceF {
   def gen[F[_]: Sync: Timer](bits: Int): F[NonceF[F]] = for {
     nc <- Ref[F].of(0)
     data <- getRandomData[F](bits)
-    created <- Clock[F].instantNow
-  } yield new NonceF(created, nc, data)
+    createdMillis <- Clock[F].monotonic(MILLISECONDS)
+  } yield new NonceF(createdMillis, nc, data)
 }

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
@@ -29,8 +29,8 @@ private[authentication] class NonceF[F[_]](val created: Date, val nc: Ref[F, Int
 private[authentication] object NonceF {
   val random = new SecureRandom()
 
-  private def getRandomData(bits: Int): String = new BigInteger(bits, random).toString(16)
+  private def getRandomData[F[_]](bits: Int)(implicit F: Sync[F]): F[String] = F.delay(new BigInteger(bits, random).toString(16))
 
   def gen[F[_]: Sync](bits: Int): F[NonceF[F]] =
-    Ref[F].of(0).map(nc => new NonceF(new Date(), nc, getRandomData(bits)))
+    Ref[F].of(0).flatMap(nc => getRandomData[F](bits).map { data => new NonceF(new Date(), nc, data) })
 }

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.middleware.authentication
+
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import cats.syntax.all._
+import org.http4s.crypto.unsafe.SecureRandom
+
+import java.math.BigInteger
+import java.util.Date
+
+private[authentication] class NonceF[F[_]](val created: Date, val nc: Ref[F, Int], val data: String)
+
+private[authentication] object NonceF {
+  val random = new SecureRandom()
+
+  private def getRandomData(bits: Int): String = new BigInteger(bits, random).toString(16)
+
+  def gen[F[_]: Sync](bits: Int): F[NonceF[F]] =
+    Ref[F].of(0).map(nc => new NonceF(new Date(), nc, getRandomData(bits)))
+}

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
@@ -29,8 +29,11 @@ private[authentication] class NonceF[F[_]](val created: Date, val nc: Ref[F, Int
 private[authentication] object NonceF {
   val random = new SecureRandom()
 
-  private def getRandomData[F[_]](bits: Int)(implicit F: Sync[F]): F[String] = F.delay(new BigInteger(bits, random).toString(16))
+  private def getRandomData[F[_]](bits: Int)(implicit F: Sync[F]): F[String] =
+    F.delay(new BigInteger(bits, random).toString(16))
 
   def gen[F[_]: Sync](bits: Int): F[NonceF[F]] =
-    Ref[F].of(0).flatMap(nc => getRandomData[F](bits).map { data => new NonceF(new Date(), nc, data) })
+    Ref[F]
+      .of(0)
+      .flatMap(nc => getRandomData[F](bits).map(data => new NonceF(new Date(), nc, data)))
 }

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
@@ -16,10 +16,28 @@
 
 package org.http4s.server.middleware.authentication
 
+import cats.effect.Clock
+import cats.effect.Concurrent
+import cats.effect.Timer
+import cats.effect.concurrent.Ref
+import cats.effect.concurrent.Semaphore
+import cats.syntax.all._
+
 import java.util.LinkedHashMap
 import scala.annotation.tailrec
+import scala.concurrent.duration.MILLISECONDS
 
 private[authentication] object NonceKeeper {
+  def apply[F[_]: Timer](
+      staleTimeout: Long,
+      nonceCleanupInterval: Long,
+      bits: Int,
+  )(implicit F: Concurrent[F]): F[NonceKeeper[F]] = for {
+    semaphore <- Semaphore[F](1)
+    currentTime <- Clock[F].realTime(MILLISECONDS)
+    lastCleanup <- Ref[F].of(currentTime)
+  } yield new NonceKeeper(staleTimeout, nonceCleanupInterval, bits, semaphore, lastCleanup)
+
   sealed abstract class Reply
 
   case object StaleReply extends Reply
@@ -36,48 +54,59 @@ private[authentication] object NonceKeeper {
   *                     purposes anymore).
   * @param bits The number of random bits a nonce should consist of.
   */
-private[authentication] class NonceKeeper(
+private[authentication] class NonceKeeper[F[_]: Timer](
     staleTimeout: Long,
     nonceCleanupInterval: Long,
     bits: Int,
-) {
+    semaphore: Semaphore[F],
+    lastCleanup: Ref[F, Long],
+)(implicit F: Concurrent[F]) {
   require(bits > 0, "Please supply a positive integer for bits.")
   private val nonces = new LinkedHashMap[String, Nonce]
-  private var lastCleanup = System.currentTimeMillis()
+
+  val clock = Clock[F]
 
   /** Removes nonces that are older than staleTimeout
     * Note: this _MUST_ be executed inside a block synchronized on `nonces`
     */
-  private def checkStale() = {
-    val d = System.currentTimeMillis()
-    if (d - lastCleanup > nonceCleanupInterval) {
-      lastCleanup = d
-
-      // Because we are using an LinkedHashMap, the keys will be returned in the order they were
-      // inserted. Therefor, once we reach a non-stale value, the remaining values are also not stale.
-      val it = nonces.values().iterator()
-      @tailrec
-      def dropStale(): Unit =
-        if (it.hasNext && staleTimeout > d - it.next().created.getTime) {
-          it.remove()
-          dropStale()
-        }
-      dropStale()
-    }
-  }
+  private def checkStale(): F[Unit] =
+    for {
+      d <- clock.realTime(MILLISECONDS)
+      lastCleanupTime <- lastCleanup.get
+      result <-
+        if (d - lastCleanupTime > nonceCleanupInterval) {
+          lastCleanup
+            .set(d)
+            .map { _ =>
+              // Because we are using an LinkedHashMap, the keys will be returned in the order they were
+              // inserted. Therefor, once we reach a non-stale value, the remaining values are also not stale.
+              val it = nonces.values().iterator()
+              @tailrec
+              def dropStale(): Unit =
+                if (it.hasNext && staleTimeout > d - it.next().created.getTime) {
+                  it.remove()
+                  dropStale()
+                }
+              dropStale()
+            }
+        } else F.pure(())
+    } yield result
 
   /** Get a fresh nonce in form of a {@link String}.
     * @return A fresh nonce.
     */
-  def newNonce(): String = {
+  def newNonce(): F[String] = {
     var n: Nonce = null
-    nonces.synchronized {
-      checkStale()
-      n = Nonce.gen(bits)
-      while (nonces.get(n.data) != null) n = Nonce.gen(bits)
-      nonces.put(n.data, n)
+    semaphore.withPermit {
+      for {
+        _ <- checkStale()
+      } yield {
+        n = Nonce.gen(bits)
+        while (nonces.get(n.data) != null) n = Nonce.gen(bits)
+        nonces.put(n.data, n)
+        n.data
+      }
     }
-    n.data
   }
 
   /** Checks if the nonce {@link data} is known and the {@link nc} value is
@@ -87,10 +116,11 @@ private[authentication] class NonceKeeper(
     * @param nc The nonce counter.
     * @return A reply indicating the status of (data, nc).
     */
-  def receiveNonce(data: String, nc: Int): NonceKeeper.Reply =
-    nonces.synchronized {
-      checkStale()
-      nonces.get(data) match {
+  def receiveNonce(data: String, nc: Int): F[NonceKeeper.Reply] =
+    semaphore.withPermit {
+      for {
+        _ <- checkStale()
+      } yield nonces.get(data) match {
         case null => NonceKeeper.StaleReply
         case n: Nonce =>
           if (nc > n.nc) {

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
@@ -22,7 +22,6 @@ import cats.effect.Timer
 import cats.effect.concurrent.Ref
 import cats.effect.concurrent.Semaphore
 import cats.syntax.all._
-
 import java.util.LinkedHashMap
 import scala.annotation.tailrec
 import scala.concurrent.duration.MILLISECONDS

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
@@ -16,27 +16,10 @@
 
 package org.http4s.server.middleware.authentication
 
-import cats.effect.Clock
-import cats.effect.Concurrent
-import cats.effect.Timer
-import cats.effect.concurrent.Ref
-import cats.effect.concurrent.Semaphore
-import cats.syntax.all._
 import java.util.LinkedHashMap
 import scala.annotation.tailrec
-import scala.concurrent.duration.MILLISECONDS
 
 private[authentication] object NonceKeeper {
-  def apply[F[_]: Timer](
-      staleTimeout: Long,
-      nonceCleanupInterval: Long,
-      bits: Int,
-  )(implicit F: Concurrent[F]): F[NonceKeeper[F]] = for {
-    semaphore <- Semaphore[F](1)
-    currentTime <- Clock[F].realTime(MILLISECONDS)
-    lastCleanup <- Ref[F].of(currentTime)
-  } yield new NonceKeeper(staleTimeout, nonceCleanupInterval, bits, semaphore, lastCleanup)
-
   sealed abstract class Reply
 
   case object StaleReply extends Reply
@@ -53,59 +36,48 @@ private[authentication] object NonceKeeper {
   *                     purposes anymore).
   * @param bits The number of random bits a nonce should consist of.
   */
-private[authentication] class NonceKeeper[F[_]: Timer](
+private[authentication] class NonceKeeper(
     staleTimeout: Long,
     nonceCleanupInterval: Long,
     bits: Int,
-    semaphore: Semaphore[F],
-    lastCleanup: Ref[F, Long],
-)(implicit F: Concurrent[F]) {
+) {
   require(bits > 0, "Please supply a positive integer for bits.")
   private val nonces = new LinkedHashMap[String, Nonce]
-
-  val clock = Clock[F]
+  private var lastCleanup = System.currentTimeMillis()
 
   /** Removes nonces that are older than staleTimeout
     * Note: this _MUST_ be executed inside a block synchronized on `nonces`
     */
-  private def checkStale(): F[Unit] =
-    for {
-      d <- clock.realTime(MILLISECONDS)
-      lastCleanupTime <- lastCleanup.get
-      result <-
-        if (d - lastCleanupTime > nonceCleanupInterval) {
-          lastCleanup
-            .set(d)
-            .map { _ =>
-              // Because we are using an LinkedHashMap, the keys will be returned in the order they were
-              // inserted. Therefor, once we reach a non-stale value, the remaining values are also not stale.
-              val it = nonces.values().iterator()
-              @tailrec
-              def dropStale(): Unit =
-                if (it.hasNext && staleTimeout > d - it.next().created.getTime) {
-                  it.remove()
-                  dropStale()
-                }
-              dropStale()
-            }
-        } else F.pure(())
-    } yield result
+  private def checkStale() = {
+    val d = System.currentTimeMillis()
+    if (d - lastCleanup > nonceCleanupInterval) {
+      lastCleanup = d
+
+      // Because we are using an LinkedHashMap, the keys will be returned in the order they were
+      // inserted. Therefor, once we reach a non-stale value, the remaining values are also not stale.
+      val it = nonces.values().iterator()
+      @tailrec
+      def dropStale(): Unit =
+        if (it.hasNext && staleTimeout > d - it.next().created.getTime) {
+          it.remove()
+          dropStale()
+        }
+      dropStale()
+    }
+  }
 
   /** Get a fresh nonce in form of a {@link String}.
     * @return A fresh nonce.
     */
-  def newNonce(): F[String] = {
+  def newNonce(): String = {
     var n: Nonce = null
-    semaphore.withPermit {
-      for {
-        _ <- checkStale()
-      } yield {
-        n = Nonce.gen(bits)
-        while (nonces.get(n.data) != null) n = Nonce.gen(bits)
-        nonces.put(n.data, n)
-        n.data
-      }
+    nonces.synchronized {
+      checkStale()
+      n = Nonce.gen(bits)
+      while (nonces.get(n.data) != null) n = Nonce.gen(bits)
+      nonces.put(n.data, n)
     }
+    n.data
   }
 
   /** Checks if the nonce {@link data} is known and the {@link nc} value is
@@ -115,11 +87,10 @@ private[authentication] class NonceKeeper[F[_]: Timer](
     * @param nc The nonce counter.
     * @return A reply indicating the status of (data, nc).
     */
-  def receiveNonce(data: String, nc: Int): F[NonceKeeper.Reply] =
-    semaphore.withPermit {
-      for {
-        _ <- checkStale()
-      } yield nonces.get(data) match {
+  def receiveNonce(data: String, nc: Int): NonceKeeper.Reply =
+    nonces.synchronized {
+      checkStale()
+      nonces.get(data) match {
         case null => NonceKeeper.StaleReply
         case n: Nonce =>
           if (nc > n.nc) {

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
@@ -33,6 +33,7 @@ private[authentication] object NonceKeeperF {
       nonceCleanupInterval: Long,
       bits: Int,
   )(implicit F: Concurrent[F]): F[NonceKeeperF[F]] = for {
+    // This semaphore controls who has access to `nonces` during stale nonce eviction. This must never be set above one.
     semaphore <- Semaphore[F](1)
     currentTime <- Clock[F].realTime(MILLISECONDS)
     lastCleanup <- Ref[F].of(currentTime)

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.middleware.authentication
+
+import cats.effect.Clock
+import cats.effect.Concurrent
+import cats.effect.Timer
+import cats.effect.concurrent.Ref
+import cats.effect.concurrent.Semaphore
+import cats.syntax.all._
+
+import java.util.LinkedHashMap
+import scala.annotation.tailrec
+import scala.concurrent.duration.MILLISECONDS
+
+private[authentication] object NonceKeeperF {
+  def apply[F[_]: Timer](
+      staleTimeout: Long,
+      nonceCleanupInterval: Long,
+      bits: Int,
+  )(implicit F: Concurrent[F]): F[NonceKeeperF[F]] = for {
+    semaphore <- Semaphore[F](1)
+    currentTime <- Clock[F].realTime(MILLISECONDS)
+    lastCleanup <- Ref[F].of(currentTime)
+  } yield new NonceKeeperF(staleTimeout, nonceCleanupInterval, bits, semaphore, lastCleanup)
+}
+
+/** A thread-safe class used to manage a database of nonces.
+  *
+  * @param staleTimeout Amount of time (in milliseconds) after which a nonce
+  *                     is considered stale (i.e. not used for authentication
+  *                     purposes anymore).
+  * @param bits The number of random bits a nonce should consist of.
+  */
+private[authentication] class NonceKeeperF[F[_]: Timer](
+    staleTimeout: Long,
+    nonceCleanupInterval: Long,
+    bits: Int,
+    semaphore: Semaphore[F],
+    lastCleanup: Ref[F, Long],
+)(implicit F: Concurrent[F]) {
+  require(bits > 0, "Please supply a positive integer for bits.")
+  private val nonces = new LinkedHashMap[String, Nonce]
+
+  val clock = Clock[F]
+
+  /** Removes nonces that are older than staleTimeout
+    * Note: this _MUST_ be executed inside a block synchronized on `nonces`
+    */
+  private def checkStale(): F[Unit] =
+    for {
+      d <- clock.realTime(MILLISECONDS)
+      lastCleanupTime <- lastCleanup.get
+      result <-
+        if (d - lastCleanupTime > nonceCleanupInterval) {
+          lastCleanup
+            .set(d)
+            .map { _ =>
+              // Because we are using an LinkedHashMap, the keys will be returned in the order they were
+              // inserted. Therefor, once we reach a non-stale value, the remaining values are also not stale.
+              val it = nonces.values().iterator()
+              @tailrec
+              def dropStale(): Unit =
+                if (it.hasNext && staleTimeout > d - it.next().created.getTime) {
+                  it.remove()
+                  dropStale()
+                }
+              dropStale()
+            }
+        } else F.pure(())
+    } yield result
+
+  /** Get a fresh nonce in form of a {@link String}.
+    * @return A fresh nonce.
+    */
+  def newNonce(): F[String] = {
+    var n: Nonce = null
+    semaphore.withPermit {
+      for {
+        _ <- checkStale()
+      } yield {
+        n = Nonce.gen(bits)
+        while (nonces.get(n.data) != null) n = Nonce.gen(bits)
+        nonces.put(n.data, n)
+        n.data
+      }
+    }
+  }
+
+  /** Checks if the nonce {@link data} is known and the {@link nc} value is
+    * correct. If this is so, the nc value associated with the nonce is increased
+    * and the appropriate status is returned.
+    * @param data The nonce.
+    * @param nc The nonce counter.
+    * @return A reply indicating the status of (data, nc).
+    */
+  def receiveNonce(data: String, nc: Int): F[NonceKeeper.Reply] =
+    semaphore.withPermit {
+      for {
+        _ <- checkStale()
+      } yield nonces.get(data) match {
+        case null => NonceKeeper.StaleReply
+        case n: Nonce =>
+          if (nc > n.nc) {
+            n.nc = n.nc + 1
+            NonceKeeper.OKReply
+          } else
+            NonceKeeper.BadNCReply
+      }
+    }
+}

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
@@ -22,7 +22,6 @@ import cats.effect.Timer
 import cats.effect.concurrent.Ref
 import cats.effect.concurrent.Semaphore
 import cats.syntax.all._
-
 import java.util.LinkedHashMap
 import scala.annotation.tailrec
 import scala.concurrent.duration.MILLISECONDS

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
@@ -75,7 +75,7 @@ private[authentication] class NonceKeeperF[F[_]: Timer](
               // Because we are using an LinkedHashMap, the keys will be returned in the order they were
               // inserted. Therefore, once we reach a non-stale value, the remaining values are also not stale.
               F.tailRecM[ju.Iterator[NonceF[F]], Unit](nonces.values().iterator()) {
-                case it if it.hasNext && staleTimeout > d - it.next().created.getTime =>
+                case it if it.hasNext && staleTimeout > d - it.next().created.toEpochMilli =>
                   F.delay(Left {
                     it.remove()
                     it

--- a/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
+++ b/server/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
@@ -36,7 +36,8 @@ private[authentication] object NonceKeeperF {
     semaphore <- Semaphore[F](1)
     currentTime <- Clock[F].realTime(MILLISECONDS)
     lastCleanup <- Ref[F].of(currentTime)
-  } yield new NonceKeeperF(staleTimeout, nonceCleanupInterval, bits, semaphore, lastCleanup)
+    nonces = new LinkedHashMap[String, NonceF[F]]
+  } yield new NonceKeeperF(staleTimeout, nonceCleanupInterval, bits, semaphore, lastCleanup, nonces)
 }
 
 /** A thread-safe class used to manage a database of nonces.
@@ -52,9 +53,9 @@ private[authentication] class NonceKeeperF[F[_]: Timer](
     bits: Int,
     semaphore: Semaphore[F],
     lastCleanup: Ref[F, Long],
+    nonces: LinkedHashMap[String, NonceF[F]],
 )(implicit F: Concurrent[F]) {
   require(bits > 0, "Please supply a positive integer for bits.")
-  private val nonces = new LinkedHashMap[String, NonceF[F]]
 
   val clock = Clock[F]
 

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -40,11 +40,13 @@ class AuthenticationSuite extends Http4sSuite {
   private val username = "Test User"
   private val password = "Test Password"
 
-  private def authStore(u: String): IO[Option[(String, String)]] =
-    IO.pure {
-      if (u === username) Some(u -> password)
-      else None
-    }
+  private val authStore: DigestAuth.AuthenticationStore[IO, String] =
+    DigestAuth.PlainTextAuthenticationStore[IO, String]((u: String) =>
+      IO.pure {
+        if (u === username) Some(u -> password)
+        else None
+      }
+    )
 
   private def validatePassword(creds: BasicCredentials): IO[Option[String]] =
     IO.pure {

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -134,7 +134,7 @@ class AuthenticationSuite extends Http4sSuite {
     test("DigestAuthentication should respond to a request without authentication with 401") {
       val req = Request[IO](uri = uri"/")
       for {
-        digestAuthMiddleware <- DigestAuth.applyF(realm, authStore)
+        digestAuthMiddleware <- DigestAuth(realm, authStore)
         authedService = digestAuthMiddleware(service)
         res <- authedService.orNotFound(req)
       } yield {
@@ -206,7 +206,7 @@ class AuthenticationSuite extends Http4sSuite {
 
     test("DigestAuthentication should respond to a request with correct credentials") {
       for {
-        digestAuthMiddleware <- DigestAuth.applyF(realm, authStore)
+        digestAuthMiddleware <- DigestAuth(realm, authStore)
         digestAuthService = digestAuthMiddleware(service)
         challenge <- doDigestAuth1(digestAuthService.orNotFound)
         _ <- IO {
@@ -232,8 +232,7 @@ class AuthenticationSuite extends Http4sSuite {
       "DigestAuthentication should respond to many concurrent requests while cleaning up nonces"
     ) {
       val n = 100
-      DigestAuth
-        .applyF(realm, authStore, 2.millis, 2.millis)
+      DigestAuth(realm, authStore, 2.millis, 2.millis)
         .flatMap { digestAuthMiddleware =>
           val digestAuthService = digestAuthMiddleware(service)
           val results = (1 to n)
@@ -265,7 +264,7 @@ class AuthenticationSuite extends Http4sSuite {
     test("DigestAuthentication should avoid many concurrent replay attacks") {
       val n = 100
       val results = for {
-        digestAuthMiddleware <- DigestAuth.applyF(realm, authStore)
+        digestAuthMiddleware <- DigestAuth(realm, authStore)
         digestAuthService = digestAuthMiddleware(service)
         challenge <- doDigestAuth1(digestAuthService.orNotFound)
         results <- (1 to n)
@@ -292,7 +291,7 @@ class AuthenticationSuite extends Http4sSuite {
       val nonce = "abcdef"
 
       for {
-        digestAuthMiddleware <- DigestAuth.applyF(realm, authStore)
+        digestAuthMiddleware <- DigestAuth(realm, authStore)
         digestAuthService = digestAuthMiddleware(service)
         response <- DigestUtil
           .computeResponse[IO](method, username, realm, password, uri, nonce, nc, cnonce, qop)

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -145,7 +145,7 @@ class AuthenticationSuite extends Http4sSuite {
     test("DigestAuthentication should respond to a request without authentication with 401") {
       val req = Request[IO](uri = uri"/")
       for {
-        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore)
+        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore, testBlocker)
         authedService = digestAuthMiddleware(service)
         res <- authedService.orNotFound(req)
       } yield {
@@ -217,7 +217,7 @@ class AuthenticationSuite extends Http4sSuite {
 
     test("DigestAuthentication should respond to a request with correct credentials") {
       for {
-        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore)
+        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore, testBlocker)
         digestAuthService = digestAuthMiddleware(service)
         challenge <- doDigestAuth1(digestAuthService.orNotFound)
         _ <- IO {
@@ -243,7 +243,7 @@ class AuthenticationSuite extends Http4sSuite {
       "DigestAuthentication should respond to a request with correct credentials when using secure hash"
     ) {
       for {
-        digestAuthMiddleware <- DigestAuth.applyF(realm, md5HashedAuthStore)
+        digestAuthMiddleware <- DigestAuth.applyF(realm, md5HashedAuthStore, testBlocker)
         digestAuthService = digestAuthMiddleware(service)
         challenge <- doDigestAuth1(digestAuthService.orNotFound)
         _ <- IO {
@@ -270,7 +270,7 @@ class AuthenticationSuite extends Http4sSuite {
     ) {
       val n = 100
       DigestAuth
-        .applyF(realm, plainTextAuthStore, 2.millis, 2.millis)
+        .applyF(realm, plainTextAuthStore, testBlocker, 2.millis, 2.millis)
         .flatMap { digestAuthMiddleware =>
           val digestAuthService = digestAuthMiddleware(service)
           val results = (1 to n)
@@ -302,7 +302,7 @@ class AuthenticationSuite extends Http4sSuite {
     test("DigestAuthentication should avoid many concurrent replay attacks") {
       val n = 100
       val results = for {
-        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore)
+        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore, testBlocker)
         digestAuthService = digestAuthMiddleware(service)
         challenge <- doDigestAuth1(digestAuthService.orNotFound)
         results <- (1 to n)
@@ -329,7 +329,7 @@ class AuthenticationSuite extends Http4sSuite {
       val nonce = "abcdef"
 
       for {
-        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore)
+        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore, testBlocker)
         digestAuthService = digestAuthMiddleware(service)
         response <- DigestUtil
           .computeResponse[IO](method, username, realm, password, uri, nonce, nc, cnonce, qop)

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -41,16 +41,16 @@ class AuthenticationSuite extends Http4sSuite {
   private val password = "Test Password"
   private val ha1 = "ef8937c627875dd03ca694994558f74e" // md5(${username}:${realm}:${password})
 
-  private val plainTextAuthStore: DigestAuth.AuthenticationStore[IO, String] =
-    DigestAuth.PlainTextAuthenticationStore[IO, String]((u: String) =>
+  private val plainTextAuthStore: DigestAuth.AuthStore[IO, String] =
+    DigestAuth.PlainTextAuthStore[IO, String]((u: String) =>
       IO.pure {
         if (u === username) Some(u -> password)
         else None
       }
     )
 
-  private val md5HashedAuthStore: DigestAuth.AuthenticationStore[IO, String] =
-    DigestAuth.Md5HashedAuthenticationStore[IO, String]((u: String) =>
+  private val md5HashedAuthStore: DigestAuth.AuthStore[IO, String] =
+    DigestAuth.Md5HashedAuthStore[IO, String]((u: String) =>
       IO.pure {
         if (u === username) Some(u -> ha1)
         else None

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -359,5 +359,11 @@ class AuthenticationSuite extends Http4sSuite {
           .assertEquals(expected)
       } yield result
     }
+
+    test("DigestAuthentication can calculate the expected ha1 using the helper function") {
+      for {
+        newHa1 <- DigestAuth.Md5HashedAuthStore.precomputeHash[IO](username, realm, password)
+      } yield assertEquals(newHa1, ha1)
+    }
   }
 }

--- a/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -184,7 +184,7 @@ class AuthenticationSuite extends Http4sSuite {
     ): IO[(Response[IO], Response[IO])] = {
       // Second request with credentials
       val method = "GET"
-      val uri = "/"
+      val uri = uri"/"
       val qop = "auth"
       val nc = "00000001"
       val cnonce = "abcdef"
@@ -197,7 +197,7 @@ class AuthenticationSuite extends Http4sSuite {
             "username" -> username,
             "realm" -> realm,
             "nonce" -> nonce,
-            "uri" -> uri,
+            "uri" -> uri.toString(),
             "qop" -> qop,
             "nc" -> nc,
             "cnonce" -> cnonce,
@@ -322,7 +322,7 @@ class AuthenticationSuite extends Http4sSuite {
 
     test("DigestAuthentication should respond to invalid requests with 401") {
       val method = "GET"
-      val uri = "/"
+      val uri = uri"/"
       val qop = "auth"
       val nc = "00000001"
       val cnonce = "abcdef"
@@ -337,7 +337,7 @@ class AuthenticationSuite extends Http4sSuite {
           "username" -> username,
           "realm" -> realm,
           "nonce" -> nonce,
-          "uri" -> uri,
+          "uri" -> uri.toString(),
           "qop" -> qop,
           "nc" -> nc,
           "cnonce" -> cnonce,


### PR DESCRIPTION
Resolves #6068

Attempting to address PR feedback in #6077

### Refactoring `NonceKeeper`

- Removing `synchronized` calls
- Switching `var` to `Ref`
- Making all exposed methods `F[_]`
- Splitting out `AuthStore` trait with a more secure scheme that doesn't require the user storing the user's passwords in plaintext

Some remaining tasks:

- [x] Performance testing
- [x] Push `F[_]` further: remove remaining `var`, `while`/`tailrec`/`return`

Opening this draft early on to communicate intent and direction, as well to get feedback early