### PR TITLE
Add `H2Connection` helper methods

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -208,9 +208,7 @@ private[ember] class H2Client[F[_]](
       } yield connection
 
     def clearClosed(h2: H2Connection[F]): F[Unit] =
-      Stream
-        .fromQueueUnterminated(h2.closedStreams)
-        .repeat
+      h2.getClosedStreams.repeat
         .foreach(i => if (i % 2 != 0) h2.removeStream(i) else F.unit)
         .compile
         .drain
@@ -237,8 +235,7 @@ private[ember] class H2Client[F[_]](
           .attempt
           .void
 
-      Stream
-        .fromQueueUnterminated(h2.createdStreams)
+      h2.getCreatedStreams
         .parEvalMap(10)(i => if (i % 2 == 0) processStream(i) else F.unit)
         .compile
         .drain

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -289,10 +289,8 @@ private[ember] class H2Client[F[_]](
       )
       // Stream Order Must Be Correct, so we must grab the global lock
       stream <- Resource.make(
-        connection.streamCreateAndHeaders.use(_ =>
-          connection.initiateLocalStream.flatMap(stream =>
-            stream.sendHeaders(PseudoHeaders.requestToHeaders(req), endStream = false).as(stream)
-          )
+        connection.createLocalStream.use(stream =>
+          stream.sendHeaders(PseudoHeaders.requestToHeaders(req), endStream = false).as(stream)
         )
       )(stream => connection.removeStream(stream.id))
       _ <- (stream.sendMessageBody(req) >> stream.sendTrailerHeaders(req)).background

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -247,7 +247,7 @@ private[ember] class H2Client[F[_]](
 
     def processSettings(h2: H2Connection[F]): F[Unit] = {
       val localSetts = H2Frame.Settings.ConnectionSettings.toSettings(localSettings)
-      h2.outgoing.offer(Chunk.singleton(localSetts))
+      h2.sendOutgoingFrame(localSetts)
     }
 
     for {

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -38,7 +38,7 @@ private[h2] class H2Connection[F[_]](
     address: Either[UnixSocketAddress, SocketAddress[Host]],
     connectionType: H2Connection.ConnectionType,
     localSettings: H2Frame.Settings.ConnectionSettings,
-    val mapRef: Ref[F, Map[Int, H2Stream[F]]],
+    mapRef: Ref[F, Map[Int, H2Stream[F]]],
     val state: Ref[F, H2Connection.State[F]], // odd if client, even if server
     val outgoing: cats.effect.std.Queue[F, Chunk[H2Frame]],
     // val outgoingData: cats.effect.std.Queue[F, Frame.Data], // TODO split data rather than backpressuring frames totally
@@ -79,7 +79,7 @@ private[h2] class H2Connection[F[_]](
       goAway,
       logger,
     )
-    _ <- mapRef.update(m => m + (id -> stream))
+    _ <- addStream(id, stream)
   } yield stream
 
   def initiateRemoteStreamById(id: Int): F[H2Stream[F]] = for {
@@ -115,7 +115,7 @@ private[h2] class H2Connection[F[_]](
       goAway,
       logger,
     )
-    _ <- mapRef.update(m => m + (id -> stream))
+    _ <- addStream(id, stream)
     _ <- state.update(s =>
       s.copy(
         highestStream = Math.max(s.highestStream, id),
@@ -168,9 +168,7 @@ private[h2] class H2Connection[F[_]](
       }
     }
     val firstGoAway = chunk.collectFirst { case g: H2Frame.GoAway =>
-      mapRef.get.flatMap { m =>
-        m.values.toList.traverse_(connection => connection.receiveGoAway(g))
-      } >> state.update(s => s.copy(closed = true))
+      foreachStream(_.receiveGoAway(g)) >> state.update(s => s.copy(closed = true))
     }
     firstGoAway.getOrElse(F.unit) >> go(chunk)
   }
@@ -221,7 +219,7 @@ private[h2] class H2Connection[F[_]](
           ) =>
         if (h.identifier == id) {
           state.update(s => s.copy(headersInProgress = None)) >>
-            mapRef.get.map(_.get(id)).flatMap {
+            getStream(id).flatMap {
               case Some(s) =>
                 s.receiveHeaders(h, cs ::: c :: Nil: _*)
               case None =>
@@ -243,7 +241,7 @@ private[h2] class H2Connection[F[_]](
           ) =>
         if (p.promisedStreamId == id) {
           state.update(s => s.copy(headersInProgress = None)) >>
-            mapRef.get.map(_.get(id)).flatMap {
+            getStream(id).flatMap {
               case Some(s) =>
                 s.receivePushPromise(p, cs ::: c :: Nil: _*)
               case None =>
@@ -302,7 +300,7 @@ private[h2] class H2Connection[F[_]](
         } else if (sd.exists(s => s.dependency == i)) {
           goAway(H2Error.ProtocolError)
         } else {
-          mapRef.get.map(_.get(i)).flatMap {
+          getStream(i).flatMap {
             case Some(s) =>
               s.receiveHeaders(h)
             case None =>
@@ -345,7 +343,7 @@ private[h2] class H2Connection[F[_]](
           logger.warn("Header Size too large for frame size - FrameSizeError - Issuing GoAway") >>
             goAway(H2Error.FrameSizeError)
         } else {
-          mapRef.get.map(_.get(i)).flatMap {
+          getStream(i).flatMap {
             case Some(s) =>
               s.receivePushPromise(h)
             case None =>
@@ -394,23 +392,16 @@ private[h2] class H2Connection[F[_]](
           }
           (settings, difference, oldWriteBlock) = t
           _ <- oldWriteBlock.complete(Either.unit)
-          _ <- mapRef.get.flatMap { map =>
-            map.toList.traverse { case (_, stream) =>
-              stream.modifyWriteWindow(difference)
-            }
-          }
+          _ <- foreachStream(_.modifyWriteWindow(difference))
           _ <- outgoing.offer(Chunk.singleton(H2Frame.Settings.Ack))
           _ <- settingsAck.complete(Either.right(settings)).void
-
         } yield ()
       case (H2Frame.Settings(0, true, _), _) => Applicative[F].unit
       case (H2Frame.Settings(_, _, _), _) =>
         logger.warn("Received Settings Not Oriented at Identifier 0 - Issuing goAway") >>
           goAway(H2Error.ProtocolError)
       case (g @ H2Frame.GoAway(0, _, _, _), _) =>
-        mapRef.get.flatMap { m =>
-          m.values.toList.traverse_(connection => connection.receiveGoAway(g))
-        } >> outgoing.offer(Chunk.singleton(H2Frame.Ping.ack))
+        foreachStream(_.receiveGoAway(g)) >> outgoing.offer(Chunk.singleton(H2Frame.Ping.ack))
       case (_: H2Frame.GoAway, _) =>
         goAway(H2Error.ProtocolError)
       case (H2Frame.Ping(0, false, bv), _) =>
@@ -444,7 +435,7 @@ private[h2] class H2Connection[F[_]](
               }
             } yield ()
           case otherwise =>
-            mapRef.get.map(_.get(otherwise)).flatMap {
+            getStream(otherwise).flatMap {
               case Some(s) =>
                 s.receiveWindowUpdate(w)
               case None =>
@@ -461,7 +452,7 @@ private[h2] class H2Connection[F[_]](
           ) >>
             goAway(H2Error.FrameSizeError)
         } else {
-          mapRef.get.map(_.get(i)).flatMap {
+          getStream(i).flatMap {
             case Some(s) =>
               for {
                 st <- state.get
@@ -496,7 +487,7 @@ private[h2] class H2Connection[F[_]](
         }
 
       case (rst @ H2Frame.RstStream(i, _), _) =>
-        mapRef.get.map(_.get(i)).flatMap {
+        getStream(i).flatMap {
           case Some(s) =>
             s.receiveRstStream(rst)
           case None =>
@@ -533,6 +524,21 @@ private[h2] class H2Connection[F[_]](
     }
   }
 
+  // stream map
+
+  def getStream(id: Int): F[Option[H2Stream[F]]] =
+    mapRef.get.map(_.get(id))
+
+  def removeStream(id: Int): F[Unit] =
+    mapRef.update(_ - id)
+
+  private def addStream(id: Int, stream: H2Stream[F]): F[Unit] =
+    mapRef.update(_.updated(id, stream))
+
+  private def foreachStream(f: H2Stream[F] => F[Unit]): F[Unit] =
+    mapRef.get.flatMap { map =>
+      map.valuesIterator.foldLeft(F.unit)((acc, stream) => F.productR(acc)(f(stream)))
+    }
 }
 
 private[h2] object H2Connection {

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -42,9 +42,8 @@ private[h2] class H2Connection[F[_]](
     val state: Ref[F, H2Connection.State[F]], // odd if client, even if server
     outgoing: Queue[F, Chunk[H2Frame]],
     // val outgoingData: Queue[F, Frame.Data], // TODO split data rather than backpressuring frames totally
-
     val createdStreams: cats.effect.std.Queue[F, Int],
-    val closedStreams: cats.effect.std.Queue[F, Int],
+    closedStreams: cats.effect.std.Queue[F, Int],
     hpack: Hpack[F],
     streamCreateAndHeaders: Resource[F, Unit],
     socket: Socket[F],
@@ -515,6 +514,12 @@ private[h2] class H2Connection[F[_]](
 
   def createLocalStream: Resource[F, H2Stream[F]] =
     streamCreateAndHeaders.evalMap(_ => initiateLocalStream)
+
+  // created and closed streams
+
+  def getCreatedStreams: Stream[F, Int] = Stream.fromQueueUnterminated(createdStreams)
+
+  def getClosedStreams: Stream[F, Int] = Stream.fromQueueUnterminated(closedStreams)
 
   // connection state
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -230,13 +230,11 @@ private[ember] object H2Server {
     ): F[Unit] = {
       def fulfillPushPromises(resp: Response[F]): F[Unit] = {
         def sender(req: Request[Pure]): F[(Request[Pure], H2Stream[F])] =
-          h2.streamCreateAndHeaders.use[(Request[Pure], H2Stream[F])](_ =>
-            h2.initiateLocalStream.flatMap { stream =>
-              stream
-                .sendPushPromise(streamIx, PseudoHeaders.requestToHeaders(req))
-                .map(_ => (req, stream))
-            }
-          )
+          h2.createLocalStream.use[(Request[Pure], H2Stream[F])] { stream =>
+            stream
+              .sendPushPromise(streamIx, PseudoHeaders.requestToHeaders(req))
+              .map(_ => (req, stream))
+          }
 
         def sendData(resp: Response[F], stream: H2Stream[F]): F[Unit] =
           resp.body.chunks

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -211,8 +211,7 @@ private[ember] object H2Server {
     } yield connection
 
     def clearClosedStreams(h2: H2Connection[F]): F[Unit] =
-      Stream
-        .fromQueueUnterminated(h2.closedStreams)
+      h2.getClosedStreams
         .map(i =>
           Stream.eval(
             // Max Time After Close We Will Still Accept Messages
@@ -278,8 +277,7 @@ private[ember] object H2Server {
     }
 
     def processCreatedStreams(h2: H2Connection[F]): F[Unit] =
-      Stream
-        .fromQueueUnterminated(h2.createdStreams)
+      h2.getCreatedStreams
         .parEvalMapUnordered(localSettings.maxConcurrentStreams.maxConcurrency)(i =>
           processCreatedStream(h2, i)
             .handleErrorWith(e => logger.error(e)(s"Error while processing stream"))

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -295,7 +295,7 @@ private[ember] object H2Server {
     for {
       h2 <- Resource.eval(initH2Connection)
       _ <- h2.writeLoop.compile.drain.background
-      _ <- Resource.eval(h2.outgoing.offer(Chunk.singleton(settingsFrame)))
+      _ <- Resource.eval(h2.sendOutgoingFrame(settingsFrame))
       _ <- h2.readLoop.background
       // h2c Initial Request Communication on h2c Upgrade
       _ <- Resource.eval(

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -41,7 +41,7 @@ private[h2] class H2Stream[F[_]: Concurrent](
     val remoteSettings: F[H2Frame.Settings.ConnectionSettings],
     val state: Ref[F, H2Stream.State[F]],
     val hpack: Hpack[F],
-    val enqueue: cats.effect.std.Queue[F, Chunk[H2Frame]],
+    enqueue: cats.effect.std.QueueSink[F, Chunk[H2Frame]],
     val onClosed: F[Unit],
     val goAway: H2Error => F[Unit],
     private[this] val logger: Logger[F],


### PR DESCRIPTION
Refactor changes are somewhat controversial, so I am not sure they are appreciated (especially in projects with work in multiple branches. So feel free to reject this PR or suggest I should target a different branch.

I was looking a bit at the HTTP2 support of ember and a lot of the internals of the different classes are shared in the `h2` package, which makes it difficult to see how things fit together (at least it did for me).

This PR adds some helper methods to `H2Connection` that:
- make things a bit easier to read (I think)
- allow us to hide most of the `H2Connection` fields (by making `H2Client` and `H2Server` use those methods)

I created separate commits for methods for the same field or state. Reviewing the commits individually may be easier than looking at the full diff.

(I have another [change to refactor `readLoop`](https://github.com/peterneyens/http4s/compare/h2connection-helper...h2connection-read-loop) that I can PR next, which is mainly what I wanted to improve, but separating these changes would make it easier to review that change.)