### PR TITLE
Add ability to disable SNI in Ember

### DIFF
--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -55,6 +55,7 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
     val additionalSocketOptions: List[SocketOption],
     val userAgent: Option[`User-Agent`],
     val checkEndpointIdentification: Boolean,
+    val serverNameIndication: Boolean,
     val retryPolicy: RetryPolicy[F],
     private val unixSockets: Option[UnixSockets[F]],
     private val enableHttp2: Boolean,
@@ -77,6 +78,7 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
       additionalSocketOptions: List[SocketOption] = self.additionalSocketOptions,
       userAgent: Option[`User-Agent`] = self.userAgent,
       checkEndpointIdentification: Boolean = self.checkEndpointIdentification,
+      serverNameIndication: Boolean = self.serverNameIndication,
       retryPolicy: RetryPolicy[F] = self.retryPolicy,
       unixSockets: Option[UnixSockets[F]] = self.unixSockets,
       enableHttp2: Boolean = self.enableHttp2,
@@ -98,6 +100,7 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
       additionalSocketOptions = additionalSocketOptions,
       userAgent = userAgent,
       checkEndpointIdentification = checkEndpointIdentification,
+      serverNameIndication = serverNameIndication,
       retryPolicy = retryPolicy,
       unixSockets = unixSockets,
       enableHttp2 = enableHttp2,
@@ -178,6 +181,18 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
   def withoutCheckEndpointAuthentication: EmberClientBuilder[F] =
     copy(checkEndpointIdentification = false)
 
+  /** Sets whether or not to enable Server Name Indication on the `TLSContext`.
+    * Enabled by default. When enabled the hostname will be indicated during SSL/TLS handshaking.
+    * This is important to reach a web server that is responsible for multiple hostnames so that it
+    * can use the correct certificate.
+    */
+  def withServerNameIndication(serverNameIndication: Boolean): EmberClientBuilder[F] =
+    copy(serverNameIndication = serverNameIndication)
+
+  /** Disables Server Name Indication */
+  def withoutServerNameIndication: EmberClientBuilder[F] =
+    copy(serverNameIndication = false)
+
   /** Sets the `RetryPolicy`. */
   def withRetryPolicy(retryPolicy: RetryPolicy[F]): EmberClientBuilder[F] =
     copy(retryPolicy = retryPolicy)
@@ -240,6 +255,7 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
                     requestKey,
                     tlsContextOptWithDefault,
                     checkEndpointIdentification,
+                    serverNameIndication,
                     sg,
                     additionalSocketOptions,
                   )
@@ -265,6 +281,7 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
           else
             default.copy(enablePush = H2Frame.Settings.SettingsEnablePush(false)),
           checkEndpointIdentification,
