### PR TITLE
RFC - Compositional builder for server response logger

### DIFF
--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -47,7 +47,7 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
   private val expectedBody: String =
     AutoCloseableResource.resource(Source.fromInputStream(testResource))(_.mkString)
 
-  private val respApp = ResponseLogger.httpApp(logHeaders = true, logBody = true)(testApp)
+  private val respApp = ResponseLogger[IO](logHeaders = true).logBody(true)(testApp)
 
   test("response should not affect a Get") {
     val req = Request[IO](uri = uri"/request")

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -47,7 +47,7 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
   private val expectedBody: String =
     AutoCloseableResource.resource(Source.fromInputStream(testResource))(_.mkString)
 
-  private val respApp = ResponseLogger[IO](logHeaders = true).logBody(true)(testApp)
+  private val respApp = ResponseLogger[IO](logHeaders = true, logBody = true).apply(testApp)
 
   test("response should not affect a Get") {
     val req = Request[IO](uri = uri"/request")

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -43,9 +43,10 @@ object Logger {
     val log: String => F[Unit] = logAction.getOrElse { s =>
       F.delay(logger.info(s))
     }
-    ResponseLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(
-      RequestLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(http)
-    )
+    ResponseLogger(logHeaders, redactHeadersWhen, log.pure[Option])
+      .logBody(logBody)(fk)(
+        RequestLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(http)
+      )
   }
 
   def logBodyText[G[_], F[_]](
@@ -58,9 +59,12 @@ object Logger {
     val log: String => F[Unit] = logAction.getOrElse { s =>
       F.delay(logger.info(s))
     }
-    ResponseLogger.impl(logHeaders, Right(logBody), fk, redactHeadersWhen, log.pure[Option])(
-      RequestLogger.impl(logHeaders, Right(logBody), fk, redactHeadersWhen, log.pure[Option])(http)
-    )
+    ResponseLogger(logHeaders, redactHeadersWhen, log.pure[Option])
+      .logBodyWith(logBody)(fk)(
+        RequestLogger.impl(logHeaders, Right(logBody), fk, redactHeadersWhen, log.pure[Option])(
+          http
+        )
+      )
   }
 
   def httpApp[F[_]: Async](

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -43,8 +43,9 @@ object Logger {
     val log: String => F[Unit] = logAction.getOrElse { s =>
       F.delay(logger.info(s))
     }
-    ResponseLogger(logHeaders, redactHeadersWhen, log.pure[Option])
-      .logBody(logBody)(fk)(
+    ResponseLogger(logHeaders, logBody)
+      .withRedactHeadersWhen(redactHeadersWhen)
+      .withLogAction(log)(fk)(
         RequestLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(http)
       )
   }
@@ -59,11 +60,13 @@ object Logger {
     val log: String => F[Unit] = logAction.getOrElse { s =>
       F.delay(logger.info(s))
     }
-    ResponseLogger(logHeaders, redactHeadersWhen, log.pure[Option])
-      .logBodyWith(logBody)(fk)(
-        RequestLogger.impl(logHeaders, Right(logBody), fk, redactHeadersWhen, log.pure[Option])(
-          http
-        )
+    ResponseLogger(logHeaders, logBody)
+      .withRedactHeadersWhen(redactHeadersWhen)
+      .withLogAction(log)(fk)(
+        RequestLogger
+          .impl(logHeaders, Right(logBody), fk, redactHeadersWhen, log.pure[Option])(
+            http
+          )
       )
   }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/internal/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/internal/Logger.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.server.middleware.internal
 
 import cats.data.Kleisli

--- a/server/shared/src/main/scala/org/http4s/server/middleware/internal/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/internal/Logger.scala
@@ -1,0 +1,26 @@
+package org.http4s.server.middleware.internal
+
+import cats.data.Kleisli
+import cats.effect.kernel.MonadCancelThrow
+import cats.~>
+import org.http4s.Response
+import org.http4s.server.middleware.Logger.Lift
+import org.typelevel.ci.CIString
+
+private[http4s] abstract class Logger[F[_], Self <: Logger[F, Self]] {
+  self: Self =>
+  def apply[G[_], A](fk: F ~> G)(
+      http: Kleisli[G, A, Response[F]]
+  )(implicit G: MonadCancelThrow[G]): Kleisli[G, A, Response[F]]
+
+  def apply[G[_], A](
+      http: Kleisli[G, A, Response[F]]
+  )(implicit lift: Lift[F, G], G: MonadCancelThrow[G]): Kleisli[G, A, Response[F]] =
+    apply(lift.fk)(http)
+
+  def withRedactHeadersWhen(f: CIString => Boolean): Self
+
+  def withLogAction(f: String => F[Unit]): Self
+  def withLogActionOpt(of: Option[String => F[Unit]]): Self =
+    of.fold(this)(withLogAction)
+}


### PR DESCRIPTION
Found myself down this rabbit hole after looking into adding more options around logging behaviour and reeling at the combinatorial explosion of logging options that would result.

This is an attempt to get that under control - all forms of feedback and bikeshedding welcome. If people agree with the approach I would apply it to (at least) the other server loggers before considering it ready to merge.

I strongly recommend hiding whitespace when looking at the diff.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 