### PR TITLE
Deprecate event stream entity decoder

### DIFF
--- a/core/shared/src/main/scala/org/http4s/EntityDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/EntityDecoder.scala
@@ -355,6 +355,7 @@ object EntityDecoder {
   ): EntityDecoder[F, Multipart[F]] =
     MultipartDecoder.mixedMultipart(headerLimit, maxSizeBeforeWrite, maxParts, failOnLimit)
 
+  @deprecated("Broken. An entity decoder cannot return a Stream", "0.23.17")
   implicit def eventStream[F[_]: Applicative]: EntityDecoder[F, EventStream[F]] =
     EntityDecoder.decodeBy(MediaType.`text/event-stream`) { msg =>
       DecodeResult.successT(msg.body.through(ServerSentEvent.decoder))

--- a/tests/shared/src/test/scala/org/http4s/ServerSentEventSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/ServerSentEventSpec.scala
@@ -180,12 +180,15 @@ class ServerSentEventSpec extends Http4sSuite {
     )
   }
 
-  test("EntityDecoder[EventStream] should decode to original event stream") {
+  test("EntityEncoder[EventStream] should decode to original event stream") {
     for {
       r <- Response[IO]()
         .withEntity(eventStream)
-        .as[EventStream[IO]]
-        .flatMap(_.dropLast.compile.toVector)
+        .body
+        .through(ServerSentEvent.decoder)
+        .dropLast
+        .compile
+        .toVector
       e <- eventStream.compile.toVector
     } yield assertEquals(r, e)
   }


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/6694. There was a reason this did not exist and I made a stupid mistake when I added it in https://github.com/http4s/http4s/pull/6413. Woops 😅 

Long story short, it's completely broken, and there is no way to fix it. See explanation in https://github.com/http4s/http4s/issues/6694#issuecomment-1254100122.

Separately, we should consider adding something so we can support streaming decoders such as this one.