### PR TITLE
Ember H2 Connection Header Compliance

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
@@ -166,7 +166,7 @@ private[h2] object PseudoHeaders {
     }.toOption
       .flatten
 
-  val connectionHeadersFields = Set(
+  val connectionHeadersFields: Set[CIString] = Set(
     org.http4s.headers.`Transfer-Encoding`.headerInstance.name,
     org.http4s.headers.Connection.headerInstance.name,
     org.http4s.headers.Upgrade.headerInstance.name,

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
@@ -171,7 +171,6 @@ private[h2] object PseudoHeaders {
     org.http4s.headers.Connection.headerInstance.name,
     org.http4s.headers.Upgrade.headerInstance.name,
     org.http4s.headers.`Keep-Alive`.headerInstance.name,
-    org.http4s.headers.Upgrade.headerInstance.name,
     CIString("Proxy-Connection"),
   )
 }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
@@ -166,6 +166,10 @@ private[h2] object PseudoHeaders {
     }.toOption
       .flatten
 
+  // Connection Specific Headers should be removed when doing h2
+  // This is because connection mechanisms are handled by h2
+  // rather than request/response cycle.
+  // https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.2
   val connectionHeadersFields: Set[CIString] = Set(
     org.http4s.headers.`Transfer-Encoding`.headerInstance.name,
     org.http4s.headers.Connection.headerInstance.name,

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/PsuedoHeadersSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/PsuedoHeadersSuite.scala
@@ -47,7 +47,7 @@ class PsuedoHeadersSuite extends Http4sSuite {
 
   }
   test("responseToHeaders should remove Connection Headers") {
-    val response = Response(Status.Ok)
+    val response = Response[fs2.Pure](Status.Ok)
       .putHeaders(connectionHeaders: _*)
 
     val test = PseudoHeaders.responseToHeaders(response)

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/PsuedoHeadersSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/PsuedoHeadersSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package ember.core.h2
+
+import cats.data.NonEmptyList
+import org.http4s.headers._
+import org.typelevel.ci._
+
+class PsuedoHeadersSuite extends Http4sSuite {
+
+  val connectionHeaders: List[Header.ToRaw] = List(
+    Connection.close,
+    `Transfer-Encoding`(NonEmptyList.of(TransferCoding.chunked)),
+    Upgrade(NonEmptyList.of(Protocol(ci"name", None))),
+    `Keep-Alive`.unsafeApply(Some(100L), None, List.empty),
+    "Proxy-Connection" -> "keep-alive",
+  )
+
+  test("requestToHeaders should remove Connection Headers") {
+    val request = Request[fs2.Pure]()
+      .putHeaders(connectionHeaders: _*)
+
+    val test = PseudoHeaders.requestToHeaders(request)
+    val expected = NonEmptyList.of(
+      (":method", "GET", false),
+      (":scheme", "https", false),
+      (":path", "/", false),
+      (":authority", "", false),
+    )
+
+    assertEquals(test, expected)
+
+  }
+  test("responseToHeaders should remove Connection Headers") {
+    val response = Response(Status.Ok)
+      .putHeaders(connectionHeaders: _*)
+
+    val test = PseudoHeaders.responseToHeaders(response)
+    val expected = NonEmptyList.of(
+      (":status", "200", false)
+    )
+    assertEquals(test, expected)
+  }
+}

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
@@ -42,6 +42,10 @@ object EmberServerH2Example extends IOApp {
           case _ -> Root / "foo" =>
             // println(req)
             Response[F](Status.Ok).withEntity("Foo Endpoint").pure[F]
+          case _ -> Root / "stream" =>
+            // println("Got stream endpoint")
+            Ok(Stream("Ok").covary[F])
+              .flatTap(Console[F].println)
           case req @ _ -> Root / "trailers" =>
             println(s"Got $req at trailers endpoint")
             req.headers
@@ -80,6 +84,11 @@ object EmberServerH2Example extends IOApp {
         .withHost(ipv4"0.0.0.0")
         .withPort(port"8081")
         .withHttpApp(simpleApp)
+        .withErrorHandler { case error =>
+          Console[F]
+            .println(s"Unexpected error:$error")
+            .as(Response(status = Status.InternalServerError))
+        }
         .build
     } yield ()
 
@@ -91,6 +100,11 @@ object EmberServerH2Example extends IOApp {
         .withHost(ipv4"0.0.0.0")
         .withPort(port"8080")
         .withHttpApp(simpleApp)
+        .withErrorHandler { case error =>
+          Console[F]
+            .println(s"Unexpected error:$error")
+            .as(Response(status = Status.InternalServerError))
+        }
         .build
 
   }


### PR DESCRIPTION
So questions: 
1. How does Blaze deal with this?
2. Removing in the backend means it appears to be using chunked when logging, but is secretly not if h2 is used.
3. Overall it seems a bit like we have queued up nice helpers for a primarily http/1.1 world, but those helpers seem wrong with http2.