### PR TITLE
Avoid Alternative-Guard

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Header.scala
+++ b/core/shared/src/main/scala/org/http4s/Header.scala
@@ -227,7 +227,7 @@ object Header {
     type Aux[A, G[_]] = Select[A] { type F[B] = G[B] }
 
     def fromRaw[A](h: Header.Raw)(implicit ev: Header[A, _]): Option[Ior[ParseFailure, A]] =
-      (h.name == Header[A].name).guard[Option].map(_ => Header[A].parse(h.value).toIor)
+      if (h.name == Header[A].name) Some(Header[A].parse(h.value).toIor) else None
 
     implicit def singleHeaders[A](implicit
         h: Header[A, Header.Single]

--- a/examples/ember-server-h2/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
+++ b/examples/ember-server-h2/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
@@ -55,7 +55,7 @@ object EmberServerH2Example extends IOApp {
         .orNotFound
     }
 
-    // This is commented since this is a different way to run 
+    // This is commented since this is a different way to run
     // a server. This is ALPN based h2, where the protocol is negotiated
     // in the TLS 1.3 handshake.
     // def testALPN[F[_]: Async: Parallel] = for {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
@@ -74,11 +74,12 @@ object Throttle {
                   val attemptSet: F[Option[TokenAvailability]] =
                     if (newTokenTotal >= 1)
                       setter((newTokenTotal - 1, currentTime))
-                        .map(_.guard[Option].as(TokenAvailable))
+                        .map(if (_) Some(TokenAvailable) else None)
                     else {
                       val timeToNextToken = refillEvery.toNanos - timeDifference
                       val successResponse = TokenUnavailable(timeToNextToken.nanos.some)
-                      setter((newTokenTotal, currentTime)).map(_.guard[Option].as(successResponse))
+                      setter((newTokenTotal, currentTime))
+                        .map(if (_) Some(successResponse) else None)
                     }
 
                   attemptSet


### PR DESCRIPTION
The `guard` method of the `Alternative` typeclass is less known that the Scala `if-then-else`