### PR TITLE
Add filename property to Content-Disposition

### DIFF
--- a/core/src/main/scala/org/http4s/headers/Content-Disposition.scala
+++ b/core/src/main/scala/org/http4s/headers/Content-Disposition.scala
@@ -127,4 +127,13 @@ object `Content-Disposition` {
 }
 
 // see https://datatracker.ietf.org/doc/html/rfc2183
-final case class `Content-Disposition`(dispositionType: String, parameters: Map[CIString, String])
+final case class `Content-Disposition`(dispositionType: String, parameters: Map[CIString, String]) {
+
+  /** Returns the `filename*` parameter if present, or else the
+    * `filename` parameter if present, or else none.
+    *
+    * @see [[https://datatracker.ietf.org/doc/html/rfc6266#section-4.3 RFC6266, Section 4.3]]
+    */
+  def filename: Option[String] =
+    parameters.get(ci"filename*").orElse(parameters.get(ci"filename"))
+}


### PR DESCRIPTION
As per RFC6266, Section 4.3, if `filename*` is defined, prefer that.  If not, try `filename`.

Kind of like #6475, but lossless.