### PR TITLE
WebSocketHelpers.scala - Use Chunks

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -184,8 +184,8 @@ private[internal] object WebSocketHelpers {
       case x => F.pure(Some(x))
     }
 
-  private def frameToBytes(frame: WebSocketFrame): List[Chunk[Byte]] =
-    nonClientTranscoder.frameToBuffer(frame).toList.map { buffer =>
+  private def frameToBytes(frame: WebSocketFrame): Chunk[Chunk[Byte]] =
+    Chunk.array(nonClientTranscoder.frameToBuffer(frame)).map { buffer =>
       // TODO followup: improve the buffering here
       val bytes = new Array[Byte](buffer.remaining())
       buffer.get(bytes)


### PR DESCRIPTION
Chunk has a slightly more efficient traverse_ method than lists.
