### PR TITLE
Tweak `build.sbt`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -903,7 +903,6 @@ def http4sCrossProject(name: String, crossType: CrossType) =
     )
     .nativeSettings(
       tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "0.23.16").toMap,
-      unusedCompileDependenciesTest := {},
       Test / envVars += "S2N_DONT_MLOCK" -> "1",
     )
     .enablePlugins(Http4sPlugin)


### PR DESCRIPTION
We get this workaround for Scala Native from the `sbt-http4s-org` plugin.