### PR TITLE
Avoid stack trace computation for `EmberException.EmptyStream`

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/EmberException.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/EmberException.scala
@@ -43,11 +43,11 @@ object EmberException {
     override def getMessage: String = message
   }
 
-  final case class EmptyStream() extends EmberException {
+  final case class EmptyStream() extends EmberException with NoStackTrace {
     override def getMessage: String = "Cannot Parse Empty Stream"
   }
 
-  final case class ReachedEndOfStream() extends EmberException {
+  final case class ReachedEndOfStream() extends EmberException with NoStackTrace {
     override def getMessage: String = "Reached End Of Stream While Reading"
   }
 


### PR DESCRIPTION
Prompted by [my question in Discord](https://discord.com/channels/632277896739946517/632286375311573032/1505973316031352914), this updates `EmberException.EmptyStream` and `EmberException.ReachedEndOfStream` to mix in `NoStackTrace`.