### PR TITLE
Tweak performance of `QueryOps#withQueryParam` 

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/QueryBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/QueryBench.scala
@@ -86,14 +86,14 @@ class QueryBench {
   def prependRawQuery: Query =
     generateKeyValue() +: rawQuery
 
-  final case class Key(key: String)
+  sealed case class Key(key: String)
 
   object Key {
     implicit val queryParam: QueryParam[Key] =
       QueryParam.fromKey("foo")
   }
 
-  final case class Value(value: String)
+  sealed case class Value(value: String)
 
   object Value {
     implicit val queryParamEncoder: QueryParamEncoder[Value] =

--- a/bench/src/main/scala/org/http4s/bench/QueryBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/QueryBench.scala
@@ -25,8 +25,8 @@ import org.openjdk.jmh.annotations._
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
-@BenchmarkMode(Array(Mode.AverageTime))
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 class QueryBench {
   @Param(Array("0", "10", "100", "1000"))

--- a/core/shared/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/shared/src/main/scala/org/http4s/QueryOps.scala
@@ -35,11 +35,14 @@ trait QueryOps {
 
   /** alias for withQueryParam */
   def +?[T: QueryParam]: Self =
-    _withQueryParam(QueryParam[T].key, Nil)
+    _withQueryParam(QueryParam[T].key, None)
 
   /** alias for withQueryParam */
   def +*?[T: QueryParamKeyLike: QueryParamEncoder](value: T): Self =
-    _withQueryParam(QueryParamKeyLike[T].getKey(value), QueryParamEncoder[T].encode(value) :: Nil)
+    _withQueryParam(
+      QueryParamKeyLike[T].getKey(value),
+      Some(QueryParamEncoder[T].encode(value).value),
+    )
 
   /** alias for withQueryParam */
   def +*?[T: QueryParam: QueryParamEncoder](values: collection.Seq[T]): Self =
@@ -51,7 +54,7 @@ trait QueryOps {
 
   /** alias for withQueryParam */
   def +?[K: QueryParamKeyLike](name: K): Self =
-    _withQueryParam(QueryParamKeyLike[K].getKey(name), Nil)
+    _withQueryParam(QueryParamKeyLike[K].getKey(name), None)
 
   /** alias for withQueryParam
     *
@@ -134,14 +137,14 @@ trait QueryOps {
     * replaced with an empty list.
     */
   def withQueryParam[T: QueryParam]: Self =
-    _withQueryParam(QueryParam[T].key, Nil)
+    _withQueryParam(QueryParam[T].key, None)
 
   /** Creates a new `Self` with the specified parameter in the [[Query]].
     * If a parameter with the given `key` already exists the values will be
     * replaced with an empty list.
     */
   def withQueryParam[K: QueryParamKeyLike](key: K): Self =
-    _withQueryParam(QueryParamKeyLike[K].getKey(key), Nil)
+    _withQueryParam(QueryParamKeyLike[K].getKey(key), None)
 
   /** Creates maybe a new `Self` with the specified parameter in the [[Query]].
     * If a parameter with the given `key` already exists the values will be
@@ -149,7 +152,10 @@ trait QueryOps {
     * instance of `Self` will be returned.
     */
   def withQueryParam[T: QueryParamEncoder, K: QueryParamKeyLike](key: K, value: T): Self =
-    _withQueryParam(QueryParamKeyLike[K].getKey(key), QueryParamEncoder[T].encode(value) :: Nil)
+    _withQueryParam(
+      QueryParamKeyLike[K].getKey(key),
+      Some(QueryParamEncoder[T].encode(value).value),
+    )
 
   /** Creates maybe a new `Self` with the specified parameters in the [[Query]].
     * If a parameter with the given `key` already exists the values will be
@@ -183,6 +189,17 @@ trait QueryOps {
   ): Self =
     params.foldLeft(self) { case (s, (k, v)) =>
       replaceQuery(Query.fromVector(s.withQueryParam(k, v).query.toVector))
+    }
+
+  private def _withQueryParam(
+      name: QueryParameterKey,
+      value: Option[String],
+  ): Self =
+    if (query == Query.blank || query == Query.empty) {
+      replaceQuery(Query(name.value -> value))
+    } else {
+      val baseQuery = query.toVector.filter(_._1 != name.value)
+      replaceQuery(Query.fromVector(baseQuery :+ (name.value -> value)))
     }
 
   private def _withQueryParam(


### PR DESCRIPTION
### Before  
- throughput
```
Benchmark                             (size)   Mode  Cnt      Score     Error   Units
QueryBench.withQueryParamParsedQuery       0  thrpt    5  26645.918 ± 365.286  ops/ms
QueryBench.withQueryParamParsedQuery      10  thrpt    5  24688.383 ±  81.462  ops/ms
QueryBench.withQueryParamParsedQuery     100  thrpt    5   2515.062 ±   5.276  ops/ms
QueryBench.withQueryParamParsedQuery    1000  thrpt    5    206.958 ±   0.536  ops/ms
QueryBench.withQueryParamRawQuery          0  thrpt    5  25385.754 ±  21.232  ops/ms
QueryBench.withQueryParamRawQuery         10  thrpt    5  23735.831 ± 638.432  ops/ms
QueryBench.withQueryParamRawQuery        100  thrpt    5   2511.501 ±   2.668  ops/ms
QueryBench.withQueryParamRawQuery       1000  thrpt    5    218.707 ±   1.387  ops/ms
```
- memory consumption
```
Benchmark                                                    (size)  Mode  Cnt     Score     Error   Units
QueryBench.withQueryParamParsedQuery:·gc.alloc.rate.norm          0  avgt    5   232.019 ±   0.001    B/op
QueryBench.withQueryParamParsedQuery:·gc.alloc.rate.norm         10  avgt    5   272.022 ±   0.001    B/op
QueryBench.withQueryParamParsedQuery:·gc.alloc.rate.norm        100  avgt    5  1136.135 ±   0.005    B/op
QueryBench.withQueryParamParsedQuery:·gc.alloc.rate.norm       1000  avgt    5  5312.780 ±   0.011    B/op
QueryBench.withQueryParamRawQuery:·gc.alloc.rate.norm             0  avgt    5   232.019 ±   0.001    B/op
QueryBench.withQueryParamRawQuery:·gc.alloc.rate.norm            10  avgt    5   272.022 ±   0.001    B/op
QueryBench.withQueryParamRawQuery:·gc.alloc.rate.norm           100  avgt    5  1136.135 ±   0.004    B/op
QueryBench.withQueryParamRawQuery:·gc.alloc.rate.norm          1000  avgt    5  5312.780 ±   0.012    B/op
```
### After
- throughput
```
Benchmark                             (size)   Mode  Cnt      Score      Error   Units
QueryBench.withQueryParamParsedQuery       0  thrpt    5  31821.586 ±  651.064  ops/ms
QueryBench.withQueryParamParsedQuery      10  thrpt    5  26747.638 ± 2846.398  ops/ms
QueryBench.withQueryParamParsedQuery     100  thrpt    5   2411.676 ±   44.376  ops/ms
QueryBench.withQueryParamParsedQuery    1000  thrpt    5    204.550 ±    5.038  ops/ms
QueryBench.withQueryParamRawQuery          0  thrpt    5  31333.871 ±  634.047  ops/ms
QueryBench.withQueryParamRawQuery         10  thrpt    5  27755.282 ±   21.222  ops/ms
QueryBench.withQueryParamRawQuery        100  thrpt    5   2418.994 ±   45.132  ops/ms
QueryBench.withQueryParamRawQuery       1000  thrpt    5    220.835 ±    1.919  ops/ms
```
- memory consumption
```
Benchmark                                                    (size)  Mode  Cnt     Score     Error   Units
QueryBench.withQueryParamParsedQuery:·gc.alloc.rate.norm          0  avgt    5   176.011 ±   0.001    B/op
QueryBench.withQueryParamParsedQuery:·gc.alloc.rate.norm         10  avgt    5   216.017 ±   0.001    B/op
QueryBench.withQueryParamParsedQuery:·gc.alloc.rate.norm        100  avgt    5  1080.129 ±   0.004    B/op
QueryBench.withQueryParamParsedQuery:·gc.alloc.rate.norm       1000  avgt    5  5256.773 ±   0.024    B/op
QueryBench.withQueryParamRawQuery:·gc.alloc.rate.norm             0  avgt    5   176.014 ±   0.001    B/op
QueryBench.withQueryParamRawQuery:·gc.alloc.rate.norm            10  avgt    5   216.018 ±   0.001    B/op
QueryBench.withQueryParamRawQuery:·gc.alloc.rate.norm           100  avgt    5  1080.129 ±   0.004    B/op
QueryBench.withQueryParamRawQuery:·gc.alloc.rate.norm          1000  avgt    5  5256.772 ±   0.023    B/op
```