### PR TITLE
JS-Artifact: set header copyright to 2022

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -685,6 +685,7 @@ lazy val bench = http4sProject("bench")
 lazy val jsArtifactSizeTest = http4sProject("js-artifact-size-test")
   .enablePlugins(ScalaJSPlugin, NoPublishPlugin)
   .settings(
+    startYear := Some(2022),
     // CI automatically links SJS test artifacts in a separate step, to avoid OOMs while running tests
     // By placing the app in Test scope it gets linked as part of that CI step
     Test / scalaJSUseMainModuleInitializer := true,

--- a/js-artifact-size-test/src/test/scala/Main.scala
+++ b/js-artifact-size-test/src/test/scala/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 http4s.org
+ * Copyright 2022 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js-artifact-size-test/src/test/scala/Main.scala
+++ b/js-artifact-size-test/src/test/scala/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 http4s.org
+ * Copyright 2023 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is hitting some builds.