### PR TITLE
Adjust public contract of Logger Middlewares 

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -48,19 +48,37 @@ object ResponseLogger {
       )(logAction.getOrElse(defaultLogAction[F]))
     }
 
+  def logWithBody[F[_]: Async](
+      logHeaders: Boolean,
+      logBody: Entity[F] => Option[F[String]],
+      redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None,
+  )(client: Client[F]): Client[F] =
+    impl(client, logBody = true) { response =>
+      InternalLogger.logMessageWithBody(response)(
+        logHeaders,
+        logBody,
+        logAction.getOrElse(defaultLogAction[F]),
+        redactHeadersWhen,
+      )
+    }
+
+  @deprecated(
+    "Use ResponseLogger.logWithBody that utilizes Entity model for a Message body",
+    "1.0.0-M39",
+  )
   def logBodyText[F[_]: Async](
       logHeaders: Boolean,
       logBody: Stream[F, Byte] => Option[F[String]],
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: Option[String => F[Unit]] = None,
   )(client: Client[F]): Client[F] =
-    impl(client, logBody = true) { response =>
-      InternalLogger.logMessageWithBodyText(response)(
-        logHeaders,
-        logBody,
-        redactHeadersWhen,
-      )(logAction.getOrElse(defaultLogAction[F]))
-    }
+    logWithBody(
+      logHeaders,
+      (entity: Entity[F]) => logBody(entity.body),
+      redactHeadersWhen,
+      logAction,
+    )(client)
 
   def customized[F[_]: Async](
       client: Client[F],

--- a/core/shared/src/main/scala/org/http4s/internal/Logger.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/Logger.scala
@@ -74,16 +74,17 @@ object Logger {
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
   )(log: String => F[Unit])(implicit F: Concurrent[F]): F[Unit] = {
-    val logBodyText = (_: Stream[F, Byte]) => defaultLogBody(message)(logBody)
+    val logBodyText = (_: Entity[F]) => defaultLogBody(message)(logBody)
 
-    logMessageWithBodyText(message)(logHeaders, logBodyText, redactHeadersWhen)(log)
+    logMessageWithBody(message)(logHeaders, logBodyText, log, redactHeadersWhen)
   }
 
-  def logMessageWithBodyText[F[_]](message: Message[F])(
+  def logMessageWithBody[F[_]](message: Message[F])(
       logHeaders: Boolean,
-      logBodyText: Stream[F, Byte] => Option[F[String]],
+      logBodyText: Entity[F] => Option[F[String]],
+      log: String => F[Unit],
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
-  )(log: String => F[Unit])(implicit F: Monad[F]): F[Unit] = {
+  )(implicit F: Monad[F]): F[Unit] = {
     def prelude =
       message match {
         case req: Request[_] => s"${req.httpVersion} ${req.method} ${req.uri}"
@@ -93,7 +94,7 @@ object Logger {
     val headers: String = defaultLogHeaders(message)(logHeaders, redactHeadersWhen)
 
     val bodyText: F[String] =
-      logBodyText(message.body) match {
+      logBodyText(message.entity) match {
         case Some(textF) => textF.map(text => s"""body="$text"""")
         case None => F.pure("")
       }
@@ -105,4 +106,19 @@ object Logger {
       .flatMap(log)
   }
 
+  @deprecated(
+    "Use Logger.logMessageWithBody that utilizes Entity model for a Message body",
+    "1.0.0-M39",
+  )
+  def logMessageWithBodyText[F[_]](message: Message[F])(
+      logHeaders: Boolean,
+      logBodyText: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
+  )(log: String => F[Unit])(implicit F: Monad[F]): F[Unit] =
+    logMessageWithBody(message)(
+      logHeaders,
+      (entity: Entity[F]) => logBodyText(entity.body),
+      log,
+      redactHeadersWhen,
+    )
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -50,7 +50,7 @@ object ResponseLogger {
 
   private[server] def impl[G[_], F[_], A](
       logHeaders: Boolean,
-      logBodyText: Either[Boolean, Stream[F, Byte] => Option[F[String]]],
+      logBodyText: Either[Boolean, Entity[F] => Option[F[String]]],
       fk: F ~> G,
       redactHeadersWhen: CIString => Boolean,
       logAction: Option[String => F[Unit]],
@@ -66,7 +66,7 @@ object ResponseLogger {
           Logger.logMessage[F, Response[F]](resp)(logHeaders, bool, redactHeadersWhen)(log(_))
         case Right(f) =>
           org.http4s.internal.Logger
-            .logMessageWithBodyText(resp)(logHeaders, f, redactHeadersWhen)(log(_))
+            .logMessageWithBody(resp)(logHeaders, f, log(_), redactHeadersWhen)
       }
 
     val logBody: Boolean = logBodyText match {
@@ -115,13 +115,32 @@ object ResponseLogger {
   )(httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
     apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
+  def httpAppLogBody[F[_]: Async, A](
+      logHeaders: Boolean,
+      logBody: Entity[F] => Option[F[String]],
+      redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None,
+  )(httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
+    impl[F, F, A](logHeaders, Right(logBody), FunctionK.id[F], redactHeadersWhen, logAction)(
+      httpApp
+    )
+
+  @deprecated(
+    "Use ResponseLogger.httpAppLogBody that utilizes Entity model for a Message body",
+    "1.0.0-M39",
+  )
   def httpAppLogBodyText[F[_]: Async, A](
       logHeaders: Boolean,
       logBody: Stream[F, Byte] => Option[F[String]],
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: Option[String => F[Unit]] = None,
   )(httpApp: Kleisli[F, A, Response[F]]): Kleisli[F, A, Response[F]] =
-    impl[F, F, A](logHeaders, Right(logBody), FunctionK.id[F], redactHeadersWhen, logAction)(
+    httpAppLogBody[F, A](
+      logHeaders,
+      (entity: Entity[F]) => logBody(entity.body),
+      redactHeadersWhen,
+      logAction,
+    )(
       httpApp
     )
 
@@ -133,9 +152,9 @@ object ResponseLogger {
   )(httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
     apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
-  def httpRoutesLogBodyText[F[_]: Async, A](
+  def httpRoutesLogBody[F[_]: Async, A](
       logHeaders: Boolean,
-      logBody: Stream[F, Byte] => Option[F[String]],
+      logBody: Entity[F] => Option[F[String]],
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: Option[String => F[Unit]] = None,
   )(httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
@@ -143,6 +162,23 @@ object ResponseLogger {
       logHeaders,
       Right(logBody),
       OptionT.liftK[F],
+      redactHeadersWhen,
+      logAction,
+    )(httpRoutes)
+
+  @deprecated(
+    "Use ResponseLogger.httpRoutesLogBody that utilizes Entity model for a Message body",
+    "1.0.0-M39",
+  )
+  def httpRoutesLogBodyText[F[_]: Async, A](
+      logHeaders: Boolean,
+      logBody: Stream[F, Byte] => Option[F[String]],
+      redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
+      logAction: Option[String => F[Unit]] = None,
+  )(httpRoutes: Kleisli[OptionT[F, *], A, Response[F]]): Kleisli[OptionT[F, *], A, Response[F]] =
+    httpRoutesLogBody[F, A](
+      logHeaders,
+      (entity: Entity[F]) => logBody(entity.body),
       redactHeadersWhen,
       logAction,
     )(httpRoutes)


### PR DESCRIPTION
`Stream[F, Byte]` is an implementation detail of a specific variant of `Entity[F]`, so let's adjust the public contract of Logger Middlewares. Naming is the second hard thing in programming, so I'm fully open to debate on it.