### PR TITLE
Improve error messages for MissingHost and MissingPort

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -662,9 +662,7 @@ lazy val emberClient = libraryCrossProject("ember-client")
     mimaBinaryIssueFilters := Seq(
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.http4s.ember.client.EmberClientBuilder.this"),
-      ProblemFilters.exclude[MissingClassProblem](
-        "org.http4s.ember.client.internal.ClientHelpersPlatform"
-      ),
+      ProblemFilters.exclude[Problem]("org.http4s.ember.client.internal.*"),
     ),
   )
   .jvmSettings(

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -239,8 +239,8 @@ private[client] object ClientHelpers {
         val host = auth.host.value
 
         for {
-          host <- Host.fromString(host).liftTo[F](MissingHost())
-          port <- Port.fromInt(port).liftTo[F](MissingPort())
+          host <- Host.fromString(host).liftTo[F](MissingOrInvalidHost(host))
+          port <- Port.fromInt(port).liftTo[F](MissingOrInvalidPort(port))
         } yield SocketAddress[Host](host, port)
     }
 
@@ -293,9 +293,11 @@ private[client] object ClientHelpers {
       }
   }
 
-  private case class MissingHost() extends RuntimeException("Invalid hostname")
+  private case class MissingOrInvalidHost(host: String)
+      extends RuntimeException(s"Invalid hostname: $host")
 
-  private case class MissingPort() extends RuntimeException("Invalid port")
+  private case class MissingOrInvalidPort(port: Int)
+      extends RuntimeException(s"Invalid port: $port")
 
   private case class MissingTlsContext()
       extends RuntimeException("EmberClient Is Not Configured for Https")


### PR DESCRIPTION
These can be deceptive in their current state - I had a URL with underscores, which org.http4s.Uri was happy with, but when I used it with ember client, ip4s.Uri was NOT happy with it, so I was getting a misleading "missing host" error, even though there was a host.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 