### PR TITLE
[RFC] EmberServerBuilder refactor for LoggerFactory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -257,7 +257,7 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
     libraryDependencies ++= Seq(
       log4catsCore.value,
       log4catsTesting.value % Test,
-      log4catsNoop.value % Test,
+      log4catsNoop.value,
     ),
   )
   .jvmSettings(

--- a/examples/docker/src/main/scala/com/example/http4s/Example.scala
+++ b/examples/docker/src/main/scala/com/example/http4s/Example.scala
@@ -23,7 +23,6 @@ import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server._
-import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 
 object Main extends IOApp {
@@ -33,16 +32,14 @@ object Main extends IOApp {
 
 object ExampleApp {
 
-  def serverStream[F[_]: Async: Network]: Resource[F, Server] = {
-    implicit val loggerFactory: LoggerFactory[F] =
-      Slf4jFactory.create[F]
-
+  def serverStream[F[_]: Async: Network]: Resource[F, Server] =
     EmberServerBuilder.default
       .withPort(port"8080")
       .withHost(host"0.0.0.0")
+      .withLoggerFactory(Slf4jFactory.create[F])
       .withHttpApp(new ExampleRoutes[F].routes.orNotFound)
       .build
-  }
+
 }
 
 final case class ExampleRoutes[F[_]: Sync]() extends Http4sDsl[F] {

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
@@ -29,15 +29,11 @@ import org.http4s._
 import org.http4s.dsl._
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits._
-import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 
 object EmberServerH2Example extends IOApp {
 
   object ServerTest {
-
-    implicit private def loggerFactory[F[_]: Sync]: LoggerFactory[F] =
-      Slf4jFactory.create[F]
 
     val resp = Response[fs2.Pure](Status.Ok).withEntity("Hello World!")
     def simpleApp[F[_]: Concurrent: Console] = {
@@ -88,6 +84,7 @@ object EmberServerH2Example extends IOApp {
         .withHttp2
         .withHost(ipv4"0.0.0.0")
         .withPort(port"8081")
+        .withLoggerFactory(Slf4jFactory.create[F])
         .withHttpApp(simpleApp)
         .withErrorHandler { case error =>
           Console[F]


### PR DESCRIPTION
Hello! That's my first PR to Http4s, so I hope everything is in the correct place.

As per the title, this PR is meant to be an RFC to change a couple of things in the `EmberServerBuilder` class.

Swapping from `1.0.0-M39` to `1.0.0-M40` in a few personal projects, I noticed that they were no more compiling due to an unsatisfied constraint in `EmberServerBuilder`, namely the addition of the type-class constraint [`LoggerFactory`](https://github.com/http4s/http4s/blob/main/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala#L281). 
(I also noticed that ember now doesn't depend on `log4cats-slf4j`, thank you, @armanbilge)

One strange thing that I noted, though, is that the `withLogger` method on the builder was still there (with an obvious default to `LoggerFactory[F].getLogger`). This allows the caller to customise the logging, passing a custom `Logger[F]` instance **without removing the need to have in scope an instance of `LoggerFactory[F]` that won't even be used** (as `withLogger` overrides the use of the factory).

I guess that the original implementer (is this a word?) idea was to make the server buildable by passing either a `Logger` or a `LoggerFactory` instance, and that's what this PR aims to solve/implement, simply adding to the builder state both a `loggerFactory` field and making the `logger` optional with precedence over the loggerFactory. I don't think my solution is binary compatible, but it shouldn't be a problem on this branch, right?

---

**DISCLAIMER**: everything you'll read from now on is my humble opinion and nothing more.

The second (and last) possible problem that I noted with this implementation is a possible design flaw.

The former implementation of EmberServerBuilder had a couple of "dependencies" in a broader sense. If you look at the default builder method, there were two context bounds, `Async` and `Network`, plus the default logger implementation was `log4cats-slf4j`.

All three dependencies were somehow already satisfied: `Async` comes from CE, which is a dependency of Ember, `Network` comes from one of the children of `fs2` (not sure which one, probably `fs2-io`) that's still a dependency, and `log4cats-slf4j` was included in the `Ember` build definition.

All of these made ember "self-contained", meaning that it was theoretically possible to declare just ember-server as a dependency, and everything was available as a transitive dependency.

With the recent changes, we reached a higher level of modularity (and no one is happier than me about not having slf4j in the classpath), but we lost some ergonomics.

To make it simpler, now the minimum code needed to use ember has passed from this:

```scala
//> using lib org.http4s::http4s-ember-server::1.0.0-M39

import cats.effect.{IO, IOApp}
import org.http4s.ember.server.EmberServerBuilder

object Main extends IOApp.Simple:

  def run = EmberServerBuilder.default[IO].build.useForever
```

to this

```scala
//> using lib org.http4s::http4s-ember-server::1.0.0-M40
//> using lib org.typelevel::log4cats-noop:2.6.0

import cats.effect.{IO, IOApp}
import org.http4s.ember.server.EmberServerBuilder
import org.typelevel.log4cats.noop.NoOpFactory
import org.typelevel.log4cats.LoggerFactory

object Main extends IOApp.Simple:

  given LoggerFactory[IO] = NoOpFactory[IO]
  
  def run = EmberServerBuilder.default[IO].build.useForever
```

This gigantic premise was meant to justify the fact that in this PR I decided to make `log4cats-noop` a declared dependency of ember, and that's the default implementation picked by `EmberServerBuilder.default`. 

I'm not happy with it, though, as by default now the server doesn't log anything, neither the starting message `Ember-Server service bound to address: ${bindAddress}`. This <strike>can be</strike> is immensely confusing for the users.

A more suitable solution would be writing a log4cats implementation based on `Console[F]` that outputs to stdout/js.console and defaults to that one, but that's a story for another pr/issue in another repo 😇

[EDIT] For context, [chris is ok with merging noop in to log4cats core](https://discord.com/channels/632277896739946517/632286375311573032/1141128996231315567), that's why I picked it.

---

To conclude, that's my proposal. Another chance was simply removing the `withLogger` helper method from the builder and leaving everything as it is now, with the added requirement of providing a `LoggerFactory` implementation in scope.

Let me know what you think about it, thanks :)
