### PR TITLE
Don't override api url

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1083,7 +1083,6 @@ lazy val commonSettings = Seq(
     logbackClassic,
     scalacheck,
   ).map(_ % Test),
-  apiURL := Some(url(s"https://http4s.org/v${tlBaseVersion.value}/api")),
 )
 
 lazy val skipUnusedDependenciesTestOnScala3 = Seq(


### PR DESCRIPTION
This unfortunate setting has mucked up our API urls for the last release cycle.