### PR TITLE
Tweak `Accept` usage to avoid variadic construction

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -19,6 +19,7 @@ package client
 
 import cats.Applicative
 import cats.data.Kleisli
+import cats.data.NonEmptyList
 import cats.effect.MonadCancelThrow
 import cats.effect.Resource
 import cats.syntax.all._
@@ -26,7 +27,6 @@ import fs2.Stream
 import org.http4s.Status.Successful
 import org.http4s.headers.Accept
 import org.http4s.headers.MediaRangeAndQValue
-import cats.data.NonEmptyList
 
 private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[F])
     extends Client[F] {

--- a/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -26,6 +26,7 @@ import fs2.Stream
 import org.http4s.Status.Successful
 import org.http4s.headers.Accept
 import org.http4s.headers.MediaRangeAndQValue
+import cats.data.NonEmptyList
 
 private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[F])
     extends Client[F] {
@@ -91,8 +92,8 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
       req: Request[F]
   )(onError: Response[F] => F[Throwable])(implicit d: EntityDecoder[F, A]): F[A] = {
     val r = if (d.consumes.nonEmpty) {
-      val m = d.consumes.toList
-      req.addHeader(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
+      val m = d.consumes.toList.map(MediaRangeAndQValue(_))
+      req.addHeader(Accept(NonEmptyList.fromListUnsafe(m)))
     } else req
 
     run(r).use {
@@ -171,8 +172,8 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
     */
   def fetchAs[A](req: Request[F])(implicit d: EntityDecoder[F, A]): F[A] = {
     val r = if (d.consumes.nonEmpty) {
-      val m = d.consumes.toList
-      req.addHeader(Accept(MediaRangeAndQValue(m.head), m.tail.map(MediaRangeAndQValue(_)): _*))
+      val m = d.consumes.toList.map(MediaRangeAndQValue(_))
+      req.addHeader(Accept(NonEmptyList.fromListUnsafe(m)))
     } else req
 
     run(r).use { resp =>

--- a/core/shared/src/main/scala/org/http4s/headers/Accept.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Accept.scala
@@ -51,7 +51,7 @@ object Accept {
         mr.withExtensions(extensions.toMap).withQValue(qValue)
     }
 
-    headerRep1(fullRange).map(xs => Accept(xs.head, xs.tail: _*))
+    headerRep1(fullRange).map(Accept(_))
   }
 
   implicit val headerInstance: Header[Accept, Header.Recurring] =


### PR DESCRIPTION
This PR tweaks `Accept` header constructions:

- in the `Parser` when we already have a `NonEmptyList`
- in `DefaultClient` when we can easily make a `NonEmptyList`