### PR TITLE
Blaze server enhancements

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
@@ -229,9 +229,9 @@ private[blaze] class Http1ServerStage[F[_]](
               F.runCancelable(action) {
                 case Right(()) => IO.unit
                 case Left(t) =>
-                  IO(logger.error(t)(s"Error running request: $req")).attempt *> IO(
-                    closeConnection()
-                  )
+                  IO(logger.error(t)(s"Error running request: $req")).attempt *>
+                    IO.delay(cancelToken.set(None)) *>
+                    IO(closeConnection())
               }.unsafeRunSync()
             )
 

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
@@ -30,9 +30,10 @@ import org.http4s.blaze.http.parser.BaseExceptions.ParserException
 import org.http4s.blaze.pipeline.Command.EOF
 import org.http4s.blaze.pipeline.TailStage
 import org.http4s.blaze.pipeline.{Command => Cmd}
-import org.http4s.blaze.util.{BufferTools, TickWheelExecutor}
+import org.http4s.blaze.util.BufferTools
 import org.http4s.blaze.util.BufferTools.emptyBuffer
 import org.http4s.blaze.util.Execution._
+import org.http4s.blaze.util.TickWheelExecutor
 import org.http4s.blazecore.Http1Stage
 import org.http4s.blazecore.IdleTimeoutStage
 import org.http4s.blazecore.util.BodylessWriter


### PR DESCRIPTION
This PR brings several proposals to the blaze server:
1. Tries to reduce lock contention in case of saving cancel token.
2. Avoid canceling the previous request in the case of failing the current one.