### PR TITLE
Add uncheckedStable to Statuses.UnprocessableContent

### DIFF
--- a/dsl/src/main/scala/org/http4s/dsl/impl/Statuses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Statuses.scala
@@ -17,6 +17,7 @@
 package org.http4s.dsl.impl
 
 import org.http4s.Status
+import scala.annotation.unchecked.uncheckedStable
 
 trait Statuses {
   val Continue: Status.Continue.type = Status.Continue
@@ -63,7 +64,27 @@ trait Statuses {
   val UnsupportedMediaType: Status.UnsupportedMediaType.type = Status.UnsupportedMediaType
   val RangeNotSatisfiable: Status.RangeNotSatisfiable.type = Status.RangeNotSatisfiable
   val ExpectationFailed: Status.ExpectationFailed.type = Status.ExpectationFailed
-  def UnprocessableContent: Status.UnprocessableContent.type = Status.UnprocessableContent
+
+  /** For binary compatibility reasons, this one is a def instead of a val.  This prevents
+    * its use as a response extractor when the constant is imported from the DSL:
+    *
+    * {{{
+    * response match {
+    *   case UnprocessableContent(_) => // not found: UnprocessableContent
+    * }
+    * }}}
+    *
+    * A stable value, like the one from status, works:
+    *
+    * {{{
+    * response match {
+    *   case Status.UnprocessableContent(_) => // ok
+    * }
+    * }}}
+    */
+  @uncheckedStable final def UnprocessableContent: Status.UnprocessableContent.type =
+    Status.UnprocessableContent
+
   @deprecated("now called UnprocessableContent", since = "0.23.31")
   val UnprocessableEntity: Status.UnprocessableEntity.type = Status.UnprocessableEntity
   val Locked: Status.Locked.type = Status.Locked

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Statuses.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Statuses.scala
@@ -17,6 +17,7 @@
 package org.http4s.dsl.impl
 
 import org.http4s.Status
+
 import scala.annotation.unchecked.uncheckedStable
 
 trait Statuses {

--- a/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
+++ b/dsl/src/test/scala/org/http4s/dsl/ResponseGeneratorSuite.scala
@@ -169,4 +169,21 @@ class ResponseGeneratorSuite extends Http4sSuite {
     // compatibility.  This makes sure it works like the others.
     val _ = UnprocessableContent()
   }
+
+  test("UnprocessableContent can be used as a status extractor") {
+    val _ = Response[IO]().status match {
+      case UnprocessableContent => true
+      case _ => false
+    }
+  }
+
+  /* Broken in 0.23.  Fixed in 1.0. */
+  /*
+  test("UnprocessableContent can be used as a response extractor") {
+    val _ = Response[IO]() match {
+      case UnprocessableContent(_) => true
+      case _ => false
+    }
+  }
+   */
 }


### PR DESCRIPTION
Thanks to @morgen-peschke for pointing out the two problems and @milessabin for the annotation that fixes one of them.

If we revert the def to a val in main, the commented test should compile and we can remove the gnarly scaladoc.