### PR TITLE
Ignore `scala-lang` updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -32,6 +32,7 @@ updates.ignore = [
   { groupId = "org.http4s", artifactId = "http4s-crypto" },
   { groupId = "org.slf4j", artifactId = "slf4j-api" },
   { groupId = "org.scala-js" },
+  { groupId = "org.scala-lang" },
   { groupId = "org.eclipse.jetty" },
   { groupId = "org.eclipse.jetty.http2" },
   { groupId = "com.eed3si9n", artifactId = "sbt-buildinfo" },


### PR DESCRIPTION
We will get updates from 0.23.