### PR TITLE
Add CustomMetricsOps

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -25,10 +25,12 @@ import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Status
 import org.http4s.client.Client
-import org.http4s.metrics.{CustomMetricsOps, MetricsOps}
+import org.http4s.metrics.CustomMetricsOps
+import org.http4s.metrics.MetricsOps
 import org.http4s.metrics.TerminationType.Error
 import org.http4s.metrics.TerminationType.Timeout
-import org.http4s.util.{SizedSeq, SizedSeq0}
+import org.http4s.util.SizedSeq
+import org.http4s.util.SizedSeq0
 
 import scala.concurrent.TimeoutException
 

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -170,6 +170,11 @@ object Metrics {
         if (e.isInstanceOf[TimeoutException])
           ops.recordAbnormalTermination(now.toNanos - start, Timeout, classifier, customLabelValues)
         else
-          ops.recordAbnormalTermination(now.toNanos - start, Error(e), classifier, customLabelValues)
+          ops.recordAbnormalTermination(
+            now.toNanos - start,
+            Error(e),
+            classifier,
+            customLabelValues,
+          )
       }
 }

--- a/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
@@ -1,0 +1,21 @@
+package org.http4s.metrics
+
+import org.http4s.util.{SizedSeq, SizedSeq0}
+
+trait CustomLabels[+SL <: SizedSeq[String]] {
+  def labels: SL
+  def values: SL
+}
+
+object CustomLabels {
+  def apply[SL <: SizedSeq[String]](pLabels: SL, pValues: SL): CustomLabels[SL] =
+    new CustomLabels[SL] {
+      override def labels: SL = pLabels
+      override def values: SL = pValues
+    }
+}
+
+case class EmptyCustomLabels() extends CustomLabels[SizedSeq0[String]] {
+  override def labels: SizedSeq0[String] = SizedSeq0[String]()
+  override def values: SizedSeq0[String] = SizedSeq0[String]()
+}

--- a/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.metrics
 
 import org.http4s.util.{SizedSeq, SizedSeq0}

--- a/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
@@ -16,7 +16,8 @@
 
 package org.http4s.metrics
 
-import org.http4s.util.{SizedSeq, SizedSeq0}
+import org.http4s.util.SizedSeq
+import org.http4s.util.SizedSeq0
 
 trait CustomLabels[+SL <: SizedSeq[String]] {
   def labels: SL
@@ -31,7 +32,7 @@ object CustomLabels {
     }
 }
 
