### PR TITLE
Delete hard-coded Scaladoc url

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -789,7 +789,6 @@ lazy val docs = http4sProject("site")
     description := "Documentation for http4s",
     tlFatalWarningsInCi := false,
     fork := false,
-    tlSiteApiUrl := Some(url("https://http4s.org/v0.22/api/")),
   )
   .dependsOn(
     client,


### PR DESCRIPTION
This will now be set automatically to the javadoc.io unidoc link.
https://www.javadoc.io/doc/org.http4s/http4s-docs_2.13/0.22.13/org/http4s/index.html