### PR TITLE
Disable Ember server TLS logging more aggressively

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -328,7 +328,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
         Resource
           .eval {
             logger match {
-              case l: SelfAwareLogger[F] @unchecked =>
+              case l: SelfAwareLogger[F] =>
                 l.isTraceEnabled.ifF(TLSLogger.Enabled(s => logger.trace(s)), TLSLogger.Disabled)
               case _ => TLSLogger.Enabled(s => logger.trace(s)).pure[F]
             }


### PR DESCRIPTION
Technically this is probably a small optimization—we can completely avoid calling the logging callback when trace logging is disabled.

But the real motivation is to work around the fact that on JS, TLS logging is not customizable unfortunately, it's either on-or-off.
https://github.com/typelevel/fs2/blob/d7f1b71a8d7badb8a7ef0a8a5468807f9e384358/io/js/src/main/scala/fs2/io/net/tls/TLSContextPlatform.scala#L77