### PR TITLE
ServerHelpers: write runConnection loop without Streams

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -399,105 +399,109 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
     def isAlive(r: Response[F]): Boolean =
       r.headers.get[Connection].exists(_.hasKeepAlive)
 
+    def step(buffer: Array[Byte], reuse: Boolean): F[Option[(Unit, State)]] = {
+      val initRead: F[Array[Byte]] = if (buffer.nonEmpty) {
+        // next request has already been (partially) received
+        buffer.pure[F]
+      } else if (reuse) {
+        // the connection is keep-alive, but we don't have any bytes.
+        // we want to be on the idle timeout until the next request is received.
+        read
+          .flatMap {
+            case Some(chunk) => chunk.toArray.pure[F]
+            case None => Concurrent[F].raiseError(EmberException.EmptyStream())
+          }
+      } else {
+        // first request begins immediately
+        Array.emptyByteArray.pure[F]
+      }
+
+      val result = initRead.flatMap { initBuffer =>
+        runApp(
+          initBuffer,
+          read,
+          maxHeaderSize,
+          requestHeaderReceiveTimeout,
+          finalApp,
+          errorHandler,
+          socket,
+          createRequestVault,
+        )
+      }
+
+      result.attempt.flatMap {
+        case Right((req, resp, drain)) =>
+          // TODO: Should we pay this cost for every HTTP request?
+          // Intercept the response for various upgrade paths
+          resp.attributes.lookup(webSocketKey) match {
+            case Some(ctx) =>
+              drain.flatMap {
+                case Some(buffer) =>
+                  WebSocketHelpers
+                    .upgrade(
+                      socket,
+                      req,
+                      ctx,
+                      buffer,
+                      receiveBufferSize,
+                      idleTimeout,
+                      onWriteFailure,
+                      errorHandler,
+                      logger,
+                    )
+                    .as(None)
+                case None =>
+                  Applicative[F].pure(None)
+              }
+            case None =>
+              resp.attributes.lookup(H2Keys.H2cUpgrade) match {
+                // Http1.1
+                case None =>
+                  for {
+                    nextResp <- postProcessResponse(req, resp)
+                    _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
+                    nextBuffer <- drain
+                  } yield nextBuffer match {
+                    case Some(buffer) if isAlive(nextResp) => Some(() -> (buffer, true))
+                    case _ => None
+                  }
+                // h2c escalation of the connection
+                case Some((settings, newReq)) =>
+                  for {
+                    nextResp <- postProcessResponse(req, resp)
+                    _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
+                    _ <- H2Server.requireConnectionPreface(socket)
+                    out <- H2Server
+                      .fromSocket(
+                        socket,
+                        httpApp,
+                        H2Frame.Settings.ConnectionSettings.default,
+                        logger,
+                        settings,
+                        newReq.some,
+                      )
+                      .use(_ => Async[F].never[Unit])
+                      .as(None)
+                  } yield out
+              }
+          }
+        case Left(err) =>
+          err match {
+            case EmberException.EmptyStream() | EmberException.RequestHeadersTimeout(_) |
+                EmberException.ReadTimeout(_) =>
+              Applicative[F].pure(None)
+            case err =>
+              errorHandler(err)
+                .handleError(_ => serverFailure.covary[F])
+                .flatMap(send(socket)(None, _, idleTimeout, onWriteFailure))
+                .as(None)
+          }
+      }
+    }
+
     Stream
       .unfoldEval[F, State, Unit](initialBuffer.toArray -> false) { case (buffer, reuse) =>
-        val initRead: F[Array[Byte]] = if (buffer.nonEmpty) {
-          // next request has already been (partially) received
-          buffer.pure[F]
-        } else if (reuse) {
-          // the connection is keep-alive, but we don't have any bytes.
-          // we want to be on the idle timeout until the next request is received.
-          read
-            .flatMap {
-              case Some(chunk) => chunk.toArray.pure[F]
-              case None => Concurrent[F].raiseError(EmberException.EmptyStream())
-            }
-        } else {
-          // first request begins immediately
-          Array.emptyByteArray.pure[F]
-        }
-
-        val result = initRead.flatMap { initBuffer =>
-          runApp(
-            initBuffer,
-            read,
-            maxHeaderSize,
-            requestHeaderReceiveTimeout,
-            finalApp,
-            errorHandler,
-            socket,
-            createRequestVault,
-          )
-        }
-
-        result.attempt.flatMap {
-          case Right((req, resp, drain)) =>
-            // TODO: Should we pay this cost for every HTTP request?
-            // Intercept the response for various upgrade paths
-            resp.attributes.lookup(webSocketKey) match {
-              case Some(ctx) =>
-                drain.flatMap {
-                  case Some(buffer) =>
-                    WebSocketHelpers
-                      .upgrade(
-                        socket,
-                        req,
-                        ctx,
-                        buffer,
-                        receiveBufferSize,
-                        idleTimeout,
-                        onWriteFailure,
-                        errorHandler,
-                        logger,
-                      )
-                      .as(None)
-                  case None =>
-                    Applicative[F].pure(None)
-                }
-              case None =>
-                resp.attributes.lookup(H2Keys.H2cUpgrade) match {
-                  // Http1.1
-                  case None =>
-                    for {
-                      nextResp <- postProcessResponse(req, resp)
-                      _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
-                      nextBuffer <- drain
-                    } yield nextBuffer match {
-                      case Some(buffer) if isAlive(nextResp) => Some(() -> (buffer, true))
-                      case _ => None
-                    }
-                  // h2c escalation of the connection
-                  case Some((settings, newReq)) =>
-                    for {
-                      nextResp <- postProcessResponse(req, resp)
-                      _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
-                      _ <- H2Server.requireConnectionPreface(socket)
-                      out <- H2Server
-                        .fromSocket(
-                          socket,
-                          httpApp,
-                          H2Frame.Settings.ConnectionSettings.default,
-                          logger,
-                          settings,
-                          newReq.some,
-                        )
-                        .use(_ => Async[F].never[Unit])
-                        .as(None)
-                    } yield out
-                }
-            }
-          case Left(err) =>
-            err match {
-              case EmberException.EmptyStream() | EmberException.RequestHeadersTimeout(_) |
-                  EmberException.ReadTimeout(_) =>
-                Applicative[F].pure(None)
-              case err =>
-                errorHandler(err)
-                  .handleError(_ => serverFailure.covary[F])
-                  .flatMap(send(socket)(None, _, idleTimeout, onWriteFailure))
-                  .as(None)
-            }
-        }
+        step(buffer, reuse)
       }
       .drain
   }

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -212,7 +212,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                   webSocketKey,
                   ByteVector.empty,
                   enableHttp2,
