### PR TITLE
Core Models - Deprecate Stream operations

### DIFF
--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -290,7 +290,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     // From ArgonautSuite, which tests similar things:
     // TODO Urgh.  We need to make testing these smoother.
     // https://github.com/http4s/http4s/issues/157
-    def getBody(body: EntityBody[IO]): IO[Array[Byte]] = body.compile.to(Array)
+    def getBody(body: Stream[IO, Byte]): IO[Array[Byte]] = body.compile.to(Array)
     val req = Request[IO]().withEntity(Json.fromDoubleOrNull(157))
     val body = req
       .decode { (json: Json) =>

--- a/client/shared/src/main/scala/org/http4s/client/Client.scala
+++ b/client/shared/src/main/scala/org/http4s/client/Client.scala
@@ -300,10 +300,10 @@ object Client {
 
     def run(req: Request[F]): Resource[F, Response[F]] =
       Resource.eval(Ref[F].of(false)).flatMap { disposed =>
-        val reqAugmented =
-          addHostHeaderIfUriIsAbsolute(req.pipeBodyThrough(until(disposed)))
+        val augmentedEntity = Entity.stream(until(disposed)(req.body))
+
         Resource
-          .eval(app(reqAugmented))
+          .eval(app(addHostHeaderIfUriIsAbsolute(req.withEntity(augmentedEntity))))
           .onFinalize(disposed.set(true))
           .flatMap(processResponse(_, disposed))
       }

--- a/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
+++ b/client/shared/src/main/scala/org/http4s/client/DefaultClient.scala
@@ -53,7 +53,8 @@ private[http4s] abstract class DefaultClient[F[_]](implicit F: MonadCancelThrow[
   def toHttpApp: HttpApp[F] =
     Kleisli { req =>
       F.map(run(req).allocated) { case (resp, release) =>
-        resp.pipeBodyThrough(_.onFinalizeWeak(release))
+        val released = resp.body.onFinalizeWeak(release)
+        resp.withEntity(Entity.stream(released))
       }
     }
 

--- a/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/RequestLogger.scala
@@ -92,7 +92,7 @@ object RequestLogger {
                   .getAndSet(true)
                   .ifM(
                     F.unit,
-                    logMessage(req.withBodyStream(newBody)).handleErrorWith { case t =>
+                    logMessage(req.withEntity(Entity.stream(newBody))).handleErrorWith { case t =>
                       logger.error(t)("Error logging request body")
                     },
                   )

--- a/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -97,7 +97,7 @@ object ResponseLogger {
                   F.pure(response.pipeBodyThrough(_.observe(dumpChunksToVec)))
                 ) { _ =>
                   val newBody = Stream.eval(vec.get).flatMap(Stream.emits).unchunks
-                  logMessage(response.withBodyStream(newBody))
+                  logMessage(response.withEntity(Entity.stream(newBody)))
                     .handleErrorWith(t => logger.error(t)("Error logging response body"))
                 }
               }

--- a/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -19,6 +19,7 @@ package client
 package middleware
 
 import cats.effect._
+import fs2.Stream
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
 import org.scalacheck.effect.PropF.forAllF
@@ -35,7 +36,7 @@ class LoggerSuite extends Http4sSuite {
       NotFound()
   }
 
-  private def body: EntityBody[IO] = fs2.Stream.emits("This is a test resource.".getBytes())
+  private def body: Stream[IO, Byte] = fs2.Stream.emits("This is a test resource.".getBytes())
 
   private val expectedBody: String = "This is a test resource."
 

--- a/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -49,7 +49,7 @@ class LoggerSuite extends Http4sSuite {
   }
 
   test("ResponseLogger should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withEntity(Entity.stream(body))
     val res = responseLoggerClient.expect[String](req)
     res.assertEquals(expectedBody)
   }
@@ -62,7 +62,7 @@ class LoggerSuite extends Http4sSuite {
   }
 
   test("RequestLogger should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withEntity(Entity.stream(body))
     val res = requestLoggerClient.expect[String](req)
     res.assertEquals(expectedBody)
   }
@@ -103,7 +103,7 @@ class LoggerSuite extends Http4sSuite {
   }
 
   test("Logger should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withEntity(Entity.stream(body))
     val res = loggerApp(req)
     res.map(_.status).assertEquals(Status.Ok)
     res.flatMap(_.as[String]).assertEquals(expectedBody)

--- a/core/shared/src/main/scala/org/http4s/Media.scala
+++ b/core/shared/src/main/scala/org/http4s/Media.scala
@@ -26,7 +26,7 @@ import org.http4s.headers._
 trait Media[+F[_]] {
 
   def entity: Entity[F]
-  final def body: EntityBody[F] = entity.body
+  final def body: Stream[F, Byte] = entity.body
   def headers: Headers
   def covary[F2[x] >: F[x]]: Media[F2]
 

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -118,6 +118,7 @@ sealed trait Message[+F[_]] extends Media[F] { self =>
     * WARNING: this method does not modify the headers of the message, and as
     * a consequence headers may be incoherent with the body.
     */
+  @deprecated("Avoid using streams in main API", "1.0.0-M42")
   private[http4s] def pipeBodyThrough[F1[x] >: F[x]](pipe: Pipe[F1, Byte, Byte]): SelfF[F1] =
     withEntity(Entity.stream(pipe(body)))
 

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -103,6 +103,7 @@ sealed trait Message[+F[_]] extends Media[F] { self =>
     * WARNING: this method does not modify the headers of the message, and as
     * a consequence headers may be incoherent with the body.
     */
+  @deprecated("Avoid using streams in main API", "1.0.0-M42")
   def withBodyStream[F1[x] >: F[x]](body: Stream[F1, Byte]): SelfF[F1] =
     change(entity = Entity.stream(body))
 
@@ -118,7 +119,7 @@ sealed trait Message[+F[_]] extends Media[F] { self =>
     * a consequence headers may be incoherent with the body.
     */
   private[http4s] def pipeBodyThrough[F1[x] >: F[x]](pipe: Pipe[F1, Byte, Byte]): SelfF[F1] =
-    withBodyStream(pipe(body))
+    withEntity(Entity.stream(pipe(body)))
 
   // General header methods
 

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -103,7 +103,7 @@ sealed trait Message[+F[_]] extends Media[F] { self =>
     * WARNING: this method does not modify the headers of the message, and as
     * a consequence headers may be incoherent with the body.
     */
-  def withBodyStream[F1[x] >: F[x]](body: EntityBody[F1]): SelfF[F1] =
+  def withBodyStream[F1[x] >: F[x]](body: Stream[F1, Byte]): SelfF[F1] =
     change(entity = Entity.stream(body))
 
   /** Set an [[Entity.Empty]] entity on this message, and remove all payload headers
@@ -595,7 +595,7 @@ object Request {
 
   def unapply[F[_]](
       request: Request[F]
-  ): Option[(Method, Uri, HttpVersion, Headers, EntityBody[F], Vault)] =
+  ): Option[(Method, Uri, HttpVersion, Headers, Stream[F, Byte], Vault)] =
     Some(
       (
         request.method,
@@ -750,7 +750,7 @@ object Response extends KleisliSyntax {
 
   def unapply[F[_]](
       response: Response[F]
-  ): Option[(Status, HttpVersion, Headers, EntityBody[F], Vault)] =
+  ): Option[(Status, HttpVersion, Headers, Stream[F, Byte], Vault)] =
     Some(
       (response.status, response.httpVersion, response.headers, response.body, response.attributes)
     )

--- a/core/shared/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/shared/src/main/scala/org/http4s/StaticFile.scala
@@ -274,7 +274,7 @@ object StaticFile {
       )
     } yield log.as(notModified)).sequence
 
-  private def fileToBody[F[_]: Files](f: Path, start: Long, end: Long): EntityBody[F] =
+  private def fileToBody[F[_]: Files](f: Path, start: Long, end: Long): Stream[F, Byte] =
     Files[F].readRange(f, DefaultBufferSize, start, end)
 
   private def nameToContentType(name: String): Option[`Content-Type`] =

--- a/core/shared/src/main/scala/org/http4s/multipart/Part.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/Part.scala
@@ -68,8 +68,8 @@ object Part {
     )
 
   // The InputStream is passed by name, and we open it in the by-name
-  // argument in callers, so we can avoid lifting into an effect.  Exposing
-  // this API publicly would invite unsafe use, and the `EntityBody` version
+  // argument in callers, so we can avoid lifting into an effect.
+  // Exposing this API publicly would invite unsafe use, and the `Entity` version
   // should be safe.
   private def fileData[F[_]](
       name: String,

--- a/core/shared/src/main/scala/org/http4s/package.scala
+++ b/core/shared/src/main/scala/org/http4s/package.scala
@@ -24,6 +24,7 @@ package object http4s {
 
   type AuthScheme = CIString
 
+  @deprecated("Avoid using Streams as major API", "1.0.0-M24")
   type EntityBody[+F[_]] = Stream[F, Byte]
 
   val ApiVersion: Http4sVersion = Http4sVersion(BuildInfo.apiVersion._1, BuildInfo.apiVersion._2)

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -449,10 +449,10 @@ it's this `Stream` that needs to be consumed within your effect `F`.
 Do not do this:
 
 ```scala mdoc:silent
-import org.http4s.EntityBody
+import fs2.Stream
 
 // response.body is not consumed within `F`
-httpClient.get[EntityBody[IO]]("some-url")(response => IO(response.body))
+httpClient.get[Stream[IO, Byte]]("some-url")(response => IO(response.body))
 ```
 
 [service]: service.md

--- a/docs/docs/server-middleware.md
+++ b/docs/docs/server-middleware.md
@@ -608,7 +608,7 @@ import org.http4s.server.middleware.ChunkAggregator
 def doubleBodyMiddleware(service: HttpRoutes[IO]): HttpRoutes[IO] = Kleisli { (req: Request[IO]) =>
   service(req).map {
     case Status.Successful(resp) =>
-      resp.withBodyStream(resp.body ++ resp.body)
+      resp.withEntity(Entity.stream(resp.body ++ resp.body))
     case resp => resp
   }
 }

--- a/docs/docs/streaming.md
+++ b/docs/docs/streaming.md
@@ -1,15 +1,15 @@
 
 # Streaming
 
-Streaming lies at the heart of the http4s model of HTTP, in the literal sense that `EntityBody[F]`
-is just a type alias for `Stream[F, Byte]`. Please see [entity] for details. This means
-HTTP streaming is provided by both http4s' service support and its client support.
+Streaming lies at the heart of the http4s model of HTTP, in the sense that a large entity
+consists of a `Stream[F, Byte]`. Please see [entity] for details. 
+This provides HTTP streaming for both http4s' servers support and its client support.
 
 
 ## Streaming responses from your service
 
-Because `EntityBody[F]`s are streams anyway, returning a stream as a response from your service is
-simplicity itself:
+Because a large entity is a stream anyway, returning a stream as a response 
+from your service is simplicity itself:
 
 ```scala mdoc:silent
 import scala.concurrent.duration._
@@ -36,11 +36,11 @@ it converts a stream of JSON objects to a JSON array, which is friendlier to cli
 
 ## Consuming Streams with the Client
 
-The http4s [client] supports consuming chunked HTTP responses as a stream, again because the
-`EntityBody[F]` is a stream anyway. http4s' `Client` interface consumes streams with the `streaming`
-function, which takes a `Request[F]` and a `Response[F] => Stream[F, A]` and returns a
-`Stream[F, A]`. Since an `EntityBody[F]` is just a `Stream[F, Byte]`, then, the easiest way
-to consume a stream is just:
+The http4s [client] supports consuming chunked HTTP responses as a stream, 
+again because a large `Entity[F]` consists of a stream anyway.
+http4s' `Client` interface consumes streams with the `streaming` function, 
+which takes a `Request[F]` and a `Response[F] => Stream[F, A]` and returns a
+`Stream[F, A]`. The easiest way to consume a stream is just:
 
 ```scala
 client.stream(req).flatMap(_.body)

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -298,7 +298,8 @@ private[ember] object H2Server {
 
       for {
         stream <- h2.mapRef.get.map(_.get(streamIx)).map(_.get) // FOLD
-        req <- stream.getRequest.map(_.covary[F].withBodyStream(stream.readBody))
+        reqx <- stream.getRequest
+        req = reqx.covary[F].withEntity(Entity.stream(stream.readBody))
         resp <- httpApp(req)
         _ <- stream.sendHeaders(PseudoHeaders.responseToHeaders(resp), false)
         _ <- fulfillPushPromises(resp)

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -277,13 +277,13 @@ private[ember] object H2Server {
             .drain >> // PP Resp Body
             stream.sendData(ByteVector.empty, true)
 
-        def respond(req: Request[Pure], stream: H2Stream[F]): F[(EntityBody[F], H2Stream[F])] =
+        def respond(req: Request[Pure], stream: H2Stream[F]): F[(Entity[F], H2Stream[F])] =
           for {
             resp <- httpApp(req.covary[F])
             // _ <- Console.make[F].println("Push Promise Response Completed")
             pseudoHeaders = PseudoHeaders.responseToHeaders(resp)
             _ <- stream.sendHeaders(pseudoHeaders, false) // PP Response
-          } yield (resp.body, stream)
+          } yield (resp.entity, stream)
 
         resp.attributes.lookup(H2Keys.PushPromises).traverse_ { (l: List[Request[Pure]]) =>
           h2.state.get.flatMap {

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -885,11 +885,11 @@ private[discipline] trait ArbitraryInstances {
       }
     }
 
-  implicit def http4sTestingCogenForEntityBody[F[_]](implicit
+  implicit def http4sTestingCogenForStreamByte[F[_]](implicit
       F: Concurrent[F],
       dispatcher: Dispatcher[F],
       testContext: TestContext,
-  ): Cogen[EntityBody[F]] =
+  ): Cogen[Stream[F, Byte]] =
     cogenFuture[Vector[Byte]].contramap { stream =>
       dispatcher.unsafeToFuture(stream.compile.toVector)
     }
@@ -926,7 +926,7 @@ private[discipline] trait ArbitraryInstances {
       dispatcher: Dispatcher[F],
       testContext: TestContext,
   ): Cogen[Entity[F]] =
-    Cogen[(EntityBody[F], Option[Long])].contramap(entity => (entity.body, entity.length))
+    Cogen[(Stream[F, Byte], Option[Long])].contramap(entity => (entity.body, entity.length))
 
   implicit def http4sTestingArbitraryForEntityEncoder[F[_], A](implicit
       CA: Cogen[A]
@@ -956,14 +956,14 @@ private[discipline] trait ArbitraryInstances {
       dispatcher: Dispatcher[F],
       testContext: TestContext,
   ): Cogen[Media[F]] =
-    Cogen[(Headers, EntityBody[F])].contramap(m => (m.headers, m.body))
+    Cogen[(Headers, Stream[F, Byte])].contramap(m => (m.headers, m.body))
 
   implicit def http4sTestingCogenForMessage[F[_]](implicit
       F: Concurrent[F],
       dispatcher: Dispatcher[F],
       testContext: TestContext,
   ): Cogen[Message[F]] =
-    Cogen[(Headers, EntityBody[F])].contramap(m => (m.headers, m.body))
+    Cogen[(Headers, Stream[F, Byte])].contramap(m => (m.headers, m.body))
 
   implicit def http4sTestingCogenForHeaders: Cogen[Headers] =
     Cogen[List[Header.Raw]].contramap(_.headers)

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -20,6 +20,7 @@ package middleware
 
 import cats.effect._
 import cats.syntax.all._
+import fs2.Stream
 import fs2.io.readInputStream
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
@@ -41,7 +42,7 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
 
   private def testResource = getClass.getResourceAsStream("/testresource.txt")
 
-  private def body: EntityBody[IO] =
+  private def body: Stream[IO, Byte] =
     readInputStream[IO](IO.pure(testResource), 4096)
 
   private val expectedBody: String =

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -56,7 +56,7 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
   }
 
   test("response should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withEntity(Entity.stream(body))
     respApp(req).flatMap { res =>
       res
         .as[String]
@@ -74,7 +74,7 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
   }
 
   test("request should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withEntity(Entity.stream(body))
     reqApp(req).flatMap { res =>
       res.as[String].map(_ === expectedBody && res.status === Status.Ok)
     }.assert
@@ -88,7 +88,7 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
   }
 
   test("logger should not affect a Post") {
-    val req = Request[IO](uri = uri"/post", method = POST).withBodyStream(body)
+    val req = Request[IO](uri = uri"/post", method = POST).withEntity(Entity.stream(body))
     loggerApp(req).flatMap { res =>
       res.as[String].map(_ === expectedBody && res.status === Status.Ok)
     }.assert

--- a/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/DefaultHead.scala
@@ -56,7 +56,8 @@ object DefaultHead {
         response
       case Entity.Strict(_) =>
         response.withEntity(Entity.empty)
-      case Entity.Streamed(_, _) =>
-        response.pipeBodyThrough(_.interruptWhen[G](G.pure(Either.unit[Throwable])).drain)
+      case Entity.Streamed(body, _) =>
+        val drained = body.interruptWhen[G](G.pure(Either.unit[Throwable])).drain
+        response.withEntity(Entity.stream(drained))
     }
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -44,8 +44,8 @@ object EntityLimiter {
           if (chunk.size.toLong < limit) http.run(req)
           else F.raiseError[B](EntityTooLarge(limit))
 
-        case Entity.Streamed(_, _) =>
-          http.run(req.pipeBodyThrough[G](takeLimited(limit)))
+        case Entity.Streamed(body, _) =>
+          http.run(req.withEntity(Entity.stream(takeLimited[G](limit).apply(body))))
       }
     }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -94,7 +94,7 @@ object GZip {
         resp
           .removeHeader[`Content-Length`]
           .putHeaders(`Content-Encoding`(ContentCoding.gzip))
-          .pipeBodyThrough(compressPipe)
+          .withEntity(Entity.stream(compressPipe(resp.body)))
       )
   }
 }

--- a/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/RequestLogger.scala
@@ -107,7 +107,7 @@ object RequestLogger {
                 val changedRequest = req.pipeBodyThrough(_.observe(collectChunks))
 
                 val newBody = Stream.eval(vec.get).flatMap(v => Stream.emits(v)).unchunks
-                val logRequest: F[Unit] = logMessage(req.withBodyStream(newBody))
+                val logRequest: F[Unit] = logMessage(req.withEntity(Entity.stream(newBody)))
 
                 http(changedRequest)
                   .guaranteeCase {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala
@@ -88,7 +88,7 @@ object ResponseLogger {
               // Cannot Be Done Asynchronously - Otherwise All Chunks May Not Be Appended Previous to Finalization
               val logPipe: Pipe[F, Byte, Byte] =
                 _.observe(_.chunks.flatMap(c => Stream.exec(vec.update(_ :+ c))))
-                  .onFinalizeWeak(logMessage(response.withBodyStream(newBody)))
+                  .onFinalizeWeak(logMessage(response.withEntity(Entity.stream(newBody))))
 
               response.pipeBodyThrough(logPipe)
             }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/BracketRequestResponseSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/BracketRequestResponseSuite.scala
@@ -209,11 +209,12 @@ final class BracketRequestResponseSuite extends Http4sSuite {
         ) { case (_, oc) =>
           IO(assert(oc.isError)) *> releaseRef.update(_ + 1L)
         }
+      entity = Entity.stream(Stream.raiseError[IO](error))
       routes = middleware(
         Kleisli(
           Function.const(
             OptionT.liftF(
-              IO(Response(status = Status.Ok).withBodyStream(Stream.raiseError[IO](error)))
+              IO(Response(status = Status.Ok).withEntity(entity))
             )
           )
         )

--- a/server/shared/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSuite.scala
@@ -44,14 +44,14 @@ class ChunkAggregatorSuite extends Http4sSuite {
     transferCodingGen
   )
 
-  private def response(body: EntityBody[IO], transferCodings: List[TransferCoding]) =
+  private def response(body: Stream[IO, Byte], transferCodings: List[TransferCoding]) =
     Ok(body, `Transfer-Encoding`(NonEmptyList(TransferCoding.chunked, transferCodings)))
       .map(_.removeHeader[`Content-Length`])
 
-  def httpRoutes(body: EntityBody[IO], transferCodings: List[TransferCoding]): HttpRoutes[IO] =
+  def httpRoutes(body: Stream[IO, Byte], transferCodings: List[TransferCoding]): HttpRoutes[IO] =
     HttpRoutes.liftF(OptionT.liftF(response(body, transferCodings)))
 
-  def httpApp(body: EntityBody[IO], transferCodings: List[TransferCoding]): HttpApp[IO] =
+  def httpApp(body: Stream[IO, Byte], transferCodings: List[TransferCoding]): HttpApp[IO] =
     HttpApp.liftF(response(body, transferCodings))
 
   def checkAppResponse(app: HttpApp[IO])(responseCheck: Response[IO] => IO[Boolean]): IO[Boolean] =

--- a/server/shared/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
@@ -64,7 +64,7 @@ class DefaultHeadSuite extends Http4sSuite {
     (for {
       open <- Ref[IO].of(false)
       route = HttpRoutes.of[IO] { case GET -> _ =>
-        val body: EntityBody[IO] =
+        val body: Stream[IO, Byte] =
           Stream.bracket(open.set(true))(_ => open.set(false)).flatMap(_ => Stream.never[IO])
         Ok(body)
       }

--- a/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -405,7 +405,7 @@ class EntityDecoderSuite extends Http4sSuite {
     Files[IO].readAll(in).through(fs2.text.utf8.decode).compile.foldMonoid
 
   private def mockServe(req: Request[IO])(route: Request[IO] => IO[Response[IO]]) =
-    route(req.withBodyStream(chunk(Chunk.array(binData))))
+    route(req.withEntity(Entity.stream(chunk(Chunk.array(binData)))))
 
   test("A File EntityDecoder should write a text file from a byte string") {
     Files[IO]

--- a/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -39,7 +39,7 @@ class EntityDecoderSuite extends Http4sSuite {
     new MediaType("application", "soap+xml", MediaType.Compressible, MediaType.NotBinary)
   val `text/x-h` = new MediaType("text", "x-h")
 
-  def getBody(body: EntityBody[IO]): IO[Array[Byte]] =
+  def getBody(body: Stream[IO, Byte]): IO[Array[Byte]] =
     body.compile.toVector.map(_.toArray)
 
   def strBody(body: String): Stream[IO, Byte] =

--- a/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -77,7 +77,7 @@ class EntityEncoderSpec extends Http4sSuite {
 
     test("EntityEncoder should render entity bodies with chunked transfer encoding") {
       assertEquals(
-        EntityEncoder[IO, EntityBody[IO]].headers.get[`Transfer-Encoding`],
+        EntityEncoder[IO, Stream[IO, Byte]].headers.get[`Transfer-Encoding`],
         Some(
           `Transfer-Encoding`(TransferCoding.chunked)
         ),

--- a/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -20,6 +20,7 @@ import cats.data.Nested
 import cats.effect.IO
 import cats.syntax.all._
 import fs2.Chunk
+import fs2.Stream
 import fs2.io.file.Files
 import fs2.io.file.Path
 import org.http4s.Status._
@@ -311,7 +312,7 @@ class StaticFileSuite extends Http4sSuite {
       val s = StaticFile
         .fromURL[IO](getClass.getResource("/lorem-ipsum.txt"))
         .value
-        .map(_.fold[EntityBody[IO]](sys.error("Couldn't find resource"))(_.body))
+        .map(_.fold[Stream[IO, Byte]](sys.error("Couldn't find resource"))(_.body))
       // Expose problem with readInputStream recycling buffer.  chunks.compile.toVector
       // saves chunks, which are mutated by naive usage of readInputStream.
       // This ensures that we're making a defensive copy of the bytes for


### PR DESCRIPTION
Since the introduction of the new Entity ADT, the use of Streams for Http is a rather secondary thing, and it should not be the main way for people to operate on messages.

- Deprecate the `EntityBody` type alias, use 
- Deprecate the `body` method of `Media`, `Message`, in favour of the `entity` field.
- Deprecate the `withBodyStream` method, in favour of `withEntity`.
- Deprecate the internal `pipeBodyThrough` method from #6011, to avoid using it in the code of Http4S, in favour of entity transformations.