### PR TITLE
Proposal: Retire `Charset` from the implicit scope in `EntityEncoder`

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/shared/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -230,7 +230,7 @@ package object oauth1 {
           val bodyparams = urlform.values.toSeq
             .flatMap { case (k, vs) => if (vs.isEmpty) Seq(k -> "") else vs.toList.map((k, _)) }
 
-          implicit val charset: Charset = req.charset.getOrElse(Charset.`UTF-8`)
+          implicit val entityEncoder = UrlForm.entityEncoder(req.charset.getOrElse(Charset.`UTF-8`))
           req.withEntity(urlform) -> (qparams ++ bodyparams)
         }
 

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
@@ -31,8 +31,11 @@ import org.http4s.syntax.literals._
 class ResponseGeneratorSuite extends Http4sSuite {
   test("Add the EntityEncoder headers along with a content-length header") {
     val body = "foo"
-    val resultheaders = Ok(body)(Monad[IO], EntityEncoder.stringEncoder).map(_.headers)
-    EntityEncoder.stringEncoder.headers.headers
+    val resultheaders = Ok(body)(Monad[IO], EntityEncoder.stringEncoder()).map(_.headers)
+    EntityEncoder
+      .stringEncoder()
+      .headers
+      .headers
       .traverse { h =>
         resultheaders.map(_.headers.exists(_ == h)).assert
       } *>
@@ -48,9 +51,9 @@ class ResponseGeneratorSuite extends Http4sSuite {
   test("Not duplicate headers when not provided") {
     val w =
       EntityEncoder.encodeBy[IO, String](
-        EntityEncoder.stringEncoder.headers.put(Accept(MediaRange.`audio/*`))
+        EntityEncoder.stringEncoder().headers.put(Accept(MediaRange.`audio/*`))
       )(
-        EntityEncoder.stringEncoder.toEntity(_)
+        EntityEncoder.stringEncoder().toEntity(_)
       )
 
     Ok("foo")(Monad[IO], w)
@@ -60,9 +63,9 @@ class ResponseGeneratorSuite extends Http4sSuite {
 
   test("Explicitly added headers have priority") {
     val w: EntityEncoder[IO, String] = EntityEncoder.encodeBy[IO, String](
-      EntityEncoder.stringEncoder.headers.put(`Content-Type`(MediaType.text.html))
+      EntityEncoder.stringEncoder().headers.put(`Content-Type`(MediaType.text.html))
     )(
-      EntityEncoder.stringEncoder.toEntity(_)
+      EntityEncoder.stringEncoder().toEntity(_)
     )
 
     val resp: IO[Response[IO]] =

--- a/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -106,7 +106,7 @@ class EntityEncoderSpec extends Http4sSuite {
 
     test("EntityEncoder should render readers") {
       val reader = new StringReader("string reader")
-      writeToString(IO(reader))(EntityEncoder.readerEncoder)
+      writeToString(IO(reader))(EntityEncoder.readerEncoder())
         .assertEquals("string reader")
     }
 
@@ -115,14 +115,14 @@ class EntityEncoderSpec extends Http4sSuite {
       // This is reproducible on input streams
       val longString = "string reader" * 5000
       val reader = new StringReader(longString)
-      writeToString[IO[Reader]](IO(reader))(EntityEncoder.readerEncoder)
+      writeToString[IO[Reader]](IO(reader))(EntityEncoder.readerEncoder())
         .assertEquals(longString)
     }
 
     test("EntityEncoder should render readers with UTF chars") {
       val utfString = "A" + "\u08ea" + "\u00f1" + "\u72fc" + "C"
       val reader = new StringReader(utfString)
-      writeToString[IO[Reader]](IO(reader))(EntityEncoder.readerEncoder)
+      writeToString[IO[Reader]](IO(reader))(EntityEncoder.readerEncoder())
         .assertEquals(utfString)
     }
 


### PR DESCRIPTION
This addresses #6561.
The whole point is that `Charset` isn't typeclass, so it shouldn't appear in implicit scope. Though this breaks binary compatibility, this was aimed to don't fail compilation for users who use default `EntityEncoder` with `UTF-8`. 
Also, this wasn't discussed at all, so don't hesitate to point out that I'm wrong.