### PR TITLE
Reduce allocations in `PathVar`

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -36,6 +36,8 @@ import org.http4s.Uri.Path._
 import org.http4s._
 import org.http4s.headers.Allow
 
+import scala.util.Try
+
 object :? {
   def unapply[F[_]](req: Request[F]): Some[(Request[F], Map[String, collection.Seq[String]])] =
     Some((req, req.multiParams))
@@ -165,6 +167,9 @@ object /: {
 }
 
 protected class PathVar[A](cast: String => Option[A]) {
+  def this(cast: String => Try[A])(implicit ev: DummyImplicit) =
+    this((str: String) => cast(str).toOption)
+
   def unapply(str: String): Option[A] =
     if (str.nonEmpty)
       cast(str)

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -186,7 +186,7 @@ protected class PathVar[A](cast: String => Option[A]) {
 object IntVar
     extends PathVar((str: String) =>
       try
-        Option(str.toInt)
+        Some(str.toInt)
       catch {
         case t if scala.util.control.NonFatal(t) => None
       }
@@ -201,7 +201,7 @@ object IntVar
 object LongVar
     extends PathVar((str: String) =>
       try
-        Option(str.toLong)
+        Some(str.toLong)
       catch {
         case t if scala.util.control.NonFatal(t) => None
       }
@@ -216,7 +216,7 @@ object LongVar
 object UUIDVar
     extends PathVar((str: String) =>
       try
-        Option(java.util.UUID.fromString(str))
+        Some(java.util.UUID.fromString(str))
       catch {
         case t if scala.util.control.NonFatal(t) => None
       }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -36,8 +36,6 @@ import org.http4s.Uri.Path._
 import org.http4s._
 import org.http4s.headers.Allow
 
-import scala.util.Try
-
 object :? {
   def unapply[F[_]](req: Request[F]): Some[(Request[F], Map[String, collection.Seq[String]])] =
     Some((req, req.multiParams))
@@ -166,10 +164,10 @@ object /: {
     }
 }
 
-protected class PathVar[A](cast: String => Try[A]) {
+protected class PathVar[A](cast: String => Option[A]) {
   def unapply(str: String): Option[A] =
-    if (!str.isEmpty)
-      cast(str).toOption
+    if (str.nonEmpty)
+      cast(str)
     else
       None
 }
@@ -180,7 +178,14 @@ protected class PathVar[A](cast: String => Try[A]) {
   *      case Root / "user" / IntVar(userId) => ...
   * }}}
   */
-object IntVar extends PathVar(str => Try(str.toInt))
+object IntVar
+    extends PathVar((str: String) =>
+      try
+        Option(str.toInt)
+      catch {
+        case t if scala.util.control.NonFatal(t) => None
+      }
+    )
 
 /** Long extractor of a path variable:
   * {{{
@@ -188,7 +193,14 @@ object IntVar extends PathVar(str => Try(str.toInt))
   *      case Root / "user" / LongVar(userId) => ...
   * }}}
   */
-object LongVar extends PathVar(str => Try(str.toLong))
+object LongVar
+    extends PathVar((str: String) =>
+      try
+        Option(str.toLong)
+      catch {
+        case t if scala.util.control.NonFatal(t) => None
+      }
+    )
 
 /** UUID extractor of a path variable:
   * {{{
@@ -196,7 +208,14 @@ object LongVar extends PathVar(str => Try(str.toLong))
   *      case Root / "user" / UUIDVar(userId) => ...
   * }}}
   */
-object UUIDVar extends PathVar(str => Try(java.util.UUID.fromString(str)))
+object UUIDVar
+    extends PathVar((str: String) =>
+      try
+        Option(java.util.UUID.fromString(str))
+      catch {
+        case t if scala.util.control.NonFatal(t) => None
+      }
+    )
 
 /** Matrix path variable extractor
   * For an example see [[https://www.w3.org/DesignIssues/MatrixURIs.html MatrixURIs]]


### PR DESCRIPTION
Before:
```
[info] PathVarBench.intVarPath                                   avgt   10  5604.150 ± 482.813   ns/op
[info] PathVarBench.intVarPath:·gc.alloc.rate.norm               avgt   10  4857.237 ±   0.024    B/op
[info] PathVarBench.intVarPath:·gc.churn.G1_Eden_Space.norm      avgt   10  4927.337 ±  45.360    B/op
[info] PathVarBench.intVarPath:·gc.churn.G1_Survivor_Space.norm  avgt   10     0.012 ±   0.008    B/op
```
After:
```
[info] PathVarBench.intVarPath                                   avgt   10  5178.997 ± 48.673   ns/op
[info] PathVarBench.intVarPath:·gc.alloc.rate.norm               avgt   10  4681.195 ±  0.013    B/op
[info] PathVarBench.intVarPath:·gc.churn.G1_Eden_Space.norm      avgt   10  4743.538 ± 29.411    B/op
[info] PathVarBench.intVarPath:·gc.churn.G1_Survivor_Space.norm  avgt   10     0.010 ±  0.004    B/op
```
How it was benchmarked:
```scala
@BenchmarkMode(Array(Mode.AverageTime))
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Benchmark)
class PathVarBench {
  val intVarPathHttpRoutes =
    HttpRoutes.of[IO] {
      case GET -> Root / "foo" / IntVar(i) =>
        Ok(i.toString)
    }
  val intVarPathRequest = Request[IO](Method.GET, uri"/foo/42")

  @Benchmark
  def intVarPath =
    intVarPathHttpRoutes(intVarPathRequest).value.unsafeRunSync()
}
```
