### PR TITLE
Server - ContextRouter - Simpler Code 

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/Router.scala
+++ b/server/shared/src/main/scala/org/http4s/server/Router.scala
@@ -78,12 +78,10 @@ object Router {
       if (prefixPath.isEmpty) routes <+> acc
       else
         Kleisli { req =>
-          (
-            if (req.pathInfo.startsWith(prefixPath))
-              routes.local(translate(prefixPath)) <+> acc
-            else
-              acc
-          )(req)
+          if (req.pathInfo.startsWith(prefixPath))
+            routes(translate(prefixPath)(req)).orElse(acc(req))
+          else
+            acc(req)
         }
     }
 


### PR DESCRIPTION
Avoid use of `<+>` and `local` methods of Kleisli.