### PR TITLE
Use ubuntu-22.04 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         scala: [3.1.3, 2.12.17, 2.13.8]
         java: [temurin@8, temurin@11, temurin@17]
         project: [rootJS, rootJVM, rootNative]
@@ -175,7 +175,7 @@ jobs:
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.23')
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         scala: [2.13.8]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ ThisBuild / scalafixAll / skip := tlIsScala3.value
 ThisBuild / ScalafixConfig / skip := tlIsScala3.value
 ThisBuild / Test / scalafixConfig := Some(file(".scalafix.test.conf"))
 
+ThisBuild / githubWorkflowOSes := Seq("ubuntu-22.04")
+
 ThisBuild / githubWorkflowBuildPreamble +=
   WorkflowStep.Run(
     List("brew install s2n"),


### PR DESCRIPTION
This fixes the Scala Native CI (sorry). See https://github.com/typelevel/fs2/pull/2992 for additional detail.