### PR TITLE
Ember-Core: Use optimised fs2 method in write Loop.

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -194,10 +194,10 @@ private[h2] class H2Connection[F[_]](
 
   def writeLoop: Stream[F, Nothing] =
     Stream
-      .fromQueueUnterminatedChunk[F, H2Frame](outgoing, Int.MaxValue)
-      .chunks
+      .fromQueueUnterminated[F, Chunk[H2Frame]](outgoing, Int.MaxValue)
       .foreach(writeChunk)
       .handleErrorWith(ex => Stream.exec(logger.debug(ex)("writeLoop terminated")))
+
   // TODO Split Frames between Data and Others Hold Data If we are at cap
   //  Currently will backpressure at the data frame till its cleared
 


### PR DESCRIPTION
Next FS2 upgrade will include the changes by @kamilkloch in https://github.com/typelevel/fs2/pull/3264 which could improve performance of this loop.
