### PR TITLE
use message failure responses

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -392,8 +392,9 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       requestVault <- if (createRequestVault) mkRequestVault(socket) else Vault.empty.pure[F]
       resp <- httpApp
         .run(req.withAttributes(requestVault))
-        .recover { case Parser.HeaderP.ParseHeadersError(_) =>
-          badRequest.covary[F]
+        .recover {
+          case Parser.HeaderP.ParseHeadersError(_) => badRequest.covary[F]
+          case mf: MessageFailure => mf.toHttpResponse[F](req.httpVersion)
         }
         .handleErrorWith(errorHandler)
         .handleError(_ => serverFailure.covary[F])

--- a/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
+++ b/ember-server/shared/src/test/scala/org/http4s/ember/server/EmberServerSuite.scala
@@ -193,4 +193,31 @@ class EmberServerSuite extends Http4sSuite {
     }
   }
 
+  test("MessageFailure is mapped to their HTTP statuses") {
+    import org.http4s.dsl.io._
+
+    val formService: HttpApp[IO] =
+      HttpRoutes
+        .of[IO] { case req @ POST -> Root / "form" =>
+          req.as[UrlForm].flatMap(form => Ok(form.toString))
+        }
+        .orNotFound
+
+    val server = EmberServerBuilder
+      .default[IO]
+      .withPort(port"0")
+      .withHttpApp(formService)
+      .build
+
+    (server, EmberClientBuilder.default[IO].build).tupled.use { case (server, client) =>
+      val req = Request[IO](
+        Method.POST,
+        uri = url(server.addressIp4s, "/form"),
+      ).withEntity("malformed request")
+        .withContentType(headers.`Content-Type`(MediaType.application.`x-www-form-urlencoded`))
+
+      client.status(req).assertEquals(Status.BadRequest)
+    }
+  }
+
 }


### PR DESCRIPTION
<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 

I'm trying to migrate tapir http4s server examples and tests from blaze to ember [here](https://github.com/softwaremill/tapir/pull/4185).
It seems that in ember the handling of MessageFailure is missing