### PR TITLE
Fix for 6851 : Uri.Path.Segment can throw from its equals method

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -467,6 +467,7 @@ object Uri extends UriPlatform {
       override def equals(obj: Any): Boolean =
         obj match {
           case s: Segment => s.encoded == encoded
+          case _ => false
         }
 
       override def hashCode(): Int = encoded.hashCode

--- a/tests/shared/src/test/scala/org/http4s/SegmentSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/SegmentSuite.scala
@@ -17,9 +17,15 @@
 package org.http4s
 
 import cats.kernel.laws.discipline.OrderTests
+import munit.Compare
 import org.http4s.Uri.Path.Segment
 import org.http4s.laws.discipline.arbitrary._
 
 class SegmentSuite extends Http4sSuite {
   checkAll("Order[Segment]", OrderTests[Segment].order)
+
+  test("equals does not throw") {
+    implicit val comp: Compare[Segment, String] = Compare.defaultCompare
+    assertNotEquals(Uri.Path.Segment.apply("123"), "123")
+  }
 }


### PR DESCRIPTION
Let me know if I've picked the wrong place for the test!