### PR TITLE
Use CE `Random.javaSecuritySecureRandom` instead of Java `SecureRandom`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -401,7 +401,7 @@ lazy val server = libraryCrossProject("server")
     ) ++ {
       if (tlIsScala3.value)
         Seq(
-          ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          ProblemFilters.exclude[DirectMissingMethodProblem](
             "org.http4s.server.middleware.CSRF.genTokenString"
           ),
           ProblemFilters.exclude[IncompatibleResultTypeProblem](

--- a/build.sbt
+++ b/build.sbt
@@ -403,7 +403,10 @@ lazy val server = libraryCrossProject("server")
         Seq(
           ProblemFilters.exclude[IncompatibleResultTypeProblem](
             "org.http4s.server.middleware.CSRF.genTokenString"
-          )
+          ),
+          ProblemFilters.exclude[IncompatibleResultTypeProblem](
+            "org.http4s.server.middleware.authentication.Nonce.random"
+          ),
         )
       else Nil
     },

--- a/build.sbt
+++ b/build.sbt
@@ -398,7 +398,15 @@ lazy val server = libraryCrossProject("server")
         .exclude[FinalClassProblem]("org.http4s.server.middleware.CORSPolicy$ExposeHeaders$In"),
       ProblemFilters
         .exclude[FinalClassProblem]("org.http4s.server.middleware.CORSPolicy$MaxAge$Some"),
-    ),
+    ) ++ {
+      if (tlIsScala3.value)
+        Seq(
+          ProblemFilters.exclude[IncompatibleResultTypeProblem](
+            "org.http4s.server.middleware.CSRF.genTokenString"
+          )
+        )
+      else Nil
+    },
   )
   .settings(BuildInfoPlugin.buildInfoScopedSettings(Test))
   .settings(BuildInfoPlugin.buildInfoDefaultSettings)

--- a/server/jvm/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -106,7 +106,7 @@ final class CSRF[F[_], G[_]] private[middleware] (
 
   /** Generate a new token */
   def generateToken[M[_]](implicit F: Sync[M]): M[CSRFToken] =
-    CSRF.genTokenString.to[M].flatMap(signToken[M])
+    CSRF.genTokenString[M].flatMap(signToken[M])
 
   /** Create a Response cookie from a signed CSRF token
     *
@@ -526,8 +526,8 @@ object CSRF {
     )
 
   /** Generate an unsigned CSRF token from a `SecureRandom` */
-  private[middleware] def genTokenString: SyncIO[String] =
-    CachedRandom.nextBytes(CSRFTokenLength).map(encodeHexString)
+  private[middleware] def genTokenString[F[_]: Sync]: F[String] =
+    CachedRandom.nextBytes(CSRFTokenLength).to[F].map(encodeHexString)
 
   /** Generate a signing Key for the CSRF token */
   def generateSigningKey[F[_]]()(implicit F: Sync[F]): F[javax.crypto.SecretKey] =

--- a/server/jvm/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -493,7 +493,8 @@ object CSRF {
     */
   private val InitialSeedArraySize: Int = 20
   private val CachedRandom: Random[SyncIO] =
-    Random.javaSecuritySecureRandom[SyncIO]
+    Random
+      .javaSecuritySecureRandom[SyncIO]
       .flatTap(_.nextBytes(InitialSeedArraySize))
       .unsafeRunSync()
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/Nonce.scala
@@ -16,19 +16,18 @@
 
 package org.http4s.server.middleware.authentication
 
-import org.http4s.crypto.unsafe.SecureRandom
+import cats.effect.SyncIO
+import cats.effect.std.Random
 
-import java.math.BigInteger
 import java.util.Date
 
-@deprecated("Contains mutable java.util.Date. Use NonceF.", "0.22.13")
+@deprecated("Contains mutable java.util.Date. Use NonceF.", "0.23.11")
 private[authentication] class Nonce(val created: Date, var nc: Int, val data: String)
 
-@deprecated("Untracked side effects. Use NonceF.", "0.22.13")
+@deprecated("Untracked side effects. Use NonceF.", "0.23.11")
 private[authentication] object Nonce {
-  val random = new SecureRandom()
+  val random: Random[SyncIO] = Random.javaSecuritySecureRandom[SyncIO].unsafeRunSync()
 
-  private def getRandomData(bits: Int): String = new BigInteger(bits, random).toString(16)
-
-  def gen(bits: Int): Nonce = new Nonce(new Date(), 0, getRandomData(bits))
+  def gen(bits: Int): Nonce =
+    new Nonce(new Date(), 0, NonceF.getRandomData[SyncIO](random, bits).unsafeRunSync())
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceF.scala
@@ -54,12 +54,14 @@ private[authentication] object NonceF {
     }
   }
 
+  def getRandomData[F[_]: Functor](random: Random[F], bits: Int): F[String] =
+    getRandomBits[F](random, bits).map(bytesToHex)
+
   def gen[F[_]](random: Random[F], bits: Int)(implicit
       F: Async[F]
   ): F[NonceF[F]] = for {
     nc <- Ref[F].of(0)
-    bits <- getRandomBits[F](random, bits)
-    data = bytesToHex(bits)
+    data <- getRandomData[F](random, bits)
     created <- F.monotonic
   } yield new NonceF(created, nc, data)
 }


### PR DESCRIPTION
The Java `SecureRandom` blocks. The JS `SecureRandom` was first shimmed in http4s-crypto, then in CE.

CE's `Random.javaSecuritySecureRandom` doesn't solve the blocking problem yet, but hopefully it will soon. In any case, this change lets us iterate in CE and reap the benefits everywhere.