### PR TITLE
NonNegative

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Media.scala
+++ b/core/shared/src/main/scala/org/http4s/Media.scala
@@ -41,7 +41,7 @@ trait Media[+F[_]] {
   final def contentType: Option[`Content-Type`] =
     headers.get[`Content-Type`]
 
-  final def contentLength: Option[Long] =
+  final def contentLength: Option[NonNegative] =
     headers.get[`Content-Length`].map(_.length)
 
   final def charset: Option[Charset] =

--- a/core/shared/src/main/scala/org/http4s/NonNegative.scala
+++ b/core/shared/src/main/scala/org/http4s/NonNegative.scala
@@ -1,0 +1,56 @@
+package org.http4s
+
+import java.io.Serializable
+import scala.math.BigInt
+
+sealed abstract class NonNegative extends Serializable {
+  import NonNegative._
+
+  def toInt: Option[Int]
+  def toLong: Option[Long]
+  def toBigInt: BigInt
+
+  override def hashCode = toBigInt.hashCode
+
+  override def equals(that: Any) = (this, that) match {
+    case (LongNonNegative(x), LongNonNegative(y)) => x == y
+    case (BigIntNonNegative(x), BigIntNonNegative(y)) => x == y
+    case (x, y: NonNegative) => x.toBigInt == y.toBigInt
+    case (_, _) => false
+  }
+}
+
+object NonNegative {
+  val zero: NonNegative =
+    fromLong(0L).get
+
+  def fromLong(value: Long): Option[NonNegative] =
+    if ((value >= 0) && (value <= Long.MaxValue)) Some(LongNonNegative(value))
+    else None
+
+  private case class LongNonNegative(value: Long) extends NonNegative {
+    def toInt: Option[Int] =
+      if (value < Int.MaxValue) Some(value.toInt) else None
+    def toLong: Option[Long] =
+      Some(value)
+    def toBigInt: BigInt =
+      BigInt(value)
+    override def toString =
+      value.toString
+  }
+
+  def fromBigInt(value: BigInt): Option[NonNegative] =
+    if (value >= BigInt(0)) Some(BigIntNonNegative(value))
+    else None
+
+  private case class BigIntNonNegative(value: BigInt) extends NonNegative {
+    def toInt: Option[Int] =
+      if (value.isValidInt) Some(value.toInt) else None
+    def toLong: Option[Long] =
+      if (value.isValidLong) Some(value.toLong) else None
+    def toBigInt: BigInt =
+      value
+    override def toString: String =
+      value.toString
+  }
+}

--- a/core/shared/src/main/scala/org/http4s/headers/Content-Length.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Content-Length.scala
@@ -27,17 +27,19 @@ import org.typelevel.ci._
   *
   * @param length the length
   */
-final case class `Content-Length`(length: Long) {
-  def modify(f: Long => Long): Option[`Content-Length`] =
-    `Content-Length`.fromLong(f(length)).toOption
+final case class `Content-Length`(length: NonNegative) {
+  // def modify(f: Long => Long): Option[`Content-Length`] =
+  //   `Content-Length`.fromLong(f(length)).toOption
 }
 
 object `Content-Length` {
-  val zero: `Content-Length` = apply(0)
+  val zero: `Content-Length` = apply(NonNegative.zero)
 
   def fromLong(length: Long): ParseResult[`Content-Length`] =
-    if (length >= 0L) ParseResult.success(apply(length))
-    else ParseResult.fail("Invalid Content-Length", length.toString)
+  NonNegative.fromLong(length) match {
+    case Some(nn) => ParseResult.success(`Content-Length`(nn))
+    case None => ParseResult.fail("Invalid Content-Length", length.toString)
+  }
 
   def unsafeFromLong(length: Long): `Content-Length` =
     fromLong(length).fold(throw _, identity)
@@ -52,7 +54,7 @@ object `Content-Length` {
   implicit val headerInstance: Header[`Content-Length`, Header.Single] =
     Header.createRendered(
       name,
-      _.length,
+      _.length.toString,
       parse,
     )
 


### PR DESCRIPTION
I do not stand behind this.  This is for discussion

---

Sketch of the non-negative type I half-heartedly advocated for in #6286.  This is necessary for the strictest standards compliance, but is quite impractical.  It matches everything with `1*DIGIT` in the spec:

* Max-Forwards: if you want to allow ten quintillion instead of nine quintillion

* Content-Length.  Again, should not be more than nine quintillion, yet we:
   > MUST anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows or precision loss due to integer conversion

* Retry-After: in case we want to tell people to come back in 30 billion years instead of 29

* Range specifiers: makes sense that they can refer to whatver is in Content-Length

Without this, we fail to parse well-formed headers, but no backend can reasonably interpret these values that exceed `Long.MaxValue`.  I think this proposal is impractical.  

We could prevent invalid constructions and cover the practical space with a `ULong` (see Spire for a robust one).  But unsigned long is not a standard JVM type, and we'll be doing range checks all over the backends to make sure nobody used that sixty-fourth bit.

We could also create a 63-bit Long, which is just a refined type.  This might be the `PosLong` that @danicheg refers to.  I think it's that or #6286.
