### PR TITLE
Update `Scala2` and `sbt-http4s-org`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        scala: [2.13.15]
+        scala: [2.13.16]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/project/Http4sPlugin.scala
+++ b/project/Http4sPlugin.scala
@@ -26,7 +26,7 @@ object Http4sPlugin extends AutoPlugin {
 
   override def requires = Http4sOrgPlugin
 
-  val scala_213 = "2.13.15"
+  val scala_213 = "2.13.16"
   val scala_212 = "2.12.20"
   val scala_3 = "3.3.4"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.0")
 addSbtPlugin("com.armanbilge" % "sbt-scala-native-config-brew" % "0.3.0")
 
 libraryDependencySchemes += "com.lihaoyi" %% "geny" % VersionScheme.Always

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ classpathTypes += "maven-plugin"
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.2.5")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("io.github.sbt-doctest" % "sbt-doctest" % "0.11.1")
-addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.17.6")
+addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.17.7")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.0")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")


### PR DESCRIPTION
So, here’s a 'maintenance paradox' — updating scala2 version to 2.13.16 requires `ch.epfl.scala:scalafix-testkit_2.13` to be published for 2.13.16, which version is currently 0.13. However, that scala2 version is supported in 0.14, which comes with the update of `sbt-http4s-org` to 0.17.7. But then, that update requires scala2 to already be at version 2.13.16 (as per the update of `ch.epfl.scala:scalafix-testkit_2.13`).

That's why this is present.