### PR TITLE
Fix StackOverflowError initializing CommonRules

### DIFF
--- a/core/shared/src/main/scala/org/http4s/headers/Server.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Server.scala
@@ -24,6 +24,8 @@ import org.http4s.util.Renderable
 import org.http4s.util.Writer
 import org.typelevel.ci.CIString
 
+import scala.annotation.nowarn
+
 object Server extends HeaderCompanion[Server]("Server") {
 
   override val name: CIString = super.name
@@ -31,6 +33,7 @@ object Server extends HeaderCompanion[Server]("Server") {
   def apply(id: ProductId, tail: ProductIdOrComment*): Server =
     apply(id, tail.toList)
 
+  @nowarn("cat=deprecation")
   @deprecated("Use parse(Int) instead", "0.23.17")
   override def parse(s: String): ParseResult[`Server`] =
     parse(CommonRules.CommentDefaultMaxDepth)(s)

--- a/core/shared/src/main/scala/org/http4s/headers/Server.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Server.scala
@@ -18,12 +18,11 @@ package org.http4s
 package headers
 
 import cats.parse.Parser
+import org.http4s.internal.parsing.CommonRules
 import org.http4s.internal.parsing.Rfc7230
 import org.http4s.util.Renderable
 import org.http4s.util.Writer
 import org.typelevel.ci.CIString
-
-import scala.annotation.nowarn
 
 object Server extends HeaderCompanion[Server]("Server") {
 
@@ -32,10 +31,9 @@ object Server extends HeaderCompanion[Server]("Server") {
   def apply(id: ProductId, tail: ProductIdOrComment*): Server =
     apply(id, tail.toList)
 
-  @nowarn("cat=deprecation")
   @deprecated("Use parse(Int) instead", "0.23.17")
   override def parse(s: String): ParseResult[`Server`] =
-    parse(Rfc7230.CommentDefaultMaxDepth)(s)
+    parse(CommonRules.CommentDefaultMaxDepth)(s)
 
   def parse(maxDepth: Int)(s: String): ParseResult[`Server`] =
     parsePartiallyApplied(maxDepth)(s)
@@ -67,7 +65,7 @@ object Server extends HeaderCompanion[Server]("Server") {
             writer
           }
         },
-      parsePartiallyApplied(100),
+      parsePartiallyApplied(CommonRules.CommentDefaultMaxDepth),
     )
 }
 

--- a/core/shared/src/main/scala/org/http4s/headers/User-Agent.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/User-Agent.scala
@@ -18,7 +18,7 @@ package org.http4s
 package headers
 
 import org.http4s.Header
-import org.http4s.internal.parsing.Rfc7230
+import org.http4s.internal.parsing.CommonRules
 import org.http4s.util.Renderable
 import org.http4s.util.Renderer
 import org.http4s.util.Writer
@@ -33,7 +33,7 @@ object `User-Agent` {
 
   @deprecated("Use parse(Int)(String) instead", "0.23.17")
   def parse(s: String): ParseResult[`User-Agent`] =
-    parse(Rfc7230.CommentDefaultMaxDepth)(s)
+    parse(CommonRules.CommentDefaultMaxDepth)(s)
 
   def parse(maxDepth: Int)(s: String): ParseResult[`User-Agent`] =
     parsePartiallyApplied(maxDepth)(s)
@@ -69,7 +69,7 @@ object `User-Agent` {
           }
 
         },
-      parsePartiallyApplied(100),
+      parsePartiallyApplied(CommonRules.CommentDefaultMaxDepth),
     )
 
   implicit def convert(implicit

--- a/core/shared/src/main/scala/org/http4s/internal/parsing/CommonRules.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/parsing/CommonRules.scala
@@ -87,10 +87,10 @@ private[parsing] trait CommonRules {
     go(maxDepth)
   }
 
-  final val CommentDefaultMaxDepth = 100
+  final val CommentDefaultMaxDepth = 10
 
   @deprecated("Use comment(Int) instead", "0.23.17")
-  private[http4s] val comment: Parser[String] =
+  private[http4s] lazy val comment: Parser[String] =
     comment(CommentDefaultMaxDepth)
 
   def headerRep[A](element: Parser[A]): Parser0[List[A]] =


### PR DESCRIPTION
A user has reported a StackOverflowError initializing CommonRules.  This PR reduces stack consumption.

1. A parser that triggers it is made lazy so what isn't used can't hurt anyone.
2. The default depth is reduced, so it works on smaller-stack environments.
3. The default depth is referenced from a canonical constant in the relevant header instances.