### PR TITLE
Plug host library leakage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,15 +90,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1772475442,
-        "narHash": "sha256-PJ6UCRAy6vJpe/DvTFm/7v3cWbhCYz0CJ4asDSgYC/4=",
+        "lastModified": 1772769788,
+        "narHash": "sha256-J0VQxFUSBN/EZsjMfnCe7TAmGcaE9qNMGJOQweZJ4rM=",
         "owner": "typelevel",
         "repo": "typelevel-nix",
-        "rev": "a271889bd7162484a1684f6f2799ef9f3264f82d",
+        "rev": "62907a6f0ba5f730d45c3f03386d091c323bcde5",
         "type": "github"
       },
       "original": {
         "owner": "typelevel",
+        "ref": "sysroot",
         "repo": "typelevel-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738422722,
-        "narHash": "sha256-Q4vhtbLYWBUnjWD4iQb003Lt+N5PuURDad1BngGKdUs=",
+        "lastModified": 1772173633,
+        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "102a39bfee444533e6b4e8611d7e92aa39b7bec1",
+        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1738606142,
-        "narHash": "sha256-tqJ24RSupaL7ERmV6MXWLj4FNNhqWPhxch7hT7QfOGg=",
+        "lastModified": 1772475442,
+        "narHash": "sha256-PJ6UCRAy6vJpe/DvTFm/7v3cWbhCYz0CJ4asDSgYC/4=",
         "owner": "typelevel",
         "repo": "typelevel-nix",
-        "rev": "16bad7be5d8e9e29fc587fc3ac1221a3b449e5b7",
+        "rev": "a271889bd7162484a1684f6f2799ef9f3264f82d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -90,16 +90,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1772769788,
+        "lastModified": 1772805355,
         "narHash": "sha256-J0VQxFUSBN/EZsjMfnCe7TAmGcaE9qNMGJOQweZJ4rM=",
         "owner": "typelevel",
         "repo": "typelevel-nix",
-        "rev": "62907a6f0ba5f730d45c3f03386d091c323bcde5",
+        "rev": "d9fc91cf66eac3e05f010fdd71c5609c3429cef8",
         "type": "github"
       },
       "original": {
         "owner": "typelevel",
-        "ref": "sysroot",
         "repo": "typelevel-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Provision a dev environment";
 
   inputs = {
-    typelevel-nix.url = "github:typelevel/typelevel-nix/sysroot";
+    typelevel-nix.url = "github:typelevel/typelevel-nix";
     nixpkgs.follows = "typelevel-nix/nixpkgs";
     flake-utils.follows = "typelevel-nix/flake-utils";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Provision a dev environment";
 
   inputs = {
-    typelevel-nix.url = "github:typelevel/typelevel-nix";
+    typelevel-nix.url = "github:typelevel/typelevel-nix/sysroot";
     nixpkgs.follows = "typelevel-nix/nixpkgs";
     flake-utils.follows = "typelevel-nix/flake-utils";
   };


### PR DESCRIPTION
The problem in #7647 is that it's picking up system libraries from `/lib`.  Worse yet, it's happenin before the devshell's (http4s-dir-lib):

Before:

```console
[http4s]$  clang -### -x c /dev/null 2>&1 | grep -oE '\-L[^ "]*'
-L/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36/lib
-L/nix/store/gnf3mv68i5g6jmabnbbncsar3kbg13zd-gcc-14-20241116/lib/gcc/x86_64-unknown-linux-gnu/14-20241116
-L/nix/store/9bzm5g670567swmg6vd1l7l4q5spvc80-gcc-14-20241116-lib/lib
-L/nix/store/gnf3mv68i5g6jmabnbbncsar3kbg13zd-gcc-14-20241116//lib
-L/nix/store/nmwhzmw3jxk5xx09jji890hqpx5vyvd4-gcc-14-20241116-libgcc/lib
-L/nix/store/ymbp8lmggn7qgb8lwrzyzxnbyz77x08r-clang-19.1.6-lib/lib
-L/nix/store/gnf3mv68i5g6jmabnbbncsar3kbg13zd-gcc-14-20241116/lib64/gcc/x86_64-unknown-linux-gnu/14.2.1
-L/nix/store/gnf3mv68i5g6jmabnbbncsar3kbg13zd-gcc-14-20241116/lib64/gcc/x86_64-unknown-linux-gnu/14.2.1/../../../../lib64
-L/lib/../lib64
-L/lib
-L/nix/store/jbp0na2bh07j0virzp3a0spfkn1hhnbm-http4s-dir/lib
-L/nix/store/jbp0na2bh07j0virzp3a0spfkn1hhnbm-http4s-dir/lib
```

After:

```console
[http4s]$  clang -### -x c /dev/null 2>&1 | grep -oE '\-L[^ "]*'
-L/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36/lib
-L/nix/store/gnf3mv68i5g6jmabnbbncsar3kbg13zd-gcc-14-20241116/lib/gcc/x86_64-unknown-linux-gnu/14-20241116
-L/nix/store/9bzm5g670567swmg6vd1l7l4q5spvc80-gcc-14-20241116-lib/lib
-L/nix/store/gnf3mv68i5g6jmabnbbncsar3kbg13zd-gcc-14-20241116//lib
-L/nix/store/nmwhzmw3jxk5xx09jji890hqpx5vyvd4-gcc-14-20241116-libgcc/lib
-L/nix/store/ymbp8lmggn7qgb8lwrzyzxnbyz77x08r-clang-19.1.6-lib/lib
-L/nix/store/gnf3mv68i5g6jmabnbbncsar3kbg13zd-gcc-14-20241116/lib64/gcc/x86_64-unknown-linux-gnu/14.2.1
-L/nix/store/q88xnck9jval5j5agkmi0p9cj4lw99la-http4s-dir/lib
-L/nix/store/q88xnck9jval5j5agkmi0p9cj4lw99la-http4s-dir/lib
```

This has been a latent problem, made acute by the openssl upgrade to 3.4 in March 2025.  It never reproduced on NixOS because even though the /lib directories were wrongly added to the path, they didn't have any offending libraries.