### PR TITLE
Ember-Core / H2Stream: avoid wrapping in Chunk

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -190,7 +190,7 @@ private[h2] class H2Connection[F[_]](
 
   def writeLoop: Stream[F, Nothing] =
     Stream
-      .fromQueueUnterminated[F, H2Frame](outgoing, Int.MaxValue)
+      .fromQueueUnterminated[F, H2Frame](outgoing, 1)
       .chunks
       .foreach(writeChunk)
       .handleErrorWith(ex => Stream.exec(logger.debug(ex)("writeLoop terminated")))

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -215,7 +215,7 @@ private[ember] object H2Server {
             None,
           )
         )
-      queue <- cats.effect.std.Queue.unbounded[F, Chunk[H2Frame]] // TODO revisit
+      queue <- cats.effect.std.Queue.unbounded[F, H2Frame] // TODO revisit
       hpack <- Hpack.create[F]
       settingsAck <- Deferred[F, Either[Throwable, H2Frame.Settings.ConnectionSettings]]
       streamCreationLock <- Semaphore[F](1)
@@ -320,7 +320,7 @@ private[ember] object H2Server {
     for {
       h2 <- Resource.eval(initH2Connection)
       _ <- h2.writeLoop.compile.drain.background
-      _ <- Resource.eval(h2.outgoing.offer(Chunk.singleton(settingsFrame)))
+      _ <- Resource.eval(h2.outgoing.offer(settingsFrame))
       _ <- h2.readLoop.background
       // h2c Initial Request Communication on h2c Upgrade
       _ <- Resource.eval(


### PR DESCRIPTION
The Queue in the H2Stream is always receiving elements as singleton
chunks, but we can just avoid those and send them directly.