### PR TITLE
httpRoutes and httpApp shortcuts for Timeout middleware

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -18,7 +18,9 @@ package org.http4s
 package server
 package middleware
 
+import cats.Applicative
 import cats.data.Kleisli
+import cats.data.OptionT
 import cats.effect.kernel.Temporal
 import cats.syntax.applicative._
 
@@ -48,4 +50,32 @@ object Timeout {
       F: Temporal[F]
   ): Kleisli[F, A, Response[G]] =
     apply(timeout, Response.timeout[G].pure[F])(http)
+
+  /** As [[[apply[F[_],G[_],A](timeout:scala\.concurrent\.duration\.FiniteDuration)* apply(timeout)]]], but for HttpRoutes
+    */
+  def httpRoutes[F[_]](timeout: FiniteDuration)(httpRoutes: HttpRoutes[F])(implicit
+      F: Temporal[F]
+  ): HttpRoutes[F] =
+    apply(timeout)(httpRoutes)
+
+  /** As [[[apply[F[_],G[_],A](timeout:scala\.concurrent\.duration\.FiniteDuration,timeoutResponse:* apply(timeout,timeoutResponse)]]], but for HttpRoutes
+    */
+  def httpRoutes[F[_]](timeout: FiniteDuration, timeoutResponse: F[Response[F]])(
+      httpRoutes: HttpRoutes[F]
+  )(implicit F: Temporal[F]): HttpRoutes[F] =
+    apply(timeout, OptionT.liftF(timeoutResponse))(httpRoutes)
+
+  /** As [[[apply[F[_],G[_],A](timeout:scala\.concurrent\.duration\.FiniteDuration)* apply(timeout)]]], but for HttpApp
+    */
+  def httpApp[F[_]](timeout: FiniteDuration)(httpApp: HttpApp[F])(implicit
+      F: Temporal[F]
+  ): HttpApp[F] =
+    apply(timeout)(httpApp)
+
+  /** As [[[apply[F[_],G[_],A](timeout:scala\.concurrent\.duration\.FiniteDuration,timeoutResponse:* apply(timeout,timeoutResponse)]]], but for HttpApp
+    */
+  def httpApp[F[_]](timeout: FiniteDuration, timeoutResponse: F[Response[F]])(httpApp: HttpApp[F])(
+      implicit F: Temporal[F]
+  ): HttpApp[F] =
+    apply(timeout, timeoutResponse)(httpApp)
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -18,7 +18,6 @@ package org.http4s
 package server
 package middleware
 
-import cats.Applicative
 import cats.data.Kleisli
 import cats.data.OptionT
 import cats.effect.kernel.Temporal

--- a/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
@@ -30,7 +30,7 @@ class TimeoutSuite extends Http4sSuite {
   // To distinguish from the inherited cats-effect-testing Timeout
   import org.http4s.server.middleware.{Timeout => TimeoutMiddleware}
 
-  private val routes = HttpRoutes.of[IO] {
+  private val defaultRoutes = HttpRoutes.of[IO] {
     case _ -> Root / "fast" =>
       Ok("Fast")
 
@@ -38,28 +38,50 @@ class TimeoutSuite extends Http4sSuite {
       IO.never[Response[IO]]
   }
 
-  private val app = TimeoutMiddleware(5.milliseconds)(routes).orNotFound
-
   private val fastReq = Request[IO](GET, uri"/fast")
   private val neverReq = Request[IO](GET, uri"/never")
 
   def checkStatus(resp: IO[Response[IO]], status: Status): IO[Unit] =
     IO.race(IO.sleep(3.seconds), resp.map(_.status)).assertEquals(Right(status))
 
+  def testMiddleware(timeout: FiniteDuration, routes: HttpRoutes[IO] = defaultRoutes)(
+      test: Http[IO, IO] => IO[Unit]
+  ) =
+    for {
+      _ <- test(TimeoutMiddleware(timeout)(routes).orNotFound)
+      _ <- test(TimeoutMiddleware.httpRoutes(timeout)(routes).orNotFound)
+      _ <- test(TimeoutMiddleware.httpApp(timeout)(routes.orNotFound))
+    } yield ()
+
+  def testMiddlewareWithResponse(
+      timeout: FiniteDuration,
+      response: Response[IO],
+      routes: HttpRoutes[IO] = defaultRoutes,
+  )(test: Http[IO, IO] => IO[Unit]) =
+    for {
+      _ <- test(TimeoutMiddleware(timeout, OptionT.pure[IO](response))(routes).orNotFound)
+      _ <- test(TimeoutMiddleware.httpRoutes(timeout, IO.pure(response))(routes).orNotFound)
+      _ <- test(TimeoutMiddleware.httpApp(timeout, IO.pure(response))(routes.orNotFound))
+    } yield ()
+
   test("have no effect if the response is timely") {
-    val app = TimeoutMiddleware(365.days)(routes).orNotFound
-    checkStatus(app(fastReq), Status.Ok)
+    testMiddleware(365.days) { app =>
+      checkStatus(app(fastReq), Status.Ok)
+    }
   }
 
   test("return a 503 error if the result takes too long") {
-    checkStatus(app(neverReq), Status.ServiceUnavailable)
+    testMiddleware(5.milliseconds) { app =>
+      checkStatus(app(neverReq), Status.ServiceUnavailable)
+    }
   }
 
   test("return the provided response if the result takes too long") {
     val customTimeout = Response[IO](Status.GatewayTimeout) // some people return 504 here.
-    val altTimeoutService =
-      TimeoutMiddleware(1.nanosecond, OptionT.pure[IO](customTimeout))(routes)
-    checkStatus(altTimeoutService.orNotFound(neverReq), customTimeout.status)
+
+    testMiddlewareWithResponse(1.nanosecond, customTimeout) { app =>
+      checkStatus(app(neverReq), customTimeout.status)
+    }
   }
 
   test("cancel the loser") {
@@ -67,9 +89,11 @@ class TimeoutSuite extends Http4sSuite {
     val routes = HttpRoutes.of[IO] { case _ =>
       IO.never.guarantee(IO(canceled.set(true)))
     }
-    val app = TimeoutMiddleware(1.millis)(routes).orNotFound
-    checkStatus(app(Request[IO]()), Status.ServiceUnavailable) *>
-      // Give the losing response enough time to finish
-      IO.sleep(100.milliseconds) *> IO(canceled.get)
+
+    testMiddleware(1.millisecond, routes) { app =>
+      checkStatus(app(Request[IO]()), Status.ServiceUnavailable) *>
+        // Give the losing response enough time to finish
+        IO.sleep(100.milliseconds) *> IO(canceled.get).map(_ => ())
+    }
   }
 }


### PR DESCRIPTION
This PR implements the httpApp and httpRoutes shortcuts of the Timeout middleware. See https://github.com/http4s/http4s/issues/2402.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 