### PR TITLE
Proposal: remove EitherT in Entity Decoding

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/CirceJsonBench.scala
@@ -34,17 +34,16 @@ class CirceJsonBench {
 
   @Benchmark
   def decode_byte_buffer(in: BenchState): Either[DecodeFailure, Json] =
-    jsonDecoderByteBuffer[IO].decode(in.req, strict = true).value.unsafeRunSync()
+    jsonDecoderByteBuffer[IO].decode(in.req, strict = true).unsafeRunSync()
 
   @Benchmark
   def decode_incremental(in: BenchState): Either[DecodeFailure, Json] =
-    jsonDecoderIncremental[IO].decode(in.req, strict = true).value.unsafeRunSync()
+    jsonDecoderIncremental[IO].decode(in.req, strict = true).unsafeRunSync()
 
   @Benchmark
   def decode_adaptive(in: BenchState): Either[DecodeFailure, Json] =
     jsonDecoderAdaptive[IO](in.cutoff, MediaType.application.json)
       .decode(in.req, strict = true)
-      .value
       .unsafeRunSync()
 }
 

--- a/circe/src/test/scala/org/http4s/circe/CirceSensitiveDataEntityDecoderSpec.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSensitiveDataEntityDecoderSpec.scala
@@ -16,7 +16,6 @@
 
 package org.http4s.circe
 
-import cats.data.EitherT
 import cats.effect.IO
 import io.circe.Decoder
 import io.circe.HCursor
