### PR TITLE
A bunch of tweaks to `ClientHelpers`' methods

### DIFF
--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -52,7 +52,7 @@ import java.io.IOException
 import scala.concurrent.duration._
 
 private[client] object ClientHelpers {
-  def requestToSocketWithKey[F[_]: Sync](
+  def requestToSocketWithKey[F[_]: MonadThrow](
       request: Request[F],
       tlsContextOpt: Option[TLSContext[F]],
       enableEndpointValidation: Boolean,
@@ -71,7 +71,7 @@ private[client] object ClientHelpers {
     )
   }
 
-  def unixSocket[F[_]: Async](
+  def unixSocket[F[_]: MonadThrow](
       request: Request[F],
       unixSockets: fs2.io.net.unixsocket.UnixSockets[F],
       address: fs2.io.net.unixsocket.UnixSocketAddress,
@@ -90,7 +90,7 @@ private[client] object ClientHelpers {
     )
   }
 
-  def requestKeyToSocketWithKey[F[_]: Sync](
+  def requestKeyToSocketWithKey[F[_]: MonadThrow](
       requestKey: RequestKey,
       tlsContextOpt: Option[TLSContext[F]],
       enableEndpointValidation: Boolean,

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -239,12 +239,8 @@ private[client] object ClientHelpers {
         val host = auth.host.value
 
         for {
-          host <- Host
-            .fromString(host)
-            .liftTo[F](new IllegalArgumentException("Invalid host"))
-          port <- Port
-            .fromInt(port)
-            .liftTo[F](new IllegalArgumentException("Invalid port"))
+          host <- Host.fromString(host).liftTo[F](MissingHost())
+          port <- Port.fromInt(port).liftTo[F](MissingPort())
         } yield SocketAddress[Host](host, port)
     }
 
@@ -296,4 +292,8 @@ private[client] object ClientHelpers {
         case _ => false
       }
   }
+
+  private case class MissingHost() extends RuntimeException("Invalid hostname")
+
+  private case class MissingPort() extends RuntimeException("Invalid port")
 }


### PR DESCRIPTION
This also addresses #7108 but for the 1.0-series only (tho it can be easily backported if we want to).