### PR TITLE
Fixes #7283: make BasicCredentials constructor safe

### DIFF
--- a/core/shared/src/main/scala/org/http4s/Credentials.scala
+++ b/core/shared/src/main/scala/org/http4s/Credentials.scala
@@ -103,15 +103,8 @@ object BasicCredentials {
     new String(bytes, charset)
 
   @deprecated("Use fromString instead", "0.23.24")
-  def apply(token: String): BasicCredentials = {
-    val bytes = Base64.getDecoder.decode(token)
-    val (userPass, charset) = decode(bytes, utf8CharsetDecoder)
-      .fold(_ => (decode(bytes, fallbackCharset), fallbackCharset), up => (up, utf8Charset))
-    userPass.indexOf(':') match {
-      case -1 => apply(userPass, "", charset)
-      case ix => apply(userPass.substring(0, ix), userPass.substring(ix + 1), charset)
-    }
-  }
+  def apply(token: String): BasicCredentials =
+    fromString(token).get
 
   def fromString(token: String): Option[BasicCredentials] =
     Try(Base64.getDecoder.decode(token)).toOption.map { bytes =>


### PR DESCRIPTION
This PR provides a fix for #7283 by replacing the existing `BasicCredentials.apply` constructor with `BasicCredentials.fromString` and using it in `BasicCredentials.unapply` to make pattern matching safe too.