### PR TITLE
Rewrite hashcode computation for `Uri.Path`

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -553,7 +553,8 @@ object Uri extends UriPlatform {
           )
       }
 
-    implicit val http4sInstancesForPath: Order[Path] with Semigroup[Path] with Hash[Path] =
+    def http4sInstancesForPath: : Order[Path] with Semigroup[Path] = http4sInstancesForPathBinCompat
+    implicit val http4sInstancesForPathBinCompat: Order[Path] with Semigroup[Path] with Hash[Path] =
       new Order[Path] with Semigroup[Path] with Hash[Path] {
         def compare(x: Path, y: Path): Int = {
           def comparePaths[A: Order](focus: Path => A): Int =

--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -339,12 +339,14 @@ object Uri extends UriPlatform {
     private def doEquals(path: Path): Boolean =
       this.segments == path.segments && path.absolute == this.absolute && path.endsWithSlash == this.endsWithSlash
 
-    override def hashCode(): Int = {
-      var hash = segments.hashCode()
-      hash += 31 * absolute.hashCode()
-      hash += 31 * endsWithSlash.hashCode()
-      hash
-    }
+    override def hashCode(): Int =
+      // this prevents hashcode clashing when two Paths have `absolute` and `endWithSlash`
+      // asymmetric values, i.e. path1 (absolute = true, endWithSlash = false), path2 (absolute = false, endWithSlash = true)
+      31 * (
+        31 * (
+          31 * endsWithSlash.##
+        ) + absolute.##
+      ) + segments.##
 
     def render(writer: Writer): writer.type = {
       val start = if (absolute) "/" else ""

--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -340,16 +340,13 @@ object Uri extends UriPlatform {
     private def doEquals(path: Path): Boolean =
       this.segments == path.segments && path.absolute == this.absolute && path.endsWithSlash == this.endsWithSlash
 
-    override def hashCode(): Int =
-      // this prevents hashcode clashing when two Paths have `absolute` and `endWithSlash`
-      // asymmetric values, i.e. path1 (absolute = true, endWithSlash = false), path2 (absolute = false, endWithSlash = true)
-      {
-        var hash = Path.hashSeed
-        hash = MurmurHash3.mix(hash, segments.##)
-        hash = MurmurHash3.mix(hash, absolute.##)
-        hash = MurmurHash3.mix(hash, endsWithSlash.##)
-        MurmurHash3.finalizeHash(hash, 3)
-      }
+    override def hashCode(): Int = {
+      var hash = Path.hashSeed
+      hash = MurmurHash3.mix(hash, segments.##)
+      hash = MurmurHash3.mix(hash, absolute.##)
+      hash = MurmurHash3.mix(hash, endsWithSlash.##)
+      MurmurHash3.finalizeHash(hash, 3)
+    }
 
     def render(writer: Writer): writer.type = {
       val start = if (absolute) "/" else ""

--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -54,7 +54,6 @@ import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets
 import java.nio.charset.{Charset => JCharset}
 import scala.collection.immutable
-import scala.math.Ordered
 import scala.util.hashing.MurmurHash3
 
 /** Representation of the [[Request]] URI

--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -428,14 +428,7 @@ object Uri extends UriPlatform {
     def toRelative: Path = copy(absolute = false)
   }
 
-  private[Uri] trait LowPriorityImplicitsForPath {
-    implicit val pathHash: Hash[Path] = new Hash[Path] {
-      override def hash(x: Path): Int = x.##
-      override def eqv(x: Path, y: Path): Boolean = x == y
-    }
-  }
-
-  object Path extends LowPriorityImplicitsForPath {
+  object Path {
     val empty: Path = new Path(Vector.empty, absolute = false, endsWithSlash = false)
     val Root: Path = new Path(Vector.empty, absolute = true, endsWithSlash = true)
     lazy val Asterisk: Path =
@@ -560,8 +553,8 @@ object Uri extends UriPlatform {
           )
       }
 
-    implicit val http4sInstancesForPath: Order[Path] with Semigroup[Path] =
-      new Order[Path] with Semigroup[Path] {
+    implicit val http4sInstancesForPath: Order[Path] with Semigroup[Path] with Hash[Path] =
+      new Order[Path] with Semigroup[Path] with Hash[Path] {
         def compare(x: Path, y: Path): Int = {
           def comparePaths[A: Order](focus: Path => A): Int =
             compareField(x, y, focus)
@@ -573,6 +566,8 @@ object Uri extends UriPlatform {
         }
 
         def combine(x: Path, y: Path): Path = x.concat(y)
+
+        def hash(x: Path): Int = x.##
       }
 
   }

--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -428,7 +428,14 @@ object Uri extends UriPlatform {
     def toRelative: Path = copy(absolute = false)
   }
 
-  object Path {
+  private[Uri] trait LowPriorityImplicitsForPath {
+    implicit val pathHash: Hash[Path] = new Hash[Path] {
+      override def hash(x: Path): Int = x.##
+      override def eqv(x: Path, y: Path): Boolean = x == y
+    }
+  }
+
+  object Path extends LowPriorityImplicitsForPath {
     val empty: Path = new Path(Vector.empty, absolute = false, endsWithSlash = false)
     val Root: Path = new Path(Vector.empty, absolute = true, endsWithSlash = true)
     lazy val Asterisk: Path =

--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -344,9 +344,7 @@ object Uri extends UriPlatform {
       // this prevents hashcode clashing when two Paths have `absolute` and `endWithSlash`
       // asymmetric values, i.e. path1 (absolute = true, endWithSlash = false), path2 (absolute = false, endWithSlash = true)
       {
-        var hash =
-          MurmurHash3.mix(MurmurHash3.productSeed, "Uri.Path".##)
-
+        var hash = Path.hashSeed
         hash = MurmurHash3.mix(hash, segments.##)
         hash = MurmurHash3.mix(hash, absolute.##)
         hash = MurmurHash3.mix(hash, endsWithSlash.##)
@@ -439,6 +437,9 @@ object Uri extends UriPlatform {
     val Root: Path = new Path(Vector.empty, absolute = true, endsWithSlash = true)
     lazy val Asterisk: Path =
       new Path(Vector(Segment("*")), absolute = false, endsWithSlash = false)
+
+    private val hashSeed: Int =
+      MurmurHash3.mix(MurmurHash3.productSeed, "Uri.Path".##)
 
     final class Segment private (val encoded: String) {
       def isEmpty = encoded.isEmpty

--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -553,7 +553,7 @@ object Uri extends UriPlatform {
           )
       }
 
-    def http4sInstancesForPath: : Order[Path] with Semigroup[Path] = http4sInstancesForPathBinCompat
+    def http4sInstancesForPath: Order[Path] with Semigroup[Path] = http4sInstancesForPathBinCompat
     implicit val http4sInstancesForPathBinCompat: Order[Path] with Semigroup[Path] with Hash[Path] =
       new Order[Path] with Semigroup[Path] with Hash[Path] {
         def compare(x: Path, y: Path): Int = {

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -25,7 +25,7 @@ import org.scalacheck.Prop._
 class PathSuite extends Http4sSuite {
   checkAll("Order[Path]", OrderTests[Path].order)
   checkAll("Semigroup[Path]", SemigroupTests[Path].semigroup)
-  checkAll("Hash[Path]", HashTests[Path](Hash.fromHashing).hash)
+  checkAll("Hash[Path]", HashTests[Path].hash)
   checkAll("Eq[Path]", EqTests[Path].eqv)
 
   test("merge should be producing a new Path according to rfc3986 5.2.3") {

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -28,9 +28,13 @@ class PathSuite extends Http4sSuite {
   test("equals should be consistent with equality") {
     forAll { (a: Path, b: Path) =>
       if (a == b)
-        (a.segments == b.segments) && (a.absolute == b.absolute) && (a.endsWithSlash == b.endsWithSlash)
+        assert(
+          (a.segments == b.segments) && (a.absolute == b.absolute) && (a.endsWithSlash == b.endsWithSlash)
+        )
       else
-        (a.segments != b.segments) || (a.absolute != b.absolute) || (a.endsWithSlash != b.endsWithSlash)
+        assert(
+          (a.segments != b.segments) || (a.absolute != b.absolute) || (a.endsWithSlash != b.endsWithSlash)
+        )
     }
   }
 
@@ -38,6 +42,21 @@ class PathSuite extends Http4sSuite {
     forAll { (a: Path, b: Path) =>
       if (a == b) a.## == b.##
       else a.## != b.##
+    }
+  }
+
+  // test devised based on the issue raised at https://github.com/http4s/http4s/issues/6538
+  test(
+    "hashcode should be consistent with equality even when two Paths with identical non-empty segments have `absolute` and `endWithSlash` asymmetric values"
+  ) {
+    val nonEmptySegmentsPathGen =
+      http4sTestingAbitraryForPath.arbitrary.suchThat(_.segments.nonEmpty)
+
+    forAll(nonEmptySegmentsPathGen) { (path0: Path) =>
+      val a = Path(path0.segments, true, false)
+      val b = Path(path0.segments, false, true)
+
+      assert(a.## != b.##)
     }
   }
 

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -40,23 +40,12 @@ class PathSuite extends Http4sSuite {
 
   test("hashcode should be consistent with equality") {
     forAll { (a: Path, b: Path) =>
-      if (a == b) a.## == b.##
-      else a.## != b.##
-    }
-  }
-
-  // test devised based on the issue raised at https://github.com/http4s/http4s/issues/6538
-  test(
-    "hashcode should be consistent with equality even when two Paths with identical non-empty segments have `absolute` and `endWithSlash` asymmetric values"
-  ) {
-    val nonEmptySegmentsPathGen =
-      http4sTestingAbitraryForPath.arbitrary.suchThat(_.segments.nonEmpty)
-
-    forAll(nonEmptySegmentsPathGen) { (path0: Path) =>
-      val a = Path(path0.segments, true, false)
-      val b = Path(path0.segments, false, true)
-
-      assert(a.## != b.##)
+      assert(
+        if (a.## != b.##)
+          a != b // if the hashCodes are different, then the Paths should be different by equality
+        else
+          (a == b) && (a.## == b.##) // if the Paths are equal, then the hashcodes should be the same
+      )
     }
   }
 

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -16,7 +16,6 @@
 
 package org.http4s
 
-import cats.Hash
 import cats.kernel.laws.discipline._
 import org.http4s.Uri.Path
 import org.http4s.laws.discipline.arbitrary._

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -16,6 +16,7 @@
 
 package org.http4s
 
+import cats.Hash
 import cats.kernel.laws.discipline._
 import org.http4s.Uri.Path
 import org.http4s.laws.discipline.arbitrary._
@@ -24,30 +25,8 @@ import org.scalacheck.Prop._
 class PathSuite extends Http4sSuite {
   checkAll("Order[Path]", OrderTests[Path].order)
   checkAll("Semigroup[Path]", SemigroupTests[Path].semigroup)
-
-  test("equals should be consistent with equality") {
-    forAll { (a: Path, b: Path) =>
-      if (a == b)
-        assert(
-          (a.segments == b.segments) && (a.absolute == b.absolute) && (a.endsWithSlash == b.endsWithSlash)
-        )
-      else
-        assert(
-          (a.segments != b.segments) || (a.absolute != b.absolute) || (a.endsWithSlash != b.endsWithSlash)
-        )
-    }
-  }
-
-  test("hashcode should be consistent with equality") {
-    forAll { (a: Path, b: Path) =>
-      assert(
-        if (a.## != b.##)
-          a != b // if the hashCodes are different, then the Paths should be different by equality
-        else
-          (a == b) && (a.## == b.##) // if the Paths are equal, then the hashcodes should be the same
-      )
-    }
-  }
+  checkAll("Hash[Path]", HashTests[Path](Hash.fromHashing).hash)
+  checkAll("Eq[Path]", EqTests[Path].eqv)
 
   test("merge should be producing a new Path according to rfc3986 5.2.3") {
     forAll { (a: Path, b: Path) =>

--- a/tests/shared/src/test/scala/org/http4s/PathSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/PathSuite.scala
@@ -25,7 +25,6 @@ class PathSuite extends Http4sSuite {
   checkAll("Order[Path]", OrderTests[Path].order)
   checkAll("Semigroup[Path]", SemigroupTests[Path].semigroup)
   checkAll("Hash[Path]", HashTests[Path].hash)
-  checkAll("Eq[Path]", EqTests[Path].eqv)
 
   test("merge should be producing a new Path according to rfc3986 5.2.3") {
     forAll { (a: Path, b: Path) =>


### PR DESCRIPTION
Closes #6538

The actual fix would be along the lines of what was discussed [here](https://github.com/http4s/http4s/discussions/5930#discussioncomment-2997587), but we'll have to wait for [cats-uri](https://github.com/typelevel/cats-uri) for a definitive solution
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 