### PR TITLE
Remove ignoring some files for `doctest`

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -87,8 +87,6 @@ object Http4sPlugin extends AutoPlugin {
         )
       },
     doctestTestFramework := DoctestTestFramework.Munit,
-    // Remove after https://github.com/tkawachi/sbt-doctest/issues/300
-    doctestIgnoreRegex := Some(".*-.*.scala"),
   )
 
   def extractApiVersion(version: String) = {


### PR DESCRIPTION
The recent `sbt-doctest` version is backed by a fix.