### PR TITLE
Ember Core: write readLoop without Streams.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -509,6 +509,8 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
     ),
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters
+        .exclude[IncompatibleResultTypeProblem]("org.http4s.ember.core.h2.H2Connection.readLoop"),
+      ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Encoder.reqToBytes"),
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#HeaderP.apply"),

--- a/build.sbt
+++ b/build.sbt
@@ -509,8 +509,6 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
     ),
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters
-        .exclude[IncompatibleResultTypeProblem]("org.http4s.ember.core.h2.H2Connection.readLoop"),
-      ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Encoder.reqToBytes"),
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.http4s.ember.core.Parser#HeaderP.apply"),

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -211,7 +211,7 @@ private[ember] class H2Client[F[_]: Async](
         socket,
         logger,
       )
-      _ <- h2.readLoop.compile.drain.background
+      _ <- h2.readLoop.background
       _ <- h2.writeLoop.compile.drain.background
       _ <-
         Stream

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -225,7 +225,7 @@ private[ember] object H2Server {
       _ <- Resource.eval(
         queue.offer(Chunk.singleton(H2Frame.Settings.ConnectionSettings.toSettings(localSettings)))
       )
-      _ <- h2.readLoop.compile.drain.background
+      _ <- h2.readLoop.background
 
       _ <- Resource.eval(h2.settingsAck.get.rethrow)
       // h2c Initial Request Communication on h2c Upgrade


### PR DESCRIPTION
The `readLoop` in the `ember-core` module made a use of fs2 Streams that was not necessary for the use-case at hand. In this use case: 

- There is no emitted outputs that the consumer may use to cut the stream processing.
- There were no interruptions that connected the flow of the stream to an outside event. 
- There were no resources acquired during the stream that had a limited nested scope.
- There was no chunking or re-chunking of outputs or intermediate values. The way the stream was constructed, it was just generating one output (in a singleton chunk) and immediately processing it, one by one. 

In this circumstances, fs2 Streams do not add any functionality, and takes some cognitive toll and a bit of memory cost. Instead, writing it as a tail-recursive `F[Unit]` operation fits the problem better.