### PR TITLE
Update quickstart guide to include Scala 3 branch

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -9,7 +9,11 @@ Getting started with http4s is easy.  Let's materialize an http4s
 skeleton project from its [giter8 template]:
 
 ```sbt
+#for Scala 2.X
 $ sbt new http4s/http4s.g8 --branch 0.23
+
+#for Scala 3.X
+$ sbt new http4s/http4s.g8 --branch 0.23-scala3
 ```
 
 Follow the prompts.  For every step along the way, a default value is

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -9,10 +9,10 @@ Getting started with http4s is easy.  Let's materialize an http4s
 skeleton project from its [giter8 template]:
 
 ```sbt
-#for Scala 2.X
+# for Scala 2.x
 $ sbt new http4s/http4s.g8 --branch 0.23
 
-#for Scala 3.X
+# for Scala 3
 $ sbt new http4s/http4s.g8 --branch 0.23-scala3
 ```
 


### PR DESCRIPTION
Following the discussion on [here](https://github.com/http4s/http4s.g8/issues/249), I added a mention to Scala 3 branch in the documentation's quick-start guide.