### PR TITLE
Ember Client : Retry when connection reset on JDK 17+

### DIFF
--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -286,7 +286,7 @@ private[client] object ClientHelpers {
         case Left(_: ClosedChannelException) => true
         case Left(ex: IOException) =>
           val msg = ex.getMessage()
-          msg == "Connection reset by peer" || msg == "Broken pipe"
+          msg == "Connection reset by peer" || msg == "Broken pipe" || msg == "Connection reset"
         case _ => false
       }
   }


### PR DESCRIPTION
On JDK 17+, the exception has changed when a connection reset occured.

We have this stack trace :

java.io.IOException: Connection reset
	at java.base/sun.nio.ch.UnixAsynchronousSocketChannelImpl.finishRead(Unknown Source)
	at java.base/sun.nio.ch.UnixAsynchronousSocketChannelImpl.finish(Unknown Source)
	at java.base/sun.nio.ch.UnixAsynchronousSocketChannelImpl.onEvent(Unknown Source)
	at java.base/sun.nio.ch.EPollPort$EventHandlerTask.run(Unknown Source)
	at java.base/sun.nio.ch.AsynchronousChannelGroupImpl$1.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
	at delay @ fs2.io.net.SocketCompanionPlatform$AsyncSocket.readChunk$$anonfun$1(SocketPlatform.scala:120)
	at async @ fs2.io.net.SocketCompanionPlatform$AsyncSocket.readChunk(SocketPlatform.scala:120)
	at flatMap @ fs2.io.net.SocketCompanionPlatform$BufferedReads.read$$anonfun$1(SocketPlatform.scala:84)
	at delay @ fs2.io.net.SocketCompanionPlatform$BufferedReads.withReadBuffer(SocketPlatform.scala:58)
	at flatten$extension @ org.http4s.ember.server.internal.Shutdown$$anon$1.<init>(Shutdown.scala:71)
	at getAndSet @ org.typelevel.keypool.KeyPool$.destroy(KeyPool.scala:120)
	at apply @ org.http4s.ember.server.EmberServerBuilder.build$$anonfun$2(EmberServerBuilder.scala:235)

This patch used in production enables us to avoid this kind of error.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 