### PR TITLE
Free invariant HTTP codecs

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/HttpVersionDecodeBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/HttpVersionDecodeBench.scala
@@ -1,0 +1,37 @@
+package org.http4s.bench
+
+import org.http4s._
+import org.openjdk.jmh.annotations._
+
+import cats.parse.Parser
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+class HttpVersionDecodeBench {
+  import HttpVersionDecodeBench._
+
+  @Benchmark
+  def parseNew: Either[Any, HttpVersion] =
+    http1Parser.parseAll("HTTP/1.1")
+
+  @Benchmark
+  def parseOld: Either[Any, HttpVersion] =
+    http1ParserOld.parseAll("HTTP/1.1")
+}
+
+object HttpVersionDecodeBench {
+  val http1Parser = HttpVersion.http1Codec.foldMap(org.http4s.codec.catsParserDecoder)
+  val http1ParserOld: Parser[HttpVersion] = {
+    import cats.parse.{Parser => P}
+    import cats.parse.Rfc5234.digit
+    // HTTP-name = %x48.54.54.50 ; HTTP
+    // HTTP-version = HTTP-name "/" DIGIT "." DIGIT
+    val httpVersion = P.string("HTTP/") *> digit ~ (P.char('.') *> digit)
+
+    httpVersion.map { case (major, minor) =>
+      new HttpVersion(major - '0', minor - '0')
+    }
+  }
+}

