### PR TITLE
Fix #7262: mulitpart decoder wrapping unwanted errors

### DIFF
--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -138,7 +138,7 @@ private[http4s] object MultipartDecoder {
               .map[Either[DecodeFailure, Multipart[F]]](parts =>
                 Right(Multipart(parts, Boundary(boundary)))
               )
-              .recover { case e: DecodeFailure =>
+              .recover { case e: MessageBodyFailure =>
                 Left(e)
               }
           }

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -138,9 +138,8 @@ private[http4s] object MultipartDecoder {
               .map[Either[DecodeFailure, Multipart[F]]](parts =>
                 Right(Multipart(parts, Boundary(boundary)))
               )
-              .handleError {
-                case e: InvalidMessageBodyFailure => Left(e)
-                case e => Left(InvalidMessageBodyFailure("Invalid multipart body", Some(e)))
+              .recover { case e: DecodeFailure =>
+                Left(e)
               }
           }
         case None =>

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartSuite.scala
@@ -254,11 +254,7 @@ I am a big moose
       val request =
         Request(method = Method.POST, uri = url, body = badBody, headers = multipart.headers)
 
-      mkDecoder.use { decoder =>
-        val decoded = decoder.decode(request, true)
-        val result = decoded.value
-        assertIO(result.attempt, Left(CustomError))
-      }.assert
+      mkDecoder.use(_.decode(request, true).value).intercept[CustomError.type]
     }
   }
 


### PR DESCRIPTION
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 
Hi, this PR implements a fix for https://github.com/http4s/http4s/issues/7262 by only catching errors related to decoding failures in `MultipartDecoder`.

Thanks!