### PR TITLE
Print a helpful message when Ember server is slow to shut down

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -200,7 +200,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
     for {
       sg <- sgOpt.getOrElse(Network[F]).pure[Resource[F, *]]
       ready <- Resource.eval(Deferred[F, Either[Throwable, SocketAddress[IpAddress]]])
-      shutdown <- Resource.eval(Shutdown[F](shutdownTimeout))
+      shutdown <- Resource.eval(Shutdown[F](shutdownTimeout, logger))
       wsBuilder <- Resource.eval(WebSocketBuilder2[F])
       _ <- unixSocketConfig.fold(
         Concurrent[F].background(


### PR DESCRIPTION
This is a common gotcha users experience, so we try to make it better by at least logging a helpful message and a suggestion on how to reduce the shutdown timeout

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 