### PR TITLE
MetricsOps: use `PreludeRequest` and `PreludeResponse`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -193,8 +193,8 @@ lazy val server = libraryCrossProject("server")
     buildInfoPackage := "org.http4s.server.test",
     libraryDependencies ++= Seq(
       crypto.value,
-      scalacheck.value,
-      scalacheckEffectMunit.value,
+      scalacheck.value % Test,
+      scalacheckEffectMunit.value % Test,
     ),
   )
   .dependsOn(core, tests % Test, theDsl % Test)
@@ -205,8 +205,8 @@ lazy val client = libraryCrossProject("client")
     startYear := Some(2014),
     libraryDependencies ++= Seq(
       crypto.value,
-      scalacheck.value,
-      scalacheckEffectMunit.value,
+      scalacheck.value % Test,
+      scalacheckEffectMunit.value % Test,
     ),
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,11 @@ lazy val server = libraryCrossProject("server")
       BuildInfoKey.map(Test / resourceDirectory) { case (k, v) => k -> v.toString }
     ),
     buildInfoPackage := "org.http4s.server.test",
-    libraryDependencies += crypto.value,
+    libraryDependencies ++= Seq(
+      crypto.value,
+      scalacheck.value,
+      scalacheckEffectMunit.value,
+    ),
   )
   .dependsOn(core, tests % Test, theDsl % Test)
 
@@ -199,7 +203,11 @@ lazy val client = libraryCrossProject("client")
   .settings(
     description := "Base library for building http4s clients",
     startYear := Some(2014),
-    libraryDependencies += crypto.value,
+    libraryDependencies ++= Seq(
+      crypto.value,
+      scalacheck.value,
+      scalacheckEffectMunit.value,
+    ),
   )
   .jvmSettings(
     libraryDependencies ++= Seq(

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -130,16 +130,18 @@ object Metrics {
 
         (responseRef.get, F.monotonic).flatMapN { case (response, now) =>
           val status = response.map(_.status)
-          ops.recordTotalTime(rp, status, tpe, now - start, classifier) *>
-            ops.recordRequestBodySize(rp, status, tpe, classifier) *>
-            response.traverse_(ops.recordResponseBodySize(rp, _, tpe, classifier))
+          ops.recordTotalTime(rp, status, tpe, now - start, classifier, customLabelValues) *>
+            ops.recordRequestBodySize(rp, status, tpe, classifier, customLabelValues) *>
+            response.traverse_(
+              ops.recordResponseBodySize(rp, _, tpe, classifier, customLabelValues)
+            )
         }
       }
 
       resp <- client.run(req)
       _ <- Resource.eval(responseRef.set(Some(resp.responsePrelude)))
       now <- Resource.monotonic
-      _ <- Resource.eval(ops.recordHeadersTime(rp, now - start, classifier))
+      _ <- Resource.eval(ops.recordHeadersTime(rp, now - start, classifier, customLabelValues))
     } yield resp
   }
 

