### PR TITLE
Revert "Ember Core: reimplement readLoop without Streams."

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -211,7 +211,7 @@ private[ember] class H2Client[F[_]: Async](
         socket,
         logger,
       )
-      _ <- h2.readLoop.background
+      _ <- h2.readLoop.compile.drain.background
       _ <- h2.writeLoop.compile.drain.background
       _ <-
         Stream

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -243,7 +243,7 @@ private[ember] object H2Server {
       _ <- Resource.eval(
         queue.offer(Chunk.singleton(H2Frame.Settings.ConnectionSettings.toSettings(localSettings)))
       )
-      _ <- h2.readLoop.background
+      _ <- h2.readLoop.compile.drain.background
 
       _ <- Resource.eval(h2.settingsAck.get.rethrow)
       // h2c Initial Request Communication on h2c Upgrade


### PR DESCRIPTION
This reverts commit 69a67490d1fa324e1f9813b6436ef54ead70ac02.

Fixes #6549 

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 