### PR TITLE
Surface Random

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala
@@ -77,9 +77,12 @@ import scala.concurrent.duration._
   * @param connectorPoolSize: Number of worker threads for the new Socket Server Group
   * @param bufferSize: Buffer size to use for IO operations
   * @param isHttp2Enabled: Whether or not to enable Http2 Server Features
+  * @param maxRequestLineLen: Maximum request line to parse
+  *    If exceeded returns a 400 Bad Request.
   * @param maxHeadersLen: Maximum data that composes the headers.
   *    If exceeded returns a 400 Bad Request.
   * @param chunkBufferMaxSize Size of the buffer that is used when Content-Length header is not specified.
+  * @param httpApp: The services that are mounted on this server to serve..
   * @param serviceErrorHandler: The last resort to recover and generate a response
   *    this is necessary to recover totality from the error condition.
   * @param banner: Pretty log to display on server start. An empty sequence

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
@@ -40,7 +40,6 @@ import org.http4s.headers.`Transfer-Encoding`
 import org.http4s.server.ServiceErrorHandler
 import org.http4s.util.StringWriter
 import org.http4s.websocket.WebSocketContext
-import org.typelevel.ci._
 import org.typelevel.vault._
 
 import java.nio.ByteBuffer
@@ -357,7 +356,7 @@ private[blaze] class Http1ServerStage[F[_]](
   ): Unit = {
     logger.debug(t)(s"Bad Request: $debugMessage")
     val resp = Response[F](Status.BadRequest)
-      .withHeaders(Connection(ci"close"), `Content-Length`.zero)
+      .withHeaders(Connection.close, `Content-Length`.zero)
     renderResponse(req, resp, () => Future.successful(emptyBuffer))
   }
 
