### PR TITLE
Use `Channel` for H2 `readBuffer`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -544,6 +544,9 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "org.http4s.ember.core.h2.H2Stream#State.apply"
       ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.ember.core.h2.H2Stream#State._8"
+      ),
     ) ++ {
       if (tlIsScala3.value)
         Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -529,6 +529,21 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "org.http4s.ember.core.h2.Hpack#Impl.this"
       ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.ember.core.h2.H2Stream#State.readBuffer"
+      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.ember.core.h2.H2Stream#State.copy"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.ember.core.h2.H2Stream#State.copy$default$8"
+      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.ember.core.h2.H2Stream#State.this"
+      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.http4s.ember.core.h2.H2Stream#State.apply"
+      ),
     ) ++ {
       if (tlIsScala3.value)
         Seq(

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -187,7 +187,7 @@ private[ember] object H2Server {
         }
         _ <- s.request.complete(Either.right(req))
         er = Either.right(req.body.compile.to(fs2.Collector.supportsByteVector(ByteVector)))
-        _ <- s.readBuffer.offer(er)
+        _ <- s.readBuffer.send(er)
         _ <- s.writeBlock.complete(Either.unit)
       } yield ()
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -333,7 +333,7 @@ private[h2] class H2Stream[F[_]: Concurrent](
             )
           )
           _ <-
-            if (sizeReadOk) s.readBuffer.send(Right(data.data))
+            if (sizeReadOk) s.readBuffer.send(Right(data.data)).void
             else rstStream(H2Error.ProtocolError)
 
           _ <-

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -19,9 +19,9 @@ package org.http4s.ember.core.h2
 import cats._
 import cats.data._
 import cats.effect._
-import cats.effect.std.Queue
 import cats.syntax.all._
 import fs2._
+import fs2.concurrent.Channel
 import org.http4s.Header
 import org.http4s.Headers
 import org.http4s.Message
@@ -333,7 +333,7 @@ private[h2] class H2Stream[F[_]: Concurrent](
             )
           )
           _ <-
-            if (sizeReadOk) s.readBuffer.offer(Either.right(data.data))
+            if (sizeReadOk) s.readBuffer.send(Right(data.data))
             else rstStream(H2Error.ProtocolError)
 
           _ <-
@@ -411,30 +411,9 @@ private[h2] class H2Stream[F[_]: Concurrent](
   def getRequest: F[org.http4s.Request[fs2.Pure]] = state.get.flatMap(_.request.get.rethrow)
   def getResponse: F[org.http4s.Response[fs2.Pure]] = state.get.flatMap(_.response.get.rethrow)
 
-  def readBody: Stream[F, Byte] = {
-    def pullBuffer(buffer: Queue[F, Either[Throwable, ByteVector]]): Pull[F, Byte, Unit] =
-      Pull.eval(buffer.tryTake).flatMap {
-        case Some(Right(s)) => Pull.output(Chunk.byteVector(s)) >> pullBuffer(buffer)
-        case Some(Left(e)) => Pull.raiseError(e)
-        case None => Pull.done
-      }
-
-    def p1(state: H2Stream.State[F]): Pull[F, Byte, Unit] =
-      Pull.eval(Concurrent[F].race(state.readBuffer.take, state.trailers.get)).flatMap {
-        case Left(Right(b)) => Pull.output(Chunk.byteVector(b))
-        case Left(Left(e)) => Pull.raiseError(e)
-        case Right(_) => Pull.done
-      }
-
-    def loop: Pull[F, Byte, Unit] =
-      Pull.eval(state.get).flatMap { state =>
-        if (state.isClosed)
-          pullBuffer(state.readBuffer)
-        else
-          p1(state) >> pullBuffer(state.readBuffer) >> loop
-      }
-
-    loop.stream
+  def readBody: Stream[F, Byte] = Stream.force(state.get.map(_.readBuffer.stream)).flatMap {
+    case Right(bv) => Stream.chunk(Chunk.byteVector(bv))
+    case Left(ex) => Stream.raiseError(ex)
   }
 
 }
@@ -448,7 +427,7 @@ private[h2] object H2Stream {
       request: Deferred[F, Either[Throwable, org.http4s.Request[fs2.Pure]]],
       response: Deferred[F, Either[Throwable, org.http4s.Response[fs2.Pure]]],
       trailers: Deferred[F, Either[Throwable, org.http4s.Headers]],
-      readBuffer: Queue[F, Either[Throwable, ByteVector]],
+      readBuffer: Channel[F, Either[Throwable, ByteVector]],
       contentLengthCheck: Option[(Long, Long)],
   ) {
     override def toString: String =
@@ -465,7 +444,7 @@ private[h2] object H2Stream {
       writeBlock.complete(Left(t)) >>
         request.complete(Left(t)) >>
         response.complete(Left(t)) >>
-        readBuffer.offer(Left(t)) >>
+        readBuffer.send(Left(t)) >>
         trailers.complete(Left(t)).void
     }
 

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
@@ -22,6 +22,7 @@ import cats.effect.Ref
 import cats.effect.std.Queue
 import cats.syntax.all._
 import fs2.Chunk
+import fs2.concurrent.Channel
 import org.http4s.Headers
 import org.http4s.Http4sSuite
 import org.http4s.HttpVersion
@@ -42,7 +43,7 @@ class H2StreamSuite extends Http4sSuite {
       req <- Deferred[IO, Either[Throwable, Request[fs2.Pure]]]
       resp <- Deferred[IO, Either[Throwable, Response[fs2.Pure]]]
       trailers <- Deferred[IO, Either[Throwable, Headers]]
-      readBuffer <- Queue.unbounded[IO, Either[Throwable, ByteVector]]
+      readBuffer <- Channel.unbounded[IO, Either[Throwable, ByteVector]]
 
       state <- Ref[IO].of(
         H2Stream.State[IO](


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/7060.

An FS2 `Channel` replaces the `Queue` used for the `readBuffer`. A `Channel` offers two advantages for us:
1. It can be explicitly closed (this fixes the bug, will explain further inline).
2. It is optimized for single-consumer as a `Stream`, which is precisely our usecase.