### PR TITLE
Fix nativeLink error on CI

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738422722,
-        "narHash": "sha256-Q4vhtbLYWBUnjWD4iQb003Lt+N5PuURDad1BngGKdUs=",
+        "lastModified": 1751786137,
+        "narHash": "sha256-lIlUKVGCGsh0Q2EA7/6xRtKUZjaQ/ur8uUyY+MynHXQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "102a39bfee444533e6b4e8611d7e92aa39b7bec1",
+        "rev": "ceb24d94c6feaa4e8737a8e2bd3cf71c3a7eaaa0",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1738606142,
-        "narHash": "sha256-tqJ24RSupaL7ERmV6MXWLj4FNNhqWPhxch7hT7QfOGg=",
+        "lastModified": 1751931198,
+        "narHash": "sha256-OULdPqMMKcSnxSUt87iQJfDrR7N7G9seKjWtotm59jc=",
         "owner": "typelevel",
         "repo": "typelevel-nix",
-        "rev": "16bad7be5d8e9e29fc587fc3ac1221a3b449e5b7",
+        "rev": "31de484f68d6a0ef88a626a0f1dfb260421138fb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,10 @@
             native.enable = true;
             native.libraries = [ pkgs.zlib pkgs.s2n-tls pkgs.openssl pkgs.pkg-config ];
           };
+          env = [{
+            name = "PKG_CONFIG_PATH";
+            value ="${pkgs.openssl.dev}/lib/pkgconfig";
+          }];
         };
       in
       rec {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
             jdk.package = jdk;
             nodejs.enable = true;
             native.enable = true;
-            native.libraries = [ pkgs.zlib pkgs.s2n-tls pkgs.openssl ];
+            native.libraries = [ pkgs.zlib pkgs.s2n-tls pkgs.openssl pkgs.pkg-config ];
           };
         };
       in


### PR DESCRIPTION
Addresses this:

```
[info] Linking with [pthread, dl, z, s2n, crypto]
[error] /nix/store/z3za8hfc24wb117s50p8b10agjkgm039-binutils-2.44/bin/ld: /nix/store/15lrl034w2rjj4rh3jhng2viykf550ci-http4s-dir/lib/libs2n.so: undefined reference to `EVP_MD_CTX_get_size_ex@OPENSSL_3.4.0'
[error] clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[error] Failed to link /home/runner/work/http4s/http4s/ember-server/native/target/scala-2.12/http4s-ember-server-test-out
[error] (ember-serverNative / Test / nativeLink) Failed to link /home/runner/work/http4s/http4s/ember-server/native/target/scala-2.12/http4s-ember-server-test-out
[error] Total time: 641 s (0:10:41.0), completed Jul 8, 2025 8:09:28 AM
```