### PR TITLE
Use `Chunk` builder in `CirceInstances#streamedJsonArray`

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
+++ b/circe/src/main/scala/org/http4s/circe/CirceInstances.scala
@@ -300,13 +300,12 @@ object CirceInstances {
               case None => Pull.pure(None)
               case Some((hd, tl)) =>
                 val interspersed = {
-                  val bldr = Vector.newBuilder[Chunk[Byte]]
-                  bldr.sizeHint(hd.size * 2)
+                  val bldr = Chunk.newBuilder[Byte]
                   hd.foreach { o =>
                     bldr += CirceInstances.comma
                     bldr += fromJsonToChunk(printer)(o)
                   }
-                  Chunk.concat(bldr.result())
+                  bldr.result
                 }
                 Pull.output(interspersed) >> Pull.pure(Some(tl))
             }


### PR DESCRIPTION
As we explored in https://github.com/http4s/http4s/pull/6919, building `Chunk` from its builder should be faster than from anything else.