### PR TITLE
A bit more efficient string building from `Seq` collections

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/DecodingFailures.scala
+++ b/circe/src/main/scala/org/http4s/circe/DecodingFailures.scala
@@ -24,5 +24,5 @@ import io.circe.DecodingFailure
   * [[accumulatingJsonOf]] to decode JSON messages.
   */
 final case class DecodingFailures(failures: NonEmptyList[DecodingFailure]) extends Exception {
-  override def getMessage: String = failures.toList.map(_.show).mkString("\n")
+  override def getMessage: String = failures.iterator.map(_.show).mkString("\n")
 }

--- a/client/shared/src/main/scala/org/http4s/client/oauth1/oauth1.scala
+++ b/client/shared/src/main/scala/org/http4s/client/oauth1/oauth1.scala
@@ -147,7 +147,7 @@ package object oauth1 {
       val baseStr = mkBaseString(
         method,
         uri,
-        (headers ++ queryParams).sorted.map(Show[ProtocolParameter].show).mkString("&"),
+        (headers ++ queryParams).sorted.iterator.map(Show[ProtocolParameter].show).mkString("&"),
       )
       val alg = SignatureAlgorithm.unsafeFromMethod(signatureMethod)
       makeSHASig(baseStr, consumer.secret, token.map(_.secret), alg).map { sig =>

--- a/core/shared/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/shared/src/main/scala/org/http4s/MessageFailure.scala
@@ -132,7 +132,7 @@ sealed abstract class UnsupportedMediaTypeFailure extends DecodeFailure with NoS
 
   protected def sanitizedResponsePrefix: String
   protected def expectedMsg: String =
-    s"Expected one of the following media ranges: ${expected.map(_.show).mkString(", ")}"
+    s"Expected one of the following media ranges: ${expected.iterator.map(_.show).mkString(", ")}"
   protected def responseMsg: String = s"$sanitizedResponsePrefix. $expectedMsg"
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =

--- a/core/shared/src/main/scala/org/http4s/RequestCookieJar.scala
+++ b/core/shared/src/main/scala/org/http4s/RequestCookieJar.scala
@@ -72,7 +72,7 @@ class RequestCookieJar private (val cookies: List[RequestCookie]) extends AnyVal
     new RequestCookieJar(cookies.filter(c => p(c.name)))
 
   override def toString(): String =
-    s"RequestCookieJar(${cookies.map(_.renderString).mkString("\n")})"
+    s"RequestCookieJar(${cookies.iterator.map(_.renderString).mkString("\n")})"
 
   def ++(cookies: collection.Iterable[RequestCookie]) =
     new RequestCookieJar(this.cookies ++ cookies)

--- a/core/shared/src/main/scala/org/http4s/internal/CurlConverter.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/CurlConverter.scala
@@ -39,6 +39,7 @@ private[http4s] object CurlConverter {
     val preparedHeaders = headers
       .redactSensitive(redactHeadersWhen)
       .headers
+      .iterator
       .map { header =>
         s"""--header '${escapeQuotationMarks(s"${header.name}: ${header.value}")}'"""
       }


### PR DESCRIPTION
```
[info] Benchmark                      (listSize)  Mode  Cnt  Score   Error  Units
[info] stringBuildingWithIterator             10  avgt    5  6.249 ± 0.014  ns/op
[info] stringBuildingWithIterator            100  avgt    5  6.252 ± 0.056  ns/op
[info] stringBuildingWithIterator           1000  avgt    5  6.241 ± 0.006  ns/op
[info] stringBuildingWithoutIterator          10  avgt    5  6.576 ± 0.103  ns/op
[info] stringBuildingWithoutIterator         100  avgt    5  6.599 ± 0.006  ns/op
[info] stringBuildingWithoutIterator        1000  avgt    5  6.584 ± 0.044  ns/op
```
A little tricky (not that tricky tbh) thing that brings a 5% performance improvement for string building.