### PR TITLE
Tweak stream compiling to hex string in `Logger`

### DIFF
--- a/core/shared/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/Logger.scala
@@ -54,9 +54,7 @@ object Logger {
             .compile
             .string
         else
-          message.body.compile
-            .to(fs2.Collector.supportsByteVector(ByteVector))
-            .map(_.toHex)
+          message.body.compile.to(ByteVector).map(_.toHex)
 
       Some(string)
     } else None

--- a/core/shared/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/Logger.scala
@@ -27,6 +27,7 @@ import org.http4s.Message
 import org.http4s.Request
 import org.http4s.Response
 import org.typelevel.ci.CIString
+import scodec.bits.ByteVector
 
 object Logger {
 
@@ -46,12 +47,18 @@ object Logger {
       val isJson = message.contentType.exists(mT =>
         mT.mediaType == MediaType.application.json || mT.mediaType.subType.endsWith("+json")
       )
-      val bodyStream = if (!isBinary || isJson) {
-        message.bodyText(implicitly, message.charset.getOrElse(Charset.`UTF-8`))
-      } else {
-        message.body.map(b => java.lang.Integer.toHexString(b & 0xff))
-      }
-      Some(bodyStream.compile.string)
+      val string =
+        if (!isBinary || isJson)
+          message
+            .bodyText(implicitly, message.charset.getOrElse(Charset.`UTF-8`))
+            .compile
+            .string
+        else
+          message.body.compile
+            .to(fs2.Collector.supportsByteVector(ByteVector))
+            .map(_.toHex)
+
+      Some(string)
     } else None
 
   def logMessage[F[_]](message: Message[F])(


### PR DESCRIPTION
A counterpart to #6880. Kudos to @armanbilge for finding this initially.
* throughput:
```
Benchmark                                  (size)  Mode  Cnt    Score     Error   Units
CurrentStringBuilding                        100  thrpt    5   95.480 ±   0.631  ops/ms
CurrentStringBuilding                       1000  thrpt    5   30.786 ±   0.392  ops/ms
CurrentStringBuilding                      10000  thrpt    5    4.903 ±   0.028  ops/ms
StreamToByteVectorStringBuilding             100  thrpt    5  166.562 ±   5.433  ops/ms
StreamToByteVectorStringBuilding            1000  thrpt    5   80.068 ± 106.562  ops/ms
StreamToByteVectorStringBuilding           10000  thrpt    5   17.376 ±   0.389  ops/ms
StreamToChunksToByteVectorStringBuilding     100  thrpt    5   96.616 ±   0.833  ops/ms
StreamToChunksToByteVectorStringBuilding    1000  thrpt    5   67.196 ±   0.701  ops/ms
StreamToChunksToByteVectorStringBuilding   10000  thrpt    5   15.592 ±   0.480  ops/ms
```

* memory consumption:
```
Benchmark                                                           (size) Mode  Cnt       Score   Error   Units
CurrentStringBuilding:·gc.alloc.rate.norm                             100  avgt    5   15977.466 ± 0.047    B/op
CurrentStringBuilding:·gc.count                                       100  avgt    5     300.000            counts
CurrentStringBuilding:·gc.alloc.rate.norm                            1000  avgt    5   68685.704 ± 0.153    B/op
CurrentStringBuilding:·gc.count                                      1000  avgt    5     392.000            counts
CurrentStringBuilding:·gc.alloc.rate.norm                           10000  avgt    5  623299.715 ± 1.102    B/op
CurrentStringBuilding:·gc.count                                     10000  avgt    5     548.000            counts
StreamToByteVectorStringBuilding:·gc.alloc.rate.norm                  100  avgt    5    5088.759 ± 0.022    B/op
StreamToByteVectorStringBuilding:·gc.count                            100  avgt    5     275.000            counts
StreamToByteVectorStringBuilding:·gc.alloc.rate.norm                 1000  avgt    5   10801.604 ± 0.060    B/op
StreamToByteVectorStringBuilding:·gc.count                           1000  avgt    5     332.000            counts
StreamToByteVectorStringBuilding:·gc.alloc.rate.norm                10000  avgt    5   97993.857 ± 0.206    B/op
StreamToByteVectorStringBuilding:·gc.count                          10000  avgt    5     371.000            counts
StreamToChunksToByteVectorStringBuilding:·gc.alloc.rate.norm          100  avgt    5   16881.402 ± 0.058    B/op
StreamToChunksToByteVectorStringBuilding:·gc.count                    100  avgt    5     294.000            counts
StreamToChunksToByteVectorStringBuilding:·gc.alloc.rate.norm         1000  avgt    5   26362.198 ± 0.096    B/op
StreamToChunksToByteVectorStringBuilding:·gc.count                   1000  avgt    5     309.000            counts
StreamToChunksToByteVectorStringBuilding:·gc.alloc.rate.norm        10000  avgt    5  149748.486 ± 0.396    B/op
StreamToChunksToByteVectorStringBuilding:·gc.count                  10000  avgt    5     420.000            counts
```
Benchmark's code is [here](https://gist.github.com/danicheg/63c563b02900481900550d91db798d2c#file-streamcompilebench-scala).