### PR TITLE
Fix for Uri macro with `org` variable

### DIFF
--- a/core/shared/src/main/scala-2/org/http4s/LiteralSyntaxMacros.scala
+++ b/core/shared/src/main/scala-2/org/http4s/LiteralSyntaxMacros.scala
@@ -24,7 +24,7 @@ object LiteralSyntaxMacros {
     def validate(c: Context)(s: String): Either[String, c.Expr[Uri]] = {
       import c.universe._
       Uri.fromString(s) match {
-        case Right(_) => Right(c.Expr(q"org.http4s.Uri.unsafeFromString($s)"))
+        case Right(_) => Right(c.Expr(q"_root_.org.http4s.Uri.unsafeFromString($s)"))
         case Left(parseError) => Left(s"invalid URI: ${parseError.details}")
       }
     }
@@ -34,7 +34,7 @@ object LiteralSyntaxMacros {
   object path extends Literally[Uri.Path] {
     def validate(c: Context)(s: String): Either[String, c.Expr[Uri.Path]] = {
       import c.universe._
-      Right(c.Expr(q"org.http4s.Uri.Path.unsafeFromString($s)"))
+      Right(c.Expr(q"_root_.org.http4s.Uri.Path.unsafeFromString($s)"))
     }
     def make(c: Context)(args: c.Expr[Any]*): c.Expr[Uri.Path] = apply(c)(args: _*)
   }
@@ -43,7 +43,7 @@ object LiteralSyntaxMacros {
     def validate(c: Context)(s: String): Either[String, c.Expr[Uri.Scheme]] = {
       import c.universe._
       Uri.Scheme.fromString(s) match {
-        case Right(_) => Right(c.Expr(q"org.http4s.Uri.Scheme.unsafeFromString($s)"))
+        case Right(_) => Right(c.Expr(q"_root_.org.http4s.Uri.Scheme.unsafeFromString($s)"))
         case Left(pf) => Left(s"invalid Scheme: ${pf.details}")
       }
     }
@@ -54,7 +54,7 @@ object LiteralSyntaxMacros {
     def validate(c: Context)(s: String): Either[String, c.Expr[MediaType]] = {
       import c.universe._
       MediaType.parse(s) match {
-        case Right(_) => Right(c.Expr(q"org.http4s.MediaType.unsafeParse($s)"))
+        case Right(_) => Right(c.Expr(q"_root_.org.http4s.MediaType.unsafeParse($s)"))
         case Left(pf) => Left(s"invalid MediaType: ${pf.details}")
       }
     }
@@ -65,7 +65,7 @@ object LiteralSyntaxMacros {
     def validate(c: Context)(s: String): Either[String, c.Expr[QValue]] = {
       import c.universe._
       QValue.fromString(s) match {
-        case Right(_) => Right(c.Expr(q"org.http4s.QValue.unsafeFromString($s)"))
+        case Right(_) => Right(c.Expr(q"_root_.org.http4s.QValue.unsafeFromString($s)"))
         case Left(pf) => Left(s"invalid QValue: ${pf.details}")
       }
     }

--- a/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
@@ -26,6 +26,11 @@ class LiteralSyntaxMacrosSuite extends Http4sSuite {
     val org = "blerf"
     assertEquals(uri"org" / org, Uri.fromString("org/blerf").toOption.get)
   }
+
+  test("'uri' macro works with implicit variable named 'org' in scope") {
+    implicit val org = "the-problem"
+    assertEquals(uri"example", uri"example")
+  }
   test("invalid uri won't compile") {
     assert(
       compileErrors {

--- a/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
@@ -30,7 +30,7 @@ class LiteralSyntaxMacrosSuite extends Http4sSuite {
   }
   test("'uri' macro works with implicit variable named 'org' in scope") {
     @nowarn implicit val org = "the-problem"
-    assertEquals(uri"example", uri"example")
+    assertEquals(uri"example", Uri.fromString("example").toOption.get)
   }
   test("invalid uri won't compile") {
     assert(

--- a/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
@@ -18,6 +18,8 @@ package org.http4s
 
 import org.http4s.implicits._
 
+import scala.annotation.nowarn
+
 class LiteralSyntaxMacrosSuite extends Http4sSuite {
   test("'uri' macro works for valid input") {
     assertEquals(uri"a.b.c", Uri.fromString("a.b.c").toOption.get)
@@ -26,9 +28,8 @@ class LiteralSyntaxMacrosSuite extends Http4sSuite {
     val org = "blerf"
     assertEquals(uri"org" / org, Uri.fromString("org/blerf").toOption.get)
   }
-
   test("'uri' macro works with implicit variable named 'org' in scope") {
-    implicit val org = "the-problem"
+    @nowarn implicit val org = "the-problem"
     assertEquals(uri"example", uri"example")
   }
   test("invalid uri won't compile") {

--- a/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/LiteralSyntaxMacrosSuite.scala
@@ -22,6 +22,10 @@ class LiteralSyntaxMacrosSuite extends Http4sSuite {
   test("'uri' macro works for valid input") {
     assertEquals(uri"a.b.c", Uri.fromString("a.b.c").toOption.get)
   }
+  test("'uri' macro works with variable named 'org'") {
+    val org = "blerf"
+    assertEquals(uri"org" / org, Uri.fromString("org/blerf").toOption.get)
+  }
   test("invalid uri won't compile") {
     assert(
       compileErrors {


### PR DESCRIPTION
without the `_root_` in the uri macro, the added test fails to compile with `error: value http4s is not a member of String`

This issue was originally fixed in #741, but in the intervening years + refactors the `_root_` qualifier was dropped. I'm just re-adding it, and I'm adding it to all the literal macros just to be safe. 

fixes #704 