### PR TITLE
Close `H2Stream` `readBuffer` on `data.endStream`

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -92,7 +92,7 @@ private[h2] class H2Connection[F[_]](
       refState,
       hpack,
       outgoing,
-      body.close *> closedStreams.offer(id),
+      closedStreams.offer(id),
       goAway,
       logger,
     )
@@ -128,7 +128,7 @@ private[h2] class H2Connection[F[_]](
       refState,
       hpack,
       outgoing,
-      body.close *> closedStreams.offer(id),
+      closedStreams.offer(id),
       goAway,
       logger,
     )

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -339,7 +339,9 @@ private[h2] class H2Stream[F[_]: Concurrent](
             if (needsWindowUpdate && !isClosed && sizeReadOk) {
               enqueue.offer(Chunk.singleton(H2Frame.WindowUpdate(id, windowSize - newSize)))
             } else Applicative[F].unit
-          _ <- if (data.endStream) s.trailWith(List.empty).void else Applicative[F].unit
+          _ <-
+            if (data.endStream) s.readBuffer.close *> s.trailWith(List.empty)
+            else Applicative[F].unit
           _ <-
             if (isClosed && sizeReadOk) onClosed else Applicative[F].unit
         } yield ()

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -25,6 +25,7 @@ import fs2.io.net.ConnectException
 import org.http4s._
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.core.EmberException
+import org.http4s.ember.core.h2.H2Keys.Http2PriorKnowledge
 import org.http4s.implicits._
 import org.http4s.server.Server
 
@@ -152,6 +153,27 @@ class EmberServerSuite extends Http4sSuite {
         IO.sleep(1.second) *> // so server shutdown propagates
           serverResource(_.withPort(port).withShutdownTimeout(0.nanos)).use(runReq(_))
       }
+  }
+
+  test("#7146 - HTTP/2 request with body".only) {
+    val server = EmberServerBuilder
+      .default[IO]
+      .withPort(port"0")
+      .withHttp2
+      .withHttpApp(service)
+      .build
+
+    val client = EmberClientBuilder
+      .default[IO]
+      .withHttp2
+      .build
+
+    (server, client).tupled.use { case (server, client) =>
+      val req = Request[IO](Method.POST, uri = url(server.addressIp4s, "/echo"))
+        .withEntity("hello")
+        .withAttribute(Http2PriorKnowledge, ())
+      client.expect[String](req).assertEquals("hello")
+    }
   }
 
 }

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -155,7 +155,7 @@ class EmberServerSuite extends Http4sSuite {
       }
   }
 
-  test("#7146 - HTTP/2 request with body".only) {
+  test("#7146 - HTTP/2 request with body") {
     val server = EmberServerBuilder
       .default[IO]
       .withPort(port"0")


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/7146. The `Channel` introduced in https://github.com/http4s/http4s/pull/7096 was not being closed in the right place.