### PR TITLE
`JavaNetClient` does not need `Async`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -403,6 +403,12 @@ lazy val client = libraryCrossProject("client")
         "org.http4s.client.websocket.WSConnectionHighLevel.sendClose$default$1"
       ),
       // end wsclient
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.client.JavaNetClientBuilder.F"
+      ), // sealed protected
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.client.JavaNetClientBuilder.this"
+      ), // private
     ) ++ {
       if (tlIsScala3.value)
         Seq(

--- a/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
+++ b/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
@@ -17,7 +17,6 @@
 package org.http4s
 package client
 
-import cats.effect.Async
 import cats.effect.Resource
 import cats.effect.Sync
 import cats.syntax.all._
@@ -56,7 +55,7 @@ sealed abstract class JavaNetClientBuilder[F[_]] private (
     val proxy: Option[Proxy],
     val hostnameVerifier: Option[HostnameVerifier],
     val sslSocketFactory: Option[SSLSocketFactory],
-)(implicit protected val F: Async[F])
+)(implicit protected val F: Sync[F])
     extends BackendBuilder[F, Client[F]] {
   private def copy(
       connectTimeout: Duration = connectTimeout,
@@ -214,7 +213,7 @@ sealed abstract class JavaNetClientBuilder[F[_]] private (
 
 /** Builder for a [[Client]] backed by on `java.net.HttpUrlConnection`. */
 object JavaNetClientBuilder {
-  def apply[F[_]: Async]: JavaNetClientBuilder[F] =
+  def apply[F[_]: Sync]: JavaNetClientBuilder[F] =
     new JavaNetClientBuilder[F](
       connectTimeout = defaults.ConnectTimeout,
       readTimeout = defaults.RequestTimeout,

--- a/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
+++ b/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
@@ -17,6 +17,7 @@
 package org.http4s
 package client
 
+import cats.effect.Async
 import cats.effect.Resource
 import cats.effect.Sync
 import cats.syntax.all._
@@ -224,4 +225,7 @@ object JavaNetClientBuilder {
       hostnameVerifier = None,
       sslSocketFactory = None,
     ) {}
+
+  @deprecated("Use overload with Sync constraint", "0.23.19")
+  def apply[F[_]](F: Async[F]): JavaNetClientBuilder[F] = apply(F: Sync[F])
 }

--- a/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
+++ b/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
@@ -167,6 +167,8 @@ sealed abstract class JavaNetClientBuilder[F[_]] private (
         F.delay(url.openConnection().asInstanceOf[HttpURLConnection])
     }
 
+  // scalafix:off Http4sFs2Linters.noFs2SyncCompiler
+  // good enough for `SyncIO`, and FS2 will upgrade compiler at runtime if `IO`
   private def writeBody(req: Request[F], conn: HttpURLConnection): F[Unit] =
     if (req.isChunked)
       F.delay(conn.setDoOutput(true)) *>
@@ -187,6 +189,7 @@ sealed abstract class JavaNetClientBuilder[F[_]] private (
         case _ =>
           F.delay(conn.setDoOutput(false))
       }
+  // scalafix:on
 
   private def readBody(conn: HttpURLConnection): Stream[F, Byte] = {
     def inputStream =

--- a/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
+++ b/client/jvm/src/main/scala/org/http4s/client/JavaNetClientBuilder.scala
@@ -227,5 +227,5 @@ object JavaNetClientBuilder {
     ) {}
 
   @deprecated("Use overload with Sync constraint", "0.23.19")
-  def apply[F[_]](F: Async[F]): JavaNetClientBuilder[F] = apply(F: Sync[F])
+  def apply[F[_], SourceBreakingDummy](F: Async[F]): JavaNetClientBuilder[F] = apply(F: Sync[F])
 }


### PR DESCRIPTION
`Sync` is sufficient, but making the change bincompatibly on `series/0.23` is not possible. Update: nevermind it was 😇 

Not sure how useful this is, but for example in our docs we _could_ use it to build a `Client[SyncIO]` that we can `unsafeRunSync()` without an implicit `IORuntime`. But that might be confusing.