### PR TITLE
`Hpack` optimizations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -526,6 +526,9 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
         "org.http4s.ember.core.h2.H2Frame#Ping.emptyBV"
       ),
       ProblemFilters.exclude[Problem]("org.http4s.ember.core.h2.H2Client*"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.ember.core.h2.Hpack#Impl.this"
+      ),
     ) ++ {
       if (tlIsScala3.value)
         Seq(

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/Hpack.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/Hpack.scala
@@ -93,7 +93,7 @@ private[h2] object Hpack extends HpackPlatform {
   }
 
   private final class ByteVectorOutputStream(size: Int) extends ByteArrayOutputStream(size) {
-    def toByteVector() = ByteVector.view(buf, 0, count)
+    def toByteVector(): ByteVector = ByteVector.view(buf, 0, count)
   }
 
 }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/Hpack.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/Hpack.scala
@@ -80,7 +80,7 @@ private[h2] object Hpack extends HpackPlatform {
       tEncoder: Encoder,
       headers: List[(String, String, Boolean)],
   ): F[ByteVector] = Sync[F].delay {
-    val os = new ByteArrayOutputStream(1024)
+    val os = new ByteVectorOutputStream(1024)
     headers.foreach { h =>
       tEncoder.encodeHeader(
         os,
@@ -89,7 +89,11 @@ private[h2] object Hpack extends HpackPlatform {
         h._3,
       )
     }
-    ByteVector.view(os.toByteArray())
+    os.toByteVector()
+  }
+
+  private final class ByteVectorOutputStream(size: Int) extends ByteArrayOutputStream(size) {
+    def toByteVector() = ByteVector.view(buf, 0, count)
   }
 
 }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/Hpack.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/Hpack.scala
@@ -22,7 +22,6 @@ import cats.effect.std._
 import cats.syntax.all._
 import scodec.bits._
 
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import scala.collection.mutable.ListBuffer
@@ -58,7 +57,7 @@ private[h2] object Hpack extends HpackPlatform {
       bv: ByteVector,
   ): F[NonEmptyList[(String, String)]] = Sync[F].delay {
     val buffer = new ListBuffer[(String, String)]
-    val is = new ByteArrayInputStream(bv.toArray)
+    val is = bv.toInputStream
     val listener = new HeaderListener {
       def addHeader(name: Array[Byte], value: Array[Byte], sensitive: Boolean): Unit = {
         buffer.+=(


### PR DESCRIPTION
1. use `ByteVector#toInputStream` and `ByteVectorOuputStream` for copy-free conversions
2. use `List.newBuilder` instead of `ListBuffer` (not sure if this makes a difference, but intent is clearer)
3. use `Mutex` instead of `Sempahore(1)` (performance is optimized and communicates intent)