### PR TITLE
Ember server fix frames

### DIFF
--- a/core/shared/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
+++ b/core/shared/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
@@ -140,7 +140,7 @@ class FrameTranscoder(val isClient: Boolean) {
       buff.flip
       Array[ByteBuffer](buff)
     } else {
-      buff.put(in.data.toByteBuffer)
+      in.data.copyToBuffer(buff)
       buff.flip
       Array[ByteBuffer](buff)
     }

--- a/core/shared/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
+++ b/core/shared/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
@@ -91,7 +91,7 @@ class FrameTranscoder(val isClient: Boolean) {
     } else if (in.length <= 0xffff) size += 2
     else size += 8
 
-    val buff = ByteBuffer.allocate(if (isClient) size + in.length else size)
+    val buff = ByteBuffer.allocate(size + in.length)
 
     val opcode = in.opcode
 
@@ -133,15 +133,16 @@ class FrameTranscoder(val isClient: Boolean) {
 
       val data = in.data
 
-      for (i <- 0 until in.length.toInt)
+      for (i <- 0 until in.length)
         buff.put(
           (data(i.toLong) ^ maskBits(i & 0x3)).toByte
         ) // i & 0x3 is the same as i % 4 but faster
       buff.flip
       Array[ByteBuffer](buff)
     } else {
+      buff.put(in.data.toByteBuffer)
       buff.flip
-      Array[ByteBuffer](buff, in.data.toByteBuffer)
+      Array[ByteBuffer](buff)
     }
   }
 

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -41,6 +41,8 @@ import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
+import scala.concurrent.duration._
+
 class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
 
   def service[F[_]](
@@ -188,6 +190,7 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
       )
       _ <- client.connect
       _ <- client.close
+      _ <- IO.sleep(100.millis) // wait update the Close
       msg <- ref.get
     } yield assertEquals(msg, "close")
   }

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -40,7 +40,6 @@ import org.java_websocket.handshake.ServerHandshake
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
-
 import scala.concurrent.duration._
 
 class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -174,14 +174,14 @@ private[internal] object WebSocketHelpers {
     frame match {
       case ping @ WebSocketFrame.Ping(data) =>
         writeFrame(WebSocketFrame.Pong(data)).as(ping.some)
-      case WebSocketFrame.Close(_) =>
+      case close @ WebSocketFrame.Close(_) =>
         closeState.get.flatMap {
           case Open =>
             for {
               frame <- F.fromEither(WebSocketFrame.Close(1000))
               _ <- writeFrame(frame)
               _ <- closeState.set(BothClosed)
-            } yield None
+            } yield Some(close)
           case _ => F.pure(None)
         }
       case x => F.pure(Some(x))


### PR DESCRIPTION
Fixes #6639 Fixes #5128

- Sometimes frames got corrupted when writing to a socket. This is because the frame headers and payload are not atomically written to the socket and the order can be changed.
- Provide CloseFrame to user's handler 