### PR TITLE
Special-case `EmptyBody` in request encoder

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -140,9 +140,13 @@ private[ember] object Encoder {
         }
 
         if (!chunked && !appliedContentLength && !NoPayloadMethods.contains(req.method)) {
-          stringBuilder.append(chunkedTransferEncodingHeaderRaw).append(CRLF)
-          chunked = true
-          ()
+          if (req.body == EmptyBody) {
+            stringBuilder.append(zeroContentLengthRaw).append(CRLF)
+            chunked = false
+          } else {
+            stringBuilder.append(chunkedTransferEncodingHeaderRaw).append(CRLF)
+            chunked = true
+          }
         }
 
         // Final CRLF terminates headers and signals body to follow.

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -139,14 +139,15 @@ private[ember] object Encoder {
           }
         }
 
-        if (!chunked && !appliedContentLength && !NoPayloadMethods.contains(req.method)) {
-          if (req.body == EmptyBody) {
-            stringBuilder.append(zeroContentLengthRaw).append(CRLF)
-            chunked = false
-          } else {
-            stringBuilder.append(chunkedTransferEncodingHeaderRaw).append(CRLF)
-            chunked = true
-          }
+        if (
+          !appliedContentLength && req.body == EmptyBody && !NoPayloadMethods.contains(req.method)
+        ) {
+          stringBuilder.append(zeroContentLengthRaw).append(CRLF)
+          chunked = false
+        } else if (!chunked && !appliedContentLength && !NoPayloadMethods.contains(req.method)) {
+          stringBuilder.append(chunkedTransferEncodingHeaderRaw).append(CRLF)
+          chunked = true
+          ()
         }
 
         // Final CRLF terminates headers and signals body to follow.

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -46,7 +46,7 @@ class EncoderSuite extends Http4sSuite {
         .map(stripLines)
   }
 
-  test("reqToBytes should encode a no body request correctly") {
+  test("reqToBytes should encode a no body GET request correctly") {
     val req = Request[IO](Method.GET, uri"http://www.google.com")
     val expected =
       """GET / HTTP/1.1
@@ -113,6 +113,18 @@ class EncoderSuite extends Http4sSuite {
     Helpers.encodeRequestRig(req).assertEquals(expected)
   }
 
+  test("reqToBytes should encode a no body POST request correctly") {
+    val req = Request[IO](Method.POST)
+
+    val expected =
+      """POST / HTTP/1.1
+      |Content-Length: 0
+      |
+      |""".stripMargin
+
+    Helpers.encodeRequestRig(req).assertEquals(expected)
+  }
+
   test("respToBytes should encode a no body response correctly") {
     val resp = Response[IO](Status.Ok)
 
@@ -135,6 +147,20 @@ class EncoderSuite extends Http4sSuite {
       |""".stripMargin
 
     Helpers.encodeResponseRig(resp).assertEquals(expected)
+  }
+
+  test("reqToBytes should encode a no body request correctly with stream") {
+    val req = Request[IO](Method.POST, body = Stream.chunk(Chunk.empty))
+
+    val expected =
+      """POST / HTTP/1.1
+      |Transfer-Encoding: chunked
+      |
+      |0
+      |
+      |""".stripMargin
+
+    Helpers.encodeRequestRig(req).assertEquals(expected)
   }
 
   test("respToBytes should encode a no body response correctly with stream") {

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -21,7 +21,6 @@ import cats.effect.Concurrent
 import cats.effect.IO
 import cats.syntax.all._
 import fs2._
-import org.http4s.headers.`Content-Length`
 import org.http4s.syntax.literals._
 
 class EncoderSuite extends Http4sSuite {
@@ -115,7 +114,7 @@ class EncoderSuite extends Http4sSuite {
   }
 
   test("respToBytes should encode a no body response correctly") {
-    val resp = Response[IO](Status.Ok).putHeaders(`Content-Length`.zero)
+    val resp = Response[IO](Status.Ok)
 
     val expected =
       """HTTP/1.1 200 OK


### PR DESCRIPTION
This PR replays https://github.com/http4s/http4s/pull/6444 for the ember request encoder. Specifically, when the body is known (by reference equality) to be the `EmptyBody` i.e. an empty `Stream`, then a `Content-Length: 0` header is added and chunked transfer encoding is disabled. This relates to https://github.com/http4s/http4s/issues/4935, and possibly even fixes it.