### PR TITLE
Write multiple frames together in `H2Connection`s `writeLoop`

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -193,8 +193,11 @@ private[h2] class H2Connection[F[_]](
   }
 
   def writeLoop: Stream[F, Nothing] =
+    // use optimized `fromQueueUnterminated`, but still pass combined chunk to `writeChunk`
     Stream
       .fromQueueUnterminated[F, Chunk[H2Frame]](outgoing, Int.MaxValue)
+      .chunks
+      .map(_.flatten)
       .foreach(writeChunk)
       .handleErrorWith(ex => Stream.exec(logger.debug(ex)("writeLoop terminated")))
 


### PR DESCRIPTION
This is a follow up of https://github.com/http4s/http4s/pull/7230.

We changed to a more performant way to turn the outgoing frames `Queue` into a `Stream`, but since we only publish frames as singleton chunks (at least at the moment if I didn't overlook an `offer` without a `Chunk.singleton`), we are writing frames one by one, while before multiple frames could be written to the socket together.