### PR TITLE
Mark method `CharPredicate.asMaskBased` as deprecated

### DIFF
--- a/core/shared/src/main/scala/org/http4s/internal/CharPredicate.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/CharPredicate.scala
@@ -27,10 +27,17 @@ sealed abstract class CharPredicate extends (Char => Boolean) {
     */
   def isMaskBased: Boolean = this.isInstanceOf[MaskBased]
 
+  @deprecated("Unsafe method. Use CharPredicate.asMaskBasedOpt instead", "0.23.17")
   def asMaskBased: MaskBased =
     this match {
       case x: MaskBased => x
       case _ => sys.error("CharPredicate is not MaskBased")
+    }
+
+  def asMaskBasedOpt: Option[MaskBased] =
+    this match {
+      case x: MaskBased => Some(x)
+      case _ => None
     }
 
   def ++(that: CharPredicate): CharPredicate


### PR DESCRIPTION
I'm in favor of removing this method since it's in the `internal` package and isn't used in the repo, but... Mima beats on the hands since that's a public class anyway. 