### PR TITLE
Update request cookie parser to handle zero or more spaces between semicolons

### DIFF
--- a/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
@@ -31,12 +31,13 @@ object Cookie {
     ParseResult.fromParser(parser, "Invalid Cookie header")(s)
 
   private[http4s] val parser: Parser[Cookie] = {
-    import Parser.{char, string}
+    import Parser.char
 
     /* cookie-string = cookie-pair *( ";" SP cookie-pair ) */
-    val cookieString = (RequestCookie.parser ~ (string("; ") *> RequestCookie.parser).rep0).map {
-      case (head, tail) =>
-        Cookie(NonEmptyList(head, tail))
+    val cookieString = (RequestCookie.parser ~ (
+      char(';').soft *> char(' ').rep0(min = 1) *> RequestCookie.parser
+    ).rep0).map { case (head, tail) =>
+      Cookie(NonEmptyList(head, tail))
     }
 
     // We also see trailing semi-colons in the wild, and grudgingly tolerate them here

--- a/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
@@ -33,7 +33,12 @@ object Cookie {
   private[http4s] val parser: Parser[Cookie] = {
     import Parser.char
 
-    /* cookie-string = cookie-pair *( ";" SP cookie-pair ) */
+    /*
+    cookie-string = cookie-pair *( ";" *SP cookie-pair )
+
+    We go slightly off spec and tolerate zero or more spaces after a semicolon separating cookies
+    to align with other HTTP implementations (netty and pekko) and what we've seen in the wild
+     */
     val cookieString = (RequestCookie.parser ~ (
       (char(';') *> char(' ').rep0).soft *> RequestCookie.parser
     ).rep0).map { case (head, tail) =>

--- a/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Cookie.scala
@@ -35,7 +35,7 @@ object Cookie {
 
     /* cookie-string = cookie-pair *( ";" SP cookie-pair ) */
     val cookieString = (RequestCookie.parser ~ (
-      char(';').soft *> char(' ').rep0(min = 1) *> RequestCookie.parser
+      (char(';') *> char(' ').rep0).soft *> RequestCookie.parser
     ).rep0).map { case (head, tail) =>
       Cookie(NonEmptyList(head, tail))
     }

--- a/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
@@ -23,8 +23,11 @@ import cats.syntax.all._
 class CookieHeaderSuite extends munit.FunSuite {
   private def parse(value: String) = headers.Cookie.parse(value).valueOr(throw _)
 
-  private val cookiestr = "key1=value1; key2=\"value2\""
+  private val cookie1str = "key1=value1"
+  private val cookie2str = "key2=\"value2\""
+  private val cookiestr = cookie1str + "; " + cookie2str
   private val cookiestrSemicolon: String = cookiestr + ";"
+  private val cookiestrMultispace: String = cookie1str + ";  " + cookie2str + ";"
   private val cookies = List(RequestCookie("key1", "value1"), RequestCookie("key2", """"value2""""))
 
   test("Cookie parser should parse a cookie") {
@@ -40,5 +43,8 @@ class CookieHeaderSuite extends munit.FunSuite {
         RequestCookie("initialTrafficSource", "utmcsr=(direct)|utmcmd=(none)|utmccn=(not set)")
       ),
     )
+  }
+  test("Cookie parser should tolerate multiple spaces between semicolons") {
+    assertEquals(parse(cookiestrMultispace).values.toList, cookies)
   }
 }

--- a/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/parser/CookieHeaderSuite.scala
@@ -27,7 +27,8 @@ class CookieHeaderSuite extends munit.FunSuite {
   private val cookie2str = "key2=\"value2\""
   private val cookiestr = cookie1str + "; " + cookie2str
   private val cookiestrSemicolon: String = cookiestr + ";"
-  private val cookiestrMultispace: String = cookie1str + ";  " + cookie2str + ";"
+  private val cookiestrNoSpace: String = cookie1str + ";" + cookie2str
+  private val cookiestrMultispace: String = cookie1str + ";  " + cookie2str
   private val cookies = List(RequestCookie("key1", "value1"), RequestCookie("key2", """"value2""""))
 
   test("Cookie parser should parse a cookie") {
@@ -43,6 +44,9 @@ class CookieHeaderSuite extends munit.FunSuite {
         RequestCookie("initialTrafficSource", "utmcsr=(direct)|utmcmd=(none)|utmccn=(not set)")
       ),
     )
+  }
+  test("Cookie parser should tolerate zero spaces between semicolons") {
+    assertEquals(parse(cookiestrNoSpace).values.toList, cookies)
   }
   test("Cookie parser should tolerate multiple spaces between semicolons") {
     assertEquals(parse(cookiestrMultispace).values.toList, cookies)


### PR DESCRIPTION
This updates the cookie header parser to handle zero or more spaces between semicolons, whereas the current code only handles a single space. For example, these are both currently invalid, but are considered valid with these changes:

```
Cookie: foo=bar;baz=quux
Cookie: foo=bar;  baz=quux
```

While this technically goes against the HTTP spec, I have seen it happen (and just had to fix a bug in production because of it 😅) and there seems to be precedent for going a little off spec, e.g. by [handling trailing semicolons in request cookies](https://github.com/http4s/http4s/blob/series/0.23/core/shared/src/main/scala/org/http4s/headers/Cookie.scala#L42) and by [handling zero or more spaces in `Set-Cookie` headers](https://github.com/http4s/http4s/blob/series/0.23/core/shared/src/main/scala/org/http4s/ResponseCookie.scala#L227).