### PR TITLE
Use jdk8 in default devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
         };
       in
       rec {
-        devShell = devShells."temurin@8";
+        devShell = mkShell pkgs.jdk8;
 
         devShells = {
           "temurin@8" = mkShell pkgs.temurin-bin-8;


### PR DESCRIPTION
The temurin package doesn't exist for all architectures, notably aarch64-darwin.  The temurin is for CI.  This is so users with Apple Silicon can build locally.