### PR TITLE
Resubmit idempotent requests with only pure entities in `Retry` middleware

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -184,7 +184,7 @@ object RetryPolicy {
     */
   def defaultRetriable[F[_]](req: Request[F], result: Either[Throwable, Response[F]]): Boolean = {
     def isReqIdempotentAndEntityPure =
-      req.method.isIdempotent && req.isPureEntity
+      req.method.isIdempotent && req.hasKnownPureEntity
 
     def isHeadersContainsIdempotencyHeader =
       req.headers.contains[`Idempotency-Key`]

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -169,7 +169,7 @@ object RetryPolicy {
     GatewayTimeout,
   )
 
-  /** Returns true if (the request method is idempotent and its entity isn't streamed;
+  /** Returns true if (the request method is idempotent and the request's entity is pure (isn't effectful);
     * or request contains [[`Idempotency-Key`]] header) and the result is either a throwable or
     * has one of the `RetriableStatuses`.
     *

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -169,9 +169,15 @@ object RetryPolicy {
     GatewayTimeout,
   )
 
-  /** Returns true if (the request method is idempotent and the request's entity is pure (isn't effectful);
-    * or request contains [[`Idempotency-Key`]] header) and the result is either a throwable or
-    * has one of the `RetriableStatuses`.
+  /** Returns true if both the request and response effect are retriable.
+    *
+    * The request is retriable if either:
+    * - its method is idempotent and its request entity is pure
+    * - it has an [[`Idempotency-Key`]] header
+    *
+    * The response effect is retriable if:
+    * - it raised an error
+    * - it is a response whose status code is a member of `RetriableStatuses`
     *
     * Caution: a request wouldn't be resubmitted if the idempotent request contains
     * streamed (effectful) [[Entity]] (nor empty, nor fully loaded into memory).

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -187,7 +187,7 @@ object RetryPolicy {
       req.method.isIdempotent && req.isPureEntity
 
     def isHeadersContainsIdempotencyHeader =
-      req.headers.get[`Idempotency-Key`].isDefined
+      req.headers.contains[`Idempotency-Key`]
 
     (isReqIdempotentAndEntityPure || isHeadersContainsIdempotencyHeader) &&
     isErrorOrRetriableStatus(result)

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -465,14 +465,13 @@ final class Request[+F[_]] private (
   def isIdempotent: Boolean =
     method.isIdempotent || headers.contains[`Idempotency-Key`]
 
-  /**
-   * Checks whether the [[Entity]] of the [[Message]] is pure in the sense of
-   * indicating that the entity body can be re-run without side effects.
-   *
-   * @return the [[Boolean]] value:
-   *         'true' if entity is empty or already loaded into memory;
-   *         'false' if entity is streamed.
-   */
+  /** Checks whether the [[Entity]] of the [[Message]] is pure in the sense of
+    * indicating that the entity body can be re-run without side effects.
+    *
+    * @return the [[Boolean]] value:
+    *         'true' if entity is empty or already loaded into memory;
+    *         'false' if entity is streamed.
+    */
   def isPureEntity: Boolean =
     entity match {
       case Entity.Empty | Entity.Strict(_) =>

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -472,7 +472,7 @@ final class Request[+F[_]] private (
     *         'true' if entity is empty or already loaded into memory;
     *         'false' if entity is streamed.
     */
-  def isPureEntity: Boolean =
+  def hasKnownPureEntity: Boolean =
     entity match {
       case Entity.Empty | Entity.Strict(_) =>
         true

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -465,6 +465,22 @@ final class Request[+F[_]] private (
   def isIdempotent: Boolean =
     method.isIdempotent || headers.contains[`Idempotency-Key`]
 
+  /**
+   * Checks whether the [[Entity]] of the [[Message]] is pure in the sense of
+   * indicating that the entity body can be re-run without side effects.
+   *
+   * @return the [[Boolean]] value:
+   *         'true' if entity is empty or already loaded into memory;
+   *         'false' if entity is streamed.
+   */
+  def isPureEntity: Boolean =
+    entity match {
+      case Entity.Empty | Entity.Strict(_) =>
+        true
+      case Entity.Default(_, _) =>
+        false
+    }
+
   def decodeWith[F2[x] >: F[x], A](decoder: EntityDecoder[F2, A], strict: Boolean)(
       f: A => F2[Response[F2]]
   )(implicit F: Monad[F2]): F2[Response[F2]] =


### PR DESCRIPTION
Closes #712. I've crossed my fingers that I correctly followed Ross's reasoning on the issue. Nevertheless, I'm open to taking rotten tomatoes.