### PR TITLE
Optimise ServerSentEvent decoder

### DIFF
--- a/bench/src/main/scala/org/http4s/bench/ServerSentEventDecoderBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/ServerSentEventDecoderBench.scala
@@ -16,13 +16,12 @@
 
 package org.http4s.bench
 
+import cats.Id
 import fs2.Stream
 import org.http4s.ServerSentEvent
-
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
-import cats.Id
 import ServerSentEventDecoderBench.sampleLine
 
 @State(Scope.Benchmark)
@@ -44,5 +43,6 @@ class ServerSentEventDecoderBench {
 }
 
 object ServerSentEventDecoderBench {
-  val sampleLine = s"data: ${"a" * 100000}\nevent: live\nid: 1727268457046.11\n\n".getBytes()
+  val sampleLine: Array[Byte] =
+    s"data: ${"a" * 100000}\nevent: live\nid: 1727268457046.11\n\n".getBytes()
 }

--- a/bench/src/main/scala/org/http4s/bench/ServerSentEventDecoderBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/ServerSentEventDecoderBench.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.bench
 
 import fs2.Stream

--- a/bench/src/main/scala/org/http4s/bench/ServerSentEventDecoderBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/ServerSentEventDecoderBench.scala
@@ -1,0 +1,31 @@
+package org.http4s.bench
+
+import fs2.Stream
+import org.http4s.ServerSentEvent
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import cats.Id
+import ServerSentEventDecoderBench.sampleLine
+
+@State(Scope.Benchmark)
+class ServerSentEventDecoderBench {
+
+  final val LINES = 1000
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OperationsPerInvocation(LINES)
+  def serverSentEventDecoder(bh: Blackhole): Unit = {
+    val input = Stream.repeatEval[Id, Array[Byte]](sampleLine).take(LINES).flatMap(s => Stream.emits(s))
+    val ret = ServerSentEvent.decoder[Id](input).compile.count
+    assert(ret == LINES + 1)
+    bh.consume(ret)
+  }
+
+}
+
+object ServerSentEventDecoderBench {
+  val sampleLine = s"data: ${"a" * 100000}\nevent: live\nid: 1727268457046.11\n\n".getBytes()
+}

