### PR TITLE
Render a trailing newline on multipart close-delimiter

### DIFF
--- a/core/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
+++ b/core/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
@@ -37,8 +37,12 @@ private[http4s] class MultipartEncoder[F[_]] extends EntityEncoder[F, Multipart[
   val delimiter: Boundary => String =
     boundary => s"${Boundary.CRLF}$dash${boundary.value}"
 
+  // The close-delimiter does not require a trailing CRLF, but adding
+  // one makes it more robust with real implementations.  The wasted
+  // two bytes go into the "epilogue", which the recipient is to
+  // ignore.
   val closeDelimiter: Boundary => String =
-    boundary => s"${delimiter(boundary)}$dash"
+    boundary => s"${delimiter(boundary)}$dash${Boundary.CRLF}"
 
   val start: Boundary => Chunk[Byte] = boundary =>
     new ChunkWriter()

--- a/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -192,6 +192,16 @@ I am a big moose
       val request = Request(method = Method.POST, uri = url, headers = multipart.headers)
       assert(request.isChunked)
     }
+
+    test("Multipart should be encoded with a \\r\\n after the final part for robustness") {
+      val field1 = Part.formData[IO]("bow", "wow")
+      val multipart = Multipart[IO](Vector(field1), Boundary("arf"))
+      val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
+      val body = entity.body
+      val request =
+        Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
+      request.as[String].map(s => assert(s.endsWith("--arf--\r\n"), s))
+    }
   }
 
   multipartSpec("with default decoder")(implicitly)


### PR DESCRIPTION
Adds a `"\r\n"` after the close-delimiter when encoding multipart bodies.  This is not required per [specification](https://datatracker.ietf.org/doc/html/rfc1521#section-7.2), but is more robust with certain server implementations.