### PR TITLE
Ember-Core: reimplement write loop without streams.

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -272,7 +272,7 @@ private[ember] class H2Client[F[_]](
     for {
       h2 <- Resource.eval(createH2Connection)
       _ <- h2.readLoop.background
-      _ <- h2.writeLoop.compile.drain.background
+      _ <- h2.writeLoop.background
       _ <- clearClosed(h2).background
       _ <- pullCreatedStreams(h2).background
       _ <- Resource.eval(processSettings(h2))

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -309,7 +309,7 @@ private[ember] object H2Server {
 
     for {
       h2 <- Resource.eval(initH2Connection)
-      _ <- h2.writeLoop.compile.drain.background
+      _ <- h2.writeLoop.background
       _ <- Resource.eval(h2.outgoing.offer(Chunk.singleton(settingsFrame)))
       _ <- h2.readLoop.background
       // h2c Initial Request Communication on h2c Upgrade


### PR DESCRIPTION
The `writeLoop` was using FS2 streams without strict need. The streams in question are generated, by pulling all available data from a queue, and immediately processed. This is the kind of processing that can be done with a monadically recursive loop. 

For this use case, we can make use of a newer Queue operation, tryTakeN, which if given a `None` parameter just dumps the entire queue on each iteration.

_Note:_ The new operation `tryTakeN` is not being added to `cats-effect` until the next minor release, so this PR should be kept as draft.