--- a/client/shared/src/test/scala/org/http4s/client/middleware/MetricsSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/MetricsSuite.scala
@@ -1,0 +1,502 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.client.middleware
+
+import cats.effect.IO
+import cats.effect.Ref
+import cats.effect.testkit.TestControl
+import cats.syntax.applicative._
+import com.comcast.ip4s._
+import munit.ScalaCheckEffectSuite
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.dsl.io._
+import org.http4s.metrics.MetricsOps
+import org.http4s.metrics.NetworkProtocol
+import org.http4s.metrics.TerminationType
+import org.http4s.syntax.literals._
+import org.scalacheck.Gen
+import org.scalacheck.effect.PropF
+
+import scala.concurrent.duration._
+
+class MetricsSuite extends Http4sSuite with ScalaCheckEffectSuite {
+  import MetricsSuite._
+
+  private val DelayGen = Gen.posNum[Int].map(_.millis)
+
+  private val PayloadGen = {
+    val empty =
+      for {
+        delay <- DelayGen
+      } yield Payload.Empty(delay)
+
+    val stream =
+      for {
+        content <- Gen.alphaNumStr
+        perChunkDelay <- DelayGen
+      } yield Payload.Stream(content, perChunkDelay)
+
+    val strict =
+      for {
+        content <- Gen.alphaNumStr
+        delay <- DelayGen
+      } yield Payload.Strict(content, delay)
+
+    Gen.oneOf(empty, stream, strict)
+  }
+
+  test("get - 200 ok") {
+    PropF.forAllF(PayloadGen) { server =>
+      val routes = HttpRoutes.of[IO] { case GET -> Root / "ok" =>
+        server match {
+          case Payload.Empty(delay) => Ok().delayBy(delay)
+          case s @ Payload.Stream(_, _) => Ok(s.stream)
+          case Payload.Strict(body, delay) => Ok(body).delayBy(delay)
+        }
+      }
+
+      val request =
+        Request[IO](GET, uri"/ok").withAttribute(Request.Keys.ConnectionInfo, connection)
+
+      val headersTime = server match {
+        case Payload.Stream(_, _) => Duration.Zero
+        case Payload.Empty(delay) => delay
+        case Payload.Strict(_, delay) => delay
+      }
+
+      val totalTime = getTotalTime(headersTime, server)
+      val responseSize = getResponseSize(server)
+      val status = Status.Ok
+      val expected = Vector(
+        MetricsOp.IncreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordHeadersTime(request.method, request.uri, headersTime),
+        MetricsOp.RecordTotalTime(request.method, request.uri, Some(status), totalTime),
+        MetricsOp.RecordRequestBodySize(request.method, request.uri, Some(status), None),
+        MetricsOp.RecordResponseBodySize(request.method, request.uri, Some(status), responseSize),
+        MetricsOp.DecreaseActiveRequests(request.method, request.uri),
+      )
+
+      TestControl.executeEmbed {
+        for {
+          metricsOps <- mkMetricsOps
+          _ <- Metrics(metricsOps)(Client.fromHttpApp(routes.orNotFound)).run(request).use_
+          ops <- metricsOps.all
+        } yield assertEquals(ops, expected)
+      }
+    }
+  }
+
+  test("post - 200 ok") {
+    PropF.forAllF(PayloadGen, PayloadGen, Gen.oneOf(true, false)) { (client, server, consumeBody) =>
+      val routes = HttpRoutes.of[IO] { case req @ POST -> Root / "ok" =>
+        val response = server match {
+          case Payload.Empty(delay) => Ok().delayBy(delay)
+          case s @ Payload.Stream(_, _) => Ok(s.stream)
+          case Payload.Strict(body, delay) => Ok(body).delayBy(delay)
+        }
+
+        req.bodyText.compile.foldMonoid.whenA(consumeBody) >> response
+      }
+
+      val request = mkPostRequest(client)
+      val headersTime = getHeadersTime(client, server, consumeBody)
+      val totalTime = getTotalTime(headersTime, server)
+      val requestSize = getRequestSize(client)
+      val responseSize = getResponseSize(server)
+      val status = Status.Ok
+
+      val expected = Vector(
+        MetricsOp.IncreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordHeadersTime(request.method, request.uri, headersTime),
+        MetricsOp.RecordTotalTime(request.method, request.uri, Some(status), totalTime),
+        MetricsOp.RecordRequestBodySize(request.method, request.uri, Some(status), requestSize),
+        MetricsOp.RecordResponseBodySize(request.method, request.uri, Some(status), responseSize),
+        MetricsOp.DecreaseActiveRequests(request.method, request.uri),
+      )
+
+      TestControl.executeEmbed {
+        for {
+          metricsOps <- mkMetricsOps
+          _ <- Metrics(metricsOps)(Client.fromHttpApp(routes.orNotFound))
+            .run(request)
+            .use(_.bodyText.compile.drain.whenA(consumeBody))
+          ops <- metricsOps.all
+        } yield assertEquals(ops, expected)
+      }
+    }
+  }
+
+  test("post - 200 ok - unhandled client error") {
+    PropF.forAllF(PayloadGen, PayloadGen, Gen.oneOf(true, false)) { (client, server, consumeBody) =>
+      val error = new RuntimeException("something went wrong")
+
+      val routes = HttpRoutes.of[IO] { case req @ POST -> Root / "ok" =>
+        val response = server match {
+          case Payload.Empty(delay) => Ok().delayBy(delay)
+          case s @ Payload.Stream(_, _) => Ok(s.stream)
+          case Payload.Strict(body, delay) => Ok(body).delayBy(delay)
+
+        }
+        req.bodyText.compile.foldMonoid.whenA(consumeBody) >> response
+      }
+
+      val request = mkPostRequest(client)
+      val headersTime = getHeadersTime(client, server, consumeBody)
+      val totalTime = getTotalTime(headersTime, server)
+      val requestSize = getRequestSize(client)
+      val responseSize = getResponseSize(server)
+      val status = Status.Ok
+      val tt = TerminationType.Error(error)
+
+      val expected = Vector(
+        MetricsOp.IncreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordHeadersTime(request.method, request.uri, headersTime),
+        MetricsOp.RecordTotalTime(request.method, request.uri, Some(status), totalTime, Some(tt)),
+        MetricsOp.RecordRequestBodySize(
+          request.method,
+          request.uri,
+          Some(status),
+          requestSize,
+          Some(tt),
+        ),
+        MetricsOp.RecordResponseBodySize(
+          request.method,
+          request.uri,
+          Some(status),
+          responseSize,
+          Some(tt),
+        ),
+        MetricsOp.DecreaseActiveRequests(request.method, request.uri),
+      )
+
+      TestControl.executeEmbed {
+        for {
+          metricsOps <- mkMetricsOps
+          _ <- Metrics(metricsOps)(Client.fromHttpApp(routes.orNotFound))
+            .run(request)
+            .use(_.bodyText.compile.drain.whenA(consumeBody) >> IO.raiseError(error))
+            .voidError
+          ops <- metricsOps.all
+        } yield assertEquals(ops, expected)
+      }
+    }
+  }
+
+  test("post - 200 ok - client cancelation") {
+    PropF.forAllF(PayloadGen, PayloadGen, Gen.oneOf(true, false)) { (client, server, consumeBody) =>
+      val routes =
+        HttpRoutes.of[IO] { case req @ POST -> Root / "ok" =>
+          val response = server match {
+            case Payload.Empty(delay) => Ok().delayBy(delay)
+            case s @ Payload.Stream(_, _) => Ok(s.stream)
+            case Payload.Strict(body, delay) => Ok(body).delayBy(delay)
+
+          }
+          req.bodyText.compile.foldMonoid.whenA(consumeBody) >> response
+        }
+
+      val request = mkPostRequest(client)
+      val headersTime = getHeadersTime(client, server, consumeBody)
+      val totalTime = getTotalTime(headersTime, server)
+      val requestSize = getRequestSize(client)
+      val responseSize = getResponseSize(server)
+      val tt = TerminationType.Canceled
+      val status = Status.Ok
+
+      val expected = Vector(
+        MetricsOp.IncreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordHeadersTime(request.method, request.uri, headersTime),
+        MetricsOp.RecordTotalTime(request.method, request.uri, Some(status), totalTime, Some(tt)),
+        MetricsOp.RecordRequestBodySize(
+          request.method,
+          request.uri,
+          Some(status),
+          requestSize,
+          Some(tt),
+        ),
+        MetricsOp.RecordResponseBodySize(
+          request.method,
+          request.uri,
+          Some(status),
+          responseSize,
+          Some(tt),
+        ),
+        MetricsOp.DecreaseActiveRequests(request.method, request.uri),
+      )
+
+      TestControl.executeEmbed {
+        for {
+          metricsOps <- mkMetricsOps
+          f <- Metrics(metricsOps)(Client.fromHttpApp(routes.orNotFound))
+            .run(request)
+            .use(_.bodyText.compile.drain.whenA(consumeBody) >> IO.canceled)
+            .start
+          _ <- f.joinWithUnit
+          ops <- metricsOps.all
+        } yield assertEquals(ops, expected)
+      }
+    }
+  }
+
+  private def mkPostRequest(payload: Payload): Request[IO] = {
+    val req = Request[IO](POST, uri"/ok").withAttribute(Request.Keys.ConnectionInfo, connection)
+
+    payload match {
+      case Payload.Empty(_) => req
+      case s @ Payload.Stream(_, _) => req.withBodyStream(s.stream)
+      case Payload.Strict(body, _) => req.withEntity(body)
+    }
+  }
+
+  private def getHeadersTime(client: Payload, server: Payload, consume: Boolean): FiniteDuration = {
+    val ct = client match {
+      case s @ Payload.Stream(_, _) if consume => s.totalDelay
+      case _ => Duration.Zero
+    }
+
+    val st = server match {
+      case Payload.Stream(_, _) => Duration.Zero
+      case Payload.Empty(delay) => delay
+      case Payload.Strict(_, delay) => delay
+    }
+
+    ct + st
+  }
+
+  private def getTotalTime(headersTime: FiniteDuration, server: Payload): FiniteDuration =
+    server match {
+      case s @ Payload.Stream(_, _) => headersTime + s.totalDelay
+      case Payload.Empty(_) => headersTime
+      case Payload.Strict(_, _) => headersTime
+    }
+
+  private def getRequestSize(payload: Payload): Option[Long] =
+    payload match {
+      case Payload.Strict(content, _) => Some(content.length.toLong)
+      case Payload.Stream(_, _) => None
+      case Payload.Empty(_) => None
+    }
+
+  private def getResponseSize(payload: Payload): Option[Long] =
+    payload match {
+      case Payload.Strict(content, _) => Some(content.length.toLong)
+      case Payload.Stream(_, _) => None
+      case Payload.Empty(_) => Some(0L)
+    }
+
+  private def mkMetricsOps: IO[InMemoryMetricsOps] =
+    for {
+      ops <- IO.ref(Vector.empty[MetricsOp])
+    } yield new InMemoryMetricsOps(ops)
+
+  private class InMemoryMetricsOps(ops: Ref[IO, Vector[MetricsOp]]) extends MetricsOps[IO] {
+    def all: IO[Vector[MetricsOp]] = ops.get
+
+    private def add(op: MetricsOp): IO[Unit] =
+      ops.update(_ :+ op)
+
+    def increaseActiveRequests(
+        method: Method,
+        uri: Uri,
+        address: Option[SocketAddress[IpAddress]],
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(MetricsOp.IncreaseActiveRequests(method, uri, address, classifier))
+
+    def decreaseActiveRequests(
+        method: Method,
+        uri: Uri,
+        address: Option[SocketAddress[IpAddress]],
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(MetricsOp.DecreaseActiveRequests(method, uri, address, classifier))
+
+    def recordHeadersTime(
+        method: Method,
+        uri: Uri,
+        protocol: NetworkProtocol,
+        address: Option[SocketAddress[IpAddress]],
+        elapsed: FiniteDuration,
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(MetricsOp.RecordHeadersTime(method, uri, elapsed, protocol, address, classifier))
+
+    def recordTotalTime(
+        method: Method,
+        uri: Uri,
+        protocol: NetworkProtocol,
+        address: Option[SocketAddress[IpAddress]],
+        status: Option[Status],
+        terminationType: Option[TerminationType],
+        elapsed: FiniteDuration,
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(
+        MetricsOp.RecordTotalTime(
+          method,
+          uri,
+          status,
+          elapsed,
+          terminationType,
+          protocol,
+          address,
+          classifier,
+        )
+      )
+
+    def recordRequestBodySize(
+        method: Method,
+        uri: Uri,
+        protocol: NetworkProtocol,
+        address: Option[SocketAddress[IpAddress]],
+        status: Option[Status],
+        terminationType: Option[TerminationType],
+        contentLength: Option[Long],
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(
+        MetricsOp.RecordRequestBodySize(
+          method,
+          uri,
+          status,
+          contentLength,
+          terminationType,
+          protocol,
+          address,
+          classifier,
+        )
+      )
+
+    def recordResponseBodySize(
+        method: Method,
+        uri: Uri,
+        protocol: NetworkProtocol,
+        address: Option[SocketAddress[IpAddress]],
+        status: Option[Status],
+        terminationType: Option[TerminationType],
+        contentLength: Option[Long],
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(
+        MetricsOp.RecordResponseBodySize(
+          method,
+          uri,
+          status,
+          contentLength,
+          terminationType,
+          protocol,
+          address,
+          classifier,
+        )
+      )
+  }
+
+}
+
+object MetricsSuite {
+
+  private val protocol = NetworkProtocol.http(HttpVersion.`HTTP/1.1`)
+  private val connection = Request.Connection(
+    SocketAddress(ip"127.0.0.1", port"8081"),
+    SocketAddress(ip"127.0.0.1", port"8082"),
+    secure = true,
+  )
+
+  private sealed trait MetricsOp
+  private object MetricsOp {
+    final case class IncreaseActiveRequests(
+        method: Method,
+        uri: Uri,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class DecreaseActiveRequests(
+        method: Method,
+        uri: Uri,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class RecordHeadersTime(
+        method: Method,
+        uri: Uri,
+        elapsed: FiniteDuration,
+        protocol: NetworkProtocol = protocol,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class RecordTotalTime(
+        method: Method,
+        uri: Uri,
+        status: Option[Status],
+        elapsed: FiniteDuration,
+        terminationType: Option[TerminationType] = None,
+        protocol: NetworkProtocol = protocol,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class RecordRequestBodySize(
+        method: Method,
+        uri: Uri,
+        status: Option[Status],
+        contentLength: Option[Long],
+        terminationType: Option[TerminationType] = None,
+        protocol: NetworkProtocol = protocol,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class RecordResponseBodySize(
+        method: Method,
+        uri: Uri,
+        status: Option[Status],
+        contentLength: Option[Long],
+        terminationType: Option[TerminationType] = None,
+        protocol: NetworkProtocol = protocol,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+  }
+
+  private sealed trait Payload extends Product with Serializable
+  private object Payload {
+    final case class Empty(responseDelay: FiniteDuration) extends Payload
+
+    final case class Stream(
+        content: String,
+        perChunkDelay: FiniteDuration,
+    ) extends Payload {
+      def stream: fs2.Stream[IO, Byte] =
+        fs2.Stream
+          .emits(content.getBytes)
+          .covary[IO]
+          .zipLeft(fs2.Stream.fixedDelay[IO](perChunkDelay))
+
+      def totalDelay: FiniteDuration = content.length * perChunkDelay
+    }
+
+    final case class Strict(
+        content: String,
+        responseDelay: FiniteDuration,
+    ) extends Payload
+  }
+
+}

--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -18,13 +18,10 @@ package org.http4s.metrics
 
 import cats.Foldable
 import cats.~>
-import com.comcast.ip4s.IpAddress
-import com.comcast.ip4s.SocketAddress
-import org.http4s.HttpVersion
-import org.http4s.Method
 import org.http4s.Request
+import org.http4s.RequestPrelude
+import org.http4s.ResponsePrelude
 import org.http4s.Status
-import org.http4s.Uri
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -37,97 +34,40 @@ trait MetricsOps[F[_]] {
 
   /** Increases the count of active requests
     *
-    * {{{
-    * | Name                | Example                    | Requirement level |
-    * |---------------------|----------------------------|-------------------|
-    * | http.request.method | `GET`, `POST`              |     Required      |
-    * | url.scheme          | `http`, `https`            |     Required      |
-    * | server.address      | `example.com`, `10.1.2.80` |     Opt-In        |
-    * | server.port         | `80`, `8080`               |     Opt-In        |
-    * }}}
-    *
-    * @param method the http method of the request
-    * @param uri the URI of the request
-    * @param address the address of the local server
+    * @param request the request
     * @param classifier the classifier to apply
     */
-  def increaseActiveRequests(
-      method: Method,
-      uri: Uri,
-      address: Option[SocketAddress[IpAddress]],
-      classifier: Option[String],
-  ): F[Unit]
+  def increaseActiveRequests(request: RequestPrelude, classifier: Option[String]): F[Unit]
 
   /** Decreases the count of active requests
     *
-    * {{{
-    * | Name                | Example                    | Requirement level |
-    * |---------------------|----------------------------|-------------------|
-    * | http.request.method | `GET`, `POST`              |     Required      |
-    * | url.scheme          | `http`, `https`            |     Required      |
-    * | server.address      | `example.com`, `10.1.2.80` |     Opt-In        |
-    * | server.port         | `80`, `8080`               |     Opt-In        |
-    * }}}
-    *
-    * @param method the http method of the request
-    * @param uri the URI of the request
-    * @param address the address of the local server
+    * @param request the request
     * @param classifier the classifier to apply
     */
-  def decreaseActiveRequests(
-      method: Method,
-      uri: Uri,
-      address: Option[SocketAddress[IpAddress]],
-      classifier: Option[String],
-  ): F[Unit]
+  def decreaseActiveRequests(request: RequestPrelude, classifier: Option[String]): F[Unit]
 
   /** Records the time to receive the response headers
     *
-    * @param method the http method of the request
-    * @param uri the URI of the request
-    * @param protocol the protocol of the request
-    * @param address the address of the local server
+    * @param request the request
     * @param elapsed the headers receiving time
     * @param classifier the classifier to apply
     */
   def recordHeadersTime(
-      method: Method,
-      uri: Uri,
-      protocol: NetworkProtocol,
-      address: Option[SocketAddress[IpAddress]],
+      request: RequestPrelude,
       elapsed: FiniteDuration,
       classifier: Option[String],
   ): F[Unit]
 
   /** Records the time to fully consume the response, including the body
     *
-    * {{{
-    * | Name                      | Example                         | Requirement level                                            |
-    * |---------------------------|---------------------------------|--------------------------------------------------------------|
-    * | http.request.method       | `GET`, `POST`                   | Required                                                     |
-    * | url.scheme                |  `http`, `https`                | Required                                                     |
-    * | error.type                | `java.net.UnknownHostException` | Required If request has ended with an error                  |
-    * | http.response.status_code | `200`, `404`                    | Conditionally Required If and only if one was received/sent. |
-    * | network.protocol.name     |  `http`, `spdy`                 | Conditionally Required                                       |
-    * | network.protocol.version  | `1.0`, `1.1`, `2`, `3`          | Recommended                                                  |
-    * | server.address            | `example.com`, `10.1.2.80`      | Opt-In                                                       |
-    * | server.port               | `80`, `8080`                    | Opt-In                                                       |
-    * }}}
-    *
-    * @param method the http method of the request
-    * @param uri the URI of the request
-    * @param protocol the protocol of the request
-    * @param address the address of the local server
+    * @param request the request
     * @param status the status of the response
     * @param terminationType the termination type
     * @param elapsed the processing time
     * @param classifier the classifier to apply
     */
   def recordTotalTime(
-      method: Method,
-      uri: Uri,
-      protocol: NetworkProtocol,
-      address: Option[SocketAddress[IpAddress]],
+      request: RequestPrelude,
       status: Option[Status],
       terminationType: Option[TerminationType],
       elapsed: FiniteDuration,
@@ -136,71 +76,29 @@ trait MetricsOps[F[_]] {
 
   /** Records the size of the request body
     *
-    * {{{
-    * | Name                      | Example                         | Requirement level                                            |
-    * |---------------------------|---------------------------------|--------------------------------------------------------------|
-    * | http.request.method       | `GET`, `POST`                   | Required                                                     |
-    * | url.scheme                |  `http`, `https`                | Required                                                     |
-    * | error.type                | `java.net.UnknownHostException` | Required If request has ended with an error                  |
-    * | http.response.status_code | `200`, `404`                    | Conditionally Required If and only if one was received/sent. |
-    * | network.protocol.name     |  `http`, `spdy`                 | Conditionally Required                                       |
-    * | network.protocol.version  | `1.0`, `1.1`, `2`, `3`          | Recommended                                                  |
-    * | server.address            | `example.com`, `10.1.2.80`      | Opt-In                                                       |
-    * | server.port               | `80`, `8080`                    | Opt-In                                                       |
-    * }}}
-    *
-    * @param method the http method of the request
-    * @param uri the URI of the request
-    * @param protocol the protocol of the request
-    * @param address the address of the local server
+    * @param request the request
     * @param status the status of the response
     * @param terminationType the termination type
-    * @param contentLength the size of the request body
     * @param classifier the classifier to apply
     */
   def recordRequestBodySize(
-      method: Method,
-      uri: Uri,
-      protocol: NetworkProtocol,
-      address: Option[SocketAddress[IpAddress]],
+      request: RequestPrelude,
       status: Option[Status],
       terminationType: Option[TerminationType],
-      contentLength: Option[Long],
       classifier: Option[String],
   ): F[Unit]
 
   /** Records the size of the response body
     *
-    * {{{
-    * | Name                      | Example                         | Requirement level                                            |
-    * |---------------------------|---------------------------------|--------------------------------------------------------------|
-    * | http.request.method       | `GET`, `POST`                   | Required                                                     |
-    * | url.scheme                |  `http`, `https`                | Required                                                     |
-    * | error.type                | `java.net.UnknownHostException` | Required If request has ended with an error                  |
-    * | http.response.status_code | `200`, `404`                    | Conditionally Required If and only if one was received/sent. |
-    * | network.protocol.name     |  `http`, `spdy`                 | Conditionally Required                                       |
-    * | network.protocol.version  | `1.0`, `1.1`, `2`, `3`          | Recommended                                                  |
-    * | server.address            | `example.com`, `10.1.2.80`      | Opt-In                                                       |
-    * | server.port               | `80`, `8080`                    | Opt-In                                                       |
-    * }}}
-    *
-    * @param method the http method of the request
-    * @param uri the URI of the request
-    * @param protocol the protocol of the request
-    * @param address the address of the local server
-    * @param status the status of the response
+    * @param request the request
+    * @param response the response
     * @param terminationType the termination type
-    * @param contentLength the size of the response body
     * @param classifier the classifier to apply
     */
   def recordResponseBodySize(
-      method: Method,
-      uri: Uri,
-      protocol: NetworkProtocol,
-      address: Option[SocketAddress[IpAddress]],
-      status: Option[Status],
+      request: RequestPrelude,
+      response: ResponsePrelude,
       terminationType: Option[TerminationType],
-      contentLength: Option[Long],
       classifier: Option[String],
   ): F[Unit]
 
@@ -214,89 +112,37 @@ trait MetricsOps[F[_]] {
     val ops = this
     new MetricsOps[G] {
       override def increaseActiveRequests(
-          method: Method,
-          uri: Uri,
-          address: Option[SocketAddress[IpAddress]],
+          request: RequestPrelude,
           classifier: Option[String],
-      ): G[Unit] = fk(ops.increaseActiveRequests(method, uri, address, classifier))
+      ): G[Unit] = fk(ops.increaseActiveRequests(request, classifier))
       override def decreaseActiveRequests(
-          method: Method,
-          uri: Uri,
-          address: Option[SocketAddress[IpAddress]],
+          request: RequestPrelude,
           classifier: Option[String],
-      ): G[Unit] = fk(ops.decreaseActiveRequests(method, uri, address, classifier))
+      ): G[Unit] = fk(ops.decreaseActiveRequests(request, classifier))
       override def recordHeadersTime(
-          method: Method,
-          uri: Uri,
-          protocol: NetworkProtocol,
-          address: Option[SocketAddress[IpAddress]],
+          request: RequestPrelude,
           elapsed: FiniteDuration,
           classifier: Option[String],
-      ): G[Unit] = fk(ops.recordHeadersTime(method, uri, protocol, address, elapsed, classifier))
+      ): G[Unit] = fk(ops.recordHeadersTime(request, elapsed, classifier))
       override def recordTotalTime(
-          method: Method,
-          uri: Uri,
-          protocol: NetworkProtocol,
-          address: Option[SocketAddress[IpAddress]],
+          request: RequestPrelude,
           status: Option[Status],
           terminationType: Option[TerminationType],
           elapsed: FiniteDuration,
           classifier: Option[String],
-      ): G[Unit] = fk(
-        ops.recordTotalTime(
-          method,
-          uri,
-          protocol,
-          address,
-          status,
-          terminationType,
-          elapsed,
-          classifier,
-        )
-      )
+      ): G[Unit] = fk(ops.recordTotalTime(request, status, terminationType, elapsed, classifier))
       override def recordRequestBodySize(
-          method: Method,
-          uri: Uri,
-          protocol: NetworkProtocol,
-          address: Option[SocketAddress[IpAddress]],
+          request: RequestPrelude,
           status: Option[Status],
           terminationType: Option[TerminationType],
-          contentLength: Option[Long],
           classifier: Option[String],
-      ): G[Unit] = fk(
-        ops.recordRequestBodySize(
-          method,
-          uri,
-          protocol,
-          address,
-          status,
-          terminationType,
-          contentLength,
-          classifier,
-        )
-      )
+      ): G[Unit] = fk(ops.recordRequestBodySize(request, status, terminationType, classifier))
       override def recordResponseBodySize(
-          method: Method,
-          uri: Uri,
-          protocol: NetworkProtocol,
-          address: Option[SocketAddress[IpAddress]],
-          status: Option[Status],
+          request: RequestPrelude,
+          response: ResponsePrelude,
           terminationType: Option[TerminationType],
-          contentLength: Option[Long],
           classifier: Option[String],
-      ): G[Unit] =
-        fk(
-          ops.recordResponseBodySize(
-            method,
-            uri,
-            protocol,
-            address,
-            status,
-            terminationType,
-            contentLength,
-            classifier,
-          )
-        )
+      ): G[Unit] = fk(ops.recordResponseBodySize(request, response, terminationType, classifier))
     }
   }
 }
@@ -355,18 +201,6 @@ object MetricsOps {
 
     Some(result)
   }
-}
-
-sealed trait NetworkProtocol {
-  def name: String
-  def version: HttpVersion
-}
-
-object NetworkProtocol {
-  def http(version: HttpVersion): NetworkProtocol =
-    Impl("http", version)
-
-  private final case class Impl(name: String, version: HttpVersion) extends NetworkProtocol
 }
 
 /** Describes the type of abnormal termination */

--- a/docs/docs/server-middleware.md
+++ b/docs/docs/server-middleware.md
@@ -478,28 +478,46 @@ data. Also provided are implementations for [Dropwizard](https://http4s.github.i
 and [Prometheus](https://http4s.github.io/http4s-prometheus-metrics/) metrics.
 
 ```scala mdoc:silent
+import org.http4s._
 import org.http4s.server.middleware.Metrics
 import org.http4s.metrics.{MetricsOps, TerminationType}
 
 val metricsOps = new MetricsOps[IO] {
-  def increaseActiveRequests(classifier: Option[String]): IO[Unit] =
+  def increaseActiveRequests(request: RequestPrelude, classifier: Option[String]): IO[Unit] =
     Console[IO].println("increaseActiveRequests")
 
-  def decreaseActiveRequests(classifier: Option[String]): IO[Unit] = IO.unit
-  def recordHeadersTime(method: Method, elapsed: Long, classifier: Option[String]): IO[Unit] =
-    IO.unit
-  def recordTotalTime(
-    method: Method,
-    status: Status,
-    elapsed: Long,
+  def decreaseActiveRequests(request: RequestPrelude, classifier: Option[String]): IO[Unit] =
+    Console[IO].println("decreaseActiveRequests")
+
+  def recordHeadersTime(
+    request: RequestPrelude, 
+    elapsed: FiniteDuration, 
     classifier: Option[String]
   ): IO[Unit] = IO.unit
 
-  def recordAbnormalTermination(
-    elapsed: Long,
-    terminationType: TerminationType,
+  def recordTotalTime(
+    request: RequestPrelude, 
+    status: Option[Status], 
+    terminationType: Option[TerminationType], 
+    elapsed: FiniteDuration, 
     classifier: Option[String]
-  ): IO[Unit] = Console[IO].println(s"abnormalTermination - $terminationType")
+  ): IO[Unit] = IO.unit
+
+  def recordRequestBodySize(
+    request: RequestPrelude, 
+    status: Option[Status], 
+    terminationType: Option[TerminationType], 
+    classifier: Option[String]
+  ): IO[Unit] =
+    Console[IO].println(s"record request body - $request")
+
+  def recordResponseBodySize(
+    request: RequestPrelude, 
+    response: ResponsePrelude, 
+    terminationType: Option[TerminationType], 
+    classifier: Option[String]
+  ): IO[Unit] =
+    Console[IO].println(s"record response body - $response")
 }
 
 val metricsService = Metrics[IO](metricsOps)(service).orNotFound

--- a/server/shared/src/test/scala/org/http4s/server/middleware/MetricsSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/MetricsSuite.scala
@@ -1,0 +1,477 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.server.middleware
+
+import cats.effect.IO
+import cats.effect.Ref
+import cats.effect.testkit.TestControl
+import cats.syntax.applicative._
+import com.comcast.ip4s._
+import munit.ScalaCheckSuite
+import org.http4s.Http4sSuite
+import org.http4s.HttpRoutes
+import org.http4s.HttpVersion
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.Status
+import org.http4s.Uri
+import org.http4s.dsl.io._
+import org.http4s.metrics.MetricsOps
+import org.http4s.metrics.NetworkProtocol
+import org.http4s.metrics.TerminationType
+import org.http4s.syntax.literals._
+import org.scalacheck.Gen
+import org.scalacheck.effect.PropF
+
+import scala.concurrent.duration._
+
+class MetricsSuite extends Http4sSuite with ScalaCheckSuite {
+  import MetricsSuite._
+
+  private val DelayGen = Gen.posNum[Int].map(_.millis)
+
+  private val PayloadGen = {
+    val empty =
+      for {
+        delay <- DelayGen
+      } yield Payload.Empty(delay)
+
+    val stream =
+      for {
+        content <- Gen.alphaNumStr
+        perChunkDelay <- DelayGen
+      } yield Payload.Stream(content, perChunkDelay)
+
+    val strict =
+      for {
+        content <- Gen.alphaNumStr
+        delay <- DelayGen
+      } yield Payload.Strict(content, delay)
+
+    Gen.oneOf(empty, stream, strict)
+  }
+
+  test("get - 200 ok") {
+    PropF.forAllF(PayloadGen) { server =>
+      val routes = HttpRoutes.of[IO] { case GET -> Root / "ok" =>
+        server match {
+          case Payload.Empty(delay) => Ok().delayBy(delay)
+          case s @ Payload.Stream(_, _) => Ok(s.stream)
+          case Payload.Strict(body, delay) => Ok(body).delayBy(delay)
+        }
+      }
+
+      val request =
+        Request[IO](GET, uri"/ok").withAttribute(Request.Keys.ConnectionInfo, connection)
+
+      val headersTime = server match {
+        case Payload.Stream(_, _) => Duration.Zero
+        case Payload.Empty(delay) => delay
+        case Payload.Strict(_, delay) => delay
+      }
+
+      val totalTime = server match {
+        case s @ Payload.Stream(_, _) => headersTime + s.totalDelay
+        case Payload.Empty(_) => headersTime
+        case Payload.Strict(_, _) => headersTime
+      }
+
+      val responseSize = getResponseSize(server)
+      val status = Status.Ok
+      val expected = Vector(
+        MetricsOp.IncreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordHeadersTime(request.method, request.uri, headersTime),
+        MetricsOp.DecreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordTotalTime(request.method, request.uri, Some(status), totalTime),
+        MetricsOp.RecordRequestBodySize(request.method, request.uri, Some(status), None),
+        MetricsOp.RecordResponseBodySize(request.method, request.uri, Some(status), responseSize),
+      )
+
+      TestControl.executeEmbed {
+        for {
+          metricsOps <- mkMetricsOps
+          r <- Metrics(metricsOps)(routes).orNotFound(request)
+          _ <- r.bodyText.compile.drain
+          ops <- metricsOps.all
+        } yield assertEquals(ops, expected)
+      }
+    }
+  }
+
+  test("post - 200 ok") {
+    PropF.forAllF(PayloadGen, PayloadGen, Gen.oneOf(true, false)) { (client, server, consumeBody) =>
+      val routes = HttpRoutes.of[IO] { case req @ POST -> Root / "ok" =>
+        val response = server match {
+          case Payload.Empty(delay) => Ok().delayBy(delay)
+          case s @ Payload.Stream(_, _) => Ok(s.stream)
+          case Payload.Strict(body, delay) => Ok(body).delayBy(delay)
+        }
+
+        req.bodyText.compile.foldMonoid.whenA(consumeBody) >> response
+      }
+
+      val request = mkPostRequest(client)
+
+      val headersTime = {
+        val ct = client match {
+          case s @ Payload.Stream(_, _) if consumeBody => s.totalDelay
+          case _ => Duration.Zero
+        }
+
+        val st = server match {
+          case Payload.Stream(_, _) => Duration.Zero
+          case Payload.Empty(delay) => delay
+          case Payload.Strict(_, delay) => delay
+        }
+
+        ct + st
+      }
+
+      val totalTime = server match {
+        case s @ Payload.Stream(_, _) => headersTime + s.totalDelay
+        case Payload.Empty(_) => headersTime
+        case Payload.Strict(_, _) => headersTime
+      }
+
+      val requestSize = getRequestSize(client)
+      val responseSize = getResponseSize(server)
+      val status = Status.Ok
+      val expected = Vector(
+        MetricsOp.IncreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordHeadersTime(request.method, request.uri, headersTime),
+        MetricsOp.DecreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordTotalTime(request.method, request.uri, Some(status), totalTime),
+        MetricsOp.RecordRequestBodySize(request.method, request.uri, Some(status), requestSize),
+        MetricsOp.RecordResponseBodySize(request.method, request.uri, Some(status), responseSize),
+      )
+
+      TestControl.executeEmbed {
+        for {
+          metricsOps <- mkMetricsOps
+          r <- Metrics(metricsOps)(routes).orNotFound(request)
+          _ <- r.bodyText.compile.drain
+          ops <- metricsOps.all
+        } yield assertEquals(ops, expected)
+      }
+    }
+  }
+
+  test("post - 500 unhandled error") {
+    PropF.forAllF(PayloadGen, DelayGen, Gen.oneOf(true, false)) { (client, serverDelay, consume) =>
+      val error = new RuntimeException("something went wrong")
+
+      val routes = HttpRoutes.of[IO] { case req @ POST -> Root / "ok" =>
+        req.bodyText.compile.foldMonoid.whenA(consume) >>
+          IO.raiseError(error).delayBy(serverDelay)
+      }
+
+      val request = mkPostRequest(client)
+
+      val headersTime = client match {
+        case s @ Payload.Stream(_, _) if consume => serverDelay + s.totalDelay
+        case _ => serverDelay
+      }
+
+      val totalTime =
+        headersTime
+
+      val requestSize = getRequestSize(client)
+      val status = Status.InternalServerError
+      val tt = TerminationType.Error(error)
+      val expected = Vector(
+        MetricsOp.IncreaseActiveRequests(request.method, request.uri),
+        MetricsOp.DecreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordHeadersTime(request.method, request.uri, headersTime),
+        MetricsOp.RecordTotalTime(request.method, request.uri, Some(status), totalTime, Some(tt)),
+        MetricsOp
+          .RecordRequestBodySize(request.method, request.uri, Some(status), requestSize, Some(tt)),
+        MetricsOp.RecordResponseBodySize(request.method, request.uri, Some(status), None, Some(tt)),
+      )
+
+      TestControl.executeEmbed {
+        for {
+          metricsOps <- mkMetricsOps
+          _ <- Metrics(metricsOps)(routes).orNotFound(request).attempt
+          ops <- metricsOps.all
+        } yield assertEquals(ops, expected)
+      }
+    }
+  }
+
+  test("post - cancelation") {
+    PropF.forAllF(PayloadGen, Gen.oneOf(true, false)) { (client, consume) =>
+      val routes =
+        HttpRoutes.of[IO] { case req @ POST -> Root / "ok" =>
+          req.bodyText.compile.foldMonoid.whenA(consume) >> IO.canceled >> Ok()
+        }
+
+      val request = mkPostRequest(client)
+
+      val headersTime = client match {
+        case s @ Payload.Stream(_, _) if consume => s.totalDelay
+        case _ => Duration.Zero
+      }
+
+      val totalTime =
+        headersTime
+
+      val requestSize = getRequestSize(client)
+      val tt = TerminationType.Canceled
+      val expected = Vector(
+        MetricsOp.IncreaseActiveRequests(request.method, request.uri),
+        MetricsOp.DecreaseActiveRequests(request.method, request.uri),
+        MetricsOp.RecordTotalTime(request.method, request.uri, None, totalTime, Some(tt)),
+        MetricsOp.RecordRequestBodySize(request.method, request.uri, None, requestSize, Some(tt)),
+        MetricsOp.RecordResponseBodySize(request.method, request.uri, None, None, Some(tt)),
+      )
+
+      TestControl.executeEmbed {
+        for {
+          metricsOps <- mkMetricsOps
+          f <- Metrics(metricsOps)(routes).orNotFound(request).void.start
+          _ <- f.joinWithUnit
+          ops <- metricsOps.all
+        } yield assertEquals(ops, expected)
+      }
+    }
+  }
+
+  private def mkPostRequest(payload: Payload): Request[IO] = {
+    val req = Request[IO](POST, uri"/ok").withAttribute(Request.Keys.ConnectionInfo, connection)
+
+    payload match {
+      case Payload.Empty(_) => req
+      case s @ Payload.Stream(_, _) => req.withBodyStream(s.stream)
+      case Payload.Strict(body, _) => req.withEntity(body)
+    }
+  }
+
+  private def getRequestSize(payload: Payload): Option[Long] =
+    payload match {
+      case Payload.Strict(content, _) => Some(content.length.toLong)
+      case Payload.Stream(_, _) => None
+      case Payload.Empty(_) => None
+    }
+
+  private def getResponseSize(payload: Payload): Option[Long] =
+    payload match {
+      case Payload.Strict(content, _) => Some(content.length.toLong)
+      case Payload.Stream(_, _) => None
+      case Payload.Empty(_) => Some(0L)
+    }
+
+  private def mkMetricsOps: IO[InMemoryMetricsOps] =
+    for {
+      ops <- IO.ref(Vector.empty[MetricsOp])
+    } yield new InMemoryMetricsOps(ops)
+
+  private class InMemoryMetricsOps(ops: Ref[IO, Vector[MetricsOp]]) extends MetricsOps[IO] {
+    def all: IO[Vector[MetricsOp]] = ops.get
+
+    private def add(op: MetricsOp): IO[Unit] =
+      ops.update(_ :+ op)
+
+    def increaseActiveRequests(
+        method: Method,
+        uri: Uri,
+        address: Option[SocketAddress[IpAddress]],
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(MetricsOp.IncreaseActiveRequests(method, uri, address, classifier))
+
+    def decreaseActiveRequests(
+        method: Method,
+        uri: Uri,
+        address: Option[SocketAddress[IpAddress]],
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(MetricsOp.DecreaseActiveRequests(method, uri, address, classifier))
+
+    def recordHeadersTime(
+        method: Method,
+        uri: Uri,
+        protocol: NetworkProtocol,
+        address: Option[SocketAddress[IpAddress]],
+        elapsed: FiniteDuration,
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(MetricsOp.RecordHeadersTime(method, uri, elapsed, protocol, address, classifier))
+
+    def recordTotalTime(
+        method: Method,
+        uri: Uri,
+        protocol: NetworkProtocol,
+        address: Option[SocketAddress[IpAddress]],
+        status: Option[Status],
+        terminationType: Option[TerminationType],
+        elapsed: FiniteDuration,
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(
+        MetricsOp.RecordTotalTime(
+          method,
+          uri,
+          status,
+          elapsed,
+          terminationType,
+          protocol,
+          address,
+          classifier,
+        )
+      )
+
+    def recordRequestBodySize(
+        method: Method,
+        uri: Uri,
+        protocol: NetworkProtocol,
+        address: Option[SocketAddress[IpAddress]],
+        status: Option[Status],
+        terminationType: Option[TerminationType],
+        contentLength: Option[Long],
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(
+        MetricsOp.RecordRequestBodySize(
+          method,
+          uri,
+          status,
+          contentLength,
+          terminationType,
+          protocol,
+          address,
+          classifier,
+        )
+      )
+
+    def recordResponseBodySize(
+        method: Method,
+        uri: Uri,
+        protocol: NetworkProtocol,
+        address: Option[SocketAddress[IpAddress]],
+        status: Option[Status],
+        terminationType: Option[TerminationType],
+        contentLength: Option[Long],
+        classifier: Option[String],
+    ): IO[Unit] =
+      add(
+        MetricsOp.RecordResponseBodySize(
+          method,
+          uri,
+          status,
+          contentLength,
+          terminationType,
+          protocol,
+          address,
+          classifier,
+        )
+      )
+  }
+
+}
+
+object MetricsSuite {
+
+  private val protocol = NetworkProtocol.http(HttpVersion.`HTTP/1.1`)
+  private val connection = Request.Connection(
+    local = SocketAddress(ip"127.0.0.1", port"8081"),
+    remote = SocketAddress(ip"127.0.0.1", port"8082"),
+    secure = true,
+  )
+
+  private sealed trait MetricsOp
+  private object MetricsOp {
+    final case class IncreaseActiveRequests(
+        method: Method,
+        uri: Uri,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class DecreaseActiveRequests(
+        method: Method,
+        uri: Uri,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class RecordHeadersTime(
+        method: Method,
+        uri: Uri,
+        elapsed: FiniteDuration,
+        protocol: NetworkProtocol = protocol,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class RecordTotalTime(
+        method: Method,
+        uri: Uri,
+        status: Option[Status],
+        elapsed: FiniteDuration,
+        terminationType: Option[TerminationType] = None,
+        protocol: NetworkProtocol = protocol,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class RecordRequestBodySize(
+        method: Method,
+        uri: Uri,
+        status: Option[Status],
+        contentLength: Option[Long],
+        terminationType: Option[TerminationType] = None,
+        protocol: NetworkProtocol = protocol,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+
+    final case class RecordResponseBodySize(
+        method: Method,
+        uri: Uri,
+        status: Option[Status],
+        contentLength: Option[Long],
+        terminationType: Option[TerminationType] = None,
+        protocol: NetworkProtocol = protocol,
+        address: Option[SocketAddress[IpAddress]] = Some(connection.local),
+        classifier: Option[String] = None,
+    ) extends MetricsOp
+  }
+
+  private sealed trait Payload extends Product with Serializable
+  private object Payload {
+    final case class Empty(responseDelay: FiniteDuration) extends Payload
+
+    final case class Stream(
+        content: String,
+        perChunkDelay: FiniteDuration,
+    ) extends Payload {
+      def stream: fs2.Stream[IO, Byte] =
+        fs2.Stream
+          .emits(content.getBytes)
+          .covary[IO]
+          .zipLeft(fs2.Stream.fixedDelay[IO](perChunkDelay))
+
+      def totalDelay: FiniteDuration = content.length * perChunkDelay
+    }
+
+    final case class Strict(
+        content: String,
+        responseDelay: FiniteDuration,
+    ) extends Payload
+  }
+
+}


### PR DESCRIPTION
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 

Closes #7448.

`PreludeRequest` provides (almost) enough details to fill out all necessary attributes - https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration. 

The only missing piece is `server.address/port` info. 