### PR TITLE
Avoid linking MimeDB in Scala Native

### DIFF
--- a/core/shared/src/main/scala/org/http4s/MediaType.scala
+++ b/core/shared/src/main/scala/org/http4s/MediaType.scala
@@ -313,7 +313,7 @@ object MediaType extends MimeDB {
   private[http4s] def getMediaType(_mainType: String, _subType: String): MediaType = {
     val mainType = _mainType.toLowerCase
     val subType = _subType.toLowerCase
-    if (Platform.isJvm || Platform.isNative)
+    if (Platform.isJvm)
       MediaType.all.getOrElse(
         (mainType, subType),
         new MediaType(mainType, subType),


### PR DESCRIPTION
Scala Native has similar problems to Scala.js since both do whole program linking.
Disabling the MimeDB in Scala Native improves the binary size and linking time!
Here you see a comparison of linking a http4s hello world application in debug mode before and after the change:
<table>
<tr><th></th><th>Before</th><th>After</th></tr>
<tr><th>Binary size</th><td>~24.5 MB</td><td>~17.4 MB</td></tr>
<tr><th>Linking time</th><td>~19 seconds</td><td>~13 seconds</td></tr>
</table>

This makes it much more fun to build http4s applications with Scala Native! :)

Most credit goes to @keynmol who told me what MimeDB was and that it was excluded from Scala.js :)