### PR TITLE
Simplify type signature for internal logger

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -55,7 +55,7 @@ object Logger {
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
   )(log: String => F[Unit])(implicit F: Async[F]): F[Unit] =
     org.http4s.internal.Logger
-      .logMessage[F, A](message)(logHeaders, logBody, redactHeadersWhen)(log)
+      .logMessage(message)(logHeaders, logBody, redactHeadersWhen)(log)
 
   def colored[F[_]: Async](
       logHeaders: Boolean,

--- a/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -53,7 +53,7 @@ object RequestLogger {
       logAction: Option[String => F[Unit]] = None,
   )(client: Client[F]): Client[F] =
     impl(client, logBody = true) { request =>
-      InternalLogger.logMessageWithBodyText[F, Request[F]](request)(
+      InternalLogger.logMessageWithBodyText(request)(
         logHeaders,
         logBody,
         redactHeadersWhen,
@@ -126,10 +126,10 @@ object RequestLogger {
         s"${request.httpVersion} $methodColor${request.method}$RESET$color $BOLD${request.uri}$RESET$color"
 
       val headers: String =
-        InternalLogger.defaultLogHeaders[F, Request[F]](request)(logHeaders, redactHeadersWhen)
+        InternalLogger.defaultLogHeaders(request)(logHeaders, redactHeadersWhen)
 
       val bodyText: F[String] =
-        InternalLogger.defaultLogBody[F, Request[F]](request)(logBody) match {
+        InternalLogger.defaultLogBody(request)(logBody) match {
           case Some(textF) => textF.map(text => s"""body="$text"""")
           case None => Sync[F].pure("")
         }

--- a/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -56,7 +56,7 @@ object ResponseLogger {
       logAction: Option[String => F[Unit]] = None,
   )(client: Client[F]): Client[F] =
     impl(client, logBody = true) { response =>
-      InternalLogger.logMessageWithBodyText[F, Response[F]](response)(
+      InternalLogger.logMessageWithBodyText(response)(
         logHeaders,
         logBody,
         redactHeadersWhen,
@@ -117,10 +117,10 @@ object ResponseLogger {
       val prelude = s"${response.httpVersion} ${response.status}"
 
       val headers: String =
-        InternalLogger.defaultLogHeaders[F, Response[F]](response)(logHeaders, redactHeadersWhen)
+        InternalLogger.defaultLogHeaders(response)(logHeaders, redactHeadersWhen)
 
       val bodyText: F[String] =
-        InternalLogger.defaultLogBody[F, Response[F]](response)(logBody) match {
+        InternalLogger.defaultLogBody(response)(logBody) match {
           case Some(textF) => textF.map(text => s"""body="$text"""")
           case None => Sync[F].pure("")
         }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -101,5 +101,5 @@ object Logger {
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
   )(log: String => F[Unit])(implicit F: Async[F]): F[Unit] =
     org.http4s.internal.Logger
-      .logMessage[F, A](message)(logHeaders, logBody, redactHeadersWhen)(log)
+      .logMessage(message)(logHeaders, logBody, redactHeadersWhen)(log)
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -71,7 +71,7 @@ object RequestLogger {
           Logger.logMessage[F, Request[F]](r)(logHeaders, bool, redactHeadersWhen)(log(_))
         case Right(f) =>
           org.http4s.internal.Logger
-            .logMessageWithBodyText[F, Request[F]](r)(logHeaders, f, redactHeadersWhen)(log(_))
+            .logMessageWithBodyText(r)(logHeaders, f, redactHeadersWhen)(log(_))
       }
 
     val logBody: Boolean = logBodyText match {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -68,7 +68,7 @@ object ResponseLogger {
           Logger.logMessage[F, Response[F]](resp)(logHeaders, bool, redactHeadersWhen)(log(_))
         case Right(f) =>
           org.http4s.internal.Logger
-            .logMessageWithBodyText[F, Response[F]](resp)(logHeaders, f, redactHeadersWhen)(log(_))
+            .logMessageWithBodyText(resp)(logHeaders, f, redactHeadersWhen)(log(_))
       }
 
     val logBody: Boolean = logBodyText match {


### PR DESCRIPTION
Simplifies type signatures for `org.http4s.internal.Logger`. For whatever reason it isn't package-private even though it's in the `internal` package, but it's binary-compatible though source-breaking so I think it's ok?

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 