### PR TITLE
Made traits and objects public for Node.js files

### DIFF
--- a/core/js/src/main/scala/org/http4s/nodejs/ClientRequest.scala
+++ b/core/js/src/main/scala/org/http4s/nodejs/ClientRequest.scala
@@ -30,7 +30,7 @@ import scala.scalajs.js
   */
 @js.native
 @nowarn212("cat=unused")
-private[http4s] trait ClientRequest extends js.Object with Writable {
+trait ClientRequest extends js.Object with Writable {
 
   protected[nodejs] def setHeader(name: String, value: js.Array[String]): Unit = js.native
 
@@ -50,7 +50,7 @@ private[http4s] trait ClientRequest extends js.Object with Writable {
     js.native
 }
 
-private[http4s] object ClientRequest {
+object ClientRequest {
 
   implicit def http4sNodeJsServerResponseOps(clientRequest: ClientRequest): ClientRequestOps =
     new ClientRequestOps(clientRequest)

--- a/core/js/src/main/scala/org/http4s/nodejs/IncomingMessage.scala
+++ b/core/js/src/main/scala/org/http4s/nodejs/IncomingMessage.scala
@@ -28,7 +28,7 @@ import scala.scalajs.js
 /** Facade for [[https://nodejs.org/api/http.html#class-httpincomingmessage]]
   */
 @js.native
-private[http4s] trait IncomingMessage extends js.Object with Readable {
+trait IncomingMessage extends js.Object with Readable {
   protected[nodejs] def httpVersionMajor: Int = js.native
   protected[nodejs] def httpVersionMinor: Int = js.native
   protected[nodejs] def rawHeaders: js.Array[String] = js.native
@@ -39,7 +39,7 @@ private[http4s] trait IncomingMessage extends js.Object with Readable {
   protected[nodejs] def statusCode: Int = js.native
 }
 
-private[http4s] object IncomingMessage {
+object IncomingMessage {
 
   implicit def http4sNodeJsIncomingMessageOps(
       incomingMessage: IncomingMessage

--- a/core/js/src/main/scala/org/http4s/nodejs/ServerResponse.scala
+++ b/core/js/src/main/scala/org/http4s/nodejs/ServerResponse.scala
@@ -28,7 +28,7 @@ import scala.scalajs.js
   */
 @js.native
 @nowarn212("cat=unused")
-private[http4s] trait ServerResponse extends js.Object with Writable {
+trait ServerResponse extends js.Object with Writable {
 
   protected[nodejs] def writeHead(
       statusCode: Int,
@@ -38,7 +38,7 @@ private[http4s] trait ServerResponse extends js.Object with Writable {
 
 }
 
-private[http4s] object ServerResponse {
+object ServerResponse {
 
   implicit def http4sNodeJsServerResponseOps(serverResponse: ServerResponse): ServerResponseOps =
     new ServerResponseOps(serverResponse)


### PR DESCRIPTION
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 
[Arman](https://github.com/armanbilge) suggested changing the traits and objects from private to public so that they could be used in [Feral](https://github.com/typelevel/feral).

Ran `sbt quicklint` and no changes from the last commit on this branch.