### PR TITLE
Use parasitic EC in the blaze for Scala 2.13

### DIFF
--- a/blaze-core/src/main/scala-2.13/org/http4s/blazecore/util/ParasiticExecutionContextCompat.scala
+++ b/blaze-core/src/main/scala-2.13/org/http4s/blazecore/util/ParasiticExecutionContextCompat.scala
@@ -16,10 +16,8 @@
 
 package org.http4s.blazecore.util
 
-import org.http4s.blaze.util.Execution
-
 import scala.concurrent.ExecutionContext
 
 private[util] trait ParasiticExecutionContextCompat {
-  final def parasitic: ExecutionContext = Execution.trampoline
+  final def parasitic: ExecutionContext = ExecutionContext.parasitic
 }


### PR DESCRIPTION
This is a follow-up from https://github.com/http4s/http4s/pull/6141#pullrequestreview-914574674. I think this is legit to use parasitic EC from std for Scala 2.13.