### PR TITLE
Relax ContextRouter's constraints

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/ContextRouter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/ContextRouter.scala
@@ -81,7 +81,7 @@ object ContextRouter {
   /** Defines an [[ContextRoutes]] based on list of mappings.
     * @see define
     */
-  def apply[F[_]: Sync, A](mappings: (String, ContextRoutes[A, F])*): ContextRoutes[A, F] =
+  def apply[F[_]: Monad, A](mappings: (String, ContextRoutes[A, F])*): ContextRoutes[A, F] =
     define(mappings: _*)(ContextRoutes.empty[A, F])
 
   /** Defines an [[ContextRoutes]] based on list of mappings and
@@ -89,7 +89,7 @@ object ContextRouter {
     *
     * The mappings are processed in descending order (longest first) of prefix length.
     */
-  def define[F[_]: Sync, A](
+  def define[F[_]: Monad, A](
       mappings: (String, ContextRoutes[A, F])*
   )(default: ContextRoutes[A, F]): ContextRoutes[A, F] =
     mappings.sortBy(_._1.length).foldLeft(default) { case (acc, (prefix, routes)) =>

--- a/server/shared/src/main/scala/org/http4s/server/ContextRouter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/ContextRouter.scala
@@ -84,7 +84,7 @@ object ContextRouter {
   def apply[F[_]: Monad, A](mappings: (String, ContextRoutes[A, F])*): ContextRoutes[A, F] =
     define(mappings: _*)(ContextRoutes.empty[A, F])
 
-  @deprecated("Kept for binary compatiblity.  Use the apply with the Monad constraint.", "0.23.13")
+  @deprecated("Kept for binary compatiblity.  Use the apply with the Monad constraint.", "0.23.12")
   def apply[F[_], A](
       mappings: Seq[(String, ContextRoutes[A, F])],
       sync: Sync[F],
@@ -101,7 +101,7 @@ object ContextRouter {
   )(default: ContextRoutes[A, F]): ContextRoutes[A, F] =
     defineHelper(mappings, default)
 
-  @deprecated("Kept for binary compatiblity.  Use the define with the Monad constraint.", "0.23.13")
+  @deprecated("Kept for binary compatiblity.  Use the define with the Monad constraint.", "0.23.12")
   def define[F[_], A](
       mappings: Seq[(String, ContextRoutes[A, F])]
   )(default: ContextRoutes[A, F], sync: Sync[F]): ContextRoutes[A, F] =


### PR DESCRIPTION
Closes #6105. Fixing this for `0.22`/`0.23` would mean breaking MiMa. I'm not confident it's worth the hassle. The fix for `1.0` is pretty straightforward and clear.