### PR TITLE
Fix hanging when stream fails

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -359,7 +359,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       .drain
       .attempt
       .flatMap {
-        case Left(err) => onWriteFailure(request, resp, err) >> MonadThrow[F].raiseError(err)
+        case Left(err) => onWriteFailure(request, resp, err) *> MonadThrow[F].raiseError(err)
         case Right(()) => Applicative[F].unit
       }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -359,7 +359,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       .drain
       .attempt
       .flatMap {
-        case Left(err) => onWriteFailure(request, resp, err)
+        case Left(err) => onWriteFailure(request, resp, err) >> MonadThrow[F].raiseError(err)
         case Right(()) => Applicative[F].unit
       }
 

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -92,7 +92,11 @@ class EmberServerSuite extends Http4sSuite {
       .compile
       .drain
       .timeout(1.second)
-      .intercept[EmberException.ReachedEndOfStream]
+      .intercept[EmberException.ReachedEndOfStream] >>
+      // server should still be alive
+      client
+        .get(url(server.addressIp4s))(_.status.pure[IO])
+        .assertEquals(Status.Ok)
   }
 
   client.test("server shuts down after exiting resource scope") { client =>

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -91,6 +91,7 @@ class EmberServerSuite extends Http4sSuite {
       .flatMap(_.body)
       .compile
       .drain
+      .timeout(1.second)
       .intercept[EmberException.ReachedEndOfStream]
   }
 


### PR DESCRIPTION
Fix connection hanging when response body stream fails. This was fixable by supplying a custom `onWriteFailure` that throws but the default behaviour was confusing.

Associated Discord discussion can be found [here](https://discord.com/channels/632277896739946517/839254871646404638/1065301202444763236).