### PR TITLE
Don't instantiate redundant `NonEmptyList` in `Writer#addList`

### DIFF
--- a/core/shared/src/main/scala/org/http4s/util/Renderable.scala
+++ b/core/shared/src/main/scala/org/http4s/util/Renderable.scala
@@ -206,10 +206,14 @@ trait Writer { self =>
       start: String = "",
       end: String = "",
   ): this.type =
-    NonEmptyList.fromList(s) match {
-      case Some(s) => addNel(s, sep, start, end)
-      case None =>
+    s match {
+      case Nil =>
         append(start)
+        append(end)
+      case x :: list =>
+        append(start)
+        append(x)
+        list.foreach(s => append(sep).append(s))
         append(end)
     }
 


### PR DESCRIPTION
The performance of `Writer#addList` shouldn't change, but fewer allocations is also fine.