### PR TITLE
Expose `Network` constraint in ember builders

### DIFF
--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -41,7 +41,7 @@ import org.typelevel.log4cats.Logger
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 
-final class EmberClientBuilder[F[_]: Async] private (
+final class EmberClientBuilder[F[_]: Async: Network] private (
     private val tlsContextOpt: Option[TLSContext[F]],
     private val sgOpt: Option[SocketGroup[F]],
     val maxTotal: Int,
@@ -351,7 +351,7 @@ final class EmberClientBuilder[F[_]: Async] private (
 
 object EmberClientBuilder extends EmberClientBuilderCompanionPlatform {
 
-  def default[F[_]: Async] =
+  def default[F[_]: Async: Network] =
     new EmberClientBuilder[F](
       tlsContextOpt = None,
       sgOpt = None,
@@ -371,6 +371,10 @@ object EmberClientBuilder extends EmberClientBuilderCompanionPlatform {
       enableHttp2 = false,
       pushPromiseSupport = None,
     )
+
+  @deprecated("Use the overload which accepts a Network", "0.23.14")
+  def default[F[_]](async: Async[F]): EmberClientBuilder[F] =
+    default(async, Network.forAsync(async))
 
   private object Defaults {
     val acgFixedThreadPoolSize: Int = 100

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -372,7 +372,7 @@ object EmberClientBuilder extends EmberClientBuilderCompanionPlatform {
       pushPromiseSupport = None,
     )
 
-  @deprecated("Use the overload which accepts a Network", "0.23.14")
+  @deprecated("Use the overload which accepts a Network", "0.23.16")
   def default[F[_]](async: Async[F]): EmberClientBuilder[F] =
     default(async, Network.forAsync(async))
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -39,7 +39,7 @@ import org.typelevel.vault.Key
 
 import scala.concurrent.duration._
 
-final class EmberServerBuilder[F[_]: Async] private (
+final class EmberServerBuilder[F[_]: Async: Network] private (
     val host: Option[Host],
     val port: Port,
     private val httpApp: WebSocketBuilder2[F] => HttpApp[F],
@@ -241,7 +241,7 @@ final class EmberServerBuilder[F[_]: Async] private (
 }
 
 object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
-  def default[F[_]: Async]: EmberServerBuilder[F] =
+  def default[F[_]: Async: Network]: EmberServerBuilder[F] =
     new EmberServerBuilder[F](
       host = Host.fromString(Defaults.host),
       port = Port.fromInt(Defaults.port).get,
@@ -261,6 +261,10 @@ object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
       None,
       false,
     )
+
+  @deprecated("Use the overload which accepts a Network", "0.23.14")
+  def default[F[_]](async: Async[F]): EmberServerBuilder[F] =
+    default(async, Network.forAsync(async))
 
   private object Defaults {
     val host: String = server.defaults.IPv4Host

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -262,7 +262,7 @@ object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
       false,
     )
 
-  @deprecated("Use the overload which accepts a Network", "0.23.14")
+  @deprecated("Use the overload which accepts a Network", "0.23.16")
   def default[F[_]](async: Async[F]): EmberServerBuilder[F] =
     default(async, Network.forAsync(async))
 


### PR DESCRIPTION
This change is motivated by the I/O Integrated Runtime Concept in https://github.com/typelevel/cats-effect/discussions/3070 which proposes an alternate implementation of `Network[IO]`. There have also been discussions of a `Network` implementation based on [fs2-netty](https://github.com/typelevel/fs2-netty).

For Ember to be able to take advantage of such advances, we must expose the `Network[F]` constraint in the builder. Fortunately this is source-compatible, because an implicit `Network[F]` is always in scope for `Async[F]` which was already required.

See also how Skunk does it:
https://github.com/tpolecat/skunk/blob/14c756d68ba88da4415699bea388149c43e4e962/modules/core/shared/src/main/scala/Session.scala#L262

~~While looking at that, I notice Skunk actually only takes a `Concurrent` constraint there. Seems to me we may be able to achieve a similar relaxation, let me give that a try.~~ No, this is not possible. We need `Sync` to interop with the HPACK implementation.