### PR TITLE
Fix/i7538 end stream by trailers cause client to hang

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -237,7 +237,7 @@ private[h2] class H2Stream[F[_]: Concurrent](
                            else Applicative[F].unit)
                       case None =>
                         logger.error("Headers Unable to be parsed") >>
-                          {rstStream(H2Error.ProtocolError)}
+                          rstStream(H2Error.ProtocolError)
                     }
                   case _ =>
                     if (headers.endStream) s.readBuffer.close *> s.trailWith(h.toList).void

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -237,9 +237,11 @@ private[h2] class H2Stream[F[_]: Concurrent](
                            else Applicative[F].unit)
                       case None =>
                         logger.error("Headers Unable to be parsed") >>
-                          rstStream(H2Error.ProtocolError)
+                          {rstStream(H2Error.ProtocolError)}
                     }
-                  case _ => s.trailWith(h.toList).void
+                  case _ =>
+                    if (headers.endStream) s.readBuffer.close *> s.trailWith(h.toList).void
+                    else s.trailWith(h.toList).void
                 }
               case H2Connection.ConnectionType.Server =>
                 request.tryGet.flatMap {

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
@@ -16,6 +16,7 @@
 
 package org.http4s.ember.core.h2
 
+import cats.data.NonEmptyList
 import cats.effect.Deferred
 import cats.effect.IO
 import cats.effect.Ref
@@ -31,7 +32,6 @@ import org.http4s.Response
 import org.http4s.Status
 import org.typelevel.log4cats
 import scodec.bits.ByteVector
-import cats.data.NonEmptyList
 
 class H2StreamSuite extends Http4sSuite {
   val defaultSettings = H2Frame.Settings.ConnectionSettings.default

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
@@ -148,7 +148,7 @@ class H2StreamSuite extends Http4sSuite {
   }
 
   test(
-    "streaming response with trailers hangs on client side if endStream is indicated by headers"
+    "client should not hang when endStream is sent by H2Frame.Headers as trailers"
   ) {
     for {
       stream <- clientStream(defaultSettings)

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
@@ -31,6 +31,7 @@ import org.http4s.Response
 import org.http4s.Status
 import org.typelevel.log4cats
 import scodec.bits.ByteVector
+import cats.data.NonEmptyList
 
 class H2StreamSuite extends Http4sSuite {
   val defaultSettings = H2Frame.Settings.ConnectionSettings.default
@@ -75,6 +76,46 @@ class H2StreamSuite extends Http4sSuite {
       )
     } yield (stream, outgoing)
 
+  def clientStream(
+      config: H2Frame.Settings.ConnectionSettings
+  ): IO[H2Stream[IO]] =
+    for {
+      writeBlock <- Deferred[IO, Either[Throwable, Unit]]
+      req <- Deferred[IO, Either[Throwable, Request[fs2.Pure]]]
+      resp <- Deferred[IO, Either[Throwable, Response[fs2.Pure]]]
+      trailers <- Deferred[IO, Either[Throwable, Headers]]
+      readBuffer <- Channel.unbounded[IO, Either[Throwable, ByteVector]]
+
+      state <- Ref[IO].of(
+        H2Stream.State[IO](
+          state = H2Stream.StreamState.Open,
+          writeWindow = defaultSettings.initialWindowSize.windowSize,
+          writeBlock = writeBlock,
+          readWindow = config.initialWindowSize.windowSize,
+          request = req,
+          response = resp,
+          trailers = trailers,
+          readBuffer = readBuffer,
+          contentLengthCheck = None,
+        )
+      )
+      hpack <- Hpack.create[IO]
+      logger <- log4cats.noop.NoOpFactory[IO].fromClass(classOf[H2StreamSuite])
+      enqueue <- Queue.unbounded[IO, Chunk[H2Frame]]
+      stream = new H2Stream[IO](
+        1,
+        defaultSettings,
+        H2Connection.ConnectionType.Client,
+        IO.pure(config),
+        state,
+        hpack,
+        enqueue,
+        IO.unit,
+        _ => IO.unit,
+        logger,
+      )
+    } yield stream
+
   private def testMessageSize(
       stream: H2Stream[IO],
       outgoing: Queue[IO, Chunk[H2Frame]],
@@ -103,6 +144,75 @@ class H2StreamSuite extends Http4sSuite {
       (stream, queue) = sq
       _ <- testMessageSize(stream, queue, 0, messageSize = 0, numFrames = 1)
       _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.HalfClosedLocal)
+    } yield ()
+  }
+
+  test(
+    "streaming response with trailers hangs on client side if endStream is indicated by headers"
+  ) {
+    for {
+      stream <- clientStream(defaultSettings)
+      headers <- stream.hpack.encodeHeaders(
+        NonEmptyList.of(
+          (":status", "200", false),
+          (":method", "GET", false),
+        )
+      )
+      init = H2Frame.Headers(
+        0,
+        None,
+        endStream = false,
+        endHeaders = false,
+        headers,
+        None,
+      )
+      headers <- stream.hpack.encodeHeaders(
+        NonEmptyList.of(
+          ("grpc-status", "0", false)
+        )
+      )
+      trailers = H2Frame.Headers(
+        1,
+        None,
+        endStream = true,
+        endHeaders = true,
+        headers,
+        None,
+      )
+
+      source = fs2.Stream.repeatEval(IO(42.toByte)).take(10000).chunkN(100)
+      actual <- Queue.unbounded[IO, Chunk[Byte]]
+
+      _ <- stream.receiveHeaders(init)
+
+      _ <- (
+        // Taken from `sendMessageBody` to emulate messages sent from server.
+        // If there's trailers, it hangs.
+        source.zipWithNext
+          .foreach { case (c, nextChunk) =>
+            val noTrailers = false
+            val isEndStream = nextChunk.isEmpty && noTrailers
+            stream.receiveData(H2Frame.Data(0, c.toByteVector, None, isEndStream)) >>
+              actual.offer(c)
+          }
+          .compile
+          .drain >>
+          // Taken from `sendTrailerHeaders` to emulate trailers headers sent from server.
+          stream
+            .receiveHeaders(trailers)
+      )
+        // `readBody` hangs forever because the inside readBuffer channel won't be closed.
+        // This is because http4s ember client assumes `endStream` to be sent as H2Frame.Data.
+        // However, it differs whether `endStream` is signaled by `H2Frame.Data` or `H2Frame.Headers`
+        // depending on server implementation.
+        .both(stream.readBody.compile.drain)
+      expect <- source.compile.count
+      _ <- assertIO(
+        actual.size,
+        expect.toInt,
+        "expect the client to consume all the elements in the streaming response body before closing",
+      )
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.HalfClosedRemote)
     } yield ()
   }
 


### PR DESCRIPTION
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 

This PR adds minimization and explanation for https://github.com/http4s/http4s/pull/7559

To be short, the client hangs on streaming response with trailers whose `endStream` is sent not by `H2Frame.Data` but by `H2Frame.Headers` as trailers.
It differs whether `endStream` is sent via `H2Frame.Data` or `H2Frame.Headers` depending on server implementation, though ember server signals `endStream` with `H2Frame.Data(endStream = true, ...)`



https://github.com/http4s/http4s-grpc/issues/122
