### PR TITLE
Allow custom labels for metrics

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -85,7 +85,7 @@ object Metrics {
   )(implicit F: Clock[F], C: Concurrent[F]): Client[F] =
     Client(withMetrics(client, ops, classifierF, List.empty))
 
-  def effect[F[_]](
+  def effectWithCustomLabelValues[F[_]](
       ops: MetricsOps[F],
       customLabelValues: List[String],
       classifierF: Request[F] => F[Option[String]],

--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -32,11 +32,21 @@ trait MetricsOps[F[_]] {
     */
   def increaseActiveRequests(classifier: Option[String]): F[Unit]
 
+  def increaseActiveRequests(
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = increaseActiveRequests(classifier)
+
   /** Decreases the count of active requests
     *
     * @param classifier the classifier to apply
     */
   def decreaseActiveRequests(classifier: Option[String]): F[Unit]
+
+  def decreaseActiveRequests(
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = decreaseActiveRequests(classifier)
 
   /** Records the time to receive the response headers
     *
@@ -45,6 +55,13 @@ trait MetricsOps[F[_]] {
     * @param classifier the classifier to apply
     */
   def recordHeadersTime(method: Method, elapsed: Long, classifier: Option[String]): F[Unit]
+
+  def recordHeadersTime(
+      method: Method,
+      elapsed: Long,
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = recordHeadersTime(method, elapsed, classifier)
 
   /** Records the time to fully consume the response, including the body
     *
@@ -60,6 +77,14 @@ trait MetricsOps[F[_]] {
       classifier: Option[String],
   ): F[Unit]
 
+  def recordTotalTime(
+      method: Method,
+      status: Status,
+      elapsed: Long,
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = recordTotalTime(method, status, elapsed, classifier)
+
   /** Record abnormal terminations, like errors, timeouts or just other abnormal terminations.
     *
     * @param elapsed the time to record
@@ -71,6 +96,13 @@ trait MetricsOps[F[_]] {
       terminationType: TerminationType,
       classifier: Option[String],
   ): F[Unit]
+
+  def recordAbnormalTermination(
+      elapsed: Long,
+      terminationType: TerminationType,
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = recordAbnormalTermination(elapsed, terminationType, classifier)
 
   /** Transform the effect of MetricOps using the supplied natural transformation
     *


### PR DESCRIPTION
Add the ability to call the MetricsOps with custom label values.

Pull request [Allow custom labels](https://github.com/http4s/http4s-prometheus-metrics/pull/165) allows the creation of MetricsOps with custom label, this PR allow calling those MetricsOps with custom label values.

For binary compatibility, the new methods of `MetricsOps` with the `customLabelValues` parameter are with a default implementation which just calls the existing corresponding method. A PR on `http4s-prometheus-metrics` will provide real implementation of these methods.

Added `withCustomLabelValues` method to both client and server `Metrics` middleware to pass custom label values.