-                ).drain
+                )
               case (socket, None) => // Cleartext Protocol
                 enableHttp2 match {
                   case true =>
@@ -234,7 +234,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                           webSocketKey,
                           bv, // Pass read bytes we thought might be the prelude
                           enableHttp2,
-                        ).drain
+                        )
                       case Right(_) =>
                         Stream
                           .resource(
@@ -263,7 +263,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                       webSocketKey,
                       ByteVector.empty,
                       enableHttp2,
-                    ).drain
+                    )
                 }
             }
 


### PR DESCRIPTION
In the `ember-server` module, in the `ServerHelpers` file, we modify the implementation of the `runConnection` function. Currently, the loop consists of generating a stream of responses, generated with a `Stream.unfoldEval` that emits the response and the next state. The generated stream is then controlled with the `takeWhile` function, and then drained.  Instead, the changes in this PR: 
 
- Extract the body of the `unfoldEval` (the long lambda expression) as a step function.
- Extract the condition `isAlive` to checks if a connection is alive or not and thus discards.
- Add a tail-recursive (in F) call to `step` and reduce its data type to `F[Unit]`, making an F-procedure.

These changes should reduce the allocations needed for generating and processing that streams of responses.

However, since the rest of the file is tied to the `Stream` type, and to avoid propagating more changes, we wrap the call to the resulting function in an `Stream.exec`. 

_Note_ most of the line changes are whitespace changes.