### PR TITLE
A bit more efficient size checking for `Seq` collections

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -425,13 +425,13 @@ object Uri extends UriPlatform {
     def splitAt(idx: Int): (Path, Path) =
       if (idx <= 0) {
         (Path.empty, this)
-      } else if (idx < segments.size) {
+      } else if (segments.sizeIs > idx) {
         val (start, end) = segments.splitAt(idx)
         (
           Path(start, absolute = absolute),
           Path(end, absolute = true, endsWithSlash = endsWithSlash),
         )
-      } else if (idx == segments.size) {
+      } else if (segments.sizeIs == idx) {
         (Path(segments, absolute = absolute), if (endsWithSlash) Path.Root else Path.empty)
       } else {
         (this, Path.empty)

--- a/core/shared/src/main/scala/org/http4s/internal/CharPredicate.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/CharPredicate.scala
@@ -135,7 +135,7 @@ object CharPredicate {
 
     implicit def fromChars(chars: Seq[Char]): ApplyMagnet =
       chars match {
-        case _ if chars.size < 128 & !chars.exists(unmaskable) =>
+        case _ if chars.sizeIs < 128 & !chars.exists(unmaskable) =>
           @tailrec def rec(ix: Int, result: CharPredicate): CharPredicate =
             if (ix == chars.length) result else rec(ix + 1, result ++ chars(ix))
           new ApplyMagnet(rec(0, Empty))


### PR DESCRIPTION
```
[info] Benchmark                 (listSize)  Mode  Cnt  Score   Error  Units
[info] SizeCheckingBench.size            10  avgt    5  2.106 ± 0.008  ns/op
[info] SizeCheckingBench.size           100  avgt    5  2.105 ± 0.010  ns/op
[info] SizeCheckingBench.size          1000  avgt    5  2.103 ± 0.006  ns/op
[info] SizeCheckingBench.size         10000  avgt    5  2.101 ± 0.021  ns/op
[info] SizeCheckingBench.sizeIs          10  avgt    5  2.003 ± 0.016  ns/op
[info] SizeCheckingBench.sizeIs         100  avgt    5  2.003 ± 0.006  ns/op
[info] SizeCheckingBench.sizeIs        1000  avgt    5  2.014 ± 0.016  ns/op
[info] SizeCheckingBench.sizeIs       10000  avgt    5  2.012 ± 0.014  ns/op
```
So, yeah, this is a 5% improvement at max (tested on `List` by equality check with '1'). 