### PR TITLE
Make Uri.Path.merge compliant

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -374,7 +374,7 @@ object Uri extends UriPlatform {
 
     /* Merge paths per RFC 3986 5.2.3 */
     def merge(path: Path): Path = {
-      val merge = if (isEmpty) segments else segments.init
+      val merge = if (isEmpty || endsWithSlash) segments else segments.init
       Path(merge ++ path.segments, absolute = absolute, endsWithSlash = path.endsWithSlash)
     }
 

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -783,10 +783,10 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
     val genSegmentNz = nonEmptyListOf(genPChar).map(_.mkString)
     val genSegment = listOf(genPChar).map(_.mkString)
     val genPathEmpty = const("")
-    val genPathAbEmpty = listOf(const("/") |+| genSegment).map(_.mkString)
-    val genPathRootless = genSegmentNz |+| genPathAbEmpty
-    val genPathNoScheme = genSegmentNzNc |+| genPathAbEmpty
-    val genPathAbsolute = const("/") |+| opt(genPathRootless)
+    val genPathAbEmpty = listOf(const("/") |+| genSegment).map(_.mkString) |+| opt("/")
+    val genPathRootless = genSegmentNz |+| genPathAbEmpty |+| opt("/")
+    val genPathNoScheme = genSegmentNzNc |+| genPathAbEmpty |+| opt("/")
+    val genPathAbsolute = const("/") |+| opt(genPathRootless) |+| opt("/")
 
     oneOf(genPathAbEmpty, genPathAbsolute, genPathNoScheme, genPathRootless, genPathEmpty).map(
       Uri.Path.unsafeFromString

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -27,14 +27,16 @@ class PathSuite extends Http4sSuite {
 
   test("equals should be consistent with equality") {
     forAll { (a: Path, b: Path) =>
-      if (a == b) (a.segments == b.segments) && (a.absolute == b.absolute) && (a.endsWithSlash == b.endsWithSlash)
-      else (a.segments != b.segments) || (a.absolute != b.absolute) || (a.endsWithSlash != b.endsWithSlash)
+      if (a == b)
+        (a.segments == b.segments) && (a.absolute == b.absolute) && (a.endsWithSlash == b.endsWithSlash)
+      else
+        (a.segments != b.segments) || (a.absolute != b.absolute) || (a.endsWithSlash != b.endsWithSlash)
     }
   }
 
   test("hashcode should be consistent with equality") {
     forAll { (a: Path, b: Path) =>
-      if (a == b) (a.## == b.##)
+      if (a == b) a.## == b.##
       else a.## != b.##
     }
   }

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -19,8 +19,21 @@ package org.http4s
 import cats.kernel.laws.discipline._
 import org.http4s.Uri.Path
 import org.http4s.laws.discipline.arbitrary._
+import org.scalacheck.Prop._
 
 class PathSuite extends Http4sSuite {
   checkAll("Order[Path]", OrderTests[Path].order)
   checkAll("Semigroup[Path]", SemigroupTests[Path].semigroup)
+
+  test("equals should be consistent with equals") {
+    forAll { (a: Path, b: Path) =>
+      (a == b) == (a.segments == b.segments) == (a.absolute == b.absolute) == (a.endsWithSlash == b.endsWithSlash)
+    }
+  }
+
+  test("hashcode should be consistent with equality") {
+    forAll { (a: Path, b: Path) =>
+      (a == b) ==> (a.## == b.##)
+    }
+  }
 }

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -25,15 +25,17 @@ class PathSuite extends Http4sSuite {
   checkAll("Order[Path]", OrderTests[Path].order)
   checkAll("Semigroup[Path]", SemigroupTests[Path].semigroup)
 
-  test("equals should be consistent with equals") {
+  test("equals should be consistent with equality") {
     forAll { (a: Path, b: Path) =>
-      (a == b) ==> (a.segments == b.segments) && (a.absolute == b.absolute) && (a.endsWithSlash == b.endsWithSlash)
+      if (a == b) (a.segments == b.segments) && (a.absolute == b.absolute) && (a.endsWithSlash == b.endsWithSlash)
+      else (a.segments != b.segments) || (a.absolute != b.absolute) || (a.endsWithSlash != b.endsWithSlash)
     }
   }
 
   test("hashcode should be consistent with equality") {
     forAll { (a: Path, b: Path) =>
-      (a == b) ==> (a.## == b.##)
+      if (a == b) (a.## == b.##)
+      else a.## != b.##
     }
   }
 }

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -27,7 +27,7 @@ class PathSuite extends Http4sSuite {
 
   test("equals should be consistent with equals") {
     forAll { (a: Path, b: Path) =>
-      (a == b) == (a.segments == b.segments) == (a.absolute == b.absolute) == (a.endsWithSlash == b.endsWithSlash)
+      (a == b) ==> (a.segments == b.segments) && (a.absolute == b.absolute) && (a.endsWithSlash == b.endsWithSlash)
     }
   }
 

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -40,4 +40,20 @@ class PathSuite extends Http4sSuite {
       else a.## != b.##
     }
   }
+
+  test("merge should be producing a new Path according to rfc3986 5.2.3") {
+    forAll { (a: Path, b: Path) =>
+      if (a.endsWithSlash)
+        assertEquals(a.merge(b), Path(a.segments ++ b.segments, a.absolute, b.endsWithSlash))
+      else
+        assertEquals(
+          a.merge(b),
+          Path(
+            (if (a.segments.nonEmpty) a.segments.init else Vector.empty) ++ b.segments,
+            a.absolute,
+            b.endsWithSlash,
+          ),
+        )
+    }
+  }
 }


### PR DESCRIPTION
Fixes #5099 

This PR aims at making Uri.Path.merge compliant with RFC 3986 5.2.3

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 