### PR TITLE
Ember H/2: emit RST_STREAM on cancel/error; opt-in cancel-on-peer-RST

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -512,15 +512,6 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "org.http4s.ember.core.h2.H2Stream#State.apply"
       ),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.ember.core.h2.H2Stream#State.copy"
-      ),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.ember.core.h2.H2Stream#State.this"
-      ),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.http4s.ember.core.h2.H2Stream#State.apply"
-      ),
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
         "org.http4s.ember.core.h2.H2Stream#State._8"
       ),

--- a/build.sbt
+++ b/build.sbt
@@ -512,6 +512,15 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "org.http4s.ember.core.h2.H2Stream#State.apply"
       ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.ember.core.h2.H2Stream#State.copy"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.ember.core.h2.H2Stream#State.this"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.http4s.ember.core.h2.H2Stream#State.apply"
+      ),
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
         "org.http4s.ember.core.h2.H2Stream#State._8"
       ),

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -214,23 +214,12 @@ private[ember] class H2Client[F[_]](
       )
 
     def clearClosed(h2: H2Connection[F]): F[Unit] =
-      // For each closed-stream id, wait `ClosedStreamGracePeriod` before
-      // removing the entry from `mapRef`. This absorbs late frames from the
-      // peer (DATA in flight when we sent RST, etc.) which would otherwise be
-      // surfaced as stale-stream protocol violations.
-      // Inner streams run as scope-owned worker fibers under
-      // `parJoin(maxConcurrentStreams)` — no `.start`-fork, no leak, real
-      // concurrency cap. Client-side filter to odd ids preserved (only
-      // client-initiated streams live in the client's `mapRef`).
       Stream
         .fromQueueUnterminated(h2.closedStreams)
-        .map { i =>
-          Stream.eval(
-            (Temporal[F].sleep(H2Connection.ClosedStreamGracePeriod) >>
-              h2.mapRef.update(m => m - i)).whenA(i % 2 != 0)
-          )
+        .parEvalMapUnordered(localSettings.maxConcurrentStreams.maxConcurrency) { i =>
+          (Temporal[F].sleep(H2Connection.ClosedStreamGracePeriod) >>
+            h2.mapRef.update(m => m - i)).whenA(i % 2 != 0)
         }
-        .parJoin(localSettings.maxConcurrentStreams.maxConcurrency)
         .compile
         .drain
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala
@@ -214,10 +214,23 @@ private[ember] class H2Client[F[_]](
       )
 
     def clearClosed(h2: H2Connection[F]): F[Unit] =
+      // For each closed-stream id, wait `ClosedStreamGracePeriod` before
+      // removing the entry from `mapRef`. This absorbs late frames from the
+      // peer (DATA in flight when we sent RST, etc.) which would otherwise be
+      // surfaced as stale-stream protocol violations.
+      // Inner streams run as scope-owned worker fibers under
+      // `parJoin(maxConcurrentStreams)` — no `.start`-fork, no leak, real
+      // concurrency cap. Client-side filter to odd ids preserved (only
+      // client-initiated streams live in the client's `mapRef`).
       Stream
         .fromQueueUnterminated(h2.closedStreams)
-        .repeat
-        .foreach(i => if (i % 2 != 0) h2.mapRef.update(m => m - i) else F.unit)
+        .map { i =>
+          Stream.eval(
+            (Temporal[F].sleep(H2Connection.ClosedStreamGracePeriod) >>
+              h2.mapRef.update(m => m - i)).whenA(i % 2 != 0)
+          )
+        }
+        .parJoin(localSettings.maxConcurrentStreams.maxConcurrency)
         .compile
         .drain
 
@@ -294,13 +307,27 @@ private[ember] class H2Client[F[_]](
         )
       )
       // Stream Order Must Be Correct, so we must grab the global lock
