### PR TITLE
Remove `BackendBuilder#allocate`

### DIFF
--- a/core/shared/src/main/scala/org/http4s/internal/BackendBuilder.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/BackendBuilder.scala
@@ -33,17 +33,4 @@ private[http4s] trait BackendBuilder[F[_], A] {
     * The backend is shut down when the stream is finalized.
     */
   def stream: Stream[F, A] = Stream.resource(resource)
-
-  /** Returns an effect that allocates a backend and an `F[Unit]` to
-    * release it.  The returned `F` waits until the backend is ready
-    * to process requests.  The second element of the tuple shuts
-    * down the backend when run.
-    *
-    * Unlike [[resource]] and [[stream]], there is no automatic
-    * release of the backend.  This function is intended for REPL
-    * sessions, tests, and other situations where composing a
-    * [[cats.effect.Resource]] or [[fs2.Stream]] is not tenable.
-    * [[resource]] or [[stream]] is recommended wherever possible.
-    */
-  def allocated: F[(A, F[Unit])] = resource.allocated
 }


### PR DESCRIPTION
This addresses #5543. Though @bplommer has suggested deprecating it, I feel that for 1.0 we should remove it. Users could still do this on their side via `serverBuilder.resource.allocated`.