### PR TITLE
Ember core write loop no streams

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -272,7 +272,7 @@ private[ember] class H2Client[F[_]](
     for {
       h2 <- Resource.eval(createH2Connection)
       _ <- h2.readLoop.background
-      _ <- h2.writeLoop.compile.drain.background
+      _ <- h2.writeLoop.background
       _ <- clearClosed(h2).background
       _ <- pullCreatedStreams(h2).background
       _ <- Resource.eval(processSettings(h2))

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -310,7 +310,7 @@ private[ember] object H2Server {
 
     for {
       h2 <- Resource.eval(initH2Connection)
-      _ <- h2.writeLoop.compile.drain.background
+      _ <- h2.writeLoop.background
       _ <- Resource.eval(h2.outgoing.offer(Chunk.singleton(settingsFrame)))
       _ <- h2.readLoop.background
       // h2c Initial Request Communication on h2c Upgrade


### PR DESCRIPTION
All the write loop does is to extract chunks from the `outgoing` queue and writing them immediately, which can be done without FS2 streams. We combine `take` and `tryTakeN` so as to ensure the loop blocks when no items available. 
Supersedes previous PR #7230.