### PR TITLE
Merge 0.22 to 0.23

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -466,12 +466,13 @@ private[ember] object Parser {
           }
 
         val body =
-          Stream
+          Pull
             .eval(consumed.get)
-            .ifM(
-              ifTrue = Stream.raiseError(BodyAlreadyConsumedError()),
-              ifFalse = Stream.chunk(Chunk.array(buffer)) ++ readAll.stream,
-            )
+            .flatMap {
+              case true => Pull.raiseError(BodyAlreadyConsumedError())
+              case false => Pull.output(Chunk.array(buffer)) >> readAll
+            }
+            .stream
 
         val drain: Drain[F] = (None: Option[Array[Byte]]).pure[F]
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -7,6 +7,6 @@ scalacOptions := Seq(
 libraryDependencies ++= List(
   "com.eed3si9n" %% "treehugger" % "0.4.4",
   "io.circe" %% "circe-generic" % "0.14.1",
-  "org.http4s" %% "http4s-ember-client" % "0.23.10",
-  "org.http4s" %% "http4s-circe" % "0.23.10",
+  "org.http4s" %% "http4s-ember-client" % "0.23.11",
+  "org.http4s" %% "http4s-circe" % "0.23.11",
 )

--- a/site/src/main/mdoc/changelog.md
+++ b/site/src/main/mdoc/changelog.md
@@ -4,6 +4,18 @@
 Maintenance branches are merged before each new release. This change log is
 ordered chronologically, so each release contains all changes described below it.
 
+# v0.21.33 (2022-03-18)
+
+This is a courtesy release for the 0.21.x series.  This series remains officially unmaintained except for urgent security patches.  It is binary compatible with the 0.21.x series.
+
+* http4s-ember-core
+    * Support parsing response bodies without Content-Length in ember (0.21) by @wemrysi in https://github.com/http4s/http4s/pull/6136
+
+* Behind the scenes
+    * Build tweaks in case there's another 0.21 by @rossabaker in https://github.com/http4s/http4s/pull/6034
+
+**Full Changelog**: https://github.com/http4s/http4s/compare/v0.21.32...v0.21.33
+
 # v0.23.11 (2022-03-18)
 
 This is a maintenance release, binary compatible with the 0.23.x series.  It also includes the changes in 0.22.12.


### PR DESCRIPTION
The only feature was a backport.  The change is because a refactor to Pull was proposed and accepted.