### PR TITLE
Deprecate `BackendBuilder#allocate`

### DIFF
--- a/core/shared/src/main/scala/org/http4s/internal/BackendBuilder.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/BackendBuilder.scala
@@ -45,5 +45,9 @@ private[http4s] trait BackendBuilder[F[_], A] {
     * [[cats.effect.Resource]] or [[fs2.Stream]] is not tenable.
     * [[resource]] or [[stream]] is recommended wherever possible.
     */
+  @deprecated(
+    "Use manually called '.resource.allocated' instead. Will be removed from public API in 1.0.",
+    "0.23.14",
+  )
   def allocated: F[(A, F[Unit])] = resource.allocated
 }


### PR DESCRIPTION
This is a follow up to #6540.
Finally fixes #5543.