### PR TITLE
httpRoutes and httpApp shortcuts for Throttle middleware

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
@@ -115,18 +115,23 @@ object Throttle {
     */
   def apply[F[_], G[_]](amount: Int, per: FiniteDuration)(
       http: Http[F, G]
-  )(implicit F: Temporal[F]): F[Http[F, G]] = {
+  )(implicit F: Temporal[F]): F[Http[F, G]] =
     createBucket(amount, per).map(bucket => apply(bucket, defaultResponse[G] _)(http))
-  }
 
   /** As [[[apply[F[_],G[_]](amount:Int,per:scala\.concurrent\.duration\.FiniteDuration* apply(amount,per)]]], but for HttpRoutes[F]
     */
-  def httpRoutes[F[_]](amount: Int, per: FiniteDuration)(httpRoutes: HttpRoutes[F])(implicit F: Temporal[F]): F[HttpRoutes[F]] =
-    createBucket(amount, per).map(bucket => Throttle.httpRoutes(bucket, defaultResponse[F] _)(httpRoutes))
+  def httpRoutes[F[_]](amount: Int, per: FiniteDuration)(
+      httpRoutes: HttpRoutes[F]
+  )(implicit F: Temporal[F]): F[HttpRoutes[F]] =
+    createBucket(amount, per).map(bucket =>
+      Throttle.httpRoutes(bucket, defaultResponse[F] _)(httpRoutes)
+    )
 
   /** As [[[apply[F[_],G[_]](amount:Int,per:scala\.concurrent\.duration\.FiniteDuration* apply(amount,per)]]], but for HttpApp[F]
     */
-  def httpAapp[F[_]](amount: Int, per: FiniteDuration)(httpApp: HttpApp[F])(implicit F: Temporal[F]): F[HttpApp[F]] =
+  def httpAapp[F[_]](amount: Int, per: FiniteDuration)(httpApp: HttpApp[F])(implicit
+      F: Temporal[F]
+  ): F[HttpApp[F]] =
     apply(amount, per)(httpApp)
 
   def defaultResponse[F[_]](@nowarn retryAfter: Option[FiniteDuration]): Response[F] =


### PR DESCRIPTION
This PR implements the httpApp and httpRoutes shortcuts of the Throttle middleware. See #2402.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 