### PR TITLE
Close H2 `readBuffer` on `headers.endStream`

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -231,7 +231,7 @@ private[h2] class H2Stream[F[_]: Concurrent](
                       case Some(resp) =>
                         response.complete(Either.right(attribute(resp))) >>
                           checkLengthOf(resp) >>
-                          (if (headers.endStream) s.trailWith(List.empty).void
+                          (if (headers.endStream) s.readBuffer.close *> s.trailWith(List.empty).void
                            else Applicative[F].unit) >>
                           (if (newstate == StreamState.Closed) onClosed
                            else Applicative[F].unit)
@@ -248,7 +248,7 @@ private[h2] class H2Stream[F[_]: Concurrent](
                       case Some(req) =>
                         request.complete(Either.right(attribute(req))) >>
                           checkLengthOf(req) >>
-                          (if (headers.endStream) s.trailWith(List.empty).void
+                          (if (headers.endStream) s.readBuffer.close *> s.trailWith(List.empty).void
                            else Applicative[F].unit) >>
                           (if (newstate == StreamState.Closed) onClosed
                            else Applicative[F].unit)


### PR DESCRIPTION
More fixing following https://github.com/http4s/http4s/pull/7147. That fix had the right idea, it just needed to be applied in a couple other places.

Unfortunately we currently cannot exercise this case with ember client on `series/0.23`. Due to the limitations of the entity model it always sends the `endStream` on the body (instead of on the headers). However if we port https://github.com/http4s/http4s/pull/6752 to H2 then it would exercise this case and we could also do so on `main`.