### PR TITLE
Add info about the entity into the `toString` of `Request` and `Response`

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -519,7 +519,7 @@ final class Request[+F[_]] private (
 
   override def toString: String =
     s"""Request(method=$method, uri=$uri, httpVersion=${httpVersion}, headers=${headers
-        .redactSensitive()})"""
+        .redactSensitive()}, entity=$entity)"""
 }
 
 object Request {
@@ -685,7 +685,7 @@ final class Response[+F[_]] private (
 
   override def toString: String =
     s"""Response(status=${status.code}, httpVersion=${httpVersion}, headers=${headers
-        .redactSensitive()})"""
+        .redactSensitive()}, entity=$entity)"""
 }
 
 object Response extends KleisliSyntax {


### PR DESCRIPTION
Since we have overridden the `toString` of `Entity`, we can enhance the `toString` of Request/Response.