### PR TITLE
Parse all WebSocket frames in a `Chunk` in ember-server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -527,6 +527,9 @@ lazy val emberServer = libraryCrossProject("ember-server")
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.http4s.ember.server.internal.ServerHelpers.runConnection"
       ),
+      ProblemFilters.exclude[Problem](
+        "org.http4s.ember.server.internal.WebSocketHelpers"
+      ),
     ) ++ {
       if (tlIsScala3.value)
         Seq(

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -203,4 +203,19 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
     } yield ()
   }
 
+  fixture.test("send and receive multiple messages") { case (server, dispatcher) =>
+    val n = 10
+    val messages = List.tabulate(n)(i => s"${i + 1}")
+    for {
+      client <- createClient(
+        URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-echo"),
+        dispatcher,
+      )
+      _ <- client.connect
+      _ <- messages.traverse_(client.send)
+      messagesReceived <- client.messages.take.replicateA(n)
+      _ <- client.close
+    } yield assertEquals(messagesReceived, messages)
+  }
+
 }

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -48,8 +48,8 @@ import scodec.bits.ByteVector
 
 import java.io.IOException
 import java.nio.ByteBuffer
-import scala.concurrent.duration.Duration
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration.Duration
 
 object WebSocketHelpers {
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -204,7 +204,7 @@ object WebSocketHelpers {
               val frames = ArrayBuffer.empty[WebSocketFrame]
               var frame = nonClientTranscoder.bufferToFrame(byteBuffer)
               while (frame != null) {
-                frames.addOne(frame)
+                frames += frame
                 // We need to slice b/c `bufferToFrame` does absolute reads.
                 byteBuffer = byteBuffer.slice()
                 frame = nonClientTranscoder.bufferToFrame(byteBuffer)

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -16,11 +16,12 @@
 
 package org.http4s.ember.server.internal
 
+import cats.ApplicativeThrow
 import cats.MonadThrow
 import cats.data.NonEmptyList
 import cats.effect.Concurrent
-import cats.effect.Temporal
 import cats.effect.Ref
+import cats.effect.Temporal
 import cats.syntax.all._
 import fs2.Chunk
 import fs2.Pipe
@@ -50,9 +51,8 @@ import java.io.IOException
 import java.nio.ByteBuffer
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.Duration
-import cats.ApplicativeThrow
 
-object WebSocketHelpers {
+private[internal] object WebSocketHelpers {
 
   private[this] val supportedWebSocketVersion = 13L
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -18,8 +18,8 @@ package org.http4s.ember.server.internal
 
 import cats.MonadThrow
 import cats.data.NonEmptyList
-import cats.effect.Async
 import cats.effect.Concurrent
+import cats.effect.Temporal
 import cats.effect.Ref
 import cats.syntax.all._
 import fs2.Chunk
@@ -50,6 +50,7 @@ import java.io.IOException
 import java.nio.ByteBuffer
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.Duration
+import cats.ApplicativeThrow
 
 object WebSocketHelpers {
 
@@ -71,7 +72,7 @@ object WebSocketHelpers {
       onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit],
       errorHandler: Throwable => F[Response[F]],
       logger: Logger[F],
-  )(implicit F: Async[F]): F[Unit] = {
+  )(implicit F: Temporal[F]): F[Unit] = {
     val wsResponse = clientHandshake(req) match {
       case Right(key) =>
         serverHandshake(key)
@@ -111,7 +112,7 @@ object WebSocketHelpers {
       buffer: Array[Byte],
       receiveBufferSize: Int,
       idleTimeout: Duration,
-  )(implicit F: Async[F]): F[Unit] = {
+  )(implicit F: Temporal[F]): F[Unit] = {
     val read: Read[F] = timeoutMaybe(socket.read(receiveBufferSize), idleTimeout)
     def writeFrame(frame: WebSocketFrame): F[Unit] =
       frameToBytes(frame).traverse_(c => timeoutMaybe(socket.write(c), idleTimeout))
@@ -189,45 +190,38 @@ object WebSocketHelpers {
       Chunk.array(bytes)
     }
 
-  private def decodeFrames[F[_]](implicit F: Async[F]): Pipe[F, Byte, WebSocketFrame] = stream => {
-    def go(rest: Stream[F, Byte], acc: Array[Byte]): Pull[F, WebSocketFrame, Unit] =
-      rest.pull.uncons.flatMap {
-        case Some((chunk, next)) =>
-          val buffer = acc ++ chunk.toArray[Byte]
-          var byteBuffer = ByteBuffer.wrap(buffer)
-          Pull
-            .eval(F.delay {
-              // A single chunk might contain multiple frames
-              // but `bufferToFrame` decodes at most one, so
-              // we call it repeatedly until all frames in the
-              // buffer are decoded.
-              val frames = ArrayBuffer.empty[WebSocketFrame]
-              var frame = nonClientTranscoder.bufferToFrame(byteBuffer)
-              while (frame != null) {
-                frames += frame
-                // We need to slice b/c `bufferToFrame` does absolute reads.
-                byteBuffer = byteBuffer.slice()
-                frame = nonClientTranscoder.bufferToFrame(byteBuffer)
-              }
-              Chunk.array(frames.toArray)
-            })
-            .flatMap { frames =>
-              // TODO followup: improve this buffering
-              if (frames.nonEmpty) {
-                val remaining = new Array[Byte](byteBuffer.remaining())
-                byteBuffer.get(remaining)
-                Pull.output(frames) >> go(next, remaining)
-              } else {
-                go(next, buffer)
-              }
+  private def decodeFrames[F[_]](implicit F: ApplicativeThrow[F]): Pipe[F, Byte, WebSocketFrame] =
+    stream => {
+      def go(rest: Stream[F, Byte], acc: Array[Byte]): Pull[F, WebSocketFrame, Unit] =
+        rest.pull.uncons.flatMap {
+          case Some((chunk, next)) =>
+            val buffer = acc ++ chunk.toArray[Byte]
+            // A single chunk might contain multiple frames
+            // but `bufferToFrame` decodes at most one, so we
+            // call it repeatedly until all frames in the buffer are decoded.
+            val frames = ArrayBuffer.empty[WebSocketFrame]
+            var byteBuffer = ByteBuffer.wrap(buffer)
+            var frame = nonClientTranscoder.bufferToFrame(byteBuffer)
+            while (frame != null) {
+              frames += frame
+              // We need to slice b/c `bufferToFrame` does absolute reads.
+              byteBuffer = byteBuffer.slice()
+              frame = nonClientTranscoder.bufferToFrame(byteBuffer)
             }
-        case None =>
-          // TODO followup: sometimes the peer closes connection before stream can interrupt itself
-          Pull.raiseError(EndOfStreamError())
-      }
+            if (frames.nonEmpty) {
+              val remaining = new Array[Byte](byteBuffer.remaining())
+              byteBuffer.get(remaining)
+              Pull.output(Chunk.array(frames.toArray)) >> go(next, remaining)
+            } else {
+              go(next, buffer)
+            }
+          case None =>
+            // TODO followup: sometimes the peer closes connection before stream can interrupt itself
+            Pull.raiseError(EndOfStreamError())
+        }
 
-    go(stream, Array.emptyByteArray).void.stream
-  }
+      go(stream, Array.emptyByteArray).void.stream
+    }
 
   private def clientHandshake[F[_]](req: Request[F]): Either[ClientHandshakeError, String] = {
     val connection = req.headers.get[Connection] match {


### PR DESCRIPTION
This is a fix for https://github.com/http4s/http4s/issues/6558.

The bug can be observed whenever a single `Chunk` of bytes contains more than one frame. In this case the current version decodes the first frame using `bufferToFrame`, emits it and recurses via `Pull.output1(value) >> go(next, remaining)`. But `go` will only continue when more data is read from the socket. This explains why sending messages "1", "2", "3" will only show "1", because the first chunk contains all three message. Messages "2" and "3" will only be decoded when further messages arrive, which might be never. The solution is simple: decode as many frames as possible from every chunk before recursing.





