### PR TITLE
Remove references to Scala 2.12 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@ val http = HttpRoutes.of {
 
 Learn more at [http4s.org](https://http4s.org/).
 
-If you run into any difficulties on Scala 2.12 please enable partial unification in your `build.sbt` (not needed for Scala 2.13 and beyond, because they enable partial unification by default)
-
-```scala
-scalacOptions ++= Seq("-Ypartial-unification")
-```
-
 ## Requirements
 
 Running the **blaze** backend requires a modern, supported version of the JVM to build and run, as it relies on server

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -6,7 +6,7 @@ http4s to try our service.
 A recap of the dependencies for this example, in case you skipped the [service] example. Ensure you have the following dependencies in your build.sbt:
 
 ```scala
-scalaVersion := "2.13.8" // Also supports 3.1.x
+scalaVersion := "2.13.8" // Also supports 3.x
 
 val http4sVersion = "@VERSION@"
 

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -6,7 +6,7 @@ http4s to try our service.
 A recap of the dependencies for this example, in case you skipped the [service] example. Ensure you have the following dependencies in your build.sbt:
 
 ```scala
-scalaVersion := "2.13.8" // Also supports 2.11.x and 2.12.x
+scalaVersion := "2.13.8" // Also supports 3.1.x
 
 val http4sVersion = "@VERSION@"
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -1,9 +1,5 @@
 # Quick Start
 
-**Note**: To run with 2.12 please make sure that the flag `-Ypartial-unification`
-is enabled in your compiler options (i.e `scalacOptions += "-Ypartial-unification"` in sbt).
-This feature is enabled by default starting in Scala 2.13.
-
 
 Getting started with http4s is easy.  Let's materialize an http4s
 skeleton project from its [giter8 template]:

--- a/docs/docs/service.md
+++ b/docs/docs/service.md
@@ -6,7 +6,7 @@ and calling it with http4s' client.
 Create a new directory, with the following build.sbt in the root:
 
 ```scala
-scalaVersion := "2.13.8" // Also supports 2.12.x and 3.x
+scalaVersion := "2.13.8" // Also supports 3.x
 
 val http4sVersion = "@VERSION@"
 
@@ -19,8 +19,6 @@ libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-ember-client" % http4sVersion
 )
 
-// Uncomment if you're using Scala 2.12.x
-// scalacOptions ++= Seq("-Ypartial-unification")
 ```
 
 This tutorial is compiled as part of the build using [mdoc].  Each page


### PR DESCRIPTION
Since it's gone.