### PR TITLE
remove deprecated `comment` parser from CommonRules

### DIFF
--- a/core/shared/src/main/scala/org/http4s/internal/parsing/CommonRules.scala
+++ b/core/shared/src/main/scala/org/http4s/internal/parsing/CommonRules.scala
@@ -89,10 +89,6 @@ private[parsing] trait CommonRules {
 
   final val CommentDefaultMaxDepth = 10
 
-  @deprecated("Use comment(Int) instead", "0.23.17")
-  private[http4s] lazy val comment: Parser[String] =
-    comment(CommentDefaultMaxDepth)
-
   def headerRep[A](element: Parser[A]): Parser0[List[A]] =
     headerRep1(element).?.map(_.fold(List.empty[A])(_.toList))
 


### PR DESCRIPTION
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 