### PR TITLE
Ember-Core State - Extract factory method

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -197,21 +197,11 @@ private[ember] class H2Client[F[_]](
         socketAdd <- RequestKey.getAddress(key)
         _ <- socket.write(Chunk.byteVector(Preface.clientBV))
         ref <- Concurrent[F].ref(Map[Int, H2Stream[F]]())
-        initialWriteBlock <- Deferred[F, Either[Throwable, Unit]]
-        stateRef <-
-          Concurrent[F].ref(
-            H2Connection.State(
-              defaultSettings,
-              defaultSettings.initialWindowSize.windowSize,
-              initialWriteBlock,
-              localSettings.initialWindowSize.windowSize,
-              0,
-              0,
-              false,
-              None,
-              None,
-            )
-          )
+        stateRef <- H2Connection.initState[F](
+          defaultSettings,
+          defaultSettings.initialWindowSize,
+          localSettings.initialWindowSize,
+        )
         queue <- cats.effect.std.Queue.unbounded[F, Chunk[H2Frame]] // TODO revisit
         hpack <- Hpack.create[F]
         settingsAck <- Deferred[F, Either[Throwable, H2Frame.Settings.ConnectionSettings]]

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -200,21 +200,11 @@ private[ember] object H2Server {
         _.leftMap(_ => UnixSocketAddress("unknown.sock"))
       )
       ref <- Concurrent[F].ref(Map[Int, H2Stream[F]]())
-      initialWriteBlock <- Deferred[F, Either[Throwable, Unit]]
-      stateRef <-
-        Concurrent[F].ref(
-          H2Connection.State(
-            initialRemoteSettings,
-            defaultSettings.initialWindowSize.windowSize,
-            initialWriteBlock,
-            localSettings.initialWindowSize.windowSize,
-            0,
-            0,
-            false,
-            None,
-            None,
-          )
-        )
+      stateRef <- H2Connection.initState[F](
+        initialRemoteSettings,
+        defaultSettings.initialWindowSize,
+        localSettings.initialWindowSize,
+      )
       queue <- cats.effect.std.Queue.unbounded[F, Chunk[H2Frame]] // TODO revisit
       hpack <- Hpack.create[F]
       settingsAck <- Deferred[F, Either[Throwable, H2Frame.Settings.ConnectionSettings]]


### PR DESCRIPTION
Make the class constructor private, and extract an F-ectful
factory method that initialises the write block. 

-------

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. --->