### PR TITLE
Handle the `Entity` model in `PartReceiver`

### DIFF
--- a/core/js-native/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
+++ b/core/js-native/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.multipart
 
 import cats.effect.kernel.Async
@@ -13,5 +29,3 @@ private[multipart] trait PartReceiverPlatform {
         entity.body.through(F.writeAll(path)).compile.drain
     }
 }
-
-private[multipart] object PartReceiverPlatform extends PartReceiverPlatform

--- a/core/js-native/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
+++ b/core/js-native/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
@@ -17,14 +17,22 @@
 package org.http4s.multipart
 
 import cats.effect.kernel.Async
+import cats.syntax.functor._
+import fs2.Chunk
 import fs2.io.file.Files
+import fs2.io.file.Flags
 import fs2.io.file.Path
 import org.http4s.Entity
 
 private[multipart] trait PartReceiverPlatform {
   def writeToFile[F[_]](path: Path, entity: Entity[F])(implicit F: Files[F], A: Async[F]): F[Unit] =
     entity match {
-      case Entity.Empty => A.unit
+      case Entity.Empty =>
+        A.unit
+      case Entity.Strict(bv) =>
+        Files[F]
+          .open(path, Flags.Write)
+          .use(_.write(Chunk.byteVector(bv), 0).void)
       case Entity.Strict(_) | Entity.Streamed(_, _) =>
         entity.body.through(F.writeAll(path)).compile.drain
     }

--- a/core/js-native/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
+++ b/core/js-native/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
@@ -1,0 +1,17 @@
+package org.http4s.multipart
+
+import cats.effect.kernel.Async
+import fs2.io.file.Files
+import fs2.io.file.Path
+import org.http4s.Entity
+
+private[multipart] trait PartReceiverPlatform {
+  def writeToFile[F[_]](path: Path, entity: Entity[F])(implicit F: Files[F], A: Async[F]): F[Unit] =
+    entity match {
+      case Entity.Empty => A.unit
+      case Entity.Strict(_) | Entity.Streamed(_, _) =>
+        entity.body.through(F.writeAll(path)).compile.drain
+    }
+}
+
+private[multipart] object PartReceiverPlatform extends PartReceiverPlatform

--- a/core/jvm/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
+++ b/core/jvm/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
@@ -1,0 +1,27 @@
+package org.http4s.multipart
+
+import cats.effect.kernel.Async
+import fs2.io.file.Files
+import fs2.io.file.Path
+import org.http4s.Entity
+
+import java.nio.file.{Files => NioFiles}
+import scala.util.Using
+
+private[multipart] trait PartReceiverPlatform {
+  def writeToFile[F[_]](path: Path, entity: Entity[F])(implicit F: Files[F], A: Async[F]): F[Unit] =
+    entity match {
+      case Entity.Empty =>
+        A.unit
+      case Entity.Strict(bv) =>
+        A.blocking {
+          Using.resource(NioFiles.newOutputStream(path.toNioPath)) { out =>
+            bv.copyToStream(out)
+          }
+        }
+      case Entity.Streamed(body, _) =>
+        body.through(F.writeAll(path)).compile.drain
+    }
+}
+
+private[multipart] object PartReceiverPlatform extends PartReceiverPlatform

--- a/core/jvm/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
+++ b/core/jvm/src/main/scala/org/http4s/multipart/PartReceiverPlatform.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.multipart
 
 import cats.effect.kernel.Async
@@ -23,5 +39,3 @@ private[multipart] trait PartReceiverPlatform {
         body.through(F.writeAll(path)).compile.drain
     }
 }
-
-private[multipart] object PartReceiverPlatform extends PartReceiverPlatform

--- a/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/MultipartReceiver.scala
@@ -19,7 +19,7 @@ package multipart
 
 import cats.Applicative
 import cats.Functor
-import cats.effect.Concurrent
+import cats.effect.kernel.Async
 import cats.syntax.foldable._
 import fs2.io.file.Files
 
