### PR TITLE
Always respond to client close frame with 1000 "normal closure"

### DIFF
--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -32,6 +32,7 @@ import org.http4s.testing.DispatcherIOFixture
 import org.http4s.websocket.WebSocketFrame
 import org.java_websocket.WebSocket
 import org.java_websocket.client.WebSocketClient
+import org.java_websocket.framing.CloseFrame
 import org.java_websocket.framing.Framedata
 import org.java_websocket.framing.PingFrame
 import org.java_websocket.handshake.ServerHandshake
@@ -90,6 +91,7 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
       messages: Queue[IO, String],
       pongs: Queue[IO, String],
       remoteClosed: Deferred[IO, Unit],
+      remoteCloseCode: Deferred[IO, Int],
       client: WebSocketClient,
   ) {
     def connect: IO[Unit] =
@@ -111,6 +113,7 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
       queue <- Queue.unbounded[IO, String]
       pongQueue <- Queue.unbounded[IO, String]
       remoteClosed <- Deferred[IO, Unit]
+      remoteCloseCode <- Deferred[IO, Int]
       client = new WebSocketClient(target) {
         override def onOpen(handshakedata: ServerHandshake): Unit = {
           val fa = waitOpen.complete(None)
@@ -120,7 +123,7 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
         override def onClose(code: Int, reason: String, remote: Boolean): Unit = {
           val fa = waitOpen
             .complete(Some(new Throwable(s"closed: code: $code, reason: $reason")))
-            .attempt >> waitClose.complete(None)
+            .attempt >> remoteCloseCode.complete(code) >> waitClose.complete(None)
           dispatcher.unsafeRunSync(fa)
           ()
         }
@@ -140,7 +143,7 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
           ()
         }
       }
-    } yield Client(waitOpen, waitClose, queue, pongQueue, remoteClosed, client)
+    } yield Client(waitOpen, waitClose, queue, pongQueue, remoteClosed, remoteCloseCode, client)
 
   fixture.test("open and close connection to server") { case (server, dispatcher) =>
     for {
@@ -179,16 +182,18 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
     } yield assertEquals(data, "hello")
   }
 
-  fixture.test("initiate close sequence on stream termination") { case (server, dispatcher) =>
-    for {
-      client <- createClient(
-        URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-close"),
-        dispatcher,
-      )
-      _ <- client.connect
-      _ <- client.messages.take
-      _ <- client.remoteClosed.get
-    } yield ()
+  fixture.test("initiate close sequence with code=1000 (NORMAL) on stream termination") {
+    case (server, dispatcher) =>
+      for {
+        client <- createClient(
+          URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-close"),
+          dispatcher,
+        )
+        _ <- client.connect
+        _ <- client.messages.take
+        _ <- client.remoteClosed.get
+        code <- client.remoteCloseCode.get
+      } yield assertEquals(code, CloseFrame.NORMAL)
   }
 
   fixture.test("respects withFilterPingPongs(false)") { case (server, dispatcher) =>

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -167,11 +167,11 @@ object WebSocketHelpers {
     frame match {
       case ping @ WebSocketFrame.Ping(data) =>
         writeFrame(WebSocketFrame.Pong(data)).as(ping.some)
-      case frame @ WebSocketFrame.Close(_) =>
+      case WebSocketFrame.Close(_) =>
         closeState.get.flatMap {
           case Open =>
             for {
-              frame <- F.fromEither(WebSocketFrame.Close(frame.closeCode))
+              frame <- F.fromEither(WebSocketFrame.Close(1000))
               _ <- writeFrame(frame)
               _ <- closeState.set(BothClosed)
             } yield None


### PR DESCRIPTION
We've been hunting this down in Discord with @armanbilge and this seems to be the right thing to do :)

The problem: when connecting to a websocket endpoint served by ember, and then disconnecting from it (`ws.close()` in the browser), there is an exception thrown in the browser: 

```
WebSocket connection to 'ws://...' failed: Received a broken close frame containing a reserved status code.
```

Another client (Dark WebSocket terminal) also reports an abnormal closure: `Close status: 1006 (Abnormal Closure)`

After some digging, we realized we are sending back the close code that the client sends in originally while initiating the connection termination, which happens to be `1005` and is not allowed to be used by the endpoint:

```
1005 is a reserved value and MUST NOT be set as a status code in a
      Close control frame by an endpoint.  It is designated for use in
      applications expecting a status code to indicate that no status
      code was actually present.
```
(@armanbilge found this, I don't have a link :) )
edit: that's the spec actually 😜 
https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1

So in this PR we're changing the close code to always be `1000` - `CLOSE NORMAL`. 

This resolves the issue and the clients are now happy with how ember terminates the connection.