### PR TITLE
Fix command syntax for Mill Build Tool

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -50,7 +50,7 @@ Or instead with [Mill Build Tool]:
 
 ```sh
 # for Scala 2.x
-$ mill -i init http4s/http4s.g8 --branch 0.23-mill
+$ mill init http4s/http4s.g8 --branch 0.23-mill
 ```
 
 Follow the prompts.  For every step along the way, a default value is


### PR DESCRIPTION
After update of `0.23-mill` branch to use Mill 1.1.5 the -i parameter should be removed. This is a follow up of https://github.com/http4s/http4s.g8/pull/494.

<!--- Thank you for contributing to http4s! Before opening a pull request, please
run `sbt quicklint` on your branch and commit the results. If this fails and you
need help, feel free to open a draft pull request. If the formatting or scalafix
check still fails in CI, run `sbt lint`. ---> 