### PR TITLE
Use `Chunk` builder instead of `Buffer` in `ChunkWriter`

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/ChunkWriterBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/ChunkWriterBench.scala
@@ -19,9 +19,8 @@ class ChunkWriterBench {
   private val alphaNum = (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')).toVector
 
   @Setup(Level.Trial)
-  def setup(): Unit = {
+  def setup(): Unit =
     singleString = Vector.fill(size)(alphaNum(Random.nextInt(alphaNum.length))).mkString
-  }
 
   @Benchmark
   def appendSingleString: Chunk[Byte] = {

--- a/bench/src/main/scala/org/http4s/bench/ChunkWriterBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/ChunkWriterBench.scala
@@ -4,6 +4,7 @@ import fs2.Chunk
 import org.http4s.internal.ChunkWriter
 import org.openjdk.jmh.annotations._
 
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.util.Random
 
@@ -15,18 +16,29 @@ class ChunkWriterBench {
   var size: Int = _
 
   private var singleString: String = _
+  private var batchOfStings: Vector[String] = _
 
   private val alphaNum = (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')).toVector
 
   @Setup(Level.Trial)
-  def setup(): Unit =
+  def setup(): Unit = {
     singleString = Vector.fill(size)(alphaNum(Random.nextInt(alphaNum.length))).mkString
+    batchOfStings = Vector.fill(size)(UUID.randomUUID().toString)
+  }
 
   @Benchmark
   def appendSingleString: Chunk[Byte] = {
     val cw = new ChunkWriter()
 
     cw.append(singleString)
+    cw.toChunk
+  }
+
+  @Benchmark
+  def appendStringBatch: Chunk[Byte] = {
+    val cw = new ChunkWriter()
+
+    batchOfStings.foreach(cw.append)
     cw.toChunk
   }
 }

--- a/bench/src/main/scala/org/http4s/bench/ChunkWriterBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/ChunkWriterBench.scala
@@ -1,0 +1,33 @@
+package org.http4s.bench
+
+import fs2.Chunk
+import org.http4s.internal.ChunkWriter
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.util.Random
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+class ChunkWriterBench {
+  @Param(Array("100", "1000", "10000"))
+  var size: Int = _
+
+  private var singleString: String = _
+
+  private val alphaNum = (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')).toVector
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    singleString = Vector.fill(size)(alphaNum(Random.nextInt(alphaNum.length))).mkString
+  }
+
+  @Benchmark
+  def appendSingleString: Chunk[Byte] = {
+    val cw = new ChunkWriter()
+
+    cw.append(singleString)
+    cw.toChunk
+  }
+}

--- a/bench/src/main/scala/org/http4s/bench/ChunkWriterBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/ChunkWriterBench.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.bench
 
 import fs2.Chunk

--- a/core/shared/src/main/scala/org/http4s/internal/ChunkWriter.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/ChunkWriter.scala
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets
 /** [[Writer]] that will result in a `Chunk`
   */
 private[http4s] class ChunkWriter(
-   charset: Charset = StandardCharsets.UTF_8
+    charset: Charset = StandardCharsets.UTF_8
 ) extends Writer {
   private[this] val builder = Chunk.newBuilder[Byte]
 

--- a/core/shared/src/main/scala/org/http4s/internal/ChunkWriter.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/ChunkWriter.scala
@@ -21,19 +21,18 @@ import org.http4s.util.Writer
 
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
-import scala.collection.mutable.Buffer
 
 /** [[Writer]] that will result in a `Chunk`
   */
 private[http4s] class ChunkWriter(
-    charset: Charset = StandardCharsets.UTF_8
+   charset: Charset = StandardCharsets.UTF_8
 ) extends Writer {
-  private[this] val chunks = Buffer[Chunk[Byte]]()
+  private[this] val builder = Chunk.newBuilder[Byte]
 
-  def toChunk: Chunk[Byte] = Chunk.concat(chunks)
+  def toChunk: Chunk[Byte] = builder.result
 
   override def append(s: String): this.type = {
-    chunks += Chunk.array(s.getBytes(charset))
+    builder += Chunk.array(s.getBytes(charset))
     this
   }
 }


### PR DESCRIPTION
* Throughput before changes:
```
Benchmark           (size)   Mode  Cnt      Score     Error   Units
appendSingleString     100  thrpt    5  21439.685 ± 814.071  ops/ms
appendSingleString    1000  thrpt    5   7990.988 ± 311.376  ops/ms
appendSingleString   10000  thrpt    5    762.789 ±  65.330  ops/ms
appendStringBatch      100  thrpt    5    366.361 ±  21.818  ops/ms
appendStringBatch     1000  thrpt    5     36.774 ±   0.392  ops/ms
appendStringBatch    10000  thrpt    5      3.120 ±   0.066  ops/ms
```
* Memory consumption before changes:
```
appendSingleString:·gc.alloc.rate.norm        100  avgt    5      464.018 ±     0.001    B/op
appendSingleString:·gc.alloc.rate.norm       1000  avgt    5     2272.061 ±     0.001    B/op
appendSingleString:·gc.alloc.rate.norm      10000  avgt    5    20272.914 ±     0.011    B/op
appendStringBatch:·gc.alloc.rate.norm         100  avgt    5    15145.028 ±     0.040    B/op
appendStringBatch:·gc.alloc.rate.norm        1000  avgt    5   148390.629 ±     0.449    B/op
appendStringBatch:·gc.alloc.rate.norm       10000  avgt    5  1531428.925 ±     4.025    B/op
```
* Throughput after changes:
```
Benchmark           (size)   Mode  Cnt      Score      Error   Units
appendSingleString     100  thrpt    5  74746.042 ± 1166.192  ops/ms
appendSingleString    1000  thrpt    5  19464.679 ± 2386.691  ops/ms
appendSingleString   10000  thrpt    5   1329.216 ±   22.597  ops/ms
appendStringBatch      100  thrpt    5    560.002 ±   10.027  ops/ms
appendStringBatch     1000  thrpt    5     54.431 ±    1.881  ops/ms
appendStringBatch    10000  thrpt    5      4.760 ±    0.254  ops/ms
```
* Memory consumption after changes:
```
Benchmark                                  (size)  Mode  Cnt        Score       Error   Units
appendSingleString:·gc.alloc.rate.norm        100  avgt    5      168.005 ±     0.001    B/op
appendSingleString:·gc.alloc.rate.norm       1000  avgt    5     1064.026 ±     0.001    B/op
appendSingleString:·gc.alloc.rate.norm      10000  avgt    5    10064.418 ±     0.002    B/op
appendStringBatch:·gc.alloc.rate.norm         100  avgt    5    16881.091 ±     0.022    B/op
appendStringBatch:·gc.alloc.rate.norm        1000  avgt    5   168085.875 ±     6.935    B/op
appendStringBatch:·gc.alloc.rate.norm       10000  avgt    5  1680145.068 ±     1.331    B/op
```

### TLDR:
* throughput of appending single string increases up to `1.74-3,48x` times, and appending of a batch of strings up to `1.5x` times;
* memory consumption reduces for appending a single string up to `2-2.74`x times, but it increases up to `1.1x` times for appending a batch of strings. That's interesting, but considering the pros shouldn't be a thing.