### PR TITLE
Add timeout and max bytes handling to `Message#toStrict`

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -31,7 +31,11 @@ import com.comcast.ip4s.Hostname
 import com.comcast.ip4s.IpAddress
 import com.comcast.ip4s.Port
 import com.comcast.ip4s.SocketAddress
-import fs2.{Chunk, Pipe, Pull, Pure, Stream}
+import fs2.Chunk
+import fs2.Pipe
+import fs2.Pull
+import fs2.Pure
+import fs2.Stream
 import fs2.io.net.unixsocket.UnixSocketAddress
 import fs2.text.utf8
 import org.http4s.Message.EntityStreamException
@@ -43,7 +47,8 @@ import org.typelevel.ci.CIString
 import org.typelevel.vault._
 
 import java.io.File
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NoStackTrace
 import scala.util.hashing.MurmurHash3
 

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -260,9 +260,17 @@ sealed trait Message[F[_]] extends Media[F] { self =>
     }
 
   /** Compiles the body stream to a single chunk and sets it as the
-    * body.  Replaces any `Transfer-Encoding: chunked` with a
-    * `Content-Length` header.  It is the caller's responsibility to
-    * assure there is enough memory to materialize the body.
+    * body. Replaces any `Transfer-Encoding: chunked` with a
+    * `Content-Length` header. It is the caller's responsibility to
+    * assure there is enough memory to materialize the entity body and
+    * set an appropriate timeout.
+    *
+    * @param timeout duration to wait for the entity stream completion.
+    *                Exceeding finite timeout duration
+    *                (an instance of [[FiniteDuration]]) will lead to
+    *                failing processing with the `TimeoutException`
+    * @param maxBytes maximum length of the entity stream. If the stream
+    *                 exceeds the limit then processing fails with the [[EntityStreamException]]
     */
   def toStrict(timeout: Duration, maxBytes: Option[Long])(implicit F: Temporal[F]): F[Self] = {
     def withTimeout[A](fa: F[A]): F[A] =

--- a/server/shared/src/main/scala/org/http4s/server/middleware/BodyCache.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/BodyCache.scala
@@ -66,7 +66,7 @@ object BodyCache {
     apply(app)(identity, _ => identity)(FunctionK.id)
 
   private def compileBody[F[_]: Concurrent](req: Request[F]): F[Request[F]] =
-    req.toStrict
+    req.unsafeToStrict
 
   def hasNoBody[F[_]](req: Request[F]): Boolean =
     req.contentLength.contains(0L)


### PR DESCRIPTION
We didn't release 0.23 after introducing `Message#toStrict`, so MiMa shouldn't bit us on these changes.