### PR TITLE
Introduce MultipartReceiver for custom, fail-fast multipart decoding

### DIFF
--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -21,7 +21,7 @@ import cats.data.EitherT
 import cats.effect.Concurrent
 import cats.effect.Resource
 import cats.effect.std.Supervisor
-import cats.syntax.all.*
+import cats.syntax.all._
 import fs2.Collector
 import fs2.Pipe
 import fs2.Stream

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -150,7 +150,7 @@ private[http4s] object MultipartDecoder {
       }
     }
 
-  private def makeDecoder[F[_]: Concurrent, A](
+  private def makeDecoder2[F[_]: Concurrent, A](
       impl: Boundary => EntityBody[F] => DecodeResult[F, A]
   ): EntityDecoder[F, A] =
     EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
@@ -171,7 +171,7 @@ private[http4s] object MultipartDecoder {
       failOnLimit: Boolean = false,
   ): Resource[F, EntityDecoder[F, A]] = Supervisor[F].map { supervisor =>
     val wrappedReceiver = recv.rejectUnexpectedParts
-    makeDecoder[F, A] { boundary =>
+    makeDecoder2[F, A] { boundary =>
       _.through(
         MultipartParser.decodePartsSupervised[F, wrappedReceiver.Partial](
           supervisor,

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -18,11 +18,14 @@ package org.http4s
 package multipart
 
 import cats.data.EitherT
+import cats.effect.Concurrent
+import cats.effect.Resource
 import cats.effect.std.Supervisor
-import cats.effect.{Concurrent, Resource}
 import cats.syntax.all.*
+import fs2.Collector
+import fs2.Pipe
+import fs2.Stream
 import fs2.io.file.Files
-import fs2.{Collector, Pipe, Stream}
 
 private[http4s] object MultipartDecoder {
 

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -18,12 +18,11 @@ package org.http4s
 package multipart
 
 import cats.data.EitherT
-import cats.effect.Concurrent
-import cats.effect.Resource
 import cats.effect.std.Supervisor
+import cats.effect.{Concurrent, Resource}
 import cats.syntax.all.*
-import fs2.{Collector, Pipe, Stream}
 import fs2.io.file.Files
+import fs2.{Collector, Pipe, Stream}
 
 private[http4s] object MultipartDecoder {
 

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartDecoder.scala
@@ -22,12 +22,91 @@ import cats.effect.Concurrent
 import cats.effect.Resource
 import cats.effect.std.Supervisor
 import cats.syntax.all.*
-import fs2.{ Pipe, Stream }
+import fs2.{Collector, Pipe, Stream}
 import fs2.io.file.Files
 
 private[http4s] object MultipartDecoder {
+
+  /** Creates an EntityDecoder for `multipart/form-data` bodies, using
+    * the given `MultipartReceiver` to decide how to handle each Part.
+    *
+    * The creation of the EntityDecoder happens as a Resource which,
+    * when release, will release any underlying Resources that may
+    * have been allocated during the decoding process (e.g. temp files
+    * used for buffering Part bodies). Since the underlying Resources
+    * will not be released until this Resource is released, it is not
+    * recommended to reuse the allocated EntityDecoder.
+    *
+    * The `MultipartReceiver` is responsible for deciding the decoding
+    * logic for each Part, on a case-by-case basis. Some `MultipartReceiver`s
+    * are uniform, processing each part the same way. Others may be fully
+    * custom, processing each part in a different way. See the [[PartReceiver]]
+    * companion for examples.
+    *
+    * This allows the decoder to avoid unnecessary work in many cases.
+    * For example, a MultipartReceiver can be defined to only expect
+    * a specific set of parts, such that a request containing a data
+    * in unexpected parts would cause decoding to halt with an error,
+    * rather than continuing to read each part and potentially write
+    * their data to buffers.
+    *
+    * This also allows for an explicit choice of how each part is
+    * buffered, if at all. As opposed to [[mixedMultipartResource]],
+    * which buffers Part bodies opaquely and exposes them as a
+    * `Stream[F, Byte]`, a `MultipartReceiver` can make explicit choices
+    * about the destination of, and representation of, its Part bodies.
+    *
+    * Furthermore, since each `Part` is subject to decoding as it is
+    * encountered (i.e. before any potential buffering), when the decoding
+    * of a Part fails, the overall decoding process can halt early, without
+    * bothering to pull the rest of the stream.
+    *
+    * @param recv A MultipartReceiver which dictates that decoding logic for each Part
+    * @param headerLimit Maximum acceptable size of any Part's headers
+    * @param maxParts Maximum acceptable number of parts
+    * @param failOnLimit If `true`, exceeding the `maxParts` will cause a decoding failure.
+    *                    If `false`, any parts beyond the limit will be ignored.
+    * @return A resource which allocates an EntityDecoder for `multipart/form-data`
+    *         media and releases any resources allocated by that decoder.
+    */
+  def fromReceiver[F[_]: Concurrent, A](
+      recv: MultipartReceiver[F, A],
+      headerLimit: Int = 1024,
+      maxParts: Option[Int] = Some(50),
+      failOnLimit: Boolean = false,
+  ): Resource[F, EntityDecoder[F, A]] =
+    Supervisor[F].map { supervisor =>
+      makeDecoder[F, recv.Partial, List, A](
+        MultipartParser.decodePartsSupervised[F, recv.Partial](
+          supervisor,
+          _,
+          part => EitherT(recv.decideOrReject(part.headers).receive(part)),
+          limit = headerLimit,
+          maxParts = maxParts,
+          failOnLimit = failOnLimit,
+        ),
+        List,
+        (partials, _) => recv.assemble(partials),
+      )
+    }
+
+  /** A decoder for `multipart/form-data` content, where each "part"
+    * is stored to an in-memory buffer which can be read repeatedly
+    * as a `Stream[F, Byte]`.
+    *
+    * Note that this decoder should typically be avoided when expecting
+    * to receive file uploads, as this would cause the content of each
+    * uploaded file to be loaded into memory.
+    *
+    * @return A decoder for `multipart/form-data` content, with part
+    *         bodies buffered in memory.
+    */
   def decoder[F[_]: Concurrent]: EntityDecoder[F, Multipart[F]] =
-    makeDecoder(MultipartParser.parseToPartsStream[F](_))
+    makeDecoder[F, Part[F], Vector, Multipart[F]](
+      MultipartParser.parseToPartsStream[F](_).andThen(_.map(Right(_))),
+      Vector,
+      (parts, boundary) => Right(Multipart(parts, boundary)),
+    )
 
   /** Multipart decoder that streams all parts past a threshold
     * (anything above `maxSizeBeforeWrite`) into a temporary file.
@@ -69,16 +148,20 @@ private[http4s] object MultipartDecoder {
       chunkSize: Int = 8192,
   ): Resource[F, EntityDecoder[F, Multipart[F]]] =
     Supervisor[F].map { supervisor =>
-      makeDecoder(
-        MultipartParser.parseToPartsSupervisedFile[F](
+      val partReceiver = PartReceiver
+        .toMixedBuffer[F](maxSizeBeforeWrite, chunkSize)
+        .mapWithHeaders(Part.apply[F])
+      makeDecoder[F, Part[F], Vector, Multipart[F]](
+        MultipartParser.decodePartsSupervised[F, Part[F]](
           supervisor,
           _,
-          headerLimit,
-          maxSizeBeforeWrite,
-          maxParts,
-          failOnLimit,
-          chunkSize,
-        )
+          part => EitherT(partReceiver.receive(part)),
+          limit = headerLimit,
+          maxParts = Some(maxParts),
+          failOnLimit = failOnLimit,
+        ),
+        Vector,
+        (parts, boundary) => Right(Multipart[F](parts, boundary)),
       )
     }
 
@@ -87,7 +170,7 @@ private[http4s] object MultipartDecoder {
     *
     * Note: (BIG NOTE) Using this decoder for multipart decoding is good for the sake of
     * not holding all information in memory, as it will never have more than
-    * `maxSizeBeforeWrite` in memory before writing to a temporary file. On top of this,
+    * `maxSizeBeforeWrite` in memory per part before writing to a temporary file. On top of this,
     * you can gate the # of parts to further stop the quantity of parts you can have.
     * That said, because after a threshold it writes into a temporary file, given
     * bincompat reasons on 0.18.x, there is no way to make a distinction about which `Part[F]`
@@ -115,80 +198,50 @@ private[http4s] object MultipartDecoder {
       maxParts: Int = 50,
       failOnLimit: Boolean = false,
   ): EntityDecoder[F, Multipart[F]] =
-    makeDecoder(
-      MultipartParser.parseToPartsStreamedFile[F](
-        _,
-        headerLimit,
-        maxSizeBeforeWrite,
-        maxParts,
-        failOnLimit,
-      )
+    makeDecoder[F, Part[F], Vector, Multipart[F]](
+      MultipartParser
+        .parseToPartsStreamedFile[F](
+          _,
+          headerLimit,
+          maxSizeBeforeWrite,
+          maxParts,
+          failOnLimit,
+        )
+        .andThen(_.map(Right(_))),
+      Vector,
+      (parts, boundary) => Right(Multipart(parts, boundary)),
     )
 
-  private def makeDecoder[F[_]: Concurrent](
-      impl: Boundary => Pipe[F, Byte, Part[F]]
-  ): EntityDecoder[F, Multipart[F]] =
-    EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
-      msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
-        case Some(boundary) =>
-          DecodeResult {
-            msg.body
-              .through(impl(Boundary(boundary)))
-              .compile
-              .toVector
-              .map[Either[DecodeFailure, Multipart[F]]](parts =>
-                Right(Multipart(parts, Boundary(boundary)))
-              )
-              .recover { case e: MessageBodyFailure =>
-                Left(e)
-              }
-          }
-        case None =>
-          DecodeResult.failureT(
-            InvalidMessageBodyFailure("Missing boundary extension to Content-Type")
-          )
-      }
-    }
-
-  private def makeDecoder2[F[_]: Concurrent, A](
-      impl: Boundary => EntityBody[F] => DecodeResult[F, A]
+  private def makeDecoder[F[_]: Concurrent, P, C[_], A](
+      pipe: Boundary => Pipe[F, Byte, Either[DecodeFailure, P]],
+      collector: Collector.Aux[P, C[P]],
+      assemble: (C[P], Boundary) => Either[DecodeFailure, A],
   ): EntityDecoder[F, A] =
     EntityDecoder.decodeBy(MediaRange.`multipart/*`) { msg =>
       msg.contentType.flatMap(_.mediaType.extensions.get("boundary")) match {
-        case Some(boundary) =>
-          impl(Boundary(boundary))(msg.body)
+        case Some(boundaryStr) =>
+          val boundary = Boundary(boundaryStr)
+          EitherT(
+            msg.body
+              // pipe to get individual parts or decode failures
+              .through(pipe(boundary))
+              // lift effect to EitherT[F, DecodeFailure, *] so that
+              // `.eval`-ing each value can short-circuit the stream
+              // when we get a `DecodeFailure`
+              .translate(EitherT.liftK[F, DecodeFailure])
+              .flatMap(r => Stream.eval(EitherT.fromEither[F](r)))
+              .compile
+              .to(collector)
+              .subflatMap(assemble(_, boundary))
+              .value
+              // catch DecodeErrors that were thrown, moving them to
+              // the EitherT's Left side
+              .recover { case e: DecodeFailure => Left(e) }
+          )
         case None =>
           DecodeResult.failureT(
             InvalidMessageBodyFailure("Missing boundary extension to Content-Type")
           )
       }
     }
-
-  def fromReceiver[F[_]: Concurrent, A](
-      recv: MultipartReceiver[F, A],
-      headerLimit: Int = 1024,
-      maxParts: Option[Int] = Some(50),
-      failOnLimit: Boolean = false,
-  ): Resource[F, EntityDecoder[F, A]] = Supervisor[F].map { supervisor =>
-    val wrappedReceiver = recv.rejectUnexpectedParts
-    makeDecoder2[F, A] { boundary =>
-      _.through(
-        MultipartParser.decodePartsSupervised[F, wrappedReceiver.Partial](
-          supervisor,
-          boundary,
-          // note: `rejectUnexpectedParts` makes `wrappedReceiver.decide` always return `Some`
-          part => EitherT(wrappedReceiver.decide(part.headers).get.receive(part)),
-          limit = headerLimit,
-          maxParts = maxParts,
-          failOnLimit = failOnLimit,
-        )
-      ).translate(
-        EitherT.liftK[F, DecodeFailure]
-      ).flatMap { r =>
-        Stream.eval(EitherT.fromEither[F](r))
-      }.compile.toList.flatMap { partials =>
-        EitherT.fromEither[F](wrappedReceiver.assemble(partials))
-      }
-    }
-  }
 }

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -21,7 +21,7 @@ import cats.effect.Concurrent
 import cats.effect.Deferred
 import cats.effect.Resource
 import cats.effect.std.Supervisor
-import cats.syntax.all.*
+import cats.syntax.all._
 import fs2.Chunk
 import fs2.Pipe
 import fs2.Pull

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -916,7 +916,7 @@ object MultipartParser {
           if (ix === dashBoundaryBytes.length) Pull.pure(remainder ++ rest)
           else go(rest, ix)
         case None =>
-          Pull.raiseError[F](MalformedMessageBodyFailure("Malformed Malformed match"))
+          Pull.raiseError[F](MalformedMessageBodyFailure("Malformed match"))
       }
 
     go(stream, 0)

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -17,7 +17,9 @@
 package org.http4s
 package multipart
 
-import cats.effect.{Concurrent, Deferred, Resource}
+import cats.effect.Concurrent
+import cats.effect.Deferred
+import cats.effect.Resource
 import cats.effect.std.Supervisor
 import cats.syntax.all.*
 import fs2.Chunk
@@ -26,12 +28,13 @@ import fs2.Pull
 import fs2.Pure
 import fs2.RaiseThrowable
 import fs2.Stream
-import fs2.concurrent.Channel
 import fs2.io.file.Files
 import fs2.io.file.Flags
 import fs2.io.file.Path
 import org.http4s.internal.bug
 import org.typelevel.ci.CIString
+
+import fs2.concurrent.Channel
 
 /** A low-level multipart-parsing pipe.  Most end users will prefer EntityDecoder[Multipart]. */
 object MultipartParser {

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -17,7 +17,6 @@
 package org.http4s
 package multipart
 
-import cats.data.EitherT
 import cats.effect.{Concurrent, Deferred, Resource}
 import cats.effect.std.Supervisor
 import cats.syntax.all.*
@@ -808,9 +807,9 @@ object MultipartParser {
                 F.race(channel.send(chunk), resultPromise.get).flatMap {
                   case Left(_) =>
                     keepPulling // send completed normally; don't care if it was closed or not
-                  case Right(Right(a)) =>
+                  case Right(Right(_)) =>
                     keepPulling // send may have blocked, but the receiver already has a result
-                  case Right(Left(err)) =>
+                  case Right(Left(_)) =>
                     stopPulling // receiver raised an error, so abort the pull
                 }
               },

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -28,13 +28,12 @@ import fs2.Pull
 import fs2.Pure
 import fs2.RaiseThrowable
 import fs2.Stream
+import fs2.concurrent.Channel
 import fs2.io.file.Files
 import fs2.io.file.Flags
 import fs2.io.file.Path
 import org.http4s.internal.bug
 import org.typelevel.ci.CIString
-
-import fs2.concurrent.Channel
 
 /** A low-level multipart-parsing pipe.  Most end users will prefer EntityDecoder[Multipart]. */
 object MultipartParser {

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartParser.scala
@@ -17,16 +17,17 @@
 package org.http4s
 package multipart
 
-import cats.effect.Concurrent
-import cats.effect.Resource
+import cats.data.EitherT
+import cats.effect.{Concurrent, Deferred, Resource}
 import cats.effect.std.Supervisor
-import cats.syntax.all._
+import cats.syntax.all.*
 import fs2.Chunk
 import fs2.Pipe
 import fs2.Pull
 import fs2.Pure
 import fs2.RaiseThrowable
 import fs2.Stream
+import fs2.concurrent.Channel
 import fs2.io.file.Files
 import fs2.io.file.Flags
 import fs2.io.file.Path
@@ -729,6 +730,156 @@ object MultipartParser {
           .useForever
       ) *> deferred.get.rethrow
     }
+
+  // //////////////////////////////////////
+  // Resource-safe receiver-based parser //
+  // //////////////////////////////////////
+
+  /** Pipe that receives PartStart / PartChunk / PartEnd events,
+    * extracting the chunk data between each PartStart / PartEnd
+    * pair and feeding it through a new `partDecoder` for each part.
+    * Emits the results from each `partDecoder`.
+    *
+    * Resources allocated by the returned Pipe are supervised by
+    * the given `supervisor`, such that when the `supervisor` closes,
+    * the allocated resources also close.
+    *
+    * The `partDecoder` may or may not actually *consume* the part body.
+    * The underlying parser will wait at a `PartEnd` event until the
+    * consumer finishes, i.e. the point when its Resource allocates a value
+    * or raises an error. If the Resource never allocates, the Pipe will
+    * hang forever.
+    *
+    * @param supervisor  A Supervisor used to restrict the lifetimes
+    *                    of resources allocated by this Pipe
+    * @param partDecoder A function that consumes the body of a part.
+    *                    Will be called once for each `PartStart` in
+    *                    the incoming stream.
+    * @tparam A Value type returned for each successfully-parsed Part
+    * @return A pipe that transforms Part events into corresponding
+    *         decoded values.
+    */
+  private[this] def decodePartEventsSupervised[F[_], A](
+      supervisor: Supervisor[F],
+      partDecoder: Part[F] => DecodeResult[Resource[F, *], A],
+  )(implicit F: Concurrent[F]): Pipe[F, Event, Either[DecodeFailure, A]] = {
+
+    def pullPartStart(
+        s: Stream[F, Event]
+    ): Pull[F, Either[DecodeFailure, A], Unit] = s.pull.uncons1.flatMap {
+      case Some((ps: PartStart, tail)) =>
+        for {
+          // Created a shared channel that allows us to represent the `partConsumer`
+          // logic as a `Stream` consumer rather than some kind of "scan" operation.
+          // As new `PartChunk` events are pulled, they will be sent to the channel,
+          // and concurrently the `partConsumer` will consume the channel's `.stream`.
+          channel <- Pull.eval(Channel.synchronous[F, Chunk[Byte]])
+
+          // Since we'll run the `partConsumer` concurrently while pulling chunk events
+          // from the input stream, we use a `Deferred` to allow us to block on the
+          // consumer's completion. This also lets us un-block the event-pull during its
+          // attempts to `send` to the channel, in case the consumer completed without
+          // consuming the entire stream.
+          resultPromise <- Pull.eval(Deferred[F, Either[Throwable, A]])
+
+          // Start the "receiver" fiber to run in the background, sending
+          // its result to the `resultPromise` when it becomes available
+          _ <- Pull.eval(supervisor.supervise[Nothing] {
+            partDecoder(Part(ps.value, channel.stream.unchunks)).value.attempt.evalTap { r =>
+              resultPromise.complete(r.flatten) *> channel.close
+            }
+              // tries to allocate the resource but never close it, but since this
+              // will be started by the supervisor, when the supervisor closes, it
+              // will cancel the usage, allowing the resource to release
+              .useForever
+          })
+
+          // Continue pulling Chunks for the current Part, feeding them to the receiver
+          // via the shared Channel. Make sure the channel push operation doesn't block,
+          // by racing its `send` effect with `resultPromise.get`, so that if the receiver
+          // decides to abort early, we can stop trying to push to the channel. If the
+          // receiver raises an error, stop pulling completely
+          restOfStream <-
+            pullUntilPartEnd(
+              tail,
+              chunk => {
+                val keepPulling = F.pure(true)
+                val stopPulling = F.pure(false)
+                F.race(channel.send(chunk), resultPromise.get).flatMap {
+                  case Left(_) =>
+                    keepPulling // send completed normally; don't care if it was closed or not
+                  case Right(Right(a)) =>
+                    keepPulling // send may have blocked, but the receiver already has a result
+                  case Right(Left(err)) =>
+                    stopPulling // receiver raised an error, so abort the pull
+                }
+              },
+            )
+              // when this part of the Pull completes, make sure to close the channel
+              // so that the `receiver` Stream sees an EOF signal.
+              .handleErrorWith { err =>
+                Pull.eval(channel.close) >> Pull.raiseError[F](err)
+              }
+              .productL(Pull.eval(channel.close))
+
+          // Once we've reached the end of the current part, wait until the consumer
+          // finishes and sends its result (or error) to the promise.
+          partResult <- Pull.eval(resultPromise.get)
+
+          // Output the partResult, continuing the Pull if it was not an error
+          _ <- partResult match {
+            case Right(a) => Pull.output1(Right(a)) >> pullPartStart(restOfStream)
+            case Left(e: DecodeFailure) => Pull.output1(Left(e)).covary[F] >> Pull.done
+            case Left(e) => Pull.raiseError[F](e)
+          }
+        } yield ()
+
+      case None =>
+        Pull.done
+
+      case Some((PartEnd, _)) =>
+        Pull.raiseError[F](new IllegalStateException("unexpected PartEnd"))
+
+      case Some((PartChunk(_), _)) =>
+        Pull.raiseError[F](new IllegalStateException("unexpected PartChunk"))
+    }
+
+    def pullUntilPartEnd(
+        s: Stream[F, Event],
+        pushChunk: Chunk[Byte] => F[Boolean],
+    ): Pull[F, Nothing, Stream[F, Event]] = s.pull.uncons1.flatMap {
+      case Some((PartEnd, tail)) =>
+        Pull.pure(tail)
+      case Some((PartChunk(chunk), tail)) =>
+        Pull.eval(pushChunk(chunk)).flatMap { keepPulling =>
+          if (keepPulling) pullUntilPartEnd(tail, pushChunk)
+          else Pull.pure(Stream.empty)
+        }
+      case Some((PartStart(_), _)) | None =>
+        Pull.raiseError[F](new IllegalStateException("Missing PartEnd"))
+    }
+
+    events => pullPartStart(events).stream
+  }
+
+  private[multipart] def decodePartsSupervised[F[_]: Concurrent, A](
+      supervisor: Supervisor[F],
+      boundary: Boundary,
+      decodePart: Part[F] => DecodeResult[Resource[F, *], A],
+      limit: Int = 1024,
+      maxParts: Option[Int] = Some(20),
+      failOnLimit: Boolean = false,
+  ): Pipe[F, Byte, Either[DecodeFailure, A]] =
+    _.through(
+      parseEvents(boundary, limit)
+    ).through(
+      maxParts match {
+        case Some(m) => limitParts(m, failOnLimit)
+        case None => identity
+      }
+    ).through(
+      decodePartEventsSupervised(supervisor, decodePart)
+    )
 
   // //////////////////////////
   // Streaming event parser //

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
@@ -1,11 +1,29 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.multipart
 
 import cats.Applicative
 import cats.effect.Sync
 import cats.syntax.foldable.*
 import fs2.io.file.Files
+import org.http4s.DecodeFailure
+import org.http4s.Headers
+import org.http4s.InvalidMessageBodyFailure
 import org.http4s.headers.`Content-Disposition`
-import org.http4s.{DecodeFailure, Headers, InvalidMessageBodyFailure}
 import org.typelevel.ci.*
 
 trait MultipartReceiver[F[_], A] { self =>
@@ -68,10 +86,9 @@ object MultipartReceiver {
 
   private abstract class ReceiverAt[F[_], A](name: String, receiver: PartReceiver[F, A]) {
     type Partial = A
-    def decide(headers: Headers): Option[PartReceiver[F, A]] = {
+    def decide(headers: Headers): Option[PartReceiver[F, A]] =
       if (partName(headers).contains(name)) Some(receiver)
       else None
-    }
   }
 
   def auto[F[_]: Sync: Files]: MultipartReceiver[F, Map[String, PartValue]] =

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
@@ -1,13 +1,13 @@
 package org.http4s.multipart
 
-import cats.arrow.FunctionK
+import cats.Applicative
 import cats.effect.Sync
 import cats.syntax.foldable.*
-import cats.{Applicative, ~>}
 import fs2.io.file.Files
 import org.http4s.headers.`Content-Disposition`
 import org.http4s.{DecodeFailure, Headers, InvalidMessageBodyFailure}
 import org.typelevel.ci.*
+import scala.language.implicitConversions
 
 trait MultipartReceiver[F[_], A] { self =>
   type Partial
@@ -40,98 +40,37 @@ object MultipartReceiver {
     headers.get[`Content-Disposition`].flatMap(_.parameters.get(ci"filename"))
   private def fail(message: String) = InvalidMessageBodyFailure(message)
 
-  private type IsFilePart = Boolean
+  def at[F[_], A](name: String, receiver: PartReceiver[F, A]) = new At[F, A](name, receiver)
 
-  def anyPart(name: String) =
-    new PartNamedPartialApply[cats.Id](name, _ => None, new ExpectOne(name))
-
-  def filePart(name: String) = new PartNamedPartialApply[cats.Id](
-    name,
-    isFile => Option.when(!isFile)(fail(s"Expected file content in '$name' part")),
-    new ExpectOne(name),
-  )
-
-  def textPart(name: String) = new PartNamedPartialApply[cats.Id](
-    name,
-    isFile => Option.when(isFile)(fail(s"Expected text content in '$name' part")),
-    new ExpectOne(name),
-  )
-
-  def anyPartOpt(name: String) =
-    new PartNamedPartialApply[Option](name, _ => None, new ExpectOpt(name))
-
-  def filePartOpt(name: String) = new PartNamedPartialApply[Option](
-    name,
-    isFile => Option.when(!isFile)(fail(s"Expected file content in '$name' part")),
-    new ExpectOpt(name),
-  )
-
-  def textPartOpt(name: String) = new PartNamedPartialApply[Option](
-    name,
-    isFile => Option.when(isFile)(fail(s"Expected text content in '$name' part")),
-    new ExpectOpt(name),
-  )
-
-  def anyPartList(name: String) = new PartNamedPartialApply[List](name, _ => None, ExpectList)
-
-  def filePartList(name: String) = new PartNamedPartialApply[List](
-    name,
-    isFile => Option.when(!isFile)(fail(s"Expected file content in '$name' part")),
-    ExpectList,
-  )
-
-  def textPartList(name: String) = new PartNamedPartialApply[List](
-    name,
-    isFile => Option.when(isFile)(fail(s"Expected text content in '$name' part")),
-    ExpectList,
-  )
-
-  class PartNamedPartialApply[C[_]](
-      name: String,
-      restriction: IsFilePart => Option[DecodeFailure],
-      assemble: List ~> Lambda[x => Either[DecodeFailure, C[x]]],
-  ) {
-    def apply[F[_], A](partReceiver: PartReceiver[F, A]): MultipartReceiver[F, C[A]] =
-      new SinglePartDecider[F, C, A](name, restriction, partReceiver, assemble)
-  }
-
-  private class ExpectOne(name: String) extends FunctionK[List, Either[DecodeFailure, *]] {
-    def apply[A](partials: List[A]): Either[DecodeFailure, A] = partials match {
-      case Nil => Left(fail(s"Missing expected part: '$name'"))
-      case one :: Nil => Right(one)
-      case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
-    }
-  }
-
-  private class ExpectOpt(name: String)
-      extends FunctionK[List, Lambda[x => Either[DecodeFailure, Option[x]]]] {
-    def apply[A](partials: List[A]): Either[DecodeFailure, Option[A]] = partials match {
-      case Nil => Right(None)
-      case one :: Nil => Right(Some(one))
-      case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
-    }
-  }
-
-  private object ExpectList extends FunctionK[List, Lambda[x => Either[DecodeFailure, List[x]]]] {
-    def apply[A](partials: List[A]): Either[DecodeFailure, List[A]] = Right(partials)
-  }
-
-  private class SinglePartDecider[F[_], C[_], A](
-      name: String,
-      restriction: IsFilePart => Option[DecodeFailure],
-      partReceiver: PartReceiver[F, A],
-      _assemble: List ~> Lambda[x => Either[DecodeFailure, C[x]]],
-  ) extends MultipartReceiver[F, C[A]] {
-    type Partial = A
-    def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] =
-      partName(partHeaders).filter(_ == name).map { _ =>
-        val isFilePart: IsFilePart = partFilename(partHeaders).isDefined
-        restriction(isFilePart) match {
-          case Some(failure) => PartReceiver.reject(failure)
-          case None => partReceiver
-        }
+  final class At[F[_], A](name: String, receiver: PartReceiver[F, A]) {
+    def once: MultipartReceiver[F, A] = new ReceiverAt(name, receiver)
+      with MultipartReceiver[F, A] {
+      def assemble(partials: List[A]): Either[DecodeFailure, A] = partials match {
+        case Nil => Left(fail(s"Missing expected part: '$name'"))
+        case one :: Nil => Right(one)
+        case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
       }
-    def assemble(partials: List[A]): Either[DecodeFailure, C[A]] = _assemble(partials)
+    }
+
+    def asOption: MultipartReceiver[F, Option[A]] = new ReceiverAt(name, receiver)
+      with MultipartReceiver[F, Option[A]] {
+      def assemble(partials: List[A]): Either[DecodeFailure, Option[A]] = partials match {
+        case Nil => Right(None)
+        case one :: Nil => Right(Some(one))
+        case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
+      }
+    }
+
+    def asList: MultipartReceiver[F, List[A]] = new ReceiverAt(name, receiver)
+      with MultipartReceiver[F, List[A]] {
+      def assemble(partials: List[Partial]): Either[DecodeFailure, List[A]] = Right(partials)
+    }
+  }
+
+  private abstract class ReceiverAt[F[_], A](name: String, receiver: PartReceiver[F, A]) {
+    type Partial = A
+    def decide(headers: Headers): Option[PartReceiver[F, A]] =
+      Option.when(partName(headers).contains(name))(receiver)
   }
 
   def auto[F[_]: Sync: Files]: MultipartReceiver[F, Map[String, PartValue]] =
@@ -152,9 +91,7 @@ object MultipartReceiver {
       )
     }
 
-  def uniform[F[_], A, C[_]](
-      partReceiver: PartReceiver[F, A]
-  ): MultipartReceiver.Aux[F, List[A], A] =
+  def uniform[F[_], A](partReceiver: PartReceiver[F, A]): MultipartReceiver.Aux[F, List[A], A] =
     new MultipartReceiver[F, List[A]] {
       type Partial = A
       def decide(partHeaders: Headers) = Some(partReceiver)
@@ -194,8 +131,9 @@ object MultipartReceiver {
     )(fa: MultipartReceiver[F, A]): MultipartReceiver[F, B] = new MultipartReceiver[F, B] {
       type Partial = Either[ff.Partial, fa.Partial]
       def decide(partHeaders: Headers): Option[PartReceiver[F, Either[ff.Partial, fa.Partial]]] =
-        // the order that the `orElse` operands appear decides the precedence in cases like `(receiver1, receiver2).mapN`
+        // The order that the `orElse` operands appear decides the precedence in cases like `(receiver1, receiver2).mapN`
         // where both receivers could decide to consume the Part; only one is allowed, so we have to choose a winner.
+        // This matters when combining a receiver for a specific field with a receiver that generically accepts all fields.
         ff.decide(partHeaders)
           .map(_.map(Left(_): Partial))
           .orElse(fa.decide(partHeaders).map(_.map(Right(_): Partial)))

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
@@ -1,0 +1,178 @@
+package org.http4s.multipart
+
+import cats.arrow.FunctionK
+import cats.effect.Sync
+import cats.{ Applicative, ~> }
+import fs2.Stream
+import fs2.io.file.{ Files, Path }
+import org.http4s.{ DecodeFailure, EntityBody, Headers, InvalidMessageBodyFailure }
+import org.http4s.headers.`Content-Disposition`
+
+trait MultipartReceiver[F[_], A] { self =>
+  type Partial
+  def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]]
+  def assemble(partials: List[Partial]): Either[DecodeFailure, A]
+
+  def ignoreUnexpectedParts: MultipartReceiver[F, A] =
+    new MultipartReceiver.IgnoreUnexpected[F, A, Partial](this)
+
+  def rejectUnexpectedParts: MultipartReceiver[F, A] =
+    new MultipartReceiver.RejectUnexpected[F, A, Partial](this)
+
+  def transformParts(f: PartReceiver[F, Partial] => PartReceiver[F, Partial]): MultipartReceiver[F, A] =
+    new MultipartReceiver.TransformPart[F, A, Partial](this, f)
+}
+
+object MultipartReceiver {
+  type Aux[F[_], A, P] = MultipartReceiver[F, A] {type Partial = P}
+
+  def apply[F[_]] = new PartialApply[F]
+
+  private def partName(headers: Headers) = headers.get[`Content-Disposition`].flatMap(_.parameters.get(ci"name"))
+  private def partFilename(headers: Headers) = headers.get[`Content-Disposition`].flatMap(_.parameters.get(ci"filename"))
+  private def fail(message: String) = InvalidMessageBodyFailure(message)
+
+  sealed trait FieldValue {
+    def rawValue[F[_] : Files]: EntityBody[F]
+    def foldValue[A](onString: String => A, onFile: (String, Path) => A): A
+  }
+  object FieldValue {
+    case class OfString(value: String) extends FieldValue {
+      def rawValue[F[_] : Files] = fs2.text.utf8.encode[F](Stream.emit(value))
+      def foldValue[A](onString: String => A, onFile: (String, Path) => A) = onString(value)
+    }
+    case class OfFile(filename: String, path: Path) extends FieldValue {
+      def rawValue[F[_] : Files]: EntityBody[F] = Files[F].readAll(path)
+      def foldValue[A](onString: String => A, onFile: (String, Path) => A): A = onFile(filename, path)
+    }
+  }
+
+  class PartialApply[F[_]] {
+    private def R = PartReceiver[F]
+    private type IsFilePart = Boolean
+
+    def anyPart(name: String) = new PartNamedPartialApply[cats.Id](name, _ => None, new ExpectOne(name))
+    def filePart(name: String) = new PartNamedPartialApply[cats.Id](name, isFile => Option.when(!isFile) { fail(s"Expected file content in '$name' part") }, new ExpectOne(name))
+    def textPart(name: String) = new PartNamedPartialApply[cats.Id](name, isFile => Option.when(isFile) { fail(s"Expected text content in '$name' part") }, new ExpectOne(name))
+
+    def anyPartOpt(name: String) = new PartNamedPartialApply[Option](name, _ => None, new ExpectOpt(name))
+    def filePartOpt(name: String) = new PartNamedPartialApply[Option](name, isFile => Option.when(!isFile) { fail(s"Expected file content in '$name' part") }, new ExpectOpt(name))
+    def textPartOpt(name: String) = new PartNamedPartialApply[Option](name, isFile => Option.when(isFile) { fail(s"Expected text content in '$name' part") }, new ExpectOpt(name))
+
+    def anyPartList(name: String) = new PartNamedPartialApply[List](name, _ => None, new ExpectList(name))
+    def filePartList(name: String) = new PartNamedPartialApply[List](name, isFile => Option.when(!isFile) { fail(s"Expected file content in '$name' part") }, new ExpectList(name))
+    def textPartList(name: String) = new PartNamedPartialApply[List](name, isFile => Option.when(isFile) { fail(s"Expected text content in '$name' part") }, new ExpectList(name))
+
+    class PartNamedPartialApply[C[_]](
+      name: String,
+      restriction: IsFilePart => Option[DecodeFailure],
+      assemble: List ~> Lambda[x => Either[DecodeFailure, C[x]]],
+    ) {
+      def apply[A](partReceiver: PartReceiver.PartialApply[F] => PartReceiver[F, A]): MultipartReceiver[F, C[A]] = {
+        new SinglePartDecider[C, A](name, restriction, partReceiver, assemble)
+      }
+    }
+
+    private class ExpectOne(name: String) extends FunctionK[List, Either[DecodeFailure, *]] {
+      def apply[A](partials: List[A]): Either[DecodeFailure, A] = partials match {
+        case Nil => Left(fail(s"Missing expected part: '$name'"))
+        case one :: Nil => Right(one)
+        case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
+      }
+    }
+    private class ExpectOpt(name: String) extends FunctionK[List, Lambda[x => Either[DecodeFailure, Option[x]]]] {
+      def apply[A](partials: List[A]): Either[DecodeFailure, Option[A]] = partials match {
+        case Nil => Right(None)
+        case one :: Nil => Right(Some(one))
+        case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
+      }
+    }
+    private class ExpectList(name: String) extends FunctionK[List, Lambda[x => Either[DecodeFailure, List[x]]]] {
+      def apply[A](partials: List[A]): Either[DecodeFailure, List[A]] = Right(partials)
+    }
+
+    private class SinglePartDecider[C[_], A](
+      name: String,
+      restriction: IsFilePart => Option[DecodeFailure],
+      partReceiver: PartReceiver.PartialApply[F] => PartReceiver[F, A],
+      _assemble: List ~> Lambda[x => Either[DecodeFailure, C[x]]],
+    ) extends MultipartReceiver[F, C[A]] {
+      type Partial = A
+      def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] = partName(partHeaders).filter(_ == name).map { _ =>
+        val isFilePart: IsFilePart = partFilename(partHeaders).isDefined
+        restriction(isFilePart) match {
+          case Some(failure) => R.reject(failure)
+          case None => partReceiver(R)
+        }
+      }
+      def assemble(partials: List[A]): Either[DecodeFailure, C[A]] = _assemble(partials)
+    }
+
+    def auto(implicit F: Sync[F], files: Files[F]): MultipartReceiver[F, Map[String, FieldValue]] = new MultipartReceiver[F, Map[String, FieldValue]] {
+      type Partial = (String, FieldValue)
+      def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] = (partName(partHeaders), partFilename(partHeaders)) match {
+        case (Some(name), Some(filename)) => Some(R.toTempFile.map { path => name -> FieldValue.OfFile(filename, path) })
+        case (Some(name), None) => Some(R.readString.map { str => name -> FieldValue.OfString(str) })
+        case _ => None
+      }
+      def assemble(partials: List[Partial]): Either[DecodeFailure, Map[String, FieldValue]] = Right(partials.toMap)
+    }
+
+  }
+
+  private class IgnoreUnexpected[F[_], A, P](inner: Aux[F, A, P]) extends MultipartReceiver[F, A] {
+    type Partial = Option[P]
+    def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] = {
+      Some(inner.decide(partHeaders).map(_.map[Partial](Some(_))).getOrElse {
+        PartReceiver[F].ignore.map[Partial](_ => None)
+      })
+    }
+    def assemble(partials: List[Partial]): Either[DecodeFailure, A] = {
+      inner.assemble(partials.flatten)
+    }
+  }
+
+  private class RejectUnexpected[F[_], A, P](inner: Aux[F, A, P]) extends MultipartReceiver[F, A] {
+    type Partial = P
+    def decide(partHeaders: Headers): Option[PartReceiver[F, P]] = inner.decide(partHeaders).orElse {
+      Some(PartReceiver[F].reject[Partial] {
+        partName(partHeaders) match {
+          case None => InvalidMessageBodyFailure("Unexpected anonymous part")
+          case Some(name) => InvalidMessageBodyFailure(s"Unexpected part: '$name'")
+        }
+      })
+    }
+    def assemble(partials: List[P]): Either[DecodeFailure, A] = inner.assemble(partials)
+  }
+
+  private class TransformPart[F[_], A, P](inner: Aux[F, A, P], f: PartReceiver[F, P] => PartReceiver[F, P]) extends MultipartReceiver[F, A] {
+    type Partial = P
+    def decide(partHeaders: Headers): Option[PartReceiver[F, P]] = inner.decide(partHeaders).map(f)
+    def assemble(partials: List[P]): Either[DecodeFailure, A] = inner.assemble(partials)
+  }
+
+  implicit def multipartReceiverApplicative[F[_]]: Applicative[MultipartReceiver[F, *]] = new MultipartReceiverApplicative[F]
+
+  class MultipartReceiverApplicative[F[_]] extends Applicative[MultipartReceiver[F, *]] {
+    def pure[A](x: A): MultipartReceiver[F, A] = new MultipartReceiver[F, A] {
+      type Partial = Unit
+      def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] = None
+      def assemble(partials: List[Partial]): Either[DecodeFailure, A] = Right(x)
+    }
+    def ap[A, B](ff: MultipartReceiver[F, A => B])(fa: MultipartReceiver[F, A]): MultipartReceiver[F, B] = new MultipartReceiver[F, B] {
+      type Partial = Either[ff.Partial, fa.Partial]
+      def decide(partHeaders: Headers): Option[PartReceiver[F, Either[ff.Partial, fa.Partial]]] = {
+        // the order that the `orElse` operands appear decides the precedence in cases like `(receiver1, receiver2).mapN`
+        // where both receivers could decide to consume the Part; only one is allowed, so we have to choose a winner.
+        ff.decide(partHeaders).map(_.map(Left(_): Partial)) orElse fa.decide(partHeaders).map(_.map(Right(_): Partial))
+      }
+      def assemble(partials: List[Either[ff.Partial, fa.Partial]]): Either[DecodeFailure, B] = {
+        val (ffs, fas) = partials.partitionEither(identity)
+        for {
+          f <- ff.assemble(ffs)
+          a <- fa.assemble(fas)
+        } yield f(a)
+      }
+    }
+  }
+}

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
@@ -2,177 +2,203 @@ package org.http4s.multipart
 
 import cats.arrow.FunctionK
 import cats.effect.Sync
-import cats.{ Applicative, ~> }
-import cats.syntax.foldable._
-import fs2.Stream
-import fs2.io.file.{ Files, Path }
-import org.http4s.{ DecodeFailure, EntityBody, Headers, InvalidMessageBodyFailure }
+import cats.syntax.foldable.*
+import cats.{Applicative, ~>}
+import fs2.io.file.Files
 import org.http4s.headers.`Content-Disposition`
-import org.typelevel.ci._
+import org.http4s.{DecodeFailure, Headers, InvalidMessageBodyFailure}
+import org.typelevel.ci.*
 
 trait MultipartReceiver[F[_], A] { self =>
   type Partial
   def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]]
   def assemble(partials: List[Partial]): Either[DecodeFailure, A]
 
+  def decideOrReject(partHeaders: Headers): PartReceiver[F, Partial] =
+    decide(partHeaders).getOrElse {
+      PartReceiver.reject[F, Partial](MultipartReceiver.partName(partHeaders) match {
+        case None => InvalidMessageBodyFailure("Unexpected anonymous part")
+        case Some(name) => InvalidMessageBodyFailure(s"Unexpected part: '$name'")
+      })
+    }
+
   def ignoreUnexpectedParts: MultipartReceiver[F, A] =
     new MultipartReceiver.IgnoreUnexpected[F, A, Partial](this)
 
-  def rejectUnexpectedParts: MultipartReceiver[F, A] =
-    new MultipartReceiver.RejectUnexpected[F, A, Partial](this)
-
-  def transformParts(f: PartReceiver[F, Partial] => PartReceiver[F, Partial]): MultipartReceiver[F, A] =
+  def transformParts(
+      f: PartReceiver[F, Partial] => PartReceiver[F, Partial]
+  ): MultipartReceiver[F, A] =
     new MultipartReceiver.TransformPart[F, A, Partial](this, f)
 }
 
 object MultipartReceiver {
-  type Aux[F[_], A, P] = MultipartReceiver[F, A] {type Partial = P}
+  type Aux[F[_], A, P] = MultipartReceiver[F, A] { type Partial = P }
 
-  def apply[F[_]] = new PartialApply[F]
-
-  private def partName(headers: Headers) = headers.get[`Content-Disposition`].flatMap(_.parameters.get(ci"name"))
-  private def partFilename(headers: Headers) = headers.get[`Content-Disposition`].flatMap(_.parameters.get(ci"filename"))
+  private def partName(headers: Headers) =
+    headers.get[`Content-Disposition`].flatMap(_.parameters.get(ci"name"))
+  private def partFilename(headers: Headers) =
+    headers.get[`Content-Disposition`].flatMap(_.parameters.get(ci"filename"))
   private def fail(message: String) = InvalidMessageBodyFailure(message)
 
-  sealed trait FieldValue {
-    def rawValue[F[_] : Files]: EntityBody[F]
-    def foldValue[A](onString: String => A, onFile: (String, Path) => A): A
-  }
-  object FieldValue {
-    case class OfString(value: String) extends FieldValue {
-      def rawValue[F[_] : Files] = fs2.text.utf8.encode[F](Stream.emit(value))
-      def foldValue[A](onString: String => A, onFile: (String, Path) => A) = onString(value)
-    }
-    case class OfFile(filename: String, path: Path) extends FieldValue {
-      def rawValue[F[_] : Files]: EntityBody[F] = Files[F].readAll(path)
-      def foldValue[A](onString: String => A, onFile: (String, Path) => A): A = onFile(filename, path)
-    }
-  }
+  private type IsFilePart = Boolean
 
-  class PartialApply[F[_]] {
-    private def R = PartReceiver[F]
-    private type IsFilePart = Boolean
+  def anyPart(name: String) =
+    new PartNamedPartialApply[cats.Id](name, _ => None, new ExpectOne(name))
 
-    def anyPart(name: String) = new PartNamedPartialApply[cats.Id](name, _ => None, new ExpectOne(name))
-    def filePart(name: String) = new PartNamedPartialApply[cats.Id](name, isFile => Option.when(!isFile) { fail(s"Expected file content in '$name' part") }, new ExpectOne(name))
-    def textPart(name: String) = new PartNamedPartialApply[cats.Id](name, isFile => Option.when(isFile) { fail(s"Expected text content in '$name' part") }, new ExpectOne(name))
+  def filePart(name: String) = new PartNamedPartialApply[cats.Id](
+    name,
+    isFile => Option.when(!isFile)(fail(s"Expected file content in '$name' part")),
+    new ExpectOne(name),
+  )
 
-    def anyPartOpt(name: String) = new PartNamedPartialApply[Option](name, _ => None, new ExpectOpt(name))
-    def filePartOpt(name: String) = new PartNamedPartialApply[Option](name, isFile => Option.when(!isFile) { fail(s"Expected file content in '$name' part") }, new ExpectOpt(name))
-    def textPartOpt(name: String) = new PartNamedPartialApply[Option](name, isFile => Option.when(isFile) { fail(s"Expected text content in '$name' part") }, new ExpectOpt(name))
+  def textPart(name: String) = new PartNamedPartialApply[cats.Id](
+    name,
+    isFile => Option.when(isFile)(fail(s"Expected text content in '$name' part")),
+    new ExpectOne(name),
+  )
 
-    def anyPartList(name: String) = new PartNamedPartialApply[List](name, _ => None, ExpectList)
-    def filePartList(name: String) = new PartNamedPartialApply[List](name, isFile => Option.when(!isFile) { fail(s"Expected file content in '$name' part") }, ExpectList)
-    def textPartList(name: String) = new PartNamedPartialApply[List](name, isFile => Option.when(isFile) { fail(s"Expected text content in '$name' part") }, ExpectList)
+  def anyPartOpt(name: String) =
+    new PartNamedPartialApply[Option](name, _ => None, new ExpectOpt(name))
 
-    class PartNamedPartialApply[C[_]](
+  def filePartOpt(name: String) = new PartNamedPartialApply[Option](
+    name,
+    isFile => Option.when(!isFile)(fail(s"Expected file content in '$name' part")),
+    new ExpectOpt(name),
+  )
+
+  def textPartOpt(name: String) = new PartNamedPartialApply[Option](
+    name,
+    isFile => Option.when(isFile)(fail(s"Expected text content in '$name' part")),
+    new ExpectOpt(name),
+  )
+
+  def anyPartList(name: String) = new PartNamedPartialApply[List](name, _ => None, ExpectList)
+
+  def filePartList(name: String) = new PartNamedPartialApply[List](
+    name,
+    isFile => Option.when(!isFile)(fail(s"Expected file content in '$name' part")),
+    ExpectList,
+  )
+
+  def textPartList(name: String) = new PartNamedPartialApply[List](
+    name,
+    isFile => Option.when(isFile)(fail(s"Expected text content in '$name' part")),
+    ExpectList,
+  )
+
+  class PartNamedPartialApply[C[_]](
       name: String,
       restriction: IsFilePart => Option[DecodeFailure],
       assemble: List ~> Lambda[x => Either[DecodeFailure, C[x]]],
-    ) {
-      def apply[A](partReceiver: PartReceiver.PartialApply[F] => PartReceiver[F, A]): MultipartReceiver[F, C[A]] = {
-        new SinglePartDecider[C, A](name, restriction, partReceiver, assemble)
-      }
-    }
+  ) {
+    def apply[F[_], A](partReceiver: PartReceiver[F, A]): MultipartReceiver[F, C[A]] =
+      new SinglePartDecider[F, C, A](name, restriction, partReceiver, assemble)
+  }
 
-    private class ExpectOne(name: String) extends FunctionK[List, Either[DecodeFailure, *]] {
-      def apply[A](partials: List[A]): Either[DecodeFailure, A] = partials match {
-        case Nil => Left(fail(s"Missing expected part: '$name'"))
-        case one :: Nil => Right(one)
-        case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
-      }
-    }
-    private class ExpectOpt(name: String) extends FunctionK[List, Lambda[x => Either[DecodeFailure, Option[x]]]] {
-      def apply[A](partials: List[A]): Either[DecodeFailure, Option[A]] = partials match {
-        case Nil => Right(None)
-        case one :: Nil => Right(Some(one))
-        case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
-      }
-    }
-    private object ExpectList extends FunctionK[List, Lambda[x => Either[DecodeFailure, List[x]]]] {
-      def apply[A](partials: List[A]): Either[DecodeFailure, List[A]] = Right(partials)
-    }
-
-    private class SinglePartDecider[C[_], A](
-      name: String,
-      restriction: IsFilePart => Option[DecodeFailure],
-      partReceiver: PartReceiver.PartialApply[F] => PartReceiver[F, A],
-      _assemble: List ~> Lambda[x => Either[DecodeFailure, C[x]]],
-    ) extends MultipartReceiver[F, C[A]] {
-      type Partial = A
-      def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] = partName(partHeaders).filter(_ == name).map { _ =>
-        val isFilePart: IsFilePart = partFilename(partHeaders).isDefined
-        restriction(isFilePart) match {
-          case Some(failure) => R.reject(failure)
-          case None => partReceiver(R)
-        }
-      }
-      def assemble(partials: List[A]): Either[DecodeFailure, C[A]] = _assemble(partials)
-    }
-
-    def auto(implicit F: Sync[F], files: Files[F]): MultipartReceiver[F, Map[String, FieldValue]] = new MultipartReceiver[F, Map[String, FieldValue]] {
-      type Partial = (String, FieldValue)
-      def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] = (partName(partHeaders), partFilename(partHeaders)) match {
-        case (Some(name), Some(filename)) => Some(R.toTempFile.map { path => name -> FieldValue.OfFile(filename, path) })
-        case (Some(name), None) => Some(R.readString.map { str => name -> FieldValue.OfString(str) })
-        case _ => None
-      }
-      def assemble(partials: List[Partial]): Either[DecodeFailure, Map[String, FieldValue]] = Right(partials.toMap)
-    }
-
-    def uniform[A](partReceiver: PartReceiver[F, A]): MultipartReceiver[F, Vector[A]] = new MultipartReceiver[F, Vector[A]] {
-      type Partial = A
-      def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] = Some(partReceiver)
-      def assemble(partials: List[Partial]): Either[DecodeFailure, Vector[A]] = Right(partials.toVector)
+  private class ExpectOne(name: String) extends FunctionK[List, Either[DecodeFailure, *]] {
+    def apply[A](partials: List[A]): Either[DecodeFailure, A] = partials match {
+      case Nil => Left(fail(s"Missing expected part: '$name'"))
+      case one :: Nil => Right(one)
+      case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
     }
   }
+
+  private class ExpectOpt(name: String)
+      extends FunctionK[List, Lambda[x => Either[DecodeFailure, Option[x]]]] {
+    def apply[A](partials: List[A]): Either[DecodeFailure, Option[A]] = partials match {
+      case Nil => Right(None)
+      case one :: Nil => Right(Some(one))
+      case _ => Left(fail(s"Unexpected multiple parts found with name '$name'"))
+    }
+  }
+
+  private object ExpectList extends FunctionK[List, Lambda[x => Either[DecodeFailure, List[x]]]] {
+    def apply[A](partials: List[A]): Either[DecodeFailure, List[A]] = Right(partials)
+  }
+
+  private class SinglePartDecider[F[_], C[_], A](
+      name: String,
+      restriction: IsFilePart => Option[DecodeFailure],
+      partReceiver: PartReceiver[F, A],
+      _assemble: List ~> Lambda[x => Either[DecodeFailure, C[x]]],
+  ) extends MultipartReceiver[F, C[A]] {
+    type Partial = A
+    def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] =
+      partName(partHeaders).filter(_ == name).map { _ =>
+        val isFilePart: IsFilePart = partFilename(partHeaders).isDefined
+        restriction(isFilePart) match {
+          case Some(failure) => PartReceiver.reject(failure)
+          case None => partReceiver
+        }
+      }
+    def assemble(partials: List[A]): Either[DecodeFailure, C[A]] = _assemble(partials)
+  }
+
+  def auto[F[_]: Sync: Files]: MultipartReceiver[F, Map[String, PartValue]] =
+    new MultipartReceiver[F, Map[String, PartValue]] {
+      type Partial = (String, PartValue)
+      def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] =
+        (partName(partHeaders), partFilename(partHeaders)) match {
+          case (Some(name), Some(filename)) =>
+            Some(PartReceiver.toTempFile[F].map { path =>
+              name -> PartValue.OfFile(filename, path)
+            })
+          case (Some(name), None) =>
+            Some(PartReceiver.bodyText[F].map(str => name -> PartValue.OfString(str)))
+          case _ => None
+        }
+      def assemble(partials: List[Partial]): Either[DecodeFailure, Map[String, PartValue]] = Right(
+        partials.toMap
+      )
+    }
+
+  def uniform[F[_], A, C[_]](
+      partReceiver: PartReceiver[F, A]
+  ): MultipartReceiver.Aux[F, List[A], A] =
+    new MultipartReceiver[F, List[A]] {
+      type Partial = A
+      def decide(partHeaders: Headers) = Some(partReceiver)
+      def assemble(partials: List[Partial]) = Right(partials)
+    }
 
   private class IgnoreUnexpected[F[_], A, P](inner: Aux[F, A, P]) extends MultipartReceiver[F, A] {
     type Partial = Option[P]
-    def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] = {
+    def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] =
       Some(inner.decide(partHeaders).map(_.map[Partial](Some(_))).getOrElse {
-        PartReceiver[F].ignore.map[Partial](_ => None)
+        PartReceiver.ignore[F].map[Partial](_ => None)
       })
-    }
-    def assemble(partials: List[Partial]): Either[DecodeFailure, A] = {
+    def assemble(partials: List[Partial]): Either[DecodeFailure, A] =
       inner.assemble(partials.flatten)
-    }
   }
 
-  private class RejectUnexpected[F[_], A, P](inner: Aux[F, A, P]) extends MultipartReceiver[F, A] {
-    type Partial = P
-    def decide(partHeaders: Headers): Option[PartReceiver[F, P]] = inner.decide(partHeaders).orElse {
-      Some(PartReceiver[F].reject[Partial] {
-        partName(partHeaders) match {
-          case None => InvalidMessageBodyFailure("Unexpected anonymous part")
-          case Some(name) => InvalidMessageBodyFailure(s"Unexpected part: '$name'")
-        }
-      })
-    }
-    def assemble(partials: List[P]): Either[DecodeFailure, A] = inner.assemble(partials)
-  }
-
-  private class TransformPart[F[_], A, P](inner: Aux[F, A, P], f: PartReceiver[F, P] => PartReceiver[F, P]) extends MultipartReceiver[F, A] {
+  private class TransformPart[F[_], A, P](
+      inner: Aux[F, A, P],
+      f: PartReceiver[F, P] => PartReceiver[F, P],
+  ) extends MultipartReceiver[F, A] {
     type Partial = P
     def decide(partHeaders: Headers): Option[PartReceiver[F, P]] = inner.decide(partHeaders).map(f)
     def assemble(partials: List[P]): Either[DecodeFailure, A] = inner.assemble(partials)
   }
 
-  implicit def multipartReceiverApplicative[F[_]]: Applicative[MultipartReceiver[F, *]] = new MultipartReceiverApplicative[F]
+  implicit def multipartReceiverApplicative[F[_]]: Applicative[MultipartReceiver[F, *]] =
+    new MultipartReceiverApplicative[F]
 
-  class MultipartReceiverApplicative[F[_]] extends Applicative[MultipartReceiver[F, *]] {
+  private class MultipartReceiverApplicative[F[_]] extends Applicative[MultipartReceiver[F, *]] {
     def pure[A](x: A): MultipartReceiver[F, A] = new MultipartReceiver[F, A] {
       type Partial = Unit
       def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] = None
       def assemble(partials: List[Partial]): Either[DecodeFailure, A] = Right(x)
     }
-    def ap[A, B](ff: MultipartReceiver[F, A => B])(fa: MultipartReceiver[F, A]): MultipartReceiver[F, B] = new MultipartReceiver[F, B] {
+    def ap[A, B](
+        ff: MultipartReceiver[F, A => B]
+    )(fa: MultipartReceiver[F, A]): MultipartReceiver[F, B] = new MultipartReceiver[F, B] {
       type Partial = Either[ff.Partial, fa.Partial]
-      def decide(partHeaders: Headers): Option[PartReceiver[F, Either[ff.Partial, fa.Partial]]] = {
+      def decide(partHeaders: Headers): Option[PartReceiver[F, Either[ff.Partial, fa.Partial]]] =
         // the order that the `orElse` operands appear decides the precedence in cases like `(receiver1, receiver2).mapN`
         // where both receivers could decide to consume the Part; only one is allowed, so we have to choose a winner.
-        ff.decide(partHeaders).map(_.map(Left(_): Partial)) orElse fa.decide(partHeaders).map(_.map(Right(_): Partial))
-      }
+        ff.decide(partHeaders)
+          .map(_.map(Left(_): Partial))
+          .orElse(fa.decide(partHeaders).map(_.map(Right(_): Partial)))
       def assemble(partials: List[Either[ff.Partial, fa.Partial]]): Either[DecodeFailure, B] = {
         val (ffs, fas) = partials.partitionEither(identity)
         for {

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
@@ -7,7 +7,6 @@ import fs2.io.file.Files
 import org.http4s.headers.`Content-Disposition`
 import org.http4s.{DecodeFailure, Headers, InvalidMessageBodyFailure}
 import org.typelevel.ci.*
-import scala.language.implicitConversions
 
 trait MultipartReceiver[F[_], A] { self =>
   type Partial
@@ -69,8 +68,10 @@ object MultipartReceiver {
 
   private abstract class ReceiverAt[F[_], A](name: String, receiver: PartReceiver[F, A]) {
     type Partial = A
-    def decide(headers: Headers): Option[PartReceiver[F, A]] =
-      Option.when(partName(headers).contains(name))(receiver)
+    def decide(headers: Headers): Option[PartReceiver[F, A]] = {
+      if (partName(headers).contains(name)) Some(receiver)
+      else None
+    }
   }
 
   def auto[F[_]: Sync: Files]: MultipartReceiver[F, Map[String, PartValue]] =

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -1,0 +1,67 @@
+package org.http4s.multipart
+
+import cats.{ Applicative, ApplicativeError }
+import cats.effect.kernel.Resource
+import fs2.{ Compiler, Pipe, Pull, RaiseThrowable, Stream }
+import fs2.io.file.{ Files, Path }
+import org.http4s.{ DecodeFailure, EntityDecoder, InvalidMessageBodyFailure }
+
+trait PartReceiver[F[_], A] {
+  def receive(part: Part[F]): Resource[F, Either[DecodeFailure, A]]
+
+  def map[B](f: A => B): PartReceiver[F, B] = part => this.receive(part).map(_.map(f))
+
+  def tapStart(onStart: F[Unit]): PartReceiver[F, A] =
+    part => Resource.eval(onStart).flatMap { _ => this.receive(part) }
+
+  def tapResult(onResult: Either[DecodeFailure, A] => F[Unit]): PartReceiver[F, A] =
+    part => this.receive(part).evalTap(onResult)
+
+  def tapRelease(onRelease: F[Unit])(implicit F: Applicative[F]): PartReceiver[F, A] =
+    part => Resource.make(F.unit)(_ => onRelease).flatMap { _ => this.receive(part) }
+
+  def preprocess(transformPartBody: Pipe[F, Byte, Byte]): PartReceiver[F, A] =
+    part => this.receive(part.copy(body = transformPartBody(part.body)))
+
+  def withSizeLimit(limit: Long)(implicit F: ApplicativeError[F, Throwable]): PartReceiver[F, A] =
+    preprocess(PartReceiver.limitPartSize[F](limit))
+}
+
+object PartReceiver {
+
+  def apply[F[_]] = new PartialApply[F]
+
+  class PartialApply[F[_]] {
+    def readString(implicit F: RaiseThrowable[F], cmp: Compiler[F, F]): PartReceiver[F, String] =
+      part => Resource.eval { part.bodyText.compile.string }.map(Right(_))
+
+    def toTempFile(implicit F: Files[F], c: Compiler[F, F]): PartReceiver[F, Path] =
+      part => F.tempFile.evalTap { path => part.body.through(F.writeAll(path)).compile.drain }.map(Right(_))
+
+    def ignore: PartReceiver[F, Unit] =
+      part => Resource.pure(Right(()))
+
+    def reject[A](err: DecodeFailure): PartReceiver[F, A] =
+      part => Resource.pure(Left(err))
+
+    def decode[A](implicit decoder: EntityDecoder[F, A]): PartReceiver[F, A] =
+      part => Resource.eval(decoder.decode(part, strict = false).value)
+
+    def decodeStrict[A](implicit decoder: EntityDecoder[F, A]): PartReceiver[F, A] =
+      part => Resource.eval(decoder.decode(part, strict = true).value)
+
+  }
+
+  private def limitPartSize[F[_]](maxPartSizeBytes: Long)(implicit F: ApplicativeError[F, Throwable]): Pipe[F, Byte, Byte] = {
+    def go(s: Stream[F, Byte], accumSize: Long): Pull[F, Byte, Unit] = s.pull.uncons.flatMap {
+      case Some((chunk, tail)) =>
+        val newSize = accumSize + chunk.size
+        if (newSize <= maxPartSizeBytes) Pull.output(chunk) >> go(tail, newSize)
+        else Pull.raiseError[F](InvalidMessageBodyFailure("Part body exceeds maximum length"))
+      case None =>
+        Pull.done
+    }
+
+    go(_, 0L).stream
+  }
+}

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -37,8 +37,8 @@ import fs2.Compiler
 
 /** Represents the decoding process of a single "part" in a `multipart/form-data` message.
   *
-  * Used in conjunction with [[MultipartReceiver]] and [[MultipartDecoder.fromReceiver]]
-  * to create robust [[EntityDecoder]]s with fail-fast behavior.
+  * Used in conjunction with `MultipartReceiver` and `MultipartDecoder.fromReceiver`
+  * to create robust `EntityDecoder`s with fail-fast behavior.
   */
 trait PartReceiver[F[_], A] {
   def receive(part: Part[F]): Resource[F, Either[DecodeFailure, A]]

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -1,24 +1,28 @@
 package org.http4s.multipart
 
-import cats.{ Applicative, ApplicativeError }
 import cats.effect.kernel.Resource
-import fs2.{ Compiler, Pipe, Pull, RaiseThrowable, Stream }
+import cats.{ Applicative, ApplicativeError, MonadThrow }
 import fs2.io.file.{ Files, Path }
-import org.http4s.{ DecodeFailure, EntityDecoder, InvalidMessageBodyFailure }
+import fs2.{ Compiler, Pipe, Pull, Pure, RaiseThrowable, Stream }
+import org.http4s.{ DecodeFailure, EntityDecoder, Headers, InvalidMessageBodyFailure }
 
 trait PartReceiver[F[_], A] {
   def receive(part: Part[F]): Resource[F, Either[DecodeFailure, A]]
 
-  def map[B](f: A => B): PartReceiver[F, B] = part => this.receive(part).map(_.map(f))
+  def map[B](f: A => B): PartReceiver[F, B] =
+    part => this.receive(part).map(_.map(f))
+
+  def mapWithHeaders[B](f: (Headers, A) => B): PartReceiver[F, B] =
+    part => this.receive(part).map(_.map(f(part.headers, _)))
 
   def tapStart(onStart: F[Unit]): PartReceiver[F, A] =
-    part => Resource.eval(onStart).flatMap { _ => this.receive(part) }
+    part => Resource.eval(onStart).flatMap(_ => this.receive(part))
 
   def tapResult(onResult: Either[DecodeFailure, A] => F[Unit]): PartReceiver[F, A] =
     part => this.receive(part).evalTap(onResult)
 
   def tapRelease(onRelease: F[Unit])(implicit F: Applicative[F]): PartReceiver[F, A] =
-    part => Resource.make(F.unit)(_ => onRelease).flatMap { _ => this.receive(part) }
+    part => Resource.make(F.unit)(_ => onRelease).flatMap(_ => this.receive(part))
 
   def preprocess(transformPartBody: Pipe[F, Byte, Byte]): PartReceiver[F, A] =
     part => this.receive(part.copy(body = transformPartBody(part.body)))
@@ -33,16 +37,19 @@ object PartReceiver {
 
   class PartialApply[F[_]] {
     def readString(implicit F: RaiseThrowable[F], cmp: Compiler[F, F]): PartReceiver[F, String] =
-      part => Resource.eval { part.bodyText.compile.string }.map(Right(_))
+      part => Resource.eval(part.bodyText.compile.string).map(Right(_))
 
     def toTempFile(implicit F: Files[F], c: Compiler[F, F]): PartReceiver[F, Path] =
-      part => F.tempFile.evalTap { path => part.body.through(F.writeAll(path)).compile.drain }.map(Right(_))
+      part =>
+        F.tempFile
+          .evalTap(path => part.body.through(F.writeAll(path)).compile.drain)
+          .map(Right(_))
 
     def ignore: PartReceiver[F, Unit] =
-      part => Resource.pure(Right(()))
+      _ => Resource.pure(Right(()))
 
     def reject[A](err: DecodeFailure): PartReceiver[F, A] =
-      part => Resource.pure(Left(err))
+      _ => Resource.pure(Left(err))
 
     def decode[A](implicit decoder: EntityDecoder[F, A]): PartReceiver[F, A] =
       part => Resource.eval(decoder.decode(part, strict = false).value)
@@ -50,9 +57,13 @@ object PartReceiver {
     def decodeStrict[A](implicit decoder: EntityDecoder[F, A]): PartReceiver[F, A] =
       part => Resource.eval(decoder.decode(part, strict = true).value)
 
+    def toMixedBuffer(maxSizeBeforeFile: Int)(implicit files: Files[F], mt: MonadThrow[F], c: Compiler[F, F]): PartReceiver[F, Stream[F, Byte]] =
+      part => readToBuffer[F](part.body, maxSizeBeforeFile).map(Right(_))
   }
 
-  private def limitPartSize[F[_]](maxPartSizeBytes: Long)(implicit F: ApplicativeError[F, Throwable]): Pipe[F, Byte, Byte] = {
+  private def limitPartSize[F[_]](
+      maxPartSizeBytes: Long
+  )(implicit F: ApplicativeError[F, Throwable]): Pipe[F, Byte, Byte] = {
     def go(s: Stream[F, Byte], accumSize: Long): Pull[F, Byte, Unit] = s.pull.uncons.flatMap {
       case Some((chunk, tail)) =>
         val newSize = accumSize + chunk.size
@@ -63,5 +74,33 @@ object PartReceiver {
     }
 
     go(_, 0L).stream
+  }
+
+  private def readToBuffer[F[_]: Files : MonadThrow](input: Stream[F, Byte], maxSizeBeforeFile: Int)(implicit c: Compiler[F, F]): Resource[F, Stream[F, Byte]] = {
+    final case class Acc(bytes: Stream[Pure, Byte], bytesSize: Int)
+    def go(acc: Acc, s: Stream[F, Byte]): Pull[F, Resource[F, Stream[F, Byte]], Unit] = s.pull.uncons.flatMap {
+      case Some((headChunk, tail)) =>
+        val newSize = acc.bytesSize + headChunk.size
+        val newBytes = acc.bytes ++ Stream.chunk(headChunk)
+        if (newSize > maxSizeBeforeFile) {
+          // dump accumulated buffer to a temp file and continue
+          // the pull, writing chunks to the file instead of accumulating
+          val toDump = newBytes ++ tail
+          Pull.output1(Files[F].tempFile.evalTap { path =>
+            toDump.through(Files[F].writeAll(path)).compile.drain
+          }.map(Files[F].readAll))
+        } else {
+          // add the incoming chunk to the in-memory buffer and recurse
+          val newAcc = Acc(acc.bytes ++ Stream.chunk(headChunk), newSize)
+          go(newAcc, tail)
+        }
+
+      case None =>
+        println("buffer stayed in memory")
+        Pull.output1(Resource.pure(acc.bytes.covary[F]))
+    }
+    Resource.suspend {
+      go(Acc(Stream.empty, 0), input).stream.compile.lastOrError
+    }
   }
 }

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -1,11 +1,16 @@
 package org.http4s.multipart
 
 import cats.effect.kernel.Resource
-import cats.{ Applicative, ApplicativeError, MonadThrow }
-import fs2.io.file.{ Files, Path }
-import fs2.{ Compiler, Pipe, Pull, Pure, RaiseThrowable, Stream }
-import org.http4s.{ DecodeFailure, EntityDecoder, Headers, InvalidMessageBodyFailure }
+import cats.{Applicative, ApplicativeError, MonadThrow}
+import fs2.io.file.{Files, Flags, Path}
+import fs2.{Compiler, Pipe, Pull, Pure, RaiseThrowable, Stream}
+import org.http4s.{DecodeFailure, EntityDecoder, Headers, InvalidMessageBodyFailure}
 
+/** Represents the decoding process of a single "part" in a `multipart/form-data` message.
+  *
+  * Used in conjunction with [[MultipartReceiver]] and [[MultipartDecoder.fromReceiver]]
+  * to create robust [[EntityDecoder]]s with fail-fast behavior.
+  */
 trait PartReceiver[F[_], A] {
   def receive(part: Part[F]): Resource[F, Either[DecodeFailure, A]]
 
@@ -29,37 +34,78 @@ trait PartReceiver[F[_], A] {
 
   def withSizeLimit(limit: Long)(implicit F: ApplicativeError[F, Throwable]): PartReceiver[F, A] =
     preprocess(PartReceiver.limitPartSize[F](limit))
+
+
 }
 
 object PartReceiver {
 
-  def apply[F[_]] = new PartialApply[F]
+  /** Creates a PartReceiver which decodes the part body to a String.
+    *
+    * The decoding will use UTF-8 unless the part provides a `Content-Type` header indicating otherwise.
+    */
+  def bodyText[F[_]](implicit F: RaiseThrowable[F], cmp: Compiler[F, F]): PartReceiver[F, String] =
+    part => Resource.eval(part.bodyText.compile.string).map(Right(_))
 
-  class PartialApply[F[_]] {
-    def readString(implicit F: RaiseThrowable[F], cmp: Compiler[F, F]): PartReceiver[F, String] =
-      part => Resource.eval(part.bodyText.compile.string).map(Right(_))
+  /** Creates a PartReceiver which writes the part body to a temporary file, then returns that file's `Path`. */
+  def toTempFile[F[_]](implicit F: Files[F], c: Compiler[F, F]): PartReceiver[F, Path] =
+    part =>
+      F.tempFile
+        .evalTap(path => part.body.through(F.writeAll(path)).compile.drain)
+        .map(Right(_))
 
-    def toTempFile(implicit F: Files[F], c: Compiler[F, F]): PartReceiver[F, Path] =
-      part =>
-        F.tempFile
-          .evalTap(path => part.body.through(F.writeAll(path)).compile.drain)
-          .map(Right(_))
+  /** Creates a PartReceiver that ignores the part body. */
+  def ignore[F[_]]: PartReceiver[F, Unit] =
+    _ => Resource.pure(Right(()))
 
-    def ignore: PartReceiver[F, Unit] =
-      _ => Resource.pure(Right(()))
+  /** Creates a PartReceiver that immediately returns the given `DecodeFailure` instead of consuming the part body.
+    *
+    * @param err The error returned by the created PartReceiver
+    */
+  def reject[F[_], A](err: DecodeFailure): PartReceiver[F, A] =
+    _ => Resource.pure(Left(err))
 
-    def reject[A](err: DecodeFailure): PartReceiver[F, A] =
-      _ => Resource.pure(Left(err))
+  /** Creates a PartReceiver that delegates to an implicitly-resolved `EntityDecoder` to decode the part body,
+    * passing `strict = false` to the underlying `decode` method.
+    *
+    * This method passes `strict = false` to the `decoder.decode` method.
+    *
+    * @param decoder The delegate EntityDecoder
+    */
+  def decode[F[_], A](implicit decoder: EntityDecoder[F, A]): PartReceiver[F, A] =
+    part => Resource.eval(decoder.decode(part, strict = false).value)
 
-    def decode[A](implicit decoder: EntityDecoder[F, A]): PartReceiver[F, A] =
-      part => Resource.eval(decoder.decode(part, strict = false).value)
+  /** Creates a PartReceiver that delegates to an implicitly-resolved `EntityDecoder` to decode the part body,
+    * passing `strict = true` to the underlying `decode` method.
+    *
+    * @param decoder The delegate EntityDecoder
+    */
+  def decodeStrict[F[_], A](implicit decoder: EntityDecoder[F, A]): PartReceiver[F, A] =
+    part => Resource.eval(decoder.decode(part, strict = true).value)
 
-    def decodeStrict[A](implicit decoder: EntityDecoder[F, A]): PartReceiver[F, A] =
-      part => Resource.eval(decoder.decode(part, strict = true).value)
-
-    def toMixedBuffer(maxSizeBeforeFile: Int)(implicit files: Files[F], mt: MonadThrow[F], c: Compiler[F, F]): PartReceiver[F, Stream[F, Byte]] =
-      part => readToBuffer[F](part.body, maxSizeBeforeFile).map(Right(_))
-  }
+  /** Creates a PartReceiver that loads the part's body into an in-memory buffer, up until
+    * a specified maximum size, at which point it will instead write the body to a temp file.
+    *
+    * The temp file created by this decoder (if any) will be released with the Resource returned
+    * by this receiver's `receive` method.
+    *
+    * @param maxSizeBeforeFile Maximum number of bytes to be buffered in memory for each part
+    *                          received by the returned receiver. When the in-memory buffer
+    *                          would exceed this limit, the buffer is dumped to a temp file
+    *                          and all subsequent data pulled from the part body will be
+    *                          appended to that file instead of accumulating the memory buffer.
+    * @param chunkSize The chunk size used when reading data back from a temporary file created by this receiver
+    * @return A PartReceiver which dynamically decides whether to buffer the part's body in memory or in a file
+    */
+  def toMixedBuffer[F[_]](
+      maxSizeBeforeFile: Int,
+      chunkSize: Int = 8192,
+  )(implicit
+      files: Files[F],
+      mt: MonadThrow[F],
+      c: Compiler[F, F],
+  ): PartReceiver[F, Stream[F, Byte]] =
+    part => readToBuffer[F](part.body, maxSizeBeforeFile, chunkSize).map(Right(_))
 
   private def limitPartSize[F[_]](
       maxPartSizeBytes: Long
@@ -76,29 +122,37 @@ object PartReceiver {
     go(_, 0L).stream
   }
 
-  private def readToBuffer[F[_]: Files : MonadThrow](input: Stream[F, Byte], maxSizeBeforeFile: Int)(implicit c: Compiler[F, F]): Resource[F, Stream[F, Byte]] = {
+  private def readToBuffer[F[_]: Files: MonadThrow](
+      input: Stream[F, Byte],
+      maxSizeBeforeFile: Int,
+      chunkSize: Int,
+  )(implicit c: Compiler[F, F]): Resource[F, Stream[F, Byte]] = {
     final case class Acc(bytes: Stream[Pure, Byte], bytesSize: Int)
-    def go(acc: Acc, s: Stream[F, Byte]): Pull[F, Resource[F, Stream[F, Byte]], Unit] = s.pull.uncons.flatMap {
-      case Some((headChunk, tail)) =>
-        val newSize = acc.bytesSize + headChunk.size
-        val newBytes = acc.bytes ++ Stream.chunk(headChunk)
-        if (newSize > maxSizeBeforeFile) {
-          // dump accumulated buffer to a temp file and continue
-          // the pull, writing chunks to the file instead of accumulating
-          val toDump = newBytes ++ tail
-          Pull.output1(Files[F].tempFile.evalTap { path =>
-            toDump.through(Files[F].writeAll(path)).compile.drain
-          }.map(Files[F].readAll))
-        } else {
-          // add the incoming chunk to the in-memory buffer and recurse
-          val newAcc = Acc(acc.bytes ++ Stream.chunk(headChunk), newSize)
-          go(newAcc, tail)
-        }
+    def go(acc: Acc, s: Stream[F, Byte]): Pull[F, Resource[F, Stream[F, Byte]], Unit] =
+      s.pull.uncons.flatMap {
+        case Some((headChunk, tail)) =>
+          val newSize = acc.bytesSize + headChunk.size
+          val newBytes = acc.bytes ++ Stream.chunk(headChunk)
+          if (newSize > maxSizeBeforeFile) {
+            // dump accumulated buffer to a temp file and continue
+            // the pull, writing chunks to the file instead of accumulating
+            val toDump = newBytes ++ tail
+            Pull.output1(
+              Files[F].tempFile
+                .evalTap { path =>
+                  toDump.through(Files[F].writeAll(path)).compile.drain
+                }
+                .map(Files[F].readAll(_, chunkSize, Flags.Read))
+            )
+          } else {
+            // add the incoming chunk to the in-memory buffer and recurse
+            val newAcc = Acc(acc.bytes ++ Stream.chunk(headChunk), newSize)
+            go(newAcc, tail)
+          }
 
-      case None =>
-        println("buffer stayed in memory")
-        Pull.output1(Resource.pure(acc.bytes.covary[F]))
-    }
+        case None =>
+          Pull.output1(Resource.pure(acc.bytes.covary[F]))
+      }
     Resource.suspend {
       go(Acc(Stream.empty, 0), input).stream.compile.lastOrError
     }

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -1,10 +1,39 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.multipart
 
+import cats.Applicative
+import cats.ApplicativeError
+import cats.MonadThrow
 import cats.effect.kernel.Resource
-import cats.{Applicative, ApplicativeError, MonadThrow}
-import fs2.io.file.{Files, Flags, Path}
-import fs2.{Compiler, Pipe, Pull, Pure, RaiseThrowable, Stream}
-import org.http4s.{DecodeFailure, EntityDecoder, Headers, InvalidMessageBodyFailure}
+import fs2.Pipe
+import fs2.Pull
+import fs2.Pure
+import fs2.RaiseThrowable
+import fs2.Stream
+import fs2.io.file.Files
+import fs2.io.file.Flags
+import fs2.io.file.Path
+import org.http4s.DecodeFailure
+import org.http4s.EntityDecoder
+import org.http4s.Headers
+import org.http4s.InvalidMessageBodyFailure
+
+import fs2.Compiler
 
 /** Represents the decoding process of a single "part" in a `multipart/form-data` message.
   *

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -20,6 +20,7 @@ import cats.Applicative
 import cats.ApplicativeError
 import cats.MonadThrow
 import cats.effect.kernel.Resource
+import fs2.Compiler
 import fs2.Pipe
 import fs2.Pull
 import fs2.Pure
@@ -32,8 +33,6 @@ import org.http4s.DecodeFailure
 import org.http4s.EntityDecoder
 import org.http4s.Headers
 import org.http4s.InvalidMessageBodyFailure
-
-import fs2.Compiler
 
 /** Represents the decoding process of a single "part" in a `multipart/form-data` message.
   *

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -47,10 +47,11 @@ trait PartReceiver[F[_], A] {
     part => this.receive(part).map(_.map(f(part.headers, _)))
 
   def withPartName: PartReceiver[F, (String, A)] =
-    part => part.name match {
-      case None => Resource.pure(Left(InvalidMessageBodyFailure(s"Part is missing a name")))
-      case Some(name) => this.receive(part).map(_.map(name -> _))
-    }
+    part =>
+      part.name match {
+        case None => Resource.pure(Left(InvalidMessageBodyFailure(s"Part is missing a name")))
+        case Some(name) => this.receive(part).map(_.map(name -> _))
+      }
 
   def tapStart(onStart: F[Unit]): PartReceiver[F, A] =
     part => Resource.eval(onStart).flatMap(_ => this.receive(part))
@@ -147,7 +148,7 @@ object PartReceiver {
     * @param chunkSize The chunk size used when reading data back from a temporary file created by this receiver
     * @return A PartReceiver which dynamically decides whether to buffer the part's body in memory or in a file
     */
-  def toMixedBuffer[F[_]: Files : Concurrent](
+  def toMixedBuffer[F[_]: Files: Concurrent](
       maxSizeBeforeFile: Int,
       chunkSize: Int = 8192,
   ): PartReceiver[F, Stream[F, Byte]] =

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -19,12 +19,12 @@ package org.http4s.multipart
 import cats.Applicative
 import cats.ApplicativeError
 import cats.MonadThrow
+import cats.effect.Concurrent
 import cats.effect.kernel.Resource
 import fs2.Compiler
 import fs2.Pipe
 import fs2.Pull
 import fs2.Pure
-import fs2.RaiseThrowable
 import fs2.Stream
 import fs2.io.file.Files
 import fs2.io.file.Flags
@@ -90,7 +90,7 @@ object PartReceiver {
     *
     * The decoding will use UTF-8 unless the part provides a `Content-Type` header indicating otherwise.
     */
-  def bodyText[F[_]](implicit F: RaiseThrowable[F], cmp: Compiler[F, F]): PartReceiver[F, String] =
+  def bodyText[F[_]](implicit F: Concurrent[F]): PartReceiver[F, String] =
     part => Resource.eval(part.bodyText.compile.string).map(Right(_))
 
   /** Creates a PartReceiver which writes the part body to a temporary file, then returns that file's `Path`. */

--- a/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
@@ -1,0 +1,58 @@
+package org.http4s.multipart
+
+import fs2.Stream
+import fs2.io.file.{Files, Flags, Path}
+import org.http4s.{EntityBody, Header, Headers}
+
+/** Generic representation of typical Multipart Part bodies, as either a string or a file path.
+  * Produced by [[PartReceiver.toMixedBuffer]].
+  *
+  * Similar to [[Part]], but with less Header-oriented detail, and a clearer distinction
+  * between in-memory data vs on-disk data.
+  */
+sealed trait PartValue {
+
+  /** Returns a byte-stream representation of the part's body.
+    *
+    * For `OfString` parts, the underlying string is piped through a UTF-8 encoder.
+    * For `OfFile` parts, the underlying file's content will be read from disk.
+    *
+    * @return The part's body as a stream of bytes
+    */
+  def bytes[F[_]: Files]: EntityBody[F]
+
+  /** Fold over the different PartValue subtypes to compute a value
+    *
+    * @param onString Called with the underlying String if this part is an `OfString`
+    * @param onFile Called with the underlying filename and file path if this part is an `OfFile`
+    * @return The value returned by either `onString` or `onFile`
+    */
+  def fold[A](onString: String => A, onFile: (String, Path) => A): A
+
+  /** Builds a new [[Part]] from this `PartValue`.
+    *
+    * @param name The name of the part
+    * @param headers Any extra headers to add to the part. `Content-Disposition` is added
+    *                automatically based on the `name`, and in the case of `OfFile` parts,
+    *                the filename
+    * @return a new [[Part]] based on the given name, applicable filename, and body of this `PartValue`.
+    */
+  def toPart[F[_]: Files](name: String, headers: Header.ToRaw*): Part[F] = fold(
+    s => Part.formData(name, s, headers: _*),
+    (filename, path) => Part.fileData(name, filename, bytes[F], headers: _*),
+  )
+}
+object PartValue {
+
+  case class OfString(value: String) extends PartValue {
+    def bytes[F[_]: Files]: EntityBody[F] = fs2.text.utf8.encode[F](Stream.emit(value))
+    def fold[A](onString: String => A, onFile: (String, Path) => A): A = onString(value)
+  }
+
+  case class OfFile(filename: String, path: Path) extends PartValue {
+    def bytes[F[_]: Files]: EntityBody[F] = Files[F].readAll(path, 8192, Flags.Read)
+    def fold[A](onString: String => A, onFile: (String, Path) => A): A =
+      onFile(filename, path)
+  }
+
+}

--- a/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
@@ -44,12 +44,12 @@ sealed trait PartValue {
 }
 object PartValue {
 
-  case class OfString(value: String) extends PartValue {
+  final case class OfString(value: String) extends PartValue {
     def bytes[F[_]: Files]: EntityBody[F] = fs2.text.utf8.encode[F](Stream.emit(value))
     def fold[A](onString: String => A, onFile: (String, Path) => A): A = onString(value)
   }
 
-  case class OfFile(filename: String, path: Path) extends PartValue {
+  final case class OfFile(filename: String, path: Path) extends PartValue {
     def bytes[F[_]: Files]: EntityBody[F] = Files[F].readAll(path, 8192, Flags.Read)
     def fold[A](onString: String => A, onFile: (String, Path) => A): A =
       onFile(filename, path)

--- a/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
@@ -1,8 +1,27 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.multipart
 
 import fs2.Stream
-import fs2.io.file.{Files, Flags, Path}
-import org.http4s.{EntityBody, Header}
+import fs2.io.file.Files
+import fs2.io.file.Flags
+import fs2.io.file.Path
+import org.http4s.EntityBody
+import org.http4s.Header
 
 /** Generic representation of typical Multipart Part bodies, as either a string or a file path.
   * Produced by [[PartReceiver.toMixedBuffer]].

--- a/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
@@ -39,7 +39,7 @@ sealed trait PartValue {
     */
   def toPart[F[_]: Files](name: String, headers: Header.ToRaw*): Part[F] = fold(
     s => Part.formData(name, s, headers: _*),
-    (filename, path) => Part.fileData(name, filename, bytes[F], headers: _*),
+    (filename, _) => Part.fileData(name, filename, bytes[F], headers: _*),
   )
 }
 object PartValue {

--- a/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
@@ -24,7 +24,7 @@ import org.http4s.EntityBody
 import org.http4s.Header
 
 /** Generic representation of typical Multipart Part bodies, as either a string or a file path.
-  * Produced by [[PartReceiver.toMixedBuffer]].
+  * Produced by [[MultipartReceiver.auto]].
   *
   * Similar to [[Part]], but with less Header-oriented detail, and a clearer distinction
   * between in-memory data vs on-disk data.

--- a/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
@@ -2,7 +2,7 @@ package org.http4s.multipart
 
 import fs2.Stream
 import fs2.io.file.{Files, Flags, Path}
-import org.http4s.{EntityBody, Header, Headers}
+import org.http4s.{EntityBody, Header}
 
 /** Generic representation of typical Multipart Part bodies, as either a string or a file path.
   * Produced by [[PartReceiver.toMixedBuffer]].

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartReceiverSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartReceiverSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s
 package multipart
 

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartReceiverSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartReceiverSuite.scala
@@ -4,9 +4,12 @@ package multipart
 import cats.effect.IO
 import cats.effect.std.Random
 import cats.syntax.apply.*
-import fs2.io.file.{Files, Path}
-import fs2.{Chunk, Stream}
+import fs2.Chunk
+import fs2.Stream
+import fs2.io.file.Files
+import fs2.io.file.Path
 import org.http4s.syntax.literals.*
+
 import scala.concurrent.duration.DurationInt
 
 class MultipartReceiverSuite extends Http4sSuite {

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartReceiverSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartReceiverSuite.scala
@@ -19,12 +19,12 @@ package multipart
 
 import cats.effect.IO
 import cats.effect.std.Random
-import cats.syntax.apply.*
+import cats.syntax.apply._
 import fs2.Chunk
 import fs2.Stream
 import fs2.io.file.Files
 import fs2.io.file.Path
-import org.http4s.syntax.literals.*
+import org.http4s.syntax.literals._
 
 import scala.concurrent.duration.DurationInt
 

--- a/tests/shared/src/test/scala/org/http4s/multipart/MultipartReceiverSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/multipart/MultipartReceiverSuite.scala
@@ -1,0 +1,636 @@
+package org.http4s
+package multipart
+
+import cats.effect.IO
+import cats.effect.std.Random
+import cats.syntax.apply.*
+import fs2.io.file.{Files, Path}
+import fs2.{Chunk, Stream}
+import org.http4s.syntax.literals.*
+import scala.concurrent.duration.DurationInt
+
+class MultipartReceiverSuite extends Http4sSuite {
+
+  private val url = uri"https://example.com/path/to/some/where"
+
+  private val rand =
+    Random
+      .scalaUtilRandom[IO]
+      .syncStep(Int.MaxValue)
+      .unsafeRunSync()
+      .toOption
+      .get
+
+  private val multiparts = Multiparts.fromRandom(rand)
+
+  private def multipartRequest(parts: Part[IO]*): IO[Request[IO]] = multiparts
+    .multipart(Vector(parts: _*))
+    .map { multipart =>
+      val entity = EntityEncoder[IO, Multipart[IO]].toEntity(multipart)
+      Request(method = Method.POST, uri = url, body = entity.body, headers = multipart.headers)
+    }
+
+  private val infiniteBytes = Stream.repeatEval(rand.nextBytes(512).map(Chunk.array(_))).unchunks
+  private val infiniteText = Stream.repeatEval(rand.nextString(32))
+
+  test("`MultipartReceiver.at(...).once` should extract the value of that field") {
+    val onlyAllowFoo = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO]).once
+    )
+
+    val requestWithOnlyFoo = multipartRequest(
+      Part.formData[IO]("foo", "bar")
+    )
+    onlyAllowFoo.use { decoder =>
+      requestWithOnlyFoo.flatMap { req =>
+        assertIO(
+          decoder.decode(req, strict = true).value,
+          Right("bar"),
+        )
+      }
+    }.assert
+  }
+
+  test("`MultipartReceiver.at(...).once` should fail if the given field is missing") {
+    val onlyAllowFoo = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO]).once
+    )
+    val requestWithoutFoo = multipartRequest(Part.formData[IO]("not-foo", "bar"))
+
+    onlyAllowFoo.use { decoder =>
+      requestWithoutFoo.flatMap { req =>
+        assertIOBoolean(
+          decoder.decode(req, strict = true).isLeft
+        )
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartReceiver.at(...).once` should raise an error if an unexpected field is encountered"
+  ) {
+    val onlyAllowFoo = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO]).once
+    )
+    // `EntityDecoder.mixedMultipartResource[IO]` would never terminate if decoding this request,
+    // and would fill up the host's hard drive eventually if not cancelled
+    val maliciousRequest = multipartRequest(Part.fileData("not-foo", "infinite.bin", infiniteBytes))
+
+    onlyAllowFoo.use { decoder =>
+      maliciousRequest.flatMap { req =>
+        assertIOBoolean(
+          decoder.decode(req, strict = true).isLeft
+        )
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartReceiver.at(..., receiver.withSizeLimit(n)).once` should raise an error when the request exceeds the limit"
+  ) {
+    val onlyAllowFooWithLimit = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO].withSizeLimit(8192)).once
+    )
+
+    val maliciousRequest = multipartRequest(
+      Part.fileData("foo", "infinite.txt", infiniteText.through(fs2.text.utf8.encode))
+    )
+
+    onlyAllowFooWithLimit.use { decoder =>
+      maliciousRequest.flatMap { req =>
+        assertIOBoolean(
+          decoder.decode(req, strict = true).isLeft
+        )
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartReceiver.at(...).once` should fail when its expected field appears multiple times"
+  ) {
+    val onlyAllowFoo = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO]).once
+    )
+    val requestWithMultipleFoos = multipartRequest(
+      Part.formData[IO]("foo", "bar1"),
+      Part.formData[IO]("foo", "bar2"),
+    )
+
+    onlyAllowFoo.use { decoder =>
+      requestWithMultipleFoos.flatMap { req =>
+        assertIOBoolean(
+          decoder.decode(req, strict = true).isLeft
+        )
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartReceiver.at(..., PartReceiver.reject(...)).once` should fail when its expected field appears"
+  ) {
+    val rejectFoo = MultipartDecoder.fromReceiver(
+      MultipartReceiver
+        .at("foo", PartReceiver.reject[IO, String](InvalidMessageBodyFailure("foo not allowed")))
+        .once
+    )
+    val requestWithFoo = multipartRequest(Part.formData[IO]("foo", "bar"))
+
+    rejectFoo.use { decoder =>
+      requestWithFoo.flatMap { req =>
+        assertIOBoolean(
+          decoder.decode(req, strict = true).isLeft
+        )
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartReceiver.at(...).once.ignoreUnexpectedParts` should extract the expected value and ignore other parts"
+  ) {
+    val extractFoo = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO]).once.ignoreUnexpectedParts
+    )
+    val requestWithFooAndOthers = multipartRequest(
+      Part.formData[IO]("bing", "bong"),
+      Part.formData[IO]("ding", "dong"),
+      Part.fileData("file", "file.txt", infiniteText.take(512).through(fs2.text.utf8.encode)),
+      Part.formData[IO]("foo", "bar"), // <- here it is!
+      Part.formData[IO]("baz", "biff"),
+    )
+    extractFoo.use { decoder =>
+      requestWithFooAndOthers.flatMap { req =>
+        assertIO(
+          decoder.decode(req, strict = true).value,
+          Right("bar"),
+        )
+      }
+    }.assert
+  }
+
+  test("`MultipartReceiver.at(...).asOption` should extract the expected value when present") {
+    val maybeExtractFoo = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO]).asOption
+    )
+    val requestWithFoo = multipartRequest(
+      Part.formData[IO]("foo", "bar")
+    )
+
+    maybeExtractFoo.use { decoder =>
+      requestWithFoo.flatMap { req =>
+        assertIO(
+          decoder.decode(req, strict = true).value,
+          Right(Some("bar")),
+        )
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartReceiver.at(...).asOption` should result in None when the expected field is missing"
+  ) {
+    val maybeExtractFoo = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO]).asOption.ignoreUnexpectedParts
+    )
+    val requestWithFoo = multipartRequest(
+      Part.formData[IO]("not-foo", "bar")
+    )
+
+    maybeExtractFoo.use { decoder =>
+      requestWithFoo.flatMap { req =>
+        assertIO(
+          decoder.decode(req, strict = true).value,
+          Right(None),
+        )
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartReceiver.at(...).asList` should extract a value for each part with the expected name"
+  ) {
+    val extractAllFoos = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO]).asList.ignoreUnexpectedParts
+    )
+    val requestWithManyFoos = multipartRequest(
+      Part.formData[IO]("foo", "bar1"),
+      Part.formData[IO]("foo", "bar2"),
+      Part.formData[IO]("not-foo", "bar3"),
+      Part.formData[IO]("foo", "bar4"),
+    )
+
+    extractAllFoos.use { decoder =>
+      requestWithManyFoos.flatMap { req =>
+        assertIO(
+          decoder.decode(req, strict = true).value,
+          Right(List("bar1", "bar2", "bar4")),
+        )
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartReceiver.at(..., PartReceiver.ignore)` will not terminate when the expected part contains infinite data"
+  ) {
+    val ignoreFoo = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.ignore[IO]).once
+    )
+    val requestWithInfiniteFoo = multipartRequest(
+      Part.fileData("foo", "foo.bin", infiniteBytes)
+    )
+
+    ignoreFoo.use { decoder =>
+      requestWithInfiniteFoo.flatMap { req =>
+        assertIOBoolean(
+          // Since the decoder won't terminate, we'll run it for 1 second before cancelling.
+          IO.race(
+            IO.sleep(1.second).as(true),
+            decoder.decode(req, strict = true).value.as(false),
+          ).map(_.merge)
+        )
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartReceiver.at(..., PartReceiver.toTempFile)` will write data to a temp file, which will be released automatically"
+  ) {
+    val decodeFooToFile = MultipartDecoder.fromReceiver(
+      MultipartReceiver.at("foo", PartReceiver.toTempFile[IO]).once
+    )
+    val requestWithFoo = multipartRequest(
+      Part.fileData("foo", "foo.bin", infiniteBytes.take(512))
+    )
+
+    decodeFooToFile
+      .use { decoder =>
+        requestWithFoo.flatMap { req =>
+          decoder
+            .decode(req, strict = true)
+            .value
+            .flatTap {
+              case Left(_) => IO.unit
+              case Right(tempFile) =>
+                assertIO(Files[IO].size(tempFile), 512L, "wrong size of temp file")
+            }
+            .rethrow // return the temp file from the `use` block, escaping its lifetime
+        }
+      }
+      .flatMap { tempFile =>
+        // since `decodeFooToFile` is a resource, any underlying resources allocated by the decoder
+        // will be released when it is released, i.e. deleting the temp file
+        assertIO(Files[IO].exists(tempFile), false, "temp file wasn't deleted")
+      }
+      .assert
+  }
+
+  test(
+    "`MultipartReceiver.auto` should decode all parts to a PartValue map, and the decoder should delete temp files after use"
+  ) {
+    val autoDecoder = MultipartDecoder.fromReceiver(MultipartReceiver.auto[IO])
+    val arbitraryRequest = multipartRequest(
+      Part.formData("a", "hello"),
+      Part.formData("b", "world"),
+      Part.fileData("c", "c.bin", infiniteBytes.take(512)),
+      Part.fileData("d", "d.bin", infiniteBytes.take(256)),
+    )
+
+    autoDecoder
+      .use { decoder =>
+        arbitraryRequest.flatMap { req =>
+          decoder
+            .decode(req, strict = true)
+            .semiflatMap { parts =>
+              for {
+                _ <- assertIO(IO(parts.get("a")), Some(PartValue.OfString("hello")))
+                _ <- assertIO(IO(parts.get("b")), Some(PartValue.OfString("world")))
+                cFileOpt <- parts.get("c") match {
+                  case Some(PartValue.OfFile("c.bin", f)) =>
+                    assertIO(Files[IO].size(f), 512L, "part 'c' not properly received").as(Some(f))
+                  case _ => assertIOBoolean(IO.pure(false), "part 'c' missing").as(None)
+                }
+                dFileOpt <- parts.get("d") match {
+                  case Some(PartValue.OfFile("d.bin", f)) =>
+                    assertIO(Files[IO].size(f), 256L, "part 'd' not properly received").as(Some(f))
+                  case _ => assertIOBoolean(IO.pure(false), "part 'c' missing").as(None)
+                }
+              } yield (cFileOpt, dFileOpt)
+            }
+            .getOrElse(None -> None)
+        }
+      }
+      .flatMap {
+        case (Some(fileC), Some(fileD)) =>
+          assertIO(
+            Files[IO].exists(fileC),
+            false,
+            "file 'c' must be deleted after decoder resource release",
+          ) *>
+            assertIO(
+              Files[IO].exists(fileD),
+              false,
+              "file 'd' must be deleted after decoder resource release",
+            )
+        case _ =>
+          assertIOBoolean(IO.pure(false), "file parts were not received")
+      }
+      .assert
+  }
+
+  test("`MultipartReceiver.uniform` receives all parts the same way") {
+    val uniformDecoder = MultipartDecoder.fromReceiver(
+      MultipartReceiver.uniform(PartReceiver.bodyText[IO])
+    )
+    val arbitraryRequest = multipartRequest(
+      Part.formData("a", "hello"),
+      Part.formData("b", "world"),
+      Part.formData("c", "how"),
+      Part.formData("d", "are"),
+      Part.formData("e", "you"),
+    )
+
+    uniformDecoder.use { decoder =>
+      arbitraryRequest.flatMap { req =>
+        assertIOBoolean(
+          decoder
+            .decode(req, strict = true)
+            .map(_ == List("hello", "world", "how", "are", "you"))
+            .getOrElse(false)
+        )
+      }
+    }.assert
+  }
+
+  locally {
+    // several tests will reuse this class and corresponding decoder; using `locally` to enclose them all
+    final case class FormBodyLoaded(foo: String, bar: String, fileContent: String)
+    final case class FormBody(foo: String, bar: String, file: Path) {
+      def load: IO[FormBodyLoaded] = (
+        IO.pure(foo),
+        IO.pure(bar),
+        Files[IO].readUtf8(file).compile.string,
+      ).mapN(FormBodyLoaded.apply)
+    }
+
+    val formBodyReceiver = (
+      MultipartReceiver.at("foo", PartReceiver.bodyText[IO].withSizeLimit(1024L)).once,
+      MultipartReceiver.at("bar", PartReceiver.bodyText[IO].withSizeLimit(1024L)).once,
+      MultipartReceiver.at("file", PartReceiver.toTempFile[IO].withSizeLimit(8192L)).once,
+    ).mapN(FormBody.apply)
+    val formBodyDecoder = MultipartDecoder.fromReceiver(formBodyReceiver)
+
+    test(
+      "Example `MultipartReceiver` constructed with Applicative will succeed under expected conditions"
+    ) {
+      val goodRequest = multipartRequest(
+        Part.formData("foo", "I AM A MOOSE"),
+        Part.formData("bar", "WE ARE MEESE"),
+        Part.fileData(
+          "file",
+          "filename.txt",
+          Stream.emit("there is some stuff in this file!").through(fs2.text.utf8.encode[IO]),
+        ),
+      )
+
+      formBodyDecoder.use { decoder =>
+        goodRequest.flatMap { request =>
+          assertIO(
+            decoder
+              .decode(request, strict = true)
+              .semiflatMap(_.load)
+              .value,
+            Right(
+              FormBodyLoaded(
+                "I AM A MOOSE",
+                "WE ARE MEESE",
+                "there is some stuff in this file!",
+              )
+            ),
+          )
+        }
+      }.assert
+    }
+
+    test(
+      "Example `MultipartReceiver` constructed with Applicative will fail upon encountering an unexpected part"
+    ) {
+      val badRequest = multipartRequest(
+        Part.formData("foo", "I AM A MOOSE"),
+        Part.formData("bar", "WE ARE MEESE"),
+        Part.formData("baz", "BOOM"), // <- unexpected!
+        Part.fileData(
+          "file",
+          "filename.txt",
+          Stream.emit("there is some stuff in this file!").through(fs2.text.utf8.encode[IO]),
+        ),
+      )
+      formBodyDecoder.use { decoder =>
+        badRequest.flatMap { request =>
+          assertIOBoolean(
+            decoder.decode(request, strict = true).isLeft
+          )
+        }
+      }.assert
+    }
+
+    test(
+      "Example `MultipartReceiver` constructed with Applicative will fail if not all required parts are received"
+    ) {
+      val badRequest = multipartRequest(
+        Part.formData("foo", "I AM A MOOSE"),
+        Part.formData("bar", "WE ARE MEESE"),
+      )
+
+      formBodyDecoder.use { decoder =>
+        badRequest.flatMap { request =>
+          assertIOBoolean(
+            decoder.decode(request, strict = true).isLeft
+          )
+        }
+      }.assert
+    }
+
+    test(
+      "Example `MultipartReceiver` constructed with Applicative will fail if any of its part receivers fail"
+    ) {
+      val badFoo = Part
+        .formData[IO]("foo", "")
+        .copy(body = infiniteText.take(8192).through(fs2.text.utf8.encode))
+      val badBar =
+        Part.formData[IO]("bar", "").copy(body = infiniteText.through(fs2.text.utf8.encode))
+      val badFile = Part.fileData[IO]("file", "upload.bin", infiniteBytes.take(65535))
+
+      val goodFoo = Part.formData[IO]("foo", "hello")
+      val goodBar = Part.formData[IO]("bar", "world")
+      val goodFile = Part.fileData[IO]("file", "upload.bin", infiniteBytes.take(1024))
+
+      // Get permutations of a `multipartRequest` with a bad part for at least one of each expected part.
+      // If "good" is a 0 and "bad" is a 1, we can get these permutations by iterating numbers 1 through 7
+      // and treating each bit in the number as a good/bad choice for that part
+      val badRequestPermutations = Stream.emits(1 to 7).evalMap { i =>
+        val fooPart = if ((i & 1) == 0) goodFoo else badFoo
+        val barPart = if ((i & 2) == 0) goodBar else badBar
+        val filePart = if ((i & 4) == 0) goodFile else badFile
+        multipartRequest(fooPart, barPart, filePart)
+      }
+
+      badRequestPermutations
+        .foreach { req =>
+          formBodyDecoder.use { decoder =>
+            assertIOBoolean(decoder.decode(req, strict = true).isLeft)
+          }
+        }
+        .compile
+        .drain
+        .assert
+    }
+
+    test(
+      "Example `MultipartReceiver` constructed with Applicative can be made resilient to unexpected parts via `ignoreUnexpectedParts`"
+    ) {
+      val lenientDecoder = MultipartDecoder.fromReceiver(formBodyReceiver.ignoreUnexpectedParts)
+      val requestIO = multipartRequest(
+        Part.formData[IO]("foo", "hello"),
+        Part.formData[IO]("bar", "world"),
+        Part.fileData[IO](
+          "file",
+          "upload.bin",
+          Stream.emit("file content here").through(fs2.text.utf8.encode[IO]),
+        ),
+        Part.formData[IO]("a", "Hey!"),
+        Part.formData[IO]("b", "I'm here"),
+        Part.formData[IO]("c", "to distract"),
+        Part.formData[IO]("d", "you!"),
+      )
+
+      lenientDecoder.use { decoder =>
+        requestIO.flatMap { req =>
+          decoder
+            .decode(req, strict = true)
+            .foldF(
+              _ => assertIOBoolean(IO.pure(false), "decoding failed"),
+              result => assertIO(result.load, FormBodyLoaded("hello", "world", "file content here")),
+            )
+        }
+      }.assert
+    }
+
+    test(
+      "Example `MultipartReceiver` constructed with Applicative will still succeed if expected parts are out of order"
+    ) {
+      val lenientDecoder = MultipartDecoder.fromReceiver(formBodyReceiver.ignoreUnexpectedParts)
+
+      val parts = List(
+        Part.formData[IO]("foo", "hello"),
+        Part.formData[IO]("bar", "world"),
+        Part.fileData[IO](
+          "file",
+          "upload.bin",
+          Stream.emit("file content here").through(fs2.text.utf8.encode[IO]),
+        ),
+        Part.formData[IO]("a", "Hey!"),
+        Part.formData[IO]("b", "I'm here"),
+        Part.formData[IO]("c", "to distract"),
+        Part.formData[IO]("d", "you!"),
+      )
+      val expected = FormBodyLoaded("hello", "world", "file content here")
+
+      Stream
+        .eval(rand.shuffleList(parts))
+        .repeatN(50)
+        .evalMap(multipartRequest(_: _*))
+        .foreach { req =>
+          lenientDecoder.use { decoder =>
+            assertIO(
+              decoder.decode(req, strict = true).semiflatMap(_.load).value,
+              Right(expected),
+            )
+          }
+        }
+        .compile
+        .drain
+        .assert
+    }
+  }
+
+  test(
+    "`MultipartDecoder.fromReceiver(..., headerLimit)` will fail when receiving a part with headers exceeding the size limit"
+  ) {
+    val badRequest = multipartRequest(
+      Part.formData("foo", "bar"),
+      Part.formData("baz", "bang"),
+      Part.formData(
+        "bing",
+        "bong",
+        "X-My-Long-Header" -> ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_" * 64),
+      ),
+    )
+    val decoderRes = MultipartDecoder.fromReceiver(
+      MultipartReceiver.auto[IO],
+      headerLimit = 512,
+    )
+    decoderRes.use { decoder =>
+      badRequest.flatMap { req =>
+        assertIOBoolean(decoder.decode(req, strict = true).isLeft)
+      }
+    }.assert
+  }
+
+  test(
+    "`MultipartDecoder.fromReceiver(..., maxParts, failOnLimit = true)` will fail if it receives too many parts"
+  ) {
+    val decoderRes = MultipartDecoder.fromReceiver(
+      MultipartReceiver.auto[IO],
+      maxParts = Some(5),
+      failOnLimit = true,
+    )
+
+    val parts =
+      Iterator.from(0).take(10).map(i => Part.formData[IO](i.toString, "whatever")).toVector
+
+    Stream
+      .emits(1 to 10)
+      .foreach { n =>
+        decoderRes.use { decoder =>
+          multipartRequest(parts.take(n): _*).flatMap { req =>
+            val decodeResult = decoder.decode(req, strict = true)
+            assertIOBoolean(
+              if (n > 5) decodeResult.isLeft // decode failure due to exceeded limit
+              else decodeResult.isRight, // decode success due to part count being within limit
+              s"$n parts should ${if (n > 5) "fail" else "pass"}",
+            )
+          }
+        }
+      }
+      .compile
+      .drain
+      .assert
+  }
+
+  test(
+    "MultipartDecoder.fromReceiver(..., maxParts, failOnLimit = false)` will ignore parts after the limit"
+  ) {
+    val decoderRes = MultipartDecoder.fromReceiver(
+      MultipartReceiver.auto[IO],
+      maxParts = Some(5),
+      failOnLimit = false,
+    )
+
+    val parts =
+      Iterator.from(0).take(10).map(i => Part.formData[IO](i.toString, "whatever")).toVector
+
+    Stream
+      .emits(1 to 10)
+      .foreach { n =>
+        decoderRes.use { decoder =>
+          multipartRequest(parts.take(n): _*).flatMap { req =>
+            val decodeResult = decoder.decode(req, strict = true).map(_.size).getOrElse(-1)
+            assertIO(decodeResult, n.min(5), "part count should be limited")
+          }
+        }
+      }
+      .compile
+      .drain
+      .assert
+  }
+
+}


### PR DESCRIPTION
Fixes #7408

Introduces two new types; `PartReceiver` and `MultipartReceiver`. A PartReceiver is like an `EntityDecoder` but with its result represented as a `Resource`. A MultipartReceiver decides what PartReceiver to use for a part based on the part's headers. A MultipartReceiver doesn't do any explicit buffering; the part bodies are decoded as they are received. A MultipartReceiver can get wrapped up as an `EntityDecoder`, using the same supervisor-based semantics as `mixedMultipartResource`.

To solve the issues I brought up in #7408:

- A MultipartReceiver is typically defined such that any unexpected parts will cause an immediate decoding failure, and will stop the pull. (You can call its `.ignoreUnexpectedParts` method to just skip past unexpected parts without consuming them or raising an error)
- For cases where your application logic is explicitly looking for a file upload, you can use `PartReceiver.toTempFile`, which gets you a `Path` to the temp file (the underlying supervisor resource will delete the temp file when released)
- PartReceiver has a `.withSizeLimit(n)` method which will cause it to raise a DecodeFailure and stop pulling after the limit is hit. This allows business logic to protect against arbitrarily-large (even infinite-sized) individual parts.
- MultipartReceiver is applicative, so you can combine one that pulls a file `Path` from one part, and a `String` from another part.