### PR TITLE
Encoding of response with empty body

### DIFF
--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -22,6 +22,7 @@ import cats.effect.IO
 import cats.syntax.all._
 import org.http4s.headers.`Content-Length`
 import org.http4s.syntax.literals._
+import fs2._
 
 class EncoderSuite extends Http4sSuite {
   private object Helpers {
@@ -131,6 +132,20 @@ class EncoderSuite extends Http4sSuite {
     val expected =
       """HTTP/1.1 200 OK
       |Content-Length: 0
+      |
+      |""".stripMargin
+
+    Helpers.encodeResponseRig(resp).assertEquals(expected)
+  }
+
+  test("respToBytes should encode a no body response correctly with stream") {
+    val resp = Response[IO](Status.Ok, body = Stream.chunk(Chunk.empty))
+
+    val expected =
+      """HTTP/1.1 200 OK
+      |Transfer-Encoding: chunked
+      |
+      |0
       |
       |""".stripMargin
 

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -20,9 +20,9 @@ package ember.core
 import cats.effect.Concurrent
 import cats.effect.IO
 import cats.syntax.all._
+import fs2._
 import org.http4s.headers.`Content-Length`
 import org.http4s.syntax.literals._
-import fs2._
 
 class EncoderSuite extends Http4sSuite {
   private object Helpers {

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -125,6 +125,18 @@ class EncoderSuite extends Http4sSuite {
     Helpers.encodeResponseRig(resp).assertEquals(expected)
   }
 
+  test("respToBytes should encode a no body response correctly with no header") {
+    val resp = Response[IO](Status.Ok)
+
+    val expected =
+      """HTTP/1.1 200 OK
+      |Content-Length: 0
+      |
+      |""".stripMargin
+
+    Helpers.encodeResponseRig(resp).assertEquals(expected)
+  }
+
   test("encoder a response where entity is not allowed correctly") {
     val resp = Response[IO](Status.NoContent)
     val expected =


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/6427

Around the repository there are different ways that empty responses are encoded. In some places the content length is set to 0, and in other places like the auth middleware, an empty response is returned with no headers set.

Here is a potential fix where an empty body with `content-length: 0` is always set when the status code allows a non-empty response and the header is not already set.

Something similar could probably also be done in the request encoding as well.