### PR TITLE
Deprecate Entity Apply

### DIFF
--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -206,7 +206,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     (for {
       stream <- streamJsonArrayDecoder[IO].decode(
         Media(
-          Entity(
+          Entity.stream(
             Stream.fromIterator[IO](
               """[{"test1":"CirceSupport"},{"test2":"CirceSupport"}]""".getBytes.iterator,
               128,
@@ -234,7 +234,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   ) {
     val result = streamJsonArrayDecoder[IO].decode(
       Media(
-        Entity(
+        Entity.stream(
           Stream.fromIterator[IO](
             """[{"test1":"CirceSupport"},{"test2":"CirceSupport"}]""".getBytes.iterator,
             128,
@@ -250,7 +250,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
   test("stream json array decoder should not fail on improper JSON") {
     val result = streamJsonArrayDecoder[IO].decode(
       Media(
-        Entity(
+        Entity.stream(
           Stream.fromIterator[IO](
             """[{"test1":"CirceSupport"},{"test2":CirceSupport"}]""".getBytes.iterator,
             128,
@@ -267,7 +267,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     (for {
       stream <- streamJsonArrayDecoder[IO].decode(
         Media(
-          Entity(
+          Entity.stream(
             Stream.fromIterator[IO](
               """[{"test1":"CirceSupport"},{"test2":CirceSupport"}]""".getBytes.iterator,
               128,

--- a/client-testkit/jvm/src/main/scala/org/http4s/client/testkit/scaffold/RoutesToNettyAdapter.scala
+++ b/client-testkit/jvm/src/main/scala/org/http4s/client/testkit/scaffold/RoutesToNettyAdapter.scala
@@ -74,7 +74,7 @@ private[http4s] class RoutesToHandlerAdapter[F[_]](
         bodyQueue <- Queue.unbounded[F, Option[Chunk[Byte]]]
         _ <- requestBodyQueue.set(bodyQueue)
         body = fs2.Stream.fromQueueNoneTerminatedChunk(bodyQueue)
-        http4sRequest = http4s.Request(method, uri, headers = headers, entity = Entity(body))
+        http4sRequest = http4s.Request(method, uri, headers = headers, entity = Entity.stream(body))
         _ <- processRequest(ctx, http4sRequest).start
       } yield ()
     )

--- a/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
+++ b/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
@@ -152,7 +152,7 @@ sealed abstract class JavaNetClientBuilder[F[_]] private (
             .toList
         )
       )
-    } yield Response(status = status, headers = headers, entity = Entity(readBody(conn)))
+    } yield Response(status = status, headers = headers, entity = Entity.stream(readBody(conn)))
 
   private def timeoutMillis(d: Duration): Int =
     d match {

--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -265,7 +265,7 @@ object Client {
           case resp: Response[F] =>
             Resource.pure(resp)
         }
-      case Entity.Default(_, _) =>
+      case Entity.Streamed(_, _) =>
         message match {
           case req: Request[F] =>
             Resource.eval(Ref[F].of(false)).flatMap { disposed =>

--- a/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -78,7 +78,7 @@ object RequestLogger {
       else
         Resource.suspend {
           req.entity match {
-            case Entity.Default(_, _) =>
+            case Entity.Streamed(_, _) =>
               (F.ref(false), F.ref(Vector.empty[Chunk[Byte]])).mapN { case (hasLogged, vec) =>
                 val newBody = Stream.eval(vec.get).flatMap(v => Stream.emits(v)).unchunks
 

--- a/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -80,7 +80,7 @@ object ResponseLogger {
         Resource.eval(logMessage(response).as(response))
       else
         response.entity match {
-          case Entity.Default(_, _) =>
+          case Entity.Streamed(_, _) =>
             Resource.suspend {
               Ref[F].of(Vector.empty[Chunk[Byte]]).map { vec =>
                 val dumpChunksToVec: Pipe[F, Byte, Nothing] =

--- a/core/js/src/main/scala/org/http4s/nodejs/IncomingMessage.scala
+++ b/core/js/src/main/scala/org/http4s/nodejs/IncomingMessage.scala
@@ -84,7 +84,7 @@ private[http4s] object IncomingMessage {
     }
 
     private def body[F[_]: Async] =
-      Entity.Default(
+      Entity.Streamed(
         Stream.resource(fs2.io.suspendReadableAndRead()(incomingMessage)).flatMap(_._2),
         None,
       )

--- a/core/shared/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityDecoder.scala
@@ -206,7 +206,7 @@ object EntityDecoder {
   /** Helper method which simply gathers the body into a single Chunk */
   def collectBinary[F[_]: Concurrent](m: Media[F]): DecodeResult[F, Chunk[Byte]] = {
     val chunkF = m.entity match {
-      case Entity.Default(body, _) =>
+      case Entity.Streamed(body, _) =>
         body.chunks.compile.to(Chunk).map(_.flatten)
 
       case Entity.Strict(b) =>
@@ -222,7 +222,7 @@ object EntityDecoder {
   /** Helper method which simply gathers the body into a single ByteVector */
   private def collectByteVector[F[_]: Concurrent](m: Media[F]): DecodeResult[F, ByteVector] = {
     val byteVectorF = m.entity match {
-      case Entity.Default(body, _) =>
+      case Entity.Streamed(body, _) =>
         body.compile.to(ByteVector)
 
       case Entity.Strict(b) =>
@@ -248,7 +248,7 @@ object EntityDecoder {
     new EntityDecoder[F, T] {
       override def decode(m: Media[F], strict: Boolean): DecodeResult[F, T] =
         m.entity match {
-          case Entity.Default(body, _) =>
+          case Entity.Streamed(body, _) =>
             DecodeResult(body.compile.drain *> F.raiseError(t))
 
           case Entity.Strict(_) | Entity.Empty =>
@@ -388,7 +388,7 @@ object EntityDecoder {
   implicit def void[F[_]: Concurrent]: EntityDecoder[F, Unit] =
     EntityDecoder.decodeBy(MediaRange.`*/*`) { msg =>
       msg.entity match {
-        case Entity.Default(body, _) =>
+        case Entity.Streamed(body, _) =>
           DecodeResult.success(body.compile.drain)
 
         case Entity.Strict(_) | Entity.Empty =>

--- a/core/shared/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/shared/src/main/scala/org/http4s/StaticFile.scala
@@ -119,12 +119,8 @@ object StaticFile {
                 case other => throw other
               },
               f = { inputStream =>
-                Some(
-                  Response(
-                    headers = headers,
-                    entity = Entity(readInputStream[F](F.pure(inputStream), DefaultBufferSize)),
-                  )
-                )
+                val e = Entity.stream(readInputStream[F](F.pure(inputStream), DefaultBufferSize))
+                Some(Response(headers = headers, entity = e))
               },
             )
         } else
@@ -210,7 +206,7 @@ object StaticFile {
 
                   val r = Response(
                     headers = hs,
-                    entity = Entity(body),
+                    entity = Entity.stream(body),
                     attributes = Vault.empty.insert(staticPathKey, f),
                   )
 

--- a/core/shared/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/Logger.scala
@@ -58,7 +58,7 @@ object Logger {
             Some(F.pure(bv.decodeStringLenient()(charset)))
           } else
             Some(F.pure(bv.toHex))
-        case Entity.Default(_, _) =>
+        case Entity.Streamed(_, _) =>
           val string =
             if (!isBinary || isJson)
               message.bodyText.compile.string

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartEncoder.scala
@@ -27,7 +27,7 @@ private[http4s] class MultipartEncoder[F[_]] extends EntityEncoder[F, Multipart[
   def headers: Headers = Headers.empty
 
   def toEntity(mp: Multipart[F]): Entity[F] =
-    Entity(renderParts(mp.boundary)(mp.parts), None)
+    Entity.stream(renderParts(mp.boundary)(mp.parts), None)
 
   val dash: String = "--"
 

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClient.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClient.scala
@@ -47,7 +47,7 @@ final class EmberClient[F[_]] private[client] (
       resp.entity match {
         case Entity.Empty | Entity.Strict(_) =>
           F.pure(UnexpectedStatus(resp.status, req.method, req.uri))
-        case Entity.Default(body, _) =>
+        case Entity.Streamed(body, _) =>
           body.compile.drain.as(UnexpectedStatus(resp.status, req.method, req.uri))
       }
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -149,7 +149,7 @@ private[ember] object Encoder {
         Stream.chunk(initSectionChunk) ++ req.body.through(ChunkedEncoding.encode[F])
       else {
         req.entity match {
-          case Entity.Default(body, _) =>
+          case Entity.Streamed(body, _) =>
             (Stream.chunk(initSectionChunk) ++ body)
               .chunkMin(writeBufferSize)
               .unchunks

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -564,8 +564,7 @@ private[ember] object Parser {
             // If the remaining bytes for the body have not yet been read, close the connection.
             // followup: Check if there are bytes immediately available without blocking
             val drain: Drain[F] = state.get
-
-            (Entity(body), drain)
+            (Entity.stream(body), drain)
           }
         }
       } else
@@ -593,7 +592,7 @@ private[ember] object Parser {
 
         val drain: Drain[F] = (None: Option[Array[Byte]]).pure[F]
 
-        (Entity(body), drain)
+        (Entity.stream(body), drain)
       }
 
     final case class BodyAlreadyConsumedError()

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -122,7 +122,7 @@ private[ember] object H2Server {
                   Applicative[F].pure(ByteVector.empty)
                 case Entity.Strict(bv) =>
                   Applicative[F].pure(bv)
-                case Entity.Default(body, _) =>
+                case Entity.Streamed(body, _) =>
                   body.compile.to(ByteVector)
               }
             val fres: F[Response[F]] = bb.map { bv =>
@@ -196,8 +196,7 @@ private[ember] object H2Server {
         bv = req.entity match {
           case Entity.Empty => ByteVector.empty
           case Entity.Strict(bv) => bv
-          case Entity.Default(body, _) =>
-            body.compile.to(ByteVector)
+          case Entity.Streamed(body, _) => body.compile.to(ByteVector)
         }
         _ <- s.readBuffer.offer(Either.right(bv))
         _ <- s.writeBlock.complete(Either.unit)

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -150,7 +150,7 @@ class EncoderSuite extends Http4sSuite {
   }
 
   test("reqToBytes should encode a no body request correctly with stream") {
-    val req = Request[IO](Method.POST, entity = Entity.Default(Stream.chunk(Chunk.empty), None))
+    val req = Request[IO](Method.POST, entity = Entity.Streamed(Stream.chunk(Chunk.empty), None))
 
     val expected =
       """POST / HTTP/1.1
@@ -164,7 +164,7 @@ class EncoderSuite extends Http4sSuite {
   }
 
   test("respToBytes should encode a no body response correctly with stream") {
-    val resp = Response[IO](Status.Ok, entity = Entity.Default(Stream.chunk(Chunk.empty), None))
+    val resp = Response[IO](Status.Ok, entity = Entity.Streamed(Stream.chunk(Chunk.empty), None))
 
     val expected =
       """HTTP/1.1 200 OK

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -370,7 +370,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
         case Entity.Empty =>
           val (initSection, _) = Encoder.initSection(resp)
           timeoutMaybe(socket.write(Chunk.array(initSection)), idleTimeout)
-        case Entity.Default(_, _) =>
+        case Entity.Streamed(_, _) =>
           Encoder
             .respToBytes[F](resp)
             .through(_.chunks.foreach(c => timeoutMaybe(socket.write(c), idleTimeout)))

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -869,11 +869,11 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
 
     val chunkedEntityGen =
       http4sTestingGenForPureByteStream
-        .map(Entity(_))
+        .map(Entity.stream(_))
 
     val chunkedWithKnowingLengthGen =
       genByteStreamWithKnowingSize.map { case (body, size) =>
-        Entity(body, Some(size.toLong))
+        Entity.stream(body, Some(size.toLong))
       }
 
     Arbitrary(
@@ -996,7 +996,7 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
         httpVersion <- getArbitrary[HttpVersion]
         headers <- getArbitrary[Headers]
         body <- http4sTestingGenForPureByteStream
-      } yield try Request(method, uri, httpVersion, headers, Entity(body))
+      } yield try Request(method, uri, httpVersion, headers, Entity.stream(body))
       catch {
         case t: Throwable => t.printStackTrace(); throw t
       }
@@ -1022,7 +1022,7 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
         httpVersion <- getArbitrary[HttpVersion]
         headers <- getArbitrary[Headers]
         body <- http4sTestingGenForPureByteStream
-      } yield Response(status, httpVersion, headers, Entity(body))
+      } yield Response(status, httpVersion, headers, Entity.stream(body))
     }
 
   implicit val http4sTestingArbitraryForSegment: Arbitrary[Uri.Path.Segment] =

--- a/server/shared/src/main/scala/org/http4s/server/middleware/BodyCache.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/BodyCache.scala
@@ -74,7 +74,7 @@ object BodyCache {
         true
       case Entity.Strict(chunk) =>
         chunk.isEmpty
-      case Entity.Default(_, _) =>
+      case Entity.Streamed(_, _) =>
         req.contentLength.contains(0L)
     }
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ChunkAggregator.scala
@@ -55,7 +55,7 @@ object ChunkAggregator {
         G.pure(r.transformHeaders(removeChunkedTransferEncoding(0L)))
       case Entity.Strict(bv) =>
         G.pure(r.transformHeaders(removeChunkedTransferEncoding(bv.size)))
-      case Entity.Default(b, _) =>
+      case Entity.Streamed(b, _) =>
         b.compile
           .to(ByteVector)
           .map(bv =>

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -56,7 +56,7 @@ object DefaultHead {
         response
       case Entity.Strict(_) =>
         response.withEntity(Entity.empty)
-      case Entity.Default(_, _) =>
+      case Entity.Streamed(_, _) =>
         response.pipeBodyThrough(_.interruptWhen[G](G.pure(Either.unit[Throwable])).drain)
     }
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -44,7 +44,7 @@ object EntityLimiter {
           if (chunk.size.toLong < limit) http.run(req)
           else F.raiseError[B](EntityTooLarge(limit))
 
-        case Entity.Default(_, _) =>
+        case Entity.Streamed(_, _) =>
           http.run(req.pipeBodyThrough[G](takeLimited(limit)))
       }
     }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Jsonp.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Jsonp.scala
@@ -72,10 +72,10 @@ object Jsonp {
         val entity = Entity.Strict(begin ++ bv ++ end)
         entity -> Some(begin.size + end.size)
 
-      case Entity.Default(body, _) =>
+      case Entity.Streamed(body, _) =>
         val begin = beginJsonpChunk(callback)
         val end = EndJsonpChunk
-        val entity = Entity.Default(fs2.Stream.chunk(begin) ++ body ++ fs2.Stream.chunk(end), None)
+        val entity = Entity.Streamed(fs2.Stream.chunk(begin) ++ body ++ fs2.Stream.chunk(end), None)
         entity -> Some(begin.size.toLong + end.size.toLong)
     }
     val newLengthHeaderOpt =

--- a/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -97,7 +97,7 @@ object RequestLogger {
           case Entity.Empty | Entity.Strict(_) =>
             logRequest(req)
 
-          case Entity.Default(_, _) =>
+          case Entity.Streamed(_, _) =>
             fk(F.ref(Vector.empty[Chunk[Byte]]))
               .flatMap { vec =>
                 val collectChunks: Pipe[F, Byte, Nothing] =

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -80,7 +80,7 @@ object ResponseLogger {
           .as(response)
       else {
         response.entity match {
-          case Entity.Default(_, _) =>
+          case Entity.Streamed(_, _) =>
             F.ref(Vector.empty[Chunk[Byte]]).map { vec =>
               val newBody = Stream.eval(vec.get).flatMap(v => Stream.emits(v)).unchunks
               // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization

--- a/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
@@ -35,9 +35,9 @@ class EntityLimiterSuite extends Http4sSuite {
     case r if r.pathInfo == path"/echo" => r.decode(Response(Ok).withEntity(_: String).pure[IO])
   }
 
-  private val defaultEntity = Entity(chunk(Chunk.array("hello".getBytes(StandardCharsets.UTF_8))))
-  private val strictEntity =
-    Entity.strict(ByteVector.view("hello".getBytes(StandardCharsets.UTF_8)))
+  private val helloBytes = "hello".getBytes(StandardCharsets.UTF_8)
+  private val defaultEntity = Entity.stream(chunk(Chunk.array(helloBytes)))
+  private val strictEntity = Entity.strict(ByteVector.view(helloBytes))
 
   test("Allow reasonable default entity") {
     EntityLimiter(routes, 100)

--- a/tests/shared/src/test/scala/org/http4s/MessageSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/MessageSuite.scala
@@ -22,6 +22,7 @@ import cats.syntax.all._
 import com.comcast.ip4s._
 import fs2.Chunk
 import fs2.Pure
+import fs2.Stream
 import org.http4s.headers.Authorization
 import org.http4s.headers.Cookie
 import org.http4s.headers.`Content-Type`
@@ -223,22 +224,22 @@ class MessageSuite extends Http4sSuite {
   test("toString should correctly print a request with a chunked entity") {
     val req = Request(
       method = Method.POST,
-      entity = Entity(fs2.Stream.chunk(Chunk(Byte.MinValue, Byte.MaxValue))),
+      entity = Entity.stream(Stream.chunk(Chunk(Byte.MinValue, Byte.MaxValue))),
     )
     assertEquals(
       req.toString,
-      "Request(method=POST, uri=/, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Default)",
+      "Request(method=POST, uri=/, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Streamed)",
     )
   }
 
   test("toString should correctly print a request with a chunked entity with a known size") {
     val req = Request(
       method = Method.POST,
-      entity = Entity(fs2.Stream.chunk(Chunk(Byte.MinValue, Byte.MaxValue)), Some(2)),
+      entity = Entity.stream(Stream.chunk(Chunk(Byte.MinValue, Byte.MaxValue)), Some(2)),
     )
     assertEquals(
       req.toString,
-      "Request(method=POST, uri=/, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Default(2 bytes total))",
+      "Request(method=POST, uri=/, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Streamed(2 bytes total))",
     )
   }
 
@@ -369,19 +370,19 @@ class MessageSuite extends Http4sSuite {
   }
 
   test("toString should correctly print a response with a chunked entity") {
-    val resp = Response(entity = Entity(fs2.Stream.chunk(Chunk(Byte.MinValue, Byte.MaxValue))))
+    val resp = Response(entity = Entity.stream(Stream.chunk(Chunk(Byte.MinValue, Byte.MaxValue))))
     assertEquals(
       resp.toString,
-      "Response(status=200, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Default)",
+      "Response(status=200, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Streamed)",
     )
   }
 
   test("toString should correctly print a response with a chunked entity with a known size") {
     val resp =
-      Response(entity = Entity(fs2.Stream.chunk(Chunk(Byte.MinValue, Byte.MaxValue)), Some(2)))
+      Response(entity = Entity.stream(Stream.chunk(Chunk(Byte.MinValue, Byte.MaxValue)), Some(2)))
     assertEquals(
       resp.toString,
-      "Response(status=200, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Default(2 bytes total))",
+      "Response(status=200, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Streamed(2 bytes total))",
     )
   }
 

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -159,7 +159,7 @@ Content-Type: application/pdf
       val request = Request[IO](
         method = Method.POST,
         uri = url,
-        entity = Entity(Stream.emit(body).through(text.utf8.encode)),
+        entity = Entity.stream(Stream.emit(body).through(text.utf8.encode)),
         headers = header,
       )
 
@@ -192,7 +192,7 @@ I am a big moose
       val request = Request[IO](
         method = Method.POST,
         uri = url,
-        entity = Entity(Stream.emit(body).through(text.utf8.encode)),
+        entity = Entity.stream(Stream.emit(body).through(text.utf8.encode)),
         headers = header,
       )
 


### PR DESCRIPTION
Since `Entity.Stream` is not a good default, because of the overhead of dealing with streams, we deprecate the Entity.apply method in favour of a explicit `stream` constructor.

We also add a explicit `string` constructor for strict entities.