### PR TITLE
EntityEncoder - Avoid implicit encoders for streams.

### DIFF
--- a/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientBase.scala
+++ b/blaze-client/src/test/scala/org/http4s/blaze/client/BlazeClientBase.scala
@@ -83,7 +83,8 @@ trait BlazeClientBase extends Http4sSuite {
         RoutesToHandlerAdapter(
           HttpRoutes.of[IO] {
             case Method.GET -> Root / "infinite" =>
-              Response[IO](Ok).withEntity(Stream.emit[IO, String]("a" * 8 * 1024).repeat).pure[IO]
+              val entity: Stream[IO, String] = Stream.emit("a" * 8 * 1024).repeat
+              Response[IO](Ok).withEntity(entity)(EntityEncoder.streamEncoder[IO, String]).pure[IO]
 
             case _ @(Method.GET -> path) =>
               GetRoutes.getPaths.getOrElse(path.toString, NotFound())

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/ServerTestRoutes.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/ServerTestRoutes.scala
@@ -136,7 +136,8 @@ object ServerTestRoutes extends Http4sDsl[IO] {
           Ok("get")
 
         case req if req.method == Method.GET && req.pathInfo == path"/chunked" =>
-          Ok(eval(IO.cede *> IO("chu")) ++ eval(IO.cede *> IO("nk")))
+          val entity = eval(IO.cede *> IO("chu")) ++ eval(IO.cede *> IO("nk"))
+          Ok(entity)(Sync[IO], EntityEncoder.streamEncoder)
 
         case req if req.method == Method.POST && req.pathInfo == path"/post" =>
           Ok("post")
@@ -145,7 +146,7 @@ object ServerTestRoutes extends Http4sDsl[IO] {
           Ok("Foo", `Transfer-Encoding`(TransferCoding.chunked))
 
         case req if req.method == Method.POST && req.pathInfo == path"/echo" =>
-          Ok(emit("post") ++ req.bodyText)
+          Ok(emit("post") ++ req.bodyText)(Sync[IO], EntityEncoder.streamEncoder)
 
         // Kind of cheating, as the real NotModified response should have a Date header representing the current? time?
         case req if req.method == Method.GET && req.pathInfo == path"/notmodified" =>

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -153,10 +153,10 @@ trait CirceInstances extends JawnInstances {
   ): EntityEncoder[F, A] =
     jsonEncoderWithPrinter[F](printer).contramap[A](encoder.apply)
 
-  implicit def streamJsonArrayEncoder[F[_]]: EntityEncoder[F, Stream[F, Json]] =
+  def streamJsonArrayEncoder[F[_]]: EntityEncoder[F, Stream[F, Json]] =
     streamJsonArrayEncoderWithPrinter(defaultPrinter)
 
-  implicit def streamJsonArrayDecoder[F[_]: Concurrent]: EntityDecoder[F, Stream[F, Json]] =
+  def streamJsonArrayDecoder[F[_]: Concurrent]: EntityDecoder[F, Stream[F, Json]] =
     EntityDecoder.decodeBy(MediaType.application.json) { media =>
       DecodeResult.successT(media.body.chunks.through(unwrapJsonArray))
     }

--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -138,13 +138,14 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   }
 
   test("stream json array encoder should write compact JSON") {
-    writeToString(jsons).assertEquals("""[{"test1":"CirceSupport"},{"test2":"CirceSupport"}]""")
+    val actual = writeToString(jsons)(streamJsonArrayEncoder[IO])
+    actual.assertEquals("""[{"test1":"CirceSupport"},{"test2":"CirceSupport"}]""")
   }
 
   test("stream json array encoder should write JSON according to custom encoders") {
     val custom = CirceInstances.withPrinter(Printer.spaces2).build
     import custom._
-    writeToString(jsons).assertEquals("""[{
+    writeToString(jsons)(streamJsonArrayEncoder[IO]).assertEquals("""[{
           |  "test1" : "CirceSupport"
           |},{
           |  "test2" : "CirceSupport"
@@ -160,7 +161,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   }
 
   test("stream json array encoder should write a valid JSON array for an empty stream") {
-    writeToString[Stream[IO, Json]](Stream.empty).assertEquals("[]")
+    writeToString[Stream[IO, Json]](Stream.empty)(streamJsonArrayEncoder[IO]).assertEquals("[]")
   }
 
   private val foos = Stream(

--- a/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
+++ b/client/shared/src/test/scala/org/http4s/client/ClientRouteTestBattery.scala
@@ -99,6 +99,7 @@ abstract class ClientRouteTestBattery(name: String) extends Http4sSuite with Htt
     serverClient().flatMap { case (server, client) =>
       val address = server().addresses.head
       val uri = Uri.fromString(s"http://$address/echo").yolo
+      implicit val enq = EntityEncoder.streamEncoder[IO, String]
       val req = POST(Stream.emits("This is chunked.".toSeq.map(_.toString)).covary[IO], uri)
       val body = client().expect[String](req)
       body.assertEquals("This is chunked.")

--- a/client/shared/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
@@ -137,7 +137,7 @@ class RetrySuite extends Http4sSuite {
         })
         val req = Request[IO](method, uri"http://localhost/status-from-body")
           .withHeaders(headers)
-          .withEntity(body)
+          .withEntity(body)(EntityEncoder.streamEncoder[IO, String])
         val policy = RetryPolicy[IO](
           (attempts: Int) =>
             if (attempts >= 2) None

--- a/client/shared/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
+++ b/client/shared/src/test/scala/org/http4s/client/testroutes/GetRoutes.scala
@@ -40,9 +40,10 @@ object GetRoutes {
       LargePath -> Response[IO](Ok)
         .withEntity("a" * 8 * 1024)
         .pure[IO], // must be at least as large as the buffers used by the client
-      ChunkedPath -> Response[IO](Ok)
-        .withEntity(Stream.emits("chunk".toSeq.map(_.toString)).covary[IO])
-        .pure[IO],
+      ChunkedPath -> {
+        val entity: Stream[IO, String] = Stream.emits("chunk".toSeq.map(_.toString))
+        Response[IO](Ok).withEntity(entity)(EntityEncoder.streamEncoder[IO, String]).pure[IO]
+      },
       DelayedPath ->
         F.sleep(1.second) *>
         Response[IO](Ok).withEntity("delayed path").pure[IO],

--- a/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
@@ -122,7 +122,7 @@ object EntityEncoder {
     * bodies in advance.  As such, it does not calculate the Content-Length in
     * advance.  This is for use with chunked transfer encoding.
     */
-  implicit def streamEncoder[F[_], A](implicit
+  def streamEncoder[F[_], A](implicit
       W: EntityEncoder[F, A]
   ): EntityEncoder[F, Stream[F, A]] =
     new EntityEncoder[F, Stream[F, A]] {

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/FileHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/FileHttpEndpoint.scala
@@ -26,6 +26,6 @@ class FileHttpEndpoint[F[_]: Sync](fileService: FileService[F]) extends Http4sDs
 
   val service: HttpRoutes[F] = HttpRoutes.of[F] {
     case GET -> Root / "dirs" :? DepthQueryParamMatcher(depth) =>
-      Ok(fileService.homeDirectories(depth))
+      Ok(fileService.homeDirectories(depth))(Sync[F], EntityEncoder.streamEncoder)
   }
 }

--- a/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/MultipartHttpEndpoint.scala
+++ b/examples/blaze/src/main/scala/com/example/http4s/blaze/demo/server/endpoints/MultipartHttpEndpoint.scala
@@ -34,9 +34,12 @@ class MultipartHttpEndpoint[F[_]: Concurrent](fileService: FileService[F]) exten
         def filterFileTypes(part: Part[F]): Boolean =
           part.headers.headers.exists(_.value.contains("filename"))
 
-        val stream = response.parts.filter(filterFileTypes).traverse(fileService.store)
+        val stream = response.parts
+          .filter(filterFileTypes)
+          .traverse(fileService.store)
+          .map(_ => s"Multipart file parsed successfully > ${response.parts}")
 
-        Ok(stream.map(_ => s"Multipart file parsed successfully > ${response.parts}"))
+        Ok(stream)(Concurrent[F], EntityEncoder.streamEncoder)
       }
   }
 }

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -59,7 +59,7 @@ class ExampleService[F[_]](implicit F: Async[F]) extends Http4sDsl[F] {
 
       case GET -> Root / "streaming" =>
         // It's also easy to stream responses to clients
-        Ok(dataStream(100))
+        Ok(dataStream(100))(F, EntityEncoder.streamEncoder)
 
       case req @ GET -> Root / "ip" =>
         // It's possible to define an EntityEncoder anywhere so you're not limited to built in types

--- a/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -34,6 +34,9 @@ import java.nio.charset.StandardCharsets
 
 class EntityEncoderSpec extends Http4sSuite {
   {
+    implicit def ofStream[A](implicit A: EntityEncoder[IO, A]): EntityEncoder[IO, Stream[IO, A]] =
+      EntityEncoder.streamEncoder[IO, A]
+
     test("EntityEncoder should render streams") {
       val helloWorld: Stream[IO, String] = Stream("hello", "world")
       writeToString(helloWorld).assertEquals("helloworld")


### PR DESCRIPTION
Streams of items can be encoded in many ways. The Core defines a simple definition, which is to append without separators the encoding of each item into the body. This may cause some problems. On the other hand, an encoding to Json may choose to wrap items in a Json array, as if the stream was just a list sent in parts.

Implicits should only be used when the mapping from type to implementation is _almost_ unique. Since this is not the case for encoding streams, it may be best to avoid implicit defs, and let users of library explicitly choose. Otherwise the implicit resolution can blindside developers. 

_Note_: this change is not source-compatible, but should be binary compatible.