### PR TITLE
Use `ByteVector#fromHex` in `CSRF` Middleware

### DIFF
--- a/core/shared/src/main/scala/org/http4s/internal/package.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/package.scala
@@ -41,6 +41,7 @@ import scala.util.control.NoStackTrace
 package object internal extends InternalPlatform {
 
   /** Hex encoding digits. Adapted from apache commons Hex.encodeHex */
+  @deprecated("Will be removed in 1.0.", "0.23.19")
   private val Digits: Array[Char] =
     Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
 
@@ -75,9 +76,11 @@ package object internal extends InternalPlatform {
     iterateData(out, l)
   }
 
+  @deprecated("Will be removed in 1.0.", "0.23.19")
   private[http4s] final def decodeHexString(data: String): Option[Array[Byte]] =
     decodeHex(data.toCharArray)
 
+  @deprecated("Will be removed in 1.0.", "0.23.19")
   private object HexDecodeException extends Exception with NoStackTrace
 
   /** Dirty, optimized hex decoding based off of apache
@@ -86,6 +89,7 @@ package object internal extends InternalPlatform {
     * @param data
     * @return
     */
+  @deprecated("Will be removed in 1.0.", "0.23.19")
   private[http4s] final def decodeHex(data: Array[Char]): Option[Array[Byte]] = {
     def toDigit(ch: Char): Int = {
       val digit = Character.digit(ch, 16)

--- a/server/jvm/src/main/scala/org/http4s/server/middleware/CSRF.scala
+++ b/server/jvm/src/main/scala/org/http4s/server/middleware/CSRF.scala
@@ -38,7 +38,6 @@ import org.http4s.headers.Referer
 import org.http4s.headers.`Content-Type`
 import org.http4s.headers.`X-Forwarded-For`
 import org.http4s.headers.{Cookie => HCookie}
-import org.http4s.internal.decodeHexString
 import org.typelevel.ci._
 import scodec.bits.Bases.Alphabets
 import scodec.bits.ByteVector
@@ -170,9 +169,9 @@ final class CSRF[F[_], G[_]] private[middleware] (
         val out = Hmac[SyncIO]
           .digest(key, ByteVector.view((raw + "-" + nonce).getBytes(StandardCharsets.UTF_8)))
           .unsafeRunSync()
-        decodeHexString(signed) match {
+        ByteVector.fromHex(signed, Alphabets.HexUppercase) match {
           case Some(decoded) =>
-            if (SecureEq[ByteVector].eqv(out, ByteVector.view(decoded)))
+            if (SecureEq[ByteVector].eqv(out, decoded))
               Right(raw)
             else
               Left(CSRFCheckFailed)


### PR DESCRIPTION
An attendant PR to the merged https://github.com/http4s/http4s/pull/6984. 
As it was previously, the method from `scodec` needs some performance tweaks.
It'd be lovely if @mpilquist could do a miracle once again 🙏🏻 
But, this time the difference isn't that dramatic for real-world usage.
```
[info] DecodeHexBench.decodeHexHttp4s    1000  thrpt    5  154.654 ± 11.577  ops/ms
[info] DecodeHexBench.decodeHexHttp4s   10000  thrpt    5   13.714 ±  0.116  ops/ms
[info] DecodeHexBench.decodeHexHttp4s  100000  thrpt    5    1.524 ±  0.507  ops/ms
[info] DecodeHexBench.decodeHexScodec    1000  thrpt    5   81.527 ±  4.917  ops/ms
[info] DecodeHexBench.decodeHexScodec   10000  thrpt    5    3.923 ±  0.063  ops/ms
[info] DecodeHexBench.decodeHexScodec  100000  thrpt    5    0.425 ±  0.024  ops/ms
```