### PR TITLE
Server Metrics Middleware

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -352,6 +352,12 @@ lazy val server = libraryCrossProject("server")
         "org.http4s.server.middleware.GZip$TrailerGen"
       ), // private
       ProblemFilters.exclude[MissingClassProblem](
+        "org.http4s.server.middleware.Metrics$MetricsRequestContext"
+      ), // private
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.http4s.server.middleware.Metrics$MetricsRequestContext$"
+      ),
+      ProblemFilters.exclude[MissingClassProblem](
         "org.http4s.server.middleware.GZip$TrailerGen$"
       ), // private
       // the following are private[middleware]


### PR DESCRIPTION
- Extract local methods for main operations: starting the metric "timer", ending the metrics "timer". 
- Rename `MetricsRequestContext` to `MetricsEntry`, because they are not directly related to requests, and "context" is also used with "ContextRequest" and "ContextResponse", which can add confusion.