### PR TITLE
Follow links when accessing file attributes in `StaticFile`

### DIFF
--- a/core/shared/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/shared/src/main/scala/org/http4s/StaticFile.scala
@@ -149,7 +149,7 @@ object StaticFile {
   def calculateETag[F[_]: Files: ApplicativeThrow]: Path => F[String] =
     f =>
       Files[F]
-        .getBasicFileAttributes(f)
+        .getBasicFileAttributes(f, followLinks = true)
         .map(attr =>
           if (attr.isRegularFile)
             s"${attr.lastModifiedTime.toMillis.toHexString}-${attr.size.toHexString}"
@@ -212,7 +212,7 @@ object StaticFile {
       etagCalculator: Path => F[String],
   ): OptionT[F, Response[F]] =
     OptionT
-      .liftF(Files[F].getBasicFileAttributes(f).map(_.size))
+      .liftF(Files[F].getBasicFileAttributes(f, followLinks = true).map(_.size))
       .flatMap { size =>
         fromPath(f, 0, size, buffsize, req, etagCalculator)
       }
@@ -256,7 +256,7 @@ object StaticFile {
         if (isFile) {
           if (start >= 0 && end >= start && buffsize > 0) {
             Files[F]
-              .getBasicFileAttributes(f)
+              .getBasicFileAttributes(f, followLinks = true)
               .flatMap { attr =>
                 val lastModified =
                   HttpDate.fromEpochSecond(attr.lastModifiedTime.toSeconds).toOption

--- a/tests/shared/src/test/resources/lipsum-symlink.txt
+++ b/tests/shared/src/test/resources/lipsum-symlink.txt
@@ -1,0 +1,1 @@
+lorem-ipsum.txt

--- a/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -114,6 +114,14 @@ class StaticFileSuite extends Http4sSuite {
     emptyFile.flatMap(StaticFile.fromPath[IO](_).value).map(_.isDefined).assert
   }
 
+  test("handle a symlink") {
+    StaticFile
+      .fromPath[IO](CrossPlatformResource("/lipsum-symlink.txt"))
+      .semiflatMap(_.body.compile.count)
+      .exists(_ == 24005)
+      .assert
+  }
+
   test("Don't send unmodified files") {
     val emptyFile = Files[IO].createTempFile(None, "empty", ".tmp", None)
 

--- a/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -119,7 +119,7 @@ class StaticFileSuite extends Http4sSuite {
       .fromPath[IO](Path("tests/shared/src/test/resources/lipsum-symlink.txt"))
       .semiflatMap(_.body.compile.count)
       .getOrElse(0)
-      .assertEquals(24005)
+      .map2(Files[IO].size(CrossPlatformResource("/lorem-ipsum.txt")))(assertEquals(_, _))
   }
 
   test("Don't send unmodified files") {

--- a/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -116,10 +116,10 @@ class StaticFileSuite extends Http4sSuite {
 
   test("handle a symlink") {
     StaticFile
-      .fromPath[IO](CrossPlatformResource("/lipsum-symlink.txt"))
+      .fromPath[IO](Path("tests/shared/src/test/resources/lipsum-symlink.txt"))
       .semiflatMap(_.body.compile.count)
-      .exists(_ == 24005)
-      .assert
+      .getOrElse(0)
+      .assertEquals(24005)
   }
 
   test("Don't send unmodified files") {


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/6363.