### PR TITLE
Do not test unix sockets on Ember on JDK 1.8

### DIFF
--- a/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
+++ b/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
@@ -71,6 +71,7 @@ class EmberUnixSocketSuite extends Http4sSuite {
   }
 
   test("http/2") {
+    assume(!sys.props.get("java.specification.version").contains("1.8"))
     run(_.withHttp2, _.withHttp2, _.withAttribute(Http2PriorKnowledge, ()))
   }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -193,6 +193,11 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
     copy(requestHeaderReceiveTimeout = requestHeaderReceiveTimeout)
   def withLogger(l: Logger[F]): EmberServerBuilder[F] = copy(logger = l)
 
+  /** Enables HTTP/2 support.
+    *
+    * As of 0.23.35, no longer tested or supported with Unix sockets
+    * on Java 8.
+    */
   def withHttp2: EmberServerBuilder[F] = copy(enableHttp2 = true)
   def withoutHttp2: EmberServerBuilder[F] = copy(enableHttp2 = false)
 


### PR DESCRIPTION
Mitigates #7889.

Not an elegant fix, but I doubt anybody is using this combination other than our CI.