### PR TITLE
Pin slf4j to 1.x and cleanup

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,13 +1,3 @@
 updates.pin = [
-  # Jetty > 9 and Tomcat > 9 are breaking changes
-  { groupId = "org.eclipse.jetty", version = "9." },
-  { groupId = "org.eclipse.jetty.http2", version = "9." },
-  # Servlet 4 breaks Jetty 9 and Tomcat 9
-  { groupId = "javax.servlet", version = "3." },
-  # simpleclient-0.12 breaks metric names
-  { groupId = "io.prometheus", version = "0.11." },
-  # okio-3 has (slight) binary incompatibilities
-  { groupId = "com.squareup.okio", artifactId = "okio", version = "2." },
-  # scalatags-0.11 breaks bincompat
-  { groupId = "com.lihaoyi", artifactId = "scalatags", version = "0.10." }
+  { groupId = "org.slf4j", artifactId = "slf4j-api", version = "1." }
 ]


### PR DESCRIPTION
See:
- https://github.com/typelevel/log4cats/pull/679
- https://github.com/http4s/http4s/pull/6625