### PR TITLE
Add warning logs for misconfigured timeouts

### DIFF
--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -237,8 +237,18 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
   def withoutPushPromiseSupport: EmberClientBuilder[F] =
     copy(pushPromiseSupport = None)
 
+  private val verifyTimeoutRelations: F[Unit] =
+    logger
+      .warn(
+        s"timeout ($timeout) is >= idleConnectionTime ($idleConnectionTime). " +
+          s"It is recommended to configure timeout < idleConnectionTime, " +
+          s"or disable one of them explicitly by setting it to Duration.Inf."
+      )
+      .whenA(timeout.isFinite && timeout >= idleConnectionTime)
+
   def build: Resource[F, Client[F]] =
     for {
+      _ <- Resource.eval(verifyTimeoutRelations)
       sg <- Resource.pure(sgOpt.getOrElse(Network[F]))
       tlsContextOptWithDefault <-
         tlsContextOpt

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -209,7 +209,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
       requestLineParseErrorHandler: Throwable => F[Response[F]]
   ): EmberServerBuilder[F] =
     copy(requestLineParseErrorHandler = requestLineParseErrorHandler)
-    
+
   def build: Resource[F, Server] =
     for {
       sg <- sgOpt.getOrElse(Network[F]).pure[Resource[F, *]]

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -209,19 +209,9 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
       requestLineParseErrorHandler: Throwable => F[Response[F]]
   ): EmberServerBuilder[F] =
     copy(requestLineParseErrorHandler = requestLineParseErrorHandler)
-
-  private val verifyTimeoutRelations: F[Unit] =
-    logger
-      .warn(
-        s"requestHeaderReceiveTimeout ($requestHeaderReceiveTimeout) is >= idleTimeout ($idleTimeout). " +
-          s"It is recommended to configure requestHeaderReceiveTimeout < idleTimeout, " +
-          s"otherwise timeout responses won't be delivered to clients."
-      )
-      .whenA(requestHeaderReceiveTimeout.isFinite && requestHeaderReceiveTimeout >= idleTimeout)
-
+    
   def build: Resource[F, Server] =
     for {
-      _ <- Resource.eval(verifyTimeoutRelations)
       sg <- sgOpt.getOrElse(Network[F]).pure[Resource[F, *]]
       ready <- Resource.eval(Deferred[F, Either[Throwable, SocketAddress[IpAddress]]])
       shutdown <- Resource.eval(Shutdown[F](shutdownTimeout))

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -210,8 +210,18 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
   ): EmberServerBuilder[F] =
     copy(requestLineParseErrorHandler = requestLineParseErrorHandler)
 
+  private val verifyTimeoutRelations: F[Unit] =
+    logger
+      .warn(
+        s"requestHeaderReceiveTimeout ($requestHeaderReceiveTimeout) is >= idleTimeout ($idleTimeout). " +
+          s"It is recommended to configure requestHeaderReceiveTimeout < idleTimeout, " +
+          s"otherwise timeout responses won't be delivered to clients."
+      )
+      .whenA(requestHeaderReceiveTimeout.isFinite && requestHeaderReceiveTimeout >= idleTimeout)
+
   def build: Resource[F, Server] =
     for {
+      _ <- Resource.eval(verifyTimeoutRelations)
       sg <- sgOpt.getOrElse(Network[F]).pure[Resource[F, *]]
       ready <- Resource.eval(Deferred[F, Either[Throwable, SocketAddress[IpAddress]]])
       shutdown <- Resource.eval(Shutdown[F](shutdownTimeout))


### PR DESCRIPTION
Adds a warning log on startup for Ember clients & servers when timeouts have likely been misconfigured

Corresponds to similar logs on Blaze [Server](https://github.com/http4s/blaze/blob/b4c5565493feea1ea99a4ca19a364bd144d0d29b/blaze-server/src/main/scala/org/http4s/blaze/server/BlazeServerBuilder.scala#L452C50-L460) and [Client](https://github.com/http4s/blaze/blob/b4c5565493feea1ea99a4ca19a364bd144d0d29b/blaze-client/src/main/scala/org/http4s/blaze/client/BlazeClientBuilder.scala#L331-L349). As far as I understand, these warnings still apply (with the caveat that the Ember client has removed the specific `requestTimeout`, which can instead now be achieved using middleware)

In particular, reduces the risk of a user increasing `timeout` in the client and forgetting to update `idleConnectionTime`