### PR TITLE
Remove unused `EntityBodyWriter.wroteHeader`

### DIFF
--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala
@@ -27,8 +27,6 @@ import scala.concurrent._
 private[http4s] trait EntityBodyWriter[F[_]] {
   implicit protected def F: Async[F]
 
-  protected val wroteHeader: Promise[Unit] = Promise[Unit]()
-
   /** Write a Chunk to the wire.
     *
     * @param chunk BodyChunk to write to wire


### PR DESCRIPTION
Zero usages found. So, let's burn it?