### PR TITLE
`Shutdown#trackConnection` should never be empty

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/Shutdown.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/Shutdown.scala
@@ -100,7 +100,7 @@ private[server] object Shutdown {
         override val signal: F[Unit] = unblock.get
         override val newConnection: F[Unit] = F.unit
         override val removeConnection: F[Unit] = F.unit
-        override val trackConnection: Stream[F, Unit] = Stream.empty
+        override val trackConnection: Stream[F, Unit] = Stream.emit(())
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/6780.