### PR TITLE
Rename HTTP 422 status

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -680,6 +680,14 @@ lazy val theDsl = libraryCrossProject("dsl", CrossType.Pure)
   .settings(
     description := "Simple DSL for writing http4s services",
     startYear := Some(2013),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "org.http4s.dsl.impl.Statuses.org$http4s$dsl$impl$Statuses$_setter_$UnprocessableContent_="
+      ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "org.http4s.dsl.impl.Statuses.UnprocessableContent"
+      ),
+    ),
   )
   .jsSettings(
     jsVersionIntroduced("0.23.5")

--- a/core/shared/src/main/scala/org/http4s/MessageFailure.scala
+++ b/core/shared/src/main/scala/org/http4s/MessageFailure.scala
@@ -121,7 +121,7 @@ final case class InvalidMessageBodyFailure(details: String, cause: Option[Throwa
     s"Invalid message body: $details"
 
   def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
-    Response(Status.UnprocessableEntity, httpVersion)
+    Response(Status.UnprocessableContent, httpVersion)
       .withEntity(s"The request body was invalid.")(EntityEncoder.stringEncoder[F])
 }
 

--- a/core/shared/src/main/scala/org/http4s/Status.scala
+++ b/core/shared/src/main/scala/org/http4s/Status.scala
@@ -216,7 +216,9 @@ object Status {
   val ExpectationFailed: Status = register(trust(417, "Expectation Failed"))
   val ImATeapot: Status = register(trust(418, "I'm A Teapot"))
   val MisdirectedRequest: Status = register(trust(421, "Misdirected Request"))
-  val UnprocessableEntity: Status = register(trust(422, "Unprocessable Entity"))
+  val UnprocessableContent: Status = register(trust(422, "Unprocessable Content"))
+  @deprecated("now called UnprocessableContent", since = "0.23.31")
+  val UnprocessableEntity: Status = UnprocessableContent
   val Locked: Status = register(trust(423, "Locked"))
   val FailedDependency: Status = register(trust(424, "Failed Dependency"))
   val TooEarly: Status = register(trust(425, "Too Early"))

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Responses.scala
@@ -131,10 +131,15 @@ trait Responses[F[_], G[_]] {
       status: MisdirectedRequest.type
   ): MisdirectedRequestOps[F, G] =
     new MisdirectedRequestOps[F, G](status, liftG)
+  implicit def http4sUnprocessableContentSyntax(
+      status: UnprocessableContent.type
+  ): UnprocessableContentOps[F, G] =
+    new UnprocessableContentOps[F, G](status, liftG)
+  @deprecated("use http4sUnprocessableContentSyntax", since = "0.23.31")
   implicit def http4sUnprocessableEntitySyntax(
       status: UnprocessableEntity.type
-  ): UnprocessableEntityOps[F, G] =
-    new UnprocessableEntityOps[F, G](status, liftG)
+  ): Responses.UnprocessableEntityOps[F, G] =
+    new Responses.UnprocessableEntityOps[F, G](status, liftG)
   implicit def http4sLockedSyntax(status: Locked.type): LockedOps[F, G] =
     new LockedOps[F, G](status, liftG)
   implicit def http4sFailedDependencySyntax(
@@ -321,6 +326,11 @@ object Responses {
       val status: MisdirectedRequest.type,
       val liftG: G ~> F,
   ) extends EntityResponseGenerator[F, G]
+  final class UnprocessableContentOps[F[_], G[_]](
+      val status: UnprocessableContent.type,
+      val liftG: G ~> F,
+  ) extends EntityResponseGenerator[F, G]
+  @deprecated("use UnprocessableContentOps", since = "0.23.31")
   final class UnprocessableEntityOps[F[_], G[_]](
       val status: UnprocessableEntity.type,
       val liftG: G ~> F,

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Statuses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Statuses.scala
@@ -63,6 +63,8 @@ trait Statuses {
   val UnsupportedMediaType: Status.UnsupportedMediaType.type = Status.UnsupportedMediaType
   val RangeNotSatisfiable: Status.RangeNotSatisfiable.type = Status.RangeNotSatisfiable
   val ExpectationFailed: Status.ExpectationFailed.type = Status.ExpectationFailed
+  val UnprocessableContent: Status.UnprocessableContent.type = Status.UnprocessableContent
+  @deprecated("now called UnprocessableContent", since = "0.23.31")
   val UnprocessableEntity: Status.UnprocessableEntity.type = Status.UnprocessableEntity
   val Locked: Status.Locked.type = Status.Locked
   val FailedDependency: Status.FailedDependency.type = Status.FailedDependency

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
@@ -27,6 +27,8 @@ import org.http4s.headers.`Content-Length`
 import org.http4s.headers.`Content-Type`
 import org.http4s.syntax.literals._
 
+import scala.annotation.nowarn
+
 class ResponseGeneratorSuite extends Http4sSuite {
   test("Add the EntityEncoder headers along with a content-length header") {
     val body = "foo"
@@ -156,5 +158,9 @@ class ResponseGeneratorSuite extends Http4sSuite {
           `Content-Length`.unsafeFromLong(3),
         ).headers
       )
+  }
+
+  test("UnprocessableEntity() has unambiguous and deprecated implicit") {
+    val _ = UnprocessableEntity(): @nowarn("cat=deprecation")
   }
 }

--- a/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/EntityDecoderSuite.scala
@@ -204,7 +204,7 @@ class EntityDecoderSuite extends Http4sSuite {
       .map(_.toHttpResponse[IO](HttpVersion.`HTTP/1.1`))
       .map(_.status)
       .value
-      .assertEquals(Right(Status.UnprocessableEntity))
+      .assertEquals(Right(Status.UnprocessableContent))
   }
 
   test("Not match invalid media type") {


### PR DESCRIPTION
Add `Status.UnprocessableContent` and associated dsl bits.
Deprecate `Status.UnprocessableEntity` and associated dsl bits.

It has been called Unprocessable Content for almost 3 years (see [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-422-unprocessable-content)). I'm a bit surprised no one else has noticed this, but even more than that, I have *no idea* how I only found out it was no longer called Unprocessable Entity *this morning*.

Also, this was *far* more work than I signed up for when I thought to myself "oh, I'll just quickly fix the name in http4s," but such is life.