### PR TITLE
Optimise putting headers, add interface to allow caching static headers

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/HeadersBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/HeadersBench.scala
@@ -43,7 +43,7 @@ class HeadersBench {
   @Benchmark
   def putHeaderRaw: Response[IO] =
     baseMessage
-      .putHeader(`Content-Length`(1000L))
-      .putHeader(cachedEncoding)
-      .putHeader(cachedServer)
+      .putRawHeader(`Content-Length`(1000L))
+      .putRawHeader(cachedEncoding)
+      .putRawHeader(cachedServer)
 }

--- a/bench/src/main/scala/org/http4s/bench/HeadersBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/HeadersBench.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package bench
+
+import cats.effect.IO
+import org.http4s.headers._
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+// sbt "bench/jmh:run -i 5 -wi 5 -f 1 -t 1 org.http4s.bench.HeadersBench"
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class HeadersBench {
+  val baseMessage: Response[IO] = Response[IO]()
+
+  val cachedEncoding: `Content-Encoding` = `Content-Encoding`(ContentCoding.gzip)
+  val cachedServer: Server = Server(ProductId("Benchmark"))
+
+  @Benchmark
+  def putHeaders: Response[IO] =
+    baseMessage
+      .putHeaders(`Content-Length`(1000L))
+      .putHeaders(`Content-Encoding`(ContentCoding.gzip))
+      .putHeaders(Server(ProductId("Benchmark")))
+
+  @Benchmark
+  def putHeaderRaw: Response[IO] =
+    baseMessage
+      .putHeader(`Content-Length`(1000L))
+      .putHeader(cachedEncoding)
+      .putHeader(cachedServer)
+}

