### PR TITLE
Remove deprecated `Client.fetch`, `DefaultClient.fetch`

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -32,28 +32,6 @@ import scala.util.control.NoStackTrace
 trait Client[F[_]] {
   def run(req: Request[F]): Resource[F, Response[F]]
 
-  /** Submits a request, and provides a callback to process the response.
-    *
-    * @param req The request to submit
-    * @param f   A callback for the response to req.  The underlying HTTP connection
-    *            is disposed when the returned task completes.  Attempts to read the
-    *            response body afterward will result in an error.
-    * @return The result of applying f to the response to req
-    */
-  @deprecated("Use run(req).use(f)", "0.21.5")
-  def fetch[A](req: Request[F])(f: Response[F] => F[A]): F[A]
-
-  /** Submits a request, and provides a callback to process the response.
-    *
-    * @param req An effect of the request to submit
-    * @param f A callback for the response to req.  The underlying HTTP connection
-    *          is disposed when the returned task completes.  Attempts to read the
-    *          response body afterward will result in an error.
-    * @return The result of applying f to the response to req
-    */
-  @deprecated("Use req.flatMap(run(_).use(f))", "0.21.5")
-  def fetch[A](req: F[Request[F]])(f: Response[F] => F[A]): F[A]
-
   /** Returns this client as a [[cats.data.Kleisli]].  All connections created
     * by this service are disposed on completion of callback task f.
     *

--- a/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -31,28 +31,6 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
     extends Client[F] {
   def run(req: Request[F]): Resource[F, Response[F]]
 
-  /** Submits a request, and provides a callback to process the response.
-    *
-    * @param req The request to submit
-    * @param f   A callback for the response to req.  The underlying HTTP connection
-    *            is disposed when the returned task completes.  Attempts to read the
-    *            response body afterward will result in an error.
-    * @return The result of applying f to the response to req
-    */
-  def fetch[A](req: Request[F])(f: Response[F] => F[A]): F[A] =
-    run(req).use(f)
-
-  /** Submits a request, and provides a callback to process the response.
-    *
-    * @param req An effect of the request to submit
-    * @param f A callback for the response to req.  The underlying HTTP connection
-    *          is disposed when the returned task completes.  Attempts to read the
-    *          response body afterward will result in an error.
-    * @return The result of applying f to the response to req
-    */
-  def fetch[A](req: F[Request[F]])(f: Response[F] => F[A]): F[A] =
-    req.flatMap(run(_).use(f))
-
   /** Returns this client as a [[cats.data.Kleisli]].  All connections created
     * by this service are disposed on completion of callback task f.
     *


### PR DESCRIPTION
Those methods were deprecated since `0.21`, so I feel we can do that clean-up. If not now, then when? `2.0` is probably too far from nowadays.