### PR TITLE
Fix resource leaks

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
@@ -64,7 +64,7 @@ private[internal] object StreamForking {
           .handleErrorWith(stopFailed)
           .guarantee(available.release >> decrementRunning)
 
-        F.uncancelable(poll => available.acquire >> incrementRunning >> F.start(poll(fa)).void)
+        F.uncancelable(_ => available.acquire >> incrementRunning >> F.start(fa).void)
       }
 
       val runOuter: F[Unit] =

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/StreamForking.scala
@@ -64,7 +64,7 @@ private[internal] object StreamForking {
           .handleErrorWith(stopFailed)
           .guarantee(available.release >> decrementRunning)
 
-        available.acquire >> incrementRunning >> F.start(fa).void
+        F.uncancelable(poll => available.acquire >> incrementRunning >> F.start(poll(fa)).void)
       }
 
       val runOuter: F[Unit] =


### PR DESCRIPTION
Ensures that the fiber is always started. This in turn guarantees that we will decrement the running counter and release the semaphore.