### PR TITLE
Fix regression of `Router#define`

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/Router.scala
+++ b/server/shared/src/main/scala/org/http4s/server/Router.scala
@@ -76,12 +76,14 @@ object Router {
     mappings.sortBy(_._1.length).foldLeft(default) { case (acc, (prefix, routes)) =>
       val prefixPath = Uri.Path.unsafeFromString(prefix)
 
-      Kleisli { req =>
-        if (req.pathInfo.startsWith(prefixPath))
-          routes(translate(prefixPath)(req)).orElse(acc(req))
-        else
-          acc(req)
-      }
+      if (prefixPath.isEmpty) routes <+> acc
+      else
+        Kleisli { req =>
+          if (req.pathInfo.startsWith(prefixPath))
+            routes(translate(prefixPath)(req)).orElse(acc(req))
+          else
+            acc(req)
+        }
     }
 
   def of[F[_]: Monad](mappings: Routable[F]*): HttpRoutes[F] =

--- a/server/shared/src/test/scala/org/http4s/server/RouterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/RouterSuite.scala
@@ -80,6 +80,14 @@ class RouterSuite extends Http4sSuite {
     "/routable" -> routable,
   )
 
+  private val emptyAttributeTestRoutes = {
+    import org.http4s.dsl.io._
+    HttpRoutes.of[IO] { case r @ GET -> Root / "foo" =>
+      assert(r.attributes.isEmpty, "Requests attributes should be empty")
+      Ok()
+    }
+  }
+
   test("routable") {
     service
       .orNotFound(Request[IO](GET, uri"/routable/1"))
@@ -173,5 +181,13 @@ class RouterSuite extends Http4sSuite {
       .orNotFound(Request[IO](uri = uri"/foo"))
       .map(_.status == Status.Ok)
       .assert
+  }
+
+  test("A router shouldn't add any attributes to requests in the empty path case") {
+    val router = Router("" -> emptyAttributeTestRoutes)
+    router
+      .orNotFound(Request[IO](uri = uri"/foo"))
+      .map(_.status)
+      .assertEquals(Status.Ok)
   }
 }


### PR DESCRIPTION
The current implementation of `Router#define` from 0.23 differs from that we have at main. I think this was done accidentally in https://github.com/http4s/http4s/commit/8b148f48ae2c167f36d27f2b64a92bb638ca24ec#diff-7b0e93ead3858152f51e0f8ceb5dd1aec7c0eee85dd58a812e1192d204e7a059L42.