### PR TITLE
Add PathVar map, emap

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -47,6 +47,7 @@ trait Http4sDsl2[F[_], G[_]] extends RequestDsl with Statuses with Responses[F, 
   val IntVar: impl.IntVar.type = impl.IntVar
   val LongVar: impl.LongVar.type = impl.LongVar
   val UUIDVar: impl.UUIDVar.type = impl.UUIDVar
+  val StringVar: impl.StringVar.type = impl.StringVar
 }
 
 trait Http4sDsl[F[_]] extends Http4sDsl2[F, F] {

--- a/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/Http4sDsl.scala
@@ -47,7 +47,7 @@ trait Http4sDsl2[F[_], G[_]] extends RequestDsl with Statuses with Responses[F, 
   val IntVar: impl.IntVar.type = impl.IntVar
   val LongVar: impl.LongVar.type = impl.LongVar
   val UUIDVar: impl.UUIDVar.type = impl.UUIDVar
-  val StringVar: impl.StringVar.type = impl.StringVar
+  override lazy val StringVar: impl.StringVar.type = impl.StringVar
 }
 
 trait Http4sDsl[F[_]] extends Http4sDsl2[F, F] {

--- a/dsl/src/main/scala/org/http4s/dsl/RequestDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/RequestDsl.scala
@@ -40,7 +40,7 @@ trait RequestDsl extends Methods with Auth {
   val IntVar: impl.IntVar.type
   val LongVar: impl.LongVar.type
   val UUIDVar: impl.UUIDVar.type
-  val StringVar: impl.StringVar.type
+  lazy val StringVar: impl.StringVar.type = impl.StringVar
 
   type QueryParamDecoderMatcher[T] = impl.QueryParamDecoderMatcher[T]
   type QueryParamMatcher[T] = impl.QueryParamMatcher[T]

--- a/dsl/src/main/scala/org/http4s/dsl/RequestDsl.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/RequestDsl.scala
@@ -40,6 +40,7 @@ trait RequestDsl extends Methods with Auth {
   val IntVar: impl.IntVar.type
   val LongVar: impl.LongVar.type
   val UUIDVar: impl.UUIDVar.type
+  val StringVar: impl.StringVar.type
 
   type QueryParamDecoderMatcher[T] = impl.QueryParamDecoderMatcher[T]
   type QueryParamMatcher[T] = impl.QueryParamMatcher[T]

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -208,11 +208,11 @@ object LongVar extends PathVar(str => Try(str.toLong))
 object UUIDVar extends PathVar(str => Try(java.util.UUID.fromString(str)))
 
 /** StringVar extractor of a path variable, used mostly for composition:
- * {{{
- *   Path("/user/John") match {
- *      case Root / "user" / StringVar(userName) => ...
- * }}}
- */
+  * {{{
+  *   Path("/user/John") match {
+  *      case Root / "user" / StringVar(userName) => ...
+  * }}}
+  */
 object StringVar extends PathVar(str => Success(str))
 
 /** Matrix path variable extractor

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Path.scala
@@ -36,7 +36,9 @@ import org.http4s.Uri.Path._
 import org.http4s._
 import org.http4s.headers.Allow
 
+import scala.util.Success
 import scala.util.Try
+import scala.util.control.NoStackTrace
 
 object :? {
   def unapply[F[_]](req: Request[F]): Some[(Request[F], Map[String, collection.Seq[String]])] =
@@ -172,6 +174,13 @@ protected class PathVar[A](cast: String => Try[A]) {
       cast(str).toOption
     else
       None
+
+  def map[B](f: A => B): PathVar[B] =
+    new PathVar[B](str => cast(str).map(f))
+
+  def emap[B](f: A => Option[B]): PathVar[B] =
+    new PathVar[B](str => cast(str).flatMap(a => f(a).toRight(new NoStackTrace {}).toTry))
+
 }
 
 /** Integer extractor of a path variable:
@@ -197,6 +206,14 @@ object LongVar extends PathVar(str => Try(str.toLong))
   * }}}
   */
 object UUIDVar extends PathVar(str => Try(java.util.UUID.fromString(str)))
+
+/** StringVar extractor of a path variable, used mostly for composition:
+ * {{{
+ *   Path("/user/John") match {
+ *      case Root / "user" / StringVar(userName) => ...
+ * }}}
+ */
+object StringVar extends PathVar(str => Success(str))
 
 /** Matrix path variable extractor
   * For an example see [[https://www.w3.org/DesignIssues/MatrixURIs.html MatrixURIs]]

--- a/dsl/src/main/scala/org/http4s/dsl/request.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/request.scala
@@ -31,4 +31,5 @@ object request extends RequestDslBinCompat {
   val IntVar: impl.IntVar.type = impl.IntVar
   val LongVar: impl.LongVar.type = impl.LongVar
   val UUIDVar: impl.UUIDVar.type = impl.UUIDVar
+  val StringVar: impl.StringVar.type = impl.StringVar
 }

--- a/dsl/src/main/scala/org/http4s/dsl/request.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/request.scala
@@ -31,5 +31,5 @@ object request extends RequestDslBinCompat {
   val IntVar: impl.IntVar.type = impl.IntVar
   val LongVar: impl.LongVar.type = impl.LongVar
   val UUIDVar: impl.UUIDVar.type = impl.UUIDVar
-  val StringVar: impl.StringVar.type = impl.StringVar
+  override lazy val StringVar: impl.StringVar.type = impl.StringVar
 }

--- a/dsl/src/test/scala/org/http4s/dsl/PathSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSuite.scala
@@ -205,6 +205,56 @@ class PathSuite extends Http4sSuite with AllSyntax {
     }))
   }
 
+  test("String extractor success") {
+    assert(
+      path"/a/123" match {
+        case Root / "a" / StringVar(s) => s == "123"
+        case _ => false
+      }
+    )
+  }
+
+  test("Custom extractor with map success") {
+    val AbsIntVar = IntVar.map(math.abs)
+    assert(
+      path"/a/-123" match {
+        case Root / "a" / AbsIntVar(n) => n == 123
+        case _ => false
+      }
+    )
+  }
+
+  test("Custom extractor with map failure") {
+    val AbsIntVar = IntVar.map(math.abs)
+    assert(
+      path"/a/abab" match {
+        case Root / "a" / AbsIntVar(_) => false
+        case _ => true
+      }
+    )
+  }
+
+  test("Custom extractor with emap success") {
+    val NewIntVar = StringVar.emap(_.toIntOption)
+    assert(
+      path"/a/-123" match {
+        case Root / "a" / NewIntVar(n) => n == -123
+        case _ => false
+      }
+    )
+  }
+
+  test("Custom extractor with emap failure") {
+    val NewIntVar = StringVar.emap(_.toIntOption)
+
+    assert(
+      path"/a/abab" match {
+        case Root / "a" / NewIntVar(_) => false
+        case _ => true
+      }
+    )
+  }
+
   object BoardExtractor extends impl.MatrixVar("square", List("x", "y"))
 
   object EmptyNameExtractor extends impl.MatrixVar("", List("x", "y"))

--- a/dsl/src/test/scala/org/http4s/dsl/PathSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/PathSuite.scala
@@ -26,6 +26,8 @@ import org.http4s.syntax.AllSyntax
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 
+import scala.util.Try
+
 class PathSuite extends Http4sSuite with AllSyntax {
   implicit val arbitraryPath: Gen[Path] =
     arbitrary[List[String]]
@@ -235,7 +237,7 @@ class PathSuite extends Http4sSuite with AllSyntax {
   }
 
   test("Custom extractor with emap success") {
-    val NewIntVar = StringVar.emap(_.toIntOption)
+    val NewIntVar = StringVar.emap(s => Try(s.toInt).toOption)
     assert(
       path"/a/-123" match {
         case Root / "a" / NewIntVar(n) => n == -123
@@ -245,7 +247,7 @@ class PathSuite extends Http4sSuite with AllSyntax {
   }
 
   test("Custom extractor with emap failure") {
-    val NewIntVar = StringVar.emap(_.toIntOption)
+    val NewIntVar = StringVar.emap(s => Try(s.toInt).toOption)
 
     assert(
       path"/a/abab" match {


### PR DESCRIPTION
Follow up from https://github.com/http4s/http4s/issues/2405

The motivation is that, as a user, in order to use make your own `PathVar` you have to make your own full extractor (e.g. `LocalDateVar` in https://http4s.org/v0.23/docs/dsl.html#handling-path-parameters) or make your own `org.http4s.dsl.impl` package so that you can access `PathVar` and its constructor.

I implemented `map` and `emap` in `PathVar`, and added  `StringVar` which can be used as a starting point for creating custom `PathVar`s. @diesalbla suggested a  "super-trait `PathMatch[A]`" but I did not understand what the purpose would be, I'll happily make the adjustment.
As it is this would encourage user-defined PathVars to be `val`s and not `object`s, which becomes inconsistent with QueryParams for example. If this is a problem (I really have no opinion) then something like
```abstract class CustomPathVar[A](cast: String => Option[A]) extends PathVar(...)``` would still be flexible enough, though less compositional.

I don't know if any of this is MiMa-approved (I ran mimaFindBinaryIssues, does that do anything?).



