### PR TITLE
Fix handling of connection closure in `WSTestClient`

### DIFF
--- a/client-testkit/shared/src/main/scala/org/http4s/client/testkit/WSTestClient.scala
+++ b/client-testkit/shared/src/main/scala/org/http4s/client/testkit/WSTestClient.scala
@@ -22,6 +22,7 @@ import cats.Applicative
 import cats.Foldable
 import cats.MonadThrow
 import cats.effect.Concurrent
+import cats.effect.Ref
 import cats.effect.Resource
 import cats.effect.implicits._
 import cats.effect.std.Queue
@@ -60,8 +61,14 @@ object WSTestClient {
         subProtocol: Option[String],
     ): Resource[F, WSConnection[F]] =
       for {
+        receivingClosed <- Concurrent[F].ref(false).toResource
         clientReceiveQueue <- Queue.bounded[F, Option[WebSocketFrame]](1).toResource
-        _ <- socket.send.enqueueNoneTerminated(clientReceiveQueue).compile.drain.background
+        _ <- socket.send
+          .enqueueNoneTerminated(clientReceiveQueue)
+          .onFinalize(receivingClosed.set(true))
+          .compile
+          .drain
+          .background
 
         clientSendQueue <- Queue.synchronous[F, Option[WebSocketFrame]].toResource
         consumer = Stream
@@ -74,31 +81,26 @@ object WSTestClient {
 
         _ <- Resource.onFinalize(socket.onClose)
 
-      } yield new WSConnection[F] {
-        def send(wsf: WSFrame): F[Unit] =
-          wsf.toWebSocketFrame.flatMap(f => clientSendQueue.offer(f.some))
-
-        def sendMany[G[_]: Foldable, A <: WSFrame](wsfs: G[A]): F[Unit] =
-          wsfs.traverse_(send)
-
-        def receive: F[Option[WSFrame]] =
-          clientReceiveQueue.take.map(_.map(_.toWSFrame))
-
-        def subprotocol: Option[String] = subProtocol
-      }
+      } yield new WSConnectionImpl[F](
+        clientSendQueue,
+        clientReceiveQueue,
+        receivingClosed,
+        subProtocol,
+      )
 
     def processCombinedSocket(
         socket: WebSocketCombinedPipe[F],
         subProtocol: Option[String],
     ): Resource[F, WSConnection[F]] =
       for {
-
+        receivingClosed <- Concurrent[F].ref(false).toResource
         clientSendQueue <- Queue.synchronous[F, Option[WebSocketFrame]].toResource
         clientReceiveQueue <- Queue.bounded[F, Option[WebSocketFrame]](1).toResource
         receiveSend = Stream
           .fromQueueNoneTerminated[F, WebSocketFrame](clientSendQueue)
           .through(socket.receiveSend)
           .enqueueNoneTerminated(clientReceiveQueue)
+          .onFinalize(receivingClosed.set(true))
           .compile
           .drain
 
@@ -108,18 +110,12 @@ object WSTestClient {
 
         _ <- Resource.onFinalize(socket.onClose)
 
-      } yield new WSConnection[F] {
-        def send(wsf: WSFrame): F[Unit] =
-          wsf.toWebSocketFrame.flatMap(f => clientSendQueue.offer(f.some))
-
-        def sendMany[G[_]: Foldable, A <: WSFrame](wsfs: G[A]): F[Unit] =
-          wsfs.traverse_(send)
-
-        def receive: F[Option[WSFrame]] =
-          clientReceiveQueue.take.map(_.map(_.toWSFrame))
-
-        def subprotocol: Option[String] = subProtocol
-      }
+      } yield new WSConnectionImpl[F](
+        clientSendQueue,
+        clientReceiveQueue,
+        receivingClosed,
+        subProtocol,
+      )
 
     for {
       wsb <- WebSocketBuilder2[F]
@@ -140,6 +136,26 @@ object WSTestClient {
         }
 
     }
+  }
+
+  private final class WSConnectionImpl[F[_]: Concurrent](
+      clientSendQueue: Queue[F, Option[WebSocketFrame]],
+      clientReceiveQueue: Queue[F, Option[WebSocketFrame]],
+      receivingClosed: Ref[F, Boolean],
+      val subprotocol: Option[String],
+  ) extends WSConnection[F] {
+    def send(wsf: WSFrame): F[Unit] =
+      wsf.toWebSocketFrame.flatMap(f => clientSendQueue.offer(f.some))
+
+    def sendMany[G[_]: Foldable, A <: WSFrame](wsfs: G[A]): F[Unit] =
+      wsfs.traverse_(send)
+
+    def receive: F[Option[WSFrame]] =
+      receivingClosed.get.ifM(
+        clientReceiveQueue.tryTake.map(_.flatten.map(_.toWSFrame)),
+        clientReceiveQueue.take.map(_.map(_.toWSFrame)),
+      )
+
   }
 
   implicit private[http4s] class WsFrameOps[F[_]: Concurrent](val wsFrame: WSFrame) {

--- a/client-testkit/shared/src/test/scala/org/http4s/client/testkit/WSTestClientSuite.scala
+++ b/client-testkit/shared/src/test/scala/org/http4s/client/testkit/WSTestClientSuite.scala
@@ -165,6 +165,7 @@ class WSTestClientSuite extends Http4sSuite {
         .flatMap(_.connectHighLevel(WSRequest(uri"/ws")))
         .use { conn =>
           conn.receive.assertEquals(Some(WSFrame.Text("hello"))) *>
+            conn.receive.assertEquals(None) *>
             conn.receive.assertEquals(None)
         }
     }

--- a/client-testkit/shared/src/test/scala/org/http4s/client/testkit/WSTestClientSuite.scala
+++ b/client-testkit/shared/src/test/scala/org/http4s/client/testkit/WSTestClientSuite.scala
@@ -20,7 +20,7 @@ package testkit
 
 import cats.effect._
 import cats.effect.std.Queue
-import cats.implicits.toBifunctorOps
+import cats.effect.testkit.TestControl
 import fs2.Stream
 import org.http4s.client.websocket.WSClient
 import org.http4s.client.websocket.WSFrame
@@ -142,10 +142,32 @@ class WSTestClientSuite extends Http4sSuite {
         )
       )
       .flatMap(_.connect(WSRequest(uri"/ws")))
-      .use(_ => IO.unit)
-      .attempt
-      .map(_.leftMap(_.getClass))
-      .assertEquals(Left(classOf[WebSocketClientInitException]))
+      .use_
+      .intercept[WebSocketClientInitException]
+  }
+
+  test("receive returns None when connection is closed") {
+    TestControl.executeEmbed {
+      Resource
+        .eval(
+          fromHttpWebSocketApp[IO] { (wsb: WebSocketBuilder2[IO]) =>
+            HttpRoutes
+              .of[IO] { case GET -> Root / "ws" =>
+                wsb
+                  .build(
+                    Stream(WebSocketFrame.Text("hello"), WebSocketFrame.Close(1000).toOption.get),
+                    _.drain,
+                  )
+              }
+              .orNotFound
+          }
+        )
+        .flatMap(_.connectHighLevel(WSRequest(uri"/ws")))
+        .use { conn =>
+          conn.receive.assertEquals(Some(WSFrame.Text("hello"))) *>
+            conn.receive.assertEquals(None)
+        }
+    }
   }
 
 }


### PR DESCRIPTION
Previously, `receive` was hanging when the connection closed, now it returns `None` as promised in the API.