### PR TITLE
Pick 'filename*' and ignore 'filename' in `Content-Disposition` header

### DIFF
--- a/tests/src/test/scala/org/http4s/parser/ContentDispositionHeaderSuite.scala
+++ b/tests/src/test/scala/org/http4s/parser/ContentDispositionHeaderSuite.scala
@@ -25,8 +25,7 @@ class ContentDispositionHeaderSuite extends Http4sSuite {
   def parse(value: String): ParseResult[`Content-Disposition`] =
     `Content-Disposition`.parse(value)
 
-  test("ContentDisposition Header should render the correct values") {
-
+  test("Content-Disposition header should render the correct values") {
     val wrongEncoding = `Content-Disposition`("form-data", Map(ci"filename" -> "http4s łł"))
     val correctOrder =
       `Content-Disposition`("form-data", Map(ci"filename*" -> "value1", ci"filename" -> "value2"))
@@ -41,4 +40,11 @@ class ContentDispositionHeaderSuite extends Http4sSuite {
     )
   }
 
+  test("Content-Disposition header should pick 'filename*' parameter and ignore 'filename'") {
+    val headerValue = """form-data; filename="filename"; filename*=UTF-8''http4s%20filename"""
+    val parsedHeader = `Content-Disposition`.parse(headerValue)
+    val header = `Content-Disposition`("form-data", Map(CIString("filename") -> "http4s filename"))
+
+    assertEquals(parsedHeader, Right(header))
+  }
 }


### PR DESCRIPTION
According to [RFC6266](https://datatracker.ietf.org/doc/html/rfc6266#section-4.3):
>  Many user agent implementations predating this specification do not
>    understand the "filename*" parameter.  Therefore, when both
>    "filename" and "filename*" are present in a single header field
>    value, recipients SHOULD pick "filename*" and ignore "filename".

I think it should be fine to fix it for 0.22, considering another [`Content-Disposition` fix](https://github.com/http4s/http4s/pull/6473).