### PR TITLE
Use `scodec.bits.ByteVector` for `Entity.Strict`

### DIFF
--- a/client/shared/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/RetrySuite.scala
@@ -30,6 +30,7 @@ import org.http4s.laws.discipline.arbitrary._
 import org.http4s.syntax.all._
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF
+import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
 
@@ -175,7 +176,7 @@ class RetrySuite extends Http4sSuite {
     val emptyEntity = Entity.Empty
 
     val strictEntity =
-      Entity.strict(fs2.Chunk.array("OK".getBytes))
+      Entity.strict(ByteVector.view("OK".getBytes))
 
     (emptyEntity, strictEntity).parTraverse_(entity =>
       resubmit(method = PUT, entity = Some(entity))(RetryPolicy.defaultRetriable)

--- a/core/shared/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityDecoder.scala
@@ -209,8 +209,8 @@ object EntityDecoder {
       case Entity.Default(body, _) =>
         body.chunks.compile.to(Chunk).map(_.flatten)
 
-      case Entity.Strict(c) =>
-        Applicative[F].pure(c)
+      case Entity.Strict(b) =>
+        Applicative[F].pure(Chunk.byteVector(b))
 
       case Entity.Empty =>
         Applicative[F].pure(Chunk.empty[Byte])
@@ -225,8 +225,8 @@ object EntityDecoder {
       case Entity.Default(body, _) =>
         body.compile.to(ByteVector)
 
-      case Entity.Strict(c) =>
-        Applicative[F].pure(c.to(ByteVector))
+      case Entity.Strict(b) =>
+        Applicative[F].pure(b)
 
       case Entity.Empty =>
         Applicative[F].pure(ByteVector.empty)

--- a/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
@@ -147,14 +147,14 @@ object EntityEncoder {
   ): EntityEncoder.Pure[Array[Char]] =
     stringEncoder.contramap(new String(_))
 
+  implicit val byteVectorEncoder: EntityEncoder.Pure[ByteVector] =
+    simple(`Content-Type`(MediaType.application.`octet-stream`))(identity)
+
   implicit val chunkEncoder: EntityEncoder.Pure[Chunk[Byte]] =
     byteVectorEncoder.contramap(_.toByteVector)
 
   implicit val byteArrayEncoder: EntityEncoder.Pure[Array[Byte]] =
     byteVectorEncoder.contramap(ByteVector.view)
-
-  implicit def byteVectorEncoder[F[_]]: EntityEncoder[F, ByteVector] =
-    simple(`Content-Type`(MediaType.application.`octet-stream`))(identity)
 
   /** Encodes an entity body.  Chunking of the stream is preserved.  A
     * `Transfer-Encoding: chunked` header is set, as we cannot know

--- a/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityEncoder.scala
@@ -139,7 +139,7 @@ object EntityEncoder {
 
   implicit def stringEncoder(implicit charset: Charset = `UTF-8`): EntityEncoder.Pure[String] = {
     val hdr = `Content-Type`(MediaType.text.plain).withCharset(charset)
-    simple(hdr)(ByteVector.encodeString(_)(charset.nioCharset).toOption.get)
+    simple(hdr)(s => ByteVector.view(s.getBytes(charset.nioCharset)))
   }
 
   implicit def charArrayEncoder(implicit

--- a/core/shared/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/Part.scala
@@ -25,10 +25,10 @@ import fs2.io.file.Path
 import fs2.io.readInputStream
 import org.http4s.headers.`Content-Disposition`
 import org.typelevel.ci._
+import scodec.bits.ByteVector
 
 import java.io.InputStream
 import java.net.URL
-import java.nio.charset.StandardCharsets.UTF_8
 
 final case class Part[+F[_]](headers: Headers, entity: Entity[F]) extends Media[F] {
   def name: Option[String] = headers.get[`Content-Disposition`].flatMap(_.parameters.get(ci"name"))
@@ -44,7 +44,7 @@ object Part {
   def formData(name: String, value: String, headers: Header.ToRaw*): Part[fs2.Pure] =
     Part(
       Headers(`Content-Disposition`("form-data", Map(ci"name" -> name))).put(headers: _*),
-      Entity.Strict(Chunk.array(value.getBytes(UTF_8))),
+      Entity.Strict(ByteVector.encodeUtf8(value).toOption.get),
     )
 
   def fileData[F[_]: Files](name: String, path: Path, headers: Header.ToRaw*): Part[F] =

--- a/core/shared/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/Part.scala
@@ -18,7 +18,6 @@ package org.http4s
 package multipart
 
 import cats.effect.Sync
-import fs2.Chunk
 import fs2.io.file.Files
 import fs2.io.file.Flags
 import fs2.io.file.Path

--- a/core/shared/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/Part.scala
@@ -28,6 +28,7 @@ import scodec.bits.ByteVector
 
 import java.io.InputStream
 import java.net.URL
+import java.nio.charset.StandardCharsets.UTF_8
 
 final case class Part[+F[_]](headers: Headers, entity: Entity[F]) extends Media[F] {
   def name: Option[String] = headers.get[`Content-Disposition`].flatMap(_.parameters.get(ci"name"))
@@ -43,7 +44,7 @@ object Part {
   def formData(name: String, value: String, headers: Header.ToRaw*): Part[fs2.Pure] =
     Part(
       Headers(`Content-Disposition`("form-data", Map(ci"name" -> name))).put(headers: _*),
-      Entity.Strict(ByteVector.encodeUtf8(value).toOption.get),
+      Entity.Strict(ByteVector.view(value.getBytes(UTF_8))),
     )
 
   def fileData[F[_]: Files](name: String, path: Path, headers: Header.ToRaw*): Part[F] =

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -153,8 +153,8 @@ private[ember] object Encoder {
             (Stream.chunk(initSectionChunk) ++ body)
               .chunkMin(writeBufferSize)
               .flatMap(Stream.chunk)
-          case Entity.Strict(chunk) =>
-            Stream.chunk(initSectionChunk ++ chunk)
+          case Entity.Strict(bytes) =>
+            Stream.chunk(initSectionChunk ++ Chunk.byteVector(bytes))
           case Entity.Empty =>
             Stream.chunk(initSectionChunk)
         }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -24,6 +24,7 @@ import cats.syntax.all._
 import fs2._
 import org.http4s._
 import org.typelevel.ci.CIString
+import scodec.bits.ByteVector
 
 import scala.annotation.switch
 import scala.collection.mutable
@@ -433,10 +434,10 @@ private[ember] object Parser {
       if (contentLength > 0) {
         if (buffer.length == contentLength) {
           val drain: Drain[F] = F.pure(Some(Array.emptyByteArray): Option[Array[Byte]])
-          F.pure(Entity.strict(Chunk.array(buffer)) -> drain)
+          F.pure(Entity.strict(ByteVector.view(buffer)) -> drain)
         } else if (buffer.length > contentLength) {
           val drain: Drain[F] = F.pure(Some(buffer.drop(contentLength.toInt)): Option[Array[Byte]])
-          F.pure(Entity.strict(Chunk.array(buffer, 0, contentLength.toInt)) -> drain)
+          F.pure(Entity.strict(ByteVector.view(buffer, 0, contentLength.toInt)) -> drain)
         } else {
           val unread = contentLength - buffer.length
           Ref.of[F, Option[Array[Byte]]](None).map { state =>

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -122,7 +122,7 @@ private[ember] object H2Server {
                 req.uri,
                 HttpVersion.`HTTP/2`,
                 req.headers,
-                Entity.Strict(Chunk.byteVector(bv)),
+                Entity.Strict(bv),
                 req.attributes,
               )
               upgradeResponse.withAttribute(H2Keys.H2cUpgrade, (settings, newReq))

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientSimpleExample.scala
@@ -28,6 +28,7 @@ import org.http4s.circe._
 import org.http4s.client._
 import org.http4s.implicits._
 import org.typelevel.log4cats.SelfAwareStructuredLogger
+import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
 
@@ -69,7 +70,7 @@ object EmberClientSimpleExample extends IOApp {
 
   def getRequestBufferedBody[F[_]: Async](client: Client[F], req: Request[F]): F[Response[Pure]] = {
     def buffer(resp: Response[F]): F[Response[Pure]] =
-      resp.body.compile.to(Chunk).map(bv => resp.copy(entity = Entity.Strict(bv)))
+      resp.body.compile.to(ByteVector).map(bv => resp.copy(entity = Entity.Strict(bv)))
 
     client.run(req).use(buffer)
   }

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -39,6 +39,7 @@ import org.scalacheck._
 import org.scalacheck.rng.Seed
 import org.typelevel.ci.CIString
 import org.typelevel.ci.testing.arbitraries._
+import scodec.bits.ByteVector
 
 import java.nio.charset.{Charset => NioCharset}
 import java.time._
@@ -864,7 +865,7 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
 
     val strictEntityGen =
       http4sTestingGenForPureByteStream
-        .map(body => Entity.strict(body.compile.to(fs2.Chunk)))
+        .map(body => Entity.strict(body.compile.to(ByteVector)))
 
     val chunkedEntityGen =
       http4sTestingGenForPureByteStream

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/MemoryCache.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/MemoryCache.scala
@@ -20,8 +20,8 @@ package staticcontent
 
 import cats.effect.Concurrent
 import cats.syntax.functor._
-import fs2.Chunk
 import org.log4s.getLogger
+import scodec.bits.ByteVector
 
 import java.util.concurrent.ConcurrentHashMap
 
@@ -55,9 +55,9 @@ class MemoryCache[F[_]] extends CacheStrategy[F] {
       F: Concurrent[F]
   ): F[Response[F]] =
     resp
-      .as[Chunk[Byte]]
-      .map { chunk =>
-        val newResponse: Response[F] = resp.copy(entity = Entity.Strict(chunk))
+      .as[ByteVector]
+      .map { bv =>
+        val newResponse: Response[F] = resp.copy(entity = Entity.Strict(bv))
         cacheMap.put(path, newResponse)
         newResponse
       }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
@@ -26,6 +26,7 @@ import org.http4s.Method._
 import org.http4s.Status._
 import org.http4s.server.middleware.EntityLimiter.EntityTooLarge
 import org.http4s.syntax.all._
+import scodec.bits.ByteVector
 
 import java.nio.charset.StandardCharsets
 
@@ -35,7 +36,8 @@ class EntityLimiterSuite extends Http4sSuite {
   }
 
   private val defaultEntity = Entity(chunk(Chunk.array("hello".getBytes(StandardCharsets.UTF_8))))
-  private val strictEntity = Entity.strict(Chunk.array("hello".getBytes(StandardCharsets.UTF_8)))
+  private val strictEntity =
+    Entity.strict(ByteVector.view("hello".getBytes(StandardCharsets.UTF_8)))
 
   test("Allow reasonable default entity") {
     EntityLimiter(routes, 100)

--- a/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -25,6 +25,7 @@ import fs2.io.file.Files
 import fs2.io.file.Path
 import org.http4s.Status.Ok
 import org.http4s.headers.`Content-Type`
+import scodec.bits.ByteVector
 
 import java.nio.charset.StandardCharsets
 import java.util.Arrays
@@ -455,7 +456,7 @@ class EntityDecoderSuite extends Http4sSuite {
 
   test("binary EntityDecoder should concat Chunks") {
     val d1 = Array[Byte](1, 2, 3); val d2 = Array[Byte](4, 5, 6)
-    val body = Chunk.array(d1) ++ Chunk.array(d2)
+    val body = ByteVector.view(d1) ++ ByteVector.view(d2)
     val msg = Request[IO](entity = Entity.Strict(body))
     val expected = Chunk.array(Array[Byte](1, 2, 3, 4, 5, 6))
     EntityDecoder.binary[IO].decode(msg, strict = false).value.assertEquals(Right(expected))
@@ -484,7 +485,7 @@ class EntityDecoderSuite extends Http4sSuite {
   sealed case class ErrorJson(value: String)
   implicit val errorJsonEntityEncoder: EntityEncoder[IO, ErrorJson] =
     EntityEncoder.simple[ErrorJson](`Content-Type`(MediaType.application.json))(json =>
-      Chunk.array(json.value.getBytes())
+      ByteVector.view(json.value.getBytes())
     )
 
 // TODO: These won't work without an Eq for (Message[IO], Boolean) => DecodeResult[IO, A]

--- a/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -28,6 +28,7 @@ import fs2.io.file.Files
 import org.http4s.headers._
 import org.http4s.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary
+import scodec.bits.ByteVector
 
 import java.io._
 import java.nio.charset.StandardCharsets
@@ -142,9 +143,9 @@ class EntityEncoderSpec extends Http4sSuite {
       sealed case class ModelB(name: String, id: Long)
 
       implicit val w1: EntityEncoder[IO, ModelA] =
-        EntityEncoder.simple[ModelA]()(_ => Chunk.array("A".getBytes))
+        EntityEncoder.simple[ModelA]()(_ => ByteVector.view("A".getBytes))
       implicit val w2: EntityEncoder[IO, ModelB] =
-        EntityEncoder.simple[ModelB]()(_ => Chunk.array("B".getBytes))
+        EntityEncoder.simple[ModelB]()(_ => ByteVector.view("B".getBytes))
 
       assertEquals(EntityEncoder[IO, ModelA], w1)
       assertEquals(EntityEncoder[IO, ModelB], w2)

--- a/tests/shared/src/test/scala/org/http4s/MessageSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/MessageSuite.scala
@@ -29,6 +29,7 @@ import org.http4s.headers.`X-Forwarded-For`
 import org.http4s.syntax.all._
 import org.typelevel.ci._
 import org.typelevel.vault._
+import scodec.bits.ByteVector
 
 class MessageSuite extends Http4sSuite {
   private val local = SocketAddress(ipv4"127.0.0.1", port"8080")
@@ -209,7 +210,10 @@ class MessageSuite extends Http4sSuite {
 
   test("toString should correctly print a request with a strict entity") {
     val req =
-      Request(method = Method.POST, entity = Entity.strict(Chunk(Byte.MinValue, Byte.MaxValue)))
+      Request(
+        method = Method.POST,
+        entity = Entity.strict(ByteVector(Byte.MinValue, Byte.MaxValue)),
+      )
     assertEquals(
       req.toString,
       "Request(method=POST, uri=/, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Strict(2 bytes total))",
@@ -357,7 +361,7 @@ class MessageSuite extends Http4sSuite {
   }
 
   test("toString should correctly print a response with a strict entity") {
-    val resp = Response(entity = Entity.strict(Chunk(Byte.MinValue, Byte.MaxValue)))
+    val resp = Response(entity = Entity.strict(ByteVector(Byte.MinValue, Byte.MaxValue)))
     assertEquals(
       resp.toString,
       "Response(status=200, httpVersion=HTTP/1.1, headers=Headers(), entity=Entity.Strict(2 bytes total))",


### PR DESCRIPTION
**tl;dr** Because `ByteVector` is specialized for `Byte`, it has idiomatic APIs for byte manipulation and copy-free interop that `Chunk` lacks.

This is a follow-up to my comments in https://github.com/http4s/http4s/issues/5812. See there for more details, summary below:

1. IMHO a `ByteVector` the more idiomatic data structure for, well, bytes. `Chunk[Byte]` is kind of an FS2 thing.
2. `ByteVector` exposes useful ops specifically for byte manipulation, not available on `Chunk[Byte]`. I wanted this in:
    https://github.com/typelevel/feral/pull/214#discussion_r882320272
3. `ByteVector` exposes better APIs for copy-free interop. I wanted this in:
    https://github.com/http4s/http4s-jdk-http-client/pull/644#discussion_r882347645
4. Even though `ByteVector` does not subsume `Chunk`, many common `Chunk`s can become a `ByteVector` without copying.
    https://github.com/typelevel/fs2/blob/79344baae70b6e3d2a3731f5e7f8e3d81ce9eedb/core/shared/src/main/scala/fs2/Chunk.scala#L364-L377
5. Does anyone have an example of a backend where `Chunk` has an advantage over `ByteVector`?
