### PR TITLE
Make `[bot]` a link in changelog.md

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6834,3 +6834,5 @@ the future client.
 # v0.1.0 (2014-04-15)
 
 * Initial public release.
+
+[bot]: https://github.com/http4s/steward


### PR DESCRIPTION
This PR makes `[bot]` a valid markdown link in our changelog.md
This feels silly, but I don't think this is the last time we'll forget to remove the `[bot]` text that GitHub adds now.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 