### PR TITLE
Add section with sbt dependencies to quickstart

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -4,7 +4,8 @@
 
 http4s is available for Scala 2.12, 2.13, and 3.
 
-You can add http4s to your build by adding its modules to your dependencies in `build.sbt`:
+You can add http4s to your build by adding its modules to your dependencies in `build.sbt`.
+Here are some common dependencies, more are available on the [integrations page][integrations].
 
 ```scala
 libraryDependencies ++= Seq(
@@ -125,3 +126,4 @@ a simple JSON service.
 [giter8 template]: https://github.com/http4s/http4s.g8
 [versions]: /versions/
 [sbt-revolver]: https://github.com/spray/sbt-revolver
+[integrations]: integrations.md

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Dependencies
 
-http4s is available for Scala 2.12, 2.13, and 3.2
+http4s is available for Scala 2.12, 2.13, and 3.
 
 You can add http4s to your build by adding its modules to your dependencies in `build.sbt`:
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -1,9 +1,30 @@
 # Quick Start
 
-**Note**: To run with 2.12 please make sure that the flag `-Ypartial-unification`
+## Dependencies
+
+http4s is available for Scala 2.12, 2.13, and 3.2
+
+You can add http4s to your build by adding its modules to your dependencies in `build.sbt`:
+
+```scala
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-core"         % @VERSION@,
+  "org.http4s" %% "http4s-client"       % @VERSION@,
+  "org.http4s" %% "http4s-server"       % @VERSION@,
+  "org.http4s" %% "http4s-dsl"          % @VERSION@,
+  "org.http4s" %% "http4s-ember-client" % @VERSION@,
+  "org.http4s" %% "http4s-ember-server" % @VERSION@,
+)
+```
+
+@:callout(info)
+To run with 2.12 please make sure that the flag `-Ypartial-unification`
 is enabled in your compiler options (i.e `scalacOptions += "-Ypartial-unification"` in sbt).
 This feature is enabled by default starting in Scala 2.13.
+@:@
 
+
+## Giter8 Template
 
 Getting started with http4s is easy.  Let's materialize an http4s
 skeleton project from its [giter8 template]:

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -8,13 +8,18 @@ You can add http4s to your build by adding its modules to your dependencies in `
 Here are some common dependencies, more are available on the [integrations page][integrations].
 
 ```scala
+val http4sVersion = "@VERSION@"
+
 libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-core"         % @VERSION@,
-  "org.http4s" %% "http4s-client"       % @VERSION@,
-  "org.http4s" %% "http4s-server"       % @VERSION@,
-  "org.http4s" %% "http4s-dsl"          % @VERSION@,
-  "org.http4s" %% "http4s-ember-client" % @VERSION@,
-  "org.http4s" %% "http4s-ember-server" % @VERSION@,
+  // get up and running with a client and server
+  "org.http4s" %% "http4s-ember-client" % http4sVersion,
+  "org.http4s" %% "http4s-ember-server" % http4sVersion,
+  "org.http4s" %% "http4s-dsl"          % http4sVersion,
+
+  // for core classes and traits, e.g. `Client[F]`
+  "org.http4s" %% "http4s-core"         % http4sVersion,
+  "org.http4s" %% "http4s-client"       % http4sVersion,
+  "org.http4s" %% "http4s-server"       % http4sVersion,
 )
 ```
 


### PR DESCRIPTION
Adds a handy list of a few dependencies in sbt format on the quickstart page.

Inspired by a user request in discord. I also like having these easily discoverable.

![image](https://user-images.githubusercontent.com/5440389/217534711-0f68aa99-5bce-4270-9446-226fcd811d11.png)
