### PR TITLE
Log errors in `upgradeSocket`

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -194,7 +194,9 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
         val handler: Stream[F, Nothing] = shutdown.trackConnection >>
           Stream
             .resource(upgradeSocket(connect, tlsInfoOpt, logger, enableHttp2))
-            .handleErrorWith(err => Stream.exec(logger.warn(err)("Failed to upgrade socket to TLS")))
+            .handleErrorWith(err =>
+              Stream.exec(logger.warn(err)("Failed to upgrade socket to TLS"))
+            )
             .flatMap {
               case (socket, Some("h2")) =>
                 // ALPN H2 Strategy

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -194,6 +194,8 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
         val handler: Stream[F, Nothing] = shutdown.trackConnection >>
           Stream
             .resource(upgradeSocket(connect, tlsInfoOpt, logger, enableHttp2))
+            .onError(err => Stream.eval(logger.warn(err)("Failed to upgrade socket to TLS")))
+            .mask
             .flatMap {
               case (socket, Some("h2")) =>
                 // ALPN H2 Strategy

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -194,8 +194,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
         val handler: Stream[F, Nothing] = shutdown.trackConnection >>
           Stream
             .resource(upgradeSocket(connect, tlsInfoOpt, logger, enableHttp2))
-            .onError(err => Stream.eval(logger.warn(err)("Failed to upgrade socket to TLS")))
-            .mask
+            .handleErrorWith(err => Stream.exec(logger.warn(err)("Failed to upgrade socket to TLS")))
             .flatMap {
               case (socket, Some("h2")) =>
                 // ALPN H2 Strategy


### PR DESCRIPTION
fixes #7356 

Prevent error logs when client closes connection during socket upgrade.