### PR TITLE
Don't backtrack in request/response prelude parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,6 +187,9 @@ lazy val core = libraryCrossProject("core")
           ProblemFilters.exclude[ReversedMissingMethodProblem](
             "org.http4s.MimeDB.org$http4s$MimeDB$$_allMediaTypes_="
           ),
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "org.http4s.ember.core.Parser#MessageP.recurseFind"
+          ),
         )
       else Seq.empty
     },

--- a/build.sbt
+++ b/build.sbt
@@ -187,9 +187,6 @@ lazy val core = libraryCrossProject("core")
           ProblemFilters.exclude[ReversedMissingMethodProblem](
             "org.http4s.MimeDB.org$http4s$MimeDB$$_allMediaTypes_="
           ),
-          ProblemFilters.exclude[DirectMissingMethodProblem](
-            "org.http4s.ember.core.Parser#MessageP.recurseFind"
-          ),
         )
       else Seq.empty
     },
@@ -441,6 +438,9 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
       ),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.http4s.ember.core.Parser#Response#RespPrelude.parsePrelude"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.ember.core.Parser#MessageP.recurseFind"
       ),
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.ember.core.EmptyStreamError"),
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.ember.core.EmptyStreamError$"),

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
@@ -131,7 +131,7 @@ private[ember] object ChunkedEncoding {
       }
     } else {
       Parser.MessageP
-        .recurseFind(buffer, read, maxHeaderSize, Parser.HeaderP.ParserState.initial(0))(
+        .recurseFind(buffer, read, maxHeaderSize, Parser.HeaderP.ParserState.initial)(
           (state, buffer) => Parser.HeaderP.parse(buffer, maxHeaderSize, state)
         )(
           _.idx

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
@@ -130,9 +130,10 @@ private[ember] object ChunkedEncoding {
           parseTrailers(maxHeaderSize)(buffer ++ chunk.toArray[Byte], read)
       }
     } else {
-      val parser = new Parser.HeaderP.Parser[F]()
       Parser.MessageP
-        .recurseFind(buffer, read, maxHeaderSize)(buffer => parser.parse(buffer, 0, maxHeaderSize))(
+        .recurseFind(buffer, read, maxHeaderSize, Parser.HeaderP.ParserState.initial)(
+          (state, buffer) => Parser.HeaderP.parse(buffer, 0, maxHeaderSize, state)
+        )(
           _.idx
         )
         .map { case (headerP, rest) => Trailers(headerP.headers, rest) }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
@@ -130,10 +130,11 @@ private[ember] object ChunkedEncoding {
           parseTrailers(maxHeaderSize)(buffer ++ chunk.toArray[Byte], read)
       }
     } else {
+      val parser = new Parser.HeaderP.Parser[F]()
       Parser.MessageP
-        .recurseFind(buffer, read, maxHeaderSize)(buffer =>
-          Parser.HeaderP.parseHeaders(buffer, 0, maxHeaderSize)
-        )(_.idx)
+        .recurseFind(buffer, read, maxHeaderSize)(buffer => parser.parse(buffer, 0, maxHeaderSize))(
+          _.idx
+        )
         .map { case (headerP, rest) => Trailers(headerP.headers, rest) }
     }
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/ChunkedEncoding.scala
@@ -131,8 +131,8 @@ private[ember] object ChunkedEncoding {
       }
     } else {
       Parser.MessageP
-        .recurseFind(buffer, read, maxHeaderSize, Parser.HeaderP.ParserState.initial)(
-          (state, buffer) => Parser.HeaderP.parse(buffer, 0, maxHeaderSize, state)
+        .recurseFind(buffer, read, maxHeaderSize, Parser.HeaderP.ParserState.initial(0))(
+          (state, buffer) => Parser.HeaderP.parse(buffer, maxHeaderSize, state)
         )(
           _.idx
         )

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -142,7 +142,6 @@ private[ember] object Parser {
 
             val hName = name // copy var to val
             name = null // set name back to null
-            println(s"header name is $hName, value is $hValue")
             val newHeader = Header.Raw(CIString(hName), hValue) // create header
             if (hName.equalsIgnoreCase(contentLengthS)) { // Check if this is content-length.
               try contentLength = hValue.toLong.some
@@ -374,7 +373,7 @@ private[ember] object Parser {
         )(_.nextIndex)
         (prelude, buffer2) = x
         y <- MessageP.recurseFind(
-          buffer,
+          buffer2,
           read,
           maxHeaderSize,
           HeaderP.ParserState.initial,

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -324,7 +324,7 @@ private[ember] object Parser {
             maxHeaderSize,
             HeaderP.ParserState.initial,
           )((state, ibuffer) => HeaderP.parse(ibuffer, maxHeaderSize, state))(_.idx)
-          //We've already consumed data to parse the prelude so empty actually means end of stream
+          // We've already consumed data to parse the prelude so empty actually means end of stream
           .adaptError { case _: EmberException.EmptyStream =>
             EmberException.ReachedEndOfStream()
           }
@@ -384,7 +384,7 @@ private[ember] object Parser {
             maxHeaderSize,
             HeaderP.ParserState.initial,
           )((state, ibuffer) => HeaderP.parse(ibuffer, maxHeaderSize, state))(_.idx)
-          //We've already consumed data to parse the prelude so empty actually means end of stream
+          // We've already consumed data to parse the prelude so empty actually means end of stream
           .adaptError { case _: EmberException.EmptyStream =>
             EmberException.ReachedEndOfStream()
           }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -536,7 +536,7 @@ private[ember] object Parser {
           RespPrelude(httpVersion, status, idx).asRight.pure[F]
       }
 
-      final case class RespPreludeError(message: String, cause: Option[Throwable])
+      case class RespPreludeError(message: String, cause: Option[Throwable])
           extends Exception(
             s"Received Error while parsing prelude - Message: $message - ${cause.map(_.getMessage)}",
             cause.orNull,

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -67,8 +67,6 @@ private[ember] object Parser {
   )
 
   object HeaderP {
-    import scala.collection.mutable.ListBuffer
-
     private[this] val colon: Byte = ':'.toByte
     private[this] val contentLengthS = "Content-Length"
     private[this] val transferEncodingS = "Transfer-Encoding"
@@ -81,7 +79,7 @@ private[ember] object Parser {
         complete: Boolean,
         chunked: Boolean,
         contentLength: Option[Long],
-        headers: ListBuffer[Header.Raw],
+        headers: List[Header.Raw],
         name: String,
         start: Int,
     )
@@ -94,7 +92,7 @@ private[ember] object Parser {
         complete = false,
         chunked = false,
         contentLength = None,
-        headers = ListBuffer.empty,
+        headers = List.empty,
         name = null,
         start = 0,
       )
@@ -110,7 +108,7 @@ private[ember] object Parser {
       var chunked: Boolean = s.chunked
       var contentLength: Option[Long] = s.contentLength
 
-      val headers: ListBuffer[Header.Raw] = s.headers
+      var headers: List[Header.Raw] = s.headers
       var name: String = s.name
       var start: Int = s.start
       val upperBound = Math.min(message.size - 1, maxHeaderSize)
@@ -157,7 +155,7 @@ private[ember] object Parser {
               chunked = hValue.contains(chunkedS)
             }
             start = idx + 1 // Next Start is after the CRLF
-            headers += newHeader // Add Header
+            headers = newHeader :: headers // Add Header
             state = false // Go back to Looking for HeaderName or Termination
           }
         }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -317,12 +317,17 @@ private[ember] object Parser {
           (state, ibuffer) => ReqPrelude.parse(ibuffer, maxHeaderSize, state)
         )(_.nextIndex)
         (prelude, buffer2) = x
-        y <- MessageP.recurseFind(
-          buffer2,
-          read,
-          maxHeaderSize,
-          HeaderP.ParserState.initial,
-        )((state, ibuffer) => HeaderP.parse(ibuffer, maxHeaderSize, state))(_.idx)
+        y <- MessageP
+          .recurseFind(
+            buffer2,
+            read,
+            maxHeaderSize,
+            HeaderP.ParserState.initial,
+          )((state, ibuffer) => HeaderP.parse(ibuffer, maxHeaderSize, state))(_.idx)
+          //We've already consumed data to parse the prelude so empty actually means end of stream
+          .adaptError { case _: EmberException.EmptyStream =>
+            EmberException.ReachedEndOfStream()
+          }
         (headerP, finalBuffer) = y
 
         baseReq = org.http4s.Request[F](
@@ -372,12 +377,18 @@ private[ember] object Parser {
           (state, ibuffer) => RespPrelude.parse(ibuffer, maxHeaderSize, state)
         )(_.nextIndex)
         (prelude, buffer2) = x
-        y <- MessageP.recurseFind(
-          buffer2,
-          read,
-          maxHeaderSize,
-          HeaderP.ParserState.initial,
-        )((state, ibuffer) => HeaderP.parse(ibuffer, maxHeaderSize, state))(_.idx)
+        y <- MessageP
+          .recurseFind(
+            buffer2,
+            read,
+            maxHeaderSize,
+            HeaderP.ParserState.initial,
+          )((state, ibuffer) => HeaderP.parse(ibuffer, maxHeaderSize, state))(_.idx)
+          //We've already consumed data to parse the prelude so empty actually means end of stream
+          .adaptError { case _: EmberException.EmptyStream =>
+            EmberException.ReachedEndOfStream()
+          }
+
         (headerP, finalBuffer) = y
 
         baseResp = org.http4s.Response[F](

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -87,8 +87,8 @@ private[ember] object Parser {
     )
 
     object ParserState {
-      def initial(idx: Int): ParserState = ParserState(
-        idx = idx,
+      def initial: ParserState = ParserState(
+        idx = 0,
         state = false,
         throwable = null,
         complete = false,
@@ -96,7 +96,7 @@ private[ember] object Parser {
         contentLength = None,
         headers = ListBuffer.empty,
         name = null,
-        start = idx,
+        start = 0,
       )
     }
 
@@ -142,6 +142,7 @@ private[ember] object Parser {
 
             val hName = name // copy var to val
             name = null // set name back to null
+            println(s"header name is $hName, value is $hValue")
             val newHeader = Header.Raw(CIString(hName), hValue) // create header
             if (hName.equalsIgnoreCase(contentLengthS)) { // Check if this is content-length.
               try contentLength = hValue.toLong.some
@@ -321,7 +322,7 @@ private[ember] object Parser {
           buffer2,
           read,
           maxHeaderSize,
-          HeaderP.ParserState.initial(prelude.nextIndex),
+          HeaderP.ParserState.initial,
         )((state, ibuffer) => HeaderP.parse(ibuffer, maxHeaderSize, state))(_.idx)
         (headerP, finalBuffer) = y
 
@@ -376,7 +377,7 @@ private[ember] object Parser {
           buffer,
           read,
           maxHeaderSize,
-          HeaderP.ParserState.initial(prelude.nextIndex),
+          HeaderP.ParserState.initial,
         )((state, ibuffer) => HeaderP.parse(ibuffer, maxHeaderSize, state))(_.idx)
         (headerP, finalBuffer) = y
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -177,7 +177,7 @@ private[ember] object Parser {
           start,
         ).asLeft.pure[F]
       } else {
-        HeaderP(Headers(headers.toList), chunked, contentLength, idx).asRight.pure[F]
+        HeaderP(Headers(headers.reverse), chunked, contentLength, idx).asRight.pure[F]
       }
     }
 

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -392,7 +392,7 @@ class ParsingSuite extends Http4sSuite {
     val asHttp = Helpers.httpifyString(base)
     val bv = asHttp.getBytes()
 
-    Parser.HeaderP.parse[IO](bv, 0, 4096, Parser.HeaderP.ParserState.initial).map {
+    Parser.HeaderP.parse[IO](bv, 4096, Parser.HeaderP.ParserState.initial(0)).map {
       case Right(headerP) =>
         assertEquals(
           headerP.headers.headers,

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -97,33 +97,33 @@ class ParsingSuite extends Http4sSuite {
     }
   }
 
-  // test("Parser.Request.parser should Parse a request with no body correctly") {
-  //   val raw =
-  //     """GET / HTTP/1.1
-  //     |Host: www.google.com
-  //     |
-  //     |""".stripMargin
-  //   val expected = Request[IO](
-  //     Method.GET,
-  //     uri"www.google.com",
-  //     headers = Headers(org.http4s.headers.Host("www.google.com")),
-  //   )
+  test("Parser.Request.parser should Parse a request with no body correctly") {
+    val raw =
+      """GET / HTTP/1.1
+      |Host: www.google.com
+      |
+      |""".stripMargin
+    val expected = Request[IO](
+      Method.GET,
+      uri"www.google.com",
+      headers = Headers(org.http4s.headers.Host("www.google.com")),
+    )
 
-  //   val result = Helpers.parseRequestRig[IO](raw)
+    val result = Helpers.parseRequestRig[IO](raw)
 
-  //   result.map(_.method).assertEquals(expected.method)
-  //   result.map(_.uri.scheme).assertEquals(expected.uri.scheme)
-  //   // result.map(_.uri.authority).assertEquals(expected.uri.authority)
-  //   // result.map(_.uri.path).assertEquals(expected.uri.path)
-  //   // result.map(_.uri.query).assertEquals(expected.uri.query)
-  //   result.map(_.uri.fragment).assertEquals(expected.uri.fragment)
-  //   result.map(_.headers).assertEquals(expected.headers)
-  //   for {
-  //     r <- result
-  //     a <- r.body.compile.toVector
-  //     b <- expected.body.compile.toVector
-  //   } yield assertEquals(a, b)
-  // }
+    result.map(_.method).assertEquals(expected.method)
+    result.map(_.uri.scheme).assertEquals(expected.uri.scheme)
+    // result.map(_.uri.authority).assertEquals(expected.uri.authority)
+    // result.map(_.uri.path).assertEquals(expected.uri.path)
+    // result.map(_.uri.query).assertEquals(expected.uri.query)
+    result.map(_.uri.fragment).assertEquals(expected.uri.fragment)
+    result.map(_.headers).assertEquals(expected.headers)
+    for {
+      r <- result
+      a <- r.body.compile.toVector
+      b <- expected.body.compile.toVector
+    } yield assertEquals(a, b)
+  }
 
   test("Parser.Request.parser should Parse a request with a body correctly") {
     val raw =
@@ -197,6 +197,7 @@ class ParsingSuite extends Http4sSuite {
           .flatMap { case (resp, _) =>
             resp.body.through(text.utf8.decode).compile.string
           }
+      _ <- IO.println(s"Parsed: $parsed")
     } yield parsed == "{}").assert
   }
 

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -97,33 +97,33 @@ class ParsingSuite extends Http4sSuite {
     }
   }
 
-  test("Parser.Request.parser should Parse a request with no body correctly") {
-    val raw =
-      """GET / HTTP/1.1
-      |Host: www.google.com
-      |
-      |""".stripMargin
-    val expected = Request[IO](
-      Method.GET,
-      uri"www.google.com",
-      headers = Headers(org.http4s.headers.Host("www.google.com")),
-    )
+  // test("Parser.Request.parser should Parse a request with no body correctly") {
+  //   val raw =
+  //     """GET / HTTP/1.1
+  //     |Host: www.google.com
+  //     |
+  //     |""".stripMargin
+  //   val expected = Request[IO](
+  //     Method.GET,
+  //     uri"www.google.com",
+  //     headers = Headers(org.http4s.headers.Host("www.google.com")),
+  //   )
 
-    val result = Helpers.parseRequestRig[IO](raw)
+  //   val result = Helpers.parseRequestRig[IO](raw)
 
-    result.map(_.method).assertEquals(expected.method)
-    result.map(_.uri.scheme).assertEquals(expected.uri.scheme)
-    // result.map(_.uri.authority).assertEquals(expected.uri.authority)
-    // result.map(_.uri.path).assertEquals(expected.uri.path)
-    // result.map(_.uri.query).assertEquals(expected.uri.query)
-    result.map(_.uri.fragment).assertEquals(expected.uri.fragment)
-    result.map(_.headers).assertEquals(expected.headers)
-    for {
-      r <- result
-      a <- r.body.compile.toVector
-      b <- expected.body.compile.toVector
-    } yield assertEquals(a, b)
-  }
+  //   result.map(_.method).assertEquals(expected.method)
+  //   result.map(_.uri.scheme).assertEquals(expected.uri.scheme)
+  //   // result.map(_.uri.authority).assertEquals(expected.uri.authority)
+  //   // result.map(_.uri.path).assertEquals(expected.uri.path)
+  //   // result.map(_.uri.query).assertEquals(expected.uri.query)
+  //   result.map(_.uri.fragment).assertEquals(expected.uri.fragment)
+  //   result.map(_.headers).assertEquals(expected.headers)
+  //   for {
+  //     r <- result
+  //     a <- r.body.compile.toVector
+  //     b <- expected.body.compile.toVector
+  //   } yield assertEquals(a, b)
+  // }
 
   test("Parser.Request.parser should Parse a request with a body correctly") {
     val raw =
@@ -392,7 +392,7 @@ class ParsingSuite extends Http4sSuite {
     val asHttp = Helpers.httpifyString(base)
     val bv = asHttp.getBytes()
 
-    Parser.HeaderP.parse[IO](bv, 4096, Parser.HeaderP.ParserState.initial(0)).map {
+    Parser.HeaderP.parse[IO](bv, 4096, Parser.HeaderP.ParserState.initial).map {
       case Right(headerP) =>
         assertEquals(
           headerP.headers.headers,

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -392,7 +392,7 @@ class ParsingSuite extends Http4sSuite {
     val asHttp = Helpers.httpifyString(base)
     val bv = asHttp.getBytes()
 
-    Parser.HeaderP.parseHeaders[IO](bv, 0, 4096).map {
+    Parser.HeaderP.parse[IO](bv, 0, 4096, Parser.HeaderP.ParserState.initial).map {
       case Right(headerP) =>
         assertEquals(
           headerP.headers.headers,
@@ -450,13 +450,15 @@ class ParsingSuite extends Http4sSuite {
     val asHttp = Helpers.httpifyString(raw)
     val bv = asHttp.getBytes()
 
-    new Parser.Request.ReqPrelude.Parser[IO]().parse(bv, 4096).map {
-      case Right(prelude) =>
-        assertEquals(prelude.method, Method.GET)
-        assertEquals(prelude.uri, uri"/")
-        assertEquals(prelude.version, HttpVersion.`HTTP/1.1`)
-      case Left(_) => fail("Prelude was not right")
-    }
+    Parser.Request.ReqPrelude
+      .parse[IO](bv, 4096, Parser.Request.ReqPrelude.ParserState.initial)
+      .map {
+        case Right(prelude) =>
+          assertEquals(prelude.method, Method.GET)
+          assertEquals(prelude.uri, uri"/")
+          assertEquals(prelude.version, HttpVersion.`HTTP/1.1`)
+        case Left(_) => fail("Prelude was not right")
+      }
   }
 
   test("Response Prelude should parse an expected value") {
@@ -465,12 +467,14 @@ class ParsingSuite extends Http4sSuite {
         |""".stripMargin
     val asHttp = Helpers.httpifyString(raw)
     val bv = asHttp.getBytes()
-    new Parser.Response.RespPrelude.Parser[IO].parse(bv, 4096).map {
-      case Right(prelude) =>
-        assertEquals(prelude.version, HttpVersion.`HTTP/1.1`)
-        assertEquals(prelude.status, Status.Ok)
-      case Left(_) => fail("Prelude was not right")
-    }
+    Parser.Response.RespPrelude
+      .parse[IO](bv, 4096, Parser.Response.RespPrelude.ParserState.initial)
+      .map {
+        case Right(prelude) =>
+          assertEquals(prelude.version, HttpVersion.`HTTP/1.1`)
+          assertEquals(prelude.status, Status.Ok)
+        case Left(_) => fail("Prelude was not right")
+      }
   }
 
   test("Parser.Response.parser should parse two responses in a row") {

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -45,6 +45,7 @@ class ParsingSuite extends Http4sSuite {
         .emit(s)
         .map(httpifyString)
         .through(fs2.text.utf8.encode[F])
+        .rechunkRandomly(0.1, 0.5)
 
       taking(byteStream).flatMap { read =>
         Parser.Request.parser[F](Int.MaxValue)(Array.emptyByteArray, read).map(_._1)
@@ -56,6 +57,7 @@ class ParsingSuite extends Http4sSuite {
         .emit(s)
         .map(httpifyString)
         .through(fs2.text.utf8.encode[F])
+        .rechunkRandomly(0.1, 0.5)
 
       Resource.eval(
         taking(byteStream).flatMap { read =>

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -448,7 +448,7 @@ class ParsingSuite extends Http4sSuite {
     val asHttp = Helpers.httpifyString(raw)
     val bv = asHttp.getBytes()
 
-    Parser.Request.ReqPrelude.parsePrelude[IO](bv, 4096).map {
+    new Parser.Request.ReqPrelude.ReqPreludeParser[IO]().parse(bv, 4096).map {
       case Right(prelude) =>
         assertEquals(prelude.method, Method.GET)
         assertEquals(prelude.uri, uri"/")

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -448,7 +448,7 @@ class ParsingSuite extends Http4sSuite {
     val asHttp = Helpers.httpifyString(raw)
     val bv = asHttp.getBytes()
 
-    new Parser.Request.ReqPrelude.ReqPreludeParser[IO]().parse(bv, 4096).map {
+    new Parser.Request.ReqPrelude.Parser[IO]().parse(bv, 4096).map {
       case Right(prelude) =>
         assertEquals(prelude.method, Method.GET)
         assertEquals(prelude.uri, uri"/")
@@ -463,7 +463,7 @@ class ParsingSuite extends Http4sSuite {
         |""".stripMargin
     val asHttp = Helpers.httpifyString(raw)
     val bv = asHttp.getBytes()
-    Parser.Response.RespPrelude.parsePrelude[IO](bv, 4096).map {
+    new Parser.Response.RespPrelude.Parser[IO].parse(bv, 4096).map {
       case Right(prelude) =>
         assertEquals(prelude.version, HttpVersion.`HTTP/1.1`)
         assertEquals(prelude.status, Status.Ok)

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/StreamingParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/StreamingParserSuite.scala
@@ -195,24 +195,9 @@ class StreamingParserSuite extends Http4sSuite {
 
   // https://github.com/http4s/http4s/issues/6580
   test("raise end of stream for request with EOF after request line") {
-    // segments is equivalent to
-    // List(
-    //   "POST /foo HTTP/1.1\r\n",
-    //   "Content-Type: text/plain\r\n",
-    //   "Content-Length: 5\r\n\r\n",
-    //   "hello",
-    // )
-    // but as bytes and repartitioned so that the end of the request line is at the end of the
-    // second chunk
-    val segments: List[List[Byte]] = List(
-      List(80),
-      List(79, 83, 84, 32, 47, 102, 111, 111, 32, 72, 84, 84, 80, 47, 49, 46, 49, 13, 10),
-      List(67, 111, 110, 116, 101, 110, 116, 45, 84, 121, 112, 101, 58, 32, 116, 101, 120, 116, 47,
-        112, 108, 97, 105, 110, 13, 10, 67, 111, 110, 116, 101, 110, 116, 45, 76, 101, 110, 103,
-        116, 104, 58, 32, 53, 13, 10, 13, 10, 104, 101, 108, 108, 111),
-    )
+    val segments = Fixtures.toBytes(List("POST /foo HTTP/1.1\r\n"))
     (for {
-      read <- Helpers.taking[IO, Byte](segments.dropRight(1))
+      read <- Helpers.taking[IO, Byte](List(segments))
       result <- Parser.Request.parser(Int.MaxValue)(Array.emptyByteArray, read)
       _ <- result._1.body.compile.drain
       _ <- result._2

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/StreamingParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/StreamingParserSuite.scala
@@ -193,6 +193,32 @@ class StreamingParserSuite extends Http4sSuite {
     }
   }
 
+  // https://github.com/http4s/http4s/issues/6580
+  test("raise end of stream for request with EOF after request line") {
+    // segments is equivalent to
+    // List(
+    //   "POST /foo HTTP/1.1\r\n",
+    //   "Content-Type: text/plain\r\n",
+    //   "Content-Length: 5\r\n\r\n",
+    //   "hello",
+    // )
+    // but as bytes and repartitioned so that the end of the request line is at the end of the
+    // second chunk
+    val segments: List[List[Byte]] = List(
+      List(80),
+      List(79, 83, 84, 32, 47, 102, 111, 111, 32, 72, 84, 84, 80, 47, 49, 46, 49, 13, 10),
+      List(67, 111, 110, 116, 101, 110, 116, 45, 84, 121, 112, 101, 58, 32, 116, 101, 120, 116, 47,
+        112, 108, 97, 105, 110, 13, 10, 67, 111, 110, 116, 101, 110, 116, 45, 76, 101, 110, 103,
+        116, 104, 58, 32, 53, 13, 10, 13, 10, 104, 101, 108, 108, 111),
+    )
+    (for {
+      read <- Helpers.taking[IO, Byte](segments.dropRight(1))
+      result <- Parser.Request.parser(Int.MaxValue)(Array.emptyByteArray, read)
+      _ <- result._1.body.compile.drain
+      _ <- result._2
+    } yield ()).intercept[EmberException.ReachedEndOfStream].void
+  }
+
   test("raise end of stream for response") {
     PropF.forAllNoShrinkF(Fixtures.genResponse(min = 3)) { segments =>
       (for {


### PR DESCRIPTION
Don't backtrack in request/response prelude parsing for better performance.

Also resolves https://github.com/http4s/http4s/issues/6580 for 1.0.x