### PR TITLE
Fix some deprecation warning messages

### DIFF
--- a/core/shared/src/main/scala/org/http4s/HttpDate.scala
+++ b/core/shared/src/main/scala/org/http4s/HttpDate.scala
@@ -86,7 +86,7 @@ object HttpDate {
     * 10000, this will throw an exception. The author intends to leave this
     * problem for future generations.
     */
-  @deprecated("0.20.16", "Use HttpDate.current instead, this breaks referential transparency")
+  @deprecated("Use HttpDate.current instead, this breaks referential transparency", "0.20.16")
   def now: HttpDate =
     unsafeFromInstant(Instant.now)
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -126,7 +126,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
   def withShutdownTimeout(shutdownTimeout: Duration): EmberServerBuilder[F] =
     copy(shutdownTimeout = shutdownTimeout)
 
-  @deprecated("0.21.17", "Use withErrorHandler - Do not allow the F to fail")
+  @deprecated("Use withErrorHandler - Do not allow the F to fail", "0.21.17")
   def withOnError(onError: Throwable => Response[F]): EmberServerBuilder[F] =
     withErrorHandler { case e => onError(e).pure[F] }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -283,7 +283,7 @@ object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
       serverFailure.covary[F].pure[F]
     }
 
-    @deprecated("0.21.17", "Use errorHandler, default fallback of failure InternalServerFailure")
+    @deprecated("Use errorHandler, default fallback of failure InternalServerFailure", "0.21.17")
     def onError[F[_]]: Throwable => Response[F] = { (_: Throwable) =>
       serverFailure.covary[F]
     }


### PR DESCRIPTION
Arguments for `@deprecated` are mixed up, which gives a bit confusing warnings like this one:
```
scala> HttpDate.now
                ^
       warning: method now in object HttpDate is deprecated (since Use HttpDate.current instead, this breaks referential transparency): 0.20.16
```