### PR TITLE
Use `parTraverse` in tests

### DIFF
--- a/server/shared/src/test/scala/org/http4s/server/middleware/HSTSSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/HSTSSuite.scala
@@ -38,7 +38,7 @@ class HSTSSuite extends Http4sSuite {
       HSTS.unsafeFromDuration(innerRoutes, 365.days).orNotFound,
       HSTS.httpRoutes.unsafeFromDuration(innerRoutes, 365.days).orNotFound,
       HSTS.httpApp.unsafeFromDuration(innerRoutes.orNotFound, 365.days),
-    ).traverse { app =>
+    ).parTraverse_ { app =>
       app(req).map(_.status).assertEquals(Status.Ok) *>
         app(req).map(_.headers.contains[`Strict-Transport-Security`]).assert
     }
@@ -51,7 +51,7 @@ class HSTSSuite extends Http4sSuite {
       HSTS(innerRoutes, hstsHeader).orNotFound,
       HSTS.httpRoutes(innerRoutes).orNotFound,
       HSTS.httpApp(innerRoutes.orNotFound),
-    ).traverse { app =>
+    ).parTraverse_ { app =>
       app(req).map(_.status).assertEquals(Status.Ok) *>
         app(req).map(_.headers.contains[`Strict-Transport-Security`]).assert
     }
@@ -62,7 +62,7 @@ class HSTSSuite extends Http4sSuite {
       HSTS(innerRoutes).orNotFound,
       HSTS.httpRoutes(innerRoutes).orNotFound,
       HSTS.httpApp(innerRoutes.orNotFound),
-    ).traverse { app =>
+    ).parTraverse_ { app =>
       app(req).map(_.status).assertEquals(Status.Ok) *>
         app(req).map(_.headers.contains[`Strict-Transport-Security`]).assert
     }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/HttpsRedirectSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/HttpsRedirectSuite.scala
@@ -41,7 +41,7 @@ class HttpsRedirectSuite extends Http4sSuite {
       HttpsRedirect(innerRoutes).orNotFound,
       HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
       HttpsRedirect.httpApp(innerRoutes.orNotFound),
-    ).traverse { app =>
+    ).parTraverse_ { app =>
       val expectedAuthority = Authority(host = RegName("example.com"))
       val expectedLocation =
         Location(
@@ -62,7 +62,7 @@ class HttpsRedirectSuite extends Http4sSuite {
       HttpsRedirect(innerRoutes).orNotFound,
       HttpsRedirect.httpRoutes(innerRoutes).orNotFound,
       HttpsRedirect.httpApp(innerRoutes.orNotFound),
-    ).traverse { app =>
+    ).parTraverse_ { app =>
       val noHeadersReq = Request[IO](method = GET, uri = Uri(path = Uri.Path.Root))
       app(noHeadersReq).map(_.status).assertEquals(Status.Ok) *>
         app(noHeadersReq).flatMap(_.as[String]).assertEquals("pong")

--- a/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -110,7 +110,7 @@ class VirtualHostSuite extends Http4sSuite {
       req.withHeaders(Host("b.service", Some(80))),
     )
 
-    reqs.traverse { req =>
+    reqs.parTraverse_ { req =>
       vhostWildcard(req).flatMap(_.as[String]).assertEquals("routesB")
     }
   }
@@ -120,7 +120,7 @@ class VirtualHostSuite extends Http4sSuite {
     val reqs =
       List(req.withHeaders(Host(".service", Some(80))), req.withHeaders(Host("service", Some(80))))
 
-    reqs.traverse { req =>
+    reqs.parTraverse_ { req =>
       vhostWildcard(req).map(_.status).assertEquals(NotFound)
     }
   }

--- a/server/shared/src/test/scala/org/http4s/server/staticcontent/FileServiceSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/staticcontent/FileServiceSuite.scala
@@ -266,7 +266,7 @@ class FileServiceSuite extends Http4sSuite with StaticContentShared {
     )
     Files[IO].size(Path(defaultSystemPath) / "testresource.txt").flatMap { size =>
       val reqs = ranges.map(r => Request[IO](uri = uri"/testresource.txt").withHeaders(r))
-      reqs.toList.traverse { req =>
+      reqs.toList.parTraverse_ { req =>
         routes.orNotFound(req).map(_.status).assertEquals(Status.RangeNotSatisfiable) *>
           routes
             .orNotFound(req)

--- a/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -45,7 +45,7 @@ class StaticFileSuite extends Http4sSuite {
       "/Animated_PNG_example_bouncing_beach_ball.png" -> Some(MediaType.image.png),
       "/test.fiddlefaddle" -> None,
     )
-    tests.traverse { case (p, om) =>
+    tests.parTraverse { case (p, om) =>
       check(CrossPlatformResource(p), om)
     }
   }
@@ -76,7 +76,7 @@ class StaticFileSuite extends Http4sSuite {
         "/missing.html" -> NotFound,
       )
 
-      tests.traverse(Function.tupled(check))
+      tests.parTraverse(Function.tupled(check))
     }
 
   if (Platform.isJvm)
@@ -105,7 +105,7 @@ class StaticFileSuite extends Http4sSuite {
         "/missing.html" -> NotFound,
       )
 
-      tests.traverse(Function.tupled(check))
+      tests.parTraverse(Function.tupled(check))
     }
 
   test("handle an empty file") {
@@ -248,7 +248,7 @@ class StaticFileSuite extends Http4sSuite {
       "./server/shared/src/test/resources/testresource.txt",
     )
 
-    tests.traverse(check)
+    tests.parTraverse(check)
   }
 
   test("Send file larger than BufferSize") {


### PR DESCRIPTION
A teeny-weeny speed-up of tests running.