### PR TITLE
Server logging middleware: change logAction to `F[String => F[Unit]]`

### DIFF
--- a/docs/docs/server-middleware.md
+++ b/docs/docs/server-middleware.md
@@ -522,7 +522,7 @@ val loggerService = Logger.httpRoutes[IO](
   logHeaders = false,
   logBody = true,
   redactHeadersWhen = _ => false,
-  logAction = Some((msg: String) => Console[IO].println(msg))
+  logAction = Some(IO.pure((msg: String) => Console[IO].println(msg)))
 )(service).orNotFound
 
 val loggerClient = Client.fromHttpApp(loggerService)

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Logger.scala
@@ -39,11 +39,11 @@ object Logger {
       logBody: Boolean,
       fk: F ~> G,
       redactHeadersWhen: CIString => Boolean = defaultRedactHeadersWhen,
-      logAction: Option[String => F[Unit]] = None,
+      logAction: Option[F[String => F[Unit]]] = None,
   )(http: Http[G, F])(implicit G: MonadCancelThrow[G], F: Concurrent[F]): Http[G, F] = {
     val logger = LoggerFactory[F].getLogger
-    val log: String => F[Unit] = logAction.getOrElse { s =>
-      logger.info(s)
+    val log: F[String => F[Unit]] = logAction.getOrElse {
+      F.pure(s => logger.info(s))
     }
     ResponseLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(
       RequestLogger(logHeaders, logBody, fk, redactHeadersWhen, log.pure[Option])(http)
@@ -55,11 +55,11 @@ object Logger {
       logBody: Stream[F, Byte] => Option[F[String]],
       fk: F ~> G,
       redactHeadersWhen: CIString => Boolean = defaultRedactHeadersWhen,
-      logAction: Option[String => F[Unit]] = None,
+      logAction: Option[F[String => F[Unit]]] = None,
   )(http: Http[G, F])(implicit G: MonadCancelThrow[G], F: Concurrent[F]): Http[G, F] = {
     val logger = LoggerFactory[F].getLogger
-    val log: String => F[Unit] = logAction.getOrElse { s =>
-      logger.info(s)
+    val log: F[String => F[Unit]] = logAction.getOrElse {
+      F.pure(s => logger.info(s))
     }
     ResponseLogger.impl(logHeaders, Right(logBody), fk, redactHeadersWhen, log.pure[Option])(
       RequestLogger.impl(logHeaders, Right(logBody), fk, redactHeadersWhen, log.pure[Option])(http)
@@ -70,7 +70,7 @@ object Logger {
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = defaultRedactHeadersWhen,
-      logAction: Option[String => F[Unit]] = None,
+      logAction: Option[F[String => F[Unit]]] = None,
   )(httpApp: HttpApp[F]): HttpApp[F] =
     apply(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
@@ -78,7 +78,7 @@ object Logger {
       logHeaders: Boolean,
       logBody: Stream[F, Byte] => Option[F[String]],
       redactHeadersWhen: CIString => Boolean = defaultRedactHeadersWhen,
-      logAction: Option[String => F[Unit]] = None,
+      logAction: Option[F[String => F[Unit]]] = None,
   )(httpApp: HttpApp[F]): HttpApp[F] =
     logBodyText(logHeaders, logBody, FunctionK.id[F], redactHeadersWhen, logAction)(httpApp)
 
@@ -86,7 +86,7 @@ object Logger {
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = defaultRedactHeadersWhen,
-      logAction: Option[String => F[Unit]] = None,
+      logAction: Option[F[String => F[Unit]]] = None,
   )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
     apply(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 
@@ -94,7 +94,7 @@ object Logger {
       logHeaders: Boolean,
       logBody: Stream[F, Byte] => Option[F[String]],
       redactHeadersWhen: CIString => Boolean = defaultRedactHeadersWhen,
-      logAction: Option[String => F[Unit]] = None,
+      logAction: Option[F[String => F[Unit]]] = None,
   )(httpRoutes: HttpRoutes[F]): HttpRoutes[F] =
     logBodyText(logHeaders, logBody, OptionT.liftK[F], redactHeadersWhen, logAction)(httpRoutes)
 


### PR DESCRIPTION
The follow-up to https://discord.com/channels/632277896739946517/632286375311573032/1239565715036442686.
Repo example: https://github.com/alexcardell/otel4s-server-logger-repro-example/tree/master

### Motivation

We want to allow capturing the 'state' while we are still within Kleisli closure. This is needed to make the MDC logging work.

### Context

When `logBody = false`, the logging is 'streamlined' - the message will be logged within the Kleisli closure.

https://github.com/http4s/http4s/blob/b5cd7d7a5cec65375f898c83534c72a1f1433145/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala#L79-L80

However, when `logBody = true`, the logic changes drastically. The middleware binds logging action to the materialization of the body. https://github.com/http4s/http4s/blob/b5cd7d7a5cec65375f898c83534c72a1f1433145/server/shared/src/main/scala/org/http4s/server/middleware/ResponseLogger.scala#L83-L89

Since the body's materialization may happen outside of the Kelisli (and/or on a different fiber), the relevant IOLocal context is missing. 