### PR TITLE
Use `Content-Length` instead of `Long` to represent entity length

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/Http4sClientDsl.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Http4sClientDsl.scala
@@ -19,7 +19,6 @@ package client
 package dsl
 
 import cats.Applicative
-import org.http4s.headers.`Content-Length`
 
 trait Http4sClientDsl[F[_]] {
   implicit def http4sClientSyntaxMethod(method: Method): MethodOps[F] =
@@ -50,13 +49,8 @@ class MethodOps[F[_]](private val method: Method) extends AnyVal {
   final def apply[A](body: A, uri: Uri, headers: Header.ToRaw*)(implicit
       w: EntityEncoder[F, A]
   ): Request[F] = {
-    val h = w.headers ++ Headers(headers: _*)
     val entity = w.toEntity(body)
-    val newHeaders = entity.length
-      .map { l =>
-        `Content-Length`.fromLong(l).fold(_ => h, c => h.put(c))
-      }
-      .getOrElse(h)
+    val newHeaders = w.headers.put(headers).put(entity.length)
     Request(method = method, uri = uri, headers = newHeaders, entity = entity)
   }
 }

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -84,17 +84,7 @@ sealed trait Message[F[_]] extends Media[F] { self =>
   def withEntity[T](b: T)(implicit w: EntityEncoder[F, T]): Self = {
     val entity = w.toEntity(b)
     val hs = entity.length match {
-      case Some(l) =>
-        `Content-Length`
-          .fromLong(l)
-          .fold[Headers](
-            _ => {
-              Message.logger.warn(s"Attempt to provide a negative content length of $l")
-              w.headers
-            },
-            cl => Headers(cl, w.headers.headers),
-          )
-
+      case Some(cl) => Headers(cl, w.headers.headers)
       case None => w.headers
     }
     change(entity = entity, headers = headers ++ hs)

--- a/core/shared/src/main/scala/org/http4s/headers/Content-Length.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Content-Length.scala
@@ -17,6 +17,8 @@
 package org.http4s
 package headers
 
+import cats.Eq
+import org.http4s.headers.`Content-Length`.unsafeFromLong
 import org.http4s.parser.AdditionalRules
 import org.typelevel.ci._
 
@@ -27,9 +29,12 @@ import org.typelevel.ci._
   *
   * @param length the length
   */
-final case class `Content-Length`(length: Long) {
+final case class `Content-Length`(length: Long) extends AnyVal {
   def modify(f: Long => Long): Option[`Content-Length`] =
     `Content-Length`.fromLong(f(length)).toOption
+
+  def +(that: `Content-Length`): `Content-Length` = `Content-Length`(length + that.length)
+  def addUnchecked(toAdd: Long): `Content-Length` = unsafeFromLong(length + toAdd)
 }
 
 object `Content-Length` {
@@ -56,4 +61,5 @@ object `Content-Length` {
       parse,
     )
 
+  implicit val eqInstance: Eq[`Content-Length`] = Eq.by(_.length)
 }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/ResponseGenerator.scala
@@ -32,7 +32,7 @@ trait ResponseGenerator extends Any {
 
 private[impl] object ResponseGenerator {
   def addEntityLength[G[_]](entity: Entity[G], headers: Headers): Headers =
-    headers.put(entity.length.flatMap(x => `Content-Length`.fromLong(x).toOption))
+    headers.put(entity.length)
 }
 
 /**  Helper for the generation of a [[org.http4s.Response]] which will not contain a body

--- a/laws/src/main/scala/org/http4s/laws/EntityEncoderLaws.scala
+++ b/laws/src/main/scala/org/http4s/laws/EntityEncoderLaws.scala
@@ -33,7 +33,7 @@ trait EntityEncoderLaws[F[_], A] {
       entity <- F.pure(encoder.toEntity(a))
       body <- entity.body.compile.toVector
       bodyLength = body.size.toLong
-      contentLength = entity.length
+      contentLength = entity.length.map(_.length)
     } yield contentLength.fold(true)(_ === bodyLength)) <-> F.pure(true)
 
   def noContentLengthInStaticHeaders: Boolean =

--- a/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -153,7 +153,7 @@ class EntityEncoderSpec extends Http4sSuite {
 
   {
     implicit def entityEq: Eq[Entity[Id]] =
-      Eq.by[Entity[Id], (Option[Long], Vector[Byte])] { entity =>
+      Eq.by[Entity[Id], (Option[`Content-Length`], Vector[Byte])] { entity =>
         (entity.length, entity.body.compile.toVector)
       }
 


### PR DESCRIPTION
Also made `Content-Length` a value class, so it shouldn't be any more costly.