### PR TITLE
Reduce use of `covary` method.

### DIFF
--- a/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -99,7 +99,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
     serverClient().flatMap { case (server, client) =>
       val address = server().addresses.head
       val uri = Uri.fromString(s"http://$address/echo").yolo
-      val req = POST(Stream.emits("This is chunked.".toSeq.map(_.toString)).covary[IO], uri)
+      val req = POST(Stream.emits("This is chunked.".toSeq.map(_.toString)), uri)
       val body = client().expect[String](req)
       body.assertEquals("This is chunked.")
     }

--- a/client/shared/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/shared/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -41,7 +41,7 @@ object GetRoutes {
         .withEntity("a" * 8 * 1024)
         .pure[IO], // must be at least as large as the buffers used by the client
       ChunkedPath -> Response[IO](Ok)
-        .withEntity(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
+        .withEntity(Stream.emits("chunk".toSeq.map(_.toString)))
         .pure[IO],
       DelayedPath ->
         F.sleep(1.second) *>

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -239,9 +239,7 @@ private[ember] class H2Client[F[_]: Async](
                 // _ <- Sync[F].delay(println(s"Push promise stream acquired for $i"))
                 req <- stream.getRequest
 
-                resp = stream.getResponse.map(
-                  _.covary[F].withBodyStream(stream.readBody)
-                )
+                resp = stream.getResponse.map(_.withBodyStream(stream.readBody))
                 // _ <- Sync[F].delay(println(s"Push promise request acquired for $i"))
                 outE <- onPushPromise(req, resp).flatMap {
                   case Outcome.Canceled() => stream.rstStream(H2Error.RefusedStream)
@@ -316,7 +314,7 @@ private[ember] class H2Client[F[_]: Async](
           .flatMap(h => h.headers.map(a => (a.name.toString.toLowerCase(), a.value, false)).toNel)
           .traverse(nel => stream.sendHeaders(nel, true))
       )).background
-      resp <- Resource.eval(stream.getResponse).map(_.covary[F].withBodyStream(stream.readBody))
+      resp <- Resource.eval(stream.getResponse).map(_.withBodyStream(stream.readBody))
     } yield resp
   }
 }

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -267,13 +267,14 @@ object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
       Response(Status.InternalServerError).putHeaders(org.http4s.headers.`Content-Length`.zero)
     // Effectful Handler - Perhaps a Logger
     // Will only arrive at this code if your HttpApp fails or the request receiving fails for some reason
-    def errorHandler[F[_]: Applicative]: Throwable => F[Response[F]] = { case (_: Throwable) =>
-      serverFailure.covary[F].pure[F]
+    def errorHandler[F[_]](implicit F: Applicative[F]): Throwable => F[Response[F]] = {
+      case (_: Throwable) =>
+        F.pure(serverFailure)
     }
 
     @deprecated("0.21.17", "Use errorHandler, default fallback of failure InternalServerFailure")
     def onError[F[_]]: Throwable => Response[F] = { (_: Throwable) =>
-      serverFailure.covary[F]
+      serverFailure
     }
 
     def onWriteFailure[F[_]: Applicative]

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -342,7 +342,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       resp <- httpApp
         .run(req.withAttributes(requestVault))
         .handleErrorWith(errorHandler)
-        .handleError(_ => serverFailure.covary[F])
+        .handleError(_ => serverFailure)
     } yield (req, resp, drain)
   }
 
@@ -488,7 +488,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                   Applicative[F].pure(None)
                 case err =>
                   errorHandler(err)
-                    .handleError(_ => serverFailure.covary[F])
+                    .handleError(_ => serverFailure)
                     .flatMap(send(socket)(None, _, idleTimeout, onWriteFailure))
                     .as(None)
               }

--- a/examples/ember-server-h2/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
+++ b/examples/ember-server-h2/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
@@ -43,8 +43,7 @@ object EmberServerH2Example extends IOApp {
             Response[F](Status.Ok).withEntity("Foo Endpoint").pure[F]
 
           case _ -> Root / "push-promise" =>
-            resp
-              .covary[F] // URI needs authority scheme, etc
+            resp // URI needs authority scheme, etc
               .withAttribute(
                 org.http4s.ember.core.h2.H2Keys.PushPromises,
                 Request[Pure](Method.GET, uri"https://localhost:8080/foo") :: Nil,

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
@@ -91,7 +91,7 @@ class GZipSuite extends Http4sSuite {
       .flatMap(n => Gen.buildableOfN[Vector[Array[Byte]], Array[Byte]](n, genByteArray))
     PropF.forAllF(genVector) { (vector: Vector[Array[Byte]]) =>
       val routes: HttpRoutes[IO] = HttpRoutes.of[IO] { case GET -> Root =>
-        Ok(Stream.emits(vector).covary[IO])
+        Ok(Stream.emits(vector))
       }
       val gzipRoutes: HttpRoutes[IO] = GZip(routes)
       val req: Request[IO] = Request[IO](Method.GET, uri"/")

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -155,7 +155,7 @@ Content-Type: application/pdf
       val request = Request[IO](
         method = Method.POST,
         uri = url,
-        entity = Entity(Stream.emit(body).covary[IO].through(text.utf8.encode)),
+        entity = Entity(Stream.emit(body).through(text.utf8.encode)),
         headers = header,
       )
 


### PR DESCRIPTION
After #5712 the `covary` method is less necessary. In some places we can just remove it. In the case of calls to `.pure[F]`, it happens that the syntax extensions fixes the type of the receiver object, so we need to use `F.pure` instead.  