### PR TITLE
Fix Keep-Alive header flaky test

### DIFF
--- a/core/shared/src/main/scala/org/http4s/headers/Keep-Alive.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Keep-Alive.scala
@@ -52,11 +52,11 @@ keep-alive-extension = token [ "=" ( token / quoted-string ) ]
       extension: List[(String, Option[String])],
   ): ParseResult[`Keep-Alive`] =
     if (timeoutSeconds.isDefined || max.isDefined || extension.nonEmpty) {
-      val reservedTokens = List("token", "max")
-      if (extension.exists(p => reservedTokens.contains(p._1))) {
+      val reservedToken ="token"
+      if (extension.exists(p => p._1 == reservedToken)) {
         ParseResult.fail(
           "Invalid Keep-Alive header",
-          s"Reserved token of list $reservedTokens was found in the extensions.",
+          s"Reserved token '$reservedToken' was found in the extensions.",
         )
       } else {
         val validatedTimeoutSeconds = timeoutSeconds.traverse(t => nonNegativeLong(t, "timeout"))

--- a/core/shared/src/main/scala/org/http4s/headers/Keep-Alive.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Keep-Alive.scala
@@ -52,7 +52,7 @@ keep-alive-extension = token [ "=" ( token / quoted-string ) ]
       extension: List[(String, Option[String])],
   ): ParseResult[`Keep-Alive`] =
     if (timeoutSeconds.isDefined || max.isDefined || extension.nonEmpty) {
-      val reservedToken ="token"
+      val reservedToken = "token"
       if (extension.exists(p => p._1 == reservedToken)) {
         ParseResult.fail(
           "Invalid Keep-Alive header",

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -1093,7 +1093,7 @@ private[discipline] trait ArbitraryInstancesBinCompat0 extends ArbitraryInstance
       max <- Gen.option(Gen.chooseNum(0L, Long.MaxValue))
       l <- Gen.listOf(genExtension)
       if timeout.isDefined || max.isDefined || l.nonEmpty // One of these fields is necessary to be valid.
-    } yield `Keep-Alive`.unsafeApply(timeout, max, l.filterNot { case (s,_) => s == "token" })
+    } yield `Keep-Alive`.unsafeApply(timeout, max, l.filterNot { case (s, _) => s == "token" })
   }
 
   val genCustomStatusReason: Gen[String] = {

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -1093,7 +1093,7 @@ private[discipline] trait ArbitraryInstancesBinCompat0 extends ArbitraryInstance
       max <- Gen.option(Gen.chooseNum(0L, Long.MaxValue))
       l <- Gen.listOf(genExtension)
       if timeout.isDefined || max.isDefined || l.nonEmpty // One of these fields is necessary to be valid.
-    } yield `Keep-Alive`.unsafeApply(timeout, max, l)
+    } yield `Keep-Alive`.unsafeApply(timeout, max, l.filterNot { case (s,_) => s == "token" })
   }
 
   val genCustomStatusReason: Gen[String] = {

--- a/tests/shared/src/test/scala/org/http4s/headers/KeepAliveSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/KeepAliveSuite.scala
@@ -20,7 +20,6 @@ package headers
 import org.http4s.laws.discipline.arbitrary._
 
 class KeepAliveSuite extends HeaderLaws {
-
   checkAll("Keep-Alive", headerLaws[`Keep-Alive`])
 
   test("invalid (empty) Keep-Alives should result in failure") {
@@ -95,6 +94,15 @@ class KeepAliveSuite extends HeaderLaws {
     assertEquals(
       Header[`Keep-Alive`].parse("timeout=3, max=33, extKey=1, max=8"),
       `Keep-Alive`(Some(3), Some(33), List(("extKey", Some("1")))),
+    )
+  }
+
+  test(
+    "parse keep-alive fails if extensions contain reserved 'token'"
+  ) {
+    assertEquals(
+      Header[`Keep-Alive`].parse("timeout=3, max=33, token=foo, max=8"),
+      Left(ParseFailure("Invalid Keep-Alive header","Reserved token 'token' was found in the extensions."))
     )
   }
 }

--- a/tests/shared/src/test/scala/org/http4s/headers/KeepAliveSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/KeepAliveSuite.scala
@@ -102,7 +102,12 @@ class KeepAliveSuite extends HeaderLaws {
   ) {
     assertEquals(
       Header[`Keep-Alive`].parse("timeout=3, max=33, token=foo, max=8"),
-      Left(ParseFailure("Invalid Keep-Alive header","Reserved token 'token' was found in the extensions."))
+      Left(
+        ParseFailure(
+          "Invalid Keep-Alive header",
+          "Reserved token 'token' was found in the extensions.",
+        )
+      ),
     )
   }
 }


### PR DESCRIPTION
Closes #6676
Remove 'max' deprecated token.
Fix generator so that it doesn't generates reserved token strings.
Add test that proved that parser fails if reserved 'token' is present in the extensions

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 