### PR TITLE
Uri: inconsistent query param names (url-encode) when .renderString-ing #7127

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Query.scala
+++ b/core/shared/src/main/scala/org/http4s/Query.scala
@@ -165,6 +165,29 @@ final class Query private (value: Either[Vector[KeyValue], String])
       CollectionCompat.mapValues(m.toMap)(_.toList)
     }
 
+  /** Creates a new encoded `Self` with all the specified parameters in the [[Query]].
+    * If the list of parameters is empty, it will do nothing.
+    */
+  def encode: Self =
+    if (query.toVector.isEmpty) {
+      query
+    } else {
+      val result = query.toVector.map {
+        case (k, None) => k -> None
+        case (k, Some(v)) =>
+          k -> Some(
+            UriCoding.encode(
+              v,
+              StandardCharsets.UTF_8,
+              spaceIsPlus = false,
+              toSkip = UriCoding.QueryNoEncode,
+            )
+          )
+      }
+
+      Query.fromVector(result)
+    }
+
   override def equals(that: Any): Boolean =
     that match {
       case that: Query => that.toVector == toVector

--- a/core/shared/src/main/scala/org/http4s/Uri.scala
+++ b/core/shared/src/main/scala/org/http4s/Uri.scala
@@ -64,7 +64,7 @@ import scala.util.hashing.MurmurHash3
   * @param query      optional Query. url-encoded.
   * @param fragment   optional Uri Fragment. url-encoded.
   */
-final case class Uri(
+final case class Uri private[http4s] (
     scheme: Option[Uri.Scheme] = None,
     authority: Option[Uri.Authority] = None,
     path: Uri.Path = Uri.Path.empty,
@@ -207,6 +207,14 @@ final case class Uri(
 }
 
 object Uri extends UriPlatform {
+
+  def apply(
+      scheme: Option[Uri.Scheme] = None,
+      authority: Option[Uri.Authority] = None,
+      path: Uri.Path = Uri.Path.empty,
+      query: Query = Query.empty,
+      fragment: Option[Uri.Fragment] = None,
+  ): Uri = Uri(scheme, authority, path, query.encode, fragment)
 
   /** Decodes the String to a [[Uri]] using the RFC 3986 uri decoding specification */
   def fromString(s: String): ParseResult[Uri] =

--- a/core/shared/src/main/scala/org/http4s/internal/UriCoding.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/UriCoding.scala
@@ -24,7 +24,7 @@ import java.nio.charset.{Charset => JCharset}
 /* Exists to work around circular dependencies */
 private[http4s] object UriCoding {
   val Unreserved: CharPredicate = AlphaNum ++ "-_.~"
-  val QueryNoEncode: CharPredicate = Unreserved ++ "?/"
+  val QueryNoEncode: CharPredicate = Unreserved ++ "!$&'()*+,;=:/?@"
 
   def encode(
       toEncode: String,

--- a/core/shared/src/main/scala/org/http4s/internal/UriCoding.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/UriCoding.scala
@@ -24,7 +24,7 @@ import java.nio.charset.{Charset => JCharset}
 /* Exists to work around circular dependencies */
 private[http4s] object UriCoding {
   val Unreserved: CharPredicate = AlphaNum ++ "-_.~"
-  val QueryNoEncode: CharPredicate = Unreserved ++ "!$&'()*+,;=:/?@"
+  val QueryNoEncode: CharPredicate = Unreserved ++ "?/"
 
   def encode(
       toEncode: String,

--- a/tests/shared/src/test/scala/org/http4s/UriSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/UriSuite.scala
@@ -1071,10 +1071,6 @@ class UriSuite extends Http4sSuite {
     assertEquals(updated.renderString, "/")
   }
 
-  test("Uri.renderString should Encode special chars in the query") {
-    val u = Uri(path = Uri.Path.Root).withQueryParam("foo", " !$&'()*+,;=:/?@~")
-    assertEquals(u.renderString, "/?foo=%20%21%24%26%27%28%29%2A%2B%2C%3B%3D%3A/?%40~")
-  }
   test("Uri.renderString should Encode special chars in the fragment") {
     val u = Uri(path = Uri.Path.Root, fragment = Some(" !$&'()*+,;=:/?@~"))
     assertEquals(u.renderString, "/#%20!$&'()*+,;=:/?@~")

--- a/tests/shared/src/test/scala/org/http4s/UriSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/UriSuite.scala
@@ -209,11 +209,11 @@ class UriSuite extends Http4sSuite {
     // Issue #75
     assertEquals(
       getQueryParams("http://localhost:8080/blah?x=a+bc&y=ijk"),
-      Map("x" -> "a bc", "y" -> "ijk"),
+      Map("x" -> "a%20bc", "y" -> "ijk"),
     )
     assertEquals(
       getQueryParams("http://localhost:8080/blah?x=a%20bc&y=ijk"),
-      Map("x" -> "a bc", "y" -> "ijk"),
+      Map("x" -> "a%20bc", "y" -> "ijk"),
     )
   }
 
@@ -1069,6 +1069,11 @@ class UriSuite extends Http4sSuite {
     val u = Uri(path = Uri.Path.Root, fragment = Some("nonsense"))
     val updated = u.withoutFragment
     assertEquals(updated.renderString, "/")
+  }
+
+  test("Uri.renderString should Encode special chars in the query") {
+    val u = Uri(path = Uri.Path.Root).withQueryParam("foo", " !$&'()*+,;=:/?@~")
+    assertEquals(u.renderString, "/?foo=%20%21%24%26%27%28%29%2A%2B%2C%3B%3D%3A/?%40~")
   }
 
   test("Uri.renderString should Encode special chars in the fragment") {

--- a/tests/shared/src/test/scala/org/http4s/parser/UriParserSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/parser/UriParserSuite.scala
@@ -285,4 +285,14 @@ class UriParserSuite extends Http4sSuite {
       """uri"not valid""""
     }.nonEmpty)
   }
+
+  test("Uri.renderString should behave correctly") {
+    val uri = Uri.fromString("https://foo.com/?with:colon=abc").toOption.get
+    val copy = uri.copy(query = Query.empty).setQueryParams(uri.multiParams)
+
+    assertEquals(
+      uri.renderString,
+      copy.renderString,
+    )
+  }
 }


### PR DESCRIPTION
This PR fixes https://github.com/http4s/http4s/issues/7127

The origin of the issue was that when we create a Uri object, the passed query value(s) doesn't get encoded. This causes the inconsistency that is mentioned in the Issue desciption.