### PR TITLE
Fix request logger to log in the case of no request body, when `logBody=true`

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -90,9 +90,10 @@ object RequestLogger {
             // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
             val logPipe: Pipe[F, Byte, Byte] =
               _.observe(_.chunks.flatMap(s => Stream.exec(vec.update(_ :+ s))))
-                .onFinalizeWeak(logAtEnd)
 
-            client.run(req.pipeBodyThrough(logPipe))
+            val resp = client.run(req.pipeBodyThrough(logPipe))
+
+            resp.onFinalize(logAtEnd)
           }
         }
     }

--- a/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -18,7 +18,6 @@ package org.http4s
 package client
 package middleware
 
-import cats.effect.Ref
 import cats.effect._
 import cats.syntax.all._
 import fs2._
@@ -79,31 +78,30 @@ object RequestLogger {
         Resource.eval(logMessage(req)) *> client.run(req)
       else
         Resource.suspend {
-          (Deferred.apply[F, Unit], Ref[F].of(Vector.empty[Chunk[Byte]])).mapN {
-            case (shouldLog, vec) =>
-              val newBody = Stream.eval(vec.get).flatMap(v => Stream.emits(v)).unchunks
+          (F.deferred[Unit], F.ref(Vector.empty[Chunk[Byte]])).mapN { case (shouldLog, vec) =>
+            val newBody = Stream.eval(vec.get).flatMap(v => Stream.emits(v)).unchunks
 
-              val logOnceAtEnd: F[Unit] = shouldLog.complete(()).flatMap {
-                case true =>
-                  logMessage(req.withBodyStream(newBody)).handleErrorWith { case t =>
-                    F.delay(logger.error(t)("Error logging request body"))
-                  }
-                case _ => F.unit
-              }
+            val logOnceAtEnd: F[Unit] = shouldLog.complete(()).flatMap {
+              case true =>
+                logMessage(req.withBodyStream(newBody)).handleErrorWith { case t =>
+                  F.delay(logger.error(t)("Error logging request body"))
+                }
+              case _ => F.unit
+            }
 
-              // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
-              val logPipe: Pipe[F, Byte, Byte] =
-                _.observe(_.chunks.flatMap(s => Stream.exec(vec.update(_ :+ s))))
-                  .onFinalizeWeak(logOnceAtEnd)
+            // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
+            val logPipe: Pipe[F, Byte, Byte] =
+              _.observe(_.chunks.flatMap(s => Stream.exec(vec.update(_ :+ s))))
+                .onFinalizeWeak(logOnceAtEnd)
 
-              val resp = client.run(req.pipeBodyThrough(logPipe))
+            val resp = client.run(req.pipeBodyThrough(logPipe))
 
-              // If the request body was not consumed (ex: bodiless GET)
-              // the second best we can do is log on the response body finalizer
-              // the third best is on the response resource finalizer (ex: if the client failed to pull the body)
-              resp
-                .map[Response[F]](r => r.withBodyStream(r.body.onFinalizeWeak(logOnceAtEnd)))
-                .onFinalize(logOnceAtEnd)
+            // If the request body was not consumed (ex: bodiless GET)
+            // the second best we can do is log on the response body finalizer
+            // the third best is on the response resource finalizer (ex: if the client failed to pull the body)
+            resp
+              .map[Response[F]](r => r.withBodyStream(r.body.onFinalizeWeak(logOnceAtEnd)))
+              .onFinalize(logOnceAtEnd)
           }
         }
     }

--- a/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -76,7 +76,7 @@ class LoggerSuite extends Http4sSuite {
   test("RequestLogger should log a Get for all values of logBody") {
     forAllF { (logBody: Boolean) =>
       val req = Request[IO](uri = uri"/request")
-      val message = "HTTP/1.1 GET /request Headers(Accept: text/*)"
+      val message = "HTTP/1.1 GET /request Headers()"
 
       for {
         logger <- Queue.unbounded[IO, String]

--- a/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -86,7 +86,8 @@ class LoggerSuite extends Http4sSuite {
       for {
         logger <- Queue.unbounded[IO, String]
         _ <- logger.offer(message)
-        _ <- configurableRequestLoggerClient(logBody, Some(logAction(logger))).successful(req)
+        _ <- configurableRequestLoggerClient(logBody, Some(logAction(logger)))
+          .successful(req)
         remaining <- logger.tryTake
       } yield assert(remaining.isEmpty, "logAction not called")
     }

--- a/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -69,7 +69,7 @@ class LoggerSuite extends Http4sSuite {
 
   private val configurableRequestLoggerClient =
     (logBody: Boolean, logAction: Option[String => IO[Unit]]) =>
-      RequestLogger.apply[IO](true, logBody, _ => false, logAction)(
+      RequestLogger.apply[IO](true, logBody, logAction = logAction)(
         Client.fromHttpApp(testApp)
       )
 

--- a/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -86,8 +86,7 @@ class LoggerSuite extends Http4sSuite {
       for {
         logger <- Queue.unbounded[IO, String]
         _ <- logger.offer(message)
-        _ <- configurableRequestLoggerClient(logBody, Some(logAction(logger)))
-          .successful(req)
+        _ <- configurableRequestLoggerClient(logBody, Some(logAction(logger))).successful(req)
         remaining <- logger.tryTake
       } yield assert(remaining.isEmpty, "logAction not called")
     }


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/2951