### PR TITLE
Add Ordering for MediaRange

### DIFF
--- a/core/shared/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/shared/src/main/scala/org/http4s/ContentCoding.scala
@@ -15,7 +15,7 @@
  */
 
 /*
- * Copyright 2013-2020 http4s.org
+ * Copyright 2013-2022 http4s.org
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/core/shared/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/shared/src/main/scala/org/http4s/ContentCoding.scala
@@ -15,7 +15,7 @@
  */
 
 /*
- * Copyright 2013-2022 http4s.org
+ * Copyright 2013-2020 http4s.org
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/core/shared/src/main/scala/org/http4s/MediaType.scala
+++ b/core/shared/src/main/scala/org/http4s/MediaType.scala
@@ -180,6 +180,10 @@ object MediaRange {
       def f(a: MediaRange) = (a.mainType, orderedSubtype(a), a.extensions.toVector.sortBy(_._1))
       Order[(String, String, Vector[(String, String)])].compare(f(x), f(y))
     }
+
+  implicit val http4sOrderingForMediaRange: Ordering[MediaRange] =
+    http4sOrderForMediaRange.toOrdering
+
   implicit val http4sHttpCodecForMediaRange: HttpCodec[MediaRange] =
     new HttpCodec[MediaRange] {
       override def parse(s: String): ParseResult[MediaRange] =


### PR DESCRIPTION
This is the only missing `Ordering` I could find - all the other data types extend `Ordered`, which then allows deriving `Ordering` with implicit extension from `cats`

Closes #5017

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 