### PR TITLE
Fix 1.0 version table compatibility with 2.12 & 2.13

### DIFF
--- a/docs/versions.md
+++ b/docs/versions.md
@@ -23,7 +23,7 @@
 
 | http4s                    | Status                                  | Scala 2.11    | Scala 2.12    | Scala 2.13    | Scala 3       | Scala.js 1.x  | cats  | fs2    | JDK  |
 | ------------------------- | --------------------------------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ----- | ------ | ---- |
-| [@VERSION_1_0@](/v1/)     | @:style(version-label, dev)Milestone@:@ | @:icon(error) | @:icon(check) | @:icon(error) | 3.1           | 1.8           | 2.x   | 3.x    | 1.8+ |
+| [@VERSION_1_0@](/v1/)     | @:style(version-label, dev)Milestone@:@ | @:icon(error) | @:icon(error) | @:icon(check) | 3.1           | 1.8           | 2.x   | 3.x    | 1.8+ |
 | [@VERSION_0_23@](/v0.23/) | @:style(version-label, stable)Stable@:@ | @:icon(error) | @:icon(check) | @:icon(check) | 3.1           | 1.8           | 2.x   | 3.x    | 1.8+ |
 | [@VERSION_0_22@](/v0.22/) | @:style(version-label, eol)EOL@:@       | @:icon(error) | @:icon(check) | @:icon(check) | 3.0           | @:icon(error) | 2.x   | 2.x    | 1.8+ |
 | [@VERSION_0_21@](/v0.21/) | @:style(version-label, eol)EOL@:@       | @:icon(error) | @:icon(check) | @:icon(check) | @:icon(error) | @:icon(error) | 2.x   | 2.x    | 1.8+ |


### PR DESCRIPTION
The version table currently suggests that 2.12 is supported and 2.13 is not for version 1.0
![image](https://user-images.githubusercontent.com/4872989/183878286-0ac2cae0-90de-45f8-b7c1-ed06a0876dc4.png)



<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 