### PR TITLE
fail parsing invalid whitespace around field name

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -26,8 +26,8 @@ import org.typelevel.ci.CIString
 import scodec.bits.ByteVector
 
 import scala.annotation.switch
-import scala.util.control.NonFatal
 import scala.util.control.NoStackTrace
+import scala.util.control.NonFatal
 
 private[ember] object Parser {
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -27,6 +27,7 @@ import scodec.bits.ByteVector
 
 import scala.annotation.switch
 import scala.util.control.NonFatal
+import scala.util.control.NoStackTrace
 
 private[ember] object Parser {
 
@@ -116,21 +117,17 @@ private[ember] object Parser {
 
       while (!complete && idx <= upperBound) {
         if (!state) {
-          val current = message(idx)
-          // if current index is colon our name is complete
-          if (current == colon) {
-            state = true // set state to check for header value
-            name = new String(message, start, idx - start) // extract name string
-            start = idx + 1 // advance past colon for next start
-
-            // TODO: This if clause may not be necessary since the header value parser trims
-            if (message.size > idx + 1 && message(idx + 1) == space) {
-              start += 1 // if colon is followed by space advance again
-              idx += 1 // double advance index here to skip the space
-            }
-            // double CRLF condition - Termination of headers
-          } else if (current == lf && (idx > 0 && message(idx - 1) == cr)) {
-            complete = true // completed terminate loop
+          (message(idx): @switch) match {
+            case ':' =>
+              state = true // set state to check for header value
+              name = new String(message, start, idx - start) // extract name string
+              start = idx + 1 // advance past colon for next start
+            case '\r' if start == idx => // proceed
+            case '\n' if idx > 0 && message(idx - 1) == cr => complete = true
+            case c if c <= 0x20 | c == 0x7f =>
+              throwable = InvalidHeaderWhitespace
+              complete = true
+            case _ => // proceed
           }
         } else {
           val current = message(idx)
@@ -182,6 +179,9 @@ private[ember] object Parser {
       }
     }
 
+    case object InvalidHeaderWhitespace extends Exception with NoStackTrace {
+      override val getMessage = "InvalidHeaderWhitespace"
+    }
     final case class ParseHeadersError(cause: Throwable)
         extends Exception(
           s"Encountered Error Attempting to Parse Headers - ${cause.getMessage}",

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -116,7 +116,7 @@ private[ember] object Parser {
 
       while (!complete && idx <= upperBound) {
         if (!state) {
-          (message(idx): @switch) match {
+          message(idx) match {
             case ':' =>
               state = true // set state to check for header value
               name = new String(message, start, idx - start) // extract name string

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Parser.scala
@@ -69,7 +69,6 @@ private[ember] object Parser {
   )
 
   object HeaderP {
-    private[this] final val colon = 58 // ':'
     private[this] final val contentLengthS = "Content-Length"
     private[this] final val transferEncodingS = "Transfer-Encoding"
     private[this] final val chunkedS = "chunked"

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/ParserSuite.scala
@@ -22,8 +22,8 @@ import cats.effect.std.Queue
 import cats.syntax.all._
 import fs2._
 import org.http4s._
-import org.http4s.headers.Expires
 import org.http4s.ember.core.Parser.HeaderP.ParseHeadersError
+import org.http4s.headers.Expires
 import org.http4s.implicits._
 import org.typelevel.ci._
 import scodec.bits.ByteVector


### PR DESCRIPTION
If we hit white space while parsing a field name, we need to stop and respond with a `BadRequest` status

This is documented in [RFC 9112, section 5.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-5.1)
> No whitespace is allowed between the field name and colon. In the past, differences in the handling of such whitespace have led to security vulnerabilities in request routing and response handling. A server MUST reject, with a response status code of 400 (Bad Request), any received request message that contains whitespace between a header field name and colon. A proxy MUST remove any such whitespace from a response message before forwarding the message downstream.