### PR TITLE
Fix handling of streaming bodies in entity limiter

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -50,8 +50,10 @@ object EntityLimiter {
     _.pull
       .take(n)
       .flatMap {
-        case Some(_) => Pull.raiseError[F](EntityTooLarge(n))
-        case None => Pull.done
+        case Some(rest) => // if rest is empty then we won't raise an error
+          (rest >> Stream.raiseError(EntityTooLarge(n))).pull.echo
+        case None =>
+          Pull.done
       }
       .stream
 }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
@@ -112,4 +112,20 @@ class EntityLimiterSuite extends Http4sSuite {
       .recover { case EntityTooLarge(i) => i }
       .assertEquals(5L)
   }
+
+  test("Acually limit the bytes prior to raising error") {
+    IO.ref(0L).flatMap { counter => // count how many bytes are observed by the app
+      def middleware(r: Request[IO]) =
+        r.pipeBodyThrough(_.evalTap(_ => counter.getAndUpdate(_ + 1)))
+      val app: HttpApp[IO] =
+        routes.local(middleware).orNotFound
+
+      EntityLimiter
+        .httpApp(app, 5L)
+        .apply(Request[IO](POST, uri"/echo", body = b ++ Stream.eval(IO[Byte](0))))
+        .as(-1L)
+        .recover { case EntityTooLarge(i) => i }
+        .assertEquals(5L) *> counter.get.assertEquals(5L)
+    }
+  }
 }


### PR DESCRIPTION
The current implementation is too strict—it's not always possible to know if a stream has ended without evaluating a "tail" effect. The new implementation begins evaluating the tail before deciding whether or not to raise an error.