### PR TITLE
Deprecate blaze TrustingSslContext

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/bits.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/bits.scala
@@ -38,6 +38,10 @@ private[http4s] object bits {
   val DefaultMaxWaitQueueLimit = 256
 
   /** Caution: trusts all certificates and disables endpoint identification */
+  @deprecated(
+    "Kept for binary compatibility.  Unfit for production.  Embeds a blocking call on some platforms.",
+    "0.23.13",
+  )
   lazy val TrustingSslContext: SSLContext = {
     val trustManager = new X509TrustManager {
       def getAcceptedIssuers(): Array[X509Certificate] = Array.empty

--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientSuite.scala
@@ -56,8 +56,12 @@ class BlazeClientSuite extends BlazeClientBase {
     val name = sslAddress.host
     val port = sslAddress.port
     val u = Uri.fromString(s"https://$name:$port/simple").yolo
-    val resp = builder(1).resource.use(_.expect[String](u))
-    resp.map(_.length > 0).assertEquals(true)
+    TrustingSslContext
+      .flatMap { ctx =>
+        val resp = builder(1, sslContextOption = Some(ctx)).resource.use(_.expect[String](u))
+        resp.map(_.length > 0)
+      }
+      .assertEquals(true)
   }
 
   test("Blaze Http1Client should reject https requests when no SSLContext is configured") {


### PR DESCRIPTION
It's unused publicly.  A safer version is ported to the test that uses it.

The unfitness for production extends beyond the blocking call, for the record.