### PR TITLE
Document Scala 2.x mill giter8 template support

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -46,7 +46,7 @@ $ sbt new http4s/http4s.g8 --branch 0.23
 $ sbt new http4s/http4s.g8 --branch 0.23-scala3
 ```
 
-Or instead with [mill]:
+Or instead with [Mill Build Tool]:
 
 ```sh
 # for Scala 2.x
@@ -109,7 +109,7 @@ that responds to `GET/hello/$USERNAME` with a JSON greeting.  Let's try it:
 $ sbt run
 ```
 
-Or with [mill]:
+Or with [Mill Build Tool]:
 
 ```sh
 $ mill run
@@ -152,4 +152,4 @@ a simple JSON service.
 [versions]: ../versions.md
 [sbt-revolver]: https://github.com/spray/sbt-revolver
 [integrations]: integrations.md
-[mill]: https://mill-build.org/mill/cli/installation-ide.html
+[Mill Build Tool]: https://mill-build.org/mill/cli/installation-ide.html

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -46,6 +46,13 @@ $ sbt new http4s/http4s.g8 --branch 0.23
 $ sbt new http4s/http4s.g8 --branch 0.23-scala3
 ```
 
+Or instead with [mill]:
+
+```sh
+# for Scala 2.x
+$ mill -i init http4s/http4s.g8 --branch 0.23-mill
+```
+
 Follow the prompts.  For every step along the way, a default value is
 provided in brackets.
 
@@ -102,6 +109,12 @@ that responds to `GET/hello/$USERNAME` with a JSON greeting.  Let's try it:
 $ sbt run
 ```
 
+Or with [mill]:
+
+```sh
+$ mill run
+```
+
 Depending on the state of your Ivy cache, several dependencies will
 download.  This is a good time to grab a beverage.  When you come
 back, you should see a line similar to this:
@@ -139,3 +152,4 @@ a simple JSON service.
 [versions]: ../versions.md
 [sbt-revolver]: https://github.com/spray/sbt-revolver
 [integrations]: integrations.md
+[mill]: https://mill-build.org/mill/cli/installation-ide.html


### PR DESCRIPTION
This is a follow up from https://github.com/http4s/http4s.g8/pull/438 where mill build tool support was added for Scala 2.x.