### PR TITLE
Ember-Core: factor to H2Server loops from H2Client, H2Server.

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -277,7 +277,6 @@ private[ember] class H2Client[F[_]](
       case None => true
     }
     val priorKnowledge = req.attributes.lookup(H2Keys.Http2PriorKnowledge).isDefined
-    val trailers = req.attributes.lookup(Message.Keys.TrailerHeaders[F])
     for {
       connection <- Resource.eval(
         getOrCreate(key, useTLS, priorKnowledge, enableEndpointValidation)
@@ -290,22 +289,7 @@ private[ember] class H2Client[F[_]](
           )
         )
       )(stream => connection.mapRef.update(m => m - stream.id))
-      _ <- (req.body.chunks.noneTerminate.zipWithNext
-        .evalMap {
-          case (Some(c), Some(Some(_))) => stream.sendData(c.toByteVector, false)
-          case (Some(c), Some(None) | None) =>
-            if (trailers.isDefined) stream.sendData(c.toByteVector, false)
-            else stream.sendData(c.toByteVector, true)
-          case (None, _) =>
-            if (trailers.isDefined) Applicative[F].unit
-            else stream.sendData(ByteVector.empty, true)
-        }
-        .compile
-        .drain >> trailers.sequence.flatMap(optTrailers =>
-        optTrailers
-          .flatMap(h => h.headers.map(a => (a.name.toString.toLowerCase(), a.value, false)).toNel)
-          .traverse(nel => stream.sendHeaders(nel, true))
-      )).background
+      _ <- (stream.sendMessageBody(req) >> stream.sendTrailerHeaders(req)).background
       resp <- Resource.eval(stream.getResponse).map(_.covary[F].withBodyStream(stream.readBody))
     } yield resp
   }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -299,24 +299,8 @@ private[ember] object H2Server {
         resp <- httpApp(req)
         _ <- stream.sendHeaders(PseudoHeaders.responseToHeaders(resp), false)
         _ <- fulfillPushPromises(resp)
-        trailers = resp.attributes.lookup(Message.Keys.TrailerHeaders[F])
-        _ <- resp.body.chunks.noneTerminate.zipWithNext
-          .evalMap {
-            case (Some(c), Some(Some(_))) => stream.sendData(c.toByteVector, false)
-            case (Some(c), Some(None) | None) =>
-              if (trailers.isDefined) stream.sendData(c.toByteVector, false)
-              else stream.sendData(c.toByteVector, true)
-            case (None, _) =>
-              if (trailers.isDefined) Applicative[F].unit
-              else stream.sendData(ByteVector.empty, true)
-          }
-          .compile
-          .drain // Initial Resp Body
-        optTrailers <- trailers.sequence
-        optNel = optTrailers.flatMap(h =>
-          h.headers.map(a => (a.name.toString.toLowerCase(), a.value, false)).toNel
-        )
-        _ <- optNel.traverse(nel => stream.sendHeaders(nel, true))
+        _ <- stream.sendMessageBody(resp) // Initial Resp Body
+        _ <- stream.sendTrailerHeaders(resp)
       } yield ()
     }
 


### PR DESCRIPTION
- Add a procedural method `sendMessageBody`, that is commonly used by both `H2Client` and `H2Server`, (one for requests and the other for responses) to send the chunks of the body of the message. 
- Add another procedure `sendTrailerHeaders`, that also takes a message, and that extract the trailer headers and sends them through the stream. 
