### PR TITLE
Fix labelling PRs for the `client-testkit` module

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -157,6 +157,12 @@ changelog:
       exclude:
         labels:
           - behind-the-scenes
+    - title: http4s-client-testkit
+      labels:
+        - module:client-testkit
+      exclude:
+        labels:
+          - behind-the-scenes
 
     - title: Scalafixes
       labels:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -91,6 +91,13 @@ pull_request_rules:
     label:
       add: ['module:circe']
 
+- name: label client-testkit PRs
+  conditions:
+    - files~=^client-testkit/
+  actions:
+    label:
+      add: ['module:client-testkit']
+
 - name: label docs PRs
   conditions:
   - or:


### PR DESCRIPTION
We encountered this when releasing yesterday with the fix in the `client-testkit` done by @armanbilge.