@@ -170,7 +170,7 @@ object MultipartReceiver {
     *         map's key is the part name, and value is the decoded part, represented as
     *         either plain text or as a temporary file.
     */
-  def auto[F[_]: Concurrent: Files]: MultipartReceiver[F, Map[String, PartValue]] =
+  def auto[F[_]: Async: Files]: MultipartReceiver[F, Map[String, PartValue]] =
     new MultipartReceiver[F, Map[String, PartValue]] {
       type Partial = (String, PartValue)
       def decide(partHeaders: Headers): Option[PartReceiver[F, Partial]] =

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -22,12 +22,17 @@ import cats.ApplicativeError
 import cats.effect.Async
 import cats.effect.Concurrent
 import cats.effect.kernel.Resource
+import cats.syntax.applicativeError._
+import cats.syntax.either._
+import cats.syntax.functor._
 import fs2.Chunk
 import fs2.Pull
 import fs2.Stream
 import fs2.io.file.Files
 import fs2.io.file.Flags
 import fs2.io.file.Path
+
+import java.nio.charset.CharacterCodingException
 
 /** Represents the decoding process of a single "part" in a `multipart/form-data` message.
   *
@@ -90,7 +95,7 @@ object PartReceiver extends PartReceiverPlatform {
 
   /** Creates a PartReceiver which decodes the part body to a String.
     *
-    * The decoding will use UTF-8 unless the part provides a `Content-Type` header indicating otherwise.
+    * The decoding will use `UTF-8` unless the part's `Content-Type` specifies a different charset.
     */
   def bodyText[F[_]](implicit F: Async[F]): PartReceiver[F, String] = part =>
     part.entity match {
@@ -98,12 +103,29 @@ object PartReceiver extends PartReceiverPlatform {
         Resource.pure(Right(""))
 
       case Entity.Strict(bv) =>
-        val cs = part.charset.getOrElse(Charset.`UTF-8`).nioCharset
-        Resource.eval(F.delay(bv.decodeStringLenient()(cs))).map(Right(_))
+        // mirrors `Media#bodyText`: UTF-8 bodies are decoded leniently,
+        // other charsets are decoded strictly
+        val decoded = part.charset.getOrElse(Charset.`UTF-8`) match {
+          case Charset.`UTF-8` => F.delay(Right(bv.decodeUtf8Lenient))
+          case cs =>
+            F
+              .delay(bv.decodeString(cs.nioCharset))
+              .map(_.leftMap(malformedPartFailure))
+        }
+        Resource.eval(decoded)
 
       case Entity.Streamed(_, _) =>
-        Resource.eval(part.bodyText.compile.string).map(Right(_))
+        Resource.eval(
+          part.bodyText.compile.string
+            .map[Either[DecodeFailure, String]](Right(_))
+            .recover { case ex: CharacterCodingException =>
+              Left(malformedPartFailure(ex))
+            }
+        )
     }
+
+  private def malformedPartFailure(ex: CharacterCodingException): DecodeFailure =
+    MalformedMessageBodyFailure("Malformed part body", Some(ex))
 
   /** Creates a PartReceiver which writes the part body to a temporary file, then returns that file's `Path`. */
   def toTempFile[F[_]](implicit F: Files[F], A: Async[F]): PartReceiver[F, Path] = part =>

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -17,10 +17,10 @@
 package org.http4s
 package multipart
 
-import java.nio.file.{Files => NioFiles}
 import cats.Applicative
 import cats.ApplicativeError
-import cats.effect.{Async, Concurrent}
+import cats.effect.Async
+import cats.effect.Concurrent
 import cats.effect.kernel.Resource
 import fs2.Chunk
 import fs2.Pull
@@ -28,8 +28,6 @@ import fs2.Stream
 import fs2.io.file.Files
 import fs2.io.file.Flags
 import fs2.io.file.Path
-
-import scala.util.Using
 
 /** Represents the decoding process of a single "part" in a `multipart/form-data` message.
   *
@@ -88,7 +86,7 @@ trait PartReceiver[F[_], A] {
       }
 }
 
-object PartReceiver {
+object PartReceiver extends PartReceiverPlatform {
 
   /** Creates a PartReceiver which decodes the part body to a String.
     *
@@ -108,24 +106,10 @@ object PartReceiver {
     }
 
   /** Creates a PartReceiver which writes the part body to a temporary file, then returns that file's `Path`. */
-  def toTempFile[F[_]](implicit F: Files[F], A: Async[F]): PartReceiver[F, Path] =
-    part =>
-      F.tempFile
-        .evalTap(path =>
-          part.entity match {
-            case Entity.Empty =>
-              A.unit
-            case Entity.Strict(bv) =>
-              A.blocking {
-                Using.resource(NioFiles.newOutputStream(path.toNioPath)) { out =>
-                  bv.copyToStream(out)
-                }
-              }
-            case Entity.Streamed(body, _) =>
-              body.through(F.writeAll(path)).compile.drain
-          }
-        )
-        .map(Right(_))
+  def toTempFile[F[_]](implicit F: Files[F], A: Async[F]): PartReceiver[F, Path] = part =>
+    F.tempFile
+      .evalTap(path => writeToFile(path, part.entity))
+      .map(Right(_))
 
   /** Creates a PartReceiver that ignores the part body. */
   def ignore[F[_]]: PartReceiver[F, Unit] =

--- a/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartReceiver.scala
@@ -17,9 +17,10 @@
 package org.http4s
 package multipart
 
+import java.nio.file.{Files => NioFiles}
 import cats.Applicative
 import cats.ApplicativeError
-import cats.effect.Concurrent
+import cats.effect.{Async, Concurrent}
 import cats.effect.kernel.Resource
 import fs2.Chunk
 import fs2.Pull
@@ -27,6 +28,8 @@ import fs2.Stream
 import fs2.io.file.Files
 import fs2.io.file.Flags
 import fs2.io.file.Path
+
+import scala.util.Using
 
 /** Represents the decoding process of a single "part" in a `multipart/form-data` message.
   *
@@ -91,14 +94,37 @@ object PartReceiver {
     *
     * The decoding will use UTF-8 unless the part provides a `Content-Type` header indicating otherwise.
     */
-  def bodyText[F[_]](implicit F: Concurrent[F]): PartReceiver[F, String] =
-    part => Resource.eval(part.bodyText.compile.string).map(Right(_))
+  def bodyText[F[_]](implicit F: Async[F]): PartReceiver[F, String] = part =>
+    part.entity match {
+      case Entity.Empty =>
+        Resource.pure(Right(""))
+
+      case Entity.Strict(bv) =>
+        val cs = part.charset.getOrElse(Charset.`UTF-8`).nioCharset
+        Resource.eval(F.delay(bv.decodeStringLenient()(cs))).map(Right(_))
+
+      case Entity.Streamed(_, _) =>
+        Resource.eval(part.bodyText.compile.string).map(Right(_))
+    }
 
   /** Creates a PartReceiver which writes the part body to a temporary file, then returns that file's `Path`. */
-  def toTempFile[F[_]](implicit F: Files[F], c: Concurrent[F]): PartReceiver[F, Path] =
+  def toTempFile[F[_]](implicit F: Files[F], A: Async[F]): PartReceiver[F, Path] =
     part =>
       F.tempFile
-        .evalTap(path => part.body.through(F.writeAll(path)).compile.drain)
+        .evalTap(path =>
+          part.entity match {
+            case Entity.Empty =>
+              A.unit
+            case Entity.Strict(bv) =>
+              A.blocking {
+                Using.resource(NioFiles.newOutputStream(path.toNioPath)) { out =>
+                  bv.copyToStream(out)
+                }
+              }
+            case Entity.Streamed(body, _) =>
+              body.through(F.writeAll(path)).compile.drain
+          }
+        )
         .map(Right(_))
 
   /** Creates a PartReceiver that ignores the part body. */

--- a/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
+++ b/core/shared/src/main/scala/org/http4s/multipart/PartValue.scala
@@ -17,11 +17,9 @@
 package org.http4s
 package multipart
 
-import fs2.Stream
 import fs2.io.file.Files
 import fs2.io.file.Flags
 import fs2.io.file.Path
-import org.http4s.EntityBody
 
 /** Generic representation of typical Multipart Part bodies, as either a string or a file path.
   * Produced by [[MultipartReceiver.auto]].
@@ -31,14 +29,14 @@ import org.http4s.EntityBody
   */
 sealed trait PartValue {
 
-  /** Returns a byte-stream representation of the part's body.
+  /** Returns the part's body representation.
     *
     * For `OfString` parts, the underlying string is piped through a UTF-8 encoder.
     * For `OfFile` parts, the underlying file's content will be read from disk.
     *
-    * @return The part's body as a stream of bytes
+    * @return The part's body representation
     */
-  def bytes[F[_]: Files]: EntityBody[F]
+  def entity[F[_]: Files]: Entity[F]
 
   /** Fold over the different PartValue subtypes to compute a value
     *
@@ -58,18 +56,18 @@ sealed trait PartValue {
     */
   def toPart[F[_]: Files](name: String, headers: Header.ToRaw*): Part[F] = fold(
     s => Part.formData(name, s, headers: _*),
-    (filename, _) => Part.fileData(name, filename, Entity.stream(bytes[F]), headers: _*),
+    (filename, _) => Part.fileData(name, filename, entity[F], headers: _*),
   )
 }
 object PartValue {
 
   final case class OfString(value: String) extends PartValue {
-    def bytes[F[_]: Files]: EntityBody[F] = fs2.text.utf8.encode[F](Stream.emit(value))
+    def entity[F[_]: Files]: Entity[F] = Entity.utf8String(value)
     def fold[A](onString: String => A, onFile: (String, Path) => A): A = onString(value)
   }
 
   final case class OfFile(filename: String, path: Path) extends PartValue {
-    def bytes[F[_]: Files]: EntityBody[F] = Files[F].readAll(path, 8192, Flags.Read)
+    def entity[F[_]: Files]: Entity[F] = Entity.stream(Files[F].readAll(path, 8192, Flags.Read))
     def fold[A](onString: String => A, onFile: (String, Path) => A): A =
       onFile(filename, path)
   }


### PR DESCRIPTION
This includes several approximations:
* I didn’t apply branching on `Entity` where the `Stream[F, Byte]` is explicitly defined in the contract
* In some places, `Concurrent` was changed to `Async`, since we need `delay` and `blocking`