### PR TITLE
Fix counting of current allocated connections in the blaze client pool manager

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/PoolManager.scala
@@ -26,6 +26,7 @@ import org.http4s.internal.CollectionCompat
 import org.log4s.getLogger
 
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -88,13 +89,13 @@ private final class PoolManager[F[_], A <: Connection[F]](
   private[this] val logger = getLogger
 
   private var isClosed = false
-  private var curTotal = 0
+  private val curTotal = new AtomicInteger(0)
   private val allocated = mutable.Map.empty[RequestKey, Int]
   private val idleQueues = mutable.Map.empty[RequestKey, mutable.Queue[PooledConnection]]
   private var waitQueue = mutable.Queue.empty[Waiting]
 
   private def stats =
-    s"curAllocated=$curTotal idleQueues.size=${idleQueues.size} waitQueue.size=${waitQueue.size} maxWaitQueueLimit=$maxWaitQueueLimit closed=${isClosed}"
+    s"curAllocated=${curTotal.intValue()} idleQueues.size=${idleQueues.size} waitQueue.size=${waitQueue.size} maxWaitQueueLimit=$maxWaitQueueLimit closed=${isClosed}"
 
   private def getConnectionFromQueue(key: RequestKey): F[Option[PooledConnection]] =
     F.delay {
@@ -109,13 +110,13 @@ private final class PoolManager[F[_], A <: Connection[F]](
 
   private def incrConnection(key: RequestKey): F[Unit] =
     F.delay {
-      curTotal += 1
+      curTotal.getAndIncrement()
       allocated.update(key, allocated.getOrElse(key, 0) + 1)
     }
 
   private def decrConnection(key: RequestKey): F[Unit] =
     F.delay {
-      curTotal -= 1
+      curTotal.getAndDecrement()
       val numConnections = allocated.getOrElse(key, 0)
       // If there are no more connections drop the key
       if (numConnections == 1) {
@@ -127,7 +128,7 @@ private final class PoolManager[F[_], A <: Connection[F]](
     }
 
   private def numConnectionsCheckHolds(key: RequestKey): Boolean =
-    curTotal < maxTotal && allocated.getOrElse(key, 0) < maxConnectionsPerRequestKey(key)
+    curTotal.intValue() < maxTotal && allocated.getOrElse(key, 0) < maxConnectionsPerRequestKey(key)
 
   private def isRequestExpired(t: Instant): Boolean = {
     val elapsed = Instant.now().toEpochMilli - t.toEpochMilli
@@ -233,7 +234,7 @@ private final class PoolManager[F[_], A <: Connection[F]](
               case None if maxConnectionsPerRequestKey(key) <= 0 =>
                 F.delay(callback(Left(NoConnectionAllowedException(key))))
 
-              case None if curTotal == maxTotal =>
+              case None if curTotal.intValue() == maxTotal =>
                 val keys = idleQueues.keys
                 if (keys.nonEmpty)
                   F.delay(
@@ -435,7 +436,7 @@ private final class PoolManager[F[_], A <: Connection[F]](
           idleQueues.foreach(_._2.foreach(_.conn.shutdown()))
           idleQueues.clear()
           allocated.clear()
-          curTotal = 0
+          curTotal.set(0)
         }
       }
     }


### PR DESCRIPTION
`-=`/`+=` operators aren't thread-safe. So this means we almost certainly* have issues in counting current allocated connections.

\* I haven't proof, just speaking from common sense.