--- a/bench/src/main/scala/org/http4s/bench/ServerSentEventDecoderBench.scala
+++ b/bench/src/main/scala/org/http4s/bench/ServerSentEventDecoderBench.scala
@@ -18,7 +18,8 @@ class ServerSentEventDecoderBench {
   @BenchmarkMode(Array(Mode.Throughput))
   @OperationsPerInvocation(LINES)
   def serverSentEventDecoder(bh: Blackhole): Unit = {
-    val input = Stream.repeatEval[Id, Array[Byte]](sampleLine).take(LINES).flatMap(s => Stream.emits(s))
+    val input =
+      Stream.repeatEval[Id, Array[Byte]](sampleLine).take(LINES).flatMap(s => Stream.emits(s))
     val ret = ServerSentEvent.decoder[Id](input).compile.count
     assert(ret == LINES + 1)
     bh.consume(ret)

--- a/core/shared/src/main/scala/org/http4s/ServerSentEvent.scala
+++ b/core/shared/src/main/scala/org/http4s/ServerSentEvent.scala
@@ -100,8 +100,7 @@ object ServerSentEvent {
           if (s.startsWith("data:")) {
             go(dataBuffer.append(dropPrefix(s, 5)), eventType, id, retry, commentBuffer, stream)
           } else if (s.startsWith("id:")) {
-            val newId = EventId(dropPrefix(s, 3))
-            go(dataBuffer, eventType, Some(newId), retry, commentBuffer, stream)
+            go(dataBuffer, eventType, Some(EventId(dropPrefix(s, 3))), retry, commentBuffer, stream)
           } else if (s.startsWith("event:")) {
             go(dataBuffer, Some(dropPrefix(s, 6)), id, retry, commentBuffer, stream)
           } else if (s.startsWith("retry:")) {
@@ -109,9 +108,14 @@ object ServerSentEvent {
             go(dataBuffer, eventType, id, newRetry, commentBuffer, stream)
           } else if (s.startsWith(":")) {
             go(dataBuffer, eventType, id, retry, commentBuffer.append(dropPrefix(s, 1)), stream)
-          } else {
-            go(dataBuffer, eventType, id, retry, commentBuffer, stream)
-          }
+          } else
+            s match {
+              case "data" => go(dataBuffer.append(""), eventType, id, retry, commentBuffer, stream)
+              case "id" =>
+                go(dataBuffer, eventType, Some(EventId("")), retry, commentBuffer, stream)
+              case "event" => go(dataBuffer, Some(""), id, retry, commentBuffer, stream)
+              case _ => go(dataBuffer, eventType, id, retry, commentBuffer, stream)
+            }
       }
     }
 

--- a/core/shared/src/main/scala/org/http4s/ServerSentEvent.scala
+++ b/core/shared/src/main/scala/org/http4s/ServerSentEvent.scala
@@ -24,7 +24,6 @@ import org.http4s.util.Renderable
 import org.http4s.util.Writer
 
 import java.util.concurrent.TimeUnit
-import java.util.regex.Pattern
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
@@ -61,20 +60,16 @@ object ServerSentEvent {
     val reset: EventId = EventId("")
   }
 
-  // Pattern instead of Regex, because Regex doesn't have split with limit. :(
-  private val FieldSeparator =
-    Pattern.compile(""": ?""")
-
   def decoder[F[_]]: Pipe[F, Byte, ServerSentEvent] = {
     case class LineBuffer(lines: Chain[String] = Chain.empty) {
       def append(line: String): LineBuffer =
-        // val scrubbed = if (line.endsWith("\n")) line.dropRight(1) else line
         copy(lines = lines :+ line)
       def reify: Option[String] =
-        if (lines.nonEmpty) {
-          Some(lines.iterator.mkString("\n"))
-        } else
-          None
+        lines.sizeCompare(1) match {
+          case c if c < 0 => None
+          case 0 => lines.headOption
+          case _ => Some(lines.iterator.mkString("\n"))
+        }
     }
     val emptyBuffer = LineBuffer()
     def go(
@@ -85,7 +80,6 @@ object ServerSentEvent {
         commentBuffer: LineBuffer,
         stream: Stream[F, String],
     ): Pull[F, ServerSentEvent, Unit] = {
-      //      def dispatch(h: Handle[F, String]): Pull[F, ServerSentEvent, Nothing] =
       def dispatch(stream: Stream[F, String]): Pull[F, ServerSentEvent, Unit] = {
         val sse = ServerSentEvent(
           dataBuffer.reify,
@@ -97,39 +91,26 @@ object ServerSentEvent {
         Pull.output1(sse) >> go(emptyBuffer, None, None, None, emptyBuffer, stream)
       }
 
-      def handleLine(
-          field: String,
-          value: String,
-          stream: Stream[F, String],
-      ): Pull[F, ServerSentEvent, Unit] =
-        field match {
-          case "" =>
-            go(dataBuffer, eventType, id, retry, commentBuffer.append(value), stream)
-          case "event" =>
-            go(dataBuffer, Some(value), id, retry, commentBuffer, stream)
-          case "data" =>
-            go(dataBuffer.append(value), eventType, id, retry, commentBuffer, stream)
-          case "id" =>
-            val newId = EventId(value)
-            go(dataBuffer, eventType, Some(newId), retry, commentBuffer, stream)
-          case "retry" =>
-            val newRetry = Try(value.toLong).toOption.orElse(retry)
-            go(dataBuffer, eventType, id, newRetry, commentBuffer, stream)
-          case _ =>
-            go(dataBuffer, eventType, id, retry, commentBuffer, stream)
-        }
-
       stream.pull.uncons1.flatMap {
         case None =>
           Pull.done
         case Some(("", stream)) =>
           dispatch(stream)
         case Some((s, stream)) =>
-          (FieldSeparator.split(s, 2): @unchecked) match {
-            case Array(field, value) =>
-              handleLine(field, value, stream)
-            case Array(line) =>
-              handleLine(line, "", stream)
+          if (s.startsWith("data:")) {
+            go(dataBuffer.append(dropPrefix(s, 5)), eventType, id, retry, commentBuffer, stream)
+          } else if (s.startsWith("id:")) {
+            val newId = EventId(dropPrefix(s, 3))
+            go(dataBuffer, eventType, Some(newId), retry, commentBuffer, stream)
+          } else if (s.startsWith("event:")) {
+            go(dataBuffer, Some(dropPrefix(s, 6)), id, retry, commentBuffer, stream)
+          } else if (s.startsWith("retry:")) {
+            val newRetry = Try(dropPrefix(s, 6).toLong).toOption.orElse(retry)
+            go(dataBuffer, eventType, id, newRetry, commentBuffer, stream)
+          } else if (s.startsWith(":")) {
+            go(dataBuffer, eventType, id, retry, commentBuffer.append(dropPrefix(s, 1)), stream)
+          } else {
+            go(dataBuffer, eventType, id, retry, commentBuffer, stream)
           }
       }
     }
@@ -143,6 +124,15 @@ object ServerSentEvent {
         emptyBuffer,
         stream.through(utf8.decode.andThen(text.lines)),
       ).stream
+  }
+
+  @inline private def dropPrefix(s: String, n: Int): String = {
+    val l = s.length
+    if (l > n && s(n) == ' ') {
+      s.slice(n + 1, l)
+    } else {
+      s.slice(n, l)
+    }
   }
 
   def encoder[F[_]]: Pipe[F, ServerSentEvent, Byte] =


### PR DESCRIPTION
Avoid using Java's regular expressions where they can be avoided.

Together with https://github.com/typelevel/fs2/pull/3481 this change improves decoding SSE messages with large data (100k bytes) by 8 times..

This change, standalone, improves perf by ~2 times:

before:
```
[info] ServerSentEventDecoderBench.serverSentEventDecoder  thrpt    3  2735.010 ± 46.708  ops/s
```

after:
```
[info] ServerSentEventDecoderBench.serverSentEventDecoder  thrpt    3  5218.262 ± 284.282  ops/s
```