### PR TITLE
Deprecate Streams as main Entity Type.

### DIFF
--- a/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
+++ b/circe/src/test/scala/org/http4s/circe/CirceSuite.scala
@@ -290,7 +290,7 @@ class CirceSuite extends JawnDecodeSupportSuite[Json] with Http4sLawSuite {
     // From ArgonautSuite, which tests similar things:
     // TODO Urgh.  We need to make testing these smoother.
     // https://github.com/http4s/http4s/issues/157
-    def getBody(body: EntityBody[IO]): IO[Array[Byte]] = body.compile.to(Array)
+    def getBody(body: Stream[IO, Byte]): IO[Array[Byte]] = body.compile.to(Array)
     val req = Request[IO]().withEntity(Json.fromDoubleOrNull(157))
     val body = req
       .decode { (json: Json) =>

--- a/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/LoggerSuite.scala
@@ -35,7 +35,8 @@ class LoggerSuite extends Http4sSuite {
       NotFound()
   }
 
-  private def body: EntityBody[IO] = fs2.Stream.emits("This is a test resource.".getBytes())
+  private def body: Stream[IO, Byte] =
+    fs2.Stream.emits("This is a test resource.".getBytes())
 
   private val expectedBody: String = "This is a test resource."
 

--- a/core/shared/src/main/scala/org/http4s/Entity.scala
+++ b/core/shared/src/main/scala/org/http4s/Entity.scala
@@ -25,7 +25,8 @@ import fs2.Stream
 import scodec.bits.ByteVector
 
 sealed trait Entity[+F[_]] {
-  def body: EntityBody[F]
+  @deprecated("Avoid using Streams as part of API", "1.0.0-M24")
+  def body: Stream[F, Byte]
   def length: Option[Long]
   def ++[F1[x] >: F[x]](that: Entity[F1]): Entity[F1]
   def translate[F1[x] >: F[x], G[_]](fk: F1 ~> G): Entity[G]
@@ -52,7 +53,7 @@ object Entity {
   def utf8String(str: String): Entity[Pure] =
     string(str, Charset.`UTF-8`)
 
-  final case class Streamed[+F[_]](body: EntityBody[F], length: Option[Long]) extends Entity[F] {
+  final case class Streamed[+F[_]](body: Stream[F, Byte], length: Option[Long]) extends Entity[F] {
     def ++[F1[x] >: F[x]](that: Entity[F1]): Entity[F1] = that match {
       case d: Streamed[F1] => Streamed(body ++ d.body, (length, d.length).mapN(_ + _))
       case strict @ Strict(bytes) => Streamed(body ++ strict.body, length.map(_ + bytes.size))
@@ -72,7 +73,8 @@ object Entity {
   }
 
   final case class Strict(bytes: ByteVector) extends Entity[Pure] {
-    def body: EntityBody[Pure] = Stream.chunk(Chunk.byteVector(bytes))
+    @deprecated("Avoid using Streams as main tool", "1.0.0-M24")
+    override def body: Stream[Pure, Byte] = Stream.chunk(Chunk.byteVector(bytes))
 
     val length: Option[Long] = Some(bytes.size)
 
@@ -89,7 +91,8 @@ object Entity {
   }
 
   case object Empty extends Entity[Pure] {
-    val body: EntityBody[Pure] = Stream.empty
+    @deprecated("Avoid using Streams as main tool", "1.0.0-M24")
+    override val body: Stream[Pure, Byte] = Stream.empty
 
     val length: Option[Long] = Some(0L)
 

--- a/core/shared/src/main/scala/org/http4s/Media.scala
+++ b/core/shared/src/main/scala/org/http4s/Media.scala
@@ -25,8 +25,10 @@ import org.http4s.headers._
 
 trait Media[+F[_]] {
 
+  @deprecated("Avoid using Streams as main API", "1.0.0-M24")
+  final def body: Stream[F, Byte] = entity.body
+
   def entity: Entity[F]
-  final def body: EntityBody[F] = entity.body
   def headers: Headers
   def covary[F2[x] >: F[x]]: Media[F2]
 

--- a/core/shared/src/main/scala/org/http4s/Message.scala
+++ b/core/shared/src/main/scala/org/http4s/Message.scala
@@ -103,7 +103,8 @@ sealed trait Message[+F[_]] extends Media[F] { self =>
     * WARNING: this method does not modify the headers of the message, and as
     * a consequence headers may be incoherent with the body.
     */
-  def withBodyStream[F1[x] >: F[x]](body: EntityBody[F1]): SelfF[F1] =
+  @deprecate("Remove Streams from front of API", "1.0.0-M24")
+  def withBodyStream[F1[x] >: F[x]](body: Stream[F1, Byte]): SelfF[F1] =
     change(entity = Entity.stream(body))
 
   /** Set an [[Entity.Empty]] entity on this message, and remove all payload headers
@@ -595,7 +596,7 @@ object Request {
 
   def unapply[F[_]](
       request: Request[F]
-  ): Option[(Method, Uri, HttpVersion, Headers, EntityBody[F], Vault)] =
+  ): Option[(Method, Uri, HttpVersion, Headers, Stream[F, Byte], Vault)] =
     Some(
       (
         request.method,
@@ -750,7 +751,7 @@ object Response extends KleisliSyntax {
 
   def unapply[F[_]](
       response: Response[F]
-  ): Option[(Status, HttpVersion, Headers, EntityBody[F], Vault)] =
+  ): Option[(Status, HttpVersion, Headers, Stream[F, Byte], Vault)] =
     Some(
       (response.status, response.httpVersion, response.headers, response.body, response.attributes)
     )

--- a/core/shared/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/shared/src/main/scala/org/http4s/StaticFile.scala
@@ -274,7 +274,7 @@ object StaticFile {
       )
     } yield log.as(notModified)).sequence
 
-  private def fileToBody[F[_]: Files](f: Path, start: Long, end: Long): EntityBody[F] =
+  private def fileToBody[F[_]: Files](f: Path, start: Long, end: Long): Stream[F, Byte] =
     Files[F].readRange(f, DefaultBufferSize, start, end)
 
   private def nameToContentType(name: String): Option[`Content-Type`] =

--- a/core/shared/src/main/scala/org/http4s/package.scala
+++ b/core/shared/src/main/scala/org/http4s/package.scala
@@ -24,6 +24,7 @@ package object http4s {
 
   type AuthScheme = CIString
 
+  @deprecated("Avoid using Streams as major API", "1.0.0-M24")
   type EntityBody[+F[_]] = Stream[F, Byte]
 
   val ApiVersion: Http4sVersion = Http4sVersion(BuildInfo.apiVersion._1, BuildInfo.apiVersion._2)

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -449,10 +449,10 @@ it's this `Stream` that needs to be consumed within your effect `F`.
 Do not do this:
 
 ```scala mdoc:silent
-import org.http4s.EntityBody
+import fs2.Stream
 
 // response.body is not consumed within `F`
-httpClient.get[EntityBody[IO]]("some-url")(response => IO(response.body))
+httpClient.get[Stream[IO, Byte]]("some-url")(response => IO(response.body))
 ```
 
 [service]: service.md

--- a/docs/docs/streaming.md
+++ b/docs/docs/streaming.md
@@ -1,9 +1,10 @@
 
 # Streaming
 
-Streaming lies at the heart of the http4s model of HTTP, in the literal sense that `EntityBody[F]`
-is just a type alias for `Stream[F, Byte]`. Please see [entity] for details. This means
-HTTP streaming is provided by both http4s' service support and its client support.
+Streaming lies at the heart of the http4s model of HTTP, in the sense that a long 
+`Streamed` entity is a wrapper for `Stream[F, Byte]`. 
+Please see [entity] for details. 
+This provides HTTP streaming for both http4s' servers support and its client support.
 
 
 ## Streaming responses from your service
@@ -39,8 +40,7 @@ it converts a stream of JSON objects to a JSON array, which is friendlier to cli
 The http4s [client] supports consuming chunked HTTP responses as a stream, again because the
 `EntityBody[F]` is a stream anyway. http4s' `Client` interface consumes streams with the `streaming`
 function, which takes a `Request[F]` and a `Response[F] => Stream[F, A]` and returns a
-`Stream[F, A]`. Since an `EntityBody[F]` is just a `Stream[F, Byte]`, then, the easiest way
-to consume a stream is just:
+`Stream[F, A]`. The easiest way to consume a stream is just:
 
 ```scala
 client.stream(req).flatMap(_.body)

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -277,13 +277,13 @@ private[ember] object H2Server {
             .drain >> // PP Resp Body
             stream.sendData(ByteVector.empty, true)
 
-        def respond(req: Request[Pure], stream: H2Stream[F]): F[(EntityBody[F], H2Stream[F])] =
+        def respond(req: Request[Pure], stream: H2Stream[F]): F[(Entity[F], H2Stream[F])] =
           for {
             resp <- httpApp(req.covary[F])
             // _ <- Console.make[F].println("Push Promise Response Completed")
             pseudoHeaders = PseudoHeaders.responseToHeaders(resp)
             _ <- stream.sendHeaders(pseudoHeaders, false) // PP Response
-          } yield (resp.body, stream)
+          } yield (resp.entity, stream)
 
         resp.attributes.lookup(H2Keys.PushPromises).traverse_ { (l: List[Request[Pure]]) =>
           h2.state.get.flatMap {

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -889,7 +889,7 @@ private[discipline] trait ArbitraryInstances {
       F: Concurrent[F],
       dispatcher: Dispatcher[F],
       testContext: TestContext,
-  ): Cogen[EntityBody[F]] =
+  ): Cogen[Stream[F, Byte]] =
     cogenFuture[Vector[Byte]].contramap { stream =>
       dispatcher.unsafeToFuture(stream.compile.toVector)
     }
@@ -926,7 +926,7 @@ private[discipline] trait ArbitraryInstances {
       dispatcher: Dispatcher[F],
       testContext: TestContext,
   ): Cogen[Entity[F]] =
-    Cogen[(EntityBody[F], Option[Long])].contramap(entity => (entity.body, entity.length))
+    Cogen[(Stream[F, Byte], Option[Long])].contramap(entity => (entity.body, entity.length))
 
   implicit def http4sTestingArbitraryForEntityEncoder[F[_], A](implicit
       CA: Cogen[A]
@@ -956,14 +956,14 @@ private[discipline] trait ArbitraryInstances {
       dispatcher: Dispatcher[F],
       testContext: TestContext,
   ): Cogen[Media[F]] =
-    Cogen[(Headers, EntityBody[F])].contramap(m => (m.headers, m.body))
+    Cogen[(Headers, Stream[F, Byte])].contramap(m => (m.headers, m.body))
 
   implicit def http4sTestingCogenForMessage[F[_]](implicit
       F: Concurrent[F],
       dispatcher: Dispatcher[F],
       testContext: TestContext,
   ): Cogen[Message[F]] =
-    Cogen[(Headers, EntityBody[F])].contramap(m => (m.headers, m.body))
+    Cogen[(Headers, Stream[F, Byte])].contramap(m => (m.headers, m.body))
 
   implicit def http4sTestingCogenForHeaders: Cogen[Headers] =
     Cogen[List[Header.Raw]].contramap(_.headers)

--- a/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/middleware/LoggerSuite.scala
@@ -41,7 +41,7 @@ class LoggerSuite extends Http4sSuite { // TODO Can we implement this without fs
 
   private def testResource = getClass.getResourceAsStream("/testresource.txt")
 
-  private def body: EntityBody[IO] =
+  private def body: Stream[IO, Byte] =
     readInputStream[IO](IO.pure(testResource), 4096)
 
   private val expectedBody: String =

--- a/server/shared/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/ChunkAggregatorSuite.scala
@@ -44,14 +44,14 @@ class ChunkAggregatorSuite extends Http4sSuite {
     transferCodingGen
   )
 
-  private def response(body: EntityBody[IO], transferCodings: List[TransferCoding]) =
+  private def response(body: Stream[IO, Byte], transferCodings: List[TransferCoding]) =
     Ok(body, `Transfer-Encoding`(NonEmptyList(TransferCoding.chunked, transferCodings)))
       .map(_.removeHeader[`Content-Length`])
 
-  def httpRoutes(body: EntityBody[IO], transferCodings: List[TransferCoding]): HttpRoutes[IO] =
+  def httpRoutes(body: Stream[IO, Byte], transferCodings: List[TransferCoding]): HttpRoutes[IO] =
     HttpRoutes.liftF(OptionT.liftF(response(body, transferCodings)))
 
-  def httpApp(body: EntityBody[IO], transferCodings: List[TransferCoding]): HttpApp[IO] =
+  def httpApp(body: Stream[IO, Byte], transferCodings: List[TransferCoding]): HttpApp[IO] =
     HttpApp.liftF(response(body, transferCodings))
 
   def checkAppResponse(app: HttpApp[IO])(responseCheck: Response[IO] => IO[Boolean]): IO[Boolean] =

--- a/server/shared/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/DefaultHeadSuite.scala
@@ -64,7 +64,7 @@ class DefaultHeadSuite extends Http4sSuite {
     (for {
       open <- Ref[IO].of(false)
       route = HttpRoutes.of[IO] { case GET -> _ =>
-        val body: EntityBody[IO] =
+        val body: Stream[IO, Byte] =
           Stream.bracket(open.set(true))(_ => open.set(false)).flatMap(_ => Stream.never[IO])
         Ok(body)
       }

--- a/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -39,7 +39,7 @@ class EntityDecoderSuite extends Http4sSuite {
     new MediaType("application", "soap+xml", MediaType.Compressible, MediaType.NotBinary)
   val `text/x-h` = new MediaType("text", "x-h")
 
-  def getBody(body: EntityBody[IO]): IO[Array[Byte]] =
+  def getBody(body: Stream[IO, Byte]): IO[Array[Byte]] =
     body.compile.toVector.map(_.toArray)
 
   def strBody(body: String): Stream[IO, Byte] =

--- a/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityEncoderSpec.scala
@@ -77,7 +77,7 @@ class EntityEncoderSpec extends Http4sSuite {
 
     test("EntityEncoder should render entity bodies with chunked transfer encoding") {
       assertEquals(
-        EntityEncoder[IO, EntityBody[IO]].headers.get[`Transfer-Encoding`],
+        EntityEncoder[IO, Stream[IO, Byte]].headers.get[`Transfer-Encoding`],
         Some(
           `Transfer-Encoding`(TransferCoding.chunked)
         ),

--- a/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/StaticFileSuite.scala
@@ -311,7 +311,7 @@ class StaticFileSuite extends Http4sSuite {
       val s = StaticFile
         .fromURL[IO](getClass.getResource("/lorem-ipsum.txt"))
         .value
-        .map(_.fold[EntityBody[IO]](sys.error("Couldn't find resource"))(_.body))
+        .map(_.fold[Stream[IO, Byte]](sys.error("Couldn't find resource"))(_.body))
       // Expose problem with readInputStream recycling buffer.  chunks.compile.toVector
       // saves chunks, which are mutated by naive usage of readInputStream.
       // This ensures that we're making a defensive copy of the bytes for


### PR DESCRIPTION
We may want to hide the use of Streams at the front of the API.

- Deprecate the EntityBody type.
- Deprecate the `body` method of Media, Entity, Message,
- Deprecate `withBodyStream` method of Message
