### PR TITLE
Canary async cancelation change from CE

### DIFF
--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -107,7 +107,7 @@ object Http4sPlugin extends AutoPlugin {
     val cryptobits = "1.3"
     val disciplineCore = "1.5.1"
     val epollcat = "0.1.2"
-    val fs2 = "3.3.0"
+    val fs2 = "3.5-1c0be5c"
     val ip4s = "3.2.0"
     val hpack = "1.0.4"
     val javaWebSocket = "1.5.3"


### PR DESCRIPTION
The change we're looking at here is typelevel/cats-effect#3205, which fundamentally changes the default semantics in `async`'s cancelation. Saving everyone a bit of time, this fails in the following areas (poking @armanbilge):

```
[error] Failed to link /home/daniel/Development/http4s/ember-server/native/target/scala-2.13/http4s-ember-server-test-out
[error] stack trace is suppressed; run last testsNative / Test / executeTests for the full output
[error] (ember-serverJS / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (ember-server / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (ember-serverNative / Test / nativeLink) Failed to link /home/daniel/Development/http4s/ember-server/native/target/scala-2.13/http4s-ember-server-test-out
[error] (client-testkit / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (serverJS / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (serverNative / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (testsNative / Test / executeTests) scala.scalanative.testinterface.common.RPCCore$ClosedException: scala.scalanative.testinterface.NativeRunnerRPC$RunTerminatedException
```

More specifically:

```
[error] Failed: Total 297, Failed 1, Errors 0, Passed 296
[error] Failed tests:
[error]         org.http4s.server.staticcontent.FileServiceSuite
```