### PR TITLE
Using `mdoc:silent` more liberally throughout docs

### DIFF
--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -86,6 +86,7 @@ val serviceSpanish: HttpRoutes[IO] = middleware(spanishRoutes) <+> frenchRoutes
 Call to the french routes will always return 401 (Unauthorized) as they are caught by the spanish routes. To allow access to other routes you can:
 
 * Use a Router with unique route prefixes
+
 ```scala mdoc:silent
 val serviceRouter = {
   Router (
@@ -96,6 +97,7 @@ val serviceRouter = {
 ```
 
 * Allow fallthrough, using `AuthMiddleware.withFallThrough`.
+
 ```scala mdoc:silent
 val middlewareWithFallThrough: AuthMiddleware[IO, User] =
   AuthMiddleware.withFallThrough(authUser)
@@ -103,6 +105,7 @@ val serviceSF: HttpRoutes[IO] = middlewareWithFallThrough(spanishRoutes) <+> fre
 ```
 
 * Reorder the routes so that authed routes compose last
+
 ```scala mdoc:silent
 val serviceFS: HttpRoutes[IO] =
   frenchRoutes <+> middlewareWithFallThrough(spanishRoutes)

--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -212,7 +212,7 @@ function.
 import org.http4s.syntax.header._
 import org.http4s.headers.Authorization
 
-val authUserHeaders: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ request =>
+val authUserHeader: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ request =>
   val message = for {
     header  <- request.headers.get[Authorization]
                  .toRight("Couldn't find an Authorization header")

--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -80,7 +80,8 @@ val frenchRoutes: HttpRoutes[IO] =
         case GET -> Root / "bonjour" => Ok(s"Bonjour")
     }
 
-val serviceSpanish: HttpRoutes[IO] = middleware(spanishRoutes) <+> frenchRoutes
+val serviceSpanish: HttpRoutes[IO] =
+  middleware(spanishRoutes) <+> frenchRoutes
 ```
 
 Call to the french routes will always return 401 (Unauthorized) as they are caught by the spanish routes. To allow access to other routes you can:
