### PR TITLE
RFC: Cookies with `Max-Age=0` should be permitted

### DIFF
--- a/core/shared/src/main/scala/org/http4s/ResponseCookie.scala
+++ b/core/shared/src/main/scala/org/http4s/ResponseCookie.scala
@@ -126,17 +126,21 @@ object ResponseCookie {
       (expires: HttpDate) => (cookie: ResponseCookie) => cookie.withExpires(expires)
     }
 
-    /* non-zero-digit    = %x31-39
-     *                   ; digits 1 through 9
+    /* digit    = %x30-39
+     *                   ; digits 0 through 9
      */
-    val nonZeroDigit = charIn(0x31.toChar to 0x39.toChar)
+    val zeroToNineDigit = charIn(0x30.toChar to 0x39.toChar)
 
     /* max-age-av        = "Max-Age=" non-zero-digit *DIGIT
      *                   ; In practice, both expires-av and max-age-av
      *                   ; are limited to dates representable by the
      *                   ; user agent.
+     *
+     * While RFC 6265 specifies non-zero digit in syntax it also mentions that
+     * Max-Age values of 0 or lower should immediately expire a cookie. For that reason, include
+     * zero in parsing so that they can be viewed and dealt with.
      */
-    val maxAgeAv = ignoreCase("Max-Age=") *> (nonZeroDigit ~ digit.rep0).string.map {
+    val maxAgeAv = ignoreCase("Max-Age=") *> (zeroToNineDigit ~ digit.rep0).string.map {
       (maxAge: String) => (cookie: ResponseCookie) => cookie.withMaxAge(maxAge.toLong)
     }
 

--- a/tests/shared/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/HeadersSpec.scala
@@ -74,6 +74,26 @@ class HeadersSpec extends Http4sSuite {
     assertEquals(hs.headers.contains(clength.toRaw1), true)
   }
 
+  test("Cookies with a Max-Age of 0 should be permitted") {
+    val resp = Response().putHeaders(
+      "Set-Cookie" -> "test1=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=None; Path=/; Secure"
+    )
+    assertEquals(
+      resp.cookies,
+      List(
+        ResponseCookie(
+          name = "test1",
+          content = "",
+          expires = Some(HttpDate.Epoch),
+          maxAge = Some(0),
+          path = Some("/"),
+          sameSite = Some(SameSite.None),
+          secure = true,
+        )
+      ),
+    )
+  }
+
   // TODO this isn't really "raw headers" anymore
   test("Headers should Work with Raw headers (++)") {
     val foo = ContentCoding.unsafeFromString("foo")


### PR DESCRIPTION
I had trouble parsing a 'discard cookie' `Set-Cookie` header from Play Framework which specified a `Max-Age=0`.

Upon examination http4s ignores cookies with a Max-Age that doesn't contain the characters 1-9.  [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.2) is murky on this point, specifying both non-zero digits in the syntax but also saying that zero or lower numbers should be parsed in the prose of section 5.2.2. I think it's safe to say that setting a `Max-Age=0` is common practice when invalidating a cookie.

The http4s client shouldn't then hide it from users in Responses by failing to parse, zero values should be permitted in the parser.