### PR TITLE
Add builder for server logger middleware

### DIFF
--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -47,7 +47,7 @@ class LoggerSuite extends Http4sSuite {
   private val expectedBody: String =
     AutoCloseableResource.resource(Source.fromInputStream(testResource))(_.mkString)
 
-  private val respApp = ResponseLogger.httpApp(logHeaders = true, logBody = true)(testApp)
+  private val respApp = ResponseLogger.builder[IO](logHeaders = true, logBody = true).apply(testApp)
 
   test("response should not affect a Get") {
     val req = Request[IO](uri = uri"/request")

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -79,7 +79,7 @@ class LoggerSuite extends Http4sSuite {
     }.assert
   }
 
-  private val loggerApp = Logger.httpApp(logHeaders = true, logBody = true)(testApp)
+  private val loggerApp = Logger.builder[IO](logHeaders = true, logBody = true).apply(testApp)
 
   test("logger should not affect a Get") {
     val req = Request[IO](uri = uri"/request")

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -65,7 +65,7 @@ class LoggerSuite extends Http4sSuite {
     }.assert
   }
 
-  private val reqApp = RequestLogger.httpApp(logHeaders = true, logBody = true)(testApp)
+  private val reqApp = RequestLogger.builder[IO](logHeaders = true, logBody = true).apply(testApp)
 
   test("request should not affect a Get") {
     val req = Request[IO](uri = uri"/request")

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -47,7 +47,7 @@ class LoggerSuite extends Http4sSuite {
   private val expectedBody: String =
     AutoCloseableResource.resource(Source.fromInputStream(testResource))(_.mkString)
 
-  private val respApp = ResponseLogger.builder[IO](logHeaders = true, logBody = true).apply(testApp)
+  private val respApp = ResponseLogger.builder(logHeaders = true, logBody = true)(testApp)
 
   test("response should not affect a Get") {
     val req = Request[IO](uri = uri"/request")
@@ -65,7 +65,7 @@ class LoggerSuite extends Http4sSuite {
     }.assert
   }
 
-  private val reqApp = RequestLogger.builder[IO](logHeaders = true, logBody = true).apply(testApp)
+  private val reqApp = RequestLogger.builder(logHeaders = true, logBody = true)(testApp)
 
   test("request should not affect a Get") {
     val req = Request[IO](uri = uri"/request")
@@ -79,7 +79,7 @@ class LoggerSuite extends Http4sSuite {
     }.assert
   }
 
-  private val loggerApp = Logger.builder[IO](logHeaders = true, logBody = true).apply(testApp)
+  private val loggerApp = Logger.builder(logHeaders = true, logBody = true)(testApp)
 
   test("logger should not affect a Get") {
     val req = Request[IO](uri = uri"/request")

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -47,7 +47,10 @@ object Logger {
       .builder(logHeaders, logBody)
       .withRedactHeadersWhen(redactHeadersWhen)
       .withLogAction(log)(fk)(
-        RequestLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(http)
+        RequestLogger
+          .builder(logHeaders, logBody)
+          .withRedactHeadersWhen(redactHeadersWhen)
+          .withLogAction(log)(fk)(http)
       )
   }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -18,12 +18,13 @@ package org.http4s
 package server
 package middleware
 
+import cats.Functor
 import cats.arrow.FunctionK
 import cats.data.OptionT
 import cats.effect.Sync
 import cats.effect.kernel.Async
 import cats.effect.kernel.MonadCancelThrow
-import cats.{Functor, ~>}
+import cats.~>
 import fs2.Stream
 import org.log4s.getLogger
 import org.typelevel.ci.CIString

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -43,9 +43,12 @@ object Logger {
     val log: String => F[Unit] = logAction.getOrElse { s =>
       F.delay(logger.info(s))
     }
-    ResponseLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(
-      RequestLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(http)
-    )
+    ResponseLogger
+      .builder(logHeaders, logBody)
+      .withRedactHeadersWhen(redactHeadersWhen)
+      .withLogAction(log)(fk)(
+        RequestLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(http)
+      )
   }
 
   def logBodyText[G[_], F[_]](

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -80,10 +80,10 @@ object Logger {
 
   def builder[F[_]: Async](
       logHeaders: Boolean,
-      logBodyWith: Stream[F, Byte] => Option[F[String]],
+      renderBodyWith: Stream[F, Byte] => Option[F[String]],
   ): Logger[F] = Impl(
-    ResponseLogger.builder(logHeaders, logBodyWith).withLogAction(defaultLogAction),
-    RequestLogger.builder(logHeaders, logBodyWith).withLogAction(defaultLogAction),
+    ResponseLogger.builder(logHeaders, renderBodyWith).withLogAction(defaultLogAction),
+    RequestLogger.builder(logHeaders, renderBodyWith).withLogAction(defaultLogAction),
   )
 
   @deprecated("Use Logger.builder", "0.23.15")

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -142,6 +142,7 @@ object Logger {
       .withRedactHeadersWhen(redactHeadersWhen)
       .withLogActionOpt(logAction)(httpRoutes)
 
+  @deprecated("Use Logger.builder", "0.23.15")
   def httpRoutesLogBodyText[F[_]: Async](
       logHeaders: Boolean,
       logBody: Stream[F, Byte] => Option[F[String]],

--- a/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -76,8 +76,8 @@ object RequestLogger {
 
   def builder[F[_]: Async](
       logHeaders: Boolean,
-      logBodyWith: Stream[F, Byte] => Option[F[String]],
-  ): RequestLogger[F] = Impl(logHeaders, Right(logBodyWith))
+      renderBodyWith: Stream[F, Byte] => Option[F[String]],
+  ): RequestLogger[F] = Impl(logHeaders, Right(renderBodyWith))
 
   @deprecated("Use RequestLogger.builder", "0.23.15")
   def apply[G[_], F[_]](

--- a/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -34,7 +34,8 @@ import fs2.Stream
 import org.log4s.getLogger
 import org.typelevel.ci.CIString
 
-sealed abstract class RequestLoggerBuilder[F[_]] extends internal.Logger[F, RequestLoggerBuilder[F]] {
+sealed abstract class RequestLoggerBuilder[F[_]]
+    extends internal.Logger[F, RequestLoggerBuilder[F]] {
   def apply[G[_]](fk: F ~> G)(
       http: Http[G, F]
   )(implicit G: MonadCancelThrow[G]): Http[G, F]
@@ -66,7 +67,8 @@ object RequestLogger {
     override def withRedactHeadersWhen(f: CIString => Boolean): RequestLoggerBuilder[F] =
       copy(redactHeadersWhen = f)
 
-    override def withLogAction(f: String => F[Unit]): RequestLoggerBuilder[F] = copy(logAction = Some(f))
+    override def withLogAction(f: String => F[Unit]): RequestLoggerBuilder[F] =
+      copy(logAction = Some(f))
   }
 
   def builder[F[_]: Async](

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -68,6 +68,7 @@ object ResponseLogger {
       logBodyWith: Stream[F, Byte] => Option[F[String]],
   ): ResponseLogger[F] = Impl(logHeaders, Right(logBodyWith))
 
+  @deprecated("Use ResponseLogger.builder", "0.23.15")
   def apply[G[_], F[_], A](
       logHeaders: Boolean,
       logBody: Boolean,
@@ -131,6 +132,7 @@ object ResponseLogger {
     }
   }
 
+  @deprecated("Use ResponseLogger.builder", "0.23.15")
   def httpApp[F[_]: Async, A](
       logHeaders: Boolean,
       logBody: Boolean,
@@ -139,6 +141,7 @@ object ResponseLogger {
   )(httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
     apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
+  @deprecated("Use ResponseLogger.builder", "0.23.15")
   def httpAppLogBodyText[F[_]: Async, A](
       logHeaders: Boolean,
       logBody: Stream[F, Byte] => Option[F[String]],
@@ -149,6 +152,7 @@ object ResponseLogger {
       httpApp
     )
 
+  @deprecated("Use ResponseLogger.builder", "0.23.15")
   def httpRoutes[F[_]: Async, A](
       logHeaders: Boolean,
       logBody: Boolean,
@@ -157,6 +161,7 @@ object ResponseLogger {
   )(httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
     apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
+  @deprecated("Use ResponseLogger.builder", "0.23.15")
   def httpRoutesLogBodyText[F[_]: Async, A](
       logHeaders: Boolean,
       logBody: Stream[F, Byte] => Option[F[String]],

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -74,8 +74,8 @@ object ResponseLogger {
 
   def builder[F[_]: Async](
       logHeaders: Boolean,
-      logBodyWith: Stream[F, Byte] => Option[F[String]],
-  ): ResponseLogger[F] = Impl(logHeaders, Right(logBodyWith))
+      renderBodyWith: Stream[F, Byte] => Option[F[String]],
+  ): ResponseLogger[F] = Impl(logHeaders, Right(renderBodyWith))
 
   @deprecated("Use ResponseLogger.builder", "0.23.15")
   def apply[G[_], F[_], A](

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -34,7 +34,16 @@ import fs2.Stream
 import org.log4s.getLogger
 import org.typelevel.ci.CIString
 
-sealed abstract class ResponseLogger[F[_]] extends internal.Logger[F, ResponseLogger[F]]
+sealed abstract class ResponseLogger[F[_]] extends internal.Logger[F, ResponseLogger[F]] {
+  def apply[G[_], A](fk: F ~> G)(
+      http: Kleisli[G, A, Response[F]]
+  )(implicit G: MonadCancelThrow[G]): Kleisli[G, A, Response[F]]
+
+  def apply[G[_], A](
+      http: Kleisli[G, A, Response[F]]
+  )(implicit lift: Logger.Lift[F, G], G: MonadCancelThrow[G]): Kleisli[G, A, Response[F]] =
+    apply(lift.fk)(http)
+}
 
 /** Simple middleware for logging responses as they are processed
   */

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -33,7 +33,8 @@ import fs2.Stream
 import org.log4s.getLogger
 import org.typelevel.ci.CIString
 
-sealed abstract class ResponseLoggerBuilder[F[_]] extends internal.Logger[F, ResponseLoggerBuilder[F]] {
+sealed abstract class ResponseLoggerBuilder[F[_]]
+    extends internal.Logger[F, ResponseLoggerBuilder[F]] {
   def apply[G[_], A](fk: F ~> G)(
       http: Kleisli[G, A, Response[F]]
   )(implicit G: MonadCancelThrow[G]): Kleisli[G, A, Response[F]]
@@ -63,7 +64,8 @@ object ResponseLogger {
     override def withRedactHeadersWhen(f: CIString => Boolean): ResponseLoggerBuilder[F] =
       copy(redactHeadersWhen = f)
 
-    override def withLogAction(f: String => F[Unit]): ResponseLoggerBuilder[F] = copy(logAction = Some(f))
+    override def withLogAction(f: String => F[Unit]): ResponseLoggerBuilder[F] =
+      copy(logAction = Some(f))
   }
 
   def builder[F[_]: Async](

--- a/server/shared/src/main/scala/org/http4s/server/middleware/internal/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/internal/Logger.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.middleware.internal
+
+import cats.data.Kleisli
+import cats.effect.kernel.MonadCancelThrow
+import cats.~>
+import org.http4s.Response
+import org.http4s.server.middleware.Logger.Lift
+import org.typelevel.ci.CIString
+
+private[http4s] abstract class Logger[F[_], Self <: Logger[F, Self]] {
+  self: Self =>
+  def apply[G[_], A](fk: F ~> G)(
+      http: Kleisli[G, A, Response[F]]
+  )(implicit G: MonadCancelThrow[G]): Kleisli[G, A, Response[F]]
+
+  def apply[G[_], A](
+      http: Kleisli[G, A, Response[F]]
+  )(implicit lift: Lift[F, G], G: MonadCancelThrow[G]): Kleisli[G, A, Response[F]] =
+    apply(lift.fk)(http)
+
+  def withRedactHeadersWhen(f: CIString => Boolean): Self
+
+  def withLogAction(f: String => F[Unit]): Self
+  def withLogActionOpt(of: Option[String => F[Unit]]): Self =
+    of.fold(this)(withLogAction)
+}

--- a/server/shared/src/main/scala/org/http4s/server/middleware/internal/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/internal/Logger.scala
@@ -16,27 +16,14 @@
 
 package org.http4s.server.middleware.internal
 
-import cats.data.Kleisli
-import cats.effect.kernel.MonadCancelThrow
-import cats.~>
-import org.http4s.Response
-import org.http4s.server.middleware.Logger.Lift
 import org.typelevel.ci.CIString
 
 private[http4s] abstract class Logger[F[_], Self <: Logger[F, Self]] {
   self: Self =>
-  def apply[G[_], A](fk: F ~> G)(
-      http: Kleisli[G, A, Response[F]]
-  )(implicit G: MonadCancelThrow[G]): Kleisli[G, A, Response[F]]
-
-  def apply[G[_], A](
-      http: Kleisli[G, A, Response[F]]
-  )(implicit lift: Lift[F, G], G: MonadCancelThrow[G]): Kleisli[G, A, Response[F]] =
-    apply(lift.fk)(http)
 
   def withRedactHeadersWhen(f: CIString => Boolean): Self
 
   def withLogAction(f: String => F[Unit]): Self
-  def withLogActionOpt(of: Option[String => F[Unit]]): Self =
+  final def withLogActionOpt(of: Option[String => F[Unit]]): Self =
     of.fold(this)(withLogAction)
 }


### PR DESCRIPTION
An attempt to impose some order on the combinatorial explosion of logging options. I've re-targeted these changes at 0.23.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 