--- a/bench/src/main/scala/org/http4s/bench/HttpVersionEncodeBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/HttpVersionEncodeBench.scala
@@ -1,0 +1,59 @@
+package org.http4s.bench
+
+import org.http4s._
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+class HttpVersionEncodeBench {
+  import HttpVersionEncodeBench._
+  import org.http4s.util._
+
+  @Benchmark
+  def renderNew: String = {
+    val sw = new StringWriter()
+    http1Render.render(sw, HttpVersion.`HTTP/1.1`)
+    sw.result
+  }
+
+  @Benchmark
+  def renderOld: String = {
+    val sw = new StringWriter()
+    http1RenderOld.render(sw, HttpVersion.`HTTP/1.1`)
+    sw.result
+  }
+
+  @Benchmark
+  def renderList: String = {
+    val sw = new StringWriter()
+    http1RenderList.render(sw, HttpVersionEncodeBench.list)
+    sw.result
+  }
+
+  @Benchmark
+  def renderListOld: String = {
+    val sw = new StringWriter()
+    http1RenderListOld.render(sw, HttpVersionEncodeBench.list)
+    sw.result
+  }
+}
+
+object HttpVersionEncodeBench {
+  import org.http4s.codec._
+
+  val http1Render = HttpVersion.http1Codec.foldMap(rendererEncoder)
+  val http1RenderList = Http1Codec.listOf(HttpVersion.http1Codec).foldMap(rendererEncoder)
+
+  val list = List.fill(100)(HttpVersion.`HTTP/1.1`)
+
+  val http1RenderOld: org.http4s.util.Renderer[HttpVersion] =
+    new org.http4s.util.Renderer[HttpVersion] {
+      def render(writer: org.http4s.util.Writer, v: HttpVersion): writer.type =
+        writer << "HTTP/" << v.major << '.' << v.minor
+    }
+  val http1RenderListOld: org.http4s.util.Renderer[List[HttpVersion]] =
+    org.http4s.util.Renderer.listRenderer(http1RenderOld)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -114,6 +114,7 @@ lazy val core = libraryCrossProject("core")
       caseInsensitive.value,
       catsCore.value,
       catsEffectStd.value,
+      catsFree.value,
       catsParse.value.exclude("org.typelevel", "cats-core_2.13"),
       crypto.value,
       fs2Core.value,

--- a/core/jvm/src/main/scala/org/http4s/codec/Http1Codec.scala
+++ b/core/jvm/src/main/scala/org/http4s/codec/Http1Codec.scala
@@ -7,6 +7,7 @@ object Http1Codec {
   final case class StringLiteral(s: String) extends Op[Unit]
   final case class CharLiteral(c: Char) extends Op[Unit]
   case object Digit extends Op[Char]
+  final case class ListOf[A](codec: Http1Codec[A]) extends Op[List[A]]
 
   def stringLiteral(s: String): Http1Codec[Unit] =
     lift(StringLiteral(s))
@@ -14,6 +15,8 @@ object Http1Codec {
     lift(CharLiteral(c))
   def digit: Http1Codec[Char] =
     lift(Digit)
+  def listOf[A](codec: Http1Codec[A]): Http1Codec[List[A]] =
+    lift(ListOf(codec))
 
   def lift[A](op: Op[A]): Http1Codec[A] =
     FreeInvariantMonoidal.lift(op)

--- a/core/jvm/src/main/scala/org/http4s/codec/Http1Codec.scala
+++ b/core/jvm/src/main/scala/org/http4s/codec/Http1Codec.scala
@@ -1,0 +1,20 @@
+package org.http4s.codec
+
+import cats.free.FreeInvariantMonoidal
+
+object Http1Codec {
+  sealed trait Op[A]
+  final case class StringLiteral(s: String) extends Op[Unit]
+  final case class CharLiteral(c: Char) extends Op[Unit]
+  case object Digit extends Op[Char]
+
+  def stringLiteral(s: String): Http1Codec[Unit] =
+    lift(StringLiteral(s))
+  def charLiteral(c: Char): Http1Codec[Unit] =
+    lift(CharLiteral(c))
+  def digit: Http1Codec[Char] =
+    lift(Digit)
+
+  def lift[A](op: Op[A]): Http1Codec[A] =
+    FreeInvariantMonoidal.lift(op)
+}

--- a/core/jvm/src/main/scala/org/http4s/codec/catsParserDecoder.scala
+++ b/core/jvm/src/main/scala/org/http4s/codec/catsParserDecoder.scala
@@ -1,0 +1,15 @@
+package org.http4s.codec
+
+import cats.parse.Parser
+import cats.parse.Parser0
+import cats.parse.Rfc5234
+import cats.~>
+
+object catsParserDecoder extends (Http1Codec.Op ~> Parser0) {
+  def apply[A](op: Http1Codec.Op[A]): Parser0[A] =
+    op match {
+      case Http1Codec.StringLiteral(s) => Parser.string(s)
+      case Http1Codec.CharLiteral(c) => Parser.char(c)
+      case Http1Codec.Digit => Rfc5234.digit
+    }
+}

--- a/core/jvm/src/main/scala/org/http4s/codec/catsParserDecoder.scala
+++ b/core/jvm/src/main/scala/org/http4s/codec/catsParserDecoder.scala
@@ -11,5 +11,7 @@ object catsParserDecoder extends (Http1Codec.Op ~> Parser0) {
       case Http1Codec.StringLiteral(s) => Parser.string(s)
       case Http1Codec.CharLiteral(c) => Parser.char(c)
       case Http1Codec.Digit => Rfc5234.digit
+      case Http1Codec.ListOf(codec) =>
+        codec.foldMap(this).asInstanceOf[Parser[A]].rep0
     }
 }

--- a/core/jvm/src/main/scala/org/http4s/codec/package.scala
+++ b/core/jvm/src/main/scala/org/http4s/codec/package.scala
@@ -1,0 +1,7 @@
+package org.http4s
+
+import cats.free.FreeInvariantMonoidal
+
+package object codec {
+  type Http1Codec[A] = FreeInvariantMonoidal[Http1Codec.Op, A]
+}

--- a/core/jvm/src/main/scala/org/http4s/codec/rendererEncoder.scala
+++ b/core/jvm/src/main/scala/org/http4s/codec/rendererEncoder.scala
@@ -9,5 +9,7 @@ object rendererEncoder extends (Http1Codec.Op ~> Renderer) {
       case Http1Codec.StringLiteral(s) => Renderer.stringLiteralRenderer(s)
       case Http1Codec.CharLiteral(c) => Renderer.charLiteralRenderer(c)
       case Http1Codec.Digit => Renderer.charRenderer
+      case Http1Codec.ListOf(codec) =>
+        Renderer.listRenderer(codec.foldMap(rendererEncoder))
     }
 }

--- a/core/jvm/src/main/scala/org/http4s/codec/rendererEncoder.scala
+++ b/core/jvm/src/main/scala/org/http4s/codec/rendererEncoder.scala
@@ -1,0 +1,13 @@
+package org.http4s.codec
+
+import cats.~>
+import org.http4s.util.Renderer
+
+object rendererEncoder extends (Http1Codec.Op ~> Renderer) {
+  def apply[A](op: Http1Codec.Op[A]): Renderer[A] =
+    op match {
+      case Http1Codec.StringLiteral(s) => Renderer.stringLiteralRenderer(s)
+      case Http1Codec.CharLiteral(c) => Renderer.charLiteralRenderer(c)
+      case Http1Codec.Digit => Renderer.charRenderer
+    }
+}

--- a/core/shared/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/shared/src/main/scala/org/http4s/HttpVersion.scala
@@ -20,9 +20,11 @@ import cats.Hash
 import cats.Order
 import cats.Show
 import cats.kernel.BoundedEnumerable
-import cats.parse.Rfc5234.digit
-import cats.parse.{Parser => P}
+import cats.parse.Parser0
 import cats.syntax.all._
+import org.http4s.codec.Http1Codec
+import org.http4s.codec.catsParserDecoder
+import org.http4s.codec.rendererEncoder
 import org.http4s.util._
 
 /** HTTP's version number consists of two decimal digits separated by
@@ -41,7 +43,7 @@ import org.http4s.util._
   * HTTP Semantics, Protocol Versioning]]
   */
 // scalafix:off Http4sGeneralLinters.nonValidatingCopyConstructor; bincompat until 1.0
-final case class HttpVersion private[HttpVersion] (major: Int, minor: Int)
+final case class HttpVersion private[http4s] (major: Int, minor: Int)
     extends Renderable
     with Ordered[HttpVersion] {
   // scalafix:on
@@ -53,7 +55,8 @@ final case class HttpVersion private[HttpVersion] (major: Int, minor: Int)
     * HTTP/1.1
     * }}}
     */
