### PR TITLE
Only create scalafix job for 2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.1.1, 2.12.15, 2.13.8]
+        scala: [2.13.8]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -402,7 +402,6 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Scalafix tests
-        if: matrix.scala == '2.13.8'
         run: |
           cd scalafix
           sbt ci

--- a/build.sbt
+++ b/build.sbt
@@ -39,10 +39,9 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
       WorkflowStep.Run(
         List("cd scalafix", "sbt ci"),
         name = Some("Scalafix tests"),
-        cond = Some(s"matrix.scala == '$scala_213'"),
       )
     ),
-    scalas = crossScalaVersions.value.toList,
+    scalas = List(scala_213),
     javas = List(JavaSpec.temurin("8")),
   )
 )


### PR DESCRIPTION
First of all the extra jobs were worthless, because they weren't doing anything.

Secondly, because they ran so quickly (i.e. without starting sbt and downloading stuff) they were the first in line to upload the cache ... of nothing 🙃 

Fixes https://github.com/http4s/http4s/issues/6360.