### PR TITLE
Use `GenTemporal` for proceeding with timeouts

### DIFF
--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
@@ -20,6 +20,7 @@ package server
 
 import cats.effect.Async
 import cats.effect.std.Dispatcher
+import cats.effect.syntax.temporal._
 import cats.syntax.all._
 import fs2.Stream._
 import fs2._
@@ -284,8 +285,7 @@ private class Http2NodeStage[F[_]](
   private[this] val raceTimeout: Request[F] => F[Response[F]] =
     responseHeaderTimeout match {
       case finite: FiniteDuration =>
-        val timeoutResponse = F.sleep(finite).as(Response.timeout[F])
-        req => F.race(runApp(req), timeoutResponse).map(_.merge)
+        req => runApp(req).timeoutTo(finite, F.pure(Response.timeout[F]))
       case _ =>
         runApp
     }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
@@ -42,7 +42,7 @@ class TimeoutSuite extends Http4sSuite {
   private val neverReq = Request[IO](GET, uri"/never")
 
   def checkStatus(resp: IO[Response[IO]], status: Status): IO[Unit] =
-    IO.race(IO.sleep(3.seconds), resp.map(_.status)).assertEquals(Right(status))
+    resp.map(_.status).timeout(3.seconds).assertEquals(status)
 
   def testMiddleware(timeout: FiniteDuration, routes: HttpRoutes[IO] = defaultRoutes)(
       test: Http[IO, IO] => IO[Unit]


### PR DESCRIPTION
Refactors the direct `race`s in favor of `GenTemporal` algebra.