### PR TITLE
Allow providing custom error handler when connection establishing fails.

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -132,8 +132,11 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
   def withShutdownTimeout(shutdownTimeout: Duration): EmberServerBuilder[F] =
     copy(shutdownTimeout = shutdownTimeout)
 
-  /** Called when an error occurs while attempting to read a connection. For example on JVM `javax.net.ssl.SSLException`
-    * may be thrown if the client doesn't speak SSL. If the [[PartialFunction]] does not match the error is just logged.
+  /** Called when an error occurs while attempting to read a connection.
+    *
+    * For example on JVM `javax.net.ssl.SSLException` may be thrown if the client doesn't speak SSL.
+    *
+    * If the [[scala.PartialFunction]] does not match the error is just logged.
     */
   def withConnectionErrorHandler(
       errorHandler: PartialFunction[Throwable, F[Unit]]
@@ -315,7 +318,7 @@ object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
     private val serverFailure =
       Response(Status.InternalServerError).putHeaders(org.http4s.headers.`Content-Length`.zero)
 
-    def connectionErrorHandler[F[_]: Applicative]: PartialFunction[Throwable, F[Unit]] =
+    def connectionErrorHandler[F[_]]: PartialFunction[Throwable, F[Unit]] =
       PartialFunction.empty[Throwable, F[Unit]]
 
     // Effectful Handler - Perhaps a Logger

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -132,12 +132,11 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
   def withShutdownTimeout(shutdownTimeout: Duration): EmberServerBuilder[F] =
     copy(shutdownTimeout = shutdownTimeout)
 
-  /**
-   * Called when an error occurs while attempting to read a connection. For example on JVM `javax.net.ssl.SSLException`
-   * may be thrown if the client doesn't speak SSL. If the [[PartialFunction]] does not match the error is just logged.
-   */
+  /** Called when an error occurs while attempting to read a connection. For example on JVM `javax.net.ssl.SSLException`
+    * may be thrown if the client doesn't speak SSL. If the [[PartialFunction]] does not match the error is just logged.
+    */
   def withConnectionErrorHandler(
-    errorHandler: PartialFunction[Throwable, F[Unit]]
+      errorHandler: PartialFunction[Throwable, F[Unit]]
   ): EmberServerBuilder[F] =
     copy(connectionErrorHandler = errorHandler)
 
@@ -316,7 +315,7 @@ object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
     private val serverFailure =
       Response(Status.InternalServerError).putHeaders(org.http4s.headers.`Content-Length`.zero)
 
-    def connectionErrorHandler[F[_] : Applicative]: PartialFunction[Throwable, F[Unit]] =
+    def connectionErrorHandler[F[_]: Applicative]: PartialFunction[Throwable, F[Unit]] =
       PartialFunction.empty[Throwable, F[Unit]]
 
     // Effectful Handler - Perhaps a Logger

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -43,6 +43,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
     private val httpApp: WebSocketBuilder2[F] => HttpApp[F],
     private val tlsInfoOpt: Option[(TLSContext[F], TLSParameters)],
     private val sgOpt: Option[SocketGroup[F]],
+    private val connectionErrorHandler: PartialFunction[Throwable, F[Unit]],
     private val errorHandler: Throwable => F[Response[F]],
     private val onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit],
     val maxConnections: Int,
@@ -67,6 +68,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
       httpApp: WebSocketBuilder2[F] => HttpApp[F] = self.httpApp,
       tlsInfoOpt: Option[(TLSContext[F], TLSParameters)] = self.tlsInfoOpt,
       sgOpt: Option[SocketGroup[F]] = self.sgOpt,
+      connectionErrorHandler: PartialFunction[Throwable, F[Unit]] = self.connectionErrorHandler,
       errorHandler: Throwable => F[Response[F]] = self.errorHandler,
       onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit] = self.onWriteFailure,
       maxConnections: Int = self.maxConnections,
@@ -88,6 +90,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
       httpApp = httpApp,
       tlsInfoOpt = tlsInfoOpt,
       sgOpt = sgOpt,
+      connectionErrorHandler = connectionErrorHandler,
       errorHandler = errorHandler,
       onWriteFailure = onWriteFailure,
       maxConnections = maxConnections,
@@ -128,6 +131,15 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
 
   def withShutdownTimeout(shutdownTimeout: Duration): EmberServerBuilder[F] =
     copy(shutdownTimeout = shutdownTimeout)
+
+  /**
+   * Called when an error occurs while attempting to read a connection. For example on JVM `javax.net.ssl.SSLException`
+   * may be thrown if the client doesn't speak SSL. If the [[PartialFunction]] does not match the error is just logged.
+   */
+  def withConnectionErrorHandler(
+    errorHandler: PartialFunction[Throwable, F[Unit]]
+  ): EmberServerBuilder[F] =
+    copy(connectionErrorHandler = errorHandler)
 
   @deprecated("Use withErrorHandler - Do not allow the F to fail", "0.21.17")
   def withOnError(onError: Throwable => Response[F]): EmberServerBuilder[F] =
