### PR TITLE
Add Timing-Allow-Origin header

### DIFF
--- a/core/shared/src/main/scala/org/http4s/headers/`Timing-Allow-Origin`.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/`Timing-Allow-Origin`.scala
@@ -18,32 +18,65 @@ package org.http4s.headers
 
 import cats.Semigroup
 import cats.data.NonEmptyList
+import cats.syntax.all.*
 import org.http4s.Header
 import org.http4s.ParseResult
 import org.http4s.internal.parsing.CommonRules
-import org.typelevel.ci._
+import org.typelevel.ci.*
+
+
+sealed trait `Timing-Allow-Origin`
+case object TimingAllowAllOrigins extends `Timing-Allow-Origin`
+final case class TimingAllowSelectedOrigins(head: CIString, tail: CIString*) extends `Timing-Allow-Origin`
+
+
 
 object `Timing-Allow-Origin` {
-  def apply(head: CIString, tail: CIString*): `Timing-Allow-Origin` =
-    apply(NonEmptyList(head, tail.toList))
+  def apply(headers: Option[NonEmptyList[CIString]]): `Timing-Allow-Origin` = headers match {
+    case Some(headers)  => TimingAllowSelectedOrigins(headers.head, headers.tail)
+    case _              => TimingAllowAllOrigins
+  }
+
+
+  private def fromString(s: String) = if (s == "*")
+                                Option.empty
+                              else Option(CIString(s))
+
+  private def fromNel(nel: NonEmptyList[Option[CIString]]) =
+    if (nel.toList.contains(Option.empty)) {
+      if (nel.size == 1)
+        ParseResult.success(TimingAllowAllOrigins)
+      else
+        ParseResult.fail(
+          "Invalid origin value",
+          s"Timing-Allow-Origin must contain either a '*' or a non-empty list of allowed origins"
+        )
+    } else ParseResult.success(
+      apply(nel.sequence)
+    )
 
   private[http4s] def parse(s: String): ParseResult[`Timing-Allow-Origin`] =
-    ParseResult.fromParser(parser, "Invalid Timing-Allow-Origin headers")(s)
+    ParseResult.fromParser(parser, "Invalid Timing-Allow-Origin headers")(s).flatten
 
   private[http4s] val parser =
     CommonRules
-      .headerRep1(CommonRules.token.map(CIString(_)))
-      .map(`Timing-Allow-Origin`(_))
+      .headerRep1(CommonRules.token.map(fromString))
+      .map(fromNel)
 
   implicit val headerInstance: Header[`Timing-Allow-Origin`, Header.Recurring] =
     Header.createRendered(
       ci"Timing-Allow-Origin",
-      _.values,
+      {
+        case TimingAllowAllOrigins => List.empty
+        case TimingAllowSelectedOrigins(origin, origins*) => origin :: origins.toList
+      },
       parse,
     )
 
   implicit val timingAllowOriginSemigroup: Semigroup[`Timing-Allow-Origin`] =
-    (a, b) => `Timing-Allow-Origin`(a.values.concatNel(b.values))
+    (a, b) => (a, b) match {
+      case (TimingAllowAllOrigins, _) | (_, TimingAllowAllOrigins) => TimingAllowAllOrigins
+      case (TimingAllowSelectedOrigins(origin1, origins1*), TimingAllowSelectedOrigins(origin2, origins2*)) =>
+        TimingAllowSelectedOrigins(origin1, (origin2 :: origins1.toList) ::: origins2.toList)
+    }
 }
-
-final case class `Timing-Allow-Origin`(values: NonEmptyList[CIString])

--- a/core/shared/src/main/scala/org/http4s/headers/`Timing-Allow-Origin`.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/`Timing-Allow-Origin`.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.headers
+
+import cats.Semigroup
+import cats.data.NonEmptyList
+import org.http4s.Header
+import org.http4s.ParseResult
+import org.http4s.internal.parsing.CommonRules
+import org.typelevel.ci._
+
+object `Timing-Allow-Origin` {
+  def apply(head: CIString, tail: CIString*): `Timing-Allow-Origin` =
+    apply(NonEmptyList(head, tail.toList))
+
+  private[http4s] def parse(s: String): ParseResult[`Timing-Allow-Origin`] =
+    ParseResult.fromParser(parser, "Invalid Timing-Allow-Origin headers")(s)
+
+  private[http4s] val parser =
+    CommonRules
+      .headerRep1(CommonRules.token.map(CIString(_)))
+      .map(`Timing-Allow-Origin`(_))
+
+  implicit val headerInstance: Header[`Timing-Allow-Origin`, Header.Recurring] =
+    Header.createRendered(
+      ci"Timing-Allow-Origin",
+      _.values,
+      parse,
+    )
+
+  implicit val timingAllowOriginSemigroup: Semigroup[`Timing-Allow-Origin`] =
+    (a, b) => `Timing-Allow-Origin`(a.values.concatNel(b.values))
+}
+
+final case class `Timing-Allow-Origin`(values: NonEmptyList[CIString])

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -572,6 +572,13 @@ private[discipline] trait ArbitraryInstances {
       } yield headers.`Access-Control-Allow-Headers`(NonEmptyList.of(values.head, values.tail: _*))
     }
 
+  implicit val http4sTestingArbitraryForTimingAllowOriginHeader: Arbitrary[`Timing-Allow-Origin`] =
+    Arbitrary {
+      for {
+        values <- nonEmptyListOf(genToken.map(CIString(_)))
+      } yield headers.`Timing-Allow-Origin`(NonEmptyList.of(values.head, values.tail *))
+    }
+
   implicit val http4sTestingArbitraryForAccessControlExposeHeaders
       : Arbitrary[headers.`Access-Control-Expose-Headers`] =
     Arbitrary {

--- a/tests/shared/src/test/scala/org/http4s/headers/TimingAllowOriginSpec.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/TimingAllowOriginSpec.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package headers
+
+import org.http4s.laws.discipline.arbitrary._
+
+final class TimingAllowOriginSpec extends HeaderLaws {
+  checkAll("Timing-Allow-Origin", headerLaws[`Timing-Allow-Origin`])
+}


### PR DESCRIPTION
This PR has been created as part of the [London Scala user group Hack Nights](https://www.meetup.com/london-scala/)' initiative.
This introduces the `Timing-Allow-Origin` header, as one of the yet to be implemented typed headers from #5010 

Thanks!