### PR TITLE
Set LoggingHandler in NettyTestServer to the default DEBUG level

### DIFF
--- a/client/src/test/scala/org/http4s/client/scaffold/NettyTestServer.scala
+++ b/client/src/test/scala/org/http4s/client/scaffold/NettyTestServer.scala
@@ -31,7 +31,6 @@ import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.codec.http._
-import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.handler.ssl.SslHandler
 import org.http4s.Uri
@@ -75,7 +74,7 @@ object NettyTestServer {
       .channelFactory(new ChannelFactory[NioServerSocketChannel] {
         override def newChannel(): NioServerSocketChannel = new NioServerSocketChannel()
       })
-      .handler(new LoggingHandler(LogLevel.INFO))
+      .handler(new LoggingHandler())
       .childHandler(new ChannelInitializer[NioSocketChannel]() {
         def initChannel(ch: NioSocketChannel): Unit = {
           logger.trace(s"Accepted new connection from [${ch.remoteAddress()}].")


### PR DESCRIPTION
I honestly don't know why I set the LoggingHandler to INFO. It's too high for such a low level log. It spams a lot in `blaze`'s tests where we have logback set to INFO. 