### PR TITLE
Added note on possible circe import error in docs

### DIFF
--- a/docs/docs/json.md
+++ b/docs/docs/json.md
@@ -44,7 +44,7 @@ import org.http4s.dsl.io._
 import org.http4s.implicits._
 ```
 
-Note: Under some setup options (we saw this in Scala 3.1.2 but not in 3.1.0), running `import io.circe._` might give you an error of `-- [E008] Not Found Error: value circe is not a member of io`. This means that `io` is set from some other package, and you can run `import _root_.io.circe._`.
+Note: Under some setup options (we saw this in Scala 3.1.2 but not in 3.1.0), running `import io.circe._` might give you an error of `-- [E008] Not Found Error: value circe is not a member of io`. This means that `io` is set from some other package. In that case, you should run `import _root_.io.circe._`, analogously for the other `circe` imports.
 
 Then the actual code:
 

--- a/docs/docs/json.md
+++ b/docs/docs/json.md
@@ -44,6 +44,8 @@ import org.http4s.dsl.io._
 import org.http4s.implicits._
 ```
 
+Note: Under some setup options (we saw this in Scala 3.1.2 but not in 3.1.0), running `import io.circe._` might give you an error of `-- [E008] Not Found Error: value circe is not a member of io`. This means that `io` is set from some other package, and you can run `import _root_.io.circe._`.
+
 Then the actual code:
 
 ```scala mdoc

--- a/docs/docs/json.md
+++ b/docs/docs/json.md
@@ -44,8 +44,11 @@ import org.http4s.dsl.io._
 import org.http4s.implicits._
 ```
 
-Note: Under some setup options (we saw this in Scala 3.1.2 but not in 3.1.0), running `import io.circe._` might give you an error of `-- [E008] Not Found Error: value circe is not a member of io`. This means that `io` is set from some other package. In that case, you should run `import _root_.io.circe._`, analogously for the other `circe` imports.
+@:callout(info)
 
+Under some setup options (we saw this in Scala 3.1.2 but not in 3.1.0), running `import io.circe._` might give you an error of `-- [E008] Not Found Error: value circe is not a member of io`. This means that `io` is shadowed from some other package. In that case, you should run `import _root_.io.circe._`, analogously for the other `circe` imports.
+
+@:@
 Then the actual code:
 
 ```scala mdoc

--- a/docs/docs/json.md
+++ b/docs/docs/json.md
@@ -49,6 +49,7 @@ import org.http4s.implicits._
 Under some setup options (we saw this in Scala 3.1.2 but not in 3.1.0), running `import io.circe._` might give you an error of `-- [E008] Not Found Error: value circe is not a member of io`. This means that `io` is shadowed from some other package. In that case, you should run `import _root_.io.circe._`, analogously for the other `circe` imports.
 
 @:@
+
 Then the actual code:
 
 ```scala mdoc


### PR DESCRIPTION
Added a note that helped resolve a `circe` import error I encountered.

This was the solution proposed by armanbilge on Discord. In my case, I set up the project with `sbt new http4s/http4s.g8 --branch 0.23-scala3` and the import `import io.circe._` will work with Scala 3.1.0, but not 3.1.2. The proposed change allows the import to run.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 