### PR TITLE
Revamp the integrations page

### DIFF
--- a/docs/docs/integrations.md
+++ b/docs/docs/integrations.md
@@ -25,12 +25,12 @@ libraryDependencies ++= Seq(
 
 ## Backend Integrations
 
-| Backend                                                          | Platform                    | Http Client | Http Server | Websocket Client | Websocket Server | Proxy support (Client) |
+| Backend                                                          | Platform                      | Http Client | Http Server | Websocket Client | Websocket Server | Proxy support (Client) |
 |------------------------------------------------------------------|-------------------------------|:-----------:|:-----------:|:----------------:|:----------------:|:----------------------:|
 | [Ember](#ember)                                                  | JDK 8+ / Node.js 16+ / Native | ✅           | ✅           | ❌                | ✅                | ❌                      |
 | [Blaze](https://github.com/http4s/blaze)                         | JDK 8+                        | ✅           | ✅           | ❌                | ✅                | ❌                      |
-| [JDK Http Client](https://jdk-http-client.http4s.org/stable/) | JDK 11+                       | ✅           | ❌           | ✅                | ❌                | ✅                      |
-| [Jetty](https://github.com/http4s/http4s-jetty)                  | JDK 8+                        | ❌           | ✅           | ❌                | ❌                | ✅                      |
+| [JDK Http Client](https://jdk-http-client.http4s.org/stable/)    | JDK 11+                       | ✅           | ❌           | ✅                | ❌                | ✅                      |
+| [Servlet](https://github.com/http4s/http4s-servlet)              | JDK 8+                        | ❌           | ✅           | ❌                | ❌                | ✅                      |
 | [DOM](https://http4s.github.io/http4s-dom)                       | Browsers                      | ✅           | ❌           | ❌                | ✅                | ❌                      |
 | [Feral](https://github.com/typelevel/feral)                      | Serverless                    | ❌           | ✅           | ❌                | ❌                | ❌                      |
 

--- a/docs/docs/integrations.md
+++ b/docs/docs/integrations.md
@@ -13,7 +13,7 @@ There are also integrations for entities, metrics, and more. Check out the "Rela
 Http4s Ember is a server and client backend developed in the core repository.
 
 - Implements HTTP/1 and HTTP/2
-- Runs on JDK 8+, Node.js 14+, and Scala Native
+- Runs on JDK 8+, Node.js 16+, and Scala Native
 - Pure FP, built with Cats Effect and FS2
 
 ```scala
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
 
 | Backend                                                          | Platform                    | Http Client | Http Server | Websocket Client | Websocket Server | Proxy support (Client) |
 |------------------------------------------------------------------|-------------------------------|:-----------:|:-----------:|:----------------:|:----------------:|:----------------------:|
-| [Ember](#ember)                                                  | JDK 8+ / Node.js 14+ / Native | ✅           | ✅           | ❌                | ✅                | ❌                      |
+| [Ember](#ember)                                                  | JDK 8+ / Node.js 16+ / Native | ✅           | ✅           | ❌                | ✅                | ❌                      |
 | [Blaze](https://github.com/http4s/blaze)                         | JDK 8+                        | ✅           | ✅           | ❌                | ✅                | ❌                      |
 | [JDK Http Client](https://jdk-http-client.http4s.org/stable/) | JDK 11+                       | ✅           | ❌           | ✅                | ❌                | ✅                      |
 | [Jetty](https://github.com/http4s/http4s-jetty)                  | JDK 8+                        | ❌           | ✅           | ❌                | ❌                | ✅                      |

--- a/docs/docs/integrations.md
+++ b/docs/docs/integrations.md
@@ -2,23 +2,42 @@
 laika.title: Integrations
 %}
 
-# Http Backend Integrations
+# Integrations
 
-Http4s provides a frontend interface compatible with cats-effect, but it supports many different backend implementations
+Http4s provides a standard interface for defining services and clients. This enables an ecosystem of interchangeable server and client backends.
 
-| Backend                                                                       | Jdk Support | Http4s Version(s) | 100% Nonblocking               | Http Client                | Http Server           | Websocket Client   | Websocket Server | Proxy support (Client) |
-|-------------------------------------------------------------------------------|-------------|-------------------|--------------------------------|----------------------------|-----------------------|--------------------|------------------|------------------------|
-| [Blaze](https://github.com/http4s/blaze)                                      | 8+          | 0.15+             | ✅ Nonblocking                  | `http4s-blaze-client`      | `http4s-blaze-server` | ❌                | ✅              | ❌                    |
-| [Async Http Client](https://github.com/AsyncHttpClient/async-http-client)     | 8+          | 0.18+             | ✅ Nonblocking | `http4s-async-http-client` | ❌                   | ❌                | ❌              | ✅     |
-| [Ember](https://github.com/http4s/http4s)                                     | 8+          | 0.21+             | ✅ Nonblocking | `http4s-ember-client`      | `http4s-ember-server` | ✅                  | ✅                | ❌                    |
-| [Jdk11 Http Client](https://jdk-http-client.http4s.org/stable/)               | 11+         | 0.21+             | ✅ Nonblocking | `http4s-jdk-http-client`   | ❌                   | ✅ | ❌              | ✅     |
-| [Jetty](https://www.eclipse.org/jetty/)                                       | 8+          | All (0.2+)        | ?                              | ❌                        | `http4s-jetty`        |                    |                  | ✅     |
-| [OkHttp](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/) | 8+          | 0.18+             | ❌ Blocking                   | `http4s-okhttp-client`     | ❌                   | ❌                | ❌              | ✅     |
+There are also integrations for entities, metrics, and more. Check out the "Related Projects" section of the navigation menu for the complete list of integrations.
+
+## Ember
+
+Http4s Ember is a server and client backend developed in the core repository.
+
+- Implements HTTP/1 and HTTP/2
+- Runs on JDK 8+, Node.js 14+, and Scala Native
+- Pure FP, built with Cats Effect and FS2
+
+```scala
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-ember-server" % "@VERSION@",
+  "org.http4s" %% "http4s-ember-client" % "@VERSION@",
+)
+```
+
+## Backend Integrations
+
+| Backend                                                          | Platform                    | Http Client | Http Server | Websocket Client | Websocket Server | Proxy support (Client) |
+|------------------------------------------------------------------|-------------------------------|:-----------:|:-----------:|:----------------:|:----------------:|:----------------------:|
+| [Ember](#ember)                                                  | JDK 8+ / Node.js 14+ / Native | ✅           | ✅           | ❌                | ✅                | ❌                      |
+| [Blaze](https://github.com/http4s/blaze)                         | JDK 8+                        | ✅           | ✅           | ❌                | ✅                | ❌                      |
+| [JDK Http Client](https://jdk-http-client.http4s.org/stable/) | JDK 11+                       | ✅           | ❌           | ✅                | ❌                | ✅                      |
+| [Jetty](https://github.com/http4s/http4s-jetty)                  | JDK 8+                        | ❌           | ✅           | ❌                | ❌                | ✅                      |
+| [DOM](https://http4s.github.io/http4s-dom)                       | Browsers                      | ✅           | ❌           | ❌                | ✅                | ❌                      |
+| [Feral](https://github.com/typelevel/feral)                      | Serverless                    | ❌           | ✅           | ❌                | ❌                | ❌                      |
 
 ## Entity Integrations
 
-Http4s has multiple smaller modules for Entity encoding and Decoding support of common types.
+Http4s has multiple smaller modules for Entity encoding and decoding support of common types.
 
-- Circe: `http4s-circe`. See the [json](json.md) docs for more.
-- Scalatags: `http4s-scalatags`
-- Scala-Xml: `http4s-scala-xml`
+- [Circe](json.md)
+- [Scalatags](https://github.com/http4s/http4s-scalatags)
+- [Scala XML](https://github.com/http4s/http4s-scala-xml)

--- a/docs/docs/integrations.md
+++ b/docs/docs/integrations.md
@@ -30,8 +30,8 @@ libraryDependencies ++= Seq(
 | [Ember](#ember)                                                  | JDK 8+ / Node.js 16+ / Native | ✅           | ✅           | ❌                | ✅                | ❌                      |
 | [Blaze](https://github.com/http4s/blaze)                         | JDK 8+                        | ✅           | ✅           | ❌                | ✅                | ❌                      |
 | [JDK Http Client](https://jdk-http-client.http4s.org/stable/)    | JDK 11+                       | ✅           | ❌           | ✅                | ❌                | ✅                      |
-| [Servlet](https://github.com/http4s/http4s-servlet)              | JDK 8+                        | ❌           | ✅           | ❌                | ❌                | ✅                      |
-| [DOM](https://http4s.github.io/http4s-dom)                       | Browsers                      | ✅           | ❌           | ❌                | ✅                | ❌                      |
+| [Servlet](https://github.com/http4s/http4s-servlet)              | JDK 8+                        | ❌           | ✅           | ❌                | ❌                | ❌                      |
+| [DOM](https://http4s.github.io/http4s-dom)                       | Browsers                      | ✅           | ❌           | ✅                | ❌                | ❌                      |
 | [Feral](https://github.com/typelevel/feral)                      | Serverless                    | ❌           | ✅           | ❌                | ❌                | ❌                      |
 
 ## Entity Integrations

--- a/docs/styles/styles.css
+++ b/docs/styles/styles.css
@@ -1,0 +1,3 @@
+.align-center {
+  text-align: center;
+}


### PR DESCRIPTION
After many complaints and questions, I finally did something about it.

Here's the old page: https://http4s.org/v0.23/docs/integrations.html

This is an opinionated refactor: I specifically highlighted Ember, and dropped IMHO not-so-important information from the table so that it renders better.

I also dropped the Async Http client because it's not maintained, and the OkHttp client because [nobody cares enough to add a README](https://github.com/http4s/http4s-okhttp-client). And self-promoted my own projects 😇 

<img width="647" alt="Screen Shot 2022-11-10 at 10 13 18 AM" src="https://user-images.githubusercontent.com/3119428/201174427-1f236e2e-923e-4344-8b57-e6e218c22897.png">
