### PR TITLE
Add doc for mixing left- and right-associative

### DIFF
--- a/docs/docs/dsl.md
+++ b/docs/docs/dsl.md
@@ -375,7 +375,7 @@ HttpRoutes.of[IO] {
 }
 ```
 
-**Please note:** You cannot mix left- and right-associative matchers in a path! So something like `case GET -> "hello" / "world" /: rest => ???` will **not compile**.
+**Please note:** You cannot mix left- and right-associative matchers in a path! So something like `case GET -> "hello" / "world" /: rest => ???` will not compile.
 
 Imagining some path parameter extractors you could still do something like this:
 

--- a/docs/docs/dsl.md
+++ b/docs/docs/dsl.md
@@ -375,6 +375,16 @@ HttpRoutes.of[IO] {
 }
 ```
 
+**Please note:** You cannot mix left- and right-associative matchers in a path! So something like `case GET -> "hello" / "world" /: rest => ???` will **not compile**.
+
+Imagining some path parameter extractors you could still do something like this:
+
+```scala mdoc:silent
+HttpRoutes.of[IO] {
+  case GET -> IntVar(anInt) /: UUIDVar(anId) /: rest => Ok(s"""Hello $anInt / $anId, ${rest.segments.mkString(" and ")}!""")
+}
+```
+
 To match a file extension on a segment, use the `~` extractor:
 
 ```scala mdoc:silent


### PR DESCRIPTION
Add a small note at the paragraph that introduces right-associative path
matchers (`/:`) that they cannot be mixed with the left-associative
ones.
