### PR TITLE
tidy: client stream should start from idle state

### DIFF
--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
@@ -88,7 +88,7 @@ class H2StreamSuite extends Http4sSuite {
 
       state <- Ref[IO].of(
         H2Stream.State[IO](
-          state = H2Stream.StreamState.Open,
+          state = H2Stream.StreamState.Idle,
           writeWindow = defaultSettings.initialWindowSize.windowSize,
           writeBlock = writeBlock,
           readWindow = config.initialWindowSize.windowSize,
@@ -184,7 +184,7 @@ class H2StreamSuite extends Http4sSuite {
       actual <- Queue.unbounded[IO, Chunk[Byte]]
 
       _ <- stream.receiveHeaders(init)
-
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Open)
       _ <- (
         // Taken from `sendMessageBody` to emulate messages sent from server.
         source.zipWithNext


### PR DESCRIPTION
Follow up https://github.com/http4s/http4s/pull/7582

To follow the state transition in
https://httpwg.org/specs/rfc7540.html#StreamStates, client stream should start from idle state.

The original test is not wrong, but new one covers more scenarios for stream state transition, that would prevent bugs from sneaking into codebase in the future.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 