### PR TITLE
Make StreamForking resource safe in the face of cancelation

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
@@ -18,6 +18,7 @@ package org.http4s.ember.server.internal
 
 import cats.effect.Concurrent
 import cats.effect.std.Semaphore
+import cats.effect.syntax.all._
 import cats.syntax.all._
 import fs2.Stream
 import fs2.concurrent.Signal
@@ -60,7 +61,8 @@ private[internal] object StreamForking {
           .interruptWhen(stopSignal)
           .compile
           .drain
-          .handleErrorWith(stopFailed) >> available.release >> decrementRunning
+          .handleErrorWith(stopFailed)
+          .guarantee(available.release >> decrementRunning)
 
         available.acquire >> incrementRunning >> F.start(fa).void
       }


### PR DESCRIPTION
This is a backport of #6610 by @TimWSpence to 0.23 branch.