### PR TITLE
Ember-Core - H2Client - Rewrite without alternative.

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -361,26 +361,21 @@ private[ember] object H2Client {
     } yield (http1Client: TinyClient[F]) => { (req: Request[F]) =>
       val key = H2Client.RequestKey.fromRequest(req)
       val priorKnowledge = req.attributes.lookup(H2Keys.Http2PriorKnowledge).isDefined
-      val h2Prior = Alternative[Option].guard(priorKnowledge).as(Http2)
-      for {
-        socketType <- Resource.eval(
-          socketMap.get.map(_.get(key))
-        )
-        resp <- h2Prior.orElse(socketType) match {
-          case Some(Http2) => h2.runHttp2Only(req)
-          case Some(Http1) => http1Client(req)
-          case None =>
-            (
-              h2.runHttp2Only(req) <*
-                Resource.eval(socketMap.update(s => s + (key -> Http2)))
-            ).handleErrorWith[org.http4s.Response[F], Throwable] {
-              case InvalidSocketType() | MissingHost() | MissingPort() =>
-                Resource.eval(socketMap.update(s => s + (key -> Http1))) >>
-                  http1Client(req)
-              case e => Resource.raiseError[F, Response[F], Throwable](e)
-            }
-        }
-      } yield resp
+      val socketTypeF = if (priorKnowledge) Some(Http2).pure[F] else socketMap.get.map(_.get(key))
+      Resource.eval(socketTypeF).flatMap {
+        case Some(Http2) => h2.runHttp2Only(req)
+        case Some(Http1) => http1Client(req)
+        case None =>
+          (
+            h2.runHttp2Only(req) <*
+              Resource.eval(socketMap.update(s => s + (key -> Http2)))
+          ).handleErrorWith[org.http4s.Response[F], Throwable] {
+            case InvalidSocketType() | MissingHost() | MissingPort() =>
+              Resource.eval(socketMap.update(s => s + (key -> Http1))) >>
+                http1Client(req)
+            case e => Resource.raiseError[F, Response[F], Throwable](e)
+          }
+      }
     }
 
   sealed trait SocketType extends Product with Serializable


### PR DESCRIPTION
In this code, the use of `Alternative[Option]` can be replaced with an if-then-else statement. Furthermore, we can replace the for-comprehension with a simple flatMap and less inlining.

_Note_: most changes are whitespace.
