### PR TITLE
Use `map` instead of `mapValues` on `Map`s

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Query.scala
+++ b/core/shared/src/main/scala/org/http4s/Query.scala
@@ -143,7 +143,9 @@ final class Query private (value: Either[Vector[KeyValue], String])
     * none exist, the empty `String` "" is returned.
     */
   lazy val params: Map[String, String] =
-    multiParams.view.mapValues(_.headOption.getOrElse("")).toMap
+    multiParams.map { case (k, v) =>
+      k -> v.headOption.getOrElse("")
+    }
 
   /** `Map[String, List[String]]` representation of the [[Query]]
     *

--- a/core/shared/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/shared/src/main/scala/org/http4s/UrlForm.scala
@@ -134,7 +134,7 @@ object UrlForm {
   )(urlForm: String): Either[MalformedMessageBodyFailure, UrlForm] =
     QueryParser
       .parseQueryString(urlForm.replace("+", "%20"), new Codec(charset.nioCharset))
-      .map(q => UrlForm(q.multiParams.view.mapValues(Chain.fromSeq).toMap))
+      .map(q => UrlForm(q.multiParams.map(x => x._1 -> Chain.fromSeq(x._2))))
       .leftMap { parseFailure =>
         MalformedMessageBodyFailure(parseFailure.message, None)
       }


### PR DESCRIPTION
```
[info] Benchmark           (size)  Mode  Cnt      Score      Error  Units
[info] MapBench.map            10  avgt    5    238.153 ±   40.219  ns/op
[info] MapBench.map           100  avgt    5   6024.884 ±  409.198  ns/op
[info] MapBench.map          1000  avgt    5  59488.263 ±  243.845  ns/op
[info] MapBench.mapValues      10  avgt    5    318.889 ±    2.540  ns/op
[info] MapBench.mapValues     100  avgt    5   6222.427 ±  104.340  ns/op
[info] MapBench.mapValues    1000  avgt    5  64835.303 ± 2168.535  ns/op
```
Test results are bouncing a little but nonetheless show that we should get a 5-10% performance boost at least.