### PR TITLE
Should Metrics classifierF use Generic vs String?

### DIFF
--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -23,19 +23,19 @@ import org.http4s.Status
 
 /** Describes an algebra capable of writing metrics to a metrics registry
   */
-trait MetricsOps[F[_]] {
+trait MetricsOps[F[_], Classifier] {
 
   /** Increases the count of active requests
     *
     * @param classifier the classifier to apply
     */
-  def increaseActiveRequests(classifier: Option[String]): F[Unit]
+  def increaseActiveRequests(classifier: Option[Classifier]): F[Unit]
 
   /** Decreases the count of active requests
     *
     * @param classifier the classifier to apply
     */
-  def decreaseActiveRequests(classifier: Option[String]): F[Unit]
+  def decreaseActiveRequests(classifier: Option[Classifier]): F[Unit]
 
   /** Records the time to receive the response headers
     *
@@ -43,7 +43,7 @@ trait MetricsOps[F[_]] {
     * @param elapsed the time to record
     * @param classifier the classifier to apply
     */
-  def recordHeadersTime(method: Method, elapsed: Long, classifier: Option[String]): F[Unit]
+  def recordHeadersTime(method: Method, elapsed: Long, classifier: Option[Classifier]): F[Unit]
 
   /** Records the time to fully consume the response, including the body
     *
@@ -56,7 +56,7 @@ trait MetricsOps[F[_]] {
       method: Method,
       status: Status,
       elapsed: Long,
-      classifier: Option[String],
+      classifier: Option[Classifier],
   ): F[Unit]
 
   /** Record abnormal terminations, like errors, timeouts or just other abnormal terminations.
@@ -68,7 +68,7 @@ trait MetricsOps[F[_]] {
   def recordAbnormalTermination(
       elapsed: Long,
       terminationType: TerminationType,
-      classifier: Option[String],
+      classifier: Option[Classifier],
   ): F[Unit]
 }
 

--- a/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/Dropwizard.scala
+++ b/dropwizard-metrics/src/main/scala/org/http4s/metrics/dropwizard/Dropwizard.scala
@@ -83,8 +83,8 @@ object Dropwizard {
     */
   def apply[F[_]](registry: MetricRegistry, prefix: String = "org.http4s.server")(implicit
       F: Sync[F]
-  ): MetricsOps[F] =
-    new MetricsOps[F] {
+  ): MetricsOps[F, String] =
+    new MetricsOps[F, String] {
       override def increaseActiveRequests(classifier: Option[String]): F[Unit] =
         F.delay {
           registry.counter(s"${namespace(prefix, classifier)}.active-requests").inc()

--- a/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
+++ b/dropwizard-metrics/src/test/scala/org/http4s/metrics/dropwizard/DropwizardServerMetricsSuite.scala
@@ -33,7 +33,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register a 2xx response") {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test1")
-    val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
+    val meteredRoutes = Metrics[IO, String](Dropwizard(registry, "server"))(testRoutes)
     val req = Request[IO](uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
@@ -68,7 +68,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register a 4xx response") {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test2")
-    val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
+    val meteredRoutes = Metrics[IO, String](Dropwizard(registry, "server"))(testRoutes)
 
     val req = Request[IO](uri = uri"/bad-request")
 
@@ -104,7 +104,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register a 5xx response") {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test3")
-    val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
+    val meteredRoutes = Metrics[IO, String](Dropwizard(registry, "server"))(testRoutes)
     val req = Request[IO](uri = uri"/internal-server-error")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
@@ -139,7 +139,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register a GET request") {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test4")
-    val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
+    val meteredRoutes = Metrics[IO, String](Dropwizard(registry, "server"))(testRoutes)
     val req = Request[IO](method = GET, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
@@ -174,7 +174,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register a POST request") {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test5")
-    val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
+    val meteredRoutes = Metrics[IO, String](Dropwizard(registry, "server"))(testRoutes)
     val req = Request[IO](method = POST, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
@@ -209,7 +209,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register a PUT request") {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test6")
-    val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
+    val meteredRoutes = Metrics[IO, String](Dropwizard(registry, "server"))(testRoutes)
     val req = Request[IO](method = PUT, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
@@ -244,7 +244,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register a DELETE request") {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test7")
-    val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
+    val meteredRoutes = Metrics[IO, String](Dropwizard(registry, "server"))(testRoutes)
     val req = Request[IO](method = DELETE, uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
@@ -279,7 +279,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register an error") {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test8")
-    val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
+    val meteredRoutes = Metrics[IO, String](Dropwizard(registry, "server"))(testRoutes)
     val req = Request[IO](method = GET, uri = uri"/error")
 
     meteredRoutes.orNotFound(req).attempt.map { resp =>
@@ -305,7 +305,7 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
   test("register an abnormal termination") {
     implicit val clock: Clock[IO] = FakeClock[IO]
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test9")
-    val meteredRoutes = Metrics[IO](Dropwizard(registry, "server"))(testRoutes)
+    val meteredRoutes = Metrics[IO, String](Dropwizard(registry, "server"))(testRoutes)
     val req = Request[IO](method = GET, uri = uri"/abnormal-termination")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>
@@ -336,7 +336,9 @@ class DropwizardServerMetricsSuite extends Http4sSuite {
     val classifierFunc = (_: Request[IO]) => Some("classifier")
     val registry: MetricRegistry = SharedMetricRegistries.getOrCreate("test10")
     val meteredRoutes =
-      Metrics[IO](ops = Dropwizard(registry, "server"), classifierF = classifierFunc)(testRoutes)
+      Metrics[IO, String](ops = Dropwizard(registry, "server"), classifierF = classifierFunc)(
+        testRoutes
+      )
     val req = Request[IO](uri = uri"/ok")
 
     meteredRoutes.orNotFound(req).flatMap { resp =>

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/BlazeMetricsExample.scala
@@ -36,7 +36,7 @@ class BlazeMetricsExample extends IOApp {
 object BlazeMetricsExampleApp {
   def httpApp[F[_]: Async]: HttpApp[F] = {
     val metricsRegistry: MetricRegistry = new MetricRegistry()
-    val metrics: HttpMiddleware[F] = Metrics[F](Dropwizard(metricsRegistry, "server"))
+    val metrics: HttpMiddleware[F] = Metrics[F, String](Dropwizard(metricsRegistry, "server"))
     Router(
       "/http4s" -> metrics(ExampleService[F].routes),
       "/http4s/metrics" -> metricsService[F](metricsRegistry),

--- a/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
+++ b/examples/jetty/src/main/scala/com/example/http4s/jetty/JettyExample.scala
@@ -33,7 +33,7 @@ object JettyExample extends IOApp {
 object JettyExampleApp {
   def builder[F[_]: Async]: JettyBuilder[F] = {
     val metricsRegistry: MetricRegistry = new MetricRegistry
-    val metrics: HttpMiddleware[F] = Metrics[F](Dropwizard(metricsRegistry, "server"))
+    val metrics: HttpMiddleware[F] = Metrics[F, String](Dropwizard(metricsRegistry, "server"))
 
     JettyBuilder[F]
       .bindHttp(8080)

--- a/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
+++ b/examples/tomcat/src/main/scala/com/example/http4s/tomcat/TomcatExample.scala
@@ -34,7 +34,7 @@ object TomcatExample extends IOApp {
 object TomcatExampleApp {
   def builder[F[_]: Async]: TomcatBuilder[F] = {
     val metricsRegistry: MetricRegistry = new MetricRegistry
-    val metrics: HttpMiddleware[F] = Metrics[F](Dropwizard(metricsRegistry, "server"))
+    val metrics: HttpMiddleware[F] = Metrics[F, String](Dropwizard(metricsRegistry, "server"))
 
     TomcatBuilder[F]
       .bindHttp(8080)

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/Prometheus.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/Prometheus.scala
@@ -92,15 +92,15 @@ object Prometheus {
       registry: CollectorRegistry,
       prefix: String = "org_http4s_server",
       responseDurationSecondsHistogramBuckets: NonEmptyList[Double] = DefaultHistogramBuckets,
-  ): Resource[F, MetricsOps[F]] =
+  ): Resource[F, MetricsOps[F, String]] =
     for {
       metrics <- createMetricsCollection(registry, prefix, responseDurationSecondsHistogramBuckets)
     } yield createMetricsOps(metrics)
 
   private def createMetricsOps[F[_]](
       metrics: MetricsCollection
-  )(implicit F: Sync[F]): MetricsOps[F] =
-    new MetricsOps[F] {
+  )(implicit F: Sync[F]): MetricsOps[F, String] =
+    new MetricsOps[F, String] {
       override def increaseActiveRequests(classifier: Option[String]): F[Unit] =
         F.delay {
           metrics.activeRequests

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
@@ -38,10 +38,10 @@ import org.http4s.metrics.TerminationType.Error
   */
 object Metrics {
 
-  private[this] final case class MetricsRequestContext(
+  private[this] final case class MetricsRequestContext[Classifier](
       method: Method,
       startTime: Long,
-      classifier: Option[String],
+      classifier: Option[Classifier],
   )
 
   /** A server middleware capable of recording metrics
@@ -52,15 +52,17 @@ object Metrics {
     * @param classifierF a function that allows to add a classifier that can be customized per request
     * @return the metrics middleware
     */
-  def apply[F[_]](
-      ops: MetricsOps[F],
+  def apply[F[_], Classifier](
+      ops: MetricsOps[F, Classifier],
       emptyResponseHandler: Option[Status] = Status.NotFound.some,
       errorResponseHandler: Throwable => Option[Status] = _ => Status.InternalServerError.some,
-      classifierF: Request[F] => Option[String] = { (_: Request[F]) =>
+      classifierF: Request[F] => Option[Classifier] = { (_: Request[F]) =>
         None
       },
   )(routes: HttpRoutes[F])(implicit F: Clock[F], C: MonadCancel[F, Throwable]): HttpRoutes[F] =
-    effect[F](ops, emptyResponseHandler, errorResponseHandler, classifierF(_).pure[F])(routes)
+    effect[F, Classifier](ops, emptyResponseHandler, errorResponseHandler, classifierF(_).pure[F])(
+      routes
+    )
 
   /** A server middleware capable of recording metrics
     *
@@ -75,77 +77,78 @@ object Metrics {
     * @param classifierF a function that allows to add a classifier that can be customized per request
     * @return the metrics middleware
     */
-  def effect[F[_]](
-      ops: MetricsOps[F],
+  def effect[F[_], Classifier](
+      ops: MetricsOps[F, Classifier],
       emptyResponseHandler: Option[Status] = Status.NotFound.some,
       errorResponseHandler: Throwable => Option[Status] = _ => Status.InternalServerError.some,
-      classifierF: Request[F] => F[Option[String]],
+      classifierF: Request[F] => F[Option[Classifier]],
   )(routes: HttpRoutes[F])(implicit F: Clock[F], C: MonadCancel[F, Throwable]): HttpRoutes[F] =
-    BracketRequestResponse.bracketRequestResponseCaseRoutes_[F, MetricsRequestContext, Status] {
-      (request: Request[F]) =>
-        classifierF(request).flatMap { classifier =>
-          ops.increaseActiveRequests(classifier) *>
-            F.monotonic
-              .map(startTime =>
-                ContextRequest(
-                  MetricsRequestContext(request.method, startTime.toNanos, classifier),
-                  request,
+    BracketRequestResponse
+      .bracketRequestResponseCaseRoutes_[F, MetricsRequestContext[Classifier], Status] {
+        (request: Request[F]) =>
+          classifierF(request).flatMap { classifier =>
+            ops.increaseActiveRequests(classifier) *>
+              F.monotonic
+                .map(startTime =>
+                  ContextRequest(
+                    MetricsRequestContext(request.method, startTime.toNanos, classifier),
+                    request,
+                  )
                 )
-              )
-        }
-    } { case (context, maybeStatus, outcome) =>
-      // Decrease active requests _first_ in case any of the other effects
-      // trigger an error. This differs from the < 0.21.14 semantics, which
-      // decreased it _after_ the other effects. This may have been the
-      // reason the active requests counter was reported to have drifted.
-      ops.decreaseActiveRequests(context.classifier) *>
-        F.monotonic
-          .map(endTime => endTime.toNanos - context.startTime)
-          .flatMap(totalTime =>
-            outcome match {
-              case Outcome.Succeeded(_) =>
-                (maybeStatus <+> emptyResponseHandler).traverse_(status =>
-                  ops.recordTotalTime(context.method, status, totalTime, context.classifier)
-                )
-              case Outcome.Errored(e) =>
-                maybeStatus.fold {
-                  // If an error occurred, and the status is empty, this means
-                  // that an error occurred before the routes could generate a
-                  // response.
-                  ops.recordHeadersTime(context.method, totalTime, context.classifier) *>
-                    ops.recordAbnormalTermination(totalTime, Error(e), context.classifier) *>
-                    errorResponseHandler(e).traverse_(status =>
-                      ops.recordTotalTime(context.method, status, totalTime, context.classifier)
-                    )
-                }(status =>
-                  // If an error occurred, but the status is non-empty, this
-                  // means the error occurred during the stream processing of
-                  // the response body. In this case recordHeadersTime would
-                  // have been invoked in the normal manner so we do not need
-                  // to invoke it here.
-                  ops.recordAbnormalTermination(totalTime, Abnormal(e), context.classifier) *>
+          }
+      } { case (context, maybeStatus, outcome) =>
+        // Decrease active requests _first_ in case any of the other effects
+        // trigger an error. This differs from the < 0.21.14 semantics, which
+        // decreased it _after_ the other effects. This may have been the
+        // reason the active requests counter was reported to have drifted.
+        ops.decreaseActiveRequests(context.classifier) *>
+          F.monotonic
+            .map(endTime => endTime.toNanos - context.startTime)
+            .flatMap(totalTime =>
+              outcome match {
+                case Outcome.Succeeded(_) =>
+                  (maybeStatus <+> emptyResponseHandler).traverse_(status =>
                     ops.recordTotalTime(context.method, status, totalTime, context.classifier)
-                )
-              case Outcome.Canceled() =>
-                ops.recordAbnormalTermination(totalTime, Canceled, context.classifier)
-            }
-          )
-    }(C)(
-      Kleisli((contextRequest: ContextRequest[F, MetricsRequestContext]) =>
-        routes
-          .run(contextRequest.req)
-          .semiflatMap(response =>
-            F.monotonic
-              .map(now => now.toNanos - contextRequest.context.startTime)
-              .flatTap(headerTime =>
-                ops.recordHeadersTime(
-                  contextRequest.context.method,
-                  headerTime,
-                  contextRequest.context.classifier,
-                )
-              ) *> C.pure(ContextResponse(response.status, response))
-          )
+                  )
+                case Outcome.Errored(e) =>
+                  maybeStatus.fold {
+                    // If an error occurred, and the status is empty, this means
+                    // that an error occurred before the routes could generate a
+                    // response.
+                    ops.recordHeadersTime(context.method, totalTime, context.classifier) *>
+                      ops.recordAbnormalTermination(totalTime, Error(e), context.classifier) *>
+                      errorResponseHandler(e).traverse_(status =>
+                        ops.recordTotalTime(context.method, status, totalTime, context.classifier)
+                      )
+                  }(status =>
+                    // If an error occurred, but the status is non-empty, this
+                    // means the error occurred during the stream processing of
+                    // the response body. In this case recordHeadersTime would
+                    // have been invoked in the normal manner so we do not need
+                    // to invoke it here.
+                    ops.recordAbnormalTermination(totalTime, Abnormal(e), context.classifier) *>
+                      ops.recordTotalTime(context.method, status, totalTime, context.classifier)
+                  )
+                case Outcome.Canceled() =>
+                  ops.recordAbnormalTermination(totalTime, Canceled, context.classifier)
+              }
+            )
+      }(C)(
+        Kleisli((contextRequest: ContextRequest[F, MetricsRequestContext[Classifier]]) =>
+          routes
+            .run(contextRequest.req)
+            .semiflatMap(response =>
+              F.monotonic
+                .map(now => now.toNanos - contextRequest.context.startTime)
+                .flatTap(headerTime =>
+                  ops.recordHeadersTime(
+                    contextRequest.context.method,
+                    headerTime,
+                    contextRequest.context.classifier,
+                  )
+                ) *> C.pure(ContextResponse(response.status, response))
+            )
+        )
       )
-    )
 
 }


### PR DESCRIPTION
This is a proof of concept for whether or not the `Metrics` middleware should use a generic type instead of a `String` for `classifierF`. When implementing a `MetricsOps`, I found myself wanting to pass along more information than is easily included in a string. My specific use case is reporting metrics to datadog, and wanting to synthesize both a metric name and a set of metric tags from the request path, e.g.,


```scala
case class Context(name: String, tags: Seq[(String, String)])
```

I was able to solve this by converting a `Request[F]` into a `Context` and then serializing to json within classifierF and deserializing within my `MetricsOps` implementation, but I had the thought that this round trip could be avoided if the classifier worked with a type besides just `String`.

This PR is mostly a proof-of-concept for how this could look, happy to close this and move into an issue if that would be better for discussion.