### PR TITLE
Highlight the uncancelable behavior in `Timeout` middleware scaladoc

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -32,13 +32,13 @@ object Timeout {
     * fires, the service's response is canceled.
     *
     * @note if the service runs uncancelable effects while responding
-    * (e.g. if service uses `MonadCancel#uncancelable` under the hood) and has exceeded
+    * (e.g. if service uses [[cats.effect.kernel.MonadCancel#uncancelable MonadCancel#uncancelable]] under the hood) and has exceeded
     * the timeout, then the expected behavior is:
     * <ul>
     *   <li> uncancelable effects will be completed naturally (regardless of how long it takes), </li>
     *   <li> after that, the timeout response will be returned. </li>
     * </ul>
-    * To get more insights on effect cancelation, dig into the Cats-Effect documentation.
+    * To get more insights on effect cancelation, dig into the [[cats.effect.kernel.MonadCancel MonadCancel]] documentation.
     *
     * @param timeout Finite duration to wait before returning the provided response
     */
@@ -52,13 +52,13 @@ object Timeout {
     * fires, the service's response is canceled.
     *
     * @note if the service runs uncancelable effects while responding
-    * (e.g. if service uses `MonadCancel#uncancelable` under the hood) and has exceeded
+    * (e.g. if service uses [[cats.effect.kernel.MonadCancel#uncancelable MonadCancel#uncancelable]] under the hood) and has exceeded
     * the timeout, then the expected behavior is:
     * <ul>
     *   <li> uncancelable effects will be completed naturally (regardless of how long it takes), </li>
     *   <li> after that, the timeout response will be returned. </li>
     * </ul>
-    * To get more insights on effect cancelation, dig into the Cats-Effect documentation.
+    * To get more insights on effect cancelation, dig into the [[cats.effect.kernel.MonadCancel MonadCancel]] documentation.
     *
     * @param timeout Finite duration to wait before returning
     * a `503 Service Unavailable` response

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -31,14 +31,14 @@ object Timeout {
     * duration if the service has not yet responded.  If the timeout
     * fires, the service's response is canceled.
     *
-    * Note, if effects of service responding is uncancelable
+    * @note if the service runs uncancelable effects while responding
     * (e.g. if service uses `MonadCancel#uncancelable` under the hood) and has exceeded
-    * the timeout, then an expected behavior is:
+    * the timeout, then the expected behavior is:
     * <ul>
-    *   <li> effects will be completed naturally (regardless of how long it takes), </li>
+    *   <li> uncancelable effects will be completed naturally (regardless of how long it takes), </li>
     *   <li> after that, the timeout response will be returned. </li>
     * </ul>
-    * To get more insights on effect canceling, dig into the Cats-Effect documentation.
+    * To get more insights on effect cancelation, dig into the Cats-Effect documentation.
     *
     * @param timeout Finite duration to wait before returning the provided response
     */
@@ -51,14 +51,14 @@ object Timeout {
     * duration if the service has not yet responded.  If the timeout
     * fires, the service's response is canceled.
     *
-    * Note, if effects of service responding is uncancelable
+    * @note if the service runs uncancelable effects while responding
     * (e.g. if service uses `MonadCancel#uncancelable` under the hood) and has exceeded
-    * the timeout, then an expected behavior is:
+    * the timeout, then the expected behavior is:
     * <ul>
-    *   <li> effects will be completed naturally (regardless of how long it takes), </li>
+    *   <li> uncancelable effects will be completed naturally (regardless of how long it takes), </li>
     *   <li> after that, the timeout response will be returned. </li>
     * </ul>
-    * To get more insights on effect canceling, dig into the Cats-Effect documentation.
+    * To get more insights on effect cancelation, dig into the Cats-Effect documentation.
     *
     * @param timeout Finite duration to wait before returning
     * a `503 Service Unavailable` response

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Timeout.scala
@@ -31,6 +31,15 @@ object Timeout {
     * duration if the service has not yet responded.  If the timeout
     * fires, the service's response is canceled.
     *
+    * Note, if effects of service responding is uncancelable
+    * (e.g. if service uses `MonadCancel#uncancelable` under the hood) and has exceeded
+    * the timeout, then an expected behavior is:
+    * <ul>
+    *   <li> effects will be completed naturally (regardless of how long it takes), </li>
+    *   <li> after that, the timeout response will be returned. </li>
+    * </ul>
+    * To get more insights on effect canceling, dig into the Cats-Effect documentation.
+    *
     * @param timeout Finite duration to wait before returning the provided response
     */
   def apply[F[_], G[_], A](timeout: FiniteDuration, timeoutResponse: F[Response[G]])(
@@ -41,6 +50,15 @@ object Timeout {
   /** Transform the service to return a timeout response after the given
     * duration if the service has not yet responded.  If the timeout
     * fires, the service's response is canceled.
+    *
+    * Note, if effects of service responding is uncancelable
+    * (e.g. if service uses `MonadCancel#uncancelable` under the hood) and has exceeded
+    * the timeout, then an expected behavior is:
+    * <ul>
+    *   <li> effects will be completed naturally (regardless of how long it takes), </li>
+    *   <li> after that, the timeout response will be returned. </li>
+    * </ul>
+    * To get more insights on effect canceling, dig into the Cats-Effect documentation.
     *
     * @param timeout Finite duration to wait before returning
     * a `503 Service Unavailable` response

--- a/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/TimeoutSuite.scala
@@ -39,7 +39,7 @@ class TimeoutSuite extends Http4sSuite {
       IO.never[Response[IO]]
 
     case _ -> Root / "uncancelable" =>
-      IO.uncancelable(_ => IO.sleep(3100.milliseconds)) *> Ok("uncancelable")
+      IO.uncancelable(_ => IO.sleep(1100.milliseconds)) *> Ok("uncancelable")
   }
 
   private val fastReq = Request[IO](GET, uri"/fast")
@@ -47,7 +47,7 @@ class TimeoutSuite extends Http4sSuite {
   private val uncancelableReq = Request[IO](GET, uri"/uncancelable")
 
   def checkStatus(resp: IO[Response[IO]], status: Status): IO[Unit] =
-    resp.map(_.status).timeout(3.seconds).assertEquals(status)
+    resp.map(_.status).timeout(1.seconds).assertEquals(status)
 
   def testMiddleware(timeout: FiniteDuration, routes: HttpRoutes[IO] = defaultRoutes)(
       test: Http[IO, IO] => IO[Unit]


### PR DESCRIPTION
I think the uncancelable behavior is noteworthy because it could lead to some surprising effects on the user site. It's indisputable that it's the user's responsibility to check how their services produce effects. But still, I'm sure it's better to highlight that behavior. 
Also, I've added the test that proves my point about `Timeout` middleware behavior when dealing with uncancelable effects.