### PR TITLE
All received messages in h2 could have trailers

### DIFF
--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
@@ -153,6 +153,18 @@ class H2StreamSuite extends Http4sSuite {
     } yield ()
   }
 
+    test("H2Stream sendMessageBody empty message without 'Trailer' header closes Stream") {
+    val config = defaultSettings
+
+    for {
+      sq <- streamAndQueue(config)
+      (stream, queue) = sq
+      resp = Response[IO](Status.Ok, HttpVersion.`HTTP/2`)
+      _ <- stream.sendMessageBody(resp)
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.HalfClosedLocal)
+    } yield ()
+  }
+
   test("H2Stream sendMessageBody empty message with 'Trailer' header keeps stream open") {
     val config = defaultSettings
 


### PR DESCRIPTION
So essentially, we have some folks who are not setting trailers but sending trailer header in h2. Meaning essentially we need to always be prepared to get trailers whenever we are reading messages.

This is funky, but seems to work out ok. 

Essentially we are guarding that we setTrailers in any of the locations one might be waiting on them.