### PR TITLE
Migrate `Uri.Scheme` and `TransferCoding` to `CIString`

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -108,7 +108,7 @@ object JsonDebugErrorHandler {
         "method" -> req.method.name.asJson,
         "uri" -> Json
           .obj(
-            "scheme" -> req.uri.scheme.map(_.value).asJson,
+            "scheme" -> req.uri.scheme.map(_.value.toString).asJson,
             "authority" -> req.uri.authority
               .map(auth =>
                 Json

--- a/client/js/src/main/scala/org/http4s/client/NodeJSClientBuilder.scala
+++ b/client/js/src/main/scala/org/http4s/client/NodeJSClientBuilder.scala
@@ -51,7 +51,7 @@ private[client] sealed abstract class NodeJSClientBuilder[F[_]](implicit protect
       F.async[IncomingMessage] { cb =>
         val options = new RequestOptions {
           method = req.method.renderString
-          protocol = req.uri.scheme.map(_.value + ":").orUndefined
+          protocol = req.uri.scheme.map(_.value.toString + ":").orUndefined
           host = req.uri.authority.map { authority =>
             authority.host match {
               case Uri.RegName(n) => n.toString

--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -39,7 +39,6 @@ import cats.syntax.all._
 import com.comcast.ip4s
 import org.http4s.internal.UriCoding
 import org.http4s.internal.compareField
-import org.http4s.internal.hashLower
 import org.http4s.internal.parsing.Rfc3986
 import org.http4s.internal.reduceComparisons
 import org.http4s.util.Renderable
@@ -231,29 +230,16 @@ object Uri extends UriPlatform {
     *
     * @see [[https://datatracker.ietf.org/doc/html/rfc3986#section-3.1 RFC 3986, Section 3.1, Scheme]]
     */
-  final class Scheme private[http4s] (val value: String) extends Ordered[Scheme] {
-    override def equals(o: Any): Boolean =
-      o match {
-        case that: Scheme => this.value.equalsIgnoreCase(that.value)
-        case _ => false
-      }
-
-    private[this] var hash = 0
-    override def hashCode(): Int = {
-      if (hash == 0)
-        hash = hashLower(value)
-      hash
-    }
-
+  final case class Scheme private[http4s] (value: CIString) extends Ordered[Scheme] {
     override def toString: String = s"Scheme($value)"
 
     override def compare(other: Scheme): Int =
-      value.compareToIgnoreCase(other.value)
+      value.compare(other.value)
   }
 
   object Scheme {
-    val http: Scheme = new Scheme("http")
-    val https: Scheme = new Scheme("https")
+    val http: Scheme = new Scheme(CIString("http"))
+    val https: Scheme = new Scheme(CIString("https"))
 
     @deprecated("Renamed to fromString", "0.21.0-M2")
     def parse(s: String): ParseResult[Scheme] = fromString(s)
@@ -1298,7 +1284,7 @@ object Uri extends UriPlatform {
         .backtrack
         .orElse((string("http") <* not(unary)).as(Uri.Scheme.http))
         .backtrack
-        .orElse((alpha *> unary.rep0).string.map(new Uri.Scheme(_)))
+        .orElse((alpha *> unary.rep0).string.map(s => new Uri.Scheme(CIString(s))))
     }
 
     /* request-target = origin-form

--- a/core/shared/src/main/scala/org/http4s/internal/package.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/package.scala
@@ -45,23 +45,6 @@ package object internal {
       s"This is a bug. Please report to https://github.com/http4s/http4s/issues: ${message}"
     )
 
-  // TODO Remove in 1.0. We can do better with MurmurHash3.
-  private[http4s] def hashLower(s: String): Int = {
-    var h = 0
-    var i = 0
-    val len = s.length
-    while (i < len) {
-      // Strings are equal ignoring case if either their uppercase or lowercase
-      // forms are equal. Equality of one does not imply the other, so we need
-      // to go in both directions. A character is not guaranteed to make this
-      // round trip, but it doesn't matter as long as all equal characters
-      // hash the same.
-      h = h * 31 + Character.toLowerCase(Character.toUpperCase(s.charAt(i)))
-      i += 1
-    }
-    h
-  }
-
   private val utf8Bom: Chunk[Byte] = Chunk(0xef.toByte, 0xbb.toByte, 0xbf.toByte)
 
   private[http4s] def skipUtf8ByteOrderMark(chunk: Chunk[Byte]): Chunk[Byte] =

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -287,9 +287,9 @@ private[ember] class H2Client[F[_]](
     // Host And Port are required
     val key = H2Client.RequestKey.fromRequest(req)
     val priorKnowledge = req.attributes.contains(H2Keys.Http2PriorKnowledge)
-    val useTLS = req.uri.scheme.map(_.value) match {
-      case Some("http") => false
-      case Some("https") => true
+    val useTLS = req.uri.scheme match {
+      case Some(Scheme.http) => false
+      case Some(Scheme.https) => true
       // How Do we Choose when to use TLS, for http/1.1 this is simple its with
       // this, but with http2, there can be arbitrary schemes
       // but also probably wrong if doing websockets over http/1.1

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
@@ -45,7 +45,7 @@ private[h2] object PseudoHeaders {
     }
     val l = NonEmptyList.of(
       (METHOD, req.method.toString, false),
-      (SCHEME, req.uri.scheme.map(_.value).getOrElse("https"), false) ::
+      (SCHEME, req.uri.scheme.map(_.value.toString).getOrElse("https"), false) ::
         (PATH, path, false) ::
         (AUTHORITY, req.uri.authority.map(_.toString).getOrElse(""), false) ::
         req.headers.headers

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -44,7 +44,6 @@ import scodec.bits.ByteVector
 import java.nio.charset.{Charset => NioCharset}
 import java.time._
 import java.util.Base64
-import java.util.Locale
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -799,7 +798,7 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
   }
 
   implicit val http4sTestingCogenForTransferCoding: Cogen[TransferCoding] =
-    Cogen[String].contramap(_.coding.toLowerCase(Locale.ROOT))
+    Cogen[CIString].contramap(_.coding)
 
   implicit val http4sTestingAbitraryForPath: Arbitrary[Uri.Path] = Arbitrary {
     val genSegmentNzNc =

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -786,7 +786,7 @@ private[discipline] trait ArbitraryInstances { this: ArbitraryInstancesBinCompat
   }
 
   implicit val http4sTestingCogenForScheme: Cogen[Uri.Scheme] =
-    Cogen[String].contramap(_.value.toLowerCase(Locale.ROOT))
+    Cogen[CIString].contramap(_.value)
 
   implicit val http4sTestingArbitraryForTransferCoding: Arbitrary[TransferCoding] = Arbitrary {
     Gen.oneOf(

--- a/tests/shared/src/test/scala/org/http4s/SchemeSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/SchemeSuite.scala
@@ -29,13 +29,13 @@ import org.scalacheck.Prop._
 class SchemeSuite extends munit.DisciplineSuite {
   test("equals should be consistent with equalsIgnoreCase of the values") {
     forAll { (a: Scheme, b: Scheme) =>
-      (a == b) == a.value.equalsIgnoreCase(b.value)
+      (a == b) == a.value.toString.equalsIgnoreCase(b.value.toString)
     }
   }
 
   test("compare should be consistent with value.compareToIgnoreCase") {
     forAll { (a: Scheme, b: Scheme) =>
-      assertEquals(a.value.compareToIgnoreCase(b.value), a.compare(b))
+      assertEquals(a.value.toString.compareToIgnoreCase(b.value.toString), a.compare(b))
     }
   }
 
@@ -47,7 +47,7 @@ class SchemeSuite extends munit.DisciplineSuite {
 
   test("render should return value") {
     forAll { (s: Scheme) =>
-      assertEquals(Renderer.renderString(s), s.value)
+      assertEquals(Renderer.renderString(s), s.value.toString)
     }
   }
 

--- a/tests/shared/src/test/scala/org/http4s/TransferCodingSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/TransferCodingSpec.scala
@@ -27,13 +27,13 @@ class TransferCodingSpec extends Http4sSuite {
 
   test("equals should be consistent with equalsIgnoreCase of the codings") {
     Prop.forAll { (a: TransferCoding, b: TransferCoding) =>
-      (a == b) == a.coding.equalsIgnoreCase(b.coding)
+      (a == b) == a.coding.toString.equalsIgnoreCase(b.coding.toString)
     }
   }
 
   test("compare should be consistent with coding.compareToIgnoreCase") {
     Prop.forAll { (a: TransferCoding, b: TransferCoding) =>
-      a.coding.compareToIgnoreCase(b.coding) == a.compare(b)
+      a.coding.toString.compareToIgnoreCase(b.coding.toString) == a.compare(b)
     }
   }
 
@@ -45,7 +45,7 @@ class TransferCodingSpec extends Http4sSuite {
 
   test("parse should parse single items") {
     Prop.forAll { (a: TransferCoding) =>
-      TransferCoding.parseList(a.coding) == ParseResult.success(NonEmptyList.one(a))
+      TransferCoding.parseList(a.coding.toString) == ParseResult.success(NonEmptyList.one(a))
     }
   }
   test("parse should parse multiple items") {
@@ -57,7 +57,7 @@ class TransferCodingSpec extends Http4sSuite {
 
   test("render should return coding") {
     Prop.forAll { (s: TransferCoding) =>
-      Renderer.renderString(s) == s.coding
+      Renderer.renderString(s) == s.coding.toString
     }
   }
 


### PR DESCRIPTION
Follow up on #3442 and #7158. Fixes parts of #7031.

Replaced internal case insensitive implementation with `CIString`