### PR TITLE
fix: proxy authorization header instanciation with basic credentials

### DIFF
--- a/core/shared/src/main/scala/org/http4s/headers/Proxy-Authorization.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Proxy-Authorization.scala
@@ -33,8 +33,13 @@ object `Proxy-Authorization` {
     import org.http4s.internal.parsing.AuthRules.credentials
     credentials.map(`Proxy-Authorization`(_))
   }
+
+  @deprecated("Use fromBasicCredentials", "0.23.33")
   def apply(basic: BasicCredentials): Authorization =
     Authorization(Credentials.Token(AuthScheme.Basic, basic.token))
+
+  def fromBasicCredentials(basic: BasicCredentials): `Proxy-Authorization` =
+    `Proxy-Authorization`(Credentials.Token(AuthScheme.Basic, basic.token))
 
   def parse(s: String): ParseResult[`Proxy-Authorization`] =
     ParseResult.fromParser(parser, "Invalid Proxy-Authorization header")(s)

--- a/tests/shared/src/test/scala/org/http4s/headers/ProxyAuthorizationSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/ProxyAuthorizationSuite.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.headers
+
+import org.http4s.BasicCredentials
+import org.http4s.implicits._
+import org.scalacheck.Prop._
+
+class ProxyAuthorizationSuite extends HeaderLaws {
+  test("fromBasicCredentials proper header render") {
+    forAll { (username: String, password: String) =>
+      val basicCredentials = BasicCredentials(username, password)
+      val header = `Proxy-Authorization`.fromBasicCredentials(basicCredentials)
+      header.renderString == s"Proxy-Authorization: Basic ${basicCredentials.token}"
+    }
+  }
+}


### PR DESCRIPTION
**Motivation:**
`Proxy-Authorization` instanciation with `BasicCredentials` result in `Authorization` header.

**Modifications:**
 * Instanciate  `Proxy-Authorization` instead of `Authorization` on `apply` with `BasicCredentials`
 * Add test suite to validate renderer string

**Result:**
Proper header value when using `Proxy-Authorization` with `BasicCredentials`

**Issue reference:** https://github.com/http4s/http4s/issues/7740