@@ -370,7 +369,7 @@ private[blaze] class Http1ServerStage[F[_]](
   ): Unit = {
     logger.error(t)(errorMsg)
     val resp = Response[F](Status.InternalServerError)
-      .withHeaders(Connection(ci"close"), `Content-Length`.zero)
+      .withHeaders(Connection.close, `Content-Length`.zero)
     renderResponse(
       req,
       resp,

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/WebSocketSupport.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/WebSocketSupport.scala
@@ -27,7 +27,6 @@ import org.http4s.blazecore.websocket.Http4sWSStage
 import org.http4s.headers._
 import org.http4s.websocket.WebSocketContext
 import org.http4s.websocket.WebSocketHandshake
-import org.typelevel.ci._
 import org.typelevel.vault.Key
 
 import java.nio.ByteBuffer
@@ -66,7 +65,7 @@ private[http4s] trait WebSocketSupport[F[_]] extends Http1ServerStage[F] {
                 wsContext.failureResponse
                   .map(
                     _.withHeaders(
-                      Connection(ci"close"),
+                      Connection.close,
                       "Sec-WebSocket-Version" -> "13",
                     )
                   )

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/ServerTestRoutes.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/ServerTestRoutes.scala
@@ -29,7 +29,7 @@ import org.typelevel.ci._
 
 object ServerTestRoutes extends Http4sDsl[IO] {
   private val textPlain = `Content-Type`(MediaType.text.plain, `UTF-8`).toRaw1
-  private val connClose = Connection(ci"close").toRaw1
+  private val connClose = Connection.close.toRaw1
   private val connKeep = Connection(ci"keep-alive").toRaw1
   private val chunked = `Transfer-Encoding`(TransferCoding.chunked).toRaw1
 

--- a/build.sbt
+++ b/build.sbt
@@ -1354,7 +1354,6 @@ lazy val commonSettings = Seq(
     logbackClassic,
     scalacheck.value,
   ).map(_ % Test),
-  apiURL := Some(url(s"https://http4s.org/v${tlBaseVersion.value}/api")),
 )
 
 def jsVersionIntroduced(v: String) = Seq(

--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -64,9 +64,7 @@ object JsonDebugErrorHandler {
             Response[G](
               Status.InternalServerError,
               req.httpVersion,
-              Headers(
-                Connection(ci"close")
-              ),
+              Headers(Connection.close),
             )
               .withEntity(JsonErrorHandlerResponse[G](req, t))
               .pure[F]

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -362,7 +362,7 @@ final class Request[F[_]] private (
     * <tr><td><code>?param=</code></td><td><code>Map("param" -> Seq(""))</code></td></tr>
     * <tr><td><code>?param</code></td><td><code>Map("param" -> Seq())</code></td></tr>
     * <tr><td><code>?=value</code></td><td><code>Map("" -> Seq("value"))</code></td></tr>
-    * <tr><td><code>?p1=v1&amp;p1=v2&amp;p2=v3&amp;p2=v3</code></td><td><code>Map("p1" -> Seq("v1","v2"), "p2" -> Seq("v3","v4"))</code></td></tr>
+    * <tr><td><code>?p1=v1&amp;p1=v2&amp;p2=v3&amp;p2=v4</code></td><td><code>Map("p1" -> Seq("v1","v2"), "p2" -> Seq("v3","v4"))</code></td></tr>
     * </table>
     *
     * The query string is lazily parsed. If an error occurs during parsing

--- a/core/shared/src/main/scala/org/http4s/headers/Connection.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Connection.scala
@@ -32,6 +32,8 @@ object Connection {
   def parse(s: String): ParseResult[Connection] =
     ParseResult.fromParser(parser, "Invalid Connection header")(s)
 
+  val close: Connection = Connection(ci"close")
+
   private[http4s] val parser = Rfc7230.headerRep1(Rfc2616.token).map { (xs: NonEmptyList[String]) =>
     Connection(CIString(xs.head), xs.tail.map(CIString(_)): _*)
   }

--- a/core/shared/src/main/scala/org/http4s/internal/package.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/package.scala
@@ -37,6 +37,7 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CompletionStage
+import scala.util.Try
 import scala.util.control.NoStackTrace
 
 package object internal {
@@ -329,4 +330,13 @@ package object internal {
       }
     }
   }
+
+  private[http4s] def javaMajorVersion[F[_]](implicit F: Sync[F]): F[Option[Int]] =
+    F.delay(sys.props.get("java.version")).map(_.flatMap(parseJavaMajorVersion))
+
+  private[internal] def parseJavaMajorVersion(javaVersion: String): Option[Int] =
+    if (javaVersion.startsWith("1."))
+      Try(javaVersion.split("\\.")(1).toInt).toOption
+    else
+      Try(javaVersion.split("\\.")(0).toInt).toOption
 }

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
@@ -37,8 +37,12 @@ private[http4s] class MultipartEncoder[F[_]] extends EntityEncoder[F, Multipart[
   val delimiter: Boundary => String =
     boundary => s"${Boundary.CRLF}$dash${boundary.value}"
 
+  // The close-delimiter does not require a trailing CRLF, but adding
+  // one makes it more robust with real implementations.  The wasted
+  // two bytes go into the "epilogue", which the recipient is to
+  // ignore.
   val closeDelimiter: Boundary => String =
-    boundary => s"${delimiter(boundary)}$dash"
+    boundary => s"${delimiter(boundary)}$dash${Boundary.CRLF}"
 
   val start: Boundary => Chunk[Byte] = boundary =>
     new ChunkWriter()

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/ConnectionSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/ConnectionSuite.scala
@@ -29,7 +29,6 @@ import org.http4s.ember.core.Parser
 import org.http4s.headers._
 import org.http4s.implicits._
 import org.http4s.server.Server
-import org.typelevel.ci._
 
 import scala.concurrent.duration._
 
@@ -46,7 +45,7 @@ class ConnectionSuite extends Http4sSuite {
         case GET -> Root / "keep-alive" =>
           Ok("keep-alive") // keep-alive enabled by default
         case GET -> Root / "close" =>
-          Ok("close").map(_.withHeaders(Connection(ci"close")))
+          Ok("close").map(_.withHeaders(Connection.close))
         case req @ POST -> Root / "echo" =>
           Ok(req.body)
         case POST -> Root / "unread" =>

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
@@ -34,11 +34,10 @@ object ClientMultipartPostExample extends IOApp with Http4sClientDsl[IO] {
   private val bottle: URL = getClass.getResource("/beerbottle.png")
 
   def go(client: Client[IO]): IO[String] = {
-    // n.b. This service does not appear to gracefully handle chunked requests.
     val url = Uri(
       scheme = Some(Scheme.http),
-      authority = Some(Authority(host = RegName("ptscom"))),
-      path = path"/t/http4s/post",
+      authority = Some(Authority(host = RegName("httpbin.org"))),
+      path = path"/post",
     )
 
     val multipart = Multipart[IO](

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -19,28 +19,63 @@ package server
 package middleware
 package authentication
 
+import cats.Functor
 import cats.Monad
 import cats.data.Kleisli
 import cats.data.NonEmptyList
+import cats.effect.Async
 import cats.effect.Sync
 import cats.syntax.all._
 import org.http4s.crypto.Hash
-import org.http4s.crypto.unsafe.SecureRandom
 import org.http4s.headers._
 
-import java.math.BigInteger
-import java.util.Date
 import scala.concurrent.duration._
 
 /** Provides Digest Authentication from RFC 2617.
   */
 object DigestAuth {
 
-  /** A function mapping username to a user object and password, or
-    * None if no user exists.  Requires that the server can recover
-    * the password in clear text, which is _strongly_ discouraged.
-    */
+  @deprecated(
+    "AuthenticationStore is going away, in favor of explicit subclasses of AuthStore. PlainTextAuthStore maintains the previous, insecure behaviour, whereas Md5HashedAuthStore is the new advised implementation going forward.",
+    "0.22.13",
+  )
   type AuthenticationStore[F[_], A] = String => F[Option[(A, String)]]
+
+  sealed trait AuthStore[F[_], A]
+
+  /** A function mapping username to a user object and password, or
+    * None if no user exists.
+    *
+    * Requires that the server can recover the password in clear text,
+    * which is _strongly_ discouraged. Please use Md5HashedAuthStore
+    * if you can.
+    */
+  object PlainTextAuthStore {
+    def apply[F[_], A](func: String => F[Option[(A, String)]]): AuthStore[F, A] =
+      new PlainTextAuthStore(func)
+  }
+  final class PlainTextAuthStore[F[_], A](val func: String => F[Option[(A, String)]])
+      extends AuthStore[F, A]
+
+  /** A function mapping username to a user object and precomputed md5
+    * hash of the username, realm, and password, or None if no user exists.
+    *
+    * More secure than PlainTextAuthStore due to only needing to
+    * store the digested hash instead of the password in plain text.
+    */
+  object Md5HashedAuthStore {
+    def apply[F[_], A](func: String => F[Option[(A, String)]]): AuthStore[F, A] =
+      new Md5HashedAuthStore(func)
+
+    def precomputeHash[F[_]: Monad: Hash](
+        username: String,
+        realm: String,
+        password: String,
+    ): F[String] =
+      DigestUtil.computeHa1(username, realm, password)
+  }
+  final class Md5HashedAuthStore[F[_], A](val func: String => F[Option[(A, String)]])
+      extends AuthStore[F, A]
 
   private trait AuthReply[+A]
   private final case class OK[A](authInfo: A) extends AuthReply[A]
@@ -52,6 +87,19 @@ object DigestAuth {
   private case object NoCredentials extends AuthReply[Nothing]
   private case object NoAuthorizationHeader extends AuthReply[Nothing]
 
+  @deprecated("Calling apply is side-effecting, please use applyF", "0.22.13")
+  def apply[F[_]: Sync, A](
+      realm: String,
+      store: String => F[Option[(A, String)]],
+      nonceCleanupInterval: Duration = 1.hour,
+      nonceStaleTime: Duration = 1.hour,
+      nonceBits: Int = 160,
+  ): AuthMiddleware[F, A] = {
+    val nonceKeeper =
+      new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits)
+    challenged(challenge(realm, store, nonceKeeper))
+  }
+
   /** @param realm The realm used for authentication purposes.
     * @param store A partial function mapping (realm, user) to the
     *              appropriate password.
@@ -62,115 +110,180 @@ object DigestAuth {
     *                       purposes anymore).
     * @param nonceBits The number of random bits a nonce should consist of.
     */
-  def apply[F[_]: Sync, A](
+  def applyF[F[_], A](
       realm: String,
-      store: AuthenticationStore[F, A],
+      store: AuthStore[F, A],
       nonceCleanupInterval: Duration = 1.hour,
       nonceStaleTime: Duration = 1.hour,
       nonceBits: Int = 160,
-  ): AuthMiddleware[F, A] = {
-    val nonceKeeper =
-      new NonceKeeper(nonceStaleTime.toMillis, nonceCleanupInterval.toMillis, nonceBits)
-    challenged(challenge(realm, store, nonceKeeper))
-  }
+  )(implicit F: Async[F]): F[AuthMiddleware[F, A]] =
+    challenge[F, A](
+      realm = realm,
+      store = store,
+      nonceCleanupInterval = nonceCleanupInterval,
+      nonceStaleTime = nonceStaleTime,
+      nonceBits = nonceBits,
+    ).map { runChallenge =>
+      challenged(runChallenge)
+    }
 
-  /** Side-effect of running the returned task: If req contains a valid
+  def challenge[F[_], A](
+      realm: String,
+      store: String => F[Option[(A, String)]],
+      nonceKeeper: NonceKeeper,
+  )(implicit
+      F: Sync[F]
+  ): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =
+    challengeInterop[F, A](
+      realm,
+      PlainTextAuthStore(store),
+      F.delay(nonceKeeper.newNonce()),
+      (data, nc) => F.delay(nonceKeeper.receiveNonce(data, nc)),
+    )
+
+  /** Similar to [[apply]], but exposing the underlying [[challenge]]
+    * [[cats.data.Kleisli]] instead of an entire [[AuthMiddleware]]
+    *
+    * Side-effect of running the returned task: If req contains a valid
     * AuthorizationHeader, the corresponding nonce counter (nc) is increased.
+    *
+    * @param realm The realm used for authentication purposes.
+    * @param store A partial function mapping (realm, user) to the
+    *              appropriate password.
+    * @param nonceCleanupInterval Interval (in milliseconds) at which stale
+    *                             nonces should be cleaned up.
+    * @param nonceStaleTime Amount of time (in milliseconds) after which a nonce
+    *                       is considered stale (i.e. not used for authentication
+    *                       purposes anymore).
+    * @param nonceBits The number of random bits a nonce should consist of.
     */
-  def challenge[F[_], A](realm: String, store: AuthenticationStore[F, A], nonceKeeper: NonceKeeper)(
-      implicit F: Sync[F]
+  def challenge[F[_], A](
+      realm: String,
+      store: AuthStore[F, A],
+      nonceCleanupInterval: Duration = 1.hour,
+      nonceStaleTime: Duration = 1.hour,
+      nonceBits: Int = 160,
+  )(implicit
+      F: Async[F]
+  ): F[Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]]] =
+    NonceKeeperF[F](nonceStaleTime, nonceCleanupInterval, nonceBits)
+      .map { nonceKeeper =>
+        challengeInterop[F, A](realm, store, nonceKeeper.newNonce(), nonceKeeper.receiveNonce _)
+      }
+
+  private[this] def challengeInterop[F[_], A](
+      realm: String,
+      store: AuthStore[F, A],
+      newNonce: F[String],
+      receiveNonce: (String, Int) => F[NonceKeeper.Reply],
+  )(implicit
+      F: Sync[F]
   ): Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]] =
     Kleisli { req =>
       def paramsToChallenge(params: Map[String, String]) =
         Either.left(Challenge("Digest", realm, params))
 
-      checkAuth(realm, store, nonceKeeper, req).flatMap {
+      checkAuth(realm, store, receiveNonce, req).flatMap {
         case OK(authInfo) => F.pure(Either.right(AuthedRequest(authInfo, req)))
-        case StaleNonce => getChallengeParams(nonceKeeper, staleNonce = true).map(paramsToChallenge)
-        case _ => getChallengeParams(nonceKeeper, staleNonce = false).map(paramsToChallenge)
+        case StaleNonce =>
+          getChallengeParams(newNonce, staleNonce = true).map(paramsToChallenge)
+        case _ => getChallengeParams(newNonce, staleNonce = false).map(paramsToChallenge)
       }
     }
 
   private def checkAuth[F[_]: Hash, A](
       realm: String,
-      store: AuthenticationStore[F, A],
-      nonceKeeper: NonceKeeper,
+      store: AuthStore[F, A],
+      receiveNonce: (String, Int) => F[NonceKeeper.Reply],
       req: Request[F],
   )(implicit F: Monad[F]): F[AuthReply[A]] =
     req.headers.get[Authorization] match {
       case Some(Authorization(Credentials.AuthParams(AuthScheme.Digest, params))) =>
-        checkAuthParams(realm, store, nonceKeeper, req, params)
+        checkAuthParams(realm, store, receiveNonce, req, params)
       case Some(_) =>
         F.pure(NoCredentials)
       case None =>
         F.pure(NoAuthorizationHeader)
     }
 
-  private def getChallengeParams[F[_]](nonceKeeper: NonceKeeper, staleNonce: Boolean)(implicit
-      F: Sync[F]
+  private def getChallengeParams[F[_]](newNonce: F[String], staleNonce: Boolean)(implicit
+      F: Functor[F]
   ): F[Map[String, String]] =
-    F.delay {
-      val nonce = nonceKeeper.newNonce()
-      val m = Map("qop" -> "auth", "nonce" -> nonce)
-      if (staleNonce)
-        m + ("stale" -> "TRUE")
-      else
-        m
-    }
+    newNonce
+      .map { nonce =>
+        val m = Map("qop" -> "auth", "nonce" -> nonce)
+        if (staleNonce)
+          m + ("stale" -> "TRUE")
+        else
+          m
+      }
 
   private def checkAuthParams[F[_]: Hash, A](
       realm: String,
-      store: AuthenticationStore[F, A],
-      nonceKeeper: NonceKeeper,
+      store: AuthStore[F, A],
+      receiveNonce: (String, Int) => F[NonceKeeper.Reply],
       req: Request[F],
       paramsNel: NonEmptyList[(String, String)],
   )(implicit F: Monad[F]): F[AuthReply[A]] = {
     val params = paramsNel.toList.toMap
-    if (!Set("realm", "nonce", "nc", "username", "cnonce", "qop").subsetOf(params.keySet))
-      return F.pure(BadParameters)
+    if (!Set("realm", "nonce", "nc", "username", "cnonce", "qop").subsetOf(params.keySet)) {
+      F.pure(BadParameters)
+    } else {
+      val method = req.method.toString
 
-    val method = req.method.toString
-    val uri = req.uri.toString
-
-    if (params.get("realm") != Some(realm))
-      return F.pure(BadParameters)
-
-    val nonce = params("nonce")
-    val nc = params("nc")
-    nonceKeeper.receiveNonce(nonce, Integer.parseInt(nc, 16)) match {
-      case NonceKeeper.StaleReply => F.pure(StaleNonce)
-      case NonceKeeper.BadNCReply => F.pure(BadNC)
-      case NonceKeeper.OKReply =>
-        store(params("username")).flatMap {
-          case None => F.pure(UserUnknown)
-          case Some((authInfo, password)) =>
-            DigestUtil
-              .computeResponse(
-                method,
-                params("username"),
-                realm,
-                password,
-                uri,
-                nonce,
-                nc,
-                params("cnonce"),
-                params("qop"),
-              )
-              .map { resp =>
-                if (resp == params("response")) OK(authInfo)
-                else WrongResponse
-              }
+      if (!params.get("realm").contains(realm)) {
+        F.pure(BadParameters)
+      } else {
+        val nonce = params("nonce")
+        val nc = params("nc")
+        receiveNonce(nonce, Integer.parseInt(nc, 16)).flatMap {
+          case NonceKeeper.StaleReply => F.pure(StaleNonce)
+          case NonceKeeper.BadNCReply => F.pure(BadNC)
+          case NonceKeeper.OKReply =>
+            (store match {
+              case authStore: PlainTextAuthStore[F, A] =>
+                authStore.func(params("username")).flatMap {
+                  case None => F.pure(UserUnknown)
+                  case Some((authInfo, password)) =>
+                    DigestUtil
+                      .computeResponse(
+                        method,
+                        params("username"),
+                        realm,
+                        password,
+                        req.uri,
+                        nonce,
+                        nc,
+                        params("cnonce"),
+                        params("qop"),
+                      )
+                      .map { resp =>
+                        if (resp == params("response")) OK(authInfo)
+                        else WrongResponse
+                      }
+                }
+              case authStore: Md5HashedAuthStore[F, A] =>
+                authStore.func(params("username")).flatMap {
+                  case None => F.pure(UserUnknown)
+                  case Some((authInfo, ha1Hash)) =>
+                    DigestUtil
+                      .computeHashedResponse(
+                        method,
+                        ha1Hash,
+                        req.uri,
+                        nonce,
+                        nc,
+                        params("cnonce"),
+                        params("qop"),
+                      )
+                      .map { resp =>
+                        if (resp == params("response")) OK(authInfo)
+                        else WrongResponse
+                      }
+                }
+            })
         }
+      }
     }
   }
-}
-
-private[authentication] class Nonce(val created: Date, var nc: Int, val data: String)
-
-private[authentication] object Nonce {
-  val random = new SecureRandom()
-
-  private def getRandomData(bits: Int): String = new BigInteger(bits, random).toString(16)
-
-  def gen(bits: Int): Nonce = new Nonce(new Date(), 0, getRandomData(bits))
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/DigestAuth.scala
@@ -127,6 +127,10 @@ object DigestAuth {
       challenged(runChallenge)
     }
 
+  @deprecated(
+    "Uses a side-effecting NonceKeeper. Use challenge(String, AuthStore, Blocker, Duration, Int, Int).",
+    "0.22.13",
+  )
   def challenge[F[_], A](
       realm: String,
       store: String => F[Option[(A, String)]],

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/DigestUtil.scala
@@ -30,6 +30,83 @@ private[authentication] object DigestUtil {
   private def md5[F[_]: Monad: Hash](str: String): F[String] =
     Hash[F].digest(HashAlgorithm.MD5, ByteVector.view(str.getBytes())).map(_.toHex)
 
+  def computeHashedResponse[F[_]: Monad: Hash](
+      method: String,
+      ha1: String,
+      uri: Uri,
+      nonce: String,
+      nc: String,
+      cnonce: String,
+      qop: String,
+  ): F[String] = computeHashedResponse[F](
+    method,
+    ha1,
+    uri.toString(),
+    nonce,
+    nc,
+    cnonce,
+    qop,
+  )
+
+  /** Computes the response value used in Digest Authentication.
+    * @param method
+    * @param ha1
+    * @param uri
+    * @param nonce
+    * @param nc
+    * @param cnonce
+    * @param qop
+    * @return
+    */
+  def computeHashedResponse[F[_]: Monad: Hash](
+      method: String,
+      ha1: String,
+      uri: String,
+      nonce: String,
+      nc: String,
+      cnonce: String,
+      qop: String,
+  ): F[String] = for {
+    ha2str <- (method + ":" + uri).pure[F]
+    ha2 <- md5(ha2str)
+    respstr = ha1 + ":" + nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2
+    result <- md5(respstr)
+  } yield result
+
+  /** Computes the ha1 component of the Digest Authentication scheme
+    * @param username
+    * @param realm
+    * @param password
+    * @return The hash of the supplied fields when concatenated together
+    */
+  def computeHa1[F[_]: Monad: Hash](username: String, realm: String, password: String): F[String] =
+    for {
+      ha1str <- (username + ":" + realm + ":" + password).pure[F]
+      ha1 <- md5(ha1str)
+    } yield ha1
+
+  def computeResponse[F[_]: Monad: Hash](
+      method: String,
+      username: String,
+      realm: String,
+      password: String,
+      uri: Uri,
+      nonce: String,
+      nc: String,
+      cnonce: String,
+      qop: String,
+  ): F[String] = computeResponse[F](
+    method,
+    username,
+    realm,
+    password,
+    uri.toString(),
+    nonce,
+    nc,
+    cnonce,
+    qop,
+  )
+
   /** Computes the response value used in Digest Authentication.
     * @param method
     * @param username
@@ -53,11 +130,7 @@ private[authentication] object DigestUtil {
       cnonce: String,
       qop: String,
   ): F[String] = for {
-    ha1str <- (username + ":" + realm + ":" + password).pure[F]
-    ha1 <- md5(ha1str)
-    ha2str = method + ":" + uri
-    ha2 <- md5(ha2str)
-    respstr = ha1 + ":" + nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2
-    result <- md5(respstr)
+    ha1 <- computeHa1(username, realm, password)
+    result <- computeHashedResponse(method, ha1, uri, nonce, nc, cnonce, qop)
   } yield result
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.middleware.authentication
+
+import org.http4s.crypto.unsafe.SecureRandom
+
+import java.math.BigInteger
+import java.util.Date
+
+private[authentication] class Nonce(val created: Date, var nc: Int, val data: String)
+
+private[authentication] object Nonce {
+  val random = new SecureRandom()
+
+  private def getRandomData(bits: Int): String = new BigInteger(bits, random).toString(16)
+
+  def gen(bits: Int): Nonce = new Nonce(new Date(), 0, getRandomData(bits))
+}

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
@@ -21,8 +21,10 @@ import org.http4s.crypto.unsafe.SecureRandom
 import java.math.BigInteger
 import java.util.Date
 
+@deprecated("Contains mutable java.util.Date. Use Nonce.F", "0.22.13")
 private[authentication] class Nonce(val created: Date, var nc: Int, val data: String)
 
+@deprecated("Untracked side effects. Use NonceF.", "0.22.13")
 private[authentication] object Nonce {
   val random = new SecureRandom()
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
@@ -21,7 +21,7 @@ import org.http4s.crypto.unsafe.SecureRandom
 import java.math.BigInteger
 import java.util.Date
 
-@deprecated("Contains mutable java.util.Date. Use Nonce.F", "0.22.13")
+@deprecated("Contains mutable java.util.Date. Use NonceF.", "0.22.13")
 private[authentication] class Nonce(val created: Date, var nc: Int, val data: String)
 
 @deprecated("Untracked side effects. Use NonceF.", "0.22.13")

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.middleware.authentication
+
+import cats.effect.Async
+import cats.effect.Ref
+import cats.effect.Sync
+import cats.syntax.all._
+import org.http4s.crypto.unsafe.SecureRandom
+
+import java.math.BigInteger
+import scala.concurrent.duration.FiniteDuration
+
+private[authentication] class NonceF[F[_]](
+    val created: FiniteDuration,
+    val nc: Ref[F, Int],
+    val data: String,
+)
+
+private[authentication] object NonceF {
+  val random = new SecureRandom()
+
+  private def getRandomData[F[_]](bits: Int)(implicit F: Sync[F]): F[String] =
+    F.delay(new BigInteger(bits, random).toString(16))
+
+  def gen[F[_]](bits: Int)(implicit
+      F: Async[F]
+  ): F[NonceF[F]] = for {
+    nc <- Ref[F].of(0)
+    data <- getRandomData[F](bits)
+    createdMillis <- F.monotonic
+  } yield new NonceF(createdMillis, nc, data)
+}

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeper.scala
@@ -36,6 +36,7 @@ private[authentication] object NonceKeeper {
   *                     purposes anymore).
   * @param bits The number of random bits a nonce should consist of.
   */
+@deprecated("Side-effecting. Use NonceKeeperF.", "0.22.13")
 private[authentication] class NonceKeeper(
     staleTimeout: Long,
     nonceCleanupInterval: Long,

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
@@ -38,7 +38,10 @@ private[authentication] object NonceKeeperF {
     current <- F.monotonic
     lastCleanupMillis <- Ref[F].of(current)
     nonces = new LinkedHashMap[String, NonceF[F]]
-    random <- Random.javaSecuritySecureRandom[F]
+    // Can't just call Random.javaSecuritySecureRandom
+    // https://github.com/typelevel/cats-effect/issues/2902
+    secureRandom <- F.delay(new org.http4s.crypto.unsafe.SecureRandom)
+    ceRandom <- Random.javaUtilRandom[F](secureRandom)
   } yield new NonceKeeperF(
     staleTimeout,
     nonceCleanupInterval,
@@ -46,7 +49,7 @@ private[authentication] object NonceKeeperF {
     semaphore,
     lastCleanupMillis,
     nonces,
-    random,
+    ceRandom,
   )
 }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.middleware.authentication
+
+import cats.effect.Async
+import cats.effect.Ref
+import cats.effect.std.Semaphore
+import cats.syntax.all._
+
+import java.util.LinkedHashMap
+import java.{util => ju}
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+
+private[authentication] object NonceKeeperF {
+  def apply[F[_]](
+      staleTimeout: Duration,
+      nonceCleanupInterval: Duration,
+      bits: Int,
+  )(implicit F: Async[F]): F[NonceKeeperF[F]] = for {
+    // This semaphore controls who has access to `nonces` during stale nonce eviction. This must never be set above one.
+    semaphore <- Semaphore[F](1)
+    current <- F.monotonic
+    lastCleanupMillis <- Ref[F].of(current)
+    nonces = new LinkedHashMap[String, NonceF[F]]
+  } yield new NonceKeeperF(
+    staleTimeout,
+    nonceCleanupInterval,
+    bits,
+    semaphore,
+    lastCleanupMillis,
+    nonces,
+  )
+}
+
+/** A thread-safe class used to manage a database of nonces.
+  *
+  * @param staleTimeout Amount of time (in milliseconds) after which a nonce
+  *                     is considered stale (i.e. not used for authentication
+  *                     purposes anymore).
+  * @param bits The number of random bits a nonce should consist of.
+  */
+private[authentication] class NonceKeeperF[F[_]](
+    staleTimeout: Duration,
+    nonceCleanupInterval: Duration,
+    bits: Int,
+    semaphore: Semaphore[F],
+    lastCleanupMillis: Ref[F, FiniteDuration],
+    nonces: LinkedHashMap[String, NonceF[F]],
+)(implicit F: Async[F]) {
+  require(bits > 0, "Please supply a positive integer for bits.")
+
+  /** Removes nonces that are older than staleTimeout
+    * Note: this _MUST_ be executed with the singleton permit from the semaphore
+    */
+  private def unsafeCheckStale(): F[Unit] =
+    for {
+      now <- F.monotonic
+      lastCleanupTime <- lastCleanupMillis.get
+      result <-
+        if (now - lastCleanupTime > nonceCleanupInterval) {
+          lastCleanupMillis
+            .set(now)
+            .flatMap { _ =>
+              // Because we are using an LinkedHashMap, the keys will be returned in the order they were
+              // inserted. Therefore, once we reach a non-stale value, the remaining values are also not stale.
+              F.tailRecM[ju.Iterator[NonceF[F]], Unit](nonces.values().iterator()) {
+                case it if it.hasNext && staleTimeout > now - it.next().created =>
+                  F.delay(Left {
+                    it.remove()
+                    it
+                  })
+                case _ => F.delay(Right(()))
+              }
+            }
+        } else F.pure(())
+    } yield result
+
+  /** Get a fresh nonce in form of a {@link String}.
+    * @return A fresh nonce.
+    */
+  def newNonce(): F[String] =
+    semaphore.permit.surround {
+      for {
+        _ <- unsafeCheckStale()
+        n <- NonceF.gen[F](bits).iterateUntil(n => nonces.get(n.data) == null)
+      } yield {
+        nonces.put(n.data, n)
+        n.data
+      }
+    }
+
+  /** Checks if the nonce {@link data} is known and the {@link nc} value is
+    * correct. If this is so, the nc value associated with the nonce is increased
+    * and the appropriate status is returned.
+    * @param data The nonce.
+    * @param nc The nonce counter.
+    * @return A reply indicating the status of (data, nc).
+    */
+  def receiveNonce(data: String, nc: Int): F[NonceKeeper.Reply] =
+    semaphore.permit.surround {
+      for {
+        _ <- unsafeCheckStale()
+        res <- nonces.get(data) match {
+          case null => F.pure(NonceKeeper.StaleReply)
+          case n: NonceF[F] =>
+            n.nc.modify { lastNc =>
+              if (nc > lastNc) {
+                (lastNc + 1, NonceKeeper.OKReply)
+              } else
+                (lastNc, NonceKeeper.BadNCReply)
+            }
+        }
+      } yield res
+    }
+}

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
@@ -31,6 +31,7 @@ private[authentication] object NonceKeeperF {
   def apply[F[_]](
       staleTimeout: Duration,
       nonceCleanupInterval: Duration,
+      random: Random[F],
       bits: Int,
   )(implicit F: Async[F]): F[NonceKeeperF[F]] = for {
     // This semaphore controls who has access to `nonces` during stale nonce eviction. This must never be set above one.
@@ -38,10 +39,6 @@ private[authentication] object NonceKeeperF {
     current <- F.monotonic
     lastCleanupMillis <- Ref[F].of(current)
     nonces = new LinkedHashMap[String, NonceF[F]]
-    // Can't just call Random.javaSecuritySecureRandom
-    // https://github.com/typelevel/cats-effect/issues/2902
-    secureRandom <- F.delay(new org.http4s.crypto.unsafe.SecureRandom)
-    ceRandom <- Random.javaUtilRandom[F](secureRandom)
   } yield new NonceKeeperF(
     staleTimeout,
     nonceCleanupInterval,
@@ -49,7 +46,7 @@ private[authentication] object NonceKeeperF {
     semaphore,
     lastCleanupMillis,
     nonces,
-    ceRandom,
+    random,
   )
 }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/package.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/package.scala
@@ -24,6 +24,7 @@ import cats.effect.Sync
 import org.http4s.headers._
 
 package object authentication {
+  // TODO Could be reduced to a Monad[F]
   def challenged[F[_], A](
       challenge: Kleisli[F, Request[F], Either[Challenge, AuthedRequest[F, A]]]
   )(routes: AuthedRoutes[A, F])(implicit F: Sync[F]): HttpRoutes[F] =

--- a/server/shared/src/main/scala/org/http4s/server/package.scala
+++ b/server/shared/src/main/scala/org/http4s/server/package.scala
@@ -26,7 +26,6 @@ import com.comcast.ip4s
 import org.http4s.headers.Connection
 import org.http4s.headers.`Content-Length`
 import org.log4s.getLogger
-import org.typelevel.ci._
 import org.typelevel.vault._
 
 import java.net.InetAddress
@@ -200,7 +199,7 @@ package object server {
             Status.InternalServerError,
             req.httpVersion,
             Headers(
-              Connection(ci"close"),
+              Connection.close,
               `Content-Length`.zero,
             ),
           )

--- a/server/shared/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/authentication/AuthenticationSuite.scala
@@ -39,12 +39,23 @@ class AuthenticationSuite extends Http4sSuite {
   private val realm = "Test Realm"
   private val username = "Test User"
   private val password = "Test Password"
+  private val ha1 = "ef8937c627875dd03ca694994558f74e" // md5(${username}:${realm}:${password})
 
-  private def authStore(u: String): IO[Option[(String, String)]] =
-    IO.pure {
-      if (u === username) Some(u -> password)
-      else None
-    }
+  private val plainTextAuthStore: DigestAuth.AuthStore[IO, String] =
+    DigestAuth.PlainTextAuthStore[IO, String]((u: String) =>
+      IO.pure {
+        if (u === username) Some(u -> password)
+        else None
+      }
+    )
+
+  private val md5HashedAuthStore: DigestAuth.AuthStore[IO, String] =
+    DigestAuth.Md5HashedAuthStore[IO, String]((u: String) =>
+      IO.pure {
+        if (u === username) Some(u -> ha1)
+        else None
+      }
+    )
 
   private def validatePassword(creds: BasicCredentials): IO[Option[String]] =
     IO.pure {
@@ -131,12 +142,13 @@ class AuthenticationSuite extends Http4sSuite {
       .fold(e => sys.error(s"Couldn't parse: '$value', error: ${e.details}'"), identity)
 
   { // DigestAuthentication
-    val digestAuthMiddleware = DigestAuth(realm, authStore)
-
     test("DigestAuthentication should respond to a request without authentication with 401") {
-      val authedService = digestAuthMiddleware(service)
       val req = Request[IO](uri = uri"/")
-      authedService.orNotFound(req).map { res =>
+      for {
+        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore)
+        authedService = digestAuthMiddleware(service)
+        res <- authedService.orNotFound(req)
+      } yield {
         assertEquals(res.status, Unauthorized)
         val opt = res.headers.get[`WWW-Authenticate`].map(_.value)
         assert(clue(opt).isDefined)
@@ -172,7 +184,7 @@ class AuthenticationSuite extends Http4sSuite {
     ): IO[(Response[IO], Response[IO])] = {
       // Second request with credentials
       val method = "GET"
-      val uri = "/"
+      val uri = uri"/"
       val qop = "auth"
       val nc = "00000001"
       val cnonce = "abcdef"
@@ -185,7 +197,7 @@ class AuthenticationSuite extends Http4sSuite {
             "username" -> username,
             "realm" -> realm,
             "nonce" -> nonce,
-            "uri" -> uri,
+            "uri" -> uri.toString(),
             "qop" -> qop,
             "nc" -> nc,
             "cnonce" -> cnonce,
@@ -204,9 +216,35 @@ class AuthenticationSuite extends Http4sSuite {
     }
 
     test("DigestAuthentication should respond to a request with correct credentials") {
-      val digestAuthService = digestAuthMiddleware(service)
-
       for {
+        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore)
+        digestAuthService = digestAuthMiddleware(service)
+        challenge <- doDigestAuth1(digestAuthService.orNotFound)
+        _ <- IO {
+          assert(
+            challenge match {
+              case Challenge("Digest", `realm`, _) => true
+              case _ => false
+            },
+            challenge,
+          )
+        }
+        results <- doDigestAuth2(digestAuthService.orNotFound, challenge, withReplay = true)
+        (res2, res3) = results
+      } yield {
+        assertEquals(res2.status, Ok)
+
+        // Digest prevents replay
+        assertEquals(res3.status, Unauthorized)
+      }
+    }
+
+    test(
+      "DigestAuthentication should respond to a request with correct credentials when using secure hash"
+    ) {
+      for {
+        digestAuthMiddleware <- DigestAuth.applyF(realm, md5HashedAuthStore)
+        digestAuthService = digestAuthMiddleware(service)
         challenge <- doDigestAuth1(digestAuthService.orNotFound)
         _ <- IO {
           assert(
@@ -231,37 +269,41 @@ class AuthenticationSuite extends Http4sSuite {
       "DigestAuthentication should respond to many concurrent requests while cleaning up nonces"
     ) {
       val n = 100
-      val digestAuthMiddleware = DigestAuth(realm, authStore, 2.millis, 2.millis)
-      val digestAuthService = digestAuthMiddleware(service)
-      val results = (1 to n)
-        .map(_ =>
-          for {
-            challenge <- doDigestAuth1(digestAuthService.orNotFound)
-            _ <- IO {
-              assert(
-                challenge match {
-                  case Challenge("Digest", `realm`, _) => true
-                  case _ => false
-                },
-                challenge,
-              )
-            }
-            res <- doDigestAuth2(digestAuthService.orNotFound, challenge, withReplay = false)
-              .map(_._1)
-          } yield
-          // We don't check whether res.status is Ok since it may not
-          // be due to the low nonce stale timer.  Instead, we check
-          // that it's found.
-          assertNotEquals(res.status, NotFound)
-        )
-        .toList
-      results.parSequence
+      DigestAuth
+        .applyF(realm, plainTextAuthStore, 2.millis, 2.millis)
+        .flatMap { digestAuthMiddleware =>
+          val digestAuthService = digestAuthMiddleware(service)
+          val results = (1 to n)
+            .map(_ =>
+              for {
+                challenge <- doDigestAuth1(digestAuthService.orNotFound)
+                _ <- IO {
+                  assert(
+                    challenge match {
+                      case Challenge("Digest", `realm`, _) => true
+                      case _ => false
+                    },
+                    challenge,
+                  )
+                }
+                res <- doDigestAuth2(digestAuthService.orNotFound, challenge, withReplay = false)
+                  .map(_._1)
+              } yield
+              // We don't check whether res.status is Ok since it may not
+              // be due to the low nonce stale timer.  Instead, we check
+              // that it's found.
+              assertNotEquals(res.status, NotFound)
+            )
+            .toList
+          results.parSequence
+        }
     }
 
     test("DigestAuthentication should avoid many concurrent replay attacks") {
       val n = 100
-      val digestAuthService = digestAuthMiddleware(service)
       val results = for {
+        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore)
+        digestAuthService = digestAuthMiddleware(service)
         challenge <- doDigestAuth1(digestAuthService.orNotFound)
         results <- (1 to n)
           .map(_ =>
@@ -279,32 +321,34 @@ class AuthenticationSuite extends Http4sSuite {
     }
 
     test("DigestAuthentication should respond to invalid requests with 401") {
-      val digestAuthService = digestAuthMiddleware(service)
       val method = "GET"
-      val uri = "/"
+      val uri = uri"/"
       val qop = "auth"
       val nc = "00000001"
       val cnonce = "abcdef"
       val nonce = "abcdef"
 
-      DigestUtil
-        .computeResponse[IO](method, username, realm, password, uri, nonce, nc, cnonce, qop)
-        .flatMap { response =>
-          val params = NonEmptyList.of(
-            "username" -> username,
-            "realm" -> realm,
-            "nonce" -> nonce,
-            "uri" -> uri,
-            "qop" -> qop,
-            "nc" -> nc,
-            "cnonce" -> cnonce,
-            "response" -> response,
-            "method" -> method,
-          )
+      for {
+        digestAuthMiddleware <- DigestAuth.applyF(realm, plainTextAuthStore)
+        digestAuthService = digestAuthMiddleware(service)
+        response <- DigestUtil
+          .computeResponse[IO](method, username, realm, password, uri, nonce, nc, cnonce, qop)
+        params = NonEmptyList.of(
+          "username" -> username,
+          "realm" -> realm,
+          "nonce" -> nonce,
+          "uri" -> uri.toString(),
+          "qop" -> qop,
+          "nc" -> nc,
+          "cnonce" -> cnonce,
+          "response" -> response,
+          "method" -> method,
+        )
 
-          val expected = List.fill(params.size + 1)(Unauthorized)
+        expected = List.fill(params.size + 1)(Unauthorized)
 
-          val result = (0 to params.size).map { i =>
+        result <- (0 to params.size).toList
+          .parTraverse { i =>
             val invalidParams = params.toList.take(i) ++ params.toList.drop(i + 1)
             val header = Authorization(
               Credentials.AuthParams(ci"Digest", invalidParams.head, invalidParams.tail: _*)
@@ -312,9 +356,14 @@ class AuthenticationSuite extends Http4sSuite {
             val req = Request[IO](uri = uri"/", headers = Headers(header))
             digestAuthService.orNotFound(req).map(_.status)
           }
+          .assertEquals(expected)
+      } yield result
+    }
 
-          result.toList.parSequence.assertEquals(expected)
-        }
+    test("DigestAuthentication can calculate the expected ha1 using the helper function") {
+      for {
+        newHa1 <- DigestAuth.Md5HashedAuthStore.precomputeHash[IO](username, realm, password)
+      } yield assertEquals(newHa1, ha1)
     }
   }
 }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/authentication/NonceFSpec.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/authentication/NonceFSpec.scala
@@ -1,0 +1,30 @@
+package org.http4s
+package server.middleware.authentication
+
+import cats.effect.IO
+import cats.effect.std.Random
+import org.scalacheck.Gen
+import org.scalacheck.effect.PropF._
+
+
+class NonceFSpec extends Http4sSuite {
+  test("nonce in expected range") {
+    Random.javaSecuritySecureRandom[IO].map { random =>
+      forAllF(Gen.chooseNum(1, 240)) { (n: Int) =>
+        NonceF
+          .gen(random, n)
+          .map(nonce => BigInt(nonce.data, 16))
+          .map(i => assert(i >= BigInt(0) && i <= BigInt(2).pow(n) - 1, i.toString))
+      }
+    }
+  }
+
+  test("nonce has correct alphabet") {
+    val alphabet = "0123456789abcdef".toSet
+    Random.javaSecuritySecureRandom[IO].map { random =>
+      forAllF { (_: Unit) =>
+        NonceF.gen(random, 160).map(nonce => assert(nonce.data.forall(alphabet), nonce.data))
+      }
+    }
+  }
+}

--- a/server/shared/src/test/scala/org/http4s/server/middleware/authentication/NonceFSpec.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/authentication/NonceFSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s
 package server.middleware.authentication
 

--- a/server/shared/src/test/scala/org/http4s/server/middleware/authentication/NonceFSpec.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/authentication/NonceFSpec.scala
@@ -22,7 +22,6 @@ import cats.effect.std.Random
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF._
 
-
 class NonceFSpec extends Http4sSuite {
   test("nonce in expected range") {
     Random.javaSecuritySecureRandom[IO].map { random =>

--- a/testing/shared/src/test/scala/org/http4s/testing/ErrorReporting.scala
+++ b/testing/shared/src/test/scala/org/http4s/testing/ErrorReporting.scala
@@ -30,7 +30,6 @@ import cats.Monad
 import cats.syntax.all._
 import org.http4s.headers.Connection
 import org.http4s.headers.`Content-Length`
-import org.typelevel.ci._
 
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
@@ -73,7 +72,7 @@ object ErrorReporting {
             Status.InternalServerError,
             req.httpVersion,
             Headers(
-              Connection(ci"close"),
+              Connection.close,
               `Content-Length`.zero,
             ),
           )

--- a/tests/shared/src/test/scala/org/http4s/ResponderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/ResponderSpec.scala
@@ -53,9 +53,9 @@ class ResponderSpec extends Http4sSuite {
   }
 
   test("Responder should Remove headers") {
-    val wHeader = resp.putHeaders(Connection(ci"close"))
+    val wHeader = resp.putHeaders(Connection.close)
     val maybeHeaderT = wHeader.headers.get[Connection]
-    assertEquals(maybeHeaderT, Some(Connection(ci"close")))
+    assertEquals(maybeHeaderT, Some(Connection.close))
 
     val newHeaders = wHeader.removeHeader[Connection]
     assert(newHeaders.headers.get[Connection].isEmpty)
@@ -63,7 +63,7 @@ class ResponderSpec extends Http4sSuite {
 
   test("Responder should Replace all headers") {
     val wHeader =
-      resp.putHeaders(Connection(ci"close"), `Content-Length`.unsafeFromLong(10), Host("foo"))
+      resp.putHeaders(Connection.close, `Content-Length`.unsafeFromLong(10), Host("foo"))
     assertEquals(wHeader.headers.headers.length, 3)
 
     val newHeaders = wHeader.withHeaders(Date(HttpDate.Epoch))
@@ -73,7 +73,7 @@ class ResponderSpec extends Http4sSuite {
 
   test("Responder should Replace all headers II") {
     val wHeader =
-      resp.putHeaders(Connection(ci"close"), `Content-Length`.unsafeFromLong(10), Host("foo"))
+      resp.putHeaders(Connection.close, `Content-Length`.unsafeFromLong(10), Host("foo"))
     assertEquals(wHeader.headers.headers.length, 3)
 
     val newHeaders = wHeader.withHeaders(Headers(Date(HttpDate.Epoch)))
@@ -83,7 +83,7 @@ class ResponderSpec extends Http4sSuite {
 
   test("Responder should Filter headers") {
     val wHeader =
-      resp.putHeaders(Connection(ci"close"), `Content-Length`.unsafeFromLong(10), Host("foo"))
+      resp.putHeaders(Connection.close, `Content-Length`.unsafeFromLong(10), Host("foo"))
     assertEquals(wHeader.headers.headers.length, 3)
 
     val newHeaders = wHeader.filterHeaders(_.name != ci"Connection")

--- a/tests/shared/src/test/scala/org/http4s/internal/JavaMajorVersionSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/internal/JavaMajorVersionSuite.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.internal
+
+import org.http4s.Http4sSuite
+
+class JavaMajorVersionSuite extends Http4sSuite {
+  test("parseJavaMajorVersion") {
+    // Through Java 8, it was "1."
+    assertEquals(parseJavaMajorVersion("1.8.0_292"), Some(8))
+    // Afterward, it's as expected
+    assertEquals(parseJavaMajorVersion("17.0.1"), Some(17))
+    // Gracefully handle trash
+    assertEquals(parseJavaMajorVersion("trash"), None)
+  }
+}

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -206,6 +206,16 @@ I am a big moose
       val request = Request(method = Method.POST, uri = url, headers = multipart.headers)
       assert(request.isChunked)
     }
+
+    test("Multipart should be encoded with a \\r\\n after the final part for robustness") {
+      val field1 = Part.formData[IO]("bow", "wow")
+      val multipart = Multipart[IO](Vector(field1), Boundary("arf"))
+      val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
+      val body = entity.body
+      val request =
+        Request(method = Method.POST, uri = url, body = body, headers = multipart.headers)
+      request.as[String].map(s => assert(s.endsWith("--arf--\r\n"), s))
+    }
   }
 
   multipartSpec("with default decoder")(Resource.pure(implicitly))


### PR DESCRIPTION
Demonstration of what `Random` looks like in the public API.  We want to decide before the next 0.23.x release, and also decide on the fate of `SecureRandom` in Cats-Effect 3 (https://github.com/typelevel/cats-effect/pull/2905).