### PR TITLE
Use cached value of `Right(())` to avoid allocations

### DIFF
--- a/client-testkit/js/src/main/scala/org/http4s/client/testkit/scaffold/ServerScaffold.scala
+++ b/client-testkit/js/src/main/scala/org/http4s/client/testkit/scaffold/ServerScaffold.scala
@@ -70,7 +70,7 @@ private[http4s] object ServerScaffold {
             }
           )
         } { server =>
-          F.async_[Unit] { cb => server.close(() => cb(Right(()))); () }
+          F.async_[Unit] { cb => server.close(() => cb(Either.unit)); () }
         }
         .evalMap { server =>
           F.async_[ServerScaffold[F]] { cb =>

--- a/client-testkit/jvm/src/main/scala/org/http4s/client/testkit/scaffold/package.scala
+++ b/client-testkit/jvm/src/main/scala/org/http4s/client/testkit/scaffold/package.scala
@@ -47,7 +47,7 @@ package object scaffold {
         ff.flatMap(f =>
           F.delay {
             f.addListener { (f: io.netty.util.concurrent.Future[_]) =>
-              if (f.isSuccess) callback(Right(()))
+              if (f.isSuccess) callback(Either.unit)
               else callback(Left(f.cause()))
             }
             None

--- a/core/shared/src/main/scala/org/http4s/websocket/WebSocketHandshake.scala
+++ b/core/shared/src/main/scala/org/http4s/websocket/WebSocketHandshake.scala
@@ -17,6 +17,7 @@
 package org.http4s.websocket
 
 import cats.effect.SyncIO
+import cats.syntax.either._
 import org.http4s.crypto.Hash
 import org.http4s.crypto.HashAlgorithm
 import scodec.bits.ByteVector
@@ -66,7 +67,7 @@ private[http4s] object WebSocketHandshake {
         headers
           .find { case (k, _) => k.equalsIgnoreCase("Sec-WebSocket-Accept") }
           .map {
-            case (_, v) if genAcceptKey(key) == v => Right(())
+            case (_, v) if genAcceptKey(key) == v => Either.unit
             case (_, v) => Left(s"Invalid key: $v")
           }
           .getOrElse(Left("Missing Sec-WebSocket-Accept header"))

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -400,7 +400,7 @@ private[h2] class H2Connection[F[_]](
             )
           }
           (settings, difference, oldWriteBlock) = t
-          _ <- oldWriteBlock.complete(Either.right(()))
+          _ <- oldWriteBlock.complete(Either.unit)
           _ <- mapRef.get.flatMap { map =>
             map.toList.traverse { case (_, stream) =>
               stream.modifyWriteWindow(difference)
@@ -444,7 +444,7 @@ private[h2] class H2Connection[F[_]](
                 )
               }
               (oldWriteBlock, valid) = t
-              _ <- oldWriteBlock.complete(Right(()))
+              _ <- oldWriteBlock.complete(Either.unit)
               _ <- {
                 if (!valid) goAway(H2Error.FlowControlError)
                 else Applicative[F].unit

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -187,7 +187,7 @@ private[ember] object H2Server {
         _ <- s.request.complete(Either.right(req))
         er = Either.right(req.body.compile.to(fs2.Collector.supportsByteVector(ByteVector)))
         _ <- s.readBuffer.offer(er)
-        _ <- s.writeBlock.complete(Either.right(()))
+        _ <- s.writeBlock.complete(Either.unit)
       } yield ()
 
     def holdWhileOpen(stateRef: Ref[F, H2Connection.State[F]]): F[Unit] =

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -391,7 +391,7 @@ private[h2] class H2Stream[F[_]: Concurrent](
 
     _ <- {
       if (!valid) rstStream(H2Error.FlowControlError)
-      else oldWriteBlock.complete(Right(())).void
+      else oldWriteBlock.complete(Either.unit).void
     }
   } yield ()
 
@@ -404,7 +404,7 @@ private[h2] class H2Stream[F[_]: Concurrent](
       (newS, s.writeBlock)
     }
 
-    _ <- oldWriteBlock.complete(Right(())).void
+    _ <- oldWriteBlock.complete(Either.unit).void
   } yield ()
 
   def getRequest: F[org.http4s.Request[fs2.Pure]] = state.get.flatMap(_.request.get.rethrow)

--- a/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/authentication/NonceKeeperF.scala
@@ -88,7 +88,7 @@ private[authentication] class NonceKeeperF[F[_]](
                     it.remove()
                     it
                   })
-                case _ => F.delay(Right(()))
+                case _ => F.delay(Either.unit)
               }
             }
         } else F.pure(())


### PR DESCRIPTION
A follow-up of the discussion https://github.com/http4s/http4s/pull/6855#pullrequestreview-1212613727.