### PR TITLE
Improve connection reuse with configurable drain parameters

### DIFF
--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/EmberClientBuilder.scala
@@ -60,6 +60,8 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
     private val pushPromiseSupport: Option[
       (Request[fs2.Pure], F[Response[F]]) => F[Outcome[F, Throwable, Unit]]
     ],
+    private val maxDrainBytes: Long,
+    private val drainTimeout: Duration,
 ) extends EmberClientBuilderPlatform { self =>
 
   private def copy(
@@ -81,6 +83,8 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
       pushPromiseSupport: Option[
         (Request[fs2.Pure], F[Response[F]]) => F[Outcome[F, Throwable, Unit]]
       ] = self.pushPromiseSupport,
+      maxDrainBytes: Long = self.maxDrainBytes,
+      drainTimeout: Duration = self.drainTimeout,
   ): EmberClientBuilder[F] =
     new EmberClientBuilder[F](
       tlsContextOpt = tlsContextOpt,
@@ -99,6 +103,8 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
       retryPolicy = retryPolicy,
       enableHttp2 = enableHttp2,
       pushPromiseSupport = pushPromiseSupport,
+      maxDrainBytes = maxDrainBytes,
+      drainTimeout = drainTimeout,
     )
 
   /** Sets a custom `TLSContext`.
@@ -233,6 +239,19 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
   def withoutPushPromiseSupport: EmberClientBuilder[F] =
     copy(pushPromiseSupport = None)
 
+  /** Set the maximum number of bytes to attempt to drain after a response
+    * is completed while deciding whether the connection can be reused.
+    */
+  def withMaxDrainBytes(maxDrainBytes: Long): EmberClientBuilder[F] =
+    copy(maxDrainBytes = maxDrainBytes)
+
+  /** Set the maximum amount of time to read `maxDrainBytes` or reach the
+    * end of the response while deciding whether the connection
+    * can be reused.
+    */
+  def withDrainTimeout(drainTimeout: Duration): EmberClientBuilder[F] =
+    copy(drainTimeout = drainTimeout)
+
   private val verifyTimeoutRelations: F[Unit] =
     logger
       .warn(
@@ -323,6 +342,9 @@ final class EmberClientBuilder[F[_]: Async: Network] private (
                   managed.value.nextBytes,
                   managed.canBeReused,
                   managed.value.startNextRead,
+                  maxDrainBytes,
+                  drainTimeout,
+                  logger,
                 )
               case _ => Applicative[F].unit
             }
@@ -398,6 +420,8 @@ object EmberClientBuilder extends EmberClientBuilderCompanionPlatform {
       retryPolicy = Defaults.retryPolicy,
       enableHttp2 = false,
       pushPromiseSupport = None,
+      maxDrainBytes = 64L * 1024L,
+      drainTimeout = 5.seconds,
     )
 
   @deprecated("Use the overload which accepts a Network", "0.23.16")

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -24,10 +24,10 @@ import cats._
 import cats.data.NonEmptyList
 import cats.effect.kernel.Async
 import cats.effect.kernel.Clock
-import cats.effect.kernel.Concurrent
 import cats.effect.kernel.Ref
 import cats.effect.kernel.Resource
 import cats.effect.kernel.Sync
+import cats.effect.kernel.Temporal
 import cats.effect.std.Hotswap
 import cats.effect.syntax.all._
 import cats.syntax.all._
@@ -48,6 +48,7 @@ import org.http4s.headers.Date
 import org.http4s.headers.`User-Agent`
 import org.typelevel.ci._
 import org.typelevel.keypool._
+import org.typelevel.log4cats.Logger
 
 import java.io.IOException
 import scala.concurrent.duration._
@@ -217,19 +218,35 @@ private[client] object ClientHelpers {
       nextBytes: Ref[F, Array[Byte]],
       canBeReused: Ref[F, Reusable],
       startNextRead: F[Unit],
-  )(implicit F: Concurrent[F]): F[Unit] =
+      maxDrainBytes: Long,
+      drainTimeout: Duration,
+      logger: Logger[F],
+  )(implicit F: Temporal[F]): F[Unit] = {
+    def reuse(bytes: Array[Byte]) =
+      nextBytes.set(bytes) *>
+        startNextRead *> // start the next read before returning to pool
+        canBeReused.set(Reusable.Reuse) // now it is safe to mark as re-usable
+
     drain.flatMap {
       case Some(bytes) =>
         val requestClose = connectionFor(req.httpVersion, req.headers).hasClose
         val responseClose = connectionFor(resp.httpVersion, resp.headers).hasClose
-
         if (requestClose || responseClose) F.unit
-        else
-          nextBytes.set(bytes) *>
-            startNextRead *> // start the next read before returning to pool
-            canBeReused.set(Reusable.Reuse) // now it is safe to mark as re-usable
-      case None => F.unit
+        else reuse(bytes)
+      case None =>
+        F.timeout(
+          resp.body
+            .take(maxDrainBytes)
+            .compile
+            .to(Array)
+            .flatMap { bytes =>
+              if (bytes.size < maxDrainBytes) reuse(bytes)
+              else F.unit
+            },
+          drainTimeout,
+        ).handleErrorWith(e => logger.error(e)("Error draining response"))
     }
+  }
 
   private def getAddress[F[_]: MonadThrow](requestKey: RequestKey): F[SocketAddress[Host]] =
     requestKey match {

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -234,11 +234,11 @@ private[client] object ClientHelpers {
         case None =>
           F.timeout(
             resp.body
-              .take(maxDrainBytes)
+              .take(maxDrainBytes + 1)
               .compile
               .count
               .flatMap { count =>
-                if (count < maxDrainBytes) {
+                if (count <= maxDrainBytes) {
                   startNextRead *>
                     canBeReused.set(Reusable.Reuse)
                 } else F.unit

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -221,32 +221,31 @@ private[client] object ClientHelpers {
       maxDrainBytes: Long,
       drainTimeout: Duration,
       logger: Logger[F],
-  )(implicit F: Temporal[F]): F[Unit] = {
-    def reuse(bytes: Array[Byte]) =
-      nextBytes.set(bytes) *>
-        startNextRead *> // start the next read before returning to pool
-        canBeReused.set(Reusable.Reuse) // now it is safe to mark as re-usable
-
+  )(implicit F: Temporal[F]): F[Unit] =
     drain.flatMap {
       case Some(bytes) =>
         val requestClose = connectionFor(req.httpVersion, req.headers).hasClose
         val responseClose = connectionFor(resp.httpVersion, resp.headers).hasClose
         if (requestClose || responseClose) F.unit
-        else reuse(bytes)
+        else
+          nextBytes.set(bytes) *>
+            startNextRead *> // start the next read before returning to pool
+            canBeReused.set(Reusable.Reuse) // now it is safe to mark as re-usable
       case None =>
         F.timeout(
           resp.body
             .take(maxDrainBytes)
             .compile
-            .to(Array)
-            .flatMap { bytes =>
-              if (bytes.size < maxDrainBytes) reuse(bytes)
-              else F.unit
+            .count
+            .flatMap { count =>
+              if (count < maxDrainBytes) {
+                startNextRead *>
+                  canBeReused.set(Reusable.Reuse)
+              } else F.unit
             },
           drainTimeout,
         ).handleErrorWith(e => logger.error(e)("Error draining response"))
     }
-  }
 
   private def getAddress[F[_]: MonadThrow](requestKey: RequestKey): F[SocketAddress[Host]] =
     requestKey match {

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -222,29 +222,32 @@ private[client] object ClientHelpers {
       drainTimeout: Duration,
       logger: Logger[F],
   )(implicit F: Temporal[F]): F[Unit] =
-    drain.flatMap {
-      case Some(bytes) =>
-        val requestClose = connectionFor(req.httpVersion, req.headers).hasClose
-        val responseClose = connectionFor(resp.httpVersion, resp.headers).hasClose
-        if (requestClose || responseClose) F.unit
-        else
+    if (
+      connectionFor(req.httpVersion, req.headers).hasClose ||
+      connectionFor(resp.httpVersion, resp.headers).hasClose
+    )
+      F.unit
+    else {
+      drain.flatMap {
+        case Some(bytes) =>
           nextBytes.set(bytes) *>
             startNextRead *> // start the next read before returning to pool
             canBeReused.set(Reusable.Reuse) // now it is safe to mark as re-usable
-      case None =>
-        F.timeout(
-          resp.body
-            .take(maxDrainBytes)
-            .compile
-            .count
-            .flatMap { count =>
-              if (count < maxDrainBytes) {
-                startNextRead *>
-                  canBeReused.set(Reusable.Reuse)
-              } else F.unit
-            },
-          drainTimeout,
-        ).handleErrorWith(e => logger.error(e)("Error draining response"))
+        case None =>
+          F.timeout(
+            resp.body
+              .take(maxDrainBytes)
+              .compile
+              .count
+              .flatMap { count =>
+                if (count < maxDrainBytes) {
+                  startNextRead *>
+                    canBeReused.set(Reusable.Reuse)
+                } else F.unit
+              },
+            drainTimeout,
+          ).handleErrorWith(e => logger.error(e)("Error draining response"))
+      }
     }
 
   private def getAddress[F[_]: MonadThrow](requestKey: RequestKey): F[SocketAddress[Host]] =

--- a/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
+++ b/ember-client/shared/src/main/scala/org/http4s/ember/client/internal/ClientHelpers.scala
@@ -222,12 +222,10 @@ private[client] object ClientHelpers {
       drainTimeout: Duration,
       logger: Logger[F],
   )(implicit F: Temporal[F]): F[Unit] =
-    if (
+    F.unlessA(
       connectionFor(req.httpVersion, req.headers).hasClose ||
-      connectionFor(resp.httpVersion, resp.headers).hasClose
-    )
-      F.unit
-    else {
+        connectionFor(resp.httpVersion, resp.headers).hasClose
+    )(
       drain.flatMap {
         case Some(bytes) =>
           nextBytes.set(bytes) *>
@@ -248,7 +246,7 @@ private[client] object ClientHelpers {
             drainTimeout,
           ).handleErrorWith(e => logger.error(e)("Error draining response"))
       }
-    }
+    )
 
   private def getAddress[F[_]: MonadThrow](requestKey: RequestKey): F[SocketAddress[Host]] =
     requestKey match {

--- a/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
+++ b/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
@@ -33,6 +33,8 @@ import scala.concurrent.duration._
 class ClientHelpersSuite extends Http4sSuite {
   private[this] val logger = NoOpFactory[IO].getLogger
 
+  private[this] val CloseHeader = Connection(NonEmptyList.of(ci"close"))
+
   test("Request Preprocessing should add a date header if not present") {
     ClientHelpers
       .preprocessRequest(Request[IO](), None)
@@ -71,7 +73,7 @@ class ClientHelpersSuite extends Http4sSuite {
   test("Request Preprocessing should not add a connection header if already present") {
     ClientHelpers
       .preprocessRequest(
-        Request[IO](headers = Headers(Connection(NonEmptyList.of(ci"close")))),
+        Request[IO](headers = Headers(CloseHeader)),
         None,
       )
       .map { req =>
@@ -157,7 +159,7 @@ class ClientHelpersSuite extends Http4sSuite {
       reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
       _ <- ClientHelpers
         .postProcessResponse[IO](
-          Request[IO](headers = Headers(Connection(NonEmptyList.of(ci"close")))),
+          Request[IO](headers = Headers(CloseHeader)),
           Response[IO](),
           IO.pure(Some(Array.emptyByteArray)),
           nextBytes,
@@ -173,14 +175,36 @@ class ClientHelpersSuite extends Http4sSuite {
     } yield testResult
   }
 
-  test("Postprocess response should do not reuse when connection close is set on response") {
+  test(
+    "Postprocess response should not reuse when connection close is set on request and response body is drained in postprocessing"
+  ) {
+    for {
+      nextBytes <- Ref[IO].of(Array.emptyByteArray)
+      reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+      body = Stream.emit('.'.toByte).repeat.take(128).covary[IO]
+      _ <- ClientHelpers.postProcessResponse[IO](
+        Request[IO](headers = Headers(CloseHeader)),
+        Response[IO](body = body),
+        IO.pure(None),
+        nextBytes,
+        reuse,
+        IO.unit,
+        maxDrainBytes = 1024L,
+        drainTimeout = 5.seconds,
+        logger = logger,
+      )
+      testResult <- reuse.get.map(r => assertEquals(r, Reusable.DontReuse))
+    } yield testResult
+  }
+
+  test("Postprocess response should not reuse when connection close is set on response") {
     for {
       nextBytes <- Ref[IO].of(Array.emptyByteArray)
       reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
       _ <- ClientHelpers
         .postProcessResponse[IO](
           Request[IO](),
-          Response[IO](headers = Headers(Connection(NonEmptyList.of(ci"close")))),
+          Response[IO](headers = Headers(CloseHeader)),
           IO.pure(Some(Array.emptyByteArray)),
           nextBytes,
           reuse,
@@ -192,6 +216,28 @@ class ClientHelpersSuite extends Http4sSuite {
       testResult <- reuse.get.map { case r =>
         assertEquals(r, Reusable.DontReuse)
       }
+    } yield testResult
+  }
+
+  test(
+    "Postprocess response should not reuse when connection close is set on response and response body is drained in postprocessing"
+  ) {
+    for {
+      nextBytes <- Ref[IO].of(Array.emptyByteArray)
+      reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+      body = Stream.emit('.'.toByte).repeat.take(128).covary[IO]
+      _ <- ClientHelpers.postProcessResponse[IO](
+        Request[IO](),
+        Response[IO](body = body, headers = Headers(CloseHeader)),
+        IO.pure(None),
+        nextBytes,
+        reuse,
+        IO.unit,
+        maxDrainBytes = 1024L,
+        drainTimeout = 5.seconds,
+        logger = logger,
+      )
+      testResult <- reuse.get.map(r => assertEquals(r, Reusable.DontReuse))
     } yield testResult
   }
 

--- a/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
+++ b/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
@@ -18,6 +18,7 @@ package org.http4s.ember.client.internal
 
 import cats.data.NonEmptyList
 import cats.effect._
+import fs2.Stream
 import org.http4s._
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.headers.Connection
@@ -25,8 +26,12 @@ import org.http4s.headers.Date
 import org.http4s.headers.`User-Agent`
 import org.typelevel.ci._
 import org.typelevel.keypool.Reusable
+import org.typelevel.log4cats.noop.NoOpFactory
+
+import scala.concurrent.duration._
 
 class ClientHelpersSuite extends Http4sSuite {
+  private[this] val logger = NoOpFactory[IO].getLogger
 
   test("Request Preprocessing should add a date header if not present") {
     ClientHelpers
@@ -116,6 +121,9 @@ class ClientHelpersSuite extends Http4sSuite {
           nextBytes,
           reuse,
           IO.unit,
+          maxDrainBytes = 1024L,
+          drainTimeout = 5.seconds,
+          logger = logger,
         )
       testResult <- reuse.get.map { case r =>
         assertEquals(r, Reusable.Reuse)
@@ -135,6 +143,9 @@ class ClientHelpersSuite extends Http4sSuite {
         nextBytes,
         reuse,
         IO.unit,
+        maxDrainBytes = 1024L,
+        drainTimeout = 5.seconds,
+        logger = logger,
       )
       drained <- nextBytes.get
     } yield assertEquals(drained.toList, List[Byte](1, 2, 3))
@@ -152,6 +163,9 @@ class ClientHelpersSuite extends Http4sSuite {
           nextBytes,
           reuse,
           IO.unit,
+          maxDrainBytes = 1024L,
+          drainTimeout = 5.seconds,
+          logger = logger,
         )
       testResult <- reuse.get.map { case r =>
         assertEquals(r, Reusable.DontReuse)
@@ -171,6 +185,9 @@ class ClientHelpersSuite extends Http4sSuite {
           nextBytes,
           reuse,
           IO.unit,
+          maxDrainBytes = 1024L,
+          drainTimeout = 5.seconds,
+          logger = logger,
         )
       testResult <- reuse.get.map { case r =>
         assertEquals(r, Reusable.DontReuse)
@@ -178,22 +195,65 @@ class ClientHelpersSuite extends Http4sSuite {
     } yield testResult
   }
 
-  test("Postprocess response should do not reuse when drain is None") {
+  test(
+    "Postprocess response should reuse when body is partially consumed but within drain limit and timeout"
+  ) {
     for {
       nextBytes <- Ref[IO].of(Array.emptyByteArray)
       reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
-      _ <- ClientHelpers
-        .postProcessResponse[IO](
-          Request[IO](),
-          Response[IO](),
-          IO.pure(None),
-          nextBytes,
-          reuse,
-          IO.unit,
-        )
-      testResult <- reuse.get.map { case r =>
-        assertEquals(r, Reusable.DontReuse)
-      }
+      body = Stream.emit('.'.toByte).repeat.take(128).covary[IO]
+      _ <- ClientHelpers.postProcessResponse[IO](
+        Request[IO](),
+        Response[IO](body = body),
+        IO.pure(None), // body not consumed by user
+        nextBytes,
+        reuse,
+        IO.unit,
+        maxDrainBytes = 1024L,
+        drainTimeout = 5.seconds,
+        logger = logger,
+      )
+      testResult <- reuse.get.map(r => assertEquals(r, Reusable.Reuse))
+    } yield testResult
+  }
+
+  test("Postprocess response should not reuse when body exceeds drain limit") {
+    for {
+      nextBytes <- Ref[IO].of(Array.emptyByteArray)
+      reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+      body = Stream.emit('.'.toByte).repeat.take(2048).covary[IO]
+      _ <- ClientHelpers.postProcessResponse[IO](
+        Request[IO](),
+        Response[IO](body = body),
+        IO.pure(None),
+        nextBytes,
+        reuse,
+        IO.unit,
+        maxDrainBytes = 1024L,
+        drainTimeout = 5.seconds,
+        logger = logger,
+      )
+      testResult <- reuse.get.map(r => assertEquals(r, Reusable.DontReuse))
+    } yield testResult
+  }
+
+  test("Postprocess response should not reuse when drain times out") {
+    for {
+      nextBytes <- Ref[IO].of(Array.emptyByteArray)
+      reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+      body = Stream.never[IO]
+      _ <- ClientHelpers.postProcessResponse[IO](
+        Request[IO](),
+        Response[IO](body = body),
+        IO.pure(None),
+        nextBytes,
+        reuse,
+        IO.unit,
+        maxDrainBytes = 1024L,
+        drainTimeout = 100.milliseconds,
+        logger = logger,
+      )
+      testResult <- reuse.get.map(r => assertEquals(r, Reusable.DontReuse))
     } yield testResult
   }
 }

--- a/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
+++ b/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
@@ -263,6 +263,28 @@ class ClientHelpersSuite extends Http4sSuite {
     } yield testResult
   }
 
+  test(
+    "Postprocess response should reuse when body is partially consumed and exact drain limit can be read within timeout"
+  ) {
+    for {
+      nextBytes <- Ref[IO].of(Array.emptyByteArray)
+      reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+      body = Stream.emit('.'.toByte).repeat.take(1024).covary[IO]
+      _ <- ClientHelpers.postProcessResponse[IO](
+        Request[IO](),
+        Response[IO](body = body),
+        IO.pure(None), // body not consumed by user
+        nextBytes,
+        reuse,
+        IO.unit,
+        maxDrainBytes = 1024L,
+        drainTimeout = 5.seconds,
+        logger = logger,
+      )
+      testResult <- reuse.get.map(r => assertEquals(r, Reusable.Reuse))
+    } yield testResult
+  }
+
   test("Postprocess response should not reuse when body exceeds drain limit") {
     for {
       nextBytes <- Ref[IO].of(Array.emptyByteArray)

--- a/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
+++ b/ember-client/shared/src/test/scala/org/http4s/ember/client/internal/ClientHelpersSuite.scala
@@ -256,4 +256,24 @@ class ClientHelpersSuite extends Http4sSuite {
       testResult <- reuse.get.map(r => assertEquals(r, Reusable.DontReuse))
     } yield testResult
   }
+
+  test("Postprocess response should not retain drained bytes for next response") {
+    for {
+      nextBytes <- Ref[IO].of(Array.emptyByteArray)
+      reuse <- Ref[IO].of(Reusable.DontReuse: Reusable)
+      body = Stream.emit('.'.toByte).repeat.take(128).covary[IO]
+      _ <- ClientHelpers.postProcessResponse[IO](
+        Request[IO](),
+        Response[IO](body = body),
+        IO.pure(None),
+        nextBytes,
+        reuse,
+        IO.unit,
+        maxDrainBytes = 1024L,
+        drainTimeout = 5.seconds,
+        logger = logger,
+      )
+      bytes <- nextBytes.get
+    } yield assert(bytes.isEmpty)
+  }
 }


### PR DESCRIPTION
When a connection is returned to Ember, attempt to read up to `maxDrainBytes` within `drainTimeout` seconds to reach the end of the stream.  If the end of the stream is reached within these parameters, mark the connection for reuse.

This helps in particular with servers that return responses with chunked transfer encoding that are small and fast.