### PR TITLE
Make Node.js interop APIs private

### DIFF
--- a/core/js/src/main/scala/org/http4s/nodejs/ClientRequest.scala
+++ b/core/js/src/main/scala/org/http4s/nodejs/ClientRequest.scala
@@ -30,7 +30,7 @@ import scala.scalajs.js
   */
 @js.native
 @nowarn
-trait ClientRequest extends js.Object with Writable {
+private[http4s] trait ClientRequest extends js.Object with Writable {
 
   protected[nodejs] def setHeader(name: String, value: js.Array[String]): Unit = js.native
 
@@ -46,7 +46,7 @@ trait ClientRequest extends js.Object with Writable {
     js.native
 }
 
-object ClientRequest {
+private[http4s] object ClientRequest {
 
   implicit def http4sNodeJsServerResponseOps(clientRequest: ClientRequest): ClientRequestOps =
     new ClientRequestOps(clientRequest)

--- a/core/js/src/main/scala/org/http4s/nodejs/IncomingMessage.scala
+++ b/core/js/src/main/scala/org/http4s/nodejs/IncomingMessage.scala
@@ -28,7 +28,7 @@ import scala.scalajs.js
 /** Facade for [[https://nodejs.org/api/http.html#class-httpincomingmessage]]
   */
 @js.native
-trait IncomingMessage extends js.Object with Readable {
+private[http4s] trait IncomingMessage extends js.Object with Readable {
   protected[nodejs] def httpVersionMajor: Int = js.native
   protected[nodejs] def httpVersionMinor: Int = js.native
   protected[nodejs] def rawHeaders: js.Array[String] = js.native
@@ -39,7 +39,7 @@ trait IncomingMessage extends js.Object with Readable {
   protected[nodejs] def statusCode: Int = js.native
 }
 
-object IncomingMessage {
+private[http4s] object IncomingMessage {
 
   implicit def http4sNodeJsIncomingMessageOps(
       incomingMessage: IncomingMessage

--- a/core/js/src/main/scala/org/http4s/nodejs/ServerResponse.scala
+++ b/core/js/src/main/scala/org/http4s/nodejs/ServerResponse.scala
@@ -28,7 +28,7 @@ import scala.scalajs.js
   */
 @js.native
 @nowarn
-trait ServerResponse extends js.Object with Writable {
+private[http4s] trait ServerResponse extends js.Object with Writable {
 
   protected[nodejs] def writeHead(
       statusCode: Int,
@@ -38,7 +38,7 @@ trait ServerResponse extends js.Object with Writable {
 
 }
 
-object ServerResponse {
+private[http4s] object ServerResponse {
 
   implicit def http4sNodeJsServerResponseOps(serverResponse: ServerResponse): ServerResponseOps =
     new ServerResponseOps(serverResponse)


### PR DESCRIPTION
I initially intended to make these APIs public since they are helpful for integrating with serverless frameworks. After thinking more, I changed my mind.

Besides these interop APIs, there is essentially nothing else JS-specific in http4s, and I think that's great.

Furthermore, the only reason we need these interop APIs in http4s at all is to implement the Node.js scaffold server for the client testkit. I'd like to reserve the option to remove the need for them completely in the future: for example, by running the scaffold server as an external process via sbt (i.e., a testkit distributed as an sbt plugin).