-  override def render(writer: Writer): writer.type = writer << "HTTP/" << major << '.' << minor
+  override def render(writer: Writer): writer.type =
+    HttpVersion.renderer.render(writer, this)
 
   /** Orders by major version ascending, then minor version ascending.
     *
@@ -153,6 +156,23 @@ object HttpVersion {
   private[this] val right_1_0 = Right(`HTTP/1.0`)
   private[this] val right_1_1 = Right(`HTTP/1.1`)
 
+  val http1Codec: Http1Codec[HttpVersion] = {
+    // HTTP-name = %x48.54.54.50 ; HTTP
+    // HTTP-version = HTTP-name "/" DIGIT "." DIGIT
+    import Http1Codec._
+    (
+      stringLiteral("HTTP/"),
+      digit.imap(_ - '0')(i => (i + '0').toChar),
+      charLiteral('.'),
+      digit.imap(_ - '0')(i => (i + '0').toChar),
+    ).imapN((_, major, _, minor) => new HttpVersion(major, minor))(httpVersion =>
+      ((), httpVersion.major, (), httpVersion.minor)
+    )
+  }
+
+  private val renderer: Renderer[HttpVersion] =
+    http1Codec.foldMap(rendererEncoder)
+
   /** Returns an HTTP version from its HTTP/1 string representation.
     *
     * {{{
@@ -168,15 +188,8 @@ object HttpVersion {
         ParseResult.fromParser(parser, "HTTP version")(s)
     }
 
-  private val parser: P[HttpVersion] = {
-    // HTTP-name = %x48.54.54.50 ; HTTP
-    // HTTP-version = HTTP-name "/" DIGIT "." DIGIT
-    val httpVersion = P.string("HTTP/") *> digit ~ (P.char('.') *> digit)
-
-    httpVersion.map { case (major, minor) =>
-      new HttpVersion(major - '0', minor - '0')
-    }
-  }
+  private val parser: Parser0[HttpVersion] =
+    http1Codec.foldMap(catsParserDecoder)
 
   /** Returns an HTTP version from a major and minor version.
     *

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -149,6 +149,7 @@ object Http4sPlugin extends AutoPlugin {
   lazy val catsEffectStd = Def.setting("org.typelevel" %%% "cats-effect-std" % V.catsEffect)
   lazy val catsEffectLaws = Def.setting("org.typelevel" %%% "cats-effect-laws" % V.catsEffect)
   lazy val catsEffectTestkit = Def.setting("org.typelevel" %%% "cats-effect-testkit" % V.catsEffect)
+  lazy val catsFree = Def.setting("org.typelevel" %%% "cats-free" % V.cats)
   lazy val catsLaws = Def.setting("org.typelevel" %%% "cats-laws" % V.cats)
   lazy val catsParse = Def.setting("org.typelevel" %%% "cats-parse" % V.catsParse)
   lazy val circeCore = Def.setting("io.circe" %%% "circe-core" % V.circe)


### PR DESCRIPTION
Replaces the renderer and parser of the core HTTP types with a free algebra.  This can then be interpreted into:

* Cats Parse for nice error and composition in String contexts
* A prospective binary parser that gets right to ByteBuffer
* Renderer for compatibility with today
* A prospective fast encoder that goes straight to ByteBuffer
* Similar for Netty's ByteBuf, if that backend wants to make its own codecs instead of intermediate passes through Netty's

A path away from #6915.  A different take on #5356.