### PR TITLE
Fix EmptyCustomLabels and SizedSeq0 singleton creation issue

### DIFF
--- a/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
@@ -32,7 +32,7 @@ object CustomLabels {
     }
 }
 
-abstract case class EmptyCustomLabels private () extends CustomLabels[SizedSeq0[String]] {
+abstract sealed case class EmptyCustomLabels private () extends CustomLabels[SizedSeq0[String]] {
   override def labels: SizedSeq0[String] = SizedSeq0[String]()
   override def values: SizedSeq0[String] = SizedSeq0[String]()
 }

--- a/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
@@ -32,7 +32,7 @@ object CustomLabels {
     }
 }
 
-abstract sealed case class EmptyCustomLabels private () extends CustomLabels[SizedSeq0[String]] {
+sealed abstract case class EmptyCustomLabels private () extends CustomLabels[SizedSeq0[String]] {
   override def labels: SizedSeq0[String] = SizedSeq0[String]()
   override def values: SizedSeq0[String] = SizedSeq0[String]()
 }

--- a/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
@@ -32,12 +32,12 @@ object CustomLabels {
     }
 }
 
-final abstract case class EmptyCustomLabels private () extends CustomLabels[SizedSeq0[String]] {
+abstract case class EmptyCustomLabels private () extends CustomLabels[SizedSeq0[String]] {
   override def labels: SizedSeq0[String] = SizedSeq0[String]()
   override def values: SizedSeq0[String] = SizedSeq0[String]()
 }
 
 object EmptyCustomLabels {
-  private[this] val instance = EmptyCustomLabels()
+  private[this] val instance: EmptyCustomLabels = new EmptyCustomLabels() {}
   def apply[A](): EmptyCustomLabels = instance
 }

--- a/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
+++ b/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
@@ -21,7 +21,7 @@ sealed trait SizedSeq[+A] {
 }
 
 // format: off
-abstract case class SizedSeq0[+A] private () extends SizedSeq[A] {
+abstract sealed case class SizedSeq0[+A] private () extends SizedSeq[A] {
   val toSeq: Seq[A] = Seq.empty[A]
 }
 object SizedSeq0 {

--- a/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
+++ b/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
@@ -21,11 +21,11 @@ sealed trait SizedSeq[+A] {
 }
 
 // format: off
-final abstract case class SizedSeq0[+A] private () extends SizedSeq[A] {
+abstract case class SizedSeq0[+A] private () extends SizedSeq[A] {
   val toSeq: Seq[A] = Seq.empty[A]
 }
 object SizedSeq0 {
-  private[this] val instance = SizedSeq0[Nothing]()
+  private[this] val instance: SizedSeq0[Nothing] = new SizedSeq0[Nothing]() {}
   def apply[A](): SizedSeq0[A] = instance
 }
 

--- a/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
+++ b/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
@@ -20,8 +20,7 @@ sealed trait SizedSeq[+A] {
   def toSeq: Seq[A]
 }
 
-// format: off
-abstract sealed case class SizedSeq0[+A] private () extends SizedSeq[A] {
+sealed abstract case class SizedSeq0[+A] private () extends SizedSeq[A] {
   val toSeq: Seq[A] = Seq.empty[A]
 }
 object SizedSeq0 {
@@ -53,6 +52,7 @@ final case class SizedSeq6[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A) extends
   val toSeq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6)
 }
 
+// format: off
 final case class SizedSeq7[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A) extends SizedSeq[A] {
   val toSeq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7)
 }


### PR DESCRIPTION
After consuming the [latest SNAPSHOT](https://s01.oss.sonatype.org/content/repositories/snapshots/org/http4s/http4s-core_2.13/0.23.27-121-b8811f9-SNAPSHOT/) of `http4s` core, this `http4s-prometheus-metrics` [build](https://github.com/http4s/http4s-prometheus-metrics/actions/runs/10725779196/job/29744402752?pr=168) failed:
```
org.http4s.metrics.prometheus.PrometheusServerMetricsSuite:
==> X org.http4s.metrics.prometheus.PrometheusServerMetricsSuite.A http routes with a prometheus metrics middleware should register a 2xx response  0.039s java.lang.NullPointerException: null
    at org.http4s.metrics.prometheus.Prometheus.createMetricsCollection(Prometheus.scala:344)
    at org.http4s.metrics.prometheus.Prometheus.buildCustomMetricsOps(Prometheus.scala:131)
    at org.http4s.metrics.prometheus.Prometheus.build(Prometheus.scala:126)
    at org.http4s.metrics.prometheus.Prometheus$.metricsOps(Prometheus.scala:408)
    at org.http4s.metrics.prometheus.PrometheusServerMetricsSuite.$anonfun$buildMeteredRoutes$1(PrometheusServerMetricsSuite.scala:236)
```
The root cause is that the singleton creation of `EmptyCustomLabels` is calling the `apply()`, which just return the singleton instance, thus it is in infinite loop.

`SizedSeq0` has the same issue.

This PR fixes these two issues by calling constructor explicitly.

