### PR TITLE
Use `Temporal#realTime` in client retry middleware

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -73,7 +73,7 @@ object Retry {
         retryHeader
           .map { h =>
             h.retry match {
-              case Left(d) => F.realTime.map(d.toDuration - _)
+              case Left(date) => F.realTime.map(date.toDuration - _)
               case Right(secs) => secs.seconds.pure[F]
             }
           }

--- a/core/shared/src/main/scala/org/http4s/HttpDate.scala
+++ b/core/shared/src/main/scala/org/http4s/HttpDate.scala
@@ -30,6 +30,7 @@ import java.time.DateTimeException
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import scala.concurrent.duration._
 
 /** An HTTP-date value represents time as an instance of Coordinated Universal
   * Time (UTC). It expresses time at a resolution of one second.  By using it
@@ -42,8 +43,9 @@ class HttpDate private (val epochSecond: Long) extends Renderable with Ordered[H
   def compare(that: HttpDate): Int =
     this.epochSecond.compare(that.epochSecond)
 
-  def toInstant: Instant =
-    Instant.ofEpochSecond(epochSecond)
+  def toDuration: FiniteDuration = epochSecond.seconds
+
+  def toInstant: Instant = Instant.ofEpochSecond(epochSecond)
 
   def render(writer: Writer): writer.type =
     writer << toInstant


### PR DESCRIPTION
This fixes an unsuspended `Instant.now()`