### PR TITLE
Run coverage job for PRs, but don't upload results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,6 @@ jobs:
 
   coverage:
     name: Generate coverage report
-    if: github.event_name != 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -449,7 +448,8 @@ jobs:
 
       - run: sbt '++${{ matrix.scala }}' coverage rootJVM/test coverageAggregate
 
-      - uses: codecov/codecov-action@v2
+      - if: github.event_name != 'pull_request'
+        uses: codecov/codecov-action@v2
 
   site:
     name: Generate Site

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
   WorkflowJob(
     id = "coverage",
     name = "Generate coverage report",
-    cond = Some("github.event_name != 'pull_request'"),
     scalas = List(scala_213),
     javas = List(JavaSpec.temurin("8")),
     steps = List(WorkflowStep.Checkout) ++
@@ -47,7 +46,8 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
             "codecov",
             "codecov-action",
             "v2",
-          )
+          ),
+          cond = Some("github.event_name != 'pull_request'"),
         ),
       ),
   ),


### PR DESCRIPTION
Sorry for the follow-up, realized I overlooked this subtlety. Occasionally the scoverage plugin will break for some otherwise valid code (like the `\r\n` thing). A PR could do this by mistake and we wouldn't find out till merge.

So actually, we _do_ want to run coverage for PRs, just to make sure it still works. We just don't want to upload the results!