### PR TITLE
Restore binary compatibility of WebSocketFrameDefragmenter

### DIFF
--- a/core/shared/src/main/scala/org/http4s/websocket/WebSocketFrameDefragmenter.scala
+++ b/core/shared/src/main/scala/org/http4s/websocket/WebSocketFrameDefragmenter.scala
@@ -172,6 +172,11 @@ private[http4s] object WebSocketFrameDefragmenter {
       go(stream, Chunk.empty[WebSocketFrame]).stream
     }
 
+  @deprecated("Preserved for binary compatibility", "0.23.36")
+  private[WebSocketFrameDefragmenter] def defragFragment[F[_]]
+      : Pipe[F, WebSocketFrame, WebSocketFrame] =
+    defragFragment(DefaultMaxMessageSize.toLong)
+
   /** Raised when a defragmented WebSocket message would exceed the configured
     * maximum size.
     */


### PR DESCRIPTION
This was missed because it's private[http4s].  Users who upgrade http4s-core to http4s-0.23.35 without also upgrading http4s-server are having a bad time right now.
