### PR TITLE
Log a `Message` body considering the `Entity` model

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Charset.scala
+++ b/core/shared/src/main/scala/org/http4s/Charset.scala
@@ -36,7 +36,7 @@ import java.util.Locale
 import scala.jdk.CollectionConverters._
 
 // scalafix:off Http4sGeneralLinters; bincompat until 1.0
-final case class Charset private (nioCharset: NioCharset) extends Renderable {
+final case class Charset private[http4s] (nioCharset: NioCharset) extends Renderable {
   def withQuality(q: QValue): CharsetRange.Atom = CharsetRange.Atom(this, q)
   def toRange: CharsetRange.Atom = withQuality(QValue.One)
 


### PR DESCRIPTION
Sorry for not bringing benchmarks this time, but building a `String` from `Entity.Strtict` directly should have better performance for throughput/memory consumption than building a `Stream` and building a `String` from it. 