### PR TITLE
Redirect `H2Connection.writeLoop` errors to logger

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -188,6 +188,7 @@ private[h2] class H2Connection[F[_]](
         }
         firstGoAway.getOrElse(F.unit) >> go(chunk)
       }
+      .handleErrorWith(ex => Stream.exec(logger.debug(ex)("writeLoop terminated")))
   // TODO Split Frames between Data and Others Hold Data If we are at cap
   //  Currently will backpressure at the data frame till its cleared
 


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/7014.