### PR TITLE
Improvements to multipart boundaries

### DIFF
--- a/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -25,7 +25,7 @@ import org.http4s.client.scaffold.ServerScaffold
 import org.http4s.client.testroutes.GetRoutes
 import org.http4s.dsl.io._
 import org.http4s.implicits._
-import org.http4s.multipart.Multipart
+import org.http4s.multipart.Multiparts
 import org.http4s.multipart.Part
 import org.typelevel.ci._
 
@@ -101,10 +101,16 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
   test(s"$name POST a multipart body") {
     val address = server().addresses.head
     val uri = Uri.fromString(s"http://${address.host}:${address.port}/echo").yolo
-    val multipart = Multipart[IO](Vector(Part.formData("text", "This is text.")))
-    val req = POST(multipart, uri).withHeaders(multipart.headers)
-    val body = client().expect[String](req)
-    body.map(_.contains("This is text.")).assert
+    Multiparts
+      .forSync[IO]
+      .flatMap { multiparts =>
+        multiparts.multipart(Vector(Part.formData("text", "This is text."))).flatMap { multipart =>
+          val req = POST(multipart, uri).withHeaders(multipart.headers)
+          val body = client().expect[String](req)
+          body.map(_.contains("This is text."))
+        }
+      }
+      .assert
   }
 
   test(s"$name Execute GET") {

--- a/core/src/main/scala/org/http4s/multipart/Boundary.scala
+++ b/core/src/main/scala/org/http4s/multipart/Boundary.scala
@@ -32,17 +32,23 @@ object Boundary {
   private val BoundaryLength = 41
   val CRLF = "\r\n"
 
-  private val DIGIT = ('0' to '9').toList
-  private val ALPHA = ('a' to 'z').toList ++ ('A' to 'Z').toList
-  // Many more chars are allowed (see bchars definition in
-  // https://www.rfc-editor.org/rfc/rfc2046), but these are known to
-  // be robust in implementation.
-  private val OTHER = "-_".toList
-  private val CHARS = DIGIT ++ ALPHA ++ OTHER
-  private val nchars = CHARS.length
+  private val alphabet = {
+    val arr = Array.newBuilder[Char]
+    arr ++= ('0' to '9')
+    arr ++= ('a' to 'z')
+    arr ++= ('A' to 'Z')
+    // Many more chars are allowed (see bchars definition in
+    // https://www.rfc-editor.org/rfc/rfc2046), but these are known to
+    // be robust in implementation.  Specifically, they don't trigger
+    // quotation in the Content-Type parameter.
+    arr += '-'
+    arr += '_'
+    arr.result()
+  }
+  private val nchars = alphabet.length
   private val rand = new Random()
 
-  private def nextChar = CHARS(rand.nextInt(nchars - 1))
+  private def nextChar = alphabet(rand.nextInt(nchars - 1))
   private def stream: CollectionCompat.LazyList[Char] =
     CollectionCompat.LazyList.continually(nextChar)
   private def value(l: Int): String = stream.take(l).mkString

--- a/core/src/main/scala/org/http4s/multipart/Boundary.scala
+++ b/core/src/main/scala/org/http4s/multipart/Boundary.scala
@@ -34,10 +34,10 @@ object Boundary {
 
   private val DIGIT = ('0' to '9').toList
   private val ALPHA = ('a' to 'z').toList ++ ('A' to 'Z').toList
-  // ' ' and '?' are also allowed by spec, but mean we need to quote
-  // the boundary in the media type, which causes some implementations
-  // pain.
-  private val OTHER = """'()+_,-./:=""".toSeq
+  // Many more chars are allowed (see bchars definition in
+  // https://www.rfc-editor.org/rfc/rfc2046), but these are known to
+  // be robust in implementation.
+  private val OTHER = "-_".toList
   private val CHARS = DIGIT ++ ALPHA ++ OTHER
   private val nchars = CHARS.length
   private val rand = new Random()

--- a/core/src/main/scala/org/http4s/multipart/Boundary.scala
+++ b/core/src/main/scala/org/http4s/multipart/Boundary.scala
@@ -29,7 +29,7 @@ final case class Boundary(value: String) extends AnyVal {
 }
 
 object Boundary {
-  private val BoundaryLength = 40
+  private val BoundaryLength = 41
   val CRLF = "\r\n"
 
   private val DIGIT = ('0' to '9').toList
@@ -45,11 +45,9 @@ object Boundary {
   private def nextChar = CHARS(rand.nextInt(nchars - 1))
   private def stream: CollectionCompat.LazyList[Char] =
     CollectionCompat.LazyList.continually(nextChar)
-  // Don't use filterNot it works for 2.11.4 and nothing else, it will hang.
-  private def endChar: Char = stream.find(_ != ' ').getOrElse('X')
   private def value(l: Int): String = stream.take(l).mkString
 
-  def create: Boundary = Boundary(value(BoundaryLength) + endChar)
+  def create: Boundary = Boundary(value(BoundaryLength))
 
   implicit val boundaryEq: Eq[Boundary] = Eq.by(_.value)
 }

--- a/core/src/main/scala/org/http4s/multipart/Boundary.scala
+++ b/core/src/main/scala/org/http4s/multipart/Boundary.scala
@@ -17,11 +17,10 @@
 package org.http4s.multipart
 
 import cats.Eq
-import cats.effect.Sync
 import fs2.Chunk
-import org.http4s.internal.CollectionCompat
 
 import java.nio.charset.StandardCharsets
+import java.util.Base64
 import scala.util.Random
 
 final case class Boundary(value: String) extends AnyVal {
@@ -30,43 +29,23 @@ final case class Boundary(value: String) extends AnyVal {
 }
 
 object Boundary {
-  private val BoundaryLength = 41
   val CRLF = "\r\n"
 
-  private val alphabet = {
-    val arr = Array.newBuilder[Char]
-    arr ++= ('0' to '9')
-    arr ++= ('a' to 'z')
-    arr ++= ('A' to 'Z')
-    // Many more chars are allowed (see bchars definition in
-    // https://www.rfc-editor.org/rfc/rfc2046), but these are known to
-    // be robust in implementation.  Specifically, they don't trigger
-    // quotation in the Content-Type parameter.
-    arr += '-'
-    arr += '_'
-    arr.result()
-  }
-  private val nchars = alphabet.length
   private val defaultRandom = new Random()
 
-  private def nextChar(random: Random) = alphabet(random.nextInt(nchars - 1))
-  private def stream(random: Random): CollectionCompat.LazyList[Char] =
-    CollectionCompat.LazyList.continually(nextChar(random))
-  private def value(random: Random, l: Int): String =
-    stream(random).take(l).mkString
-
-  @deprecated("Impure. Use fromScalaRandom", "0.22.14")
+  @deprecated("Impure. Use Multiparts.boundary", "0.22.14")
   def create: Boundary = unsafeCreate()
 
-  /** Create a new MIME boundary. */
-  def fromScalaRandom[F[_]](random: Random)(implicit F: Sync[F]): F[Boundary] =
-    F.delay(unsafeCreateFromScalaRandom(random))
+  private[multipart] def unsafeCreate(): Boundary = {
+    val bytes = new Array[Byte](30)
+    defaultRandom.nextBytes(bytes)
+    unsafeFromBytes(bytes)
+  }
 
-  private[multipart] def unsafeCreate(): Boundary =
-    unsafeCreateFromScalaRandom(defaultRandom)
+  private[this] val encoder = Base64.getUrlEncoder.withoutPadding
 
-  private def unsafeCreateFromScalaRandom(random: Random): Boundary =
-    Boundary(value(random, BoundaryLength))
+  private[multipart] def unsafeFromBytes(bytes: Array[Byte]): Boundary =
+    Boundary(encoder.encodeToString(bytes))
 
   implicit val boundaryEq: Eq[Boundary] = Eq.by(_.value)
 }

--- a/core/src/main/scala/org/http4s/multipart/Multipart.scala
+++ b/core/src/main/scala/org/http4s/multipart/Multipart.scala
@@ -21,14 +21,19 @@ import org.http4s.headers._
 
 /** Create a new multipart from a vector of parts and a boundary.
   *
-  * Caution: the default argument for boundary is impure.  There is no
-  * binary-compatible fix, but the default parameter will be dropped
-  * in 1.0.
+  * To create Multipart values from a generated boundary, see the [[Multiparts]] algebra.
   */
 final case class Multipart[F[_]](
     parts: Vector[Part[F]],
     boundary: Boundary,
 ) {
+  @deprecated(
+    "Creating a boundary is an effect.  Use Multiparts.multipart to generate an F[Multipart[F]], or call the two-parameter constructor with your own boundary.",
+    "0.22.14",
+  )
+  def this(parts: Vector[Part[F]]) =
+    this(parts, Boundary.unsafeCreate())
+
   def headers: Headers =
     Headers(
       `Transfer-Encoding`(TransferCoding.chunked),
@@ -41,4 +46,10 @@ object Multipart {
   def `<init>$default$2`: String = apply$default$2
   @deprecated("Retaining for binary-compatibility", "0.22.14")
   def apply$default$2: String = Boundary.unsafeCreate().value
+
+  @deprecated(
+    "Creating a boundary is an effect.  Use Multiparts.multipart to generate an F[Multipart[F]], or call the two-parameter apply with your own boundary.",
+    "0.22.14",
+  )
+  def apply[F[_]](parts: Vector[Part[F]]) = new Multipart(parts)
 }

--- a/core/src/main/scala/org/http4s/multipart/Multipart.scala
+++ b/core/src/main/scala/org/http4s/multipart/Multipart.scala
@@ -19,7 +19,16 @@ package multipart
 
 import org.http4s.headers._
 
-final case class Multipart[F[_]](parts: Vector[Part[F]], boundary: Boundary = Boundary.create) {
+/** Create a new multipart from a vector of parts and a boundary.
+  *
+  * Caution: the default argument for boundary is impure.  There is no
+  * binary-compatible fix, but the default parameter will be dropped
+  * in 1.0.
+  */
+final case class Multipart[F[_]](
+    parts: Vector[Part[F]],
+    boundary: Boundary = Boundary.unsafeCreate(),
+) {
   def headers: Headers =
     Headers(
       `Transfer-Encoding`(TransferCoding.chunked),

--- a/core/src/main/scala/org/http4s/multipart/Multipart.scala
+++ b/core/src/main/scala/org/http4s/multipart/Multipart.scala
@@ -27,11 +27,18 @@ import org.http4s.headers._
   */
 final case class Multipart[F[_]](
     parts: Vector[Part[F]],
-    boundary: Boundary = Boundary.unsafeCreate(),
+    boundary: Boundary,
 ) {
   def headers: Headers =
     Headers(
       `Transfer-Encoding`(TransferCoding.chunked),
       `Content-Type`(MediaType.multipartType("form-data", Some(boundary.value))),
     )
+}
+
+object Multipart {
+  @deprecated("Retaining for binary-compatibility", "0.22.14")
+  def `<init>$default$2`: String = apply$default$2
+  @deprecated("Retaining for binary-compatibility", "0.22.14")
+  def apply$default$2: String = Boundary.unsafeCreate().value
 }

--- a/core/src/main/scala/org/http4s/multipart/Multiparts.scala
+++ b/core/src/main/scala/org/http4s/multipart/Multiparts.scala
@@ -21,7 +21,10 @@ import cats.syntax.all._
 
 import scala.util.Random
 
-/** An algebra for creating multipart values and boundaries */
+/** An algebra for creating multipart values and boundaries.
+  *
+  * A single instance may be shared by the entire application.
+  */
 trait Multiparts[F[_]] {
 
   /** Generate a random multipart boundary */
@@ -32,6 +35,14 @@ trait Multiparts[F[_]] {
 }
 
 object Multiparts {
+
+  /** Creates a `scala.util.Random` and provides Multiparts around it.
+    * This instance can be shared, or is cheap enough to create closer
+    * to where Multipart values are generated.
+    */
+  def forSync[F[_]](implicit F: Sync[F]): F[Multiparts[F]] =
+    F.delay(new Random()).map(fromScalaRandom[F])
+
   def fromScalaRandom[F[_]](random: Random)(implicit F: Sync[F]): Multiparts[F] =
     new Multiparts[F] {
       def boundary: F[Boundary] = F

--- a/core/src/main/scala/org/http4s/multipart/Multiparts.scala
+++ b/core/src/main/scala/org/http4s/multipart/Multiparts.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.multipart
+
+import cats.effect.Sync
+import cats.syntax.all._
+
+import scala.util.Random
+
+/** An algebra for creating multipart values and boundaries */
+trait Multiparts[F[_]] {
+
+  /** Generate a random multipart boundary */
+  def boundary: F[Boundary]
+
+  /** Generate a multipart value from Parts with a random multipart boundary */
+  def multipart(parts: Vector[Part[F]]): F[Multipart[F]]
+}
+
+object Multiparts {
+  def fromScalaRandom[F[_]](random: Random)(implicit F: Sync[F]): Multiparts[F] =
+    new Multiparts[F] {
+      def boundary: F[Boundary] = F
+        .delay {
+          val bytes = new Array[Byte](30)
+          random.nextBytes(bytes)
+          bytes
+        }
+        .map(Boundary.unsafeFromBytes)
+
+      def multipart(parts: Vector[Part[F]]): F[Multipart[F]] =
+        F.map(boundary)(Multipart(parts, _))
+    }
+}

--- a/tests/src/test/scala/org/http4s/multipart/BoundarySuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/BoundarySuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package multipart
+
+import cats.effect.IO
+import org.scalacheck.effect.PropF._
+
+import scala.util.Random
+
+class BoundarySuite extends Http4sSuite {
+  val random = new Random()
+
+  test("generates 30-70 characters") {
+    forAllF { (_: Unit) =>
+      for {
+        b <- Boundary.fromScalaRandom[IO](random)
+        len = b.value.length
+      } yield assert(len >= 30 && len <= 70, b.value)
+    }
+  }
+
+  test("pulls from correct alphabet") {
+    val alphabet =
+      Set('A' to 'Z': _*) ++ Set('a' to 'z': _*) ++ Set('0' to '9': _*) ++ Set('_', '-')
+    forAllF { (_: Unit) =>
+      Boundary.fromScalaRandom[IO](random).map(b => assert(b.value.forall(alphabet), b.value))
+    }
+  }
+}

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -33,7 +33,9 @@ class MultipartSuite extends Http4sSuite {
   implicit val contextShift: ContextShift[IO] = Http4sSuite.TestContextShift
 
   private val url = uri"https://example.com/path/to/some/where"
+
   private val random = new Random()
+  private val multiparts = Multiparts.fromScalaRandom[IO](random)
 
   implicit def partIOEq: Eq[Part[IO]] =
     Eq.instance[Part[IO]] { case (a, b) =>
@@ -57,10 +59,9 @@ class MultipartSuite extends Http4sSuite {
       val field1 =
         Part.formData[IO]("field1", "Text_Field_1", `Content-Type`(MediaType.text.plain))
       val field2 = Part.formData[IO]("field2", "Text_Field_2")
-      Boundary
-        .fromScalaRandom[IO](random)
-        .flatMap { boundary =>
-          val multipart = Multipart(Vector(field1, field2), boundary)
+      multiparts
+        .multipart(Vector(field1, field2))
+        .flatMap { multipart =>
           val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
           val body = entity.body
           val request =
@@ -73,10 +74,9 @@ class MultipartSuite extends Http4sSuite {
 
     test(s"Multipart form data $name should be encoded and decoded without content types") {
       val field1 = Part.formData[IO]("field1", "Text_Field_1")
-      Boundary
-        .fromScalaRandom[IO](random)
-        .flatMap { boundary =>
-          val multipart = Multipart[IO](Vector(field1), boundary)
+      multiparts
+        .multipart(Vector(field1))
+        .flatMap { multipart =>
           val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
           val body = entity.body
           val request =
@@ -93,11 +93,9 @@ class MultipartSuite extends Http4sSuite {
       val field1 = Part.formData[IO]("field1", "Text_Field_1")
       val field2 = Part
         .fileData[IO]("image", file, Http4sSuite.TestBlocker, `Content-Type`(MediaType.image.png))
-      Boundary
-        .fromScalaRandom[IO](random)
-        .flatMap { boundary =>
-          val multipart = Multipart[IO](Vector(field1, field2), boundary)
-
+      multiparts
+        .multipart(Vector(field1, field2))
+        .flatMap { multipart =>
           val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
           val body = entity.body
           val request =
@@ -197,13 +195,10 @@ I am a big moose
     test(
       s"Multipart form data $name should include chunked transfer encoding header so that body is streamed by client"
     ) {
-      Boundary
-        .fromScalaRandom[IO](random)
-        .map { boundary =>
-          val multipart = Multipart(Vector(), boundary)
-          Request(method = Method.POST, uri = url, headers = multipart.headers).isChunked
-        }
-        .assert
+      multiparts.boundary.map { boundary =>
+        val multipart = Multipart(Vector(), boundary)
+        Request(method = Method.POST, uri = url, headers = multipart.headers).isChunked
+      }.assert
     }
   }
 

--- a/tests/src/test/scala/org/http4s/multipart/MultipartsSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartsSuite.scala
@@ -22,23 +22,24 @@ import org.scalacheck.effect.PropF._
 
 import scala.util.Random
 
-class BoundarySuite extends Http4sSuite {
-  val random = new Random()
+class MultipartsSuite extends Http4sSuite {
+  private val random = new Random()
+  private val multiparts = Multiparts.fromScalaRandom[IO](random)
+  private val alphabet =
+    Set('A' to 'Z': _*) ++ Set('a' to 'z': _*) ++ Set('0' to '9': _*) ++ Set('_', '-')
 
-  test("generates 30-70 characters") {
+  test("generates 30-70 character boundaries") {
     forAllF { (_: Unit) =>
       for {
-        b <- Boundary.fromScalaRandom[IO](random)
+        b <- multiparts.boundary
         len = b.value.length
       } yield assert(len >= 30 && len <= 70, b.value)
     }
   }
 
-  test("pulls from correct alphabet") {
-    val alphabet =
-      Set('A' to 'Z': _*) ++ Set('a' to 'z': _*) ++ Set('0' to '9': _*) ++ Set('_', '-')
+  test("pulls boundaries from correct alphabet") {
     forAllF { (_: Unit) =>
-      Boundary.fromScalaRandom[IO](random).map(b => assert(b.value.forall(alphabet), b.value))
+      multiparts.boundary.map(b => assert(b.value.forall(alphabet), b.value))
     }
   }
 }


### PR DESCRIPTION
Not all servers gracefully handle multipart quoted boundaries.  We remove all non-token characters.  This new alphabet is consistent with the generators in both Apache HTTP and Spring.  It's also a built-in Base64 decoder, so we can use the platform's optimized encoder from an array of bytes vs. our (ugh) random access into a List!

`Boundary.create` is impure and deprecated.

Introduces a `Multiparts` algebra to house all this.