@@ -214,6 +226,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
               tlsInfoOpt,
               ready,
               shutdown,
+              connectionErrorHandler,
               errorHandler,
               onWriteFailure,
               maxConnections,
@@ -240,6 +253,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
             tlsInfoOpt,
             ready,
             shutdown,
+            connectionErrorHandler,
             errorHandler,
             onWriteFailure,
             maxConnections,
@@ -273,6 +287,7 @@ object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
       httpApp = _ => Defaults.httpApp[F],
       tlsInfoOpt = None,
       sgOpt = None,
+      connectionErrorHandler = Defaults.connectionErrorHandler[F],
       errorHandler = Defaults.errorHandler[F],
       onWriteFailure = Defaults.onWriteFailure[F],
       maxConnections = Defaults.maxConnections,
@@ -300,6 +315,10 @@ object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
 
     private val serverFailure =
       Response(Status.InternalServerError).putHeaders(org.http4s.headers.`Content-Length`.zero)
+
+    def connectionErrorHandler[F[_] : Applicative]: PartialFunction[Throwable, F[Unit]] =
+      PartialFunction.empty[Throwable, F[Unit]]
+
     // Effectful Handler - Perhaps a Logger
     // Will only arrive at this code if your HttpApp fails or the request receiving fails for some reason
     def errorHandler[F[_]: Applicative]: Throwable => F[Response[F]] = { case (_: Throwable) =>

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -287,7 +287,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
         def fullConnectionErrorHandler(t: Throwable): F[Unit] =
           connectionErrorHandler.applyOrElse(
             t,
-            logger.error(_)("Request handler failed with exception"),
+            (t: Throwable) => logger.error(t)("Request handler failed with exception")
           )
         handler.handleErrorWith { t =>
           Stream.eval(fullConnectionErrorHandler(t)).drain

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -163,11 +163,10 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
     )
   }
 
-  /**
-   * @param connectionErrorHandler called when an error occurs while attempting to read a connection. For example on JVM
-   *                               `javax.net.ssl.SSLException` maybe be thrown if the client doesn't speak SSL. By
-   *                               default this just logs the error.
-   */
+  /** @param connectionErrorHandler called when an error occurs while attempting to read a connection. For example on JVM
+    *                               `javax.net.ssl.SSLException` maybe be thrown if the client doesn't speak SSL. By
+    *                               default this just logs the error.
+    */
   def serverInternal[F[_]: Async](
       server: Stream[F, Socket[F]],
       httpApp: HttpApp[F],
@@ -285,9 +284,11 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                 }
             }
 
-        def fullConnectionErrorHandler(t: Throwable): F[Unit] = {
-          connectionErrorHandler.applyOrElse(t, logger.error(_)("Request handler failed with exception"))
-        }
+        def fullConnectionErrorHandler(t: Throwable): F[Unit] =
+          connectionErrorHandler.applyOrElse(
+            t,
+            logger.error(_)("Request handler failed with exception"),
+          )
         handler.handleErrorWith { t =>
           Stream.eval(fullConnectionErrorHandler(t)).drain
         }

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -64,6 +64,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       ready: Deferred[F, Either[Throwable, SocketAddress[IpAddress]]],
       shutdown: Shutdown[F],
       // Defaults
+      connectionErrorHandler: PartialFunction[Throwable, F[Unit]],
       errorHandler: Throwable => F[Response[F]],
       onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit],
       maxConnections: Int,
@@ -89,6 +90,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       tlsInfoOpt: Option[(TLSContext[F], TLSParameters)],
       shutdown: Shutdown[F],
       // Defaults
+      connectionErrorHandler: PartialFunction[Throwable, F[Unit]],
       errorHandler: Throwable => F[Response[F]],
       onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit],
       maxConnections: Int,
@@ -114,6 +116,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       ready: Deferred[F, Either[Throwable, SocketAddress[IpAddress]]],
       shutdown: Shutdown[F],
       // Defaults
+      connectionErrorHandler: PartialFunction[Throwable, F[Unit]],
       errorHandler: Throwable => F[Response[F]],
       onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit],
       maxConnections: Int,
@@ -144,6 +147,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       tlsInfoOpt: Option[(TLSContext[F], TLSParameters)],
       shutdown: Shutdown[F],
       // Defaults
+      connectionErrorHandler: PartialFunction[Throwable, F[Unit]],
       errorHandler: Throwable => F[Response[F]],
       onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit],
       maxConnections: Int,
@@ -159,12 +163,18 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
     )
   }
 
+  /**
+   * @param connectionErrorHandler called when an error occurs while attempting to read a connection. For example on JVM
+   *                               `javax.net.ssl.SSLException` maybe be thrown if the client doesn't speak SSL. By
+   *                               default this just logs the error.
+   */
   def serverInternal[F[_]: Async](
       server: Stream[F, Socket[F]],
       httpApp: HttpApp[F],
       tlsInfoOpt: Option[(TLSContext[F], TLSParameters)],
       shutdown: Shutdown[F],
       // Defaults
+      connectionErrorHandler: PartialFunction[Throwable, F[Unit]],
       errorHandler: Throwable => F[Response[F]],
       onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit],
       maxConnections: Int,
