### PR TITLE
cookie parser should tolerate missing leading space

### DIFF
--- a/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
@@ -20,7 +20,8 @@ package headers
 import cats.data.NonEmptyList
 import cats.parse.Parser
 import cats.parse.Parser.char
-import org.http4s.util.{Renderable, Writer}
+import org.http4s.util.Renderable
+import org.http4s.util.Writer
 import org.typelevel.ci._
 
 object Cookie {

--- a/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
@@ -19,7 +19,8 @@ package headers
 
 import cats.data.NonEmptyList
 import cats.parse.Parser
-import org.http4s.util.{Renderable, Writer}
+import org.http4s.util.Renderable
+import org.http4s.util.Writer
 import org.typelevel.ci._
 
 object Cookie {
@@ -32,9 +33,10 @@ object Cookie {
   private[http4s] val parser: Parser[Cookie] = {
     import Parser.{char, string}
 
-    ((RequestCookie.parser <* (char(';') ~ string(" ").?)) ~ (RequestCookie.parser <* char(';').?).rep0).map {
-      case (head, tail) =>
-        Cookie(NonEmptyList(head, tail))
+    ((RequestCookie.parser <* (char(';') ~ string(" ").?)) ~ (RequestCookie.parser <* char(
+      ';'
+    ).?).rep0).map { case (head, tail) =>
+      Cookie(NonEmptyList(head, tail))
     }
   }
 

--- a/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
@@ -19,8 +19,8 @@ package headers
 
 import cats.data.NonEmptyList
 import cats.parse.Parser
-import org.http4s.util.Renderable
-import org.http4s.util.Writer
+import cats.parse.Parser.char
+import org.http4s.util.{Renderable, Writer}
 import org.typelevel.ci._
 
 object Cookie {
@@ -30,15 +30,9 @@ object Cookie {
   def parse(s: String): ParseResult[Cookie] =
     ParseResult.fromParser(parser, "Invalid Cookie header")(s)
 
-  private[http4s] val parser: Parser[Cookie] = {
-    import Parser.{char, string}
-
-    ((RequestCookie.parser <* (char(';') ~ string(" ").?)) ~ (RequestCookie.parser <* char(
-      ';'
-    ).?).rep0).map { case (head, tail) =>
-      Cookie(NonEmptyList(head, tail))
-    }
-  }
+  private[http4s] val parser: Parser[Cookie] =
+    (RequestCookie.parser <* (char(';') ~ char(' ').?).?).rep
+      .map(Cookie(_))
 
   val name: CIString = ci"Cookie"
 

--- a/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
@@ -19,9 +19,7 @@ package headers
 
 import cats.data.NonEmptyList
 import cats.parse.Parser
-import org.http4s.Header
-import org.http4s.util.Renderable
-import org.http4s.util.Writer
+import org.http4s.util.{Renderable, Writer}
 import org.typelevel.ci._
 
 object Cookie {
@@ -34,15 +32,10 @@ object Cookie {
   private[http4s] val parser: Parser[Cookie] = {
     import Parser.{char, string}
 
-    /* cookie-string = cookie-pair *( ";" SP cookie-pair ) */
-    val cookieString = (RequestCookie.parser ~ (string("; ") *> RequestCookie.parser).rep0).map {
+    ((RequestCookie.parser <* (char(';') ~ string(" ").?)) ~ (RequestCookie.parser <* char(';').?).rep0).map {
       case (head, tail) =>
         Cookie(NonEmptyList(head, tail))
     }
-
-    /* We also see trailing semi-colons in the wild, and grudgingly tolerate them
-     * here. */
-    cookieString <* char(';').?
   }
 
   val name: CIString = ci"Cookie"

--- a/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
@@ -28,16 +28,18 @@ class CookieHeaderSuite extends munit.FunSuite {
   private val cookiestrSemicolon: String = cookiestr
   private val cookies = List(RequestCookie("key1", "value1"), RequestCookie("key2", """"value2""""))
 
-  test("Cookie parser should parse a cookie") {
+  test("Cookie parser should parse a single cookie") {
+    assertEquals(parse("key1=value1").values.toList, List(RequestCookie("key1", "value1")))
+  }
+  test("Cookie parser should parse two cookies") {
     assertEquals(parse(cookiestr).values.toList, cookies)
   }
-  test("Cookie parser should parse a cookie (semicolon at the end)") {
+  test("Cookie parser should parse two cookies with semicolon at the end") {
     assertEquals(parse(cookiestrSemicolon).values.toList, cookies)
   }
   test("Cookie parser should tolerate missing leading space") {
     assertEquals(parse(cookiestrWithoutSpace).values.toList, cookies)
   }
-
   test("Cookie parser should tolerate spaces") {
     assertEquals(
       parse("initialTrafficSource=utmcsr=(direct)|utmcmd=(none)|utmccn=(not set);").values,

--- a/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
@@ -25,7 +25,7 @@ class CookieHeaderSuite extends munit.FunSuite {
 
   private val cookiestr = "key1=value1; key2=\"value2\""
   private val cookiestrWithoutSpace = "key1=value1;key2=\"value2\""
-  private val cookiestrSemicolon: String = cookiestr
+  private val cookiestrSemicolon: String = cookiestr + ";"
   private val cookies = List(RequestCookie("key1", "value1"), RequestCookie("key2", """"value2""""))
 
   test("Cookie parser should parse a single cookie") {

--- a/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
@@ -24,7 +24,8 @@ class CookieHeaderSuite extends munit.FunSuite {
   private def parse(value: String) = headers.Cookie.parse(value).valueOr(throw _)
 
   private val cookiestr = "key1=value1; key2=\"value2\""
-  private val cookiestrSemicolon: String = cookiestr + ";"
+  private val cookiestrWithoutSpace = "key1=value1;key2=\"value2\""
+  private val cookiestrSemicolon: String = cookiestr
   private val cookies = List(RequestCookie("key1", "value1"), RequestCookie("key2", """"value2""""))
 
   test("Cookie parser should parse a cookie") {
@@ -33,6 +34,10 @@ class CookieHeaderSuite extends munit.FunSuite {
   test("Cookie parser should parse a cookie (semicolon at the end)") {
     assertEquals(parse(cookiestrSemicolon).values.toList, cookies)
   }
+  test("Cookie parser should tolerate missing leading space") {
+    assertEquals(parse(cookiestrWithoutSpace).values.toList, cookies)
+  }
+
   test("Cookie parser should tolerate spaces") {
     assertEquals(
       parse("initialTrafficSource=utmcsr=(direct)|utmcmd=(none)|utmccn=(not set);").values,


### PR DESCRIPTION
Currently the http4s cookie parser fails on cookies with no leading space after the delimiter `;`.

E.g. `key1=value1;key2=value2` is not supported.

By the [IETF Standard](https://datatracker.ietf.org/doc/html/draft-ietf-httpstate-cookie-10#section-2.2) it is not required to have a leading space after the delimiter.

This PR fixes this and allows leading spaces after the delimiter.