### PR TITLE
Optimize Headers put and ++ using ListBuffer

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Headers.scala
+++ b/core/shared/src/main/scala/org/http4s/Headers.scala
@@ -111,18 +111,14 @@ final class Headers(val headers: List[Header.Raw]) extends AnyVal {
       those.headers match {
         case thatHeader :: Nil =>
           val thatHeaderName = thatHeader.name
-          if (!headers.exists(_.name == thatHeader.name)) {
-            Headers(this.headers :+ thatHeader)
-          } else {
-            val newHeaders = mutable.ListBuffer.empty[Header.Raw]
-            headers.foreach { h =>
-              if (h.name != thatHeaderName) {
-                newHeaders += h
-              }
+          val newHeaders = mutable.ListBuffer.empty[Header.Raw]
+          headers.foreach { h =>
+            if (h.name != thatHeaderName) {
+              newHeaders += h
             }
-            newHeaders += thatHeader
-            Headers(newHeaders.toList)
           }
+          newHeaders += thatHeader
+          Headers(newHeaders.toList)
         case thoseHeaders =>
           val thoseNames = mutable.Set.empty[CIString]
           val newHeaders = mutable.ListBuffer.empty[Header.Raw]


### PR DESCRIPTION
I'm opening this as a draft for now, as I have some questions.

1. There's some repetition here, which is done to optimize for performance. Is it worth the added lines? I'd like to think so, as this file hasn't been changed much over time, and the functionality is fairly basic, but if you disagree, I can remove some of it.
2. Is changing "appended to "prepended" in `Message.addHeader` actually a non-breaking change? As far as I can tell, the order doesn't actually matter, and prepending that is more efficient (the number of header values we already have are likely to be larger than the number of header values we're adding), but...
3. We could keep track of header names in a mutable set internally, which would remove the need for an extra traversal in `!headers.exists(_.name == thatHeaderName)`, but would that be worth doing, in terms of added code, memory usage, and mutable state? I haven't done any benchmarks on this, yet.
4. Not directly related to this PR, but I'm wondering if there's any interest in considering something different than a `List` for `val headers: List[Header.Raw]`, as it's not a great choice if we want efficient append while also replacing previous values. Maybe a multimap or other data structure would be more appropriate, as the order doesn't seem to actually matter?

As for the benefit, this improves plaintext performance on Techempower benchmarks from 308k req/s to 314k req/s, which isn't huge but not insignificant for that benchmark, as it's using almost no headers.

The result matches my expectations based on profiling, where this headers stuff take a small, yet surprisingly large amount of time (about 2% of total CPU time).

EDIT: Test failures may have answered question 2. Might still be worth considering for 1.x if we don't go for 4.