### PR TITLE
Ember server reduce state

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -396,102 +396,101 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
         case _: TimeoutException => EmberException.ReadTimeout(idleTimeout)
       }
     Stream
-      .unfoldEval[F, State, Response[F]](initialBuffer.toArray -> false) {
-        case (buffer, reuse) =>
-          val initRead: F[Array[Byte]] = if (buffer.nonEmpty) {
-            // next request has already been (partially) received
-            buffer.pure[F]
-          } else if (reuse) {
-            // the connection is keep-alive, but we don't have any bytes.
-            // we want to be on the idle timeout until the next request is received.
-            read
-              .flatMap {
-                case Some(chunk) => chunk.toArray.pure[F]
-                case None => Concurrent[F].raiseError(EmberException.EmptyStream())
-              }
-          } else {
-            // first request begins immediately
-            Array.emptyByteArray.pure[F]
-          }
+      .unfoldEval[F, State, Response[F]](initialBuffer.toArray -> false) { case (buffer, reuse) =>
+        val initRead: F[Array[Byte]] = if (buffer.nonEmpty) {
+          // next request has already been (partially) received
+          buffer.pure[F]
+        } else if (reuse) {
+          // the connection is keep-alive, but we don't have any bytes.
+          // we want to be on the idle timeout until the next request is received.
+          read
+            .flatMap {
+              case Some(chunk) => chunk.toArray.pure[F]
+              case None => Concurrent[F].raiseError(EmberException.EmptyStream())
+            }
+        } else {
+          // first request begins immediately
+          Array.emptyByteArray.pure[F]
+        }
 
-          val result = initRead.flatMap { initBuffer =>
-            runApp(
-              initBuffer,
-              read,
-              maxHeaderSize,
-              requestHeaderReceiveTimeout,
-              finalApp,
-              errorHandler,
-              socket,
-              createRequestVault,
-            )
-          }
+        val result = initRead.flatMap { initBuffer =>
+          runApp(
+            initBuffer,
+            read,
+            maxHeaderSize,
+            requestHeaderReceiveTimeout,
+            finalApp,
+            errorHandler,
+            socket,
+            createRequestVault,
+          )
+        }
 
-          result.attempt.flatMap {
-            case Right((req, resp, drain)) =>
-              // TODO: Should we pay this cost for every HTTP request?
-              // Intercept the response for various upgrade paths
-              resp.attributes.lookup(webSocketKey) match {
-                case Some(ctx) =>
-                  drain.flatMap {
-                    case Some(buffer) =>
-                      WebSocketHelpers
-                        .upgrade(
+        result.attempt.flatMap {
+          case Right((req, resp, drain)) =>
+            // TODO: Should we pay this cost for every HTTP request?
+            // Intercept the response for various upgrade paths
+            resp.attributes.lookup(webSocketKey) match {
+              case Some(ctx) =>
+                drain.flatMap {
+                  case Some(buffer) =>
+                    WebSocketHelpers
+                      .upgrade(
+                        socket,
+                        req,
+                        ctx,
+                        buffer,
+                        receiveBufferSize,
+                        idleTimeout,
+                        onWriteFailure,
+                        errorHandler,
+                        logger,
+                      )
+                      .as(None)
+                  case None =>
+                    Applicative[F].pure(None)
+                }
+              case None =>
+                resp.attributes.lookup(H2Keys.H2cUpgrade) match {
+                  // Http1.1
+                  case None =>
+                    for {
+                      nextResp <- postProcessResponse(req, resp)
+                      _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
+                      nextBuffer <- drain
+                    } yield nextBuffer.map(buffer => (nextResp, (buffer, true)))
+                  // h2c escalation of the connection
+                  case Some((settings, newReq)) =>
+                    for {
+                      nextResp <- postProcessResponse(req, resp)
+                      _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
+                      _ <- H2Server.requireConnectionPreface(socket)
+                      out <- H2Server
+                        .fromSocket(
                           socket,
-                          req,
-                          ctx,
-                          buffer,
-                          receiveBufferSize,
-                          idleTimeout,
-                          onWriteFailure,
-                          errorHandler,
+                          httpApp,
+                          H2Frame.Settings.ConnectionSettings.default,
                           logger,
+                          settings,
+                          newReq.some,
                         )
+                        .use(_ => Async[F].never[Unit])
                         .as(None)
-                    case None =>
-                      Applicative[F].pure(None)
-                  }
-                case None =>
-                  resp.attributes.lookup(H2Keys.H2cUpgrade) match {
-                    // Http1.1
-                    case None =>
-                      for {
-                        nextResp <- postProcessResponse(req, resp)
-                        _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
-                        nextBuffer <- drain
-                      } yield nextBuffer.map(buffer => (nextResp, (buffer, true)))
-                    // h2c escalation of the connection
-                    case Some((settings, newReq)) =>
-                      for {
-                        nextResp <- postProcessResponse(req, resp)
-                        _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
-                        _ <- H2Server.requireConnectionPreface(socket)
-                        out <- H2Server
-                          .fromSocket(
-                            socket,
-                            httpApp,
-                            H2Frame.Settings.ConnectionSettings.default,
-                            logger,
-                            settings,
-                            newReq.some,
-                          )
-                          .use(_ => Async[F].never[Unit])
-                          .as(None)
-                      } yield out
-                  }
-              }
-            case Left(err) =>
-              err match {
-                case EmberException.EmptyStream() | EmberException.RequestHeadersTimeout(_) |
-                    EmberException.ReadTimeout(_) =>
-                  Applicative[F].pure(None)
-                case err =>
-                  errorHandler(err)
-                    .handleError(_ => serverFailure.covary[F])
-                    .flatMap(send(socket)(None, _, idleTimeout, onWriteFailure))
-                    .as(None)
-              }
-          }
+                    } yield out
+                }
+            }
+          case Left(err) =>
+            err match {
+              case EmberException.EmptyStream() | EmberException.RequestHeadersTimeout(_) |
+                  EmberException.ReadTimeout(_) =>
+                Applicative[F].pure(None)
+              case err =>
+                errorHandler(err)
+                  .handleError(_ => serverFailure.covary[F])
+                  .flatMap(send(socket)(None, _, idleTimeout, onWriteFailure))
+                  .as(None)
+            }
+        }
       }
       .takeWhile(_.headers.get[Connection].exists(_.hasKeepAlive))
       .drain


### PR DESCRIPTION
The stream generated by the call to unfoldEval emits requests-response pairs, but the downstream only uses the response to decide if it continues pulling from that stream. Thus we reduce what the stream emits.

This in turn triggers a lot of Scalafmt changes to the block. 

Reviewers may find it convenient to hide whitespace changes