### PR TITLE
Use Vault#contains to check for PriorKnowledge

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -276,7 +276,7 @@ private[ember] class H2Client[F[_]](
       case Some(_) => true
       case None => true
     }
-    val priorKnowledge = req.attributes.lookup(H2Keys.Http2PriorKnowledge).isDefined
+    val priorKnowledge = req.attributes.contains(H2Keys.Http2PriorKnowledge)
     for {
       connection <- Resource.eval(
         getOrCreate(key, useTLS, priorKnowledge, enableEndpointValidation)
@@ -335,7 +335,7 @@ private[ember] object H2Client {
       h2 = new H2Client(Network[F], settings, tlsContext, mapH2, onPushPromise, logger)
     } yield (http1Client: TinyClient[F]) => { (req: Request[F]) =>
       val key = H2Client.RequestKey.fromRequest(req)
-      val priorKnowledge = req.attributes.lookup(H2Keys.Http2PriorKnowledge).isDefined
+      val priorKnowledge = req.attributes.contains(H2Keys.Http2PriorKnowledge)
       val socketTypeF = if (priorKnowledge) Some(Http2).pure[F] else socketMap.get.map(_.get(key))
       Resource.eval(socketTypeF).flatMap {
         case Some(Http2) => h2.runHttp2Only(req, enableEndpointValidation)


### PR DESCRIPTION
_Not intended to actually merge into `update/series/0.23/vault-3.5.0`, the base should change when https://github.com/http4s/http4s/pull/6892 merges._

This PR simply uses the [new `contains` method](https://www.javadoc.io/doc/org.typelevel/vault_2.13/latest/org/typelevel/vault/Vault.html#contains(k:org.typelevel.vault.DeleteKey):Boolean) on `Vault` when checking for Http2PriorKnowledge.