### PR TITLE
Proposal: Change `Query` model

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/QueryBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/QueryBench.scala
@@ -1,0 +1,70 @@
+package org.http4s.bench
+
+import org.http4s.Query
+import org.http4s.Query.KeyValue
+import org.openjdk.jmh.annotations._
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+class QueryBench {
+  @Param(Array("0", "10", "100", "1000"))
+  var size: Int = _
+
+  var rawData: Seq[(String, Option[String])] = _
+  var parsedQuery: Query = _
+  var rawQuery: Query = _
+
+  def generateKeyValue(): KeyValue =
+    UUID.randomUUID().toString -> Option(UUID.randomUUID().toString)
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    rawData = (0 to size).map(_ => generateKeyValue())
+    parsedQuery = Query(rawData: _*)
+    rawQuery = Query.parser
+      .parse(rawData.map(x => s"${x._1}=${x._2.get}").mkString(";"))
+      .map(_._2)
+      .toOption
+      .get
+  }
+
+  @Benchmark
+  def parseQuery: Query =
+    Query.unsafeFromString(rawData.map(x => s"${x._1}=${x._2.get}").mkString(";"))
+
+  @Benchmark
+  def sliceHalfParsedQuery: Query =
+    parsedQuery.slice(0, size / 2 + 1)
+
+  @Benchmark
+  def sliceHalfRawQuery: Query =
+    rawQuery.slice(0, size / 2 + 1)
+
+  @Benchmark
+  def filterParsedQuery: Query =
+    parsedQuery.filter(_._2.hashCode() % 2 == 0)
+
+  @Benchmark
+  def filterRawQuery: Query =
+    rawQuery.filter(_._2.hashCode() % 2 == 0)
+
+  @Benchmark
+  def isEmptyParsedQuery: Boolean =
+    parsedQuery.isEmpty
+
+  @Benchmark
+  def isEmptyRawQuery: Boolean =
+    rawQuery.isEmpty
+
+  @Benchmark
+  def prependParsedQuery: Query =
+    generateKeyValue() +: parsedQuery
+
+  @Benchmark
+  def prependRawQuery: Query =
+    generateKeyValue() +: rawQuery
+}

--- a/bench/src/main/scala/org/http4s/bench/QueryBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/QueryBench.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.bench
 
 import org.http4s.Query

--- a/core/shared/src/main/scala/org/http4s/Query.scala
+++ b/core/shared/src/main/scala/org/http4s/Query.scala
@@ -34,83 +34,257 @@ import java.nio.charset.StandardCharsets
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
-/** Collection representation of a query string
+/** Representation of a query string.
   *
-  * It is a indexed sequence of key and maybe a value pairs which maps
-  * precisely to a query string, modulo
+  * When a query is none, it is represented by the [[Query.Empty]].
+  *
+  * When a query is parsed – it is represented by the [[Query.Parsed]],
+  * an indexed sequence of key and maybe value pairs
+  * which maps precisely to a query string, modulo
   * [[https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 percent-encoding]].
+  * The resulting `String` will have the pairs separated
+  * by '&' while the key is separated from the value with '='.
   *
-  * When rendered, the resulting `String` will have the pairs separated
-  * by '&' while the key is separated from the value with '='
+  * Otherwise, a query is represented by the [[Query.Raw]] containing unparsed string.
   */
