### PR TITLE
Change context bounds from LoggerFactory to LoggerFactoryGen

### DIFF
--- a/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
+++ b/circe/src/main/scala/org/http4s/circe/middleware/JsonDebugErrorHandler.scala
@@ -26,19 +26,20 @@ import org.http4s.circe._
 import org.http4s.headers.Connection
 import org.typelevel.ci._
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 
 object JsonDebugErrorHandler {
 
   // Can be parametric on my other PR is merged.
-  def apply[F[_]: Concurrent: LoggerFactory, G[_]](
+  def apply[F[_]: Concurrent: LoggerFactoryGen, G[_]](
       service: Kleisli[F, Request[G], Response[G]],
       redactWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
   ): Kleisli[F, Request[G], Response[G]] = {
-    val serviceErrorLogger = LoggerFactory[F].getLoggerFromName(
+    val serviceErrorLogger = LoggerFactory.getLoggerFromName[F](
       "org.http4s.circe.middleware.jsondebugerrorhandler.service-errors"
     )
 
-    val messageFailureLogger = LoggerFactory[F].getLoggerFromName(
+    val messageFailureLogger = LoggerFactory.getLoggerFromName[F](
       "org.http4s.circe.middleware.jsondebugerrorhandler.message-failures"
     )
 

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Logger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Logger.scala
@@ -21,7 +21,7 @@ package middleware
 import cats.effect._
 import fs2.Stream
 import org.typelevel.ci.CIString
-import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 
 /** Simple Middleware for Logging All Requests and Responses
   */
@@ -29,7 +29,7 @@ object Logger {
   def defaultRedactHeadersWhen(name: CIString): Boolean =
     Headers.SensitiveHeaders.contains(name) || name.toString.toLowerCase.contains("token")
 
-  def apply[F[_]: Concurrent: LoggerFactory](
+  def apply[F[_]: Concurrent: LoggerFactoryGen](
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = defaultRedactHeadersWhen,
@@ -41,7 +41,7 @@ object Logger {
       )
     )
 
-  def logBodyText[F[_]: Concurrent: LoggerFactory](
+  def logBodyText[F[_]: Concurrent: LoggerFactoryGen](
       logHeaders: Boolean,
       logBody: Stream[F, Byte] => Option[F[String]],
       redactHeadersWhen: CIString => Boolean = defaultRedactHeadersWhen,
@@ -61,7 +61,7 @@ object Logger {
     org.http4s.internal.Logger
       .logMessage(message)(logHeaders, logBody, redactHeadersWhen)(log)
 
-  def colored[F[_]: Concurrent: LoggerFactory](
+  def colored[F[_]: Concurrent: LoggerFactoryGen](
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = defaultRedactHeadersWhen,

--- a/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/ResponseLogger.scala
@@ -34,13 +34,13 @@ object ResponseLogger {
   private def defaultLogAction[F[_]: log4cats.Logger](s: String): F[Unit] =
     log4cats.Logger[F].info(s)
 
-  def apply[F[_]: Concurrent: log4cats.LoggerFactory](
+  def apply[F[_]: Concurrent: log4cats.LoggerFactoryGen](
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: Option[String => F[Unit]] = None,
   )(client: Client[F]): Client[F] = {
-    implicit val logger: log4cats.Logger[F] = log4cats.LoggerFactory[F].getLogger
+    implicit val logger: log4cats.Logger[F] = log4cats.LoggerFactory.getLogger[F]
     impl(client, logBody) { response =>
       Logger.logMessage(response)(
         logHeaders,
@@ -50,13 +50,13 @@ object ResponseLogger {
     }
   }
 
-  def logBodyText[F[_]: Concurrent: log4cats.LoggerFactory](
+  def logBodyText[F[_]: Concurrent: log4cats.LoggerFactoryGen](
       logHeaders: Boolean,
       logBody: Stream[F, Byte] => Option[F[String]],
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
       logAction: Option[String => F[Unit]] = None,
   )(client: Client[F]): Client[F] = {
-    implicit val logger: log4cats.Logger[F] = log4cats.LoggerFactory[F].getLogger
+    implicit val logger: log4cats.Logger[F] = log4cats.LoggerFactory.getLogger[F]
     impl(client, logBody = true) { response =>
       InternalLogger.logMessageWithBodyText(response)(
         logHeaders,
@@ -66,12 +66,12 @@ object ResponseLogger {
     }
   }
 
-  def customized[F[_]: Concurrent: log4cats.LoggerFactory](
+  def customized[F[_]: Concurrent: log4cats.LoggerFactoryGen](
       client: Client[F],
       logBody: Boolean = true,
       logAction: Option[String => F[Unit]] = None,
   )(responseToText: Response[F] => F[String]): Client[F] = {
-    implicit val logger: log4cats.Logger[F] = log4cats.LoggerFactory[F].getLogger
+    implicit val logger: log4cats.Logger[F] = log4cats.LoggerFactory.getLogger[F]
     impl(client, logBody) { response =>
       val log = logAction.getOrElse(defaultLogAction[F] _)
       responseToText(response).flatMap(log)
@@ -121,7 +121,7 @@ object ResponseLogger {
       case Status.ServerError => Console.RED
     }
 
-  def colored[F[_]: Concurrent: log4cats.LoggerFactory](
+  def colored[F[_]: Concurrent: log4cats.LoggerFactoryGen](
       logHeaders: Boolean,
       logBody: Boolean,
       redactHeadersWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Retry.scala
@@ -27,6 +27,7 @@ import org.http4s.headers.`Idempotency-Key`
 import org.http4s.headers.`Retry-After`
 import org.typelevel.ci.CIString
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 import org.typelevel.vault.Key
 
 import scala.concurrent.duration._
@@ -44,18 +45,18 @@ object Retry {
     */
   val AttemptCountKey: Key[Int] = Key.newKey[cats.effect.SyncIO, Int].unsafeRunSync()
 
-  def apply[F[_]: LoggerFactory](
+  def apply[F[_]: LoggerFactoryGen](
       policy: RetryPolicy[F],
       redactHeaderWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
   )(client: Client[F])(implicit F: Temporal[F]): Client[F] =
     create[F](policy, redactHeaderWhen)(client)
 
-  def create[F[_]: LoggerFactory](
+  def create[F[_]: LoggerFactoryGen](
       policy: RetryPolicy[F],
       redactHeaderWhen: CIString => Boolean = Headers.SensitiveHeaders.contains,
       logRetries: Boolean = true,
   )(client: Client[F])(implicit F: Temporal[F]): Client[F] = {
-    val logger = LoggerFactory[F].getLogger
+    val logger = LoggerFactory.getLogger[F]
 
     def showRequest(request: Request[F], redactWhen: CIString => Boolean): String = {
       val headers = request.headers.mkString(",", redactWhen)

--- a/core/shared/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/shared/src/main/scala/org/http4s/StaticFile.scala
@@ -35,6 +35,7 @@ import org.http4s.headers._
 import org.http4s.syntax.header._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 import org.typelevel.vault._
 
 import java.io._
@@ -43,7 +44,7 @@ import java.net.URL
 object StaticFile {
   val DefaultBufferSize = 10240
 
-  def fromString[F[_]: Files: MonadThrow: LoggerFactory](
+  def fromString[F[_]: Files: MonadThrow: LoggerFactoryGen](
       url: String,
       req: Option[Request[F]] = None,
   ): OptionT[F, Response[F]] =
@@ -142,20 +143,20 @@ object StaticFile {
           else ""
         )
 
-  def fromPath[F[_]: Files: MonadThrow: LoggerFactory](
+  def fromPath[F[_]: Files: MonadThrow: LoggerFactoryGen](
       f: Path,
       req: Option[Request[F]] = None,
   ): OptionT[F, Response[F]] =
     fromPath(f, DefaultBufferSize, req, calculateETag[F])
 
-  def fromPath[F[_]: Files: MonadThrow: LoggerFactory](
+  def fromPath[F[_]: Files: MonadThrow: LoggerFactoryGen](
       f: Path,
       req: Option[Request[F]],
       etagCalculator: Path => F[String],
   ): OptionT[F, Response[F]] =
     fromPath(f, DefaultBufferSize, req, etagCalculator)
 
-  def fromPath[F[_]: Files: MonadThrow: LoggerFactory](
+  def fromPath[F[_]: Files: MonadThrow: LoggerFactoryGen](
       f: Path,
       buffsize: Int,
       req: Option[Request[F]],
@@ -170,7 +171,7 @@ object StaticFile {
         OptionT.none
       }
 
-  def fromPath[F[_]: Files: LoggerFactory](
+  def fromPath[F[_]: Files: LoggerFactoryGen](
       f: Path,
       start: Long,
       end: Long,
@@ -180,7 +181,7 @@ object StaticFile {
   )(implicit
       F: MonadError[F, Throwable]
   ): OptionT[F, Response[F]] = {
-    implicit val logger: Logger[F] = LoggerFactory[F].getLogger
+    implicit val logger: Logger[F] = LoggerFactory.getLogger[F]
 
     OptionT(for {
       etagCalc <- etagCalculator(f).map(et => ETag(et))

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -38,10 +38,11 @@ import org.http4s.headers.`User-Agent`
 import org.typelevel.keypool._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 
 import scala.concurrent.duration._
 
-final class EmberClientBuilder[F[_]: Async: Network: LoggerFactory] private (
+final class EmberClientBuilder[F[_]: Async: Network: LoggerFactoryGen] private (
     private val tlsContextOpt: Option[TLSContext[F]],
     private val sgOpt: Option[SocketGroup[F]],
     val maxTotal: Int,
@@ -399,14 +400,14 @@ final class EmberClientBuilder[F[_]: Async: Network: LoggerFactory] private (
 
 object EmberClientBuilder {
 
-  def default[F[_]: Async: Network: LoggerFactory] =
+  def default[F[_]: Async: Network: LoggerFactoryGen] =
     new EmberClientBuilder[F](
       tlsContextOpt = None,
       sgOpt = None,
       maxTotal = Defaults.maxTotal,
       maxPerKey = Defaults.maxPerKey,
       idleTimeInPool = Defaults.idleTimeInPool,
-      logger = LoggerFactory[F].getLogger,
+      logger = LoggerFactory.getLogger[F],
       chunkSize = Defaults.chunkSize,
       maxResponseHeaderSize = Defaults.maxResponseHeaderSize,
       idleConnectionTime = Defaults.idleConnectionTime,

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -35,6 +35,7 @@ import org.http4s.ember.server.internal.Shutdown
 import org.http4s.server.Server
 import org.http4s.server.websocket.WebSocketBuilder
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 
 import scala.concurrent.duration._
 
@@ -299,7 +300,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
 }
 
 object EmberServerBuilder {
-  def default[F[_]: Async: Network: LoggerFactory]: EmberServerBuilder[F] =
+  def default[F[_]: Async: Network: LoggerFactoryGen]: EmberServerBuilder[F] =
     new EmberServerBuilder[F](
       host = Host.fromString(Defaults.host),
       port = Port.fromInt(Defaults.port).get,
@@ -316,7 +317,7 @@ object EmberServerBuilder {
       idleTimeout = Defaults.idleTimeout,
       shutdownTimeout = Defaults.shutdownTimeout,
       additionalSocketOptions = Defaults.additionalSocketOptions,
-      logger = LoggerFactory[F].getLogger,
+      logger = LoggerFactory.getLogger[F],
       unixSocketConfig = None,
       enableHttp2 = false,
       requestLineParseErrorHandler = Defaults.requestLineParseErrorHandler,

--- a/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -26,6 +26,7 @@ import org.http4s.headers._
 import org.http4s.syntax.header._
 import org.typelevel.ci._
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 
 import scala.concurrent.duration._
 
@@ -84,7 +85,7 @@ sealed class CORSPolicy(
 ) {
   import CORSPolicy._
 
-  def apply[F[_]: Applicative, G[_]: Applicative: LoggerFactory](
+  def apply[F[_]: Applicative, G[_]: Applicative: LoggerFactoryGen](
       http: Http[F, G]
   ): G[Http[F, G]] = {
     val allowCredentialsHeader =
@@ -280,7 +281,7 @@ sealed class CORSPolicy(
       }
 
     if (allowOrigin == AllowOrigin.All && allowCredentials == AllowCredentials.Allow) {
-      LoggerFactory[G].getLogger
+      LoggerFactory.getLogger[G]
         .warn(
           "CORS disabled due to insecure config prohibited by spec. Call withCredentials(false) to avoid sharing credential-tainted responses with arbitrary origins, or call withAllowOrigin* method to be explicit who you trust with credential-tainted responses."
         )
@@ -289,10 +290,10 @@ sealed class CORSPolicy(
       Kleisli(dispatch).pure[G]
   }
 
-  def httpRoutes[F[_]: Monad: LoggerFactory](httpRoutes: HttpRoutes[F]): F[HttpRoutes[F]] =
+  def httpRoutes[F[_]: Monad: LoggerFactoryGen](httpRoutes: HttpRoutes[F]): F[HttpRoutes[F]] =
     apply(httpRoutes)
 
-  def httpApp[F[_]: Applicative: LoggerFactory](httpApp: HttpApp[F]): F[HttpApp[F]] =
+  def httpApp[F[_]: Applicative: LoggerFactoryGen](httpApp: HttpApp[F]): F[HttpApp[F]] =
     apply(httpApp)
 
   private def copy(

--- a/server/shared/src/main/scala/org/http4s/server/middleware/ErrorHandling.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/ErrorHandling.scala
@@ -17,17 +17,17 @@
 package org.http4s.server
 package middleware
 
-import cats._
+import cats.*
 import cats.data.Kleisli
 import cats.data.OptionT
-import cats.syntax.all._
-import org.http4s._
-import org.http4s.headers._
-import org.typelevel.ci._
-import org.typelevel.log4cats.LoggerFactory
+import cats.syntax.all.*
+import org.http4s.*
+import org.http4s.headers.*
+import org.typelevel.ci.*
+import org.typelevel.log4cats.LoggerFactoryGen
 
 object ErrorHandling {
-  def apply[F[_]: LoggerFactory, G[_]](
+  def apply[F[_]: LoggerFactoryGen, G[_]](
       k: Kleisli[F, Request[G], Response[G]]
   )(implicit F: MonadThrow[F]): Kleisli[F, Request[G], Response[G]] =
     Kleisli { req =>
@@ -41,12 +41,13 @@ object ErrorHandling {
       }
     }
 
-  def httpRoutes[F[_]: MonadThrow: LoggerFactory](httpRoutes: HttpRoutes[F]): HttpRoutes[F] = {
-    implicit val factory: LoggerFactory[OptionT[F, *]] = LoggerFactory[F].mapK(OptionT.liftK)
+  def httpRoutes[F[_]: MonadThrow: LoggerFactoryGen](httpRoutes: HttpRoutes[F]): HttpRoutes[F] = {
+    implicit val factory: LoggerFactoryGen[OptionT[F, *]] =
+      implicitly[LoggerFactoryGen[F]].mapK(OptionT.liftK)
     apply(httpRoutes)
   }
 
-  def httpApp[F[_]: MonadThrow: LoggerFactory](httpApp: HttpApp[F]): HttpApp[F] =
+  def httpApp[F[_]: MonadThrow: LoggerFactoryGen](httpApp: HttpApp[F]): HttpApp[F] =
     apply(httpApp)
 
   object Custom {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -31,13 +31,13 @@ object GZip {
 
   // TODO: It could be possible to look for F.pure type bodies, and change the Content-Length header after
   // TODO      zipping and buffering all the input. Just a thought.
-  def apply[F[_]: Monad: log4cats.LoggerFactory, G[_]: Compression](
+  def apply[F[_]: Monad: log4cats.LoggerFactoryGen, G[_]: Compression](
       http: Http[F, G],
       bufferSize: Int = 32 * 1024,
       level: DeflateParams.Level = DeflateParams.Level.DEFAULT,
       isZippable: Response[G] => Boolean = defaultIsZippable[G](_: Response[G]),
   ): Http[F, G] = {
-    implicit val logger: log4cats.Logger[F] = log4cats.LoggerFactory[F].getLogger
+    implicit val logger: log4cats.Logger[F] = log4cats.LoggerFactory.getLogger[F]
     Kleisli { (req: Request[G]) =>
       req.headers.get[`Accept-Encoding`] match {
         case Some(acceptEncoding) if satisfiedByGzip(acceptEncoding) =>

--- a/server/shared/src/main/scala/org/http4s/server/middleware/package.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/package.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package server
+
+import cats.syntax.functor._
+import cats.Functor
+import cats.~>
+import org.typelevel.log4cats
+import org.typelevel.log4cats.LoggerFactoryGen
+
+package object middleware {
+
+  implicit private[middleware] class LoggerFactoryGenOps[F[_]](private val lf: LoggerFactoryGen[F])
+      extends AnyVal {
+
+    def mapK[G[_]](fk: F ~> G)(implicit F: Functor[F]): LoggerFactoryGen[G] =
+      new LoggerFactoryGen[G] {
+        type LoggerType = log4cats.Logger[G]
+
+        def getLoggerFromName(name: String): LoggerType =
+          lf.getLoggerFromName(name).mapK(fk)
+
+        def fromName(name: String): G[LoggerType] = {
+          val logger = lf.fromName(name).map(_.mapK(fk))
+          fk(logger)
+        }
+      }
+
+  }
+}

--- a/server/shared/src/main/scala/org/http4s/server/package.scala
+++ b/server/shared/src/main/scala/org/http4s/server/package.scala
@@ -27,6 +27,7 @@ import com.comcast.ip4s
 import org.http4s.headers.Connection
 import org.http4s.headers.`Content-Length`
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 import org.typelevel.vault._
 
 import java.net.InetAddress
@@ -151,19 +152,19 @@ package object server {
         }
   }
 
-  private[this] def messageFailureLogger[F[_]: LoggerFactory] =
-    LoggerFactory[F].getLoggerFromName("org.http4s.server.message-failures")
-  private[this] def serviceErrorLogger[F[_]: LoggerFactory] =
-    LoggerFactory[F].getLoggerFromName("org.http4s.server.service-errors")
+  private[this] def messageFailureLogger[F[_]: LoggerFactoryGen] =
+    LoggerFactory.getLoggerFromName[F]("org.http4s.server.message-failures")
+  private[this] def serviceErrorLogger[F[_]: LoggerFactoryGen] =
+    LoggerFactory.getLoggerFromName[F]("org.http4s.server.service-errors")
 
   type ServiceErrorHandler[F[_]] = Request[F] => PartialFunction[Throwable, F[Response[F]]]
 
-  def DefaultServiceErrorHandler[F[_]: LoggerFactory](implicit
+  def DefaultServiceErrorHandler[F[_]: LoggerFactoryGen](implicit
       F: Functor[F]
   ): Request[F] => PartialFunction[Throwable, F[Response[F]]] =
     inDefaultServiceErrorHandler[F, F]
 
-  def inDefaultServiceErrorHandler[F[_]: LoggerFactory, G[_]](implicit
+  def inDefaultServiceErrorHandler[F[_]: LoggerFactoryGen, G[_]](implicit
       F: Functor[F]
   ): Request[G] => PartialFunction[Throwable, F[Response[G]]] =
     req => {

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/MemoryCache.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/MemoryCache.scala
@@ -22,6 +22,7 @@ import cats.effect.Concurrent
 import cats.syntax.apply._
 import cats.syntax.functor._
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 import scodec.bits.ByteVector
 
 import java.util.concurrent.ConcurrentHashMap
@@ -31,8 +32,8 @@ import java.util.concurrent.ConcurrentHashMap
   * This is useful when serving a very limited amount of static content and want
   * to avoid disk access.
   */
-class MemoryCache[F[_]: LoggerFactory] extends CacheStrategy[F] {
-  private[this] val logger = LoggerFactory[F].getLogger
+class MemoryCache[F[_]: LoggerFactoryGen] extends CacheStrategy[F] {
+  private[this] val logger = LoggerFactory.getLogger[F]
   private val cacheMap = new ConcurrentHashMap[Uri.Path, Response[F]]()
 
   override def cache(uriPath: Uri.Path, resp: Response[F])(implicit
@@ -63,5 +64,5 @@ class MemoryCache[F[_]: LoggerFactory] extends CacheStrategy[F] {
 }
 
 object MemoryCache {
-  def apply[F[_]: LoggerFactory](): MemoryCache[F] = new MemoryCache[F]
+  def apply[F[_]: LoggerFactoryGen](): MemoryCache[F] = new MemoryCache[F]
 }

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/ResourceService.scala
@@ -24,6 +24,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import org.http4s.server.middleware.TranslateUri
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 
 import java.io.File
 import java.nio.file.Paths
@@ -41,7 +42,7 @@ import scala.util.control.NoStackTrace
   * @param preferGzipped whether to serve pre-gzipped files (with extension ".gz") if they exist
   * @param classLoader optional classloader for extracting the resources
   */
-class ResourceServiceBuilder[F[_]: LoggerFactory] private (
+class ResourceServiceBuilder[F[_]: LoggerFactoryGen] private (
     basePath: String,
     pathPrefix: String,
     bufferSize: Int,
@@ -49,7 +50,7 @@ class ResourceServiceBuilder[F[_]: LoggerFactory] private (
     preferGzipped: Boolean,
     classLoader: Option[ClassLoader],
 ) {
-  private[this] val logger = LoggerFactory[F].getLogger
+  private[this] val logger = LoggerFactory.getLogger[F]
 
   private def copy(
       basePath: String = basePath,
@@ -130,7 +131,7 @@ class ResourceServiceBuilder[F[_]: LoggerFactory] private (
 }
 
 object ResourceServiceBuilder {
-  def apply[F[_]: LoggerFactory](basePath: String): ResourceServiceBuilder[F] =
+  def apply[F[_]: LoggerFactoryGen](basePath: String): ResourceServiceBuilder[F] =
     new ResourceServiceBuilder[F](
       basePath = basePath,
       pathPrefix = "",

--- a/server/shared/src/main/scala/org/http4s/server/staticcontent/package.scala
+++ b/server/shared/src/main/scala/org/http4s/server/staticcontent/package.scala
@@ -20,7 +20,7 @@ package server
 import cats.effect.kernel.Concurrent
 import fs2.io.file.Files
 import org.http4s.headers.`Accept-Ranges`
-import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.LoggerFactoryGen
 
 /** Helpers for serving static content from http4s
   *
@@ -30,11 +30,11 @@ import org.typelevel.log4cats.LoggerFactory
 package object staticcontent {
 
   /** Make a new [[org.http4s.HttpRoutes]] that serves static files, possibly from the classpath. */
-  def resourceServiceBuilder[F[_]: LoggerFactory](basePath: String): ResourceServiceBuilder[F] =
+  def resourceServiceBuilder[F[_]: LoggerFactoryGen](basePath: String): ResourceServiceBuilder[F] =
     ResourceServiceBuilder[F](basePath)
 
   /** Make a new [[org.http4s.HttpRoutes]] that serves static files. */
-  def fileService[F[_]: Concurrent: Files: LoggerFactory](
+  def fileService[F[_]: Concurrent: Files: LoggerFactoryGen](
       config: FileService.Config[F]
   ): HttpRoutes[F] =
     FileService(config)


### PR DESCRIPTION
This should make it much simpler to implement custom logger-factories as the type of the returned logger is reduced on the core functionalities of a logger:

`log4cats.LoggerFactory` requires to return a `log4cats.SelfAwareStructuredLogger` which implements a bunch of methods from the `log4cats.SelfAwareLogger` and `log4cats.StructuredLogger` traits that (depending on the logging framework one want to adapt to) might not be trivial to implement and are not used in http4s at all.
By changing the contextbound to `log4cats.LoggerFactoryGen`, the required type of the returned logger is reduced to `log4cats.Logger` wich is sufficient for http4s and is much simpler to implement.

(Somewhat related to  #7300 where it was noted that implementing a LoggerFactory for scribe is not as simple as one would expect.)

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 