### PR TITLE
`Cross-Origin-Resource-Policy` header model

### DIFF
--- a/core/shared/src/main/scala/org/http4s/headers/Cross-Origin-Resource-Policy.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Cross-Origin-Resource-Policy.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package headers
+
+import cats.parse.Parser
+import cats.parse.Parser.string
+import org.typelevel.ci._
+
+/** This response header conveys a desire that the browser blocks no-cors cross-origin/cross-site
+  * requests to the given resource
+  *
+  * @see [[https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy]]
+  */
+sealed abstract class `Cross-Origin-Resource-Policy`(val value: String)
+    extends Product
+    with Serializable
+
+object `Cross-Origin-Resource-Policy` {
+  case object SameSite extends `Cross-Origin-Resource-Policy`("same-site")
+  case object SameOrigin extends `Cross-Origin-Resource-Policy`("same-origin")
+  case object CrossOrigin extends `Cross-Origin-Resource-Policy`("cross-origin")
+
+  private[http4s] val parser: Parser[`Cross-Origin-Resource-Policy`] = {
+    val sameSiteParser = string("same-site").as(SameSite)
+    val sameOriginParser = string("same-origin").as(SameOrigin)
+    val crossOriginParser = string("cross-origin").as(CrossOrigin)
+    sameSiteParser | sameOriginParser | crossOriginParser
+  }
+
+  def parse(s: String): ParseResult[`Cross-Origin-Resource-Policy`] =
+    ParseResult.fromParser(parser, "Invalid Cross-Origin-Resource-Policy header")(s)
+
+  implicit val headerInstance: Header[`Cross-Origin-Resource-Policy`, Header.Single] =
+    Header.create(
+      ci"Cross-Origin-Resource-Policy",
+      _.value,
+      parse,
+    )
+}

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -1124,6 +1124,15 @@ private[discipline] trait ArbitraryInstancesBinCompat0 extends ArbitraryInstance
     } yield headers.`Accept-Post`(values)
   }
 
+  implicit val arbitraryCrossOriginResourcePolicy: Arbitrary[`Cross-Origin-Resource-Policy`] =
+    Arbitrary[`Cross-Origin-Resource-Policy`](
+      Gen.oneOf(
+        `Cross-Origin-Resource-Policy`.SameSite,
+        `Cross-Origin-Resource-Policy`.SameOrigin,
+        `Cross-Origin-Resource-Policy`.CrossOrigin,
+      )
+    )
+
   val genObsText: Gen[String] = Gen.stringOf(Gen.choose(0x80.toChar, 0xff.toChar))
   val genVcharExceptDquote: Gen[Char] = genVchar.filter(_ != 0x22.toChar)
 

--- a/tests/shared/src/test/scala/org/http4s/headers/CrossOriginResourcePolicySuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/CrossOriginResourcePolicySuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package headers
+
+import cats.syntax.either._
+import org.http4s.laws.discipline.arbitrary._
+
+class CrossOriginResourcePolicySuite extends HeaderLaws {
+  checkAll("Cross-Origin-Resource-Policy", headerLaws[`Cross-Origin-Resource-Policy`])
+
+  test("parsing same-site into SameSite") {
+    assertEquals(
+      `Cross-Origin-Resource-Policy`.parser.parseAll("same-site"),
+      `Cross-Origin-Resource-Policy`.SameSite.asRight,
+    )
+  }
+
+  test("parsing same-origin into SameOrigin") {
+    assertEquals(
+      `Cross-Origin-Resource-Policy`.parser.parseAll("same-origin"),
+      `Cross-Origin-Resource-Policy`.SameOrigin.asRight,
+    )
+  }
+
+  test("parsing cross-origin into CrossOrigin") {
+    assertEquals(
+      `Cross-Origin-Resource-Policy`.parser.parseAll("cross-origin"),
+      `Cross-Origin-Resource-Policy`.CrossOrigin.asRight,
+    )
+  }
+}


### PR DESCRIPTION
- adds a model for the `Cross-Origin-Resource-Policy` header, following the [mozilla reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy)
- tests as well
  - I looked at some other examples and they were adding the `checkAll` header laws test as well as explicit checks, but it kind of looked to me like those header laws would have already covered these explicit checks? Could anyone explain why we do both? 🙏🏻 
https://github.com/http4s/http4s/blob/d6e5f6ab0db674e857a0f4f4331655dddfc0f35a/tests/shared/src/test/scala/org/http4s/headers/HeaderLaws.scala#L33-L35

related to #5010