@@ -275,8 +285,11 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                 }
             }
 
+        def fullConnectionErrorHandler(t: Throwable): F[Unit] = {
+          connectionErrorHandler.applyOrElse(t, logger.error(_)("Request handler failed with exception"))
+        }
         handler.handleErrorWith { t =>
-          Stream.eval(logger.error(t)("Request handler failed with exception")).drain
+          Stream.eval(fullConnectionErrorHandler(t)).drain
         }
       }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -287,7 +287,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
         def fullConnectionErrorHandler(t: Throwable): F[Unit] =
           connectionErrorHandler.applyOrElse(
             t,
-            (t: Throwable) => logger.error(t)("Request handler failed with exception")
+            (t: Throwable) => logger.error(t)("Request handler failed with exception"),
           )
         handler.handleErrorWith { t =>
           Stream.eval(fullConnectionErrorHandler(t)).drain


### PR DESCRIPTION
When someone tries to make non-SSL connection to your SSL HTTP server you get this in your log:
```
[o.h.e.s.EmberServerBuilderCompanionPlatform] Request handler failed with exception
javax.net.ssl.SSLException: Unrecognized SSL message, plaintext connection?
        at java.base/sun.security.ssl.SSLEngineInputRecord.bytesInCompletePacket(SSLEngineInputRecord.java:146)
        at java.base/sun.security.ssl.SSLEngineInputRecord.bytesInCompletePacket(SSLEngineInputRecord.java:64)
        at java.base/sun.security.ssl.SSLEngineImpl.readRecord(SSLEngineImpl.java:557)
        at java.base/sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:454)
        at java.base/sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:433)
        at java.base/javax.net.ssl.SSLEngine.unwrap(SSLEngine.java:637)
        at fs2.io.net.tls.TLSEngine$$anon$1.unwrapHandshake$$anonfun$1(TLSEngine.scala:250)
        at fs2.io.net.tls.InputOutputBuffer$.fs2$io$net$tls$InputOutputBuffer$$anon$1$$_$perform$$anonfun$1$$anonfun$1$$anonfun$1(InputOutputBuffer.scala:92)
        at delay @ fs2.io.net.tls.InputOutputBuffer$$anon$1.perform$$anonfun$1$$anonfun$1(InputOutputBuffer.scala:95)
        at flatMap @ fs2.io.net.tls.InputOutputBuffer$$anon$1.perform$$anonfun$1(InputOutputBuffer.scala:95)
        at flatMap @ fs2.io.net.tls.InputOutputBuffer$$anon$1.perform(InputOutputBuffer.scala:96)
        at flatTap @ dev.profunktor.fs2rabbit.algebra.ConnectionResource$$anon$1.<init>(Connection.scala:154)
        at flatMap @ fs2.io.net.tls.TLSEngine$$anon$1.unwrapHandshake(TLSEngine.scala:262)
        at delay @ fs2.io.net.tls.InputOutputBuffer$$anon$1.input$$anonfun$2(InputOutputBuffer.scala:82)
        at flatMap @ fs2.io.net.tls.InputOutputBuffer$$anon$1.input(InputOutputBuffer.scala:75)
        at flatMap @ fs2.io.net.tls.InputOutputBuffer$$anon$1.input(InputOutputBuffer.scala:82)
        at delay @ fs2.io.net.SocketCompanionPlatform$BufferedReads.releaseBuffer(SocketPlatform.scala:78)
        at map @ fs2.io.net.SocketCompanionPlatform$BufferedReads.read$$anonfun$1$$anonfun$1(SocketPlatform.scala:84)
```

Which isn't great:
1. It spams your log files.
2. If you're using an error collector like Sentry, it raises unnecessary alerts and consumes your event quotas.

This allows you to provide a custom error handler for the failing connections, defaulting to logging an error.

```scala
      .withConnectionErrorHandler {
        case e: SSLException if e.getMessage == "Unrecognized SSL message, plaintext connection?" =>
          given LogCorrelationId.Concrete = LogCorrelationId.random()(Random)

          IO(log.debug(s"Received non-SSL request into an SSL endpoint @ $serverStr"))
        case e: SSLHandshakeException =>
          given LogCorrelationId.Concrete = LogCorrelationId.random()(Random)

          IO(log.debug(s"SSL handshake error at SSL endpoint @ $serverStr: ${e.getMessage}"))

        case e: IOException if e.getMessage == "Broken pipe" =>
          given LogCorrelationId.Concrete = LogCorrelationId.random()(Random)

          IO(log.debug(s"Broken pipe @ $serverStr"))

        case e =>
          given LogCorrelationId.Concrete = LogCorrelationId.random()(Random)
          IO(log.debug(s"$e @ $serverStr"))
      }
```