+          serverNameIndication,
         )
       }
     } yield {
@@ -309,6 +326,8 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
       def unixSocketClient(
           request: Request[F],
           address: UnixSocketAddress,
+          enableEndpointValidation: Boolean,
+          enableServerNameIndication: Boolean,
       ): Resource[F, Response[F]] =
         Resource
           .eval(
@@ -324,7 +343,14 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
             Resource
               .make(
                 EmberConnection(
-                  ClientHelpers.unixSocket(request, unixSockets, address, tlsContextOpt)
+                  ClientHelpers.unixSocket(
+                    request,
+                    unixSockets,
+                    address,
+                    tlsContextOpt,
+                    enableEndpointValidation,
+                    enableServerNameIndication,
+                  )
                 )
               )(ec => ec.shutdown)
           )
@@ -346,9 +372,9 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
       val client = Client[F] { request =>
         request.attributes
           .lookup(Request.Keys.UnixSocketAddress)
-          .fold(webClient(request)) { (address: UnixSocketAddress) =>
-            unixSocketClient(request, address)
-          }
+          .fold(webClient(request))(
+            unixSocketClient(request, _, checkEndpointIdentification, serverNameIndication)
+          )
       }
       val stackClient = Retry.create(retryPolicy, logRetries = false)(client)
       val iClient = new EmberClient[F](stackClient, pool)
@@ -377,6 +403,7 @@ object EmberClientBuilder extends EmberClientBuilderCompanionPlatform {
       additionalSocketOptions = Defaults.additionalSocketOptions,
       userAgent = Defaults.userAgent,
       checkEndpointIdentification = true,
+      serverNameIndication = true,
       retryPolicy = Defaults.retryPolicy,
       unixSockets = None,
       enableHttp2 = false,

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -55,6 +55,7 @@ private[client] object ClientHelpers {
       request: Request[F],
       tlsContextOpt: Option[TLSContext[F]],
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
       sg: SocketGroup[F],
       additionalSocketOptions: List[SocketOption],
   ): Resource[F, RequestKeySocket[F]] = {
@@ -63,6 +64,7 @@ private[client] object ClientHelpers {
       requestKey,
       tlsContextOpt,
       enableEndpointValidation,
+      enableServerNameIndication,
       sg,
       additionalSocketOptions,
     )
@@ -73,13 +75,16 @@ private[client] object ClientHelpers {
       unixSockets: fs2.io.net.unixsocket.UnixSockets[F],
       address: fs2.io.net.unixsocket.UnixSocketAddress,
       tlsContextOpt: Option[TLSContext[F]],
+      enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
   ): Resource[F, RequestKeySocket[F]] = {
     val requestKey = RequestKey.fromRequest(request)
     elevateSocket(
       requestKey,
       unixSockets.client(address),
       tlsContextOpt,
-      false,
+      enableEndpointValidation,
+      enableServerNameIndication,
       None,
     )
   }
@@ -88,6 +93,7 @@ private[client] object ClientHelpers {
       requestKey: RequestKey,
       tlsContextOpt: Option[TLSContext[F]],
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
       sg: SocketGroup[F],
       additionalSocketOptions: List[SocketOption],
   ): Resource[F, RequestKeySocket[F]] =
@@ -96,10 +102,11 @@ private[client] object ClientHelpers {
       .flatMap { address =>
         val s = sg.client(address, options = additionalSocketOptions)
         elevateSocket(
-          requestKey: RequestKey,
-          s: Resource[F, Socket[F]],
-          tlsContextOpt: Option[TLSContext[F]],
-          enableEndpointValidation: Boolean,
+          requestKey,
+          s,
+          tlsContextOpt,
+          enableEndpointValidation,
+          enableServerNameIndication,
           Some(address),
         )
       }
@@ -109,6 +116,7 @@ private[client] object ClientHelpers {
       initSocket: Resource[F, Socket[F]],
       tlsContextOpt: Option[TLSContext[F]],
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
       optionNames: Option[SocketAddress[Host]],
   ): Resource[F, RequestKeySocket[F]] =
     for {
@@ -122,7 +130,13 @@ private[client] object ClientHelpers {
           } { tlsContext =>
             tlsContext
               .clientBuilder(iSocket)
-              .withParameters(Util.mkClientTLSParameters(optionNames, enableEndpointValidation))
+              .withParameters(
+                Util.mkClientTLSParameters(
+                  optionNames,
+                  enableEndpointValidation,
+                  enableServerNameIndication,
+                )
+              )
               .build
               .widen[Socket[F]]
           }

--- a/ember-core/js/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
+++ b/ember-core/js/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
@@ -32,9 +32,11 @@ private[core] trait UtilPlatform {
   def mkClientTLSParameters(
       address: Option[SocketAddress[Host]],
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
   ): TLSParameters =
     TLSParameters(
-      servername = address.map(a => extractHostname(a.host))
+      servername =
+        if (enableServerNameIndication) address.map(a => extractHostname(a.host)) else None
     ) // TODO how to enable endpoint validation?
 
   @tailrec

--- a/ember-core/jvm/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
+++ b/ember-core/jvm/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
@@ -31,9 +31,11 @@ private[core] trait UtilPlatform {
   def mkClientTLSParameters(
       address: Option[SocketAddress[Host]],
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
   ): TLSParameters =
     TLSParameters(
-      serverNames = address.map(a => List(extractHostname(a.host))),
+      serverNames =
+        if (enableServerNameIndication) address.map(a => List(extractHostname(a.host))) else None,
       endpointIdentificationAlgorithm = if (enableEndpointValidation) Some("HTTPS") else None,
     )
 

--- a/ember-core/native/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
+++ b/ember-core/native/src/main/scala/org/http4s/ember/core/UtilPlatform.scala
@@ -32,9 +32,11 @@ private[core] trait UtilPlatform {
   def mkClientTLSParameters(
       address: Option[SocketAddress[Host]],
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
   ): TLSParameters =
     TLSParameters(
-      serverName = address.map(a => extractHostname(a.host))
+      serverName =
+        if (enableServerNameIndication) address.map(a => extractHostname(a.host)) else None
     ) // TODO how to enable endpoint validation?
 
   @tailrec

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -87,27 +87,33 @@ private[ember] class H2Client[F[_]](
       useTLS: Boolean,
       priorKnowledge: Boolean,
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
   ): F[H2Connection[F]] =
     connections.get.map(_.get(key).map(_._1)).flatMap {
       case Some(connection) => Applicative[F].pure(connection)
       case None =>
-        createConnection(key, useTLS, priorKnowledge, enableEndpointValidation).allocated.flatMap(
-          tup =>
-            connections
-              .modify { map =>
-                val current = map.get(key)
-                val newMap = current.fold(map.+((key, tup)))(_ => map)
-                val out = current.fold(
-                  Either.left[H2Connection[F], (H2Connection[F], F[Unit])](tup._1)
-                )(r => Either.right((r._1, tup._2)))
-                (newMap, out)
-              }
-              .flatMap {
-                case Right((connection, shutdown)) =>
-                  shutdown.map(_ => connection)
-                case Left(connection) =>
-                  connection.pure[F]
-              }
+        createConnection(
+          key,
+          useTLS,
+          priorKnowledge,
+          enableEndpointValidation,
+          enableServerNameIndication,
+        ).allocated.flatMap(tup =>
+          connections
+            .modify { map =>
+              val current = map.get(key)
+              val newMap = current.fold(map.+((key, tup)))(_ => map)
+              val out = current.fold(
+                Either.left[H2Connection[F], (H2Connection[F], F[Unit])](tup._1)
+              )(r => Either.right((r._1, tup._2)))
+              (newMap, out)
+            }
+            .flatMap {
+              case Right((connection, shutdown)) =>
+                shutdown.map(_ => connection)
+              case Left(connection) =>
+                connection.pure[F]
+            }
         )
     }
 
@@ -117,11 +123,13 @@ private[ember] class H2Client[F[_]](
       useTLS: Boolean,
       priorKnowledge: Boolean,
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
   ): Resource[F, H2Connection[F]] =
-    createSocket(key, useTLS, priorKnowledge, enableEndpointValidation).flatMap {
-      case (socket, Http2) => fromSocket(ByteVector.empty, socket, key)
-      case (_, Http1) => Resource.eval(InvalidSocketType().raiseError)
-    }
+    createSocket(key, useTLS, priorKnowledge, enableEndpointValidation, enableServerNameIndication)
+      .flatMap {
+        case (socket, Http2) => fromSocket(ByteVector.empty, socket, key)
+        case (_, Http1) => Resource.eval(InvalidSocketType().raiseError)
+      }
 
   // This is currently how we create http2 only sockets, will need to actually handle which
   // protocol to take
@@ -130,12 +138,17 @@ private[ember] class H2Client[F[_]](
       useTLS: Boolean,
       priorKnowledge: Boolean,
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
   ): Resource[F, (Socket[F], SocketType)] = for {
     address <- Resource.eval(RequestKey.getAddress(key))
     baseSocket <- sg.client(address)
     socket <- {
       if (useTLS) {
-        val tlsParams = Util.mkClientTLSParameters(address.some, enableEndpointValidation)
+        val tlsParams = Util.mkClientTLSParameters(
+          address.some,
+          enableEndpointValidation,
+          enableServerNameIndication,
+        )
         for {
           tlsSocket <- tls
             .clientBuilder(baseSocket)
@@ -264,7 +277,11 @@ private[ember] class H2Client[F[_]](
     } yield h2
   }
 
-  def runHttp2Only(req: Request[F], enableEndpointValidation: Boolean): Resource[F, Response[F]] = {
+  def runHttp2Only(
+      req: Request[F],
+      enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
+  ): Resource[F, Response[F]] = {
     // Host And Port are required
     val key = H2Client.RequestKey.fromRequest(req)
     val useTLS = req.uri.scheme.map(_.value) match {
@@ -279,7 +296,13 @@ private[ember] class H2Client[F[_]](
     val priorKnowledge = req.attributes.contains(H2Keys.Http2PriorKnowledge)
     for {
       connection <- Resource.eval(
-        getOrCreate(key, useTLS, priorKnowledge, enableEndpointValidation)
+        getOrCreate(
+          key,
+          useTLS,
+          priorKnowledge,
+          enableEndpointValidation,
+          enableServerNameIndication,
+        )
       )
       // Stream Order Must Be Correct, so we must grab the global lock
       stream <- Resource.make(
@@ -306,9 +329,9 @@ private[ember] object H2Client {
       logger: Logger[F],
       settings: H2Frame.Settings.ConnectionSettings = defaultSettings,
       enableEndpointValidation: Boolean,
+      enableServerNameIndication: Boolean,
   ): Resource[F, TinyClient[F] => TinyClient[F]] =
     for {
-
       mapH2 <- Resource.make {
         Concurrent[F].ref(
           Map[H2Client.RequestKey, (H2Connection[F], F[Unit])]()
@@ -338,11 +361,12 @@ private[ember] object H2Client {
       val priorKnowledge = req.attributes.contains(H2Keys.Http2PriorKnowledge)
       val socketTypeF = if (priorKnowledge) Some(Http2).pure[F] else socketMap.get.map(_.get(key))
       Resource.eval(socketTypeF).flatMap {
-        case Some(Http2) => h2.runHttp2Only(req, enableEndpointValidation)
+        case Some(Http2) =>
+          h2.runHttp2Only(req, enableEndpointValidation, enableServerNameIndication)
         case Some(Http1) => http1Client(req)
         case None =>
           (
-            h2.runHttp2Only(req, enableEndpointValidation) <*
+            h2.runHttp2Only(req, enableEndpointValidation, enableServerNameIndication) <*
               Resource.eval(socketMap.update(s => s + (key -> Http2)))
           ).handleErrorWith[org.http4s.Response[F], Throwable] {
             case InvalidSocketType() | MissingHost() | MissingPort() =>


### PR DESCRIPTION
Hi,

We are having issue using Ember client instead of Blaze client due to our custom certificat that needs both endpoint verification and TLS SNI disabled.

If we try with Java NET, the following succeeds with the commented line, or fails if uncommented:
```
val connection = new URL("https://my-endpoint.com").openConnection().asInstanceOf[HttpsURLConnection]
connection.setSSLSocketFactory(ourSslContext.getSocketFactory)
// connection.setHostnameVerifier((hostname, session) => true)
connection.setDoOutput(true)
connection.setRequestMethod("GET")

val br = new BufferedReader(new InputStreamReader(connection.getInputStream))
println(br.readLine())
```
Here is the error:
```
Caused by: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
        at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:131)
        at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:353)
        at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:296)
        at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:291)
        at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1357)
        at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.onConsumeCertificate(CertificateMessage.java:1232)
        at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.consume(CertificateMessage.java:1175)
        at java.base/sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:392)
        at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:443)
        at java.base/sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:421)
        at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:183)
        at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:172)
        at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1506)
        at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1416)
        at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:456)
        at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:427)
        at com.netflix.metatron.ipc.security.DelegatingSSLSocket.startHandshake(DelegatingSSLSocket.java:88)
        at java.base/sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:572)
        at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:201)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1597)
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1525)
        at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:250)
        at HelloWorld$.<clinit>(metatron.scala:53)
        ... 1 more
Caused by: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
        at java.base/sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:439)
        at java.base/sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:306)
        at java.base/sun.security.validator.Validator.validate(Validator.java:264)
        at java.base/sun.security.ssl.X509TrustManagerImpl.validate(X509TrustManagerImpl.java:313)
        at java.base/sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:222)
        at java.base/sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:129)
        at com.netflix.metatron.ipc.security.DelegateX509ExtendedTrustManager.checkServerTrusted(DelegateX509ExtendedTrustManager.java:26)
        at com.netflix.metatron.ipc.security.MetatronTrustManagerFactory$MetatronTrustManager.checkServerTrusted(MetatronTrustManagerFactory.java:107)
        at java.base/sun.security.ssl.CertificateMessage$T13CertificateConsumer.checkServerCerts(CertificateMessage.java:1341)
        ... 19 more
Caused by: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
        at java.base/sun.security.provider.certpath.SunCertPathBuilder.build(SunCertPathBuilder.java:141)
        at java.base/sun.security.provider.certpath.SunCertPathBuilder.engineBuild(SunCertPathBuilder.java:126)
        at java.base/java.security.cert.CertPathBuilder.build(CertPathBuilder.java:297)
        at java.base/sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:434)
        ... 27 more
```

So we need some way to disable SNI checks either like Java NET, together with the endpoint verification or like Akka HTTP:
https://doc.akka.io/docs/akka-http/10.0/client-side/client-https-support.html#disabling-tls-security-features-at-your-own-risk

https://www.cloudflare.com/learning/ssl/what-is-sni/

Thanks to @armanbilge and @ChristopherDavenport for the help on Discord!