### PR TITLE
docs: remove `Future[_]` from presupplied encoders

### DIFF
--- a/docs/docs/entity.md
+++ b/docs/docs/entity.md
@@ -81,8 +81,7 @@ println(response.flatMap(_.as[Resp]).unsafeRunSync())
 The `EntityEncoder`/`EntityDecoder`s shipped with http4s.
 
 ### Raw Data Types
-These are already in implicit scope by default, e.g. `String`, `File`,
-`Future[_]`, and `InputStream`. Consult [EntityEncoder] and [EntityDecoder] for
+These are already in implicit scope by default, e.g. `String`, `File`, and `InputStream`. Consult [EntityEncoder] and [EntityDecoder] for
 a full list.
 
 ### JSON


### PR DESCRIPTION
follow up: #1694
Presupplied future has been deleted in 13527d6c320efd25800680a8fd841365dec7965e. Isn't it?

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 

Thank you :)