### PR TITLE
Add safer wildcard method to VirtualHost

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -49,17 +49,17 @@ object VirtualHost {
       http: Http[F, G],
       requestHost: String,
       port: Option[Int] = None,
-  ): HostService[F, G] =
+  ): HostService[F, G] = {
+    val lowerCaseHost = requestHost.toLowerCase(Locale.ROOT)
     HostService(
       http,
-      h =>
-        h.host.toLowerCase(Locale.ROOT) == requestHost.toLowerCase(Locale.ROOT) &&
-          (port.isEmpty || port == h.port),
+      h => h.host.toLowerCase(Locale.ROOT) == lowerCaseHost && (port.isEmpty || port == h.port),
     )
+  }
 
-  /** Create a [[HostService]] that will match if the host string in * "." + requestHost,
+  /** Create a [[HostService]] that will match if the host string in `"." + domain``,
     * discounting case, and matches the port, if the port is given. If the port
-    * is not given, it is ignored.
+    * is not given, it is ignored. It will *not* match `domain` alone, only a subdomain.
     */
   def subdomain[F[_], G[_]](
       http: Http[F, G],

--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -23,6 +23,7 @@ import cats.data.Kleisli
 import org.http4s.Status.BadRequest
 import org.http4s.Status.NotFound
 import org.http4s.headers.Host
+import java.util.Locale
 
 /** Middleware for virtual host mapping
   *
@@ -48,26 +49,44 @@ object VirtualHost {
       requestHost: String,
       port: Option[Int] = None,
   ): HostService[F, G] =
-    HostService(http, h => h.host.equalsIgnoreCase(requestHost) && (port.isEmpty || port == h.port))
+    HostService(
+      http,
+      h =>
+        h.host.toLowerCase(Locale.ROOT) == requestHost.toLowerCase(Locale.ROOT) &&
+          (port.isEmpty || port == h.port),
+    )
 
-  /** Create a [[HostService]] that will match if the host string ends with the `requestHost`
-    * (discounting case) and matches the port, if the port is given. If the port is not
+  /** Create a [[HostService]] that will match if the host string equals
+    * `requestHost` or the host string ends in "." + requestHost, discounting
+    * case, and matches the port, if the port is * given. If the port is not
     * given, it is ignored.
     */
-  def endsWith[F[_], G[_]](
+  def belongsToDomain[F[_], G[_]](
       http: Http[F, G],
       requestHost: String,
       port: Option[Int] = None,
-  ): HostService[F, G] =
-    HostService(http, h => h.host.endsWith(requestHost) && (port.isEmpty || port == h.port))
+  ): HostService[F, G] = {
+    val lowerCaseRequestHost = requestHost.toLowerCase(Locale.ROOT)
+    val suffix = "." + lowerCaseRequestHost
+
+    HostService(
+      http,
+      h => {
+        val lowerCaseHost = h.host.toLowerCase(Locale.ROOT)
+
+        (lowerCaseHost == lowerCaseRequestHost || lowerCaseHost.endsWith(suffix)) &&
+        (port.isEmpty || port == h.port)
+      },
+    )
+  }
 
   /** Create a [[HostService]] that will match based on the host string allowing
     * for wildcard matching of the lowercase host string and port, if the port is
     * given. If the port is not given, it is ignored.
     */
   @deprecated(
-    message = "Use VirtualHost.endsWith or VirtualHost.pattern instead",
-    since = "0.23.33",
+    message = "Use VirtualHost.belongsToDomain or VirtualHost.matches instead",
+    since = "0.23.35",
   )
   def wildcard[F[_], G[_]](
       http: Http[F, G],
@@ -84,22 +103,22 @@ object VirtualHost {
     */
   @deprecated(
     message =
-      "Use VirtualHost.pattern for entire string matching, or VirtualHost.patternUnanchored to preserve the current substring matching behavior",
-    since = "0.23.33",
+      "Use VirtualHost.matches for entire string matching, or VirtualHost.matchesSubstring to preserve the current substring matching behavior",
+    since = "0.23.35",
   )
   def regex[F[_], G[_]](
       http: Http[F, G],
       hostRegex: String,
       port: Option[Int] = None,
-  ): HostService[F, G] = patternUnanchored(http, hostRegex, port)
+  ): HostService[F, G] = matchesSubstring(http, hostRegex, port)
 
-  /** Create a [[HostService]] that uses a regular expression to find a substring match in the host
-    * string (which will be provided in lower case form) and port, if the port
-    * is given. If the port is not given, it is ignored.
+  /** Create a [[HostService]] that uses a regular expression to find a substring
+    * match in the host string (which will be provided in lower case form) and
+    * port, if the port is given. If the port * is not given, it is ignored.
     *
     * Note: the pattern may only match a substring. Use `VirtualHost.pattern` to require the entire string to match.
     */
-  def patternUnanchored[F[_], G[_]](
+  def matchesSubstring[F[_], G[_]](
       http: Http[F, G],
       hostRegex: String,
       port: Option[Int] = None,
@@ -107,7 +126,8 @@ object VirtualHost {
     val r = hostRegex.r
     HostService(
       http,
-      h => r.findFirstIn(h.host.toLowerCase).nonEmpty && (port.isEmpty || port == h.port),
+      h =>
+        r.findFirstIn(h.host.toLowerCase(Locale.ROOT)).nonEmpty && (port.isEmpty || port == h.port),
     )
   }
 
@@ -116,7 +136,7 @@ object VirtualHost {
     * is given. If the port is not given, it is ignored. Unlike [[regex]], this
     * method requires the entire hostname to match.
     */
-  def pattern[F[_], G[_]](
+  def matches[F[_], G[_]](
       http: Http[F, G],
       hostRegex: String,
       port: Option[Int] = None,
@@ -124,7 +144,8 @@ object VirtualHost {
     val pattern = hostRegex.r.pattern
     HostService(
       http,
-      h => pattern.matcher(h.host.toLowerCase).matches && (port.isEmpty || port == h.port),
+      h =>
+        pattern.matcher(h.host.toLowerCase(Locale.ROOT)).matches && (port.isEmpty || port == h.port),
     )
   }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -23,6 +23,7 @@ import cats.data.Kleisli
 import org.http4s.Status.BadRequest
 import org.http4s.Status.NotFound
 import org.http4s.headers.Host
+
 import java.util.Locale
 
 /** Middleware for virtual host mapping
@@ -56,12 +57,11 @@ object VirtualHost {
           (port.isEmpty || port == h.port),
     )
 
-  /** Create a [[HostService]] that will match if the host string equals
-    * `requestHost` or the host string ends in "." + requestHost, discounting
-    * case, and matches the port, if the port is * given. If the port is not
-    * given, it is ignored.
+  /** Create a [[HostService]] that will match if the host string in * "." + requestHost,
+    * discounting case, and matches the port, if the port is given. If the port
+    * is not given, it is ignored.
     */
-  def belongsToDomain[F[_], G[_]](
+  def subdomain[F[_], G[_]](
       http: Http[F, G],
       requestHost: String,
       port: Option[Int] = None,
@@ -71,12 +71,7 @@ object VirtualHost {
 
     HostService(
       http,
-      h => {
-        val lowerCaseHost = h.host.toLowerCase(Locale.ROOT)
-
-        (lowerCaseHost == lowerCaseRequestHost || lowerCaseHost.endsWith(suffix)) &&
-        (port.isEmpty || port == h.port)
-      },
+      h => h.host.toLowerCase(Locale.ROOT).endsWith(suffix) && (port.isEmpty || port == h.port),
     )
   }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -24,8 +24,6 @@ import org.http4s.Status.BadRequest
 import org.http4s.Status.NotFound
 import org.http4s.headers.Host
 
-import scala.util.matching.Regex
-
 /** Middleware for virtual host mapping
   *
   * The `VirtualHost` middleware allows multiple services to be mapped
@@ -52,11 +50,25 @@ object VirtualHost {
   ): HostService[F, G] =
     HostService(http, h => h.host.equalsIgnoreCase(requestHost) && (port.isEmpty || port == h.port))
 
+  /** Create a [[HostService]] that will match if the host string ends with the `requestHost`
+    * (discounting case) and matches the port, if the port is given. If the port is not
+    * given, it is ignored.
+    */
+  def endsWith[F[_], G[_]](
+      http: Http[F, G],
+      requestHost: String,
+      port: Option[Int] = None,
+  ): HostService[F, G] =
+    HostService(http, h => h.host.endsWith(requestHost) && (port.isEmpty || port == h.port))
+
   /** Create a [[HostService]] that will match based on the host string allowing
     * for wildcard matching of the lowercase host string and port, if the port is
     * given. If the port is not given, it is ignored.
     */
-  @deprecated(message = "Use VirtualHost.glob instead", since = "0.23.33")
+  @deprecated(
+    message = "Use VirtualHost.endsWith or VirtualHost.pattern instead",
+    since = "0.23.33",
+  )
   def wildcard[F[_], G[_]](
       http: Http[F, G],
       wildcardHost: String,
@@ -64,39 +76,13 @@ object VirtualHost {
   ): HostService[F, G] =
     regex(http, wildcardHost.replace("*", "\\w+").replace(".", "\\.").replace("-", "\\-"), port)
 
-  /** Create a [[HostService]] that will match based on the host string allowing
-    * for simple glob-style matching with domain name segments and port, if the
-    * port is given. If the port is not given, it is ignored. A `*` character
-    * matches a single segment and `**` matches any number of segments. Other
-    * character sequences are matched literally.
-    */
-  def glob[F[_], G[_]](
-      http: Http[F, G],
-      globHost: String,
-      port: Option[Int] = None,
-  ): HostService[F, G] = {
-    val validDomainNameSegment = """\p{Alnum}([\p{Alnum}-]*\p{Alnum})?"""
-
-    // Chop the input into sequences of "*", or anything else
-    val hostRegex = """\*+|[^\*]+""".r
-      .findAllIn(globHost)
-      .map {
-        case "*" => validDomainNameSegment
-        case "**" => s"($validDomainNameSegment)+(\\.$validDomainNameSegment)*"
-        case other => Regex.quote(other.toLowerCase())
-      }
-      .mkString("^", "", "$")
-
-    regex(http, hostRegex, port)
-  }
-
   /** Create a [[HostService]] that uses a regular expression to find a match in the host
     * string (which will be provided in lower case form) and port, if the port
     * is given. If the port is not given, it is ignored.
     *
-    * Note: the pattern may only match a substring. To match the entire string, use anchors
-    * in the expression. e.g. `^.*\.example.com$`
+    * Note: the pattern may only match a substring. Use `VirtualHost.pattern` for anchored matching.
     */
+  @deprecated(message = "Use VirtualHost.pattern instead", since = "0.23.33")
   def regex[F[_], G[_]](
       http: Http[F, G],
       hostRegex: String,
@@ -106,6 +92,23 @@ object VirtualHost {
     HostService(
       http,
       h => r.findFirstIn(h.host.toLowerCase).nonEmpty && (port.isEmpty || port == h.port),
+    )
+  }
+
+  /** Create a [[HostService]] that uses a regular expression to match the host
+    * string (which will be provided in lower case form) and port, if the port
+    * is given. If the port is not given, it is ignored. Unlike [[regex]], this
+    * method requires the entire hostname to match.
+    */
+  def pattern[F[_], G[_]](
+      http: Http[F, G],
+      hostRegex: String,
+      port: Option[Int] = None,
+  ): HostService[F, G] = {
+    val r = hostRegex.r
+    HostService(
+      http,
+      h => r.matches(h.host.toLowerCase) && (port.isEmpty || port == h.port),
     )
   }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -80,10 +80,26 @@ object VirtualHost {
     * string (which will be provided in lower case form) and port, if the port
     * is given. If the port is not given, it is ignored.
     *
-    * Note: the pattern may only match a substring. Use `VirtualHost.pattern` for anchored matching.
+    * Note: the pattern may only match a substring. Use `VirtualHost.pattern` to require the entire string to match.
     */
-  @deprecated(message = "Use VirtualHost.pattern instead", since = "0.23.33")
+  @deprecated(
+    message =
+      "Use VirtualHost.pattern for entire string matching, or VirtualHost.patternUnanchored to preserve the current substring matching behavior",
+    since = "0.23.33",
+  )
   def regex[F[_], G[_]](
+      http: Http[F, G],
+      hostRegex: String,
+      port: Option[Int] = None,
+  ): HostService[F, G] = patternUnanchored(http, hostRegex, port)
+
+  /** Create a [[HostService]] that uses a regular expression to find a substring match in the host
+    * string (which will be provided in lower case form) and port, if the port
+    * is given. If the port is not given, it is ignored.
+    *
+    * Note: the pattern may only match a substring. Use `VirtualHost.pattern` to require the entire string to match.
+    */
+  def patternUnanchored[F[_], G[_]](
       http: Http[F, G],
       hostRegex: String,
       port: Option[Int] = None,

--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -105,10 +105,10 @@ object VirtualHost {
       hostRegex: String,
       port: Option[Int] = None,
   ): HostService[F, G] = {
-    val r = hostRegex.r
+    val pattern = hostRegex.r.pattern
     HostService(
       http,
-      h => r.matches(h.host.toLowerCase) && (port.isEmpty || port == h.port),
+      h => pattern.matcher(h.host.toLowerCase).matches && (port.isEmpty || port == h.port),
     )
   }
 

--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -82,7 +82,7 @@ object VirtualHost {
       .findAllIn(globHost)
       .map {
         case "*" => validDomainNameSegment
-        case "**" => s"$validDomainNameSegment+(\\.$validDomainNameSegment)*"
+        case "**" => s"($validDomainNameSegment)+(\\.$validDomainNameSegment)*"
         case other => Regex.quote(other.toLowerCase())
       }
       .mkString("^", "", "$")

--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -24,6 +24,8 @@ import org.http4s.Status.BadRequest
 import org.http4s.Status.NotFound
 import org.http4s.headers.Host
 
+import scala.util.matching.Regex
+
 /** Middleware for virtual host mapping
   *
   * The `VirtualHost` middleware allows multiple services to be mapped
@@ -54,6 +56,7 @@ object VirtualHost {
     * for wildcard matching of the lowercase host string and port, if the port is
     * given. If the port is not given, it is ignored.
     */
+  @deprecated(message = "Use VirtualHost.glob instead", since = "0.23.33")
   def wildcard[F[_], G[_]](
       http: Http[F, G],
       wildcardHost: String,
@@ -61,9 +64,38 @@ object VirtualHost {
   ): HostService[F, G] =
     regex(http, wildcardHost.replace("*", "\\w+").replace(".", "\\.").replace("-", "\\-"), port)
 
-  /** Create a [[HostService]] that uses a regular expression to match the host
+  /** Create a [[HostService]] that will match based on the host string allowing
+    * for simple glob-style matching with domain name segments and port, if the
+    * port is given. If the port is not given, it is ignored. A `*` character
+    * matches a single segment and `**` matches any number of segments. Other
+    * character sequences are matched literally.
+    */
+  def glob[F[_], G[_]](
+      http: Http[F, G],
+      globHost: String,
+      port: Option[Int] = None,
+  ): HostService[F, G] = {
+    val validDomainNameSegment = """\p{Alnum}([\p{Alnum}-]*\p{Alnum})?"""
+
+    // Chop the input into sequences of "*", or anything else
+    val hostRegex = """\*+|[^\*]+""".r
+      .findAllIn(globHost)
+      .map {
+        case "*" => validDomainNameSegment
+        case "**" => s"$validDomainNameSegment+(\\.$validDomainNameSegment)*"
+        case other => Regex.quote(other.toLowerCase())
+      }
+      .mkString("^", "", "$")
+
+    regex(http, hostRegex, port)
+  }
+
+  /** Create a [[HostService]] that uses a regular expression to find a match in the host
     * string (which will be provided in lower case form) and port, if the port
     * is given. If the port is not given, it is ignored.
+    *
+    * Note: the pattern may only match a substring. To match the entire string, use anchors
+    * in the expression. e.g. `^.*\.example.com$`
     */
   def regex[F[_], G[_]](
       http: Http[F, G],

--- a/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/VirtualHost.scala
@@ -63,15 +63,16 @@ object VirtualHost {
     */
   def subdomain[F[_], G[_]](
       http: Http[F, G],
-      requestHost: String,
+      domain: String,
       port: Option[Int] = None,
   ): HostService[F, G] = {
-    val lowerCaseRequestHost = requestHost.toLowerCase(Locale.ROOT)
-    val suffix = "." + lowerCaseRequestHost
+    val lowerCaseDomain = "." + domain.toLowerCase(Locale.ROOT)
 
     HostService(
       http,
-      h => h.host.toLowerCase(Locale.ROOT).endsWith(suffix) && (port.isEmpty || port == h.port),
+      h =>
+        h.host.toLowerCase(Locale.ROOT).endsWith(lowerCaseDomain) &&
+          (port.isEmpty || port == h.port),
     )
   }
 
@@ -80,7 +81,7 @@ object VirtualHost {
     * given. If the port is not given, it is ignored.
     */
   @deprecated(
-    message = "Use VirtualHost.belongsToDomain or VirtualHost.matches instead",
+    message = "Use VirtualHost.subdomain or VirtualHost.matches instead",
     since = "0.23.35",
   )
   def wildcard[F[_], G[_]](

--- a/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -82,29 +82,36 @@ class VirtualHostSuite extends Http4sSuite {
     vhostExact(req).map(_.status).assertEquals(NotFound)
   }
 
-  private val vhostEndsWith = VirtualHost(
-    VirtualHost.endsWith(routesA, "routesA", None)
+  private val vhostBelongsToDomain = VirtualHost(
+    VirtualHost.belongsToDomain(routesA, "routesA", None)
   ).orNotFound
 
-  test("endsWith should match exact") {
+  test("belongsToDomain should match exact") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesA"))
 
-    vhostEndsWith(req).flatMap(_.as[String]).assertEquals("routesA")
+    vhostBelongsToDomain(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
-  test("endsWith should match prefix") {
+  test("belongsToDomain should match prefix") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("www.routesA"))
 
-    vhostEndsWith(req).flatMap(_.as[String]).assertEquals("routesA")
+    vhostBelongsToDomain(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
-  test("endsWith should not match suffix") {
+  test("belongsToDomain should not match suffix") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesA.service"))
 
-    vhostEndsWith(req).map(_.status).assertEquals(NotFound)
+    vhostBelongsToDomain(req).map(_.status).assertEquals(NotFound)
+  }
+
+  test("belongsToDomain should not match prefix without dot") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("not-routesA"))
+
+    vhostBelongsToDomain(req).map(_.status).assertEquals(NotFound)
   }
 
   @annotation.nowarn("cat=deprecation")
@@ -151,56 +158,56 @@ class VirtualHostSuite extends Http4sSuite {
     }
   }
 
-  private val vhostPatternUnanchored = VirtualHost(
-    VirtualHost.patternUnanchored(routesA, "routesa", None),
-    VirtualHost.patternUnanchored(routesB, """.*\.service""", Some(80)),
-    VirtualHost.patternUnanchored(default, """^.*\.anchored-service$""", Some(80)),
+  private val vhostMatchesSubstring = VirtualHost(
+    VirtualHost.matchesSubstring(routesA, "routesa", None),
+    VirtualHost.matchesSubstring(routesB, """.*\.service""", Some(80)),
+    VirtualHost.matchesSubstring(default, """^.*\.anchored-service$""", Some(80)),
   ).orNotFound
 
-  test("regex match an exact route") {
+  test("matchesSubstring match an exact route") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesa", Some(80)))
 
-    vhostPatternUnanchored(req).flatMap(_.as[String]).assertEquals("routesA")
+    vhostMatchesSubstring(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
-  test("regex should match when not anchored") {
+  test("matchesSubstring should match when not anchored") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("test.service.example.com", Some(80)))
 
-    vhostPatternUnanchored(req).flatMap(_.as[String]).assertEquals("routesB")
+    vhostMatchesSubstring(req).flatMap(_.as[String]).assertEquals("routesB")
   }
 
-  test("regex should not match suffix when anchored") {
+  test("matchesSubstring should not match suffix when anchored") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("test.anchored-service.example.com", Some(80)))
 
-    vhostPatternUnanchored(req).map(_.status).assertEquals(NotFound)
+    vhostMatchesSubstring(req).map(_.status).assertEquals(NotFound)
   }
 
-  private val vhostPattern = VirtualHost(
-    VirtualHost.pattern(routesA, "routesa", None),
-    VirtualHost.pattern(routesB, """route-.\.service""", Some(80)),
+  private val vhostMatches = VirtualHost(
+    VirtualHost.matches(routesA, "routesa", None),
+    VirtualHost.matches(routesB, """route-.\.service""", Some(80)),
   ).orNotFound
 
-  test("pattern should match an exact route") {
+  test("matches should match an exact route") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesa", Some(80)))
 
-    vhostPattern(req).flatMap(_.as[String]).assertEquals("routesA")
+    vhostMatches(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
-  test("pattern should match a wildcard route") {
+  test("matches should match a wildcard route") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("route-b.service", Some(80)))
 
-    vhostPattern(req).flatMap(_.as[String]).assertEquals("routesB")
+    vhostMatches(req).flatMap(_.as[String]).assertEquals("routesB")
   }
 
-  test("pattern does not match when not anchored") {
+  test("matches does not match when not anchored") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("route-b.service.prod", Some(80)))
 
-    vhostPattern(req).map(_.status).assertEquals(NotFound)
+    vhostMatches(req).map(_.status).assertEquals(NotFound)
   }
 }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -82,6 +82,31 @@ class VirtualHostSuite extends Http4sSuite {
     vhostExact(req).map(_.status).assertEquals(NotFound)
   }
 
+  private val vhostEndsWith = VirtualHost(
+    VirtualHost.endsWith(routesA, "routesA", None)
+  ).orNotFound
+
+  test("endsWith should match exact") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("routesA"))
+
+    vhostEndsWith(req).flatMap(_.as[String]).assertEquals("routesA")
+  }
+
+  test("endsWith should match prefix") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("www.routesA"))
+
+    vhostEndsWith(req).flatMap(_.as[String]).assertEquals("routesA")
+  }
+
+  test("endsWith should not match suffix") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("routesA.service"))
+
+    vhostEndsWith(req).map(_.status).assertEquals(NotFound)
+  }
+
   @annotation.nowarn("cat=deprecation")
   private val vhostWildcard = VirtualHost(
     VirtualHost.wildcard(routesA, "routesa", None),
@@ -116,7 +141,7 @@ class VirtualHostSuite extends Http4sSuite {
     }
   }
 
-  test("wildcard not match a route with an abscent wildcard") {
+  test("wildcard not match a route with an absent wildcard") {
     val req = Request[IO](GET, uri"/numbers/1")
     val reqs =
       List(req.withHeaders(Host(".service", Some(80))), req.withHeaders(Host("service", Some(80))))
@@ -126,6 +151,7 @@ class VirtualHostSuite extends Http4sSuite {
     }
   }
 
+  @annotation.nowarn("cat=deprecation")
   private val vhostRegex = VirtualHost(
     VirtualHost.regex(routesA, "routesa", None),
     VirtualHost.regex(routesB, """.*\.service""", Some(80)),
@@ -139,73 +165,43 @@ class VirtualHostSuite extends Http4sSuite {
     vhostRegex(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
-  test("regex matches when not anchored") {
+  test("regex should match when not anchored") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("test.service.example.com", Some(80)))
 
     vhostRegex(req).flatMap(_.as[String]).assertEquals("routesB")
   }
 
-  test("regex does not match suffix when anchored") {
+  test("regex should not match suffix when anchored") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("test.anchored-service.example.com", Some(80)))
 
     vhostRegex(req).map(_.status).assertEquals(NotFound)
   }
 
-  private val vhostGlob = VirtualHost(
-    VirtualHost.glob(routesA, "*.serviceA", None),
-    VirtualHost.glob(routesB, "**.serviceB", Some(80)),
-    VirtualHost.glob(default, "**.default-service.*", Some(80)),
+  private val vhostPattern = VirtualHost(
+    VirtualHost.pattern(routesA, "routesa", None),
+    VirtualHost.pattern(routesB, """route-.\.service""", Some(80)),
   ).orNotFound
 
-  test("glob matches *") {
+  test("pattern should match an exact route") {
     val req = Request[IO](GET, uri"/numbers/1")
-      .withHeaders(Host("glob.serviceA", Some(80)))
+      .withHeaders(Host("routesa", Some(80)))
 
-    vhostGlob(req).flatMap(_.as[String]).assertEquals("routesA")
+    vhostPattern(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
-  test("glob matches **") {
+  test("pattern should match a wildcard route") {
     val req = Request[IO](GET, uri"/numbers/1")
-      .withHeaders(Host("g.l.o.b.serviceB", Some(80)))
+      .withHeaders(Host("route-b.service", Some(80)))
 
-    vhostGlob(req).flatMap(_.as[String]).assertEquals("routesB")
+    vhostPattern(req).flatMap(_.as[String]).assertEquals("routesB")
   }
 
-  test("glob matches * and **") {
+  test("pattern does not match when not anchored") {
     val req = Request[IO](GET, uri"/numbers/1")
-      .withHeaders(Host("g.l.o.b.default-service.com", Some(80)))
+      .withHeaders(Host("route-b.service.prod", Some(80)))
 
-    vhostGlob(req).flatMap(_.as[String]).assertEquals("default")
-  }
-
-  test("glob does not match other routes") {
-    val req = Request[IO](GET, uri"/numbers/1")
-    val reqs = List(
-      req.withHeaders(Host("a.b.serviceA", Some(80))),
-      req.withHeaders(Host("a.serviceB.com", Some(80))),
-      req.withHeaders(Host("b.service.on.ca", Some(80))),
-    )
-
-    reqs.parTraverse_ { req =>
-      vhostGlob(req).map(_.status).assertEquals(NotFound)
-    }
-  }
-
-  test("glob treats regex characters literally") {
-    val regexGlobs = VirtualHost(
-      VirtualHost.glob(routesA, "*.serviceA.\\w+", None),
-      VirtualHost.glob(routesB, ".*", Some(80)),
-    ).orNotFound
-    val req = Request[IO](GET, uri"/numbers/1")
-    val reqs = List(
-      req.withHeaders(Host("a.serviceA.com", Some(80))),
-      req.withHeaders(Host("any-service", Some(80))),
-    )
-
-    reqs.parTraverse_ { req =>
-      regexGlobs(req).map(_.status).assertEquals(NotFound)
-    }
+    vhostPattern(req).map(_.status).assertEquals(NotFound)
   }
 }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -151,32 +151,31 @@ class VirtualHostSuite extends Http4sSuite {
     }
   }
 
-  @annotation.nowarn("cat=deprecation")
-  private val vhostRegex = VirtualHost(
-    VirtualHost.regex(routesA, "routesa", None),
-    VirtualHost.regex(routesB, """.*\.service""", Some(80)),
-    VirtualHost.regex(default, """^.*\.anchored-service$""", Some(80)),
+  private val vhostPatternUnanchored = VirtualHost(
+    VirtualHost.patternUnanchored(routesA, "routesa", None),
+    VirtualHost.patternUnanchored(routesB, """.*\.service""", Some(80)),
+    VirtualHost.patternUnanchored(default, """^.*\.anchored-service$""", Some(80)),
   ).orNotFound
 
   test("regex match an exact route") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesa", Some(80)))
 
-    vhostRegex(req).flatMap(_.as[String]).assertEquals("routesA")
+    vhostPatternUnanchored(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
   test("regex should match when not anchored") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("test.service.example.com", Some(80)))
 
-    vhostRegex(req).flatMap(_.as[String]).assertEquals("routesB")
+    vhostPatternUnanchored(req).flatMap(_.as[String]).assertEquals("routesB")
   }
 
   test("regex should not match suffix when anchored") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("test.anchored-service.example.com", Some(80)))
 
-    vhostRegex(req).map(_.status).assertEquals(NotFound)
+    vhostPatternUnanchored(req).map(_.status).assertEquals(NotFound)
   }
 
   private val vhostPattern = VirtualHost(

--- a/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -86,28 +86,35 @@ class VirtualHostSuite extends Http4sSuite {
     VirtualHost.subdomain(routesA, "routesA", None)
   ).orNotFound
 
-  test("Subdomain should not match exact") {
+  test("subdomain should not match exact") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesA"))
 
     vhostSubdomain(req).map(_.status).assertEquals(NotFound)
   }
 
-  test("Subdomain should match prefix") {
+  test("subdomain should match prefix") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("www.routesA"))
 
     vhostSubdomain(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
-  test("Subdomain should not match suffix") {
+  test("subdomain should not match suffix") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesA.service"))
 
     vhostSubdomain(req).map(_.status).assertEquals(NotFound)
   }
 
-  test("Subdomain should not match prefix without dot") {
+  test("subdomain should not match prefix and suffix") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("www.routesA.service"))
+
+    vhostSubdomain(req).map(_.status).assertEquals(NotFound)
+  }
+
+  test("subdomain should not match prefix without dot") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("not-routesA"))
 

--- a/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -82,6 +82,7 @@ class VirtualHostSuite extends Http4sSuite {
     vhostExact(req).map(_.status).assertEquals(NotFound)
   }
 
+  @annotation.nowarn("cat=deprecation")
   private val vhostWildcard = VirtualHost(
     VirtualHost.wildcard(routesA, "routesa", None),
     VirtualHost.wildcard(routesB, "*.service", Some(80)),
@@ -122,6 +123,89 @@ class VirtualHostSuite extends Http4sSuite {
 
     reqs.parTraverse_ { req =>
       vhostWildcard(req).map(_.status).assertEquals(NotFound)
+    }
+  }
+
+  private val vhostRegex = VirtualHost(
+    VirtualHost.regex(routesA, "routesa", None),
+    VirtualHost.regex(routesB, """.*\.service""", Some(80)),
+    VirtualHost.regex(default, """^.*\.anchored-service$""", Some(80)),
+  ).orNotFound
+
+  test("regex match an exact route") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("routesa", Some(80)))
+
+    vhostRegex(req).flatMap(_.as[String]).assertEquals("routesA")
+  }
+
+  test("regex matches when not anchored") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("test.service.example.com", Some(80)))
+
+    vhostRegex(req).flatMap(_.as[String]).assertEquals("routesB")
+  }
+
+  test("regex does not match suffix when anchored") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("test.anchored-service.example.com", Some(80)))
+
+    vhostRegex(req).map(_.status).assertEquals(NotFound)
+  }
+
+  private val vhostGlob = VirtualHost(
+    VirtualHost.glob(routesA, "*.serviceA", None),
+    VirtualHost.glob(routesB, "**.serviceB", Some(80)),
+    VirtualHost.glob(default, "**.default-service.*", Some(80)),
+  ).orNotFound
+
+  test("glob matches *") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("glob.serviceA", Some(80)))
+
+    vhostGlob(req).flatMap(_.as[String]).assertEquals("routesA")
+  }
+
+  test("glob matches **") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("g.l.o.b.serviceB", Some(80)))
+
+    vhostGlob(req).flatMap(_.as[String]).assertEquals("routesB")
+  }
+
+  test("glob matches * and **") {
+    val req = Request[IO](GET, uri"/numbers/1")
+      .withHeaders(Host("g.l.o.b.default-service.com", Some(80)))
+
+    vhostGlob(req).flatMap(_.as[String]).assertEquals("default")
+  }
+
+  test("glob does not match other routes") {
+    val req = Request[IO](GET, uri"/numbers/1")
+    val reqs = List(
+      req.withHeaders(Host("a.b.serviceA", Some(80))),
+      req.withHeaders(Host("a.serviceB.com", Some(80))),
+      req.withHeaders(Host("b.service.on.ca", Some(80))),
+    )
+
+    reqs.parTraverse_ { req =>
+      vhostGlob(req).map(_.status).assertEquals(NotFound)
+    }
+  }
+
+  test("glob treats regex characters literally") {
+    val regexGlobs = VirtualHost(
+      VirtualHost.glob(routesA, "*.serviceA.\\w+", None),
+      VirtualHost.glob(routesB, ".*", Some(80)),
+    ).orNotFound
+    val req = Request[IO](GET, uri"/numbers/1")
+    val reqs = List(
+      req.withHeaders(Host("a.serviceA.com", Some(80))),
+      req.withHeaders(Host("any-service", Some(80))),
+    )
+
+    reqs.parTraverse_ { req =>
+      regexGlobs(req).map(_.status).assertEquals(NotFound)
     }
   }
 }

--- a/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/VirtualHostSuite.scala
@@ -82,36 +82,36 @@ class VirtualHostSuite extends Http4sSuite {
     vhostExact(req).map(_.status).assertEquals(NotFound)
   }
 
-  private val vhostBelongsToDomain = VirtualHost(
-    VirtualHost.belongsToDomain(routesA, "routesA", None)
+  private val vhostSubdomain = VirtualHost(
+    VirtualHost.subdomain(routesA, "routesA", None)
   ).orNotFound
 
-  test("belongsToDomain should match exact") {
+  test("Subdomain should not match exact") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesA"))
 
-    vhostBelongsToDomain(req).flatMap(_.as[String]).assertEquals("routesA")
+    vhostSubdomain(req).map(_.status).assertEquals(NotFound)
   }
 
-  test("belongsToDomain should match prefix") {
+  test("Subdomain should match prefix") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("www.routesA"))
 
-    vhostBelongsToDomain(req).flatMap(_.as[String]).assertEquals("routesA")
+    vhostSubdomain(req).flatMap(_.as[String]).assertEquals("routesA")
   }
 
-  test("belongsToDomain should not match suffix") {
+  test("Subdomain should not match suffix") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("routesA.service"))
 
-    vhostBelongsToDomain(req).map(_.status).assertEquals(NotFound)
+    vhostSubdomain(req).map(_.status).assertEquals(NotFound)
   }
 
-  test("belongsToDomain should not match prefix without dot") {
+  test("Subdomain should not match prefix without dot") {
     val req = Request[IO](GET, uri"/numbers/1")
       .withHeaders(Host("not-routesA"))
 
-    vhostBelongsToDomain(req).map(_.status).assertEquals(NotFound)
+    vhostSubdomain(req).map(_.status).assertEquals(NotFound)
   }
 
   @annotation.nowarn("cat=deprecation")


### PR DESCRIPTION
Fixes #7848 and #7845

- deprecate `wildcard` and `regex` methods
- add `subdomain` method for typical usages of `wildcard`
- add `matchesSubstring` for users that really do want the `regex` behavior
- add `matches` for safer full string regex matching