### PR TITLE
Mask errors in Ember server `runConnection`

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -365,7 +365,9 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       .through(_.chunks.foreach(c => timeoutMaybe(socket.write(c), idleTimeout)))
       .compile
       .drain
-      .onError(onWriteFailure(request, resp, _))
+      .onError { case err =>
+        onWriteFailure(request, resp, err)
+      }
 
   private[internal] def postProcessResponse[F[_]: Concurrent: Clock](
       req: Request[F],


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/7149.

Ok, so I'm not entirely sold on this change. Masking errors seems like a world of pain when things go wrong in unexpected ways. Here's my thinking:

1. all errors _should_ already be reported through side-channels. So letting them leak to the unhandled error reporting just results in duplicate logging.

2. Random unhandled errors popping up is very unpopular. This issue is not the first time we've gotten complaints.
   https://github.com/http4s/http4s/issues/7149

I did have one other implementation idea: after reporting an error through a side-channel, we could self-cancel the current fiber. Then, there would be no need to mask errors, and any errors that did appear would be legit. However, cancelation is rather drastic (unrecoverable) and may have unintended effects. Also `Error` and `Canceled` are distinct pathways e.g. in `onFinalizeCase` so it could be confusing for that as well.