@@ -50,8 +49,7 @@ class CirceSensitiveDataEntityDecoderSpec extends Http4sSuite {
   ) {
     val json: Json = Json.obj("ssn" := 123456789)
     val response: Response[IO] = Response[IO](status = Status.Ok).withEntity(json)
-    val attmptedAs: EitherT[IO, DecodeFailure, Person] = response.attemptAs[Person]
-    val result: IO[Either[DecodeFailure, Person]] = attmptedAs.value
+    val result: IO[Either[DecodeFailure, Person]] = response.attemptAs[Person]
     result.map { (it: Either[DecodeFailure, Person]) =>
       it match {
         case Left(InvalidMessageBodyFailure(details, Some(cause))) =>
@@ -67,8 +65,7 @@ class CirceSensitiveDataEntityDecoderSpec extends Http4sSuite {
   test("not include the JSON when failing to decode due to incorrect JSON key's name") {
     val json: Json = Json.obj("the_ssn" := "123456789")
     val response: Response[IO] = Response[IO](status = Status.Ok).withEntity(json)
-    val attmptedAs: EitherT[IO, DecodeFailure, Person] = response.attemptAs[Person]
-    val result: IO[Either[DecodeFailure, Person]] = attmptedAs.value
+    val result: IO[Either[DecodeFailure, Person]] = response.attemptAs[Person]
 
     result.map { (it: Either[DecodeFailure, Person]) =>
       it match {

--- a/client/shared/src/main/scala/org/http4s/client/dsl/Http4sClientDsl.scala
+++ b/client/shared/src/main/scala/org/http4s/client/dsl/Http4sClientDsl.scala
@@ -19,6 +19,7 @@ package client
 package dsl
 
 import cats.Applicative
+import cats.syntax.functor._
 import org.http4s.headers.`Content-Length`
 
 trait Http4sClientDsl[F[_]] {
@@ -31,7 +32,7 @@ trait Http4sClientDsl[F[_]] {
   ): EntityDecoder[F, (Headers, T)] = {
     val s = decoder.consumes.toList
     EntityDecoder.decodeBy(s.head, s.tail: _*)(resp =>
-      decoder.decode(resp, strict = true).map(t => (resp.headers, t))
+      decoder.decode(resp, strict = true).map(_.map(t => (resp.headers, t)))
     )
   }
 }

--- a/client/shared/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/ClientSyntaxSuite.scala
@@ -286,7 +286,7 @@ class ClientSyntaxSuite extends Http4sSuite with Http4sClientDsl[IO] {
   test("Client should combine entity decoder media types correctly") {
     // This is more of an EntityDecoder spec
     val edec =
-      EntityDecoder.decodeBy[IO, String](MediaType.image.jpeg)(_ => DecodeResult.successT("foo!"))
+      EntityDecoder.decodeBy[IO, String](MediaType.image.jpeg)(_ => IO.pure(Right("foo!")))
     client
       .expect(Request[IO](GET, uri"http://www.foo.com/echoheaders"))(
         EntityDecoder.text[IO].orElse(edec)

--- a/core/shared/src/main/scala/org/http4s/DecodeResult.scala
+++ b/core/shared/src/main/scala/org/http4s/DecodeResult.scala
@@ -18,21 +18,21 @@ package org.http4s
 
 import cats.Applicative
 import cats.Functor
-import cats.data.EitherT
 
 object DecodeResult {
-  def apply[F[_], A](fa: F[Either[DecodeFailure, A]]): DecodeResult[F, A] =
-    EitherT(fa)
+  def failed[A](df: DecodeFailure): DecodeResult[A] = Left(df)
 
-  def success[F[_], A](fa: F[A])(implicit F: Functor[F]): DecodeResult[F, A] =
-    EitherT.right[DecodeFailure](fa)
+  def succeed[A](a: A): DecodeResult[A] = Right(a)
 
-  def successT[F[_], A](a: A)(implicit F: Applicative[F]): DecodeResult[F, A] =
-    EitherT.rightT[F, DecodeFailure](a)
+  def success[F[_], A](fa: F[A])(implicit F: Functor[F]): F[DecodeResult[A]] =
+    F.map(fa)(Right(_))
 
-  def failure[F[_], A](fe: F[DecodeFailure])(implicit F: Functor[F]): DecodeResult[F, A] =
-    EitherT.left[A](fe)
+  def failure[F[_], A](fe: F[DecodeFailure])(implicit F: Functor[F]): F[DecodeResult[A]] =
+    F.map(fe)(Left(_))
 
-  def failureT[F[_], A](e: DecodeFailure)(implicit F: Applicative[F]): DecodeResult[F, A] =
-    EitherT.leftT[F, A](e)
+  def successT[F[_], A](a: A)(implicit F: Applicative[F]): F[DecodeResult[A]] =
+    F.pure(succeed(a))
+
+  def failureT[F[_], A](e: DecodeFailure)(implicit F: Applicative[F]): F[DecodeResult[A]] =
+    F.pure(failed(e))
 }

--- a/core/shared/src/main/scala/org/http4s/Media.scala
+++ b/core/shared/src/main/scala/org/http4s/Media.scala
@@ -60,7 +60,7 @@ object Media {
       * @tparam T type of the result
       * @return the effect which will generate the `DecodeResult[T]`
       */
-    def attemptAs[T](implicit decoder: EntityDecoder[F, T]): DecodeResult[F, T] =
+    def attemptAs[T](implicit decoder: EntityDecoder[F, T]): F[DecodeResult[T]] =
       decoder.decode(self, strict = false)
 
     /** Decode the [[Media]] to the specified type
@@ -72,7 +72,7 @@ object Media {
       * @return the effect which will generate the A
       */
     def as[A](implicit F: MonadThrow[F], decoder: EntityDecoder[F, A]): F[A] =
-      F.rethrow(attemptAs.value)
+      F.rethrow(attemptAs)
   }
 
   def apply[F[_]](e: Entity[F], h: Headers): Media[F] =

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -521,7 +521,7 @@ final class Request[+F[_]] private (
   )(implicit F: Monad[F2]): F2[Response[F2]] =
     decoder
       .decode(this, strict = strict)
-      .foldF(e => F.pure(e.toHttpResponse(httpVersion)), f)
+      .flatMap(_.fold(e => F.pure(e.toHttpResponse(httpVersion)), f))
 
   /** Helper method for decoding [[Request]]s
     *

--- a/core/shared/src/main/scala/org/http4s/UrlForm.scala
+++ b/core/shared/src/main/scala/org/http4s/UrlForm.scala
@@ -124,11 +124,9 @@ object UrlForm {
       defaultCharset: Charset = `UTF-8`,
   ): EntityDecoder[F, UrlForm] =
     EntityDecoder.decodeBy(MediaType.application.`x-www-form-urlencoded`) { m =>
-      DecodeResult(
-        EntityDecoder
-          .decodeText(m)
-          .map(decodeString(m.charset.getOrElse(defaultCharset)))
-      )
+      EntityDecoder
+        .decodeText(m)
+        .map(decodeString(m.charset.getOrElse(defaultCharset)))
     }
 
   implicit val eqInstance: Eq[UrlForm] = Eq.instance { (x: UrlForm, y: UrlForm) =>

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -124,29 +124,25 @@ private[http4s] object MultipartDecoder {
       )
     )
 
-  private def makeDecoder[F[_]: Concurrent](
+  private def makeDecoder[F[_]](
       impl: Boundary => Pipe[F, Byte, Part[F]]
-  ): EntityDecoder[F, Multipart[F]] =
+  )(implicit F: Concurrent[F]): EntityDecoder[F, Multipart[F]] =
     EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
       msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
         case Some(boundary) =>
-          DecodeResult {
-            msg.body
-              .through(impl(Boundary(boundary)))
-              .compile
-              .toVector
-              .map[Either[DecodeFailure, Multipart[F]]](parts =>
-                Right(Multipart(parts, Boundary(boundary)))
-              )
-              .handleError {
-                case e: InvalidMessageBodyFailure => Left(e)
-                case e => Left(InvalidMessageBodyFailure("Invalid multipart body", Some(e)))
-              }
-          }
+          msg.body
+            .through(impl(Boundary(boundary)))
+            .compile
+            .toVector
+            .map[Either[DecodeFailure, Multipart[F]]](parts =>
+              Right(Multipart(parts, Boundary(boundary)))
+            )
+            .handleError {
+              case e: InvalidMessageBodyFailure => Left(e)
+              case e => Left(InvalidMessageBodyFailure("Invalid multipart body", Some(e)))
+            }
         case None =>
-          DecodeResult.failureT(
-            InvalidMessageBodyFailure("Missing boundary extension to Content-Type")
-          )
+          F.pure(Left(InvalidMessageBodyFailure("Missing boundary extension to Content-Type")))
       }
     }
 }

--- a/core/shared/src/main/scala/org/http4s/package.scala
+++ b/core/shared/src/main/scala/org/http4s/package.scala
@@ -28,7 +28,7 @@ package object http4s {
 
   val ApiVersion: Http4sVersion = Http4sVersion(BuildInfo.apiVersion._1, BuildInfo.apiVersion._2)
 
-  type DecodeResult[F[_], A] = EitherT[F, DecodeFailure, A]
+  type DecodeResult[+A] = Either[DecodeFailure, A]
 
   type ParseResult[+A] = Either[ParseFailure, A]
 

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -416,7 +416,7 @@ includes the decoding functionality, but ignores the media type.
 ```scala mdoc:silent
 val endpoint = uri"http://localhost:8080/hello/Ember"
 httpClient.get[Either[String, String]](endpoint) {
-  case Status.Successful(r) => r.attemptAs[String].leftMap(_.message).value
+  case Status.Successful(r) => r.attemptAs[String].map(_.leftMap(_.message))
   case r => r.as[String]
     .map(b => Left(s"Request failed with status ${r.status.code} and body $b"))
 }

--- a/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
+++ b/jawn/src/main/scala/org/http4s/jawn/JawnInstances.scala
@@ -37,21 +37,19 @@ trait JawnInstances {
   // some decoders may reuse it and avoid extra content negotiation
   private[http4s] def jawnDecoderImpl[F[_]: Concurrent, J: Facade](
       m: Media[F]
-  ): DecodeResult[F, J] =
-    DecodeResult {
-      m.body.chunks
-        .parseJson(AsyncParser.SingleValue)
-        .map(Either.right)
-        .handleErrorWith {
-          case pe: ParseException =>
-            Stream.emit(Left(jawnParseExceptionMessage(pe)))
-          case e =>
-            Stream.raiseError[F](e)
-        }
-        .compile
-        .last
-        .map(_.getOrElse(Left(jawnEmptyBodyMessage)))
-    }
+  ): F[DecodeResult[J]] =
+    m.body.chunks
+      .parseJson(AsyncParser.SingleValue)
+      .map(Either.right)
+      .handleErrorWith {
+        case pe: ParseException =>
+          Stream.emit(Left(jawnParseExceptionMessage(pe)))
+        case e =>
+          Stream.raiseError[F](e)
+      }
+      .compile
+      .last
+      .map(_.getOrElse(Left(jawnEmptyBodyMessage)))
 }
 
 object JawnInstances {

--- a/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSuite.scala
+++ b/jawn/src/test/scala/org/http4s/jawn/JawnDecodeSupportSuite.scala
@@ -24,7 +24,7 @@ trait JawnDecodeSupportSuite[J] extends Http4sSuite {
   def testJsonDecoder(decoder: EntityDecoder[IO, J]): Unit = {
     test("return right when the entity is valid") {
       val resp = Response[IO](Status.Ok).withEntity("""{"valid": true}""")
-      decoder.decode(resp, strict = false).value.map(_.isRight).assert
+      decoder.decode(resp, strict = false).map(_.isRight).assert
     }
 
     testErrors(decoder)(
@@ -49,7 +49,6 @@ trait JawnDecodeSupportSuite[J] extends Http4sSuite {
       val resp = Response[IO](Status.Ok).withEntity("""garbage""")
       decoder
         .decode(resp, strict = false)
-        .value
         .map(_.leftMap(r => emptyBody.applyOrElse(r, (_: DecodeFailure) => false)))
     }
 
@@ -57,7 +56,6 @@ trait JawnDecodeSupportSuite[J] extends Http4sSuite {
       val resp = Response[IO](Status.Ok).withEntity("")
       decoder
         .decode(resp, strict = false)
-        .value
         .map(_.leftMap(r => parseError.applyOrElse(r, (_: DecodeFailure) => false)))
     }
   }

--- a/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
+++ b/laws/src/main/scala/org/http4s/laws/EntityCodecLaws.scala
@@ -30,7 +30,7 @@ trait EntityCodecLaws[F[_], A] extends EntityEncoderLaws[F, A] {
     (for {
       entity <- F.pure(encoder.toEntity(a))
       message = Request(entity = entity, headers = encoder.headers)
-      a0 <- decoder.decode(message, strict = true).value
+      a0 <- decoder.decode(message, strict = true)
     } yield a0) <-> F.pure(Right(a))
 }
 

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -905,13 +905,13 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
       F: Concurrent[F],
       dispatcher: Dispatcher[F],
       testContext: TestContext,
-      g: Arbitrary[DecodeResult[F, A]],
+      g: Arbitrary[F[DecodeResult[A]]],
   ): Arbitrary[EntityDecoder[F, A]] =
     Arbitrary(for {
-      f <- getArbitrary[(Media[F], Boolean) => DecodeResult[F, A]]
+      f <- getArbitrary[(Media[F], Boolean) => F[DecodeResult[A]]]
       mrs <- getArbitrary[Set[MediaRange]]
     } yield new EntityDecoder[F, A] {
-      def decode(m: Media[F], strict: Boolean): DecodeResult[F, A] = f(m, strict)
+      def decode(m: Media[F], strict: Boolean): F[DecodeResult[A]] = f(m, strict)
       def consumes = mrs
     })
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -415,7 +415,6 @@ object CSRF {
     def getFormToken: F[Option[String]] = {
       def extractToken: G[Option[String]] =
         r.attemptAs[UrlForm]
-          .value
           .map(_.fold(_ => none[String], _.values.get(fieldName).flatMap(_.uncons.map(_._1))))
 
       r.headers.get[`Content-Type`] match {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/HttpMethodOverrider.scala
@@ -134,7 +134,6 @@ object HttpMethodOverrider {
               UrlForm
                 .entityDecoder[G]
                 .decode(req, strict = true)
-                .value
                 .map(_.toOption.map(_.values))
             )
           } yield formFields.flatMap(_.get(field).flatMap(_.uncons.map(_._1)))

--- a/tests/shared/src/test/scala/org/http4s/UrlFormSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/UrlFormSpec.scala
@@ -45,17 +45,9 @@ class UrlFormSpec extends Http4sSuite {
 
     test("UrlForm should entityDecoder . entityEncoder == right") {
       PropF.forAllF { (urlForm: UrlForm) =>
-        DecodeResult
-          .success(
-            Request[IO]()
-              .withEntity(urlForm)(UrlForm.entityEncoder(charset))
-              .pure[IO]
-          )
-          .flatMap { req =>
-            UrlForm.entityDecoder[IO].decode(req, strict = false)
-          }
-          .value
-          .assertEquals(Right(urlForm))
+        val req = Request[IO]().withEntity(urlForm)(UrlForm.entityEncoder(charset))
+
+        UrlForm.entityDecoder[IO].decode(req, strict = false).assertEquals(Right(urlForm))
       }
     }
 

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -74,8 +74,7 @@ class MultipartSuite extends Http4sSuite {
             Request(method = Method.POST, uri = url, entity = entity, headers = multipart.headers)
 
           mkDecoder.use { decoder =>
-            val decoded = decoder.decode(request, true)
-            val result = decoded.value
+            val result = decoder.decode(request, true)
 
             assertIOBoolean(
               EitherT(result).semiflatMap(eqMultipartIO(_, multipart)).getOrElse(false)
@@ -96,8 +95,7 @@ class MultipartSuite extends Http4sSuite {
             Request(method = Method.POST, uri = url, entity = entity, headers = multipart.headers)
 
           mkDecoder.use { decoder =>
-            val decoded = decoder.decode(request, true)
-            val result = decoded.value
+            val result = decoder.decode(request, true)
 
             assertIOBoolean(
               EitherT(result).semiflatMap(eqMultipartIO(_, multipart)).getOrElse(false)
@@ -121,8 +119,7 @@ class MultipartSuite extends Http4sSuite {
             Request(method = Method.POST, uri = url, entity = entity, headers = multipart.headers)
 
           mkDecoder.use { decoder =>
-            val decoded = decoder.decode(request, true)
-            val result = decoded.value
+            val result = decoder.decode(request, true)
 
             assertIOBoolean(
               EitherT(result).semiflatMap(eqMultipartIO(_, multipart)).getOrElse(false)
@@ -165,9 +162,7 @@ Content-Type: application/pdf
 
       mkDecoder.use { decoder =>
         val decoded = decoder.decode(request, true)
-        val result = decoded.value.map(_.isRight)
-
-        result.assertEquals(true)
+        decoded.map(_.isRight).assertEquals(true)
       }
     }
 
@@ -198,7 +193,7 @@ I am a big moose
 
       mkDecoder.use { decoder =>
         val decoded = decoder.decode(request, true)
-        val result = decoded.value.map(_.isRight)
+        val result = decoded.map(_.isRight)
 
         result.assertEquals(true)
       }


### PR DESCRIPTION
Rationale: there has been a conversation about removing the use of monad transformers from the external API of `http4s`.

- Change the type alias `DecodeResult` to just be the Either`
- As a consequence of this, the `F` effect comes out in the signature of most functions and methods.
- Rewrite implementation of `EntityDecoder` combinators, to operate without the `EitherT`.