-final class Query private (value: Either[Vector[KeyValue], String])
-    extends QueryOps
-    with Renderable {
-  private[this] var _pairs: Vector[KeyValue] = null
 
-  def pairs: Vector[KeyValue] = {
-    if (_pairs == null) {
-      _pairs = value.fold(identity, Query.parse)
-    }
-    _pairs
+sealed trait Query extends QueryOps with Renderable {
+  def pairs: Vector[KeyValue]
+
+  def get(idx: Int): Option[KeyValue] = this match {
+    case Query.Empty => None
+    case parsed: Query.Parsed => parsed.pairs.get(idx.toLong)
+    case raw: Query.Raw => raw.pairs.get(idx.toLong)
   }
 
-  private def this(vec: Vector[KeyValue]) = this(Left(vec))
+  def length: Int = this match {
+    case Query.Empty => 0
+    case parsed: Query.Parsed => parsed.pairs.length
+    case raw: Query.Raw => raw.pairs.length
+  }
 
-  @deprecated("Unsafe method. Use get(idx) instead", "0.23.17")
-  def apply(idx: Int): KeyValue = pairs(idx)
+  def slice(from: Int, until: Int): Query = this match {
+    case Query.Empty => this
 
-  def get(idx: Int): Option[KeyValue] = pairs.get(idx.toLong)
+    case parsed: Query.Parsed =>
+      val sliced = parsed.pairs.slice(from, until)
+      if (sliced.lengthIs == 0) Query.Empty
+      else new Query.Parsed(sliced)
 
-  def length: Int = pairs.length
+    case raw: Query.Raw =>
+      val sliced = raw.pairs.slice(from, until)
+      if (sliced.lengthIs == 0) Query.Empty
+      else new Query.Parsed(sliced)
+  }
 
-  def slice(from: Int, until: Int): Query = new Query(Left(pairs.slice(from, until)))
+  def isEmpty: Boolean = this match {
+    case Query.Empty => true
+    case parsed: Query.Parsed => parsed.pairs.isEmpty
+    case raw: Query.Raw => raw.pairs.isEmpty
+  }
 
-  def isEmpty: Boolean = pairs.isEmpty
+  def nonEmpty: Boolean = !isEmpty
 
-  def nonEmpty: Boolean = pairs.nonEmpty
+  def drop(n: Int): Query = this match {
+    case Query.Empty => this
 
-  def drop(n: Int): Query = new Query(Left(pairs.drop(n)))
+    case parsed: Query.Parsed =>
+      val prepared = parsed.pairs.drop(n)
+      if (prepared.sizeIs == 0) Query.Empty
+      else new Query.Parsed(prepared)
 
-  def dropRight(n: Int): Query = new Query(Left(pairs.dropRight(n)))
+    case raw: Query.Raw =>
+      val prepared = raw.pairs.drop(n)
+      if (prepared.sizeIs == 0) Query.Empty
+      else new Query.Parsed(prepared)
+  }
 
-  def exists(f: KeyValue => Boolean): Boolean =
-    pairs.exists(f)
+  def dropRight(n: Int): Query = this match {
+    case Query.Empty => this
 
-  def filterNot(f: KeyValue => Boolean): Query =
-    new Query(Left(pairs.filterNot(f)))
+    case parsed: Query.Parsed =>
+      val prepared = parsed.pairs.dropRight(n)
+      if (prepared.sizeIs == 0) Query.Empty
+      else new Query.Parsed(prepared)
 
-  def filter(f: KeyValue => Boolean): Query =
-    new Query(Left(pairs.filter(f)))
+    case raw: Query.Raw =>
+      val prepared = raw.pairs.dropRight(n)
+      if (prepared.sizeIs == 0) Query.Empty
+      else new Query.Parsed(prepared)
+  }
 
-  def foreach(f: KeyValue => Unit): Unit =
-    pairs.foreach(f)
+  def exists(f: KeyValue => Boolean): Boolean = this match {
+    case Query.Empty => false
+    case parsed: Query.Parsed => parsed.pairs.exists(f)
+    case raw: Query.Raw => raw.pairs.exists(f)
+  }
 
-  def foldLeft[Z](z: Z)(f: (Z, KeyValue) => Z): Z =
-    pairs.foldLeft(z)(f)
+  def filter(f: KeyValue => Boolean): Query = this match {
+    case Query.Empty => this
+
+    case parsed: Query.Parsed =>
+      val prepared = parsed.pairs.filter(f)
+      if (prepared.sizeIs == 0) Query.Empty
+      else new Query.Parsed(prepared)
+
+    case raw: Query.Raw =>
+      val prepared = raw.pairs.filter(f)
+      if (prepared.sizeIs == 0) Query.Empty
+      else new Query.Parsed(prepared)
+  }
+
+  def filterNot(f: KeyValue => Boolean): Query = this match {
+    case Query.Empty => this
+
+    case parsed: Query.Parsed =>
+      val prepared = parsed.pairs.filterNot(f)
+      if (prepared.sizeIs == 0) Query.Empty
+      else new Query.Parsed(prepared)
+
+    case raw: Query.Raw =>
+      val prepared = raw.pairs.filterNot(f)
+      if (prepared.sizeIs == 0) Query.Empty
+      else new Query.Parsed(prepared)
+  }
+
+  def foreach(f: KeyValue => Unit): Unit = this match {
+    case Query.Empty => ()
+    case parsed: Query.Parsed => parsed.pairs.foreach(f)
+    case raw: Query.Raw => raw.pairs.foreach(f)
+  }
+
+  def foldLeft[Z](z: Z)(f: (Z, KeyValue) => Z): Z = this match {
+    case Query.Empty => z
+    case parsed: Query.Parsed => parsed.pairs.foldLeft(z)(f)
+    case raw: Query.Raw => raw.pairs.foldLeft(z)(f)
+  }
 
   def foldRight[Z](z: Eval[Z])(f: (KeyValue, Eval[Z]) => Eval[Z]): Eval[Z] =
-    Foldable[Vector].foldRight(pairs, z)(f)
+    this match {
+      case Query.Empty => z
+      case parsed: Query.Parsed =>
+        Foldable[Vector].foldRight(parsed.pairs, z)(f)
+      case raw: Query.Raw =>
+        Foldable[Vector].foldRight(raw.pairs, z)(f)
+    }
 
-  def +:(elem: KeyValue): Query =
-    new Query(Left(elem +: pairs))
+  def +:(elem: KeyValue): Query = this match {
+    case Query.Empty =>
+      new Query.Parsed(Vector(elem))
+    case parsed: Query.Parsed =>
+      new Query.Parsed(elem +: parsed.pairs)
+    case raw: Query.Raw =>
+      new Query.Parsed(elem +: raw.pairs)
+  }
 
-  def :+(elem: KeyValue): Query =
-    new Query(Left(pairs :+ elem))
+  def :+(elem: KeyValue): Query = this match {
+    case Query.Empty =>
+      new Query.Parsed(Vector(elem))
+    case parsed: Query.Parsed =>
+      new Query.Parsed(parsed.pairs :+ elem)
+    case raw: Query.Raw =>
+      new Query.Parsed(raw.pairs :+ elem)
+  }
 
   def ++(pairs: collection.Iterable[(String, Option[String])]): Query =
-    new Query(Left(this.pairs ++ pairs))
+    this match {
+      case Query.Empty =>
+        new Query.Parsed(pairs.toVector)
+      case parsed: Query.Parsed =>
+        new Query.Parsed(parsed.pairs ++ pairs)
+      case raw: Query.Raw =>
+        new Query.Parsed(raw.pairs ++ pairs)
+    }
 
-  def toVector: Vector[(String, Option[String])] = pairs
+  def toVector: Vector[(String, Option[String])] = this match {
+    case Query.Empty => Vector.empty
+    case parsed: Query.Parsed => parsed.pairs
+    case raw: Query.Raw => raw.pairs
+  }
 
-  def toList: List[(String, Option[String])] = toVector.toList
+  def toList: List[(String, Option[String])] = this match {
+    case Query.Empty => List.empty
+    case parsed: Query.Parsed => parsed.pairs.toList
+    case raw: Query.Raw => raw.pairs.toList
+  }
 
-  /** Render the Query as a `String`.
+  /** Map[String, String] representation of the [[Query]]
     *
-    * Pairs are separated by '&' and keys are separated from values by '='
+    * If multiple values exist for a key, the first is returned. If
+    * none exist, the empty `String` "" is returned.
     */
-  override def render(writer: Writer): writer.type = value.fold(
-    { pairs =>
+  lazy val params: Map[String, String] = this match {
+    case Query.Empty => Map.empty
+    case _: Query.Parsed | _: Query.Raw =>
+      multiParams.map { case (k, v) =>
+        k -> v.headOption.getOrElse("")
+      }
+  }
+
+  /** `Map[String, List[String]]` representation of the [[Query]]
+    *
+    * Params are represented as a `List[String]` and may be empty.
+    */
+  lazy val multiParams: Map[String, List[String]] = this match {
+    case Query.Empty => Map.empty
+    case _: Query.Parsed | _: Query.Raw =>
+      val pairs = toVector
+
+      if (pairs.isEmpty) Map.empty
+      else {
+        val m = mutable.Map.empty[String, ListBuffer[String]]
+        pairs.foreach {
+          case (k, None) => m.getOrElseUpdate(k, new ListBuffer)
+          case (k, Some(v)) => m.getOrElseUpdate(k, new ListBuffer) += v
+        }
+        m.view.mapValues(_.toList).toMap
+      }
+  }
+
+  override protected type Self = Query
+  override protected val query: Query = this
+  override protected def self: Self = this
+  override protected def replaceQuery(query: Query): Self = query
+}
+
+object Query {
+  case object Empty extends Query {
+    def pairs: Vector[KeyValue] = Vector.empty
+
+    override def render(writer: Writer): writer.type =
+      writer
+  }
+
+  final class Raw private[http4s] (value: String) extends Query {
+    private[this] var _pairs: Vector[KeyValue] = _
+
+    def pairs: Vector[KeyValue] = {
+      if (_pairs == null) {
+        _pairs = Query.parse(value)
+      }
+      _pairs
+    }
+
+    override def render(writer: Writer): writer.type =
+      writer.append(value)
+
+    override def equals(that: Any): Boolean =
+      that match {
+        case that: Query => that.toVector == toVector
+        case _ => false
+      }
+
+    override def hashCode: Int = 31 + pairs.##
+  }
+
+  final class Parsed private[http4s] (value: Vector[KeyValue]) extends Query {
+    def pairs: Vector[KeyValue] = value
+
+    /** Render the Query as a `String`.
+      *
+      * Pairs are separated by '&' and keys are separated from values by '='
+      */
+    override def render(writer: Writer): writer.type = {
       var first = true
 
       def encode(s: String) =
@@ -121,7 +295,7 @@ final class Query private (value: Either[Vector[KeyValue], String])
           toSkip = UriCoding.QueryNoEncode,
         )
 
-      pairs.foreach {
+      value.foreach {
         case (n, None) =>
           if (!first) writer.append('&')
           else first = false
@@ -136,79 +310,48 @@ final class Query private (value: Either[Vector[KeyValue], String])
             .append(encode(v))
       }
       writer
-    },
-    raw => writer.append(raw),
-  )
-
-  /** Map[String, String] representation of the [[Query]]
-    *
-    * If multiple values exist for a key, the first is returned. If
-    * none exist, the empty `String` "" is returned.
-    */
-  lazy val params: Map[String, String] =
-    multiParams.map { case (k, v) =>
-      k -> v.headOption.getOrElse("")
     }
 
-  /** `Map[String, List[String]]` representation of the [[Query]]
-    *
-    * Params are represented as a `List[String]` and may be empty.
-    */
-  lazy val multiParams: Map[String, List[String]] =
-    if (toVector.isEmpty) Map.empty
-    else {
-      val m = mutable.Map.empty[String, ListBuffer[String]]
-      toVector.foreach {
-        case (k, None) => m.getOrElseUpdate(k, new ListBuffer)
-        case (k, Some(v)) => m.getOrElseUpdate(k, new ListBuffer) += v
+    override def equals(that: Any): Boolean =
+      that match {
+        case that: Query => that.toVector == toVector
+        case _ => false
       }
-      m.view.mapValues(_.toList).toMap
-    }
 
-  override def equals(that: Any): Boolean =
-    that match {
-      case that: Query => that.toVector == toVector
-      case _ => false
-    }
+    override def hashCode: Int = 31 + value.##
+  }
 
-  override def hashCode: Int = 31 + toVector.##
-
-  // ///////////////////// QueryOps methods and types /////////////////////////
-  override protected type Self = Query
-  override protected val query: Query = this
-  override protected def self: Self = this
-  override protected def replaceQuery(query: Query): Self = query
-  // //////////////////////////////////////////////////////////////////////////
-}
-
-object Query {
   type KeyValue = (String, Option[String])
 
   /** Represents the absence of a query string. */
-  val empty: Query = new Query(Vector.empty)
+  val empty: Query = Query.Empty
 
   /** Represents a query string with no keys or values: `?` */
-  val blank = new Query(Vector("" -> None))
+  val blank = new Query.Parsed(Vector("" -> None))
 
   def apply(xs: (String, Option[String])*): Query =
-    new Query(xs.toVector)
+    if (xs.sizeIs == 0) Query.Empty
+    else new Query.Parsed(xs.toVector)
 
   def fromVector(xs: Vector[(String, Option[String])]): Query =
-    new Query(xs)
+    if (xs.sizeIs == 0) Query.Empty
+    else new Query.Parsed(xs)
 
   def fromPairs(xs: (String, String)*): Query =
-    new Query(
-      xs.toList.foldLeft(Vector.empty[KeyValue]) { case (m, (k, s)) =>
-        m :+ (k -> Some(s))
-      }
-    )
+    if (xs.sizeIs == 0) Query.Empty
+    else
+      new Query.Parsed(
+        xs.toList.foldLeft(Vector.empty[KeyValue]) { case (m, (k, s)) =>
+          m :+ (k -> Some(s))
+        }
+      )
 
   /** Generate a [[Query]] from its `String` representation
     *
     * If parsing fails, the empty [[Query]] is returned
     */
   def unsafeFromString(query: String): Query =
-    if (query.isEmpty) new Query(Vector("" -> None))
+    if (query.isEmpty) new Query.Parsed(Vector("" -> None))
     else
       QueryParser.parseQueryString(query) match {
         case Right(query) => query
@@ -221,7 +364,7 @@ object Query {
 
   /** Build a [[Query]] from the `Map` structure */
   def fromMap(map: collection.Map[String, collection.Seq[String]]): Query =
-    new Query(map.foldLeft(Vector.empty[KeyValue]) {
+    new Query.Parsed(map.foldLeft(Vector.empty[KeyValue]) {
       case (m, (k, Seq())) => m :+ (k -> None)
       case (m, (k, vs)) => vs.toList.foldLeft(m) { case (m, v) => m :+ (k -> Some(v)) }
     })
@@ -244,7 +387,7 @@ object Query {
     import cats.parse.Parser.charIn
     import Rfc3986.pchar
 
-    pchar.orElse(charIn("/?[]")).rep0.string.map(pchars => new Query(Right(pchars)))
+    pchar.orElse(charIn("/?[]")).rep0.string.map(pchars => new Query.Raw(pchars))
   }
 
   implicit val catsInstancesForHttp4sQuery: Hash[Query] with Order[Query] with Show[Query] =

--- a/core/shared/src/main/scala/org/http4s/Query.scala
+++ b/core/shared/src/main/scala/org/http4s/Query.scala
@@ -277,8 +277,7 @@ object Query {
     override def hashCode: Int = 31 + pairs.##
   }
 
-  final class Parsed private[http4s] (value: Vector[KeyValue]) extends Query {
-    def pairs: Vector[KeyValue] = value
+  final class Parsed private[http4s] (val pairs: Vector[KeyValue]) extends Query {
 
     /** Render the Query as a `String`.
       *
@@ -295,7 +294,7 @@ object Query {
           toSkip = UriCoding.QueryNoEncode,
         )
 
-      value.foreach {
+      pairs.foreach {
         case (n, None) =>
           if (!first) writer.append('&')
           else first = false
@@ -318,7 +317,7 @@ object Query {
         case _ => false
       }
 
-    override def hashCode: Int = 31 + value.##
+    override def hashCode: Int = 31 + pairs.##
   }
 
   type KeyValue = (String, Option[String])


### PR DESCRIPTION
This PR aims to make a model of `Query` more straightforward (and to retire the allocation of `Either`).
```scala
final class Query private (value: Either[Vector[KeyValue], String])
```
versus
```scala
sealed trait Query extends QueryOps with Renderable
object Query {
  case object Empty extends Query 
  final class Raw private[http4s] (value: String) extends Query
  final class Parsed private[http4s] (value: Vector[KeyValue]) extends Query
}
```

It's a proposal, so I'm open to any comments on that.

## Performance
Performance within fluctuation remained the same.

before
```
[info] Benchmark                        (size)   Mode  Cnt       Score       Error   Units
[info] QueryBench.filterParsedQuery          0  thrpt    5  101507.478 ±   419.039  ops/ms
[info] QueryBench.filterParsedQuery         10  thrpt    5   16419.723 ±   145.474  ops/ms
[info] QueryBench.filterParsedQuery        100  thrpt    5    1702.907 ±     9.961  ops/ms
[info] QueryBench.filterParsedQuery       1000  thrpt    5     146.354 ±     0.419  ops/ms
[info] QueryBench.filterRawQuery             0  thrpt    5   92902.523 ±   595.655  ops/ms
[info] QueryBench.filterRawQuery            10  thrpt    5   12797.116 ±  1561.480  ops/ms
[info] QueryBench.filterRawQuery           100  thrpt    5    1376.502 ±    54.955  ops/ms
[info] QueryBench.filterRawQuery          1000  thrpt    5     147.778 ±     2.300  ops/ms
[info] QueryBench.isEmptyParsedQuery         0  thrpt    5  451307.200 ± 26229.110  ops/ms
[info] QueryBench.isEmptyParsedQuery        10  thrpt    5  459002.947 ±  2871.149  ops/ms
[info] QueryBench.isEmptyParsedQuery       100  thrpt    5  463494.037 ±  6096.403  ops/ms
[info] QueryBench.isEmptyParsedQuery      1000  thrpt    5  457077.897 ± 53214.980  ops/ms
[info] QueryBench.isEmptyRawQuery            0  thrpt    5  457737.264 ±  1468.678  ops/ms
[info] QueryBench.isEmptyRawQuery           10  thrpt    5  437616.912 ±  8443.496  ops/ms
[info] QueryBench.isEmptyRawQuery          100  thrpt    5  465647.184 ±  2795.944  ops/ms
[info] QueryBench.isEmptyRawQuery         1000  thrpt    5  460094.743 ± 10366.918  ops/ms
[info] QueryBench.parseQuery                 0  thrpt    5    2715.890 ±    10.020  ops/ms
[info] QueryBench.parseQuery                10  thrpt    5     215.392 ±    28.554  ops/ms
[info] QueryBench.parseQuery               100  thrpt    5      21.097 ±     0.229  ops/ms
[info] QueryBench.parseQuery              1000  thrpt    5       1.907 ±     0.030  ops/ms
[info] QueryBench.prependParsedQuery         0  thrpt    5    1332.830 ±    40.513  ops/ms
[info] QueryBench.prependParsedQuery        10  thrpt    5    1381.962 ±    85.910  ops/ms
[info] QueryBench.prependParsedQuery       100  thrpt    5    1149.776 ±   130.352  ops/ms
[info] QueryBench.prependParsedQuery      1000  thrpt    5    1190.669 ±    86.394  ops/ms
[info] QueryBench.prependRawQuery            0  thrpt    5    1391.598 ±    38.045  ops/ms
[info] QueryBench.prependRawQuery           10  thrpt    5    1381.388 ±    91.171  ops/ms
[info] QueryBench.prependRawQuery          100  thrpt    5    1228.547 ±    45.970  ops/ms
[info] QueryBench.prependRawQuery         1000  thrpt    5    1164.858 ±    90.548  ops/ms
[info] QueryBench.sliceHalfParsedQuery       0  thrpt    5  173791.650 ±  1914.851  ops/ms
[info] QueryBench.sliceHalfParsedQuery      10  thrpt    5   92678.610 ±   666.011  ops/ms
[info] QueryBench.sliceHalfParsedQuery     100  thrpt    5   34289.443 ±  1378.834  ops/ms
[info] QueryBench.sliceHalfParsedQuery    1000  thrpt    5   30999.891 ±    54.828  ops/ms
[info] QueryBench.sliceHalfRawQuery          0  thrpt    5  174246.506 ±  1383.400  ops/ms
[info] QueryBench.sliceHalfRawQuery         10  thrpt    5   94638.441 ±  1246.186  ops/ms
[info] QueryBench.sliceHalfRawQuery        100  thrpt    5   34010.746 ±  2705.160  ops/ms
[info] QueryBench.sliceHalfRawQuery       1000  thrpt    5   29070.040 ±  6898.233  ops/ms
```
after
```
[info] Benchmark                        (size)   Mode  Cnt       Score       Error   Units
[info] QueryBench.filterParsedQuery          0  thrpt    5  125112.052 ±   269.180  ops/ms
[info] QueryBench.filterParsedQuery         10  thrpt    5   18170.039 ±   117.447  ops/ms
[info] QueryBench.filterParsedQuery        100  thrpt    5    1691.472 ±    48.133  ops/ms
[info] QueryBench.filterParsedQuery       1000  thrpt    5     146.326 ±     1.672  ops/ms
[info] QueryBench.filterRawQuery             0  thrpt    5  119818.520 ±  3184.840  ops/ms
[info] QueryBench.filterRawQuery            10  thrpt    5   13899.793 ±    63.296  ops/ms
[info] QueryBench.filterRawQuery           100  thrpt    5    1545.466 ±     1.546  ops/ms
[info] QueryBench.filterRawQuery          1000  thrpt    5     151.913 ±     2.996  ops/ms
[info] QueryBench.isEmptyParsedQuery         0  thrpt    5  438149.754 ± 22818.420  ops/ms
[info] QueryBench.isEmptyParsedQuery        10  thrpt    5  447012.329 ±  4631.002  ops/ms
[info] QueryBench.isEmptyParsedQuery       100  thrpt    5  462690.306 ±  4388.934  ops/ms
[info] QueryBench.isEmptyParsedQuery      1000  thrpt    5  462609.103 ±  5139.394  ops/ms
[info] QueryBench.isEmptyRawQuery            0  thrpt    5  447738.371 ±   594.162  ops/ms
[info] QueryBench.isEmptyRawQuery           10  thrpt    5  434970.727 ± 12788.456  ops/ms
[info] QueryBench.isEmptyRawQuery          100  thrpt    5  451769.683 ± 19311.524  ops/ms
[info] QueryBench.isEmptyRawQuery         1000  thrpt    5  464884.523 ±  1643.294  ops/ms
[info] QueryBench.parseQuery                 0  thrpt    5    2718.778 ±    32.716  ops/ms
[info] QueryBench.parseQuery                10  thrpt    5     216.652 ±     0.846  ops/ms
[info] QueryBench.parseQuery               100  thrpt    5      20.982 ±     0.113  ops/ms
[info] QueryBench.parseQuery              1000  thrpt    5       1.914 ±     0.016  ops/ms
[info] QueryBench.prependParsedQuery         0  thrpt    5    1300.867 ±    34.019  ops/ms
[info] QueryBench.prependParsedQuery        10  thrpt    5    1522.673 ±    21.713  ops/ms
[info] QueryBench.prependParsedQuery       100  thrpt    5    1176.870 ±    46.216  ops/ms
[info] QueryBench.prependParsedQuery      1000  thrpt    5    1202.466 ±    78.854  ops/ms
[info] QueryBench.prependRawQuery            0  thrpt    5    1424.427 ±   266.030  ops/ms
[info] QueryBench.prependRawQuery           10  thrpt    5    1490.961 ±    82.051  ops/ms
[info] QueryBench.prependRawQuery          100  thrpt    5    1276.975 ±   286.531  ops/ms
[info] QueryBench.prependRawQuery         1000  thrpt    5    1258.148 ±   230.296  ops/ms
[info] QueryBench.sliceHalfParsedQuery       0  thrpt    5  168781.553 ±   825.006  ops/ms
[info] QueryBench.sliceHalfParsedQuery      10  thrpt    5   92949.332 ±  1552.694  ops/ms
[info] QueryBench.sliceHalfParsedQuery     100  thrpt    5   39651.132 ±   200.127  ops/ms
[info] QueryBench.sliceHalfParsedQuery    1000  thrpt    5   31954.834 ±    94.616  ops/ms
[info] QueryBench.sliceHalfRawQuery          0  thrpt    5  170116.904 ±   246.680  ops/ms
[info] QueryBench.sliceHalfRawQuery         10  thrpt    5   93275.785 ±   318.445  ops/ms
[info] QueryBench.sliceHalfRawQuery        100  thrpt    5   39352.343 ±    55.206  ops/ms
[info] QueryBench.sliceHalfRawQuery       1000  thrpt    5   31805.869 ±   139.338  ops/ms
```