### PR TITLE
Immediately release invalid connections in `getValidManaged`

### DIFF
--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -29,6 +29,7 @@ import cats.effect.kernel.Concurrent
 import cats.effect.kernel.Ref
 import cats.effect.kernel.Resource
 import cats.effect.kernel.Sync
+import cats.effect.std.Hotswap
 import cats.effect.syntax.all._
 import cats.syntax.all._
 import com.comcast.ip4s.Host
@@ -245,28 +246,25 @@ private[client] object ClientHelpers {
     }
 
   // Assumes that the request doesn't have fancy finalizers besides shutting down the pool
-  private[client] def getValidManaged[F[_]: Sync](
+  private[client] def getValidManaged[F[_]: Async](
       pool: KeyPool[F, RequestKey, EmberConnection[F]],
       request: Request[F],
   ): Resource[F, Managed[F, EmberConnection[F]]] =
-    pool.take(RequestKey.fromRequest(request)).flatMap { managed =>
-      Resource
-        .eval(managed.value.isValid)
-        .ifM(
-          managed.pure[Resource[F, *]],
-          // Already Closed,
-          // The Resource Scopes Aren't doing us anything
-          // if we have max removed from pool we will need to revisit
-          if (managed.isReused) {
-            Resource.eval(managed.canBeReused.set(Reusable.DontReuse)) >>
-              getValidManaged(pool, request)
-          } else
-            Resource.eval(
+    Hotswap.create[F, Managed[F, EmberConnection[F]]].evalMap { hs =>
+      def go: F[Managed[F, EmberConnection[F]]] =
+        hs.clear *> hs.swap(pool.take(RequestKey.fromRequest(request))).flatMap { managed =>
+          managed.value.isValid.ifM(
+            managed.pure,
+            if (managed.isReused) // keep swapping connections until we find a valid one
+              managed.canBeReused.set(Reusable.DontReuse) *> go
+            else
               Sync[F].raiseError(
                 new fs2.io.net.SocketException("Fresh connection from pool was not open")
-              )
-            ),
-        )
+              ),
+          )
+        }
+
+      go
     }
 
   private[ember] object RetryLogic {

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -176,4 +176,21 @@ class EmberServerSuite extends Http4sSuite {
     }
   }
 
+  test("#7216 - client can replace a terminated connection with max total of 1") {
+    EmberClientBuilder.default[IO].withMaxTotal(1).build.use { client =>
+      def runReq(server: Server) = {
+        val req =
+          Request[IO](Method.POST, uri = url(server.addressIp4s, "/echo")).withEntity("Hello!")
+        client.expect[String](req).assertEquals("Hello!")
+      }
+
+      serverResource(_.withShutdownTimeout(0.nanos))
+        .use(server => runReq(server).as(server.addressIp4s.port))
+        .flatMap { port =>
+          IO.sleep(1.second) *> // so server shutdown propagates
+            serverResource(_.withPort(port).withShutdownTimeout(0.nanos)).use(runReq(_))
+        }
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes https://github.com/http4s/http4s/issues/7216.

Previously, if an invalid connection was obtained from the pool, instead of returning it back to the pool so that it could dispose/recycle it, we would continue `flatMap`ping resources until we could obtain a valid connection. Thus we'd retain leases to the invalid connections much longer than necessary, which is problematic when the pool itself has a limited number of slots.

By using a `Hotswap` we can release the invalid connection immediately before attempting to obtain a new one.