-case class EmptyCustomLabels() extends CustomLabels[SizedSeq0[String]] {
+final case class EmptyCustomLabels() extends CustomLabels[SizedSeq0[String]] {
   override def labels: SizedSeq0[String] = SizedSeq0[String]()
   override def values: SizedSeq0[String] = SizedSeq0[String]()
 }

--- a/core/shared/src/main/scala/org/http4s/metrics/CustomMetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomMetricsOps.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.metrics
+
+import cats.~>
+import org.http4s.util.{SizedSeq, SizedSeq0}
+import org.http4s.{Method, Status}
+
+/** Describes an algebra capable of writing metrics to a metrics registry
+  */
+trait CustomMetricsOps[F[_], SL <: SizedSeq[String]] extends MetricsOps[F] {
+
+  /** @return the custom label object used to define this CustomMetricsOps
+    */
+  def definingCustomLabels: CustomLabels[SL]
+
+  /** Increases the count of active requests
+    *
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def increaseActiveRequests(classifier: Option[String], customLabelValues: SL): F[Unit]
+  override def increaseActiveRequests(classifier: Option[String]): F[Unit] =
+    increaseActiveRequests(classifier, definingCustomLabels.values)
+
+  /** Decreases the count of active requests
+    *
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def decreaseActiveRequests(classifier: Option[String], customLabelValues: SL): F[Unit]
+  override def decreaseActiveRequests(classifier: Option[String]): F[Unit] =
+    decreaseActiveRequests(classifier, definingCustomLabels.values)
+
+  /** Records the time to receive the response headers
+    *
+    * @param method the http method of the request
+    * @param elapsed the time to record
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def recordHeadersTime(
+      method: Method,
+      elapsed: Long,
+      classifier: Option[String],
+      customLabelValues: SL,
+  ): F[Unit]
+  override def recordHeadersTime(
+      method: Method,
+      elapsed: Long,
+      classifier: Option[String],
+  ): F[Unit] = recordHeadersTime(method, elapsed, classifier, definingCustomLabels.values)
+
+  /** Records the time to fully consume the response, including the body
+    *
+    * @param method the http method of the request
+    * @param status the http status code of the response
+    * @param elapsed the time to record
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def recordTotalTime(
+      method: Method,
+      status: Status,
+      elapsed: Long,
+      classifier: Option[String],
+      customLabelValues: SL,
+  ): F[Unit]
+  override def recordTotalTime(
+      method: Method,
+      status: Status,
+      elapsed: Long,
+      classifier: Option[String],
+  ): F[Unit] = recordTotalTime(method, status, elapsed, classifier, definingCustomLabels.values)
+
+  /** Record abnormal terminations, like errors, timeouts or just other abnormal terminations.
+    *
+    * @param elapsed the time to record
+    * @param terminationType the type of termination
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def recordAbnormalTermination(
+      elapsed: Long,
+      terminationType: TerminationType,
+      classifier: Option[String],
+      customLabelValues: SL,
+  ): F[Unit]
+  override def recordAbnormalTermination(
+      elapsed: Long,
+      terminationType: TerminationType,
+      classifier: Option[String],
+  ): F[Unit] =
+    recordAbnormalTermination(elapsed, terminationType, classifier, definingCustomLabels.values)
+
+  /** Transform the effect of MetricOps using the supplied natural transformation
+    *
+    * @param fk natural transformation
+    * @tparam G the effect to transform to
+    * @return a new metric ops in the transformed effect
+    */
+  override def mapK[G[_]](fk: F ~> G): CustomMetricsOps[G, SL] = {
+    val ops: CustomMetricsOps[F, SL] = this
+    new CustomMetricsOps[G, SL] {
+      override def definingCustomLabels: CustomLabels[SL] = ops.definingCustomLabels
+      override def increaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] =
+        fk(ops.increaseActiveRequests(classifier, customLabelValues))
+
+      override def decreaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] =
+        fk(ops.decreaseActiveRequests(classifier, customLabelValues))
+
+      override def recordHeadersTime(
+          method: Method,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] = fk(ops.recordHeadersTime(method, elapsed, classifier, customLabelValues))
+
+      override def recordTotalTime(
+          method: Method,
+          status: Status,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] = fk(ops.recordTotalTime(method, status, elapsed, classifier, customLabelValues))
+
+      override def recordAbnormalTermination(
+          elapsed: Long,
+          terminationType: TerminationType,
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] =
+        fk(ops.recordAbnormalTermination(elapsed, terminationType, classifier, customLabelValues))
+
+    }
+  }
+}
+
+object CustomMetricsOps {
+  def fromMetricsOps[F[_]](ops: MetricsOps[F]): CustomMetricsOps[F, SizedSeq0[String]] = {
+    val emptyCustomLabels: EmptyCustomLabels = EmptyCustomLabels()
+
+    new CustomMetricsOps[F, SizedSeq0[String]]() {
+
+      override def definingCustomLabels: EmptyCustomLabels = emptyCustomLabels
+
+      override def increaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.increaseActiveRequests(classifier)
+
+      override def decreaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.decreaseActiveRequests(classifier)
+
+      override def recordHeadersTime(
+          method: Method,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.recordHeadersTime(method, elapsed, classifier)
+
+      override def recordTotalTime(
+          method: Method,
+          status: Status,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.recordTotalTime(method, status, elapsed, classifier)
+
+      override def recordAbnormalTermination(
+          elapsed: Long,
+          terminationType: TerminationType,
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.recordAbnormalTermination(elapsed, terminationType, classifier)
+    }
+  }
+}

--- a/core/shared/src/main/scala/org/http4s/metrics/CustomMetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomMetricsOps.scala
@@ -17,8 +17,10 @@
 package org.http4s.metrics
 
 import cats.~>
-import org.http4s.util.{SizedSeq, SizedSeq0}
-import org.http4s.{Method, Status}
+import org.http4s.Method
+import org.http4s.Status
+import org.http4s.util.SizedSeq
+import org.http4s.util.SizedSeq0
 
 /** Describes an algebra capable of writing metrics to a metrics registry
   */

--- a/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
+++ b/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
@@ -1,0 +1,56 @@
+package org.http4s.util
+
+sealed trait SizedSeq[+A] {
+  def toSeq: Seq[A]
+}
+
+abstract class SizedSeqBase[+A] extends SizedSeq[A] {
+  protected val seq: Seq[A]
+  override def toSeq: Seq[A] = seq
+}
+
+// format: off
+case class SizedSeq0[+A]() extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq.empty
+}
+
+case class SizedSeq1[+A](s1: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1)
+}
+
+case class SizedSeq2[+A](s1: A, s2: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2)
+}
+
+case class SizedSeq3[+A](s1: A, s2: A, s3: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3)
+}
+
+case class SizedSeq4[+A](s1: A, s2: A, s3: A, s4: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4)
+}
+
+case class SizedSeq5[+A](s1: A, s2: A, s3: A, s4: A, s5: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5)
+}
+
+case class SizedSeq6[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6)
+}
+
+case class SizedSeq7[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7)
+}
+
+case class SizedSeq8[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7, s8)
+}
+
+case class SizedSeq9[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A, s9: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7, s8, s9)
+}
+
+case class SizedSeq10[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A, s9: A, s10: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10)
+}
+// format: on