--- a/client/shared/src/main/scala/org/http4s/client/middleware/GZip.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/GZip.scala
@@ -38,6 +38,9 @@ object GZip {
   private val supportedCompressions =
     NonEmptyList.of(ContentCoding.gzip, ContentCoding.deflate)
 
+  private val acceptEncodingHeader =
+    `Accept-Encoding`(supportedCompressions)
+
   def apply[F[_]](bufferSize: Int = 32 * 1024)(client: Client[F])(implicit F: Async[F]): Client[F] =
     Client[F] { req =>
       val reqWithEncoding = addHeaders(req)
@@ -53,7 +56,7 @@ object GZip {
       case Some(_) =>
         req
       case _ =>
-        req.putHeaders(`Accept-Encoding`(supportedCompressions))
+        req.putRawHeader(acceptEncodingHeader)
     }
 
   private def decompress[F[_]](bufferSize: Int, response: Response[F])(implicit

--- a/core/shared/src/main/scala/org/http4s/Header.scala
+++ b/core/shared/src/main/scala/org/http4s/Header.scala
@@ -195,6 +195,12 @@ object Header {
     }
   }
 
+  /** Abstracts over headers that can be cached. The most common use case would be
+    * extending a modelled header (e.g. Accept-Encoding), extending the class
+    * and overriding asRaw1 using lazy val.
+    * This enables better efficiency when the same 'static' header is added to the headers
+    * of many responses, as it's not re-created on every single response.
+    */
   trait AsRaw1 {
     def asRaw1: Header.Raw
   }

--- a/core/shared/src/main/scala/org/http4s/Header.scala
+++ b/core/shared/src/main/scala/org/http4s/Header.scala
@@ -179,9 +179,24 @@ object Header {
     // Required for 2.12 to convert variadic args.
     implicit def scalaCollectionSeqToRaw[H](
         h: collection.Seq[H]
+    )(implicit convert: H => ToRaw with Primitive): Header.ToRaw =
+      scalaCollectionListToRaw(h.toList)
+
+    implicit def scalaCollectionListToRaw[H](
+        h: List[H]
     )(implicit convert: H => ToRaw with Primitive): Header.ToRaw = new Header.ToRaw {
-      val values: List[Raw] = h.toList.foldMap(v => convert(v).values)
+      val values: List[Raw] = {
+        val result = List.newBuilder[Raw]
+        h.foreach { v =>
+          result ++= convert(v).values
+        }
+        result.result()
+      }
     }
+  }
+
+  trait AsRaw1 {
+    def asRaw1: Header.Raw
   }
 
   /** Abstracts over Single and Recurring Headers

--- a/core/shared/src/main/scala/org/http4s/Headers.scala
+++ b/core/shared/src/main/scala/org/http4s/Headers.scala
@@ -72,7 +72,7 @@ final class Headers(val headers: List[Header.Raw]) extends AnyVal {
   def put(in: Header.ToRaw*): Headers =
     this ++ Headers(in.values)
 
-  def putOne(in: Header.Raw): Headers =
+  def putOneRaw(in: Header.Raw): Headers =
     if (this.headers.isEmpty) new Headers(List(in))
     else {
       new Headers(this.headers.filterNot(_.name == in.name) :+ in)

--- a/core/shared/src/main/scala/org/http4s/Headers.scala
+++ b/core/shared/src/main/scala/org/http4s/Headers.scala
@@ -78,6 +78,17 @@ final class Headers(val headers: List[Header.Raw]) extends AnyVal {
       new Headers(this.headers.filterNot(_.name == in.name) :+ in)
     }
 
+  def putManyRaw(in: List[Header.Raw]): Headers =
+    if (this.headers.isEmpty) new Headers(in)
+    else {
+      val inNames = {
+        val builder = Set.newBuilder[CIString]
+        in.foreach(h => builder += h.name)
+        builder.result()
+      }
+      new Headers(this.headers.filterNot(h => inNames.contains(h.name)) ::: in)
+    }
+
   def ++(those: Headers): Headers =
     if (those.headers.isEmpty) this
     else if (this.headers.isEmpty) those

--- a/core/shared/src/main/scala/org/http4s/Headers.scala
+++ b/core/shared/src/main/scala/org/http4s/Headers.scala
@@ -72,6 +72,12 @@ final class Headers(val headers: List[Header.Raw]) extends AnyVal {
   def put(in: Header.ToRaw*): Headers =
     this ++ Headers(in.values)
 
+  def putOne(in: Header.Raw): Headers =
+    if (this.headers.isEmpty) new Headers(List(in))
+    else {
+      new Headers(this.headers.filterNot(_.name == in.name) :+ in)
+    }
+
   def ++(those: Headers): Headers =
     if (those.headers.isEmpty) this
     else if (this.headers.isEmpty) those

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -176,11 +176,11 @@ sealed trait Message[F[_]] extends Media[F] { self =>
   def putHeaders(headers: Header.ToRaw*): Self =
     transformHeaders(_.put(headers: _*))
 
-  def putHeader(header: Header.Raw): Self =
-    transformHeaders(_.putOne(header))
+  def putRawHeader(header: Header.Raw): Self =
+    transformHeaders(_.putOneRaw(header))
 
-  def putHeader(header: Header.AsRaw1): Self =
-    transformHeaders(_.putOne(header.asRaw1))
+  def putRawHeader(header: Header.AsRaw1): Self =
+    transformHeaders(_.putOneRaw(header.asRaw1))
 
   /** Add a header to these headers.  The header should be a type with a
     * recurring `Header` instance to ensure that the new value can be

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -176,6 +176,12 @@ sealed trait Message[F[_]] extends Media[F] { self =>
   def putHeaders(headers: Header.ToRaw*): Self =
     transformHeaders(_.put(headers: _*))
 
+  def putHeader(header: Header.Raw): Self =
+    transformHeaders(_.putOne(header))
+
+  def putHeader(header: Header.AsRaw1): Self =
+    transformHeaders(_.putOne(header.asRaw1))
+
   /** Add a header to these headers.  The header should be a type with a
     * recurring `Header` instance to ensure that the new value can be
     * appended to any existing values.

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -176,12 +176,32 @@ sealed trait Message[F[_]] extends Media[F] { self =>
   def putHeaders(headers: Header.ToRaw*): Self =
     transformHeaders(_.put(headers: _*))
 
-  def putRawHeader(header: Header.Raw): Self =
-    transformHeaders(_.putOneRaw(header))
-
+  /** Add the providers headers to the existing headers, replacing those
+    * of the same header name.
+    *
+    * Note this method is different to [[putHeaders]] by being efficient, but slightly
+    * less flexible, as no implicits conversions are provided into a Header.Raw
+    *
+    * Consider using [[putRawHeader]] if you only have a single header to add, as it
+    * avoids creating a list.
+    */
   def putRawHeaders(headers: List[Header.Raw]): Self =
     transformHeaders(_.putManyRaw(headers))
 
+  /** Add the providers headers to the existing headers, replacing those
+    * of the same header name.
+    *
+    * This is a more efficient version of [[putHeaders]]
+    */
+  def putRawHeader(header: Header.Raw): Self =
+    transformHeaders(_.putOneRaw(header))
+
+  /** Add the providers headers to the existing headers, replacing those
+    * of the same header name.
+    *
+    * This is a more efficient version of [[putHeaders]] and similar to [[putRawHeader]],
+    * but accept a modelled header.
+    */
   def putRawHeader(header: Header.AsRaw1): Self =
     transformHeaders(_.putOneRaw(header.asRaw1))
 

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -179,6 +179,9 @@ sealed trait Message[F[_]] extends Media[F] { self =>
   def putRawHeader(header: Header.Raw): Self =
     transformHeaders(_.putOneRaw(header))
 
+  def putRawHeaders(headers: List[Header.Raw]): Self =
+    transformHeaders(_.putManyRaw(headers))
+
   def putRawHeader(header: Header.AsRaw1): Self =
     transformHeaders(_.putOneRaw(header.asRaw1))
 

--- a/core/shared/src/main/scala/org/http4s/headers/Content-Encoding.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Content-Encoding.scala
@@ -29,7 +29,7 @@ object `Content-Encoding` {
 
   implicit val headerInstance: Header[`Content-Encoding`, Header.Single] =
     Header.createRendered(
-      ci"Content-Encoding",
+      name,
       _.contentCoding,
       parse,
     )

--- a/core/shared/src/main/scala/org/http4s/headers/Content-Encoding.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Content-Encoding.scala
@@ -25,6 +25,8 @@ object `Content-Encoding` {
 
   private[http4s] val parser = ContentCoding.parser.map(`Content-Encoding`(_))
 
+  val name = ci"Content-Encoding"
+
   implicit val headerInstance: Header[`Content-Encoding`, Header.Single] =
     Header.createRendered(
       ci"Content-Encoding",
@@ -33,4 +35,7 @@ object `Content-Encoding` {
     )
 }
 
-final case class `Content-Encoding`(contentCoding: ContentCoding)
+final case class `Content-Encoding`(contentCoding: ContentCoding) extends Header.AsRaw1 {
+  lazy val asRaw1: Header.Raw =
+    Header.Raw(`Content-Encoding`.name, `Content-Encoding`.headerInstance.value(this))
+}

--- a/core/shared/src/main/scala/org/http4s/headers/Content-Length.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Content-Length.scala
@@ -27,9 +27,12 @@ import org.typelevel.ci._
   *
   * @param length the length
   */
-final case class `Content-Length`(length: Long) {
+final case class `Content-Length`(length: Long) extends Header.AsRaw1 {
   def modify(f: Long => Long): Option[`Content-Length`] =
     `Content-Length`.fromLong(f(length)).toOption
+
+  lazy val asRaw1: Header.Raw =
+    Header.Raw(`Content-Length`.name, `Content-Length`.headerInstance.value(this))
 }
 
 object `Content-Length` {

--- a/core/shared/src/main/scala/org/http4s/headers/Server.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Server.scala
@@ -53,4 +53,7 @@ object Server extends HeaderCompanion[Server]("Server") {
 /** Server header
   * https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.2
   */
-final case class Server(product: ProductId, rest: List[ProductIdOrComment])
+final case class Server(product: ProductId, rest: List[ProductIdOrComment]) extends Header.AsRaw1 {
+  lazy val asRaw1: Header.Raw =
+    Header.Raw(Server.name, Server.headerInstance.value(this))
+}

--- a/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -244,9 +244,12 @@ object CORS {
           .putRawHeaders(
             List(
               // TODO model me
-              Header.Raw(ci"Access-Control-Allow-Methods", config.allowedMethods.fold(method.renderString)(
-                _.mkString("", ", ", "")
-              )),
+              Header.Raw(
+                ci"Access-Control-Allow-Methods",
+                config.allowedMethods.fold(method.renderString)(
+                  _.mkString("", ", ", "")
+                ),
+              ),
               // TODO model me
               Header.Raw(ci"Access-Control-Allow-Origin", origin.value),
               // TODO model me

--- a/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -87,7 +87,7 @@ object GZip extends GZipPlatform {
     logger.trace("GZip middleware encoding content").unsafeRunSync()
     resp
       .removeHeader[`Content-Length`]
-      .putHeader(ContentEncodingHeader)
+      .putRawHeader(ContentEncodingHeader)
       .pipeBodyThrough(compressPipe)
   }
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -26,6 +26,7 @@ import org.http4s.headers._
 
 object GZip extends GZipPlatform {
   private[this] val logger = Platform.loggerFactory.getLogger
+  private[this] final val ContentEncodingHeader = `Content-Encoding`(ContentCoding.gzip)
 
   // TODO: It could be possible to look for F.pure type bodies, and change the Content-Length header after
   // TODO      zipping and buffering all the input. Just a thought.
@@ -86,7 +87,7 @@ object GZip extends GZipPlatform {
     logger.trace("GZip middleware encoding content").unsafeRunSync()
     resp
       .removeHeader[`Content-Length`]
-      .putHeaders(`Content-Encoding`(ContentCoding.gzip))
+      .putHeader(ContentEncodingHeader)
       .pipeBodyThrough(compressPipe)
   }
 }


### PR DESCRIPTION
I'm opening this PR in draft mode because I don't really understand why the existing logic of *putting* a header is so complicated and perhaps we're missing something.

Note I haven't updated all headers, although probably all headers could be updated to extend the `AsRaw1` interface which allows automatic caching of the value.


**Benchmarks**
Performance of `putHeaders` in `master`, using the same benchmark added in this PR:
```
[info] Benchmark                                                   Mode  Cnt     Score     Error   Units
[info] HeadersBench.putHeaders                                     avgt   10   891.876 ±  15.552   ns/op
[info] HeadersBench.putHeaders:·gc.alloc.rate                      avgt   10  4635.263 ±  81.338  MB/sec
[info] HeadersBench.putHeaders:·gc.alloc.rate.norm                 avgt   10  4552.203 ±   0.003    B/op
[info] HeadersBench.putHeaders:·gc.churn.G1_Eden_Space             avgt   10  4636.559 ±  90.078  MB/sec
[info] HeadersBench.putHeaders:·gc.churn.G1_Eden_Space.norm        avgt   10  4553.459 ±  32.059    B/op
[info] HeadersBench.putHeaders:·gc.churn.G1_Survivor_Space         avgt   10     0.017 ±   0.007  MB/sec
[info] HeadersBench.putHeaders:·gc.churn.G1_Survivor_Space.norm    avgt   10     0.017 ±   0.006    B/op
[info] HeadersBench.putHeaders:·gc.count                           avgt   10   990.000            counts
[info] HeadersBench.putHeaders:·gc.time                            avgt   10  1054.000                ms
```

Performance of `putHeaders` with minor changes in this PR:
```
[info] Benchmark                                                 Mode  Cnt     Score     Error   Units
[info] HeadersBench.putHeaders                                   avgt   10   822.643 ±  80.883   ns/op
[info] HeadersBench.putHeaders:·gc.alloc.rate                    avgt   10  4998.685 ± 472.242  MB/sec
[info] HeadersBench.putHeaders:·gc.alloc.rate.norm               avgt   10  4512.201 ±   0.002    B/op
[info] HeadersBench.putHeaders:·gc.churn.G1_Eden_Space           avgt   10  5001.228 ± 483.802  MB/sec
[info] HeadersBench.putHeaders:·gc.churn.G1_Eden_Space.norm      avgt   10  4514.091 ±  21.311    B/op
[info] HeadersBench.putHeaders:·gc.churn.G1_Survivor_Space       avgt   10     0.014 ±   0.006  MB/sec
[info] HeadersBench.putHeaders:·gc.churn.G1_Survivor_Space.norm  avgt   10     0.013 ±   0.005    B/op
[info] HeadersBench.putHeaders:·gc.count                         avgt   10  1068.000            counts
[info] HeadersBench.putHeaders:·gc.time                          avgt   10  1087.000                ms
```

However, the new `putHeader` (note singular) together with the caching and `AsRaw1` trait, we get the following:
```
[info] Benchmark                                                   Mode  Cnt     Score     Error   Units
[info] HeadersBench.putHeaderRaw                                   avgt   10   100.361 ±  15.176   ns/op
[info] HeadersBench.putHeaderRaw:·gc.alloc.rate                    avgt   10  4597.130 ± 624.751  MB/sec
[info] HeadersBench.putHeaderRaw:·gc.alloc.rate.norm               avgt   10   504.022 ±   0.001    B/op
[info] HeadersBench.putHeaderRaw:·gc.churn.G1_Eden_Space           avgt   10  4603.441 ± 615.393  MB/sec
[info] HeadersBench.putHeaderRaw:·gc.churn.G1_Eden_Space.norm      avgt   10   504.796 ±   4.592    B/op
[info] HeadersBench.putHeaderRaw:·gc.churn.G1_Survivor_Space       avgt   10     0.012 ±   0.005  MB/sec
[info] HeadersBench.putHeaderRaw:·gc.churn.G1_Survivor_Space.norm  avgt   10     0.001 ±   0.001    B/op
[info] HeadersBench.putHeaderRaw:·gc.count                         avgt   10   975.000            counts
[info] HeadersBench.putHeaderRaw:·gc.time                          avgt   10   966.000                ms
```

As you can see, approximately 9x the performance while maintaining the same GC. In order to further improve performance, we'd need to get rid of the `List` data structure here which doesn't seem compatible at all with the idea of `Headers`, given that we need to always `append` rather than `prepend`, so every time we add a header to the list, we have to traverse the whole existing list of headers and add it to the end. Sounds like we should be using `Chain` or something.