### PR TITLE
Fix link to edit `adopters.md`

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -184,5 +184,5 @@ G8 templates provide a fast way to get started with SBT projects by just running
 ----
 
 @:style(footer)
-[@:icon(edit) Add yourself](https://github.com/http4s/http4s/edit/main/website/src/hugo/content/adopters.md), alphabetically, if you please.
+[@:icon(edit) Add yourself](https://github.com/http4s/http4s/edit/main/docs/adopters.md), alphabetically, if you please.
 @:@


### PR DESCRIPTION
`website/src/hugo/content/adopters.md` does not exist in `main` anymore.