### PR TITLE
Respond with a 413 when raising an `EntityTooLarge` 

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -21,11 +21,28 @@ package middleware
 import cats.ApplicativeThrow
 import cats.data.Kleisli
 import fs2._
+import org.http4s.headers.{Connection, `Content-Length`}
 
 import scala.util.control.NoStackTrace
 
 object EntityLimiter {
-  final case class EntityTooLarge(limit: Long) extends Exception with NoStackTrace
+  final case class EntityTooLarge(limit: Long) extends Exception with NoStackTrace { self =>
+    def toMessageFailure: MessageFailure = new MessageFailure {
+      override def message: String = s"Content Too Large [limit=$limit]"
+
+      override def cause: Option[Throwable] = Some(self)
+
+      override def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
+        Response(
+          Status.PayloadTooLarge,
+          httpVersion,
+          Headers(
+            Connection.close,
+            `Content-Length`.zero,
+          ),
+        )
+    }
+  }
 
   val DefaultMaxEntitySize: Long = 2L * 1024L * 1024L // 2 MB default
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -27,22 +27,19 @@ import org.http4s.headers.`Content-Length`
 import scala.util.control.NoStackTrace
 
 object EntityLimiter {
-  final case class EntityTooLarge(limit: Long) extends Exception with NoStackTrace { self =>
-    def toMessageFailure: MessageFailure = new MessageFailure {
-      override def message: String = s"Content Too Large [limit=$limit]"
+  final case class EntityTooLarge(limit: Long) extends MessageFailure with NoStackTrace { self =>
+    override def message: String = s"Content Too Large [limit=$limit]"
 
-      override def cause: Option[Throwable] = Some(self)
+    override def cause: Option[Throwable] = Some(self)
 
-      override def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
-        Response(
-          Status.PayloadTooLarge,
-          httpVersion,
-          Headers(
-            Connection.close,
-            `Content-Length`.zero,
-          ),
-        )
-    }
+    override def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] = Response(
+      Status.PayloadTooLarge,
+      httpVersion,
+      Headers(
+        Connection.close,
+        `Content-Length`.zero,
+      ),
+    )
   }
 
   val DefaultMaxEntitySize: Long = 2L * 1024L * 1024L // 2 MB default

--- a/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/EntityLimiter.scala
@@ -21,7 +21,8 @@ package middleware
 import cats.ApplicativeThrow
 import cats.data.Kleisli
 import fs2._
-import org.http4s.headers.{Connection, `Content-Length`}
+import org.http4s.headers.Connection
+import org.http4s.headers.`Content-Length`
 
 import scala.util.control.NoStackTrace
 

--- a/server/shared/src/main/scala/org/http4s/server/package.scala
+++ b/server/shared/src/main/scala/org/http4s/server/package.scala
@@ -25,7 +25,6 @@ import cats.syntax.all._
 import com.comcast.ip4s
 import org.http4s.headers.Connection
 import org.http4s.headers.`Content-Length`
-import org.http4s.server.middleware.EntityLimiter.EntityTooLarge
 import org.typelevel.vault._
 
 import java.net.InetAddress
@@ -183,41 +182,31 @@ package object server {
 
   def inDefaultServiceErrorHandler[F[_], G[_]](implicit
       F: Monad[F]
-  ): Request[G] => PartialFunction[Throwable, F[Response[G]]] = {
-    val handleMessageFailure =
-      (req: Request[G]) =>
-        (mf: MessageFailure) => {
-          messageFailureLogger
-            .debug(mf)(
-              s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
-                  .getOrElse("<unknown>")}"""
-            )
-            .unsafeRunSync()
-          mf.toHttpResponse[G](req.httpVersion).pure[F]
-        }
-
-    req => {
-      case etl: EntityTooLarge =>
-        handleMessageFailure(req)(etl.toMessageFailure)
-      case mf: MessageFailure =>
-        handleMessageFailure(req)(mf)
-      case NonFatal(t) =>
-        serviceErrorLogger
-          .error(t)(
-            s"""Error servicing request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
-                .getOrElse("<unknown>")}"""
-          )
-          .unsafeRunSync()
-        F.pure(
-          Response(
-            Status.InternalServerError,
-            req.httpVersion,
-            Headers(
-              Connection.close,
-              `Content-Length`.zero,
-            ),
-          )
+  ): Request[G] => PartialFunction[Throwable, F[Response[G]]] = req => {
+    case mf: MessageFailure =>
+      messageFailureLogger
+        .debug(mf)(
+          s"""Message failure handling request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
+              .getOrElse("<unknown>")}"""
         )
-    }
+        .unsafeRunSync()
+      F.pure(mf.toHttpResponse[G](req.httpVersion))
+    case NonFatal(t) =>
+      serviceErrorLogger
+        .error(t)(
+          s"""Error servicing request: ${req.method} ${req.pathInfo} from ${req.remoteAddr
+              .getOrElse("<unknown>")}"""
+        )
+        .unsafeRunSync()
+      F.pure(
+        Response(
+          Status.InternalServerError,
+          req.httpVersion,
+          Headers(
+            Connection.close,
+            `Content-Length`.zero,
+          ),
+        )
+      )
   }
 }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
@@ -24,7 +24,8 @@ import fs2.Stream._
 import fs2._
 import org.http4s.Method._
 import org.http4s.Status._
-import org.http4s.headers.{Connection, `Content-Length`}
+import org.http4s.headers.Connection
+import org.http4s.headers.`Content-Length`
 import org.http4s.server.middleware.EntityLimiter.EntityTooLarge
 import org.http4s.syntax.all._
 

--- a/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/EntityLimiterSuite.scala
@@ -131,10 +131,10 @@ class EntityLimiterSuite extends Http4sSuite {
     }
   }
 
-  test("EntityTooLarge should translate to a 413 response") {
+  test("EntityTooLarge should encode a 413 response") {
     val etl = EntityTooLarge(42)
     val response =
-      etl.toMessageFailure.toHttpResponse(HttpVersion.`HTTP/1.0`)
+      etl.toHttpResponse(HttpVersion.`HTTP/1.0`)
     val expectedResponse =
       Response(
         Status.PayloadTooLarge,


### PR DESCRIPTION
Materializing my suggestions from https://github.com/http4s/http4s/pull/7602#issuecomment-2542072000