### PR TITLE
feat: suppress stack trace on protocol exceptions

### DIFF
--- a/core/shared/src/main/scala/org/http4s/websocket/protocolexceptions.scala
+++ b/core/shared/src/main/scala/org/http4s/websocket/protocolexceptions.scala
@@ -21,8 +21,10 @@ import fs2.io.net.ProtocolException
 
 final class ReservedOpcodeException(opcode: Int)
     extends ProtocolException(s"Opcode $opcode is reserved for future use as per RFC 6455")
+    with scala.util.control.NoStackTrace
 
 final class UnknownOpcodeException(opcode: Int)
     extends ProtocolException(
       s"RFC 6455 protocol violation, unknown websocket frame opcode: $opcode"
     )
+    with scala.util.control.NoStackTrace


### PR DESCRIPTION
When an user sends `0x4` opcode to [websocket](https://github.com/http4s/http4s/blob/v0.23.26/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerSimpleExample.scala#L74-L81) following exception is printed:

```
[io-compute-8] ERROR o.h.e.s.EmberServerBuilderCompanionPlatform - WebSocket connection terminated with exception
org.http4s.websocket.ReservedOpcodeException: Opcode 4 is reserved for future use as per RFC 6455
	at org.http4s.websocket.package$.makeFrame(package.scala:49)
	at org.http4s.websocket.FrameTranscoder.bufferToFrame(FrameTranscoder.scala:187)
	at org.http4s.ember.server.internal.WebSocketHelpers$.$anonfun$decodeFrames$3(WebSocketHelpers.scala:208)
	at cats.ApplicativeError.catchNonFatal(ApplicativeError.scala:269)
	at cats.ApplicativeError.catchNonFatal$(ApplicativeError.scala:268)
	at fs2.PullMonadErrorInstance.catchNonFatal(Pull.scala:1365)
	at org.http4s.ember.server.internal.WebSocketHelpers$.$anonfun$decodeFrames$2(WebSocketHelpers.scala:201)
	at fs2.Pull$$anon$1.cont(Pull.scala:149)
	at fs2.Pull$.fs2$Pull$$bindBindAux(Pull.scala:748)
	at fs2.Pull$BindBind.cont(Pull.scala:735)
	at fs2.Pull$ContP.apply(Pull.scala:683)
	at fs2.Pull$ContP.apply$(Pull.scala:683)
	at fs2.Pull$Bind.apply(Pull.scala:691)
	at fs2.Pull$Bind.apply(Pull.scala:691)
	at fs2.Pull$UnconsRunR$1.$anonfun$out$2(Pull.scala:1020)
	at fs2.Pull$.$anonfun$compile$2(Pull.scala:953)
	at get @ fs2.internal.Scope.openScope(Scope.scala:275)
	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
	at flatMap @ fs2.Pull$.$anonfun$compile$21(Pull.scala:1215)
	at update @ org.http4s.ember.server.internal.Shutdown$$anon$1.<init>(Shutdown.scala:77)
	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
	at modify @ org.http4s.ember.server.internal.Shutdown$$anon$1.<init>(Shutdown.scala:83)
	at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
	at flatMap @ fs2.Pull$.$anonfun$compile$18(Pull.scala:1214)
	at handleErrorWith @ fs2.Compiler$Target.handleErrorWith(Compiler.scala:161)
	at flatMap @ fs2.Pull$.goCloseScope$1(Pull.scala:1200)
	at get @ fs2.internal.Scope.openScope(Scope.scala:275)
```

This exception is pretty easy to track when and where it's thrown so stack trace doesn't add much here IMHO.

Added [scala.util.control.NoStackTrace](https://www.scala-lang.org/api/2.12.0/scala/util/control/NoStackTrace.html) to exception, result is now it logs only two lines

```
[io-compute-0] ERROR o.h.e.s.EmberServerBuilderCompanionPlatform - WebSocket connection terminated with exception
org.http4s.websocket.ReservedOpcodeException: Opcode 4 is reserved for future use as per RFC 6455
```