### PR TITLE
Tweak body interrupting for better performance of `DefaultHead` Middleware

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -324,13 +324,6 @@ lazy val server = libraryCrossProject("server")
         .exclude[FinalClassProblem]("org.http4s.server.middleware.CORSPolicy$ExposeHeaders$In"),
       ProblemFilters
         .exclude[FinalClassProblem]("org.http4s.server.middleware.CORSPolicy$MaxAge$Some"),
-      // relaxing constraints
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.http4s.server.middleware.DefaultHead.apply"
-      ),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.http4s.server.middleware.DefaultHead.httpRoutes"
-      ),
     ) ++ {
       if (tlIsScala3.value)
         Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -324,6 +324,13 @@ lazy val server = libraryCrossProject("server")
         .exclude[FinalClassProblem]("org.http4s.server.middleware.CORSPolicy$ExposeHeaders$In"),
       ProblemFilters
         .exclude[FinalClassProblem]("org.http4s.server.middleware.CORSPolicy$MaxAge$Some"),
+      // relaxing constraints
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.server.middleware.DefaultHead.apply"
+      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.server.middleware.DefaultHead.httpRoutes"
+      ),
     ) ++ {
       if (tlIsScala3.value)
         Seq(

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -53,15 +53,7 @@ object DefaultHead {
       G: Concurrent[G],
       M: MonoidK[F],
   ): Http[F, G] = {
-    implicit val functor = F
-    implicit val monoidK = M
-
-    Kleisli { req =>
-      req.method match {
-        case HEAD => http(req) <+> http(req.withMethod(GET)).map(r => drainBody[G](r)(G))
-        case _ => http(req)
-      }
-    }
+    apply(http)(F, G, M)
   }
 
   def httpRoutes[F[_]: Monad](httpRoutes: HttpRoutes[F]): HttpRoutes[F] =

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -67,7 +67,5 @@ object DefaultHead {
   private[this] def drainBody[G[_]](
       response: Response[G]
   )(implicit G: Applicative[G]): Response[G] =
-    response.pipeBodyThrough(
-      _.interruptWhen[G](G.pure[Either[Throwable, Unit]](Right(()))).drain
-    )
+    response.pipeBodyThrough(_.interruptWhen[G](G.pure(Either.unit[Throwable])).drain)
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -47,5 +47,5 @@ object DefaultHead {
     apply(httpRoutes)
 
   private[this] def drainBody[G[_]: Concurrent](response: Response[G]): Response[G] =
-    response.pipeBodyThrough(_.interruptWhen[G](Stream(true)).drain)
+    response.pipeBodyThrough(_.interruptWhen[G](Concurrent[G].unit.attempt).drain)
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -23,6 +23,7 @@ import cats.Functor
 import cats.Monad
 import cats.MonoidK
 import cats.data.Kleisli
+import cats.effect.kernel.Concurrent
 import cats.syntax.all._
 import org.http4s.Method.GET
 import org.http4s.Method.HEAD
@@ -45,8 +46,32 @@ object DefaultHead {
       }
     }
 
+  @deprecated("Use overload with Applicative constraint", "0.23.17")
+  def apply[F[_], G[_]](
+      http: Http[F, G],
+      F: Functor[F],
+      G: Concurrent[G],
+      M: MonoidK[F],
+  ): Http[F, G] = {
+    implicit val functor = F
+    implicit val monoidK = M
+
+    Kleisli { req =>
+      req.method match {
+        case HEAD => http(req) <+> http(req.withMethod(GET)).map(r => drainBody[G](r)(G))
+        case _ => http(req)
+      }
+    }
+  }
+
   def httpRoutes[F[_]: Monad](httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
     apply(httpRoutes)
+
+  @deprecated("Use overload with Monad constraint", "0.23.17")
+  def httpRoutes[F[_]](httpRoutes: HttpRoutes[F], F: Concurrent[F]): HttpRoutes[F] = {
+    implicit val concurrent = F
+    apply(httpRoutes)
+  }
 
   private[this] def drainBody[G[_]](
       response: Response[G]

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -52,9 +52,8 @@ object DefaultHead {
       F: Functor[F],
       G: Concurrent[G],
       M: MonoidK[F],
-  ): Http[F, G] = {
+  ): Http[F, G] =
     apply(http)(F, G, M)
-  }
 
   def httpRoutes[F[_]: Monad](httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
     apply(httpRoutes)

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -18,11 +18,12 @@ package org.http4s
 package server
 package middleware
 
-import cats.{Applicative, Functor, Monad, MonoidK}
+import cats.Applicative
+import cats.Functor
+import cats.Monad
+import cats.MonoidK
 import cats.data.Kleisli
-import cats.effect.Concurrent
 import cats.syntax.all._
-import fs2.Stream
 import org.http4s.Method.GET
 import org.http4s.Method.HEAD
 


### PR DESCRIPTION
```
[info] Benchmark                                     Mode  Cnt      Score      Error   Units
[info] InterruptWhenBench.interruptWhenIOBench      thrpt    5  14981.354 ±   47.508  ops/ms
[info] InterruptWhenBench.interruptWhenStreamBench  thrpt    5  11910.674 ± 1005.696  ops/ms
```
```scala
  def stream: fs2.Stream[IO, String] =
    fs2.Stream.emit("foo").repeat

  @Benchmark
  def interruptWhenStreamBench: IO[Unit] =
    stream.interruptWhen(fs2.Stream(true)).compile.drain

  @Benchmark
  def interruptWhenIOBench: IO[Unit] =
    stream.interruptWhen(IO.pure[Either[Throwable, Unit]](Right(()))).compile.drain
```