### PR TITLE
Set `serverNames` TLS parameter for ember h2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -576,7 +576,10 @@ lazy val emberClient = libraryCrossProject("ember-client")
     ),
     mimaBinaryIssueFilters := Seq(
       ProblemFilters
-        .exclude[DirectMissingMethodProblem]("org.http4s.ember.client.EmberClientBuilder.this")
+        .exclude[DirectMissingMethodProblem]("org.http4s.ember.client.EmberClientBuilder.this"),
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.http4s.ember.client.internal.ClientHelpersPlatform"
+      ),
     ),
   )
   .jvmSettings(

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -262,6 +262,7 @@ final class EmberClientBuilder[F[_]: Async] private (
           if (pushPromiseSupport.isDefined) default
           else
             default.copy(enablePush = H2Frame.Settings.SettingsEnablePush(false)),
+          checkEndpointIdentification,
         )
       }
     } yield {

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -40,6 +40,7 @@ import org.http4s.client.RequestKey
 import org.http4s.client.middleware._
 import org.http4s.ember.client._
 import org.http4s.ember.core.EmberException
+import org.http4s.ember.core.Util
 import org.http4s.headers.Connection
 import org.http4s.headers.Date
 import org.http4s.headers.`User-Agent`
@@ -49,7 +50,7 @@ import org.typelevel.keypool._
 import java.io.IOException
 import scala.concurrent.duration._
 
-private[client] object ClientHelpers extends ClientHelpersPlatform {
+private[client] object ClientHelpers {
   def requestToSocketWithKey[F[_]: Sync](
       request: Request[F],
       tlsContextOpt: Option[TLSContext[F]],
@@ -121,7 +122,7 @@ private[client] object ClientHelpers extends ClientHelpersPlatform {
           } { tlsContext =>
             tlsContext
               .clientBuilder(iSocket)
-              .withParameters(mkTLSParameters(optionNames, enableEndpointValidation))
+              .withParameters(Util.mkTLSParameters(optionNames, enableEndpointValidation))
               .build
               .widen[Socket[F]]
           }

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -122,7 +122,7 @@ private[client] object ClientHelpers {
           } { tlsContext =>
             tlsContext
               .clientBuilder(iSocket)
-              .withParameters(Util.mkTLSParameters(optionNames, enableEndpointValidation))
+              .withParameters(Util.mkClientTLSParameters(optionNames, enableEndpointValidation))
               .build
               .widen[Socket[F]]
           }

--- a/ember-core/js/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
+++ b/ember-core/js/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
@@ -29,7 +29,7 @@ import scala.annotation.tailrec
 private[core] trait UtilPlatform {
 
   @nowarn("msg=never used")
-  def mkTLSParameters(
+  def mkClientTLSParameters(
       address: Option[SocketAddress[Host]],
       enableEndpointValidation: Boolean,
   ): TLSParameters =

--- a/ember-core/js/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
+++ b/ember-core/js/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.http4s.ember.client.internal
+package org.http4s.ember.core
 
 import com.comcast.ip4s.Host
 import com.comcast.ip4s.Hostname
@@ -26,10 +26,10 @@ import fs2.io.net.tls.TLSParameters
 import scala.annotation.nowarn
 import scala.annotation.tailrec
 
-private[internal] trait ClientHelpersPlatform {
+private[core] trait UtilPlatform {
 
   @nowarn("msg=never used")
-  private[internal] def mkTLSParameters(
+  def mkTLSParameters(
       address: Option[SocketAddress[Host]],
       enableEndpointValidation: Boolean,
   ): TLSParameters =

--- a/ember-core/jvm/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
+++ b/ember-core/jvm/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.http4s.ember.client.internal
+package org.http4s.ember.core
 
 import com.comcast.ip4s.Host
 import com.comcast.ip4s.Hostname
@@ -26,9 +26,9 @@ import fs2.io.net.tls.TLSParameters
 import javax.net.ssl.SNIHostName
 import scala.annotation.tailrec
 
-private[internal] trait ClientHelpersPlatform {
+private[core] trait UtilPlatform {
 
-  private[internal] def mkTLSParameters(
+  def mkTLSParameters(
       address: Option[SocketAddress[Host]],
       enableEndpointValidation: Boolean,
   ): TLSParameters =

--- a/ember-core/jvm/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
+++ b/ember-core/jvm/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
@@ -28,7 +28,7 @@ import scala.annotation.tailrec
 
 private[core] trait UtilPlatform {
 
-  def mkTLSParameters(
+  def mkClientTLSParameters(
       address: Option[SocketAddress[Host]],
       enableEndpointValidation: Boolean,
   ): TLSParameters =

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Util.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Util.scala
@@ -31,7 +31,7 @@ import java.time.Instant
 import java.util.Locale
 import scala.concurrent.duration._
 
-private[ember] object Util {
+private[ember] object Util extends UtilPlatform {
 
   private[this] val closeCi = ci"close"
   private[this] val keepAliveCi = ci"keep-alive"

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -138,7 +138,7 @@ private[ember] class H2Client[F[_]: Async](
             .clientBuilder(baseSocket)
             .withParameters(
               // TODO `enableEndpointValidation`
-              H2TLS.transform(Util.mkTLSParameters(address.some, true))
+              H2TLS.transform(Util.mkClientTLSParameters(address.some, true))
             )
             .build
           _ <- Resource.eval(tlsSocket.write(Chunk.empty))

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -141,7 +141,6 @@ private[ember] class H2Client[F[_]: Async](
           tlsSocket <- tls
             .clientBuilder(baseSocket)
             .withParameters(
-              // TODO `enableEndpointValidation`
               H2TLS.transform(Util.mkClientTLSParameters(address.some, enableEndpointValidation))
             )
             .build

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -27,6 +27,7 @@ import fs2.io.net.tls._
 import org.http4s.Uri.Authority
 import org.http4s.Uri.Scheme
 import org.http4s._
+import org.http4s.ember.core.Util
 import org.typelevel.log4cats.Logger
 import scodec.bits._
 
@@ -136,7 +137,8 @@ private[ember] class H2Client[F[_]: Async](
           tlsSocket <- tls
             .clientBuilder(baseSocket)
             .withParameters(
-              H2TLS.transform(TLSParameters.Default)
+              // TODO `enableEndpointValidation`
+              H2TLS.transform(Util.mkTLSParameters(address.some, true))
             )
             .build
           _ <- Resource.eval(tlsSocket.write(Chunk.empty))

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -104,10 +104,8 @@ private[ember] class H2Client[F[_]: Async](
               }
               .flatMap {
                 case Right((connection, shutdown)) =>
-                  // println("Using Reused Connection")
                   shutdown.map(_ => connection)
                 case Left(connection) =>
-                  // println("Using Created Connection")
                   connection.pure[F]
               }
         )


### PR DESCRIPTION
This fixes h2 on ember.js and achieves parity with http/1.1 on all platforms.