### PR TITLE
Properly handle `NoSuchElementException` in `tlsSocket.applicationProtocol`

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -296,12 +296,12 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
   //     case Some(value) => Stream.chunk(value)
   //   }
 
-  private[internal] def upgradeSocket[F[_]: Monad](
+  private[internal] def upgradeSocket[F[_]](
       socketInit: Socket[F],
       tlsInfoOpt: Option[(TLSContext[F], TLSParameters)],
       logger: Logger[F],
       enableHttp2: Boolean,
-  ): Resource[F, (Socket[F], Option[String])] =
+  )(implicit M: MonadError[F, Throwable]): Resource[F, (Socket[F], Option[String])] =
     tlsInfoOpt.fold((socketInit, Option.empty[String]).pure[Resource[F, *]]) {
       case (context, params) =>
         val newParams = if (enableHttp2) {
@@ -317,7 +317,13 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
           .build
           .evalMap(tlsSocket =>
             tlsSocket.write(fs2.Chunk.empty) >>
-              tlsSocket.applicationProtocol.map(protocol => (tlsSocket: Socket[F], protocol.some))
+              tlsSocket.applicationProtocol
+                .map(protocol => (tlsSocket: Socket[F], protocol.some))
+                .handleErrorWith {
+                  case _: NoSuchElementException =>
+                    (tlsSocket: Socket[F], None: Option[String]).pure[F]
+                  case other => M.raiseError(other)
+                }
           )
     }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -319,8 +319,8 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
             tlsSocket.write(fs2.Chunk.empty) >>
               tlsSocket.applicationProtocol
                 .map(protocol => (tlsSocket: Socket[F], protocol.some))
-                .recover {
-                  case _: NoSuchElementException => (tlsSocket, Option.empty)
+                .recover { case _: NoSuchElementException =>
+                  (tlsSocket, Option.empty)
                 }
           )
     }


### PR DESCRIPTION
See also: https://github.com/typelevel/fs2/pull/3215

Running `sbt quicklint` gives off these:
```
[error] failed to generate semanticdb for E:\work\scala\http4s\ember-server\shared\src\test\scala\org\http4s\ember\server\EmberServerSuite.scala:
[error] java.lang.IllegalArgumentException: 5184 is not a valid offset, allowed [0..5179]
[error]         at scala.meta.internal.inputs.InternalInput.offsetToLine(InternalInput.scala:48)
[error]         at scala.meta.internal.inputs.InternalInput.offsetToLine$(InternalInput.scala:42)
[error]         at scala.meta.inputs.Input$File.offsetToLine(Input.scala:51)
[error]         at scala.meta.inputs.Position$Range.endLine(Position.scala:39)
[error]         at scala.meta.internal.inputs.package$XtensionPositionToRange$.toRange$extension(package.scala:47)
[error]         at scala.meta.internal.semanticdb.scalac.TextDocumentOps$XtensionCompilationUnitDocument$traverser$3$.tryFindSynthetic(TextDocumentOps.scala:576)
[error]         at scala.meta.internal.semanticdb.scalac.TextDocumentOps$XtensionCompilationUnitDocument$traverser$3$.traverse(TextDocumentOps.scala:718)
[error]         at scala.meta.internal.semanticdb.scalac.TextDocumentOps$XtensionCompilationUnitDocument$traverser$3$.traverse(TextDocumentOps.scala:207)
...
```