### PR TITLE
Scala specific nowarnX annotations

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -50,6 +50,7 @@ object Http4sPlugin extends AutoPlugin {
     headerSources / excludeFilter := HiddenFileFilter,
     doctestTestFramework := DoctestTestFramework.Munit,
     libraryDependencies += scalacCompatAnnotation,
+    unusedCompileDependenciesFilter ~= { _ & (_ == scalacCompatAnnotation) },
     ivyConfigurations += CompileTime,
     Compile / unmanagedClasspath ++= update.value.select(configurationFilter(CompileTime.name)),
   )

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -47,6 +47,7 @@ object Http4sPlugin extends AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     headerSources / excludeFilter := HiddenFileFilter,
     doctestTestFramework := DoctestTestFramework.Munit,
+    libraryDependencies += scalacCompatAnnotation,
   )
 
   def extractApiVersion(version: String) = {
@@ -124,6 +125,7 @@ object Http4sPlugin extends AutoPlugin {
     val munitDiscipline = "2.0.0-M3"
     val netty = "4.1.84.Final"
     val quasiquotes = "2.1.0"
+    val scalacCompat = "0.1.0"
     val scalacheck = "1.17.0"
     val scalacheckEffect = "2.0.0-M2"
     val scalaJavaLocales = "1.4.1"
@@ -181,6 +183,8 @@ object Http4sPlugin extends AutoPlugin {
   lazy val nettyBuffer = "io.netty" % "netty-buffer" % V.netty
   lazy val nettyCodecHttp = "io.netty" % "netty-codec-http" % V.netty
   lazy val quasiquotes = "org.scalamacros" %% "quasiquotes" % V.quasiquotes
+  lazy val scalacCompatAnnotation =
+    "org.typelevel" %% "scalac-compat-annotation" % V.scalacCompat % CompileTime
   lazy val scalacheck = Def.setting("org.scalacheck" %%% "scalacheck" % V.scalacheck)
   lazy val scalacheckEffect =
     Def.setting("org.typelevel" %%% "scalacheck-effect" % V.scalacheckEffect)

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -29,6 +29,8 @@ object Http4sPlugin extends AutoPlugin {
   val scala_212 = "2.12.17"
   val scala_3 = "3.2.0"
 
+  private val CompileTime = config("compile-time").hide
+
   override lazy val globalSettings = Seq(
     isCi := githubIsWorkflowBuild.value
   )
@@ -48,6 +50,8 @@ object Http4sPlugin extends AutoPlugin {
     headerSources / excludeFilter := HiddenFileFilter,
     doctestTestFramework := DoctestTestFramework.Munit,
     libraryDependencies += scalacCompatAnnotation,
+    ivyConfigurations += CompileTime,
+    Compile / unmanagedClasspath ++= update.value.select(configurationFilter(CompileTime.name)),
   )
 
   def extractApiVersion(version: String) = {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -28,8 +28,8 @@ import org.http4s.Method.OPTIONS
 import org.http4s.headers._
 import org.http4s.syntax.header._
 import org.typelevel.ci._
+import org.typelevel.scalaccompat.annotation._
 
-import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.util.hashing.MurmurHash3
 
@@ -194,11 +194,11 @@ object CORS {
     "Depends on a deficient `CORSConfig`. See https://github.com/http4s/http4s/security/advisories/GHSA-52cf-226f-rhr6. If config.anyOrigin is true and config.allowCredentials is true, then the `Access-Control-Allow-Credentials` header will be suppressed starting with 0.22.3.",
     "0.21.27",
   )
-  @nowarn // silence deprecation warning on Scala 3
+  @nowarn212("cat=deprecation")
+  @nowarn3("cat=deprecation")
   def apply[F[_], G[_]](http: Http[F, G], config: CORSConfig = CORSConfig.default)(implicit
       F: Applicative[F]
   ): Http[F, G] = {
-    def purposelyUnused = 0 // to satisfy @nowarn on Scala 2
     if (config.anyOrigin && config.allowCredentials)
       logger
         .warn(


### PR DESCRIPTION
Introduces a bunch of Scala-version specific `@nowarnX` annotation which map to a real `scala.annotation.nowarn` according to the table:
| Scala | 2.12 | 2.13 | 3 |
| -- | -- | -- | -- |
| `@nowarn2` | ✅ | ✅ | ☠️ |
| `@nowarn212` | ✅ | ☠️ | ☠️ |
| `@nowarn213` | ☠️ | ✅ | ☠️ |
| `@nowarn3` | ☠️ | ☠️ | ✅ |

Also this PR re-fixes https://github.com/http4s/http4s/pull/6750#discussion_r994977997 in a nicer and more generic way (hopefully). As well as the proposed annotations can be used in the future to address similar issues related to differences in Scalac warning detection/generation.

Basically it should allow to avoid inventing ad-hoc solutions every time and let us simply use a set of `nowarn` options that works for all current cross-build Scala versions in the project.

Also, Scala3 may use a set of filters for compiler messages that can be different from one used by Scala2. Therefore, these annotations could allow adjusting the filters in a finer and more precise way.

---
In fact, this approach can be generalized to make these custom annotations available for other projects. Perhaps we could consider extracting them into a separate <sub>(micro-)</sub>module for that 🤔