### PR TITLE
Remove `http4s.EmptyBody`

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
@@ -232,9 +232,9 @@ private class Http2NodeStage[F[_]](
     if (error.length > 0)
       closePipeline(Some(Http2Exception.PROTOCOL_ERROR.rst(streamId, error)))
     else {
-      val body = if (endStream) EmptyBody else getBody(contentLength)
+      val entity = if (endStream) Entity.Empty else Entity(getBody(contentLength))
       val hs = Headers(headers.result())
-      val req = Request(method, path, HttpVersion.`HTTP/2`, hs, Entity(body), attributes())
+      val req = Request(method, path, HttpVersion.`HTTP/2`, hs, entity, attributes())
       executionContext.execute(new Runnable {
         def run(): Unit = {
           val action = F

--- a/core/shared/src/main/scala/org/http4s/package.scala
+++ b/core/shared/src/main/scala/org/http4s/package.scala
@@ -26,8 +26,6 @@ package object http4s {
 
   type EntityBody[+F[_]] = Stream[F, Byte]
 
-  val EmptyBody: EntityBody[Nothing] = Stream.empty[Nothing]
-
   val ApiVersion: Http4sVersion = Http4sVersion(BuildInfo.apiVersion._1, BuildInfo.apiVersion._2)
 
   type DecodeResult[F[_], A] = EitherT[F, DecodeFailure, A]

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -451,7 +451,7 @@ private[ember] object Parser {
           }
         }
       } else {
-        (EmptyBody.covary[F], (Some(buffer): Option[Array[Byte]]).pure[F]).pure[F]
+        (Stream.empty.covaryAll[F, Byte], Option(buffer).pure[F]).pure[F]
       }
 
     def parseUnknownBody[F[_]: Concurrent](

--- a/server/shared/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSuite.scala
@@ -67,7 +67,7 @@ class ChunkAggregatorSuite extends Http4sSuite {
     }
 
   test("handle an empty body") {
-    checkRoutesResponse(httpRoutes(EmptyBody, Nil)) { response =>
+    checkRoutesResponse(httpRoutes(Stream.empty[Nothing], Nil)) { response =>
       response.body.compile.toVector.map(_.isEmpty && response.contentLength.isEmpty)
     }.assert
   }


### PR DESCRIPTION
`EmptyBody` clashes a bit with the current `Entity` model in the sense that it's an implementation detail of `Entity.Default`, so it should be gone from public API (and overall IMO).