### PR TITLE
Move ember H2Keys Http2PriorKnowledge key to core

### DIFF
--- a/core/shared/src/main/scala/org/http4s/h2/H2Keys.scala
+++ b/core/shared/src/main/scala/org/http4s/h2/H2Keys.scala
@@ -20,10 +20,12 @@ import cats.effect._
 import org.typelevel.vault._
 
 object H2Keys {
-  // Client Side Key To Try Http2-Prior-Knowledge
-  // which means immediately using http2 without any upgrade mechanism
-  // but is invalid if the receiving server does not support the
-  // mechanism.
+
+  /** Client Side Key To Try Http2-Prior-Knowledge
+    * which means immediately using http2 without any upgrade mechanism
+    * but is invalid if the receiving server does not support the
+    * mechanism.
+    */
   val Http2PriorKnowledge: Key[Unit] = Key.newKey[SyncIO, Unit].unsafeRunSync()
 
 }

--- a/core/shared/src/main/scala/org/http4s/h2/H2Keys.scala
+++ b/core/shared/src/main/scala/org/http4s/h2/H2Keys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 http4s.org
+ * Copyright 2013 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,16 @@
  * limitations under the License.
  */
 
-package org.http4s.ember.core.h2
+package org.http4s.h2
 
 import cats.effect._
-import fs2.Pure
-import org.http4s.Request
 import org.typelevel.vault._
 
 object H2Keys {
-  val PushPromiseInitialStreamIdentifier: Key[Int] = Key.newKey[SyncIO, Int].unsafeRunSync()
-  val StreamIdentifier: Key[Int] = Key.newKey[SyncIO, Int].unsafeRunSync()
-
-  val PushPromises: Key[List[Request[Pure]]] =
-    Key.newKey[SyncIO, List[org.http4s.Request[fs2.Pure]]].unsafeRunSync()
-
   // Client Side Key To Try Http2-Prior-Knowledge
   // which means immediately using http2 without any upgrade mechanism
   // but is invalid if the receiving server does not support the
   // mechanism.
-  @deprecated(message = "Use org.http4s.h2.H2Keys.Http2PriorKnowledge instead", since = "0.23.27")
-  val Http2PriorKnowledge: Key[Unit] = org.http4s.h2.H2Keys.Http2PriorKnowledge
+  val Http2PriorKnowledge: Key[Unit] = Key.newKey[SyncIO, Unit].unsafeRunSync()
 
-  private[ember] val H2cUpgrade =
-    Key.newKey[SyncIO, (H2Frame.Settings.ConnectionSettings, Request[fs2.Pure])].unsafeRunSync()
 }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -30,6 +30,7 @@ import org.http4s.Uri.Authority
 import org.http4s.Uri.Scheme
 import org.http4s._
 import org.http4s.ember.core.Util
+import org.http4s.h2.H2Keys.Http2PriorKnowledge
 import org.typelevel.log4cats.Logger
 import scodec.bits._
 
@@ -286,7 +287,7 @@ private[ember] class H2Client[F[_]](
   ): Resource[F, Response[F]] = {
     // Host And Port are required
     val key = H2Client.RequestKey.fromRequest(req)
-    val priorKnowledge = req.attributes.contains(H2Keys.Http2PriorKnowledge)
+    val priorKnowledge = req.attributes.contains(Http2PriorKnowledge)
     val useTLS = req.uri.scheme.map(_.value) match {
       case Some("http") => false
       case Some("https") => true
@@ -361,7 +362,7 @@ private[ember] object H2Client {
       h2 = new H2Client(Network[F], unixSockets, settings, tlsContext, mapH2, onPushPromise, logger)
     } yield (http1Client: TinyClient[F]) => { (req: Request[F]) =>
       val key = H2Client.RequestKey.fromRequest(req)
-      val priorKnowledge = req.attributes.contains(H2Keys.Http2PriorKnowledge)
+      val priorKnowledge = req.attributes.contains(Http2PriorKnowledge)
       val socketTypeF = if (priorKnowledge) Some(Http2).pure[F] else socketMap.get.map(_.get(key))
       Resource.eval(socketTypeF).flatMap {
         case Some(Http2) =>

--- a/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
+++ b/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
@@ -24,7 +24,7 @@ import fs2.io.net.unixsocket.UnixSockets
 import org.http4s._
 import org.http4s.client.middleware.UnixSocket
 import org.http4s.ember.client.EmberClientBuilder
-import org.http4s.ember.core.h2.H2Keys
+import org.http4s.h2.H2Keys.Http2PriorKnowledge
 
 import scala.concurrent.duration._
 
@@ -73,7 +73,7 @@ class EmberUnixSocketSuite extends Http4sSuite {
   }
 
   test("http/2") {
-    run(_.withHttp2, _.withHttp2, _.withAttribute(H2Keys.Http2PriorKnowledge, ()))
+    run(_.withHttp2, _.withHttp2, _.withAttribute(Http2PriorKnowledge, ()))
   }
 
 }

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -25,7 +25,7 @@ import fs2.io.net.ConnectException
 import org.http4s._
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.core.EmberException
-import org.http4s.ember.core.h2.H2Keys.Http2PriorKnowledge
+import org.http4s.h2.H2Keys.Http2PriorKnowledge
 import org.http4s.implicits._
 import org.http4s.server.Server
 

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientH2Example.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberClientH2Example.scala
@@ -22,7 +22,7 @@ import cats.syntax.all._
 import fs2.io.net._
 import org.http4s._
 import org.http4s.ember.client.EmberClientBuilder
-import org.http4s.ember.core.h2._
+import org.http4s.h2.H2Keys.Http2PriorKnowledge
 import org.http4s.implicits._
 
 object EmberClientH2Example extends IOApp {
@@ -73,7 +73,7 @@ object EmberClientH2Example extends IOApp {
                   uri = uri"http://localhost:8080/trailers",
                   // uri = uri"https://www.nikkei.com/" // PUSH PROMISES
                 )
-                .withAttribute(H2Keys.Http2PriorKnowledge, ())
+                .withAttribute(Http2PriorKnowledge, ())
                 .putHeaders(Headers("trailers" -> "x-test-client"))
                 .withTrailerHeaders(Headers("x-test-client" -> "client-info").pure[F])
             )


### PR DESCRIPTION
This should rather live in http4s-client so more clients have a standard way to detect weather the request should be sent into http/2 prior knowledge land.

Had to put this into core, since H2Client lives in ember-core and should not depend on client.
