### PR TITLE
fix typo in `Throttle` middleware `httpAapp->httpApp`

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
@@ -129,9 +129,14 @@ object Throttle {
       Throttle.httpRoutes(bucket, defaultResponse[F] _)(httpRoutes)
     )
 
+  @deprecated("Use httpApp instead.", "0.23.14")
+  def httpAapp[F[_]](amount: Int, per: FiniteDuration)(httpApp: HttpApp[F])(implicit
+      F: Temporal[F]
+  ): F[HttpApp[F]] = this.httpApp(amount, per)(httpApp)
+
   /** As [[[apply[F[_],G[_]](amount:Int,per:scala\.concurrent\.duration\.FiniteDuration* apply(amount,per)]]], but for HttpApp[F]
     */
-  def httpAapp[F[_]](amount: Int, per: FiniteDuration)(httpApp: HttpApp[F])(implicit
+  def httpApp[F[_]](amount: Int, per: FiniteDuration)(httpApp: HttpApp[F])(implicit
       F: Temporal[F]
   ): F[HttpApp[F]] =
     apply(amount, per)(httpApp)


### PR DESCRIPTION
replaces #6500 now targeting series/0.23 rather than main