### PR TITLE
Use separate `Dispatcher` instances in the blaze client builder

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala
@@ -408,7 +408,6 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
             sslContextOption = sslContext,
             bufferSize = bufferSize,
             asynchronousChannelGroup = asynchronousChannelGroup,
-            executionContextConfig = executionContextConfig,
             scheduler = scheduler,
             checkEndpointIdentification = checkEndpointIdentification,
             maxResponseLineSize = maxResponseLineSize,
@@ -422,7 +421,7 @@ sealed abstract class BlazeClientBuilder[F[_]] private (
             dispatcher = dispatcher,
             idleTimeout = idleTimeout,
             getAddress = customDnsResolver.getOrElse(BlazeClientBuilder.getAddress(_)),
-          ).makeClient(requestKey)
+          ).makeClient(requestKey, executionContext)
 
     for {
       dispatcher <- Dispatcher[F]

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Support.scala
@@ -73,7 +73,10 @@ private final class Http1Support[F[_]](
     connectTimeout,
   )
 
-  def makeClient(requestKey: RequestKey, executionContext: ExecutionContext): F[BlazeConnection[F]] =
+  def makeClient(
+      requestKey: RequestKey,
+      executionContext: ExecutionContext,
+  ): F[BlazeConnection[F]] =
     getAddress(requestKey) match {
       case Right(a) =>
         fromFutureNoShift(F.delay(buildPipeline(requestKey, a, executionContext)))

--- a/build.sbt
+++ b/build.sbt
@@ -866,6 +866,10 @@ lazy val blazeClient = libraryProject("blaze-client")
         .exclude[IncompatibleResultTypeProblem]("org.http4s.blaze.client.Connection.isRecyclable"),
       ProblemFilters
         .exclude[ReversedMissingMethodProblem]("org.http4s.blaze.client.Connection.isRecyclable"),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("org.http4s.blaze.client.Http1Support.this"),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("org.http4s.blaze.client.Http1Support.makeClient"),
     ) ++ {
       if (tlIsScala3.value)
         Seq(


### PR DESCRIPTION
[It's proposed by CE](https://github.com/typelevel/cats-effect/blob/27307cfe6cd9ea3cb230a8f9be5e16f624a914cd/std/shared/src/main/scala/cats/effect/std/Dispatcher.scala#L40-L42) to use separate instances of Dispatcher when possible to reduce contentions on submitting effects.