### PR TITLE
Update `Uri.fromString` return type in client docs

### DIFF
--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -232,9 +232,9 @@ val invalidUri = "yeah whatever"
 ```
 
 ```scala mdoc
-val uri: Either[ParseFailure, Uri] = Uri.fromString(validUri)
+val uri: ParseResult[Uri] = Uri.fromString(validUri)
 
-val parseFailure: Either[ParseFailure, Uri] = Uri.fromString(invalidUri)
+val parseFailure: ParseResult[Uri] = Uri.fromString(invalidUri)
 ```
 
 You can also build up a URI incrementally, e.g.:


### PR DESCRIPTION
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 

## Description

The current return type of `Uri.fromString` in `client.md` docs is `Either[ParseFailure, Uri]`. But, actually return type is `ParseResult[Uri]`. This PR is fixes it.

https://github.com/http4s/http4s/blob/008602f534c82dda4cc79cd8d8add6a56c250da3/core/shared/src/main/scala/org/http4s/Uri.scala#L212

```scala
scala> import org.http4s.Uri
import org.http4s.Uri

scala> Uri.fromString(validUri)
val res0: org.http4s.ParseResult[org.http4s.Uri] = Right(https://my-awesome-service.com/foo/bar?wow=yeah)

scala> Uri.fromString(invalidUri)
val res1: org.http4s.ParseResult[org.http4s.Uri] =
Left(org.http4s.ParseFailure: Invalid URI: yeah whatever
    ^
expectation:
* must end the string)
```

## Before

![uri-before](https://user-images.githubusercontent.com/11273093/208233165-89d027f8-6b70-4c74-912f-fda4c5036d66.jpg)

## After

![uri-after](https://user-images.githubusercontent.com/11273093/208233176-89363a80-4d21-4a2a-b392-8f4ff84bcc32.jpg)

---

Thank you :)