### PR TITLE
Removed reference to TSec in documentation

### DIFF
--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -231,11 +231,6 @@ val authUserHeader: Kleisli[IO, Request[IO], Either[String,User]] = Kleisli({ re
 })
 ```
 
-### Using tsec-http4s for Authentication and Authorization
-The [TSec] project provides an authentication and authorization module
- for the http4s project 0.18-M4+. Docs specific to http4s are located [Here](https://jmcardon.github.io/tsec/docs/http4s-auth.html).
-
 [service]: service.md
 [SPA]: https://en.wikipedia.org/wiki/Single-page_application
 [ADT]: https://typelevel.org/blog/2014/11/10/why_is_adt_pattern_matching_allowed.html
-[TSec]: https://jmcardon.github.io/tsec/


### PR DESCRIPTION
I removed the reference to the TSec library in the documentation as it seems like it is in the process of being deprecated. The original repo is archived and the fork https://github.com/davenverse/tsec has this in the readme: This software is in the process of finding its way out of your builds. This is maintained only for compatibility and security fixes. We hope you will work with others to find solutions to this space for the Scala community.

There is also:
- https://github.com/pac4j/http4s-pac4j
- https://github.com/profunktor/http4s-jwt-auth

A link to these could be useful, but they might grow stale like the TSec one, and it is probably not the responsibility of the http4s documentation to link to these?