@@ -101,7 +102,8 @@ val serviceRouter = {
 ```scala mdoc:silent
 val middlewareWithFallThrough: AuthMiddleware[IO, User] =
   AuthMiddleware.withFallThrough(authUser)
-val serviceSF: HttpRoutes[IO] = middlewareWithFallThrough(spanishRoutes) <+> frenchRoutes
+val serviceSF: HttpRoutes[IO] =
+  middlewareWithFallThrough(spanishRoutes) <+> frenchRoutes
 ```
 
 * Reorder the routes so that authed routes compose last
@@ -128,7 +130,8 @@ To allow for failure, the `authUser` function has to be adjusted to a `Request[F
 error handling, we recommend an error [ADT] instead of a `String`.
 
 ```scala mdoc:silent
-val authUserEither: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli(_ => IO(???))
+val authUserEither: Kleisli[IO, Request[IO], Either[String,User]] =
+  Kleisli(_ => IO(???))
 
 val onFailure: AuthedRoutes[String, IO] =
   Kleisli(req => OptionT.liftF(Forbidden(req.context)))

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -151,8 +151,7 @@ the world" varies by context:
 * Here in the REPL, the last line is the end of the world.  Here we go:
 
 ```scala mdoc
-val greetingsStringEffect = greetingList.map(_.mkString("\n"))
-greetingsStringEffect.unsafeRunSync()
+greetingList.map(_.mkString("\n")).unsafeRunSync()
 ```
 
 ## Constructing a URI

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
 ```
 
 Then we create the [service] again so [mdoc] picks it up:
->
+
 ```scala mdoc:silent
 import cats.effect._
 import com.comcast.ip4s._

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -43,7 +43,7 @@ implicit val runtime: IORuntime = IORuntime.global
 
 Finish setting up our server:
 
-```scala mdoc
+```scala mdoc:silent
 val app = HttpRoutes.of[IO] {
   case GET -> Root / "hello" / name =>
     Ok(s"Hello, $name.")
@@ -61,7 +61,7 @@ val server = EmberServerBuilder
 
 We'll start the server in the background.
 
-```scala mdoc
+```scala mdoc:silent
 val shutdown = server.allocated.unsafeRunSync()._2
 ```
 
@@ -103,7 +103,7 @@ val httpClient: Client[IO] = JavaNetClientBuilder[IO].create
 To execute a GET request, we can call `expect` with the type we expect
 and the URI we want:
 
-```scala mdoc
+```scala mdoc:silent
 val helloJames = httpClient.expect[String]("http://localhost:8080/hello/James")
 ```
 
@@ -126,7 +126,7 @@ import cats._, cats.effect._, cats.implicits._
 import org.http4s.Uri
 ```
 
-```scala mdoc
+```scala mdoc:silent
 def hello(name: String): IO[String] = {
   val target = uri"http://localhost:8080/hello/" / name
   httpClient.expect[String](target)
@@ -293,7 +293,7 @@ Out of the Box middleware for [Dropwizard](https://http4s.github.io/http4s-dropw
 
 You can send a GET by calling the `expect` method on the client, passing a `Uri`:
 
-```scala mdoc
+```scala mdoc:silent
 httpClient.expect[String](uri"https://google.com/")
 ```
 

--- a/docs/docs/cors.md
+++ b/docs/docs/cors.md
@@ -40,14 +40,16 @@ implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 
 Let's start by making a simple service.
 
-```scala mdoc
+```scala mdoc:silent
 val service = HttpRoutes.of[IO] {
-  case _ =>
-    Ok()
+  case _ => Ok()
 }
 
 val request = Request[IO](Method.GET, uri"/")
+```
 
+
+```scala mdoc
 service.orNotFound(request).unsafeRunSync()
 ```
 
@@ -55,11 +57,11 @@ Now we can wrap the service in the `CORS` middleware.
 
 ```scala mdoc:silent
 import org.http4s.server.middleware._
+
+val corsService = CORS.policy.withAllowOriginAll(service)
 ```
 
 ```scala mdoc
-val corsService = CORS.policy.withAllowOriginAll(service)
-
 corsService.orNotFound(request).unsafeRunSync()
 ```
 
@@ -98,16 +100,16 @@ and `POST`, pass that to the `CORS` middleware, and try it out on our requests.
 
 ```scala mdoc:silent
 import scala.concurrent.duration._
-```
 
-```scala mdoc
 val corsMethodSvc = CORS.policy
   .withAllowOriginAll
   .withAllowMethodsIn(Set(Method.GET, Method.POST))
   .withAllowCredentials(false)
   .withMaxAge(1.day)
   .apply(service)
+```
 
+```scala mdoc
 corsMethodSvc.orNotFound(googleGet).unsafeRunSync()
 corsMethodSvc.orNotFound(yahooPut).unsafeRunSync()
 corsMethodSvc.orNotFound(duckPost).unsafeRunSync()
@@ -118,7 +120,7 @@ Next, we'll create a configuration that limits the origins to "yahoo.com" and
 "duckduckgo.com". `withAllowOriginHost` accepts an `Origin.Host => Boolean`.
 If you're simply enumerating allowed hosts, a `Set` is convenient:
 
-```scala mdoc
+```scala mdoc:silent
 import org.http4s.headers.Origin
 
 val corsOriginSvc = CORS.policy
@@ -129,7 +131,9 @@ val corsOriginSvc = CORS.policy
   .withAllowCredentials(false)
   .withMaxAge(1.day)
   .apply(service)
+```
 
+```scala mdoc
 corsOriginSvc.orNotFound(googleGet).unsafeRunSync()
 corsOriginSvc.orNotFound(yahooPut).unsafeRunSync()
 corsOriginSvc.orNotFound(duckPost).unsafeRunSync()

--- a/docs/docs/csrf.md
+++ b/docs/docs/csrf.md
@@ -31,14 +31,15 @@ implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 
 Let's start by making a simple service.
 
-```scala mdoc
+```scala mdoc:silent
 val service = HttpRoutes.of[IO] {
-  case _ =>
-    Ok()
+  case _ => Ok()
 }
 
 val request = Request[IO](Method.GET, uri"/")
+```
 
+```scala mdoc
 service.orNotFound(request).unsafeRunSync()
 ```
 
@@ -55,7 +56,7 @@ val csrfBuilder = CSRF[IO,IO](key, defaultOriginCheck)
 More info on what is possible in the [CSRFBuilder] Docs,
 but we will create a fairly simple CSRF Middleware in our example.
 
-```scala mdoc
+```scala mdoc:silent
 val csrf = csrfBuilder
   .withCookieName(cookieName)
   .withCookieDomain(Some("localhost"))
@@ -64,9 +65,12 @@ val csrf = csrfBuilder
 ```
 
 Now we need to wrap this around our service! We're gonna start with a safe call
-```scala mdoc
+```scala mdoc:silent
 val dummyRequest: Request[IO] =
     Request[IO](method = Method.GET).putHeaders("Origin" -> "http://localhost")
+```
+
+```scala mdoc
 val resp = csrf.validate()(service.orNotFound)(dummyRequest).unsafeRunSync()
 ```
 Notice how the response has the CSRF cookies added. How easy was

--- a/docs/docs/dsl.md
+++ b/docs/docs/dsl.md
@@ -57,7 +57,7 @@ anything.  The right hand side of the request must return a
 
 In the following we use `cats.effect.IO` as the effect type `F`.
 
-```scala mdoc
+```scala mdoc:silent
 val service = HttpRoutes.of[IO] {
   case _ =>
     IO(Response(Status.Ok))
@@ -70,7 +70,7 @@ One beautiful thing about the `HttpRoutes[F]` model is that we don't
 need a server to test our route.  We can construct our own request
 and experiment directly in the REPL.
 
-```scala mdoc
+```scala mdoc:silent
 val getRoot = Request[IO](Method.GET, uri"/")
 
 val serviceIO = service.orNotFound.run(getRoot)
@@ -106,9 +106,8 @@ generating `F[Response]`s.
 http4s-dsl provides a shortcut to create an `F[Response]` by
 applying a status code:
 
-```scala mdoc
-val okIo = Ok()
-val ok = okIo.unsafeRunSync()
+```scala mdoc:silent
+val okIo: IO[Response[IO]] = Ok()
 ```
 
 This simple `Ok()` expression succinctly says what we mean in a
@@ -172,7 +171,7 @@ Ok("Ok response.").map(_.addCookie(ResponseCookie("foo", "bar")))
 
 `Cookie` can be further customized to set, e.g., expiration, the secure flag, httpOnly, flag, etc
 
-```scala mdoc
+```scala mdoc:silent
 val cookieResp = {
   for {
     resp <- Ok("Ok response.")
@@ -180,6 +179,9 @@ val cookieResp = {
   } yield resp.addCookie(ResponseCookie("foo", "bar",
       expires = Some(now), httpOnly = true, secure = true))
 }
+```
+
+```scala mdoc
 cookieResp.unsafeRunSync().headers
 ```
 
@@ -239,22 +241,28 @@ effectful, unless we wrap it in `IO`:
 `IO.fromFuture` requires an implicit `ContextShift`, to ensure that the
 suspended future is shifted to the correct thread pool.
 
-```scala mdoc
+```scala mdoc:silent
 val ioFuture = Ok(IO.fromFuture(IO(Future {
   println("I run when the future is constructed.")
   "Greetings from the future!"
 })))
+```
+
+```scala mdoc
 ioFuture.unsafeRunSync()
 ```
 
 As good functional programmers who like to delay our side effects, we
 of course prefer to operate in `F`s:
 
-```scala mdoc
+```scala mdoc:silent
 val io = Ok(IO {
   println("I run when the IO is run.")
   "Mission accomplished!"
 })
+```
+
+```scala mdoc
 io.unsafeRunSync()
 ```
 
@@ -276,9 +284,7 @@ for one second:
 ```scala mdoc:silent
 import fs2.Stream
 import scala.concurrent.duration._
-```
 
-```scala mdoc
 val drip: Stream[IO, String] =
   Stream.awakeEvery[IO](100.millis).map(_.toString).take(10)
 ```
@@ -317,7 +323,7 @@ info via the `->` object.  On the left side is the method, and on the
 right side, the path info.  The following matches a request to `GET
 /hello`:
 
-```scala mdoc
+```scala mdoc:silent
 HttpRoutes.of[IO] {
   case GET -> Root / "hello" => Ok("hello")
 }
@@ -389,7 +395,7 @@ Path params can be extracted and converted to a specific type but are
 `String`s by default. There are numeric extractors provided in the form
 of `IntVar` and `LongVar`, as well as `UUIDVar` extractor for `java.util.UUID`.
 
-```scala mdoc
+```scala mdoc:silent
 def getUserName(userId: Int): IO[String] = ???
 
 val usersService = HttpRoutes.of[IO] {
@@ -406,9 +412,7 @@ in which `IntVar` does it.
 import java.time.LocalDate
 import scala.util.Try
 import org.http4s.client.dsl.io._
-```
 
-```scala mdoc
 object LocalDateVar {
   def unapply(str: String): Option[LocalDate] = {
     if (!str.isEmpty)
@@ -427,6 +431,9 @@ val dailyWeatherService = HttpRoutes.of[IO] {
 }
 
 val req = GET(uri"/weather/temperature/2016-11-05")
+```
+
+```scala mdoc
 dailyWeatherService.orNotFound(req).unsafeRunSync()
 ```
 
@@ -434,21 +441,21 @@ dailyWeatherService.orNotFound(req).unsafeRunSync()
 
 [Matrix path parameters](https://www.w3.org/DesignIssues/MatrixURIs.html) can be extracted using `MatrixVar`.
 
-```scala mdoc:silent
-import org.http4s.dsl.impl.MatrixVar
-```
-
 In following example, we extract the `first` and `last` matrix path parameters.
 By default, matrix path parameters are extracted as `String`s.
 
-```scala mdoc
+```scala mdoc:silent
+import org.http4s.dsl.impl.MatrixVar
+
 object FullNameExtractor extends MatrixVar("name", List("first", "last"))
 
 val greetingService = HttpRoutes.of[IO] {
   case GET -> Root / "hello" / FullNameExtractor(first, last) / "greeting" =>
     Ok(s"Hello, $first $last.")
 }
+```
 
+```scala mdoc
 greetingService
   .orNotFound(GET(uri"/hello/name;first=john;last=doe/greeting"))
   .unsafeRunSync()
@@ -456,14 +463,16 @@ greetingService
 
 Like standard path parameters, matrix path parameters can be extracted as numeric types using `IntVar` or `LongVar`.
 
-```scala mdoc
+```scala mdoc:silent
 object FullNameAndIDExtractor extends MatrixVar("name", List("first", "last", "id"))
 
 val greetingWithIdService = HttpRoutes.of[IO] {
   case GET -> Root / "hello" / FullNameAndIDExtractor(first, last, IntVar(id)) / "greeting" =>
     Ok(s"Hello, $first $last. Your User ID is $id.")
 }
+```
 
+```scala mdoc
 greetingWithIdService
   .orNotFound(GET(uri"/hello/name;first=john;last=doe;id=123/greeting"))
   .unsafeRunSync()

--- a/docs/docs/dsl.md
+++ b/docs/docs/dsl.md
@@ -238,8 +238,8 @@ Note: unlike `IO`, wrapping a side effect in `Future` does not
 suspend it, and the resulting expression would still be side
 effectful, unless we wrap it in `IO`:
 
-`IO.fromFuture` requires an implicit `ContextShift`, to ensure that the
-suspended future is shifted to the correct thread pool.
+`IO.fromFuture` ensures that the suspended future is shifted to the correct
+thread pool.
 
 ```scala mdoc:silent
 val ioFuture = Ok(IO.fromFuture(IO(Future {

--- a/docs/docs/entity.md
+++ b/docs/docs/entity.md
@@ -58,7 +58,7 @@ import cats.effect.unsafe.IORuntime
 implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 ```
 
-```scala mdoc
+```scala mdoc:silent
 val response = Ok("").map(_.withContentType(`Content-Type`(MediaType.audio.ogg)))
 val audioDec = EntityDecoder.decodeBy(MediaType.audio.ogg) { (m: Media[IO]) =>
   EitherT {
@@ -71,6 +71,9 @@ val videoDec = EntityDecoder.decodeBy(MediaType.video.ogg) { (m: Media[IO]) =>
   }
 }
 implicit val bothDec = audioDec.widen[Resp] orElse videoDec.widen[Resp]
+```
+
+```scala mdoc
 println(response.flatMap(_.as[Resp]).unsafeRunSync())
 ```
 

--- a/docs/docs/gzip.md
+++ b/docs/docs/gzip.md
@@ -31,14 +31,16 @@ implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 Let's start by making a simple service that returns a (relatively) large string
 in its body. We'll use `as[String]` to examine the body.
 
-```scala mdoc
+```scala mdoc:silent
 val service = HttpRoutes.of[IO] {
   case _ =>
     Ok("I repeat myself when I'm under stress. " * 3)
 }
 
 val request = Request[IO](Method.GET, uri"/")
+```
 
+```scala mdoc
 // Do not call 'unsafeRun' in your code - see note at bottom.
 val response = service.orNotFound(request).unsafeRunSync()
 val body = response.as[String].unsafeRunSync()
@@ -47,10 +49,12 @@ body.length
 
 Now we can wrap the service in the `GZip` middleware.
 
-```scala mdoc
+```scala mdoc:silent
 import org.http4s.server.middleware._
 val serviceZip = GZip(service)
+```
 
+```scala mdoc
 // Do not call 'unsafeRun' in your code - see note at bottom.
 val respNormal = serviceZip.orNotFound(request).unsafeRunSync()
 val bodyNormal = respNormal.as[String].unsafeRunSync()

--- a/docs/docs/hsts.md
+++ b/docs/docs/hsts.md
@@ -35,14 +35,15 @@ implicit val runtime: IORuntime = cats.effect.unsafe.IORuntime.global
 
 Let's make a simple service that will be exposed and wrapped with HSTS.
 
-```scala mdoc
+```scala mdoc:silent
 val service = HttpRoutes.of[IO] {
-  case _ =>
-    Ok("ok")
+  case _ => Ok("ok")
 }
 
 val request = Request[IO](Method.GET, uri"/")
+```
 
+```scala mdoc
 // Do not call 'unsafeRunSync' in your code
 val responseOk = service.orNotFound(request).unsafeRunSync()
 responseOk.headers
@@ -52,11 +53,11 @@ If we were to wrap this on the `HSTS` middleware.
 
 ```scala mdoc:silent
 import org.http4s.server.middleware._
+
+val hstsService = HSTS(service)
 ```
 
 ```scala mdoc
-val hstsService = HSTS(service)
-
 // Do not call 'unsafeRunSync' in your code
 val responseHSTS = hstsService.orNotFound(request).unsafeRunSync()
 responseHSTS.headers
@@ -78,13 +79,13 @@ If you want to `preload` or change other default values you can pass a custom he
 ```scala mdoc:silent
 import org.http4s.headers._
 import scala.concurrent.duration._
-```
 
-```scala mdoc
 val hstsHeader = `Strict-Transport-Security`
   .unsafeFromDuration(30.days, includeSubDomains = true, preload = true)
 val hstsServiceCustom = HSTS(service, hstsHeader)
+```
 
+```scala mdoc
 // Do not call 'unsafeRunSync' in your code
 val responseCustom = hstsServiceCustom.orNotFound(request).unsafeRunSync()
 responseCustom.headers

--- a/docs/docs/json.md
+++ b/docs/docs/json.md
@@ -83,9 +83,7 @@ useful on client requests:
 
 ```scala mdoc:silent
 import org.http4s.client.dsl.io._
-```
 
-```scala mdoc
 POST(json"""{"name": "Alice"}""", uri"/hello")
 ```
 
@@ -254,7 +252,7 @@ val server = EmberServerBuilder
 
 We start a server resource in the background.
 
-```scala mdoc
+```scala mdoc:silent
 val shutdown = server.allocated.unsafeRunSync()._2
 ```
 

--- a/docs/docs/methods.md
+++ b/docs/docs/methods.md
@@ -11,7 +11,7 @@ import org.http4s._, org.http4s.dsl.io._
 import org.http4s.circe._
 ```
 
-```scala mdoc
+```scala mdoc:silent
 case class TweetWithId(id: Int, message: String)
 case class Tweet(message: String)
 

--- a/docs/docs/middleware.md
+++ b/docs/docs/middleware.md
@@ -43,8 +43,7 @@ def myMiddle(service: HttpRoutes[IO], header: Header.ToRaw): HttpRoutes[IO] = Kl
   service(req).map {
     case Status.Successful(resp) =>
       resp.putHeaders(header)
-    case resp =>
-      resp
+    case resp => resp
   }
 }
 ```
@@ -61,17 +60,18 @@ we need to call `unsafeRunSync` on the result of the function to extract the `Re
 Note that basically, you shouldn't use `unsafeRunSync` in your application. 
 Here we use it for demo reasons only.
 
-```scala mdoc
+```scala mdoc:silent
 val service = HttpRoutes.of[IO] {
   case GET -> Root / "bad" =>
     BadRequest()
-  case _ =>
-    Ok()
+  case _ => Ok()
 }
 
 val goodRequest = Request[IO](Method.GET, uri"/")
 val badRequest = Request[IO](Method.GET, uri"/bad")
+```
 
+```scala mdoc
 service.orNotFound(goodRequest).unsafeRunSync()
 service.orNotFound(badRequest).unsafeRunSync()
 ```
@@ -80,7 +80,9 @@ Now, we'll apply the service to our middleware function to create a new service,
 
 ```scala mdoc:silent
 val modifiedService = myMiddle(service, "SomeKey" -> "SomeValue");
+```
 
+```scala mdoc
 modifiedService.orNotFound(goodRequest).unsafeRunSync()
 modifiedService.orNotFound(badRequest).unsafeRunSync()
 ```
@@ -90,7 +92,7 @@ Note that the successful response has your header added to it.
 If you intend to use you middleware in multiple places, you may want to implement
 it as an `object` and use the `apply` method.
 
-```scala mdoc
+```scala mdoc:silent
 object MyMiddle {
   def addHeader(resp: Response[IO], header: Header.ToRaw) =
     resp match {
@@ -103,7 +105,9 @@ object MyMiddle {
 }
 
 val newService = MyMiddle(service, "SomeKey" -> "SomeValue")
+```
 
+```scala mdoc
 newService.orNotFound(goodRequest).unsafeRunSync()
 newService.orNotFound(badRequest).unsafeRunSync()
 ```
@@ -125,7 +129,7 @@ Additionally, you can compose services before applying the middleware function,
 and/or compose services with the service obtained by applying some middleware function. 
 For example:
 
-```scala mdoc
+```scala mdoc:silent
 val apiService = HttpRoutes.of[IO] {
   case GET -> Root / "api" =>
     Ok()
@@ -139,7 +143,9 @@ val anotherService = HttpRoutes.of[IO] {
 val aggregateService = apiService <+> MyMiddle(service <+> anotherService, "SomeKey" -> "SomeValue")
 
 val apiRequest = Request[IO](Method.GET, uri"/api")
+```
 
+```scala mdoc
 aggregateService.orNotFound(goodRequest).unsafeRunSync()
 aggregateService.orNotFound(apiRequest).unsafeRunSync()
 ```

--- a/docs/docs/service.md
+++ b/docs/docs/service.md
@@ -64,7 +64,7 @@ matching the request.  Let's build a service that matches requests to
 `GET /hello/:name`, where `:name` is a path parameter for the person to
 greet.
 
-```scala mdoc
+```scala mdoc:silent
 val helloWorldService = HttpRoutes.of[IO] {
   case GET -> Root / "hello" / name =>
     Ok(s"Hello, $name.")
@@ -84,7 +84,7 @@ We've defined `tweetsEncoder` as being implicit so that we don't need to explici
 reference it when serving the response, which can be seen as
 `getPopularTweets().flatMap(Ok(_))`.
 
-```scala mdoc
+```scala mdoc:silent
 case class Tweet(id: Int, message: String)
 
 implicit def tweetEncoder: EntityEncoder[IO, Tweet] = ???
@@ -126,7 +126,7 @@ import org.http4s.server.Router
 import scala.concurrent.duration._
 ```
 
-```scala mdoc
+```scala mdoc:silent
 val services = tweetService <+> helloWorldService
 val httpApp = Router("/" -> helloWorldService, "/api" -> services).orNotFound
 val server = EmberServerBuilder
@@ -141,7 +141,7 @@ The `withHttpApp` call associates the specified routes with this http server ins
 
 We start a server resource in the background.
 
-```scala mdoc
+```scala mdoc:silent
 val shutdown = server.allocated.unsafeRunSync()._2
 ```
 
@@ -155,7 +155,7 @@ $ curl http://localhost:8080/hello/Pete
 
 We can shut down the server by canceling its fiber.
 
-```scala mdoc
+```scala mdoc:silent
 shutdown.unsafeRunSync()
 ```
 

--- a/docs/docs/static.md
+++ b/docs/docs/static.md
@@ -72,14 +72,14 @@ val routes = HttpRoutes.of[IO] {
 For simple file serving, it's possible to package resources with the jar and
 deliver them from there. For example, for all resources in the classpath under `assets`:
 
-```scala mdoc
+```scala mdoc:silent
 val assetsRoutes = resourceServiceBuilder[IO]("/assets").toRoutes
 ```
 
 For custom behaviour, `StaticFile.fromResource` can be used. In this example,
 only files matching a list of extensions are served. Append to the `List` as needed.
 
-```scala mdoc
+```scala mdoc:silent
 def static(file: String, request: Request[IO]) =
   StaticFile.fromResource("/" + file, Some(request)).getOrElseF(NotFound())
 
@@ -108,7 +108,7 @@ Then, mount the `WebjarService` like any other service:
 import org.http4s.server.staticcontent.WebjarServiceBuilder.WebjarAsset
 ```
 
-```scala mdoc
+```scala mdoc:silent
 // only allow js assets
 def isJsAsset(asset: WebjarAsset): Boolean =
   asset.asset.endsWith(".js")

--- a/docs/docs/streaming.md
+++ b/docs/docs/streaming.md
@@ -52,7 +52,7 @@ First, let's assume we want to use [Circe] for JSON support. Please see [json] f
 ```scala
 libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-circe" % "@VERSION@",
-  "io.circe" %% "circe-generic" % "@CIRCE_VERSION"
+  "io.circe" %% "circe-generic" % "@CIRCE_VERSION@"
 )
 ```
 

--- a/docs/docs/uri.md
+++ b/docs/docs/uri.md
@@ -25,7 +25,7 @@ or you could use the URLTemplates.
 
 Use the methods on the [uri class].
 
-```scala mdoc
+```scala mdoc:silent
 val docs = uri.withPath(path"/docs/0.15")
 val docs2 = uri / "docs" / "0.15"
 assert(docs == docs2)
@@ -35,15 +35,15 @@ assert(docs == docs2)
 
 ```scala mdoc:silent
 import org.http4s.UriTemplate._
-```
 
-```scala mdoc
 val template = UriTemplate(
   authority = Some(Uri.Authority(host = Uri.RegName("http4s.org"))),
   scheme = Some(Uri.Scheme.http),
   path = List(PathElm("docs"), PathElm("0.15"))
 )
+```
 
+```scala mdoc
 template.toUriIfPossible
 ```
 


### PR DESCRIPTION
This PR does a quick once over all our docs using mdoc to see if there are easy clean up wins by using `mdoc:silent`.

This main goal of this PR is to reduce unhelpful mdoc output.
So only minor modifications are being made to serve that goal.
There's certainly more work to do here, this is just a first small attempt to clean up low hanging fruit.

<details><summary>Example Screenshots From service.md</summary>

*Before:*

![Screenshot from 2022-10-01 07-43-41](https://user-images.githubusercontent.com/5440389/193407994-97c72776-ddd1-48d0-a4f5-06e2a3f69e2c.png)

*After:*

![Screenshot from 2022-10-01 07-44-16](https://user-images.githubusercontent.com/5440389/193408001-41f92fb0-1957-4354-b4d8-60992f17e90d.png)
</details>

<details><summary>Example Screenshots From lient.md</summary>

*Before:*

![Screenshot from 2022-10-01 07-55-56](https://user-images.githubusercontent.com/5440389/193408458-f690c78e-e29e-439d-8572-85b913e36307.png)

*After:*

![Screenshot from 2022-10-01 07-56-21](https://user-images.githubusercontent.com/5440389/193408463-b662cab7-aafd-4d43-9052-27dee6e0a564.png)

</details>

---

**Edit:** This PR fixes a few other things unrelated to silencing output from IO values:

  - [Fix CIRCE_VERSION ref in streaming.md](https://github.com/http4s/http4s/pull/6705/commits/21b67ccd157cbb665888b43475983bf837b2bdf3)
  - [Remove old ContextShift mention in dsl.md](https://github.com/http4s/http4s/pull/6705/commits/a98c2f8eb6dd144b648436275bbf14dbcc01557d)
  - [Add newlines before code block to fix formatting](https://github.com/http4s/http4s/pull/6705/commits/11e2d4e4f54a5b7d8dd37dc5becfbd31aaf846a5)

## Checklist

- [x] docs/docs/auth.md
- [x] docs/docs/client.md
- [x] docs/docs/cors.md **
- [x] docs/docs/csrf.md **
- [x] docs/docs/deployment.md
- [x] docs/docs/dsl.md **
- [x] docs/docs/entity.md
- [x] docs/docs/error-handling.md
- [x] docs/docs/gzip.md
- [x] docs/docs/hsts.md
- [x] docs/docs/integrations.md
- [x] docs/docs/json.md
- [x] docs/docs/methods.md
- [x] docs/docs/middleware.md
- [x] docs/docs/quickstart.md
- [x] docs/docs/service.md
- [x] docs/docs/static.md
- [x] docs/docs/streaming.md
- [x] docs/docs/testing.md
- [x] docs/docs/upgrading.md
- [x] docs/docs/uri.md

** still lots of mdoc output we could perhaps trim or better direct attention to the important parts
