### PR TITLE
Reduce JS size

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -701,7 +701,8 @@ lazy val jsArtifactSizeTest = http4sProject("js-artifact-size-test")
       val sizeKB = size / 1000
       // not a hard target. increase *moderately* if need be
       // linking MimeDB results in a 100 KB increase. don't let that happen :)
-      val targetKB = 350
+      // linking java.time.* also results in a 100 KB increase
+      val targetKB = 250
       val msg = s"fullOptJS+gzip generated ${sizeKB} KB artifact (target: <$targetKB KB)"
       if (sizeKB < targetKB)
         log.info(msg)

--- a/build.sbt
+++ b/build.sbt
@@ -701,8 +701,8 @@ lazy val jsArtifactSizeTest = http4sProject("js-artifact-size-test")
       val sizeKB = size / 1000
       // not a hard target. increase *moderately* if need be
       // linking MimeDB results in a 100 KB increase. don't let that happen :)
-      // linking java.time.* also results in a 100 KB increase
-      val targetKB = 250
+      // linking java.time.* results in a 70 KB increase
+      val targetKB = 280
       val msg = s"fullOptJS+gzip generated ${sizeKB} KB artifact (target: <$targetKB KB)"
       if (sizeKB < targetKB)
         log.info(msg)

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -177,10 +177,10 @@ trait CirceInstances extends JawnInstances {
   ): EntityEncoder[F, Stream[F, A]] =
     streamJsonArrayEncoderWithPrinter[F](printer).contramap[Stream[F, A]](_.map(encoder.apply))
 
-  implicit val encodeUri: Encoder[Uri] =
+  implicit lazy val encodeUri: Encoder[Uri] =
     Encoder.encodeString.contramap[Uri](_.toString)
 
-  implicit val decodeUri: Decoder[Uri] =
+  implicit lazy val decodeUri: Decoder[Uri] =
     Decoder.decodeString.emap { str =>
       Uri.fromString(str).leftMap(_ => "Uri")
     }

--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -177,10 +177,10 @@ trait CirceInstances extends JawnInstances {
   ): EntityEncoder[F, Stream[F, A]] =
     streamJsonArrayEncoderWithPrinter[F](printer).contramap[Stream[F, A]](_.map(encoder.apply))
 
-  implicit lazy val encodeUri: Encoder[Uri] =
+  implicit val encodeUri: Encoder[Uri] =
     Encoder.encodeString.contramap[Uri](_.toString)
 
-  implicit lazy val decodeUri: Decoder[Uri] =
+  implicit val decodeUri: Decoder[Uri] =
     Decoder.decodeString.emap { str =>
       Uri.fromString(str).leftMap(_ => "Uri")
     }

--- a/core/shared/src/main/scala/org/http4s/util/Renderable.scala
+++ b/core/shared/src/main/scala/org/http4s/util/Renderable.scala
@@ -47,7 +47,7 @@ object Renderer {
 
   def renderString[T: Renderer](t: T): String = new StringWriter().append(t).result
 
-  implicit val RFC7231InstantRenderer: Renderer[Instant] = new Renderer[Instant] {
+  implicit lazy val RFC7231InstantRenderer: Renderer[Instant] = new Renderer[Instant] {
     private val dateFormat =
       DateTimeFormatter
         .ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")


### PR DESCRIPTION
Adding a couple `lazy val`s allows the Scala.js linker to completely elide the `java.time` package, reducing size of generated JavaScript by ~ ~~30%~~ 20%. Bincompat got in the way a bit. Oh well.