### PR TITLE
Fix a broken link to JDKHttpClient in the docs

### DIFF
--- a/docs/docs/integrations.md
+++ b/docs/docs/integrations.md
@@ -30,7 +30,7 @@ libraryDependencies ++= Seq(
 | [Ember](#ember)                                                  | JDK 8+ / Node.js 16+ / Native | ✅           | ✅           | ❌                | ✅                | ❌                      |
 | [Blaze](https://github.com/http4s/blaze)                         | JDK 8+                        | ✅           | ✅           | ❌                | ✅                | ❌                      |
 | [Netty](https://github.com/http4s/http4s-netty)                  | JDK 8+                        | ✅           | ✅           | ✅                | ✅                | ✅                      |
-| [JDK Http Client](https://jdk-http-client.http4s.org/stable/)    | JDK 11+                       | ✅           | ❌           | ✅                | ❌                | ✅                      |
+| [JDK Http Client](https://jdk-http-client.http4s.org)            | JDK 11+                       | ✅           | ❌           | ✅                | ❌                | ✅                      |
 | [Servlet](https://github.com/http4s/http4s-servlet)              | JDK 8+                        | ❌           | ✅           | ❌                | ❌                | ❌                      |
 | [DOM](https://http4s.github.io/http4s-dom)                       | Browsers                      | ✅           | ❌           | ✅                | ❌                | ❌                      |
 | [Feral](https://github.com/typelevel/feral)                      | Serverless                    | ❌           | ✅           | ❌                | ❌                | ❌                      |


### PR DESCRIPTION
https://github.com/http4s/http4s/blob/96428ee587edbd343226153faff8df871c93e12a/docs/docs/integrations.md?plain=1#L33

The old link does not work. Whereas https://jdk-http-client.http4s.org redirects to the latest release version automatically. So I think it should be a safe change.