--- a/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
+++ b/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
@@ -20,7 +20,7 @@ sealed trait SizedSeq[+A] {
   def toSeq: Seq[A]
 }
 
-abstract class SizedSeqBase[+A] extends SizedSeq[A] {
+sealed abstract class SizedSeqBase[+A] extends SizedSeq[A] {
   protected val seq: Seq[A]
   override def toSeq: Seq[A] = seq
 }

--- a/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
+++ b/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.util
 
 sealed trait SizedSeq[+A] {

--- a/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
+++ b/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
@@ -26,47 +26,47 @@ abstract class SizedSeqBase[+A] extends SizedSeq[A] {
 }
 
 // format: off
-case class SizedSeq0[+A]() extends SizedSeqBase[A] {
+final case class SizedSeq0[+A]() extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq.empty
 }
 
-case class SizedSeq1[+A](s1: A) extends SizedSeqBase[A] {
+final case class SizedSeq1[+A](s1: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1)
 }
 
-case class SizedSeq2[+A](s1: A, s2: A) extends SizedSeqBase[A] {
+final case class SizedSeq2[+A](s1: A, s2: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1, s2)
 }
 
-case class SizedSeq3[+A](s1: A, s2: A, s3: A) extends SizedSeqBase[A] {
+final case class SizedSeq3[+A](s1: A, s2: A, s3: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1, s2, s3)
 }
 
-case class SizedSeq4[+A](s1: A, s2: A, s3: A, s4: A) extends SizedSeqBase[A] {
+final case class SizedSeq4[+A](s1: A, s2: A, s3: A, s4: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1, s2, s3, s4)
 }
 
-case class SizedSeq5[+A](s1: A, s2: A, s3: A, s4: A, s5: A) extends SizedSeqBase[A] {
+final case class SizedSeq5[+A](s1: A, s2: A, s3: A, s4: A, s5: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5)
 }
 
-case class SizedSeq6[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A) extends SizedSeqBase[A] {
+final case class SizedSeq6[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6)
 }
 
-case class SizedSeq7[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A) extends SizedSeqBase[A] {
+final case class SizedSeq7[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7)
 }
 
-case class SizedSeq8[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A) extends SizedSeqBase[A] {
+final case class SizedSeq8[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7, s8)
 }
 
-case class SizedSeq9[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A, s9: A) extends SizedSeqBase[A] {
+final case class SizedSeq9[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A, s9: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7, s8, s9)
 }
 
-case class SizedSeq10[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A, s9: A, s10: A) extends SizedSeqBase[A] {
+final case class SizedSeq10[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A, s9: A, s10: A) extends SizedSeqBase[A] {
   override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10)
 }
 // format: on

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
@@ -21,11 +21,14 @@ import cats.effect.Clock
 import cats.effect.kernel.*
 import cats.syntax.all.*
 import org.http4s.*
-import org.http4s.metrics.{CustomMetricsOps, MetricsOps, TerminationType}
+import org.http4s.metrics.CustomMetricsOps
+import org.http4s.metrics.MetricsOps
+import org.http4s.metrics.TerminationType
 import org.http4s.metrics.TerminationType.Abnormal
 import org.http4s.metrics.TerminationType.Canceled
 import org.http4s.metrics.TerminationType.Error
-import org.http4s.util.{SizedSeq, SizedSeq0}
+import org.http4s.util.SizedSeq
+import org.http4s.util.SizedSeq0
 
 /** Server middleware to record metrics for the http4s server.
   *

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
@@ -138,7 +138,12 @@ object Metrics {
       for {
         now <- F.monotonic
         headerTime = now.toNanos - metrics.startTime
-        _ <- ops.recordHeadersTime(metrics.method, headerTime, metrics.classifier, customLabelValues)
+        _ <- ops.recordHeadersTime(
+          metrics.method,
+          headerTime,
+          metrics.classifier,
+          customLabelValues,
+        )
       } yield ContextResponse(resp.status, resp)
 
     BracketRequestResponse.bracketRequestResponseCaseRoutes_[F, MetricsEntry, Status] {
@@ -146,7 +151,13 @@ object Metrics {
     } { case (metrics, maybeStatus, outcome) =>
       stopMetrics(metrics).flatMap { totalTime =>
         def recordTotal(status: Status): F[Unit] =
-          ops.recordTotalTime(metrics.method, status, totalTime, metrics.classifier, customLabelValues)
+          ops.recordTotalTime(
+            metrics.method,
+            status,
+            totalTime,
+            metrics.classifier,
+            customLabelValues,
+          )
 
         def recordAbnormal(term: TerminationType): F[Unit] =
           ops.recordAbnormalTermination(totalTime, term, metrics.classifier, customLabelValues)
@@ -159,7 +170,12 @@ object Metrics {
           case (Outcome.Errored(e), None) =>
             // If an error occurred, and the status is empty, this means
             // the error occurred before the routes could generate a response.
-            ops.recordHeadersTime(metrics.method, totalTime, metrics.classifier, customLabelValues) *>
+            ops.recordHeadersTime(
+              metrics.method,
+              totalTime,
+              metrics.classifier,
+              customLabelValues,
+            ) *>
               recordAbnormal(Error(e)) *>
               errorResponseHandler(e).traverse_(recordTotal)
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
@@ -18,14 +18,14 @@ package org.http4s.server.middleware
 
 import cats.data.Kleisli
 import cats.effect.Clock
-import cats.effect.kernel._
-import cats.syntax.all._
-import org.http4s._
-import org.http4s.metrics.MetricsOps
-import org.http4s.metrics.TerminationType
+import cats.effect.kernel.*
+import cats.syntax.all.*
+import org.http4s.*
+import org.http4s.metrics.{CustomMetricsOps, MetricsOps, TerminationType}
 import org.http4s.metrics.TerminationType.Abnormal
 import org.http4s.metrics.TerminationType.Canceled
 import org.http4s.metrics.TerminationType.Error
+import org.http4s.util.{SizedSeq, SizedSeq0}
 
 /** Server middleware to record metrics for the http4s server.
   *
@@ -63,6 +63,23 @@ object Metrics {
   )(routes: HttpRoutes[F])(implicit F: Clock[F], C: MonadCancel[F, Throwable]): HttpRoutes[F] =
     effect[F](ops, emptyResponseHandler, errorResponseHandler, classifierF(_).pure[F])(routes)
 
+  def withCustomLabels[F[_], SL <: SizedSeq[String]](
+      ops: CustomMetricsOps[F, SL],
+      customLabelValues: SL,
+      emptyResponseHandler: Option[Status] = Status.NotFound.some,
+      errorResponseHandler: Throwable => Option[Status] = _ => Status.InternalServerError.some,
+      classifierF: Request[F] => Option[String] = { (_: Request[F]) =>
+        None
+      },
+  )(routes: HttpRoutes[F])(implicit F: Clock[F], C: MonadCancel[F, Throwable]): HttpRoutes[F] =
+    effectWithCustomLabels[F, SL](
+      ops,
+      customLabelValues,
+      emptyResponseHandler,
+      errorResponseHandler,
+      classifierF(_).pure[F],
+    )(routes)
+
   /** A server middleware capable of recording metrics
     *
     * Same as [[apply]], but can classify requests effectually, e.g. performing side-effects.
@@ -82,10 +99,29 @@ object Metrics {
       errorResponseHandler: Throwable => Option[Status] = _ => Status.InternalServerError.some,
       classifierF: Request[F] => F[Option[String]],
   )(routes: HttpRoutes[F])(implicit F: Clock[F], C: MonadCancel[F, Throwable]): HttpRoutes[F] = {
+    val cops = CustomMetricsOps.fromMetricsOps(ops)
+    val emptyCustomLabelValues = SizedSeq0[String]()
+    effectWithCustomLabels(
+      cops,
+      emptyCustomLabelValues,
+      emptyResponseHandler,
+      errorResponseHandler,
+      classifierF,
+    )(routes)
+
+  }
+
+  def effectWithCustomLabels[F[_], SL <: SizedSeq[String]](
+      ops: CustomMetricsOps[F, SL],
+      customLabelValues: SL,
+      emptyResponseHandler: Option[Status] = Status.NotFound.some,
+      errorResponseHandler: Throwable => Option[Status] = _ => Status.InternalServerError.some,
+      classifierF: Request[F] => F[Option[String]],
+  )(routes: HttpRoutes[F])(implicit F: Clock[F], C: MonadCancel[F, Throwable]): HttpRoutes[F] = {
     def startMetrics(request: Request[F]): F[ContextRequest[F, MetricsEntry]] =
       for {
         classifier <- classifierF(request)
-        _ <- ops.increaseActiveRequests(classifier)
+        _ <- ops.increaseActiveRequests(classifier, customLabelValues)
         startTime <- F.monotonic
       } yield ContextRequest(MetricsEntry(request.method, startTime.toNanos, classifier), request)
 
@@ -94,7 +130,7 @@ object Metrics {
       // This differs from the < 0.21.14 semantics, which decreased it _after_ the other effects.
       // This may have caused the bugs that reported the active requests counter to have drifted.
       for {
-        _ <- ops.decreaseActiveRequests(metrics.classifier)
+        _ <- ops.decreaseActiveRequests(metrics.classifier, customLabelValues)
         endTime <- F.monotonic
       } yield endTime.toNanos - metrics.startTime
 
@@ -102,7 +138,7 @@ object Metrics {
       for {
         now <- F.monotonic
         headerTime = now.toNanos - metrics.startTime
-        _ <- ops.recordHeadersTime(metrics.method, headerTime, metrics.classifier)
+        _ <- ops.recordHeadersTime(metrics.method, headerTime, metrics.classifier, customLabelValues)
       } yield ContextResponse(resp.status, resp)
 
     BracketRequestResponse.bracketRequestResponseCaseRoutes_[F, MetricsEntry, Status] {
@@ -110,10 +146,10 @@ object Metrics {
     } { case (metrics, maybeStatus, outcome) =>
       stopMetrics(metrics).flatMap { totalTime =>
         def recordTotal(status: Status): F[Unit] =
-          ops.recordTotalTime(metrics.method, status, totalTime, metrics.classifier)
+          ops.recordTotalTime(metrics.method, status, totalTime, metrics.classifier, customLabelValues)
 
         def recordAbnormal(term: TerminationType): F[Unit] =
-          ops.recordAbnormalTermination(totalTime, term, metrics.classifier)
+          ops.recordAbnormalTermination(totalTime, term, metrics.classifier, customLabelValues)
 
         (outcome, maybeStatus) match {
           case (Outcome.Succeeded(_), None) => emptyResponseHandler.traverse_(recordTotal)
@@ -123,7 +159,7 @@ object Metrics {
           case (Outcome.Errored(e), None) =>
             // If an error occurred, and the status is empty, this means
             // the error occurred before the routes could generate a response.
-            ops.recordHeadersTime(metrics.method, totalTime, metrics.classifier) *>
+            ops.recordHeadersTime(metrics.method, totalTime, metrics.classifier, customLabelValues) *>
               recordAbnormal(Error(e)) *>
               errorResponseHandler(e).traverse_(recordTotal)
 


### PR DESCRIPTION
Add `CustomMetricsOps` and update client and server Metrics middleware to allow adding custom labels to metrics.

**Background**
In a situation where a service interacts with multiple providers, a few of them do not have a lot of traffic, so when one of these light providers is down, the alert of the service is not triggered due to the small percentage counted in the failing traffic; So we want to create alerts specific to providers, and I’m searching for ways to identify the metrics entries related to a provider.

I can think of two options currently available:
- Use provider specific prefix when create `MetricsOps` instance, but the metrics of this client will be excluded from a generic Http4S metrics dashboard;
- Add provider specific prefix to classifier when create `org.http4s.client.middleware.Metrics`.

The second option is better than the first option, but not ideal.

**What it does**
This PR
- Add `CustomMetricsOps` (extends existing `MetricsOps`) to allow adding custom labels to metrics records;
- Add `withCustomLabels` method to both client and server `Metrics` middleware to pass custom label values when they call the `CustomMetricsOps` with custom label values.

When `CustomMetricsOps` with some custom labels is created, the Metrics middleware calling it must supply the same number of label values, so the type parameter SL (sized list) is added to enforce this constraint.

We could use `shapeless`'s `Sized` type to express this constraint, but `shapeless` is not on the dependency list and it's unlikely it will be added. So we temporarily created `SizedSeq` to mimic `shapeless`'s `Sized` type.

`http4s-prometheus-metrics` will be updated to adapt this feature, a draft pull request on `http4s-prometheus-metrics` [Allow custom labels](https://github.com/http4s/http4s-prometheus-metrics/pull/168) allows creating instance of `CustomMetricsOps` with custom label. [epimetheus-http4s](https://github.com/davenverse/epimetheus-http4s) could also be updated.

**Code example**
First call `http4s-prometheus-metrics`'s `Prometheus` to create an instance of `CustomMetricsOps`, notice the prefix `payments:org_http4s_client`, and one single custom label `payment_provider`.
Then create a Metrics client middleware, passing value `Paylly` to custom label.
```
for {
    # Create a CustomMetricsOps using the new method to be added to http4-promethues-metrics
    # with one custom label "payment_provider"
    customMetricsOps: CustomMetricsOps[F, SizedSeq1[String]] <- Stream.resource(
        Prometheus
          .default(cr)
          .withPrefix("payments:org_http4s_client")
          .buildCustomMetricsOps(CustomLabels(SizedSeq1("payment_provider"), SizedSeq1("")))
      )
    # Create client middleware calling the customMetricsOps, passing custom label value "Paylly"
    client <- BlazeClientBuilder[F]
        .resource
        .map { client =>
            Metrics.withCustomLabels(
                customMetricsOps,
                SizedSeq1("Paylly")   # SizedSeq2("Paylly", "Other") would cause compilation error here
                (req: Request[F]) => req.uri.host.map(_.value))(client)
        }
}
```

**Output examples**
The above code will generate below metrics entries; Notice that the entries with prefix `payments:org_http4s_client_` have custom label `payment_provider` with value `Paylly`.
```
# Normal metrics entries:
org_http4s_client_response_duration_seconds_count{classifier="localhost",method="get",phase="body",} 3.0
org_http4s_client_response_duration_seconds_sum{classifier="localhost",method="get",phase="body",} 0.511480755
org_http4s_client_response_duration_seconds_bucket{classifier="localhost",method="get",phase="headers",le="0.005",} 0.0

# Custom metrics entries with custom label payment_provider:
payments:org_http4s_client_response_duration_seconds_bucket{classifier="test.com",method="post",phase="headers",payment_provider="Paylly",le="0.005",} 0.0
payments:org_http4s_client_response_duration_seconds_bucket{classifier="test.com",method="post",phase="headers",payment_provider="Paylly",le="+Inf",} 1.0
payments:org_http4s_client_response_duration_seconds_count{classifier="test.com",method="post",phase="headers",payment_provider="Paylly",} 1.0
payments:org_http4s_client_response_duration_seconds_sum{classifier="test.com",method="post",phase="headers",payment_provider="Paylly",} 0.526104997
payments:org_http4s_client_response_duration_seconds_count{classifier="test.com",method="post",phase="body",payment_provider="Paylly",} 1.0
payments:org_http4s_client_response_duration_seconds_sum{classifier="test.com",method="post",phase="body",payment_provider="Paylly",} 0.571559018
payments:org_http4s_client_request_count_total{classifier="test.com",method="post",status="2xx",payment_provider="Paylly",} 1.0
payments:org_http4s_client_request_count_created{classifier="test.com",method="post",status="2xx",payment_provider="Paylly",} 1.717544234533E9
payments:org_http4s_client_response_duration_seconds_created{classifier="test.com",method="post",phase="headers",payment_provider="Paylly",} 1.717544234488E9
payments:org_http4s_client_response_duration_seconds_created{classifier="test.com",method="post",phase="body",payment_provider="Paylly",} 1.717544234533E9
```