### PR TITLE
FS2 Streams: replace "evalMap" with "foreach".

### DIFF
--- a/client-testkit/jvm/src/main/scala/org/http4s/client/testkit/scaffold/RoutesToNettyAdapter.scala
+++ b/client-testkit/jvm/src/main/scala/org/http4s/client/testkit/scaffold/RoutesToNettyAdapter.scala
@@ -121,7 +121,7 @@ private[http4s] class RoutesToHandlerAdapter[F[_]](
         )
         .liftToF
       _ <- response.body.chunks
-        .evalMap(chunk =>
+        .foreach(chunk =>
           F.delay(HandlerHelpers.sendChunk(ctx, Unpooled.copiedBuffer(chunk.toArray))).liftToF
         )
         .compile

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -145,7 +145,7 @@ private[h2] class H2Connection[F[_]](
     Stream
       .fromQueueUnterminatedChunk[F, H2Frame](outgoing, Int.MaxValue)
       .chunks
-      .evalMap { chunk =>
+      .foreach { chunk =>
         def go(chunk: Chunk[H2Frame]): F[Unit] = state.get.flatMap { s =>
           val fullDataSize = chunk.foldLeft(0) {
             case (init, H2Frame.Data(_, data, _, _)) => init + data.size.toInt
@@ -188,7 +188,6 @@ private[h2] class H2Connection[F[_]](
         }
         firstGoAway.getOrElse(F.unit) >> go(chunk)
       }
-      .drain
   // TODO Split Frames between Data and Others Hold Data If we are at cap
   //  Currently will backpressure at the data frame till its cleared
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -267,7 +267,7 @@ private[ember] object H2Server {
 
         def sendData(resp: Response[F], stream: H2Stream[F]): F[Unit] =
           resp.body.chunks
-            .evalMap(c => stream.sendData(c.toByteVector, false))
+            .foreach(c => stream.sendData(c.toByteVector, false))
             .compile
             .drain >> // PP Resp Body
             stream.sendData(ByteVector.empty, true)

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -35,7 +35,7 @@ class ParsingSuite extends Http4sSuite {
     def taking[F[_]: Concurrent, A](stream: Stream[F, A]): F[F[Option[Chunk[A]]]] =
       for {
         q <- Queue.unbounded[F, Option[Chunk[A]]]
-        _ <- stream.chunks.map(Some(_)).evalMap(q.offer(_)).compile.drain
+        _ <- stream.chunks.map(Some(_)).foreach(q.offer(_)).compile.drain
         _ <- q.offer(None)
       } yield q.take
 

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/TraversalSpec.scala
@@ -33,7 +33,7 @@ class TraversalSpec extends Http4sSuite {
     def taking[F[_]: Concurrent, A](stream: Stream[F, A]): F[F[Option[Chunk[A]]]] =
       for {
         q <- Queue.unbounded[F, Option[Chunk[A]]]
-        _ <- stream.chunks.map(Some(_)).evalMap(q.offer(_)).compile.drain
+        _ <- stream.chunks.map(Some(_)).foreach(q.offer(_)).compile.drain
         _ <- q.offer(None)
       } yield q.take
   }

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
@@ -69,7 +69,7 @@ private[internal] object StreamForking {
 
       val runOuter: F[Unit] =
         streams
-          .evalMap(runInner(_))
+          .foreach(runInner(_))
           .interruptWhen(stopSignal)
           .compile
           .drain


### PR DESCRIPTION
Unlike "evalMap", the "foreach" method of Stream does not emit any outputs, so it is more suited for the cases where we just want to consume the stream inputs without passing them on.

Since it emits no outputs, it allocates fewer items, which is more efficient.