-      stream <- Resource.make(
+      stream <- Resource.makeCase(
         connection.streamCreateAndHeaders.use(_ =>
           connection.initiateLocalStream.flatMap(stream =>
             stream.sendHeaders(PseudoHeaders.requestToHeaders(req), endStream = false).as(stream)
           )
         )
-      )(stream => connection.mapRef.update(m => m - stream.id))
+      ) { (stream, exitCase) =>
+        // Propagate local cancellation/error to the peer as RST_STREAM.
+        // `rstStream` is idempotent: if the stream is already Closed (e.g. peer
+        // sent RST, or the inner `sendMessageBody` finalizer already RST'd
+        // because the background body-send fiber was canceled/errored), this
+        // becomes a no-op. The two emission points cover disjoint failure
+        // domains separated by `.background` below.
+        // Stream removal from `connection.mapRef` is delegated to the
+        // connection's `clearClosed` pump via the `onClosed` hook.
+        exitCase match {
+          case Resource.ExitCase.Canceled => stream.rstStream(H2Error.Cancel)
+          case Resource.ExitCase.Errored(_) => stream.rstStream(H2Error.InternalError)
+          case Resource.ExitCase.Succeeded => Applicative[F].unit
+        }
+      }
       _ <- (stream.sendMessageBody(req) >> stream.sendTrailerHeaders(req)).background
       resp <- Resource.eval(stream.getResponse).map(_.covary[F].withBodyStream(stream.readBody))
     } yield resp

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -540,8 +540,8 @@ private[h2] class H2Connection[F[_]](
           state.update(s => s.copy(closed = true))
       case Outcome.Errored(e) =>
         logger.error(e)(s"ReadLoop has errored") >>
-          state.update(s => s.copy(closed = true)) >>
-          goAway(H2Error.InternalError)
+          goAway(H2Error.InternalError) >>
+          state.update(s => s.copy(closed = true))
 
       case _ => state.update(s => s.copy(closed = true))
     }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -82,7 +82,6 @@ private[h2] class H2Connection[F[_]](
         trailers,
         body,
         None,
-        cancelSignal,
       )
     )
     stream = new H2Stream(
@@ -91,6 +90,7 @@ private[h2] class H2Connection[F[_]](
       connectionType,
       state.get.map(_.remoteSettings),
       refState,
+      cancelSignal,
       hpack,
       outgoing,
       closedStreams.offer(id),
@@ -120,7 +120,6 @@ private[h2] class H2Connection[F[_]](
         trailers,
         body,
         None,
-        cancelSignal,
       )
     )
     stream = new H2Stream(
@@ -129,6 +128,7 @@ private[h2] class H2Connection[F[_]](
       connectionType,
       state.get.map(_.remoteSettings),
       refState,
+      cancelSignal,
       hpack,
       outgoing,
       closedStreams.offer(id),
@@ -540,8 +540,8 @@ private[h2] class H2Connection[F[_]](
           state.update(s => s.copy(closed = true))
       case Outcome.Errored(e) =>
         logger.error(e)(s"ReadLoop has errored") >>
-          goAway(H2Error.InternalError) >>
-          state.update(s => s.copy(closed = true))
+          state.update(s => s.copy(closed = true)) >>
+          goAway(H2Error.InternalError)
 
       case _ => state.update(s => s.copy(closed = true))
     }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Connection.scala
@@ -27,6 +27,8 @@ import fs2.io.net.Socket
 import org.typelevel.log4cats.Logger
 import scodec.bits._
 
+import scala.concurrent.duration._
+
 import H2Frame.Settings.SettingsInitialWindowSize
 
 private[h2] class H2Connection[F[_]](
@@ -68,6 +70,7 @@ private[h2] class H2Connection[F[_]](
     response <- Deferred[F, Either[Throwable, org.http4s.Response[fs2.Pure]]]
     trailers <- Deferred[F, Either[Throwable, org.http4s.Headers]]
     body <- Channel.unbounded[F, Either[Throwable, ByteVector]]
+    cancelSignal <- Deferred[F, H2Error]
     refState <- Ref.of[F, H2Stream.State[F]](
       H2Stream.State(
         H2Stream.StreamState.Idle,
@@ -79,6 +82,7 @@ private[h2] class H2Connection[F[_]](
         trailers,
         body,
         None,
+        cancelSignal,
       )
     )
     stream = new H2Stream(
@@ -104,6 +108,7 @@ private[h2] class H2Connection[F[_]](
     response <- Deferred[F, Either[Throwable, org.http4s.Response[fs2.Pure]]]
     trailers <- Deferred[F, Either[Throwable, org.http4s.Headers]]
     body <- Channel.unbounded[F, Either[Throwable, ByteVector]]
+    cancelSignal <- Deferred[F, H2Error]
     refState <- Ref.of[F, H2Stream.State[F]](
       H2Stream.State(
         H2Stream.StreamState.Idle,
@@ -115,6 +120,7 @@ private[h2] class H2Connection[F[_]](
         trailers,
         body,
         None,
+        cancelSignal,
       )
     )
     stream = new H2Stream(
@@ -544,6 +550,15 @@ private[h2] class H2Connection[F[_]](
 }
 
 private[h2] object H2Connection {
+
+  /** How long after a stream transitions to Closed we keep its entry in
+    *  `mapRef` to gracefully absorb late frames from the peer (e.g. DATA
+    *  arriving after we sent RST_STREAM). After this window the entry is
+    *  removed and any further frames for that id are treated as
+    *  protocol-level stale-frame conditions per RFC 9113 §5.1.
+    */
+  val ClosedStreamGracePeriod: FiniteDuration = 1.second
+
   final case class State[F[_]](
       remoteSettings: H2Frame.Settings.ConnectionSettings,
       writeWindow: Int,

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -226,22 +226,12 @@ private[ember] object H2Server {
     )
 
     def clearClosedStreams(h2: H2Connection[F]): F[Unit] =
-      // For each closed-stream id, wait `ClosedStreamGracePeriod` before
-      // removing the entry from `mapRef`. This absorbs late frames from the
-      // peer (DATA in flight when we sent RST, etc.) which would otherwise be
-      // surfaced as stale-stream protocol violations.
-      // Inner streams run as scope-owned worker fibers under
-      // `parJoin(maxConcurrentStreams)` — no `.start`-fork, no leak, real
-      // concurrency cap.
       Stream
         .fromQueueUnterminated(h2.closedStreams)
-        .map { i =>
-          Stream.eval(
-            Temporal[F].sleep(H2Connection.ClosedStreamGracePeriod) >>
-              h2.mapRef.update(m => m - i)
-          )
+        .parEvalMapUnordered(localSettings.maxConcurrentStreams.maxConcurrency) { i =>
+          Temporal[F].sleep(H2Connection.ClosedStreamGracePeriod) >>
+            h2.mapRef.update(m => m - i)
         }
-        .parJoin(localSettings.maxConcurrentStreams.maxConcurrency)
         .compile
         .drain
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -173,10 +173,6 @@ private[ember] object H2Server {
       // Only Used for http1 upgrade where remote settings are provided prior to escalation
       initialRemoteSettings: H2Frame.Settings.ConnectionSettings = defaultSettings,
       initialRequest: Option[Request[fs2.Pure]] = None,
-      // When true, an inbound RST_STREAM (or stream-level GOAWAY) cancels the
-      // in-flight route-handler fiber for that stream. When false, the route
-      // runs to completion and its response is silently discarded after the
-      // stream has been reset.
       cancelOnPeerReset: Boolean = false,
   )(implicit F: Async[F]): Resource[F, Unit] = {
     import cats.effect.kernel.instances.spawn._
@@ -308,7 +304,7 @@ private[ember] object H2Server {
           } yield ()
         _ <-
           if (cancelOnPeerReset)
-            stream.state.get.flatMap(_.cancelSignal.get).race(respond).void
+            stream.cancelSignal.get.race(respond).void
           else respond
       } yield ()
     }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -173,6 +173,11 @@ private[ember] object H2Server {
       // Only Used for http1 upgrade where remote settings are provided prior to escalation
       initialRemoteSettings: H2Frame.Settings.ConnectionSettings = defaultSettings,
       initialRequest: Option[Request[fs2.Pure]] = None,
+      // When true, an inbound RST_STREAM (or stream-level GOAWAY) cancels the
+      // in-flight route-handler fiber for that stream. When false, the route
+      // runs to completion and its response is silently discarded after the
+      // stream has been reset.
+      cancelOnPeerReset: Boolean = false,
   )(implicit F: Async[F]): Resource[F, Unit] = {
     import cats.effect.kernel.instances.spawn._
 
@@ -225,15 +230,21 @@ private[ember] object H2Server {
     )
 
     def clearClosedStreams(h2: H2Connection[F]): F[Unit] =
+      // For each closed-stream id, wait `ClosedStreamGracePeriod` before
+      // removing the entry from `mapRef`. This absorbs late frames from the
+      // peer (DATA in flight when we sent RST, etc.) which would otherwise be
+      // surfaced as stale-stream protocol violations.
+      // Inner streams run as scope-owned worker fibers under
+      // `parJoin(maxConcurrentStreams)` — no `.start`-fork, no leak, real
+      // concurrency cap.
       Stream
         .fromQueueUnterminated(h2.closedStreams)
-        .map(i =>
+        .map { i =>
           Stream.eval(
-            // Max Time After Close We Will Still Accept Messages
-            (Temporal[F].sleep(1.seconds) >>
-              h2.mapRef.update(m => m - i)).timeout(15.seconds).attempt.start
+            Temporal[F].sleep(H2Connection.ClosedStreamGracePeriod) >>
+              h2.mapRef.update(m => m - i)
           )
-        )
+        }
         .parJoin(localSettings.maxConcurrentStreams.maxConcurrency)
         .compile
         .drain
@@ -281,11 +292,24 @@ private[ember] object H2Server {
       for {
         stream <- h2.mapRef.get.map(_.get(streamIx)).map(_.get) // FOLD
         req <- stream.getRequest.map(_.covary[F].withBodyStream(stream.readBody))
-        resp <- httpApp(req)
-        _ <- stream.sendHeaders(PseudoHeaders.responseToHeaders(resp), endStream = false)
-        _ <- fulfillPushPromises(resp)
-        _ <- stream.sendMessageBody(resp) // Initial Resp Body
-        _ <- stream.sendTrailerHeaders(resp)
+        // When opt-in cancel-on-peer-reset is enabled, race the response
+        // pipeline against the per-stream `cancelSignal` (completed by
+        // `receiveRstStream`/`receiveGoAway`). On peer abort, the route
+        // fiber is canceled — its finalizers run, the stream is already
+        // Closed (state-machine-wise) so any RST emitted from canceled
+        // body sends is a no-op via `RstAction.AlreadyClosed`.
+        respond =
+          for {
+            resp <- httpApp(req)
+            _ <- stream.sendHeaders(PseudoHeaders.responseToHeaders(resp), endStream = false)
+            _ <- fulfillPushPromises(resp)
+            _ <- stream.sendMessageBody(resp) // Initial Resp Body
+            _ <- stream.sendTrailerHeaders(resp)
+          } yield ()
+        _ <-
+          if (cancelOnPeerReset)
+            stream.state.get.flatMap(_.cancelSignal.get).race(respond).void
+          else respond
       } yield ()
     }
 

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -41,6 +41,7 @@ private[h2] class H2Stream[F[_]: Concurrent](
     connectionType: H2Connection.ConnectionType,
     val remoteSettings: F[H2Frame.Settings.ConnectionSettings],
     val state: Ref[F, H2Stream.State[F]],
+    val cancelSignal: Deferred[F, H2Error],
     val hpack: Hpack[F],
     val enqueue: cats.effect.std.Queue[F, Chunk[H2Frame]],
     val onClosed: F[Unit],
@@ -384,14 +385,16 @@ private[h2] class H2Stream[F[_]: Concurrent](
   // Will eventually allow us to know we can retry if we are above the processed window declared
   def receiveGoAway(goAway: H2Frame.GoAway): F[Unit] = for {
     s <- state.modify(s => (s.copy(state = StreamState.Closed), s))
-    _ <- s.cancelSignal.complete(H2Error.fromInt(goAway.errorCode).getOrElse(H2Error.InternalError))
+    _ <- cancelSignal
+      .complete(H2Error.fromInt(goAway.errorCode).getOrElse(H2Error.InternalError))
+      .whenA(goAway.errorCode != H2Error.NoError.value)
     _ <- s.cancelWith(s"Received GoAway, cancelling: $goAway")
     _ <- onClosed
   } yield ()
 
   def receiveRstStream(rst: H2Frame.RstStream): F[Unit] = for {
     s <- state.modify(s => (s.copy(state = StreamState.Closed), s))
-    _ <- s.cancelSignal.complete(H2Error.fromInt(rst.value).getOrElse(H2Error.Cancel))
+    _ <- cancelSignal.complete(H2Error.fromInt(rst.value).getOrElse(H2Error.Cancel))
     _ <- s.cancelWith(s"Received RstStream, cancelling: $rst")
     _ <- onClosed
   } yield ()
@@ -465,11 +468,6 @@ private[h2] object H2Stream {
       trailers: Deferred[F, Either[Throwable, org.http4s.Headers]],
       readBuffer: Channel[F, Either[Throwable, ByteVector]],
       contentLengthCheck: Option[(Long, Long)],
-      // Completed when the peer aborts the stream (RST_STREAM or stream-level
-      // GOAWAY). Used by the server-side opt-in cancel-on-peer-reset feature
-      // to interrupt in-flight route execution. Idempotent — multiple completes
-      // are silently ignored. Carries the H2 error code observed from the peer.
-      cancelSignal: Deferred[F, H2Error],
   ) {
     override def toString: String =
       s"H2Stream.State(state=$state, writeWindow=$writeWindow, readWindow=$readWindow, contentLengthCheck=$contentLengthCheck)"

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -19,6 +19,7 @@ package org.http4s.ember.core.h2
 import cats._
 import cats.data._
 import cats.effect._
+import cats.effect.syntax.all._
 import cats.syntax.all._
 import fs2._
 import fs2.concurrent.Channel
@@ -85,8 +86,10 @@ private[h2] class H2Stream[F[_]: Concurrent](
           .foreach(c => sendData(c.toByteVector, endStream = false))
           .compile
           .drain >> sendData(ByteVector.empty, endStream = true).whenA(noTrailers)
-      sendBody.onError { case _ =>
-        rstStream(H2Error.InternalError)
+      sendBody.guaranteeCase {
+        case Outcome.Errored(_) => rstStream(H2Error.InternalError)
+        case Outcome.Canceled() => rstStream(H2Error.Cancel)
+        case Outcome.Succeeded(_) => Applicative[F].unit
       }
     }
   }
@@ -350,25 +353,45 @@ private[h2] class H2Stream[F[_]: Concurrent](
   }
 
   def rstStream(error: H2Error): F[Unit] = {
-    val rst = error.toRst(id)
-    for {
-      s <- state.modify(s => (s.copy(state = StreamState.Closed), s))
-      _ <- enqueue.offer(Chunk.singleton(rst))
-      _ <- s.cancelWith(s"Sending RstStream, cancelling: $rst")
-      _ <- onClosed
-    } yield ()
+    import H2Stream.RstAction
+    state
+      .modify[RstAction[F]] { s =>
+        s.state match {
+          case StreamState.Closed =>
+            (s, RstAction.AlreadyClosed[F]())
+          case StreamState.Idle =>
+            // Defensive: never emit RST on an Idle stream (RFC 9113 §5.4.2).
+            // Mark closed locally and run cleanup; do not enqueue a frame.
+            (s.copy(state = StreamState.Closed), RstAction.SkipFrame(s))
+          case _ =>
+            (s.copy(state = StreamState.Closed), RstAction.Send(s))
+        }
+      }
+      .flatMap {
+        case RstAction.AlreadyClosed() =>
+          Applicative[F].unit
+        case RstAction.SkipFrame(prev) =>
+          prev.cancelWith(s"Closing stream $id without sending RstStream") *> onClosed
+        case RstAction.Send(prev) =>
+          val rst = error.toRst(id)
+          enqueue.offer(Chunk.singleton(rst)) *>
+            prev.cancelWith(s"Sending RstStream, cancelling: $rst") *>
+            onClosed
+      }
   }
 
   // Broadcast Frame
   // Will eventually allow us to know we can retry if we are above the processed window declared
   def receiveGoAway(goAway: H2Frame.GoAway): F[Unit] = for {
     s <- state.modify(s => (s.copy(state = StreamState.Closed), s))
+    _ <- s.cancelSignal.complete(H2Error.fromInt(goAway.errorCode).getOrElse(H2Error.InternalError))
     _ <- s.cancelWith(s"Received GoAway, cancelling: $goAway")
     _ <- onClosed
   } yield ()
 
   def receiveRstStream(rst: H2Frame.RstStream): F[Unit] = for {
     s <- state.modify(s => (s.copy(state = StreamState.Closed), s))
+    _ <- s.cancelSignal.complete(H2Error.fromInt(rst.value).getOrElse(H2Error.Cancel))
     _ <- s.cancelWith(s"Received RstStream, cancelling: $rst")
     _ <- onClosed
   } yield ()
@@ -415,6 +438,23 @@ private[h2] class H2Stream[F[_]: Concurrent](
 }
 
 private[h2] object H2Stream {
+
+  /** Decision returned by the atomic state transition in [[H2Stream.rstStream]].
+    *
+    *  - [[RstAction.AlreadyClosed]]: stream was already `Closed`; no-op.
+    *  - [[RstAction.SkipFrame]]: stream was `Idle`; transition to `Closed` and
+    *    run cleanup, but do not enqueue an RST_STREAM frame (RFC 9113 §5.4.2
+    *    forbids RST on idle streams).
+    *  - [[RstAction.Send]]: stream was active; transition to `Closed`, enqueue
+    *    the RST_STREAM frame, and run cleanup.
+    */
+  private[h2] sealed trait RstAction[F[_]]
+  private[h2] object RstAction {
+    final case class AlreadyClosed[F[_]]() extends RstAction[F]
+    final case class SkipFrame[F[_]](prev: State[F]) extends RstAction[F]
+    final case class Send[F[_]](prev: State[F]) extends RstAction[F]
+  }
+
   final case class State[F[_]](
       state: StreamState,
       writeWindow: Int,
@@ -425,6 +465,11 @@ private[h2] object H2Stream {
       trailers: Deferred[F, Either[Throwable, org.http4s.Headers]],
       readBuffer: Channel[F, Either[Throwable, ByteVector]],
       contentLengthCheck: Option[(Long, Long)],
+      // Completed when the peer aborts the stream (RST_STREAM or stream-level
+      // GOAWAY). Used by the server-side opt-in cancel-on-peer-reset feature
+      // to interrupt in-flight route execution. Idempotent — multiple completes
+      // are silently ignored. Carries the H2 error code observed from the peer.
+      cancelSignal: Deferred[F, H2Error],
   ) {
     override def toString: String =
       s"H2Stream.State(state=$state, writeWindow=$writeWindow, readWindow=$readWindow, contentLengthCheck=$contentLengthCheck)"

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala
@@ -353,33 +353,28 @@ private[h2] class H2Stream[F[_]: Concurrent](
     }
   }
 
-  def rstStream(error: H2Error): F[Unit] = {
-    import H2Stream.RstAction
-    state
-      .modify[RstAction[F]] { s =>
-        s.state match {
-          case StreamState.Closed =>
-            (s, RstAction.AlreadyClosed[F]())
-          case StreamState.Idle =>
-            // Defensive: never emit RST on an Idle stream (RFC 9113 §5.4.2).
-            // Mark closed locally and run cleanup; do not enqueue a frame.
-            (s.copy(state = StreamState.Closed), RstAction.SkipFrame(s))
-          case _ =>
-            (s.copy(state = StreamState.Closed), RstAction.Send(s))
-        }
-      }
-      .flatMap {
-        case RstAction.AlreadyClosed() =>
-          Applicative[F].unit
-        case RstAction.SkipFrame(prev) =>
-          prev.cancelWith(s"Closing stream $id without sending RstStream") *> onClosed
-        case RstAction.Send(prev) =>
+  def rstStream(error: H2Error): F[Unit] =
+    state.flatModify { s =>
+      s.state match {
+        case StreamState.Closed =>
+          (s, Applicative[F].unit)
+        case StreamState.Idle =>
+          // Defensive: never emit RST on an Idle stream (RFC 9113 §5.4.2).
+          // Mark closed locally and run cleanup; do not enqueue a frame.
+          (
+            s.copy(state = StreamState.Closed),
+            s.cancelWith(s"Closing stream $id without sending RstStream") *> onClosed,
+          )
+        case _ =>
           val rst = error.toRst(id)
-          enqueue.offer(Chunk.singleton(rst)) *>
-            prev.cancelWith(s"Sending RstStream, cancelling: $rst") *>
-            onClosed
+          (
+            s.copy(state = StreamState.Closed),
+            enqueue.offer(Chunk.singleton(rst)) *>
+              s.cancelWith(s"Sending RstStream, cancelling: $rst") *>
+              onClosed,
+          )
       }
-  }
+    }
 
   // Broadcast Frame
   // Will eventually allow us to know we can retry if we are above the processed window declared
@@ -441,22 +436,6 @@ private[h2] class H2Stream[F[_]: Concurrent](
 }
 
 private[h2] object H2Stream {
-
-  /** Decision returned by the atomic state transition in [[H2Stream.rstStream]].
-    *
-    *  - [[RstAction.AlreadyClosed]]: stream was already `Closed`; no-op.
-    *  - [[RstAction.SkipFrame]]: stream was `Idle`; transition to `Closed` and
-    *    run cleanup, but do not enqueue an RST_STREAM frame (RFC 9113 §5.4.2
-    *    forbids RST on idle streams).
-    *  - [[RstAction.Send]]: stream was active; transition to `Closed`, enqueue
-    *    the RST_STREAM frame, and run cleanup.
-    */
-  private[h2] sealed trait RstAction[F[_]]
-  private[h2] object RstAction {
-    final case class AlreadyClosed[F[_]]() extends RstAction[F]
-    final case class SkipFrame[F[_]](prev: State[F]) extends RstAction[F]
-    final case class Send[F[_]](prev: State[F]) extends RstAction[F]
-  }
 
   final case class State[F[_]](
       state: StreamState,

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
@@ -47,6 +47,7 @@ class H2StreamSuite extends Http4sSuite {
       resp <- Deferred[IO, Either[Throwable, Response[fs2.Pure]]]
       trailers <- Deferred[IO, Either[Throwable, Headers]]
       readBuffer <- Channel.unbounded[IO, Either[Throwable, ByteVector]]
+      cancelSignal <- Deferred[IO, H2Error]
 
       state <- Ref[IO].of(
         H2Stream.State[IO](
@@ -59,6 +60,7 @@ class H2StreamSuite extends Http4sSuite {
           trailers = trailers,
           readBuffer = readBuffer,
           contentLengthCheck = None,
+          cancelSignal = cancelSignal,
         )
       )
       hpack <- Hpack.create[IO]
@@ -87,6 +89,7 @@ class H2StreamSuite extends Http4sSuite {
       resp <- Deferred[IO, Either[Throwable, Response[fs2.Pure]]]
       trailers <- Deferred[IO, Either[Throwable, Headers]]
       readBuffer <- Channel.unbounded[IO, Either[Throwable, ByteVector]]
+      cancelSignal <- Deferred[IO, H2Error]
 
       state <- Ref[IO].of(
         H2Stream.State[IO](
@@ -99,6 +102,7 @@ class H2StreamSuite extends Http4sSuite {
           trailers = trailers,
           readBuffer = readBuffer,
           contentLengthCheck = None,
+          cancelSignal = cancelSignal,
         )
       )
       hpack <- Hpack.create[IO]
@@ -337,6 +341,103 @@ class H2StreamSuite extends Http4sSuite {
       _ <- IO(assertFrame(lastChunk, "", endStream = true))
       _ <- fiber.joinWithNever
       _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.HalfClosedLocal)
+    } yield ()
+  }
+
+  test("H2Stream rstStream is idempotent: second call does not enqueue another frame") {
+    for {
+      sq <- streamAndQueue(defaultSettings)
+      (stream, queue) = sq
+      _ <- stream.rstStream(H2Error.Cancel)
+      _ <- stream.rstStream(H2Error.Cancel)
+      all <- queue.tryTakeN(None)
+      frames = all.flatMap(_.toList)
+      rsts = frames.collect { case r: H2Frame.RstStream => r }
+      _ <- IO(assertEquals(rsts.size, 1))
+      _ <- IO(assertEquals(rsts.head.identifier, stream.id))
+      _ <- IO(assertEquals(rsts.head.value: Int, H2Error.Cancel.value))
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Closed)
+    } yield ()
+  }
+
+  test("H2Stream rstStream skips frame on Idle stream (RFC 9113 §5.4.2)") {
+    for {
+      sq <- streamAndQueue(defaultSettings)
+      (stream, queue) = sq
+      _ <- stream.state.update(_.copy(state = H2Stream.StreamState.Idle))
+      _ <- stream.rstStream(H2Error.Cancel)
+      all <- queue.tryTakeN(None)
+      frames = all.flatMap(_.toList)
+      rsts = frames.collect { case r: H2Frame.RstStream => r }
+      _ <- IO(assertEquals(rsts.size, 0))
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Closed)
+    } yield ()
+  }
+
+  test("H2Stream sendMessageBody cancellation emits RST_STREAM(CANCEL)") {
+    for {
+      sq <- streamAndQueue(defaultSettings)
+      (stream, queue) = sq
+      started <- Deferred[IO, Unit]
+      bodyStream =
+        Stream.exec(started.complete(()).void) ++ Stream.eval(IO.never[Byte]).drain
+      resp = Response[IO](Status.Ok, HttpVersion.`HTTP/2`).withBodyStream(bodyStream)
+      fiber <- stream.sendMessageBody(resp).start
+      _ <- started.get
+      _ <- fiber.cancel
+      all <- queue.tryTakeN(None)
+      frames = all.flatMap(_.toList)
+      rsts = frames.collect { case r: H2Frame.RstStream => r }
+      _ <- IO(assertEquals(rsts.size, 1))
+      _ <- IO(assertEquals(rsts.head.value: Int, H2Error.Cancel.value))
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Closed)
+    } yield ()
+  }
+
+  test("H2Stream sendMessageBody error emits RST_STREAM(INTERNAL_ERROR)") {
+    val boom = new RuntimeException("boom")
+    for {
+      sq <- streamAndQueue(defaultSettings)
+      (stream, queue) = sq
+      bodyStream = Stream.raiseError[IO](boom)
+      resp = Response[IO](Status.Ok, HttpVersion.`HTTP/2`).withBodyStream(bodyStream)
+      outcome <- stream.sendMessageBody(resp).attempt
+      _ <- IO(assertEquals(outcome.left.map(_.getMessage), Left("boom")))
+      all <- queue.tryTakeN(None)
+      frames = all.flatMap(_.toList)
+      rsts = frames.collect { case r: H2Frame.RstStream => r }
+      _ <- IO(assertEquals(rsts.size, 1))
+      _ <- IO(assertEquals(rsts.head.value: Int, H2Error.InternalError.value))
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Closed)
+    } yield ()
+  }
+
+  test("H2Stream receiveRstStream populates cancelSignal with parsed error") {
+    for {
+      sq <- streamAndQueue(defaultSettings)
+      (stream, _) = sq
+      rst = H2Frame.RstStream(stream.id, H2Error.Cancel.value)
+      _ <- stream.receiveRstStream(rst)
+      signal <- stream.state.get.flatMap(_.cancelSignal.tryGet)
+      _ <- IO(assertEquals(signal, Some(H2Error.Cancel: H2Error)))
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Closed)
+    } yield ()
+  }
+
+  test("H2Stream receiveGoAway populates cancelSignal with parsed error") {
+    for {
+      sq <- streamAndQueue(defaultSettings)
+      (stream, _) = sq
+      goAway = H2Frame.GoAway(
+        identifier = 0,
+        lastStreamId = 0,
+        errorCode = H2Error.NoError.value,
+        additionalDebugData = None,
+      )
+      _ <- stream.receiveGoAway(goAway)
+      signal <- stream.state.get.flatMap(_.cancelSignal.tryGet)
+      _ <- IO(assertEquals(signal, Some(H2Error.NoError: H2Error)))
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Closed)
     } yield ()
   }
 }

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/h2/H2StreamSuite.scala
@@ -60,7 +60,6 @@ class H2StreamSuite extends Http4sSuite {
           trailers = trailers,
           readBuffer = readBuffer,
           contentLengthCheck = None,
-          cancelSignal = cancelSignal,
         )
       )
       hpack <- Hpack.create[IO]
@@ -72,6 +71,7 @@ class H2StreamSuite extends Http4sSuite {
         H2Connection.ConnectionType.Server,
         IO.pure(config),
         state,
+        cancelSignal,
         hpack,
         outgoing,
         IO.unit,
@@ -102,7 +102,6 @@ class H2StreamSuite extends Http4sSuite {
           trailers = trailers,
           readBuffer = readBuffer,
           contentLengthCheck = None,
-          cancelSignal = cancelSignal,
         )
       )
       hpack <- Hpack.create[IO]
@@ -114,6 +113,7 @@ class H2StreamSuite extends Http4sSuite {
         H2Connection.ConnectionType.Client,
         IO.pure(config),
         state,
+        cancelSignal,
         hpack,
         enqueue,
         IO.unit,
@@ -418,13 +418,30 @@ class H2StreamSuite extends Http4sSuite {
       (stream, _) = sq
       rst = H2Frame.RstStream(stream.id, H2Error.Cancel.value)
       _ <- stream.receiveRstStream(rst)
-      signal <- stream.state.get.flatMap(_.cancelSignal.tryGet)
+      signal <- stream.cancelSignal.tryGet
       _ <- IO(assertEquals(signal, Some(H2Error.Cancel: H2Error)))
       _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Closed)
     } yield ()
   }
 
-  test("H2Stream receiveGoAway populates cancelSignal with parsed error") {
+  test("H2Stream receiveGoAway with error completes cancelSignal with parsed error") {
+    for {
+      sq <- streamAndQueue(defaultSettings)
+      (stream, _) = sq
+      goAway = H2Frame.GoAway(
+        identifier = 0,
+        lastStreamId = 0,
+        errorCode = H2Error.ProtocolError.value,
+        additionalDebugData = None,
+      )
+      _ <- stream.receiveGoAway(goAway)
+      signal <- stream.cancelSignal.tryGet
+      _ <- IO(assertEquals(signal, Some(H2Error.ProtocolError: H2Error)))
+      _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Closed)
+    } yield ()
+  }
+
+  test("H2Stream receiveGoAway with NO_ERROR does not complete cancelSignal") {
     for {
       sq <- streamAndQueue(defaultSettings)
       (stream, _) = sq
@@ -435,8 +452,8 @@ class H2StreamSuite extends Http4sSuite {
         additionalDebugData = None,
       )
       _ <- stream.receiveGoAway(goAway)
-      signal <- stream.state.get.flatMap(_.cancelSignal.tryGet)
-      _ <- IO(assertEquals(signal, Some(H2Error.NoError: H2Error)))
+      signal <- stream.cancelSignal.tryGet
+      _ <- IO(assertEquals(signal, None))
       _ <- assertIO(stream.state.get.map(_.state), H2Stream.StreamState.Closed)
     } yield ()
   }

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/h2/H2CancelSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/h2/H2CancelSuite.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.ember.server.h2
+
+import cats.effect._
+import com.comcast.ip4s._
+import org.http4s._
+import org.http4s.dsl.io._
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.h2.H2Keys.Http2PriorKnowledge
+import org.http4s.implicits._
+
+class H2CancelSuite extends Http4sSuite {
+
+  def runScenario(cancelOnPeerReset: Boolean): IO[(Boolean, Boolean)] =
+    for {
+      routeStarted <- Deferred[IO, Unit]
+      finishRoute <- Deferred[IO, Unit]
+      cancelObserved <- Deferred[IO, Unit]
+      routeCompleted <- Deferred[IO, Unit]
+
+      app = HttpRoutes
+        .of[IO] { case GET -> Root / "slow" =>
+          (routeStarted.complete(()).void *> finishRoute.get *>
+            routeCompleted.complete(()).void)
+            .onCancel(cancelObserved.complete(()).void)
+            .as(Response[IO](Status.Ok))
+        }
+        .orNotFound
+
+      flags <- EmberServerBuilder
+        .default[IO]
+        .withHost(host"127.0.0.1")
+        .withPort(port"0")
+        .withHttp2
+        .withHttp2CancelOnPeerReset(cancelOnPeerReset)
+        .withHttpApp(app)
+        .build
+        .use { server =>
+          EmberClientBuilder.default[IO].withHttp2.build.use { client =>
+            val uri = Uri.unsafeFromString(s"http://${server.addressIp4s}/slow")
+            val req = Request[IO](Method.GET, uri)
+              .withAttribute(Http2PriorKnowledge, ())
+
+            client.run(req).use(_ => IO.never[Unit]).start.flatMap { fiber =>
+              for {
+                _ <- routeStarted.get
+                _ <- fiber.cancel
+                _ <-
+                  if (cancelOnPeerReset) cancelObserved.get
+                  else finishRoute.complete(()).void *> routeCompleted.get
+                cancel <- cancelObserved.tryGet
+                done <- routeCompleted.tryGet
+              } yield (cancel.isDefined, done.isDefined)
+            }
+          }
+        }
+    } yield flags
+
+  test("server runs route to completion when http2CancelOnPeerReset is false (default)") {
+    runScenario(cancelOnPeerReset = false).map { case (cancel, done) =>
+      assertEquals(cancel, false, "route fiber should not have been canceled")
+      assertEquals(done, true, "route should have completed normally")
+    }
+  }
+
+  test("server cancels in-flight route when http2CancelOnPeerReset is true") {
+    runScenario(cancelOnPeerReset = true).map { case (cancel, done) =>
+      assertEquals(cancel, true, "route fiber should have been canceled")
+      assertEquals(done, false, "route should not have completed normally")
+    }
+  }
+}

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/h2/H2CancelSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/h2/H2CancelSuite.scala
@@ -25,18 +25,22 @@ import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.h2.H2Keys.Http2PriorKnowledge
 import org.http4s.implicits._
 
+import scala.concurrent.duration._
+
 class H2CancelSuite extends Http4sSuite {
 
-  def runScenario(cancelOnPeerReset: Boolean): IO[(Boolean, Boolean)] =
+  def runScenario(cancelOnPeerReset: Boolean): IO[(Boolean, Boolean)] = {
+    val routeDuration: FiniteDuration = 500.milli
+
     for {
       routeStarted <- Deferred[IO, Unit]
-      finishRoute <- Deferred[IO, Unit]
       cancelObserved <- Deferred[IO, Unit]
       routeCompleted <- Deferred[IO, Unit]
 
       app = HttpRoutes
         .of[IO] { case GET -> Root / "slow" =>
-          (routeStarted.complete(()).void *> finishRoute.get *>
+          (routeStarted.complete(()).void *>
+            IO.sleep(routeDuration) *>
             routeCompleted.complete(()).void)
             .onCancel(cancelObserved.complete(()).void)
             .as(Response[IO](Status.Ok))
@@ -52,25 +56,30 @@ class H2CancelSuite extends Http4sSuite {
         .withHttpApp(app)
         .build
         .use { server =>
-          EmberClientBuilder.default[IO].withHttp2.build.use { client =>
-            val uri = Uri.unsafeFromString(s"http://${server.addressIp4s}/slow")
-            val req = Request[IO](Method.GET, uri)
-              .withAttribute(Http2PriorKnowledge, ())
+          EmberClientBuilder
+            .default[IO]
+            .withHttp2
+            .build
+            .use { client =>
+              val uri = Uri.unsafeFromString(s"http://${server.addressIp4s}/slow")
+              val req = Request[IO](Method.GET, uri)
+                .withAttribute(Http2PriorKnowledge, ())
 
-            client.run(req).use(_ => IO.never[Unit]).start.flatMap { fiber =>
-              for {
-                _ <- routeStarted.get
-                _ <- fiber.cancel
-                _ <-
-                  if (cancelOnPeerReset) cancelObserved.get
-                  else finishRoute.complete(()).void *> routeCompleted.get
-                cancel <- cancelObserved.tryGet
-                done <- routeCompleted.tryGet
-              } yield (cancel.isDefined, done.isDefined)
+              client.run(req).use(_ => IO.never[Unit]).start.flatMap { fiber =>
+                for {
+                  _ <- routeStarted.get
+                  _ <- fiber.cancel
+                  _ <-
+                    if (cancelOnPeerReset) cancelObserved.get
+                    else routeCompleted.get
+                  cancel <- cancelObserved.tryGet
+                  done <- routeCompleted.tryGet
+                } yield (cancel.isDefined, done.isDefined)
+              }
             }
-          }
         }
     } yield flags
+  }
 
   test("server runs route to completion when http2CancelOnPeerReset is false (default)") {
     runScenario(cancelOnPeerReset = false).map { case (cancel, done) =>

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -56,6 +56,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
     private val logger: Logger[F],
     private val unixSocketConfig: Option[(UnixSocketAddress, Boolean, Boolean)],
     private val enableHttp2: Boolean,
+    private val http2CancelOnPeerReset: Boolean,
     private val requestLineParseErrorHandler: Throwable => F[Response[F]],
     private val maxHeaderSizeErrorHandler: EmberException.MessageTooLong => F[Response[F]],
 ) { self =>
@@ -81,6 +82,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
       logger: Logger[F] = self.logger,
       unixSocketConfig: Option[(UnixSocketAddress, Boolean, Boolean)] = self.unixSocketConfig,
       enableHttp2: Boolean = self.enableHttp2,
+      http2CancelOnPeerReset: Boolean = self.http2CancelOnPeerReset,
       requestLineParseErrorHandler: Throwable => F[Response[F]] = self.requestLineParseErrorHandler,
       maxHeaderSizeErrorHandler: EmberException.MessageTooLong => F[Response[F]] =
         self.maxHeaderSizeErrorHandler,
@@ -103,6 +105,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
       logger = logger,
       unixSocketConfig = unixSocketConfig,
       enableHttp2 = enableHttp2,
+      http2CancelOnPeerReset = http2CancelOnPeerReset,
       requestLineParseErrorHandler = requestLineParseErrorHandler,
       maxHeaderSizeErrorHandler = maxHeaderSizeErrorHandler,
     )
@@ -193,6 +196,17 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
   def withHttp2: EmberServerBuilder[F] = copy(enableHttp2 = true)
   def withoutHttp2: EmberServerBuilder[F] = copy(enableHttp2 = false)
 
+  /** When `true` and HTTP/2 is enabled, an inbound `RST_STREAM` (or stream-level
+    * `GOAWAY`) from the peer cancels the in-flight route-handler fiber for that
+    * stream. When `false` (default), the route runs to completion and its
+    * response is silently discarded after the stream has been reset.
+    *
+    * Defaults to `false` to preserve existing behavior. Opt in to surface
+    * client-side cancellations as fiber cancellations on the server.
+    */
+  def withHttp2CancelOnPeerReset(b: Boolean): EmberServerBuilder[F] =
+    copy(http2CancelOnPeerReset = b)
+
   // If used will bind to UnixSocket
   @deprecated("Use overload that doesn't take a UnixSockets[F]", "0.23.34")
   def withUnixSocketConfig(
@@ -268,6 +282,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
               logger,
               wsBuilder.webSocketKey,
               enableHttp2,
+              http2CancelOnPeerReset,
               requestLineParseErrorHandler,
               maxHeaderSizeErrorHandler,
             )
@@ -296,6 +311,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
             logger,
             wsBuilder.webSocketKey,
             enableHttp2,
+            http2CancelOnPeerReset,
             requestLineParseErrorHandler,
             maxHeaderSizeErrorHandler,
           )
@@ -332,6 +348,7 @@ object EmberServerBuilder extends EmberServerBuilderCompanionPlatform {
       logger = defaultLogger[F],
       unixSocketConfig = None,
       enableHttp2 = false,
+      http2CancelOnPeerReset = false,
       requestLineParseErrorHandler = Defaults.requestLineParseErrorHandler,
       maxHeaderSizeErrorHandler = Defaults.maxHeaderSizeErrorHandler,
     )

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -196,10 +196,12 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
   def withHttp2: EmberServerBuilder[F] = copy(enableHttp2 = true)
   def withoutHttp2: EmberServerBuilder[F] = copy(enableHttp2 = false)
 
-  /** When `true` and HTTP/2 is enabled, an inbound `RST_STREAM` (or stream-level
-    * `GOAWAY`) from the peer cancels the in-flight route-handler fiber for that
-    * stream. When `false` (default), the route runs to completion and its
-    * response is silently discarded after the stream has been reset.
+  /** When `true` and HTTP/2 is enabled, an inbound `RST_STREAM` from the peer,
+    * or a connection-level `GOAWAY` with an error, cancels the in-flight
+    * route-handler fiber for the affected stream. A graceful `GOAWAY(NO_ERROR)`
+    * (RFC 9113 §6.8) does not trigger cancellation. When `false` (default),
+    * the route runs to completion and its response is silently discarded after
+    * the stream has been reset.
     *
     * Defaults to `false` to preserve existing behavior. Opt in to surface
     * client-side cancellations as fiber cancellations on the server.

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -76,6 +76,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       logger: Logger[F],
       webSocketKey: Key[WebSocketContext[F]],
       enableHttp2: Boolean,
+      http2CancelOnPeerReset: Boolean,
       requestLineParseErrorHandler: Throwable => F[Response[F]],
       maxHeaderSizeErrorHandler: EmberException.MessageTooLong => F[Response[F]],
   )(implicit F: Async[F], F2: Network[F]): Stream[F, Nothing] = {
@@ -109,6 +110,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       createRequestVault = true,
       webSocketKey,
       enableHttp2 = enableHttp2,
+      http2CancelOnPeerReset = http2CancelOnPeerReset,
       requestLineParseErrorHandler,
       maxHeaderSizeErrorHandler,
     )
@@ -135,6 +137,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       logger: Logger[F],
       webSocketKey: Key[WebSocketContext[F]],
       enableHttp2: Boolean,
+      http2CancelOnPeerReset: Boolean,
       requestLineParseErrorHandler: Throwable => F[Response[F]],
       maxHeaderSizeErrorHandler: EmberException.MessageTooLong => F[Response[F]],
   ): Stream[F, Nothing] = {
@@ -173,6 +176,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       createRequestVault = false,
       webSocketKey,
       enableHttp2 = enableHttp2,
+      http2CancelOnPeerReset = http2CancelOnPeerReset,
       requestLineParseErrorHandler,
       maxHeaderSizeErrorHandler,
     )
@@ -200,6 +204,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       createRequestVault: Boolean,
       webSocketKey: Key[WebSocketContext[F]],
       enableHttp2: Boolean,
+      http2CancelOnPeerReset: Boolean,
       requestLineParseErrorHandler: Throwable => F[Response[F]],
       maxHeaderSizeErrorHandler: EmberException.MessageTooLong => F[Response[F]],
   ): Stream[F, Nothing] = {
@@ -224,6 +229,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                           httpApp,
                           H2Frame.Settings.ConnectionSettings.default,
                           logger,
+                          cancelOnPeerReset = http2CancelOnPeerReset,
                         )
                     )
                     .drain
@@ -245,6 +251,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                   webSocketKey,
                   ByteVector.empty,
                   enableHttp2,
+                  http2CancelOnPeerReset,
                   requestLineParseErrorHandler,
                   maxHeaderSizeErrorHandler,
                 ).drain
@@ -269,6 +276,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                           webSocketKey,
                           bv, // Pass read bytes we thought might be the prelude
                           enableHttp2,
+                          http2CancelOnPeerReset,
                           requestLineParseErrorHandler,
                           maxHeaderSizeErrorHandler,
                         ).drain
@@ -280,6 +288,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                               httpApp,
                               H2Frame.Settings.ConnectionSettings.default,
                               logger,
+                              cancelOnPeerReset = http2CancelOnPeerReset,
                             )
                           )
                           .drain
@@ -300,6 +309,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                       webSocketKey,
                       ByteVector.empty,
                       enableHttp2,
+                      http2CancelOnPeerReset,
                       requestLineParseErrorHandler,
                       maxHeaderSizeErrorHandler,
                     ).drain
@@ -446,6 +456,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       webSocketKey: Key[WebSocketContext[F]],
       initialBuffer: ByteVector,
       enableHttp2: Boolean,
+      http2CancelOnPeerReset: Boolean,
       requestLineParseErrorHandler: Throwable => F[Response[F]],
       maxHeaderSizeErrorHandler: EmberException.MessageTooLong => F[Response[F]],
   ): Stream[F, Nothing] = {
@@ -534,6 +545,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                           logger,
                           settings,
                           newReq.some,
+                          cancelOnPeerReset = http2CancelOnPeerReset,
                         )
                         .use(_ => Async[F].never[Unit])
                         .as(None)


### PR DESCRIPTION
Stream cancellation in Ember's HTTP/2 implementation did not propagate end-to-end.

On the client, canceling an in-flight request did not send `RST_STREAM` to the peer, leaving the server-side route running.

On the server, receiving `RST_STREAM` from a peer transitioned the stream to Closed for protocol bookkeeping but did not interrupt the in-flight httpApp fiber.

This change addresses both directions:
- `H2Stream.sendMessageBody` now uses `guaranteeCase` to emit `RST_STREAM(CANCEL)` on cancellation and `RST_STREAM(INTERNAL_ERROR)` on error. `H2Client` wraps the per-request stream in `Resource.makeCase` with the same mapping for the caller's outer fiber. `rstStream` is made idempotent via a small `RstAction` ADT to handle the two emission points safely.
- A new `cancelSignal: Deferred[F, H2Error]` is added to H2Stream, populated by `receiveRstStream` and `receiveGoAway`. Per `RFC 9113 §6.8`, `receiveGoAway` only fires the signal when the `GOAWAY` carries a non-`NO_ERROR` code, so graceful shutdowns do not cancel in-flight work. H2Server races route execution against this signal when the new flag is enabled.
- `EmberServerBuilder.withHttp2CancelOnPeerReset(b: Boolean)` (default false) gates the server-side behaviour. The flag is threaded through ServerHelpers to every H2Server.fromSocket call site. Defaults to false so existing deployments observe no behaviour change; operators must opt in.
- A shared `H2Connection.ClosedStreamGracePeriod` (1 second) replaces ad-hoc grace handling in client `clearClosed` and server `clearClosedStreams`, aligning the two paths.
- `H2CancelSuite`exercises both cancelOnPeerReset=true and =false against a long-running route with deterministic invariants on whether the route observes cancellation, replacing the previous deferred-unblock pattern.