### PR TITLE
Call Chunk.toByteBuffer directly

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -30,8 +30,6 @@ import org.http4s.jawn.JawnInstances
 import org.typelevel.jawn.ParseException
 import org.typelevel.jawn.fs2.unwrapJsonArray
 
-import java.nio.ByteBuffer
-
 trait CirceInstances extends JawnInstances {
   protected val circeSupportParser =
     new CirceSupportParser(maxValueSize = None, allowDuplicateKeys = false)
@@ -54,7 +52,7 @@ trait CirceInstances extends JawnInstances {
 
   private def jsonDecoderByteBufferImpl[F[_]: Concurrent](m: Media[F]): DecodeResult[F, Json] =
     EntityDecoder.collectBinary(m).subflatMap { chunk =>
-      val bb = ByteBuffer.wrap(chunk.toArray)
+      val bb = chunk.toByteBuffer
       if (bb.hasRemaining)
         circeSupportParser
           .parseFromByteBuffer(bb)


### PR DESCRIPTION
Once https://github.com/typelevel/fs2/pull/2990 is released and we upgrade fs2 version, this operation should be significantly cheaper in many cases (or at worst: the same as before).

See also https://github.com/typelevel/jawn-fs2/pull/376