### PR TITLE
Compose multiple subsequent `Message#putHeaders` calls

### DIFF
--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -189,9 +189,7 @@ private[client] object ClientHelpers extends ClientHelpersPlatform {
     val userAgentHeader: Option[`User-Agent`] = req.headers.get[`User-Agent`].orElse(userAgent)
     for {
       date <- req.headers.get[Date].fold(HttpDate.current[F].map(Date(_)))(_.pure[F])
-    } yield req
-      .putHeaders(date, connection)
-      .putHeaders(userAgentHeader)
+    } yield req.putHeaders(date, connection, userAgentHeader)
   }
 
   private[ember] def postProcessResponse[F[_]](

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Caching.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Caching.scala
@@ -50,7 +50,7 @@ object Caching {
   def `no-store-response`[G[_]]: PartiallyAppliedNoStoreCache[G] =
     new PartiallyAppliedNoStoreCache[G] {
       def apply[F[_]](resp: Response[F])(implicit G: Temporal[G]): G[Response[F]] =
-        HttpDate.current[G].map(now => resp.putHeaders(HDate(now)).putHeaders(noStoreStaticHeaders))
+        HttpDate.current[G].map(now => resp.putHeaders(HDate(now), noStoreStaticHeaders))
     }
 
   // These never change, so don't recreate them each time.


### PR DESCRIPTION
Two subsequent calls of `Message#putHeaders` could be composed into one. It should bring itsy bitsy reducing allocations.