### PR TITLE
Add support for RFC 10008 (The HTTP QUERY Method)

### DIFF
--- a/client/shared/src/test/scala/org/http4s/client/middleware/FollowRedirectSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/FollowRedirectSuite.scala
@@ -221,4 +221,31 @@ class FollowRedirectSuite extends Http4sSuite with Http4sClientDsl[IO] {
       }
       .assertEquals(Status.Ok)
   }
+
+  test("FollowRedirect should redirect QUERY to GET on 303 and strip payload") {
+    val req = Request[IO](QUERY, uri"http://localhost/303").withEntity("query payload")
+    client
+      .run(req)
+      .use { resp =>
+        (
+          resp.headers.get(ci"X-Original-Method").map(_.head.value).pure[IO],
+          resp.headers.get(ci"X-Original-Content-Length").map(_.head.value).pure[IO],
+        ).tupled
+      }
+      .assertEquals((Some("GET"), Some("0")))
+  }
+
+  test("FollowRedirect should keep QUERY on 307 and preserve payload") {
+    val req = Request[IO](QUERY, uri"http://localhost/307").withEntity("query payload")
+    client
+      .run(req)
+      .use { resp =>
+        (
+          resp.headers.get(ci"X-Original-Method").map(_.head.value).pure[IO],
+          resp.headers.get(ci"X-Original-Content-Length").map(_.head.value).pure[IO],
+          resp.as[String],
+        ).tupled
+      }
+      .assertEquals((Some("QUERY"), Some("13"), "query payload"))
+  }
 }

--- a/core/shared/src/main/scala/org/http4s/Method.scala
+++ b/core/shared/src/main/scala/org/http4s/Method.scala
@@ -102,6 +102,7 @@ object Method {
   val PROPFIND: Method = safe("PROPFIND")
   val PROPPATCH: Method = idempotent("PROPPATCH")
   val PUT: Method = idempotent("PUT")
+  val QUERY: Method = safe("QUERY")
   val REBIND: Method = idempotent("REBIND")
   val REPORT: Method = safe("REPORT")
   val SEARCH: Method = safe("SEARCH")
@@ -143,6 +144,7 @@ object Method {
     PROPFIND,
     PROPPATCH,
     PUT,
+    QUERY,
     REBIND,
     REPORT,
     SEARCH,

--- a/core/shared/src/main/scala/org/http4s/headers/Accept-Query.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Accept-Query.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package headers
+
+import cats.parse.Parser
+import cats.parse.Parser0
+import org.http4s.internal.parsing.CommonRules
+import org.http4s.util.Renderer
+import org.http4s.util.Writer
+import org.typelevel.ci._
+
+object `Accept-Query` {
+  def apply(values: MediaType*): `Accept-Query` = apply(values.toList)
+
+  def parse(s: String): ParseResult[`Accept-Query`] =
+    ParseResult.fromParser(parser, "Invalid Accept-Query header")(s)
+
+  private[http4s] val parser: Parser0[`Accept-Query`] = {
+    val quoted = (CommonRules.quotedString ~ MediaRange.mediaTypeExtensionParser.rep0).flatMap {
+      case (mtStr, exts) =>
+        MediaType.parse(mtStr) match {
+          case Right(mt) => Parser.pure(if (exts.nonEmpty) mt.withExtensions(exts.toMap) else mt)
+          case Left(failure) => Parser.failWith(failure.message)
+        }
+    }
+
+    val item = quoted.orElse(MediaType.parser)
+
+    CommonRules.headerRep(item).map(`Accept-Query`(_))
+  }
+
+  implicit val renderer: Renderer[`Accept-Query`] = new Renderer[`Accept-Query`] {
+    override def render(writer: Writer, t: `Accept-Query`): writer.type = {
+      var first = true
+      t.values.foreach { mt =>
+        if (!first) {
+          writer << ", "
+        }
+        first = false
+        val mtStr = s"${mt.mainType}/${mt.subType}"
+        if (isSfToken(mtStr)) {
+          writer << mtStr
+        } else {
+          writer.quote(mtStr)
+        }
+        mt.extensions.foreach { case (k, v) =>
+          writer << ';' << k << '=' <<# v
+        }
+      }
+      writer
+    }
+  }
+
+  implicit val headerInstance: Header[`Accept-Query`, Header.Recurring] =
+    Header.createRendered(
+      ci"Accept-Query",
+      identity,
+      parse,
+    )
+
+  implicit val headerSemigroupInstance: cats.Monoid[`Accept-Query`] =
+    cats.Monoid.instance(
+      `Accept-Query`(Nil),
+      (one, two) => `Accept-Query`(one.values ++ two.values),
+    )
+
+  private def isSfToken(s: String): Boolean =
+    if (s.isEmpty) false
+    else {
+      val first = s.charAt(0)
+      val isFirstOk =
+        (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || first == '*'
+      if (!isFirstOk) false
+      else {
+        var i = 1
+        var ok = true
+        while (i < s.length && ok) {
+          val c = s.charAt(i)
+          val isCharOk = (c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') ||
+            c == '_' || c == '-' || c == '.' || c == '*' || c == '/' || c == ':' || c == '@'
+          if (!isCharOk) ok = false
+          i += 1
+        }
+        ok
+      }
+    }
+}
+
+final case class `Accept-Query`(values: List[MediaType])

--- a/core/shared/src/main/scala/org/http4s/headers/Accept-Query.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Accept-Query.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 http4s.org
+ * Copyright 2013 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/shared/src/main/scala/org/http4s/headers/Accept-Query.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Accept-Query.scala
@@ -17,20 +17,21 @@
 package org.http4s
 package headers
 
+import cats.data.NonEmptyList
 import cats.parse.Parser
-import cats.parse.Parser0
 import org.http4s.internal.parsing.CommonRules
 import org.http4s.util.Renderer
 import org.http4s.util.Writer
 import org.typelevel.ci._
 
 object `Accept-Query` {
-  def apply(values: MediaType*): `Accept-Query` = apply(values.toList)
+  def apply(head: MediaType, tail: MediaType*): `Accept-Query` =
+    apply(NonEmptyList(head, tail.toList))
 
   def parse(s: String): ParseResult[`Accept-Query`] =
     ParseResult.fromParser(parser, "Invalid Accept-Query header")(s)
 
-  private[http4s] val parser: Parser0[`Accept-Query`] = {
+  private[http4s] val parser: Parser[`Accept-Query`] = {
     val quoted = (CommonRules.quotedString ~ MediaRange.mediaTypeExtensionParser.rep0).flatMap {
       case (mtStr, exts) =>
         MediaType.parse(mtStr) match {
@@ -41,13 +42,13 @@ object `Accept-Query` {
 
     val item = quoted.orElse(MediaType.parser)
 
-    CommonRules.headerRep(item).map(`Accept-Query`(_))
+    CommonRules.headerRep1(item).map(`Accept-Query`(_))
   }
 
   implicit val renderer: Renderer[`Accept-Query`] = new Renderer[`Accept-Query`] {
     override def render(writer: Writer, t: `Accept-Query`): writer.type = {
       var first = true
-      t.values.foreach { mt =>
+      t.values.toList.foreach { mt =>
         if (!first) {
           writer << ", "
         }
@@ -73,11 +74,8 @@ object `Accept-Query` {
       parse,
     )
 
-  implicit val headerSemigroupInstance: cats.Monoid[`Accept-Query`] =
-    cats.Monoid.instance(
-      `Accept-Query`(Nil),
-      (one, two) => `Accept-Query`(one.values ++ two.values),
-    )
+  implicit val headerSemigroupInstance: cats.Semigroup[`Accept-Query`] =
+    (a, b) => `Accept-Query`(a.values.concatNel(b.values))
 
   private def isSfToken(s: String): Boolean =
     if (s.isEmpty) false
@@ -103,4 +101,4 @@ object `Accept-Query` {
     }
 }
 
-final case class `Accept-Query`(values: List[MediaType])
+final case class `Accept-Query`(values: NonEmptyList[MediaType])

--- a/core/shared/src/main/scala/org/http4s/headers/Accept-Query.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Accept-Query.scala
@@ -20,10 +20,9 @@ package headers
 import cats.data.NonEmptyList
 import cats.parse.Parser
 import org.http4s.internal.parsing.CommonRules
-import org.http4s.util.Renderer
-import org.http4s.util.Writer
 import org.typelevel.ci._
 
+// This implementation is incomplete, as this requires support for Structured Fields.
 object `Accept-Query` {
   def apply(head: MediaType, tail: MediaType*): `Accept-Query` =
     apply(NonEmptyList(head, tail.toList))
@@ -39,66 +38,19 @@ object `Accept-Query` {
           case Left(failure) => Parser.failWith(failure.message)
         }
     }
-
     val item = quoted.orElse(MediaType.parser)
-
     CommonRules.headerRep1(item).map(`Accept-Query`(_))
-  }
-
-  implicit val renderer: Renderer[`Accept-Query`] = new Renderer[`Accept-Query`] {
-    override def render(writer: Writer, t: `Accept-Query`): writer.type = {
-      var first = true
-      t.values.toList.foreach { mt =>
-        if (!first) {
-          writer << ", "
-        }
-        first = false
-        val mtStr = s"${mt.mainType}/${mt.subType}"
-        if (isSfToken(mtStr)) {
-          writer << mtStr
-        } else {
-          writer.quote(mtStr)
-        }
-        mt.extensions.foreach { case (k, v) =>
-          writer << ';' << k << '=' <<# v
-        }
-      }
-      writer
-    }
   }
 
   implicit val headerInstance: Header[`Accept-Query`, Header.Recurring] =
     Header.createRendered(
       ci"Accept-Query",
-      identity,
+      _.values,
       parse,
     )
 
   implicit val headerSemigroupInstance: cats.Semigroup[`Accept-Query`] =
     (a, b) => `Accept-Query`(a.values.concatNel(b.values))
-
-  private def isSfToken(s: String): Boolean =
-    if (s.isEmpty) false
-    else {
-      val first = s.charAt(0)
-      val isFirstOk =
-        (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || first == '*'
-      if (!isFirstOk) false
-      else {
-        var i = 1
-        var ok = true
-        while (i < s.length && ok) {
-          val c = s.charAt(i)
-          val isCharOk = (c >= 'a' && c <= 'z') ||
-            (c >= 'A' && c <= 'Z') ||
-            (c >= '0' && c <= '9') ||
-            c == '_' || c == '-' || c == '.' || c == '*' || c == '/' || c == ':' || c == '@'
-          if (!isCharOk) ok = false
-          i += 1
-        }
-        ok
-      }
-    }
 }
 
 final case class `Accept-Query`(values: NonEmptyList[MediaType])

--- a/docs/docs/methods.md
+++ b/docs/docs/methods.md
@@ -45,5 +45,20 @@ val tweetService = HttpRoutes.of[IO] {
 There's also [`DefaultHead`] which replicates the functionality of the native
 implementation of the `HEAD` route.
 
+## Safe and Idempotent Requests with a Body: QUERY
+
+Http4s supports the `QUERY` method defined in RFC 10008. The `QUERY` method is designed for safe and idempotent requests that need to carry a payload (request body), bridging the gap between `GET` (which does not have defined semantics for request bodies) and `POST` (which is neither safe nor idempotent).
+
+You can match on `QUERY` requests in your routing DSL:
+
+```scala
+val searchService = HttpRoutes.of[IO] {
+  case req @ QUERY -> Root / "search" =>
+    req.as[SearchQuery].flatMap(performSearch).flatMap(Ok(_))
+}
+```
+
+To support content negotiation for query formats, http4s also provides the `Accept-Query` header (defined in RFC 10008 Section 3).
+
 [methods]: @API_URL@/org/http4s/Method$.html
 [`DefaultHead`]: @API_URL@/org/http4s/server/middleware/DefaultHead$.html

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Methods.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Methods.scala
@@ -28,4 +28,5 @@ trait Methods {
   val OPTIONS: Method.OPTIONS.type = Method.OPTIONS
   val TRACE: Method.TRACE.type = Method.TRACE
   val PATCH: Method.PATCH.type = Method.PATCH
+  val QUERY: Method.QUERY.type = Method.QUERY
 }

--- a/dsl/src/main/scala/org/http4s/dsl/impl/Methods.scala
+++ b/dsl/src/main/scala/org/http4s/dsl/impl/Methods.scala
@@ -28,5 +28,5 @@ trait Methods {
   val OPTIONS: Method.OPTIONS.type = Method.OPTIONS
   val TRACE: Method.TRACE.type = Method.TRACE
   val PATCH: Method.PATCH.type = Method.PATCH
-  val QUERY: Method.QUERY.type = Method.QUERY
+  final def QUERY: Method.QUERY.type = Method.QUERY
 }

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -1170,6 +1170,12 @@ private[discipline] trait ArbitraryInstancesBinCompat0 extends ArbitraryInstance
     } yield headers.`Accept-Post`(values)
   }
 
+  implicit val arbitraryAcceptQuery: Arbitrary[`Accept-Query`] = Arbitrary {
+    for {
+      values <- listOf(http4sGenMediaType)
+    } yield headers.`Accept-Query`(values)
+  }
+
   implicit val arbitraryCrossOriginResourcePolicy: Arbitrary[`Cross-Origin-Resource-Policy`] =
     Arbitrary[`Cross-Origin-Resource-Policy`](
       Gen.oneOf(

--- a/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/org/http4s/laws/discipline/arbitrary.scala
@@ -1172,8 +1172,8 @@ private[discipline] trait ArbitraryInstancesBinCompat0 extends ArbitraryInstance
 
   implicit val arbitraryAcceptQuery: Arbitrary[`Accept-Query`] = Arbitrary {
     for {
-      values <- listOf(http4sGenMediaType)
-    } yield headers.`Accept-Query`(values)
+      media <- getArbitrary[NonEmptyList[MediaType]]
+    } yield headers.`Accept-Query`(media)
   }
 
   implicit val arbitraryCrossOriginResourcePolicy: Arbitrary[`Cross-Origin-Resource-Policy`] =

--- a/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/CORS.scala
@@ -166,7 +166,15 @@ object CORS {
     CORSPolicy.AllowCredentials.Deny,
     CORSPolicy.ExposeHeaders.None,
     CORSPolicy.AllowMethods.In(
-      Set(Method.GET, Method.HEAD, Method.PUT, Method.PATCH, Method.POST, Method.DELETE)
+      Set(
+        Method.GET,
+        Method.HEAD,
+        Method.PUT,
+        Method.PATCH,
+        Method.POST,
+        Method.DELETE,
+        Method.QUERY,
+      )
     ),
     CORSPolicy.AllowHeaders.Reflect,
     CORSPolicy.MaxAge.Default,

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Caching.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Caching.scala
@@ -78,7 +78,7 @@ object Caching {
       }
 
     def defaultMethodsToSetOn(m: Method): Boolean =
-      m == Method.GET || m == Method.HEAD
+      m == Method.GET || m == Method.HEAD || m == Method.QUERY
   }
 
   /** Sets headers for response to be publicly cached for the specified duration.

--- a/tests/shared/src/test/scala/org/http4s/headers/AcceptQuerySuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/AcceptQuerySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 http4s.org
+ * Copyright 2013 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/shared/src/test/scala/org/http4s/headers/AcceptQuerySuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/AcceptQuerySuite.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package headers
+
+import org.http4s.laws.discipline.arbitrary._
+import org.http4s.syntax.header._
+
+class AcceptQuerySuite extends HeaderLaws {
+  checkAll("Accept-Query", headerLaws[`Accept-Query`])
+
+  test("parse should fail on invalid formats") {
+    assert(`Accept-Query`.parse("applic/*/").isLeft)
+  }
+
+  test("parse should succeed on wildcard formats") {
+    assert(`Accept-Query`.parse("application/*").isRight)
+    assert(`Accept-Query`.parse("text/*").isRight)
+    assert(`Accept-Query`.parse("*/*").isRight)
+  }
+
+  test("parse should succeed on many comma separated values") {
+    assert(`Accept-Query`.parse("application/*, text/*").isRight)
+  }
+
+  test("parse and render quoted and unquoted values (Structured Fields)") {
+    // Standard unquoted
+    val unquoted = "application/sql"
+    val parsedUnquoted = `Accept-Query`.parse(unquoted)
+    assert(parsedUnquoted.isRight)
+    assertEquals(parsedUnquoted.toOption.get.values, List(MediaType.application.sql))
+    assertEquals(parsedUnquoted.toOption.get.renderString, s"Accept-Query: $unquoted")
+
+    // Quoted string (used for names containing + or starting with digit, or general Structured Fields strings)
+    val quoted = "\"application/jsonpath\""
+    val parsedQuoted = `Accept-Query`.parse(quoted)
+    assert(parsedQuoted.isRight)
+    assertEquals(parsedQuoted.toOption.get.values, List(new MediaType("application", "jsonpath")))
+    // application/jsonpath is a valid token, so it renders unquoted
+    assertEquals(parsedQuoted.toOption.get.renderString, "Accept-Query: application/jsonpath")
+
+    // Quoted string with suffix (+)
+    val suffixedQuoted = "\"application/ld+json\""
+    val parsedSuffixed = `Accept-Query`.parse(suffixedQuoted)
+    assert(parsedSuffixed.isRight)
+    assertEquals(parsedSuffixed.toOption.get.values, List(new MediaType("application", "ld+json")))
+    // application/ld+json contains +, which is not a valid token character, so it renders quoted!
+    assertEquals(parsedSuffixed.toOption.get.renderString, "Accept-Query: \"application/ld+json\"")
+
+    // Mix of quoted/unquoted and parameters
+    val mixed = "\"application/jsonpath\", application/sql;charset=\"UTF-8\""
+    val parsedMixed = `Accept-Query`.parse(mixed)
+    assert(parsedMixed.isRight)
+    assertEquals(
+      parsedMixed.toOption.get.values,
+      List(
+        new MediaType("application", "jsonpath"),
+        MediaType.application.sql.withExtensions(Map("charset" -> "UTF-8")),
+      ),
+    )
+    assertEquals(
+      parsedMixed.toOption.get.renderString,
+      "Accept-Query: application/jsonpath, application/sql;charset=\"UTF-8\"",
+    )
+  }
+}

--- a/tests/shared/src/test/scala/org/http4s/headers/AcceptQuerySuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/AcceptQuerySuite.scala
@@ -47,16 +47,16 @@ class AcceptQuerySuite extends HeaderLaws {
     assertEquals(parsedUnquoted.toOption.get.values, NonEmptyList.of(MediaType.application.sql))
     assertEquals(parsedUnquoted.toOption.get.renderString, s"Accept-Query: $unquoted")
 
-    // Quoted string (used for media types starting with a digit, containing forbidden characters like '+', or general Structured Fields strings)
-    val quoted = "\"application/jsonpath\""
-    val parsedQuoted = `Accept-Query`.parse(quoted)
-    assert(parsedQuoted.isRight)
+    // Media type starting with a digit (must be quoted because sf-token must start with ALPHA or *)
+    val digitQuoted = "\"3gpp/media\""
+    val parsedDigit = `Accept-Query`.parse(digitQuoted)
+    assert(parsedDigit.isRight)
     assertEquals(
-      parsedQuoted.toOption.get.values,
-      NonEmptyList.of(new MediaType("application", "jsonpath")),
+      parsedDigit.toOption.get.values,
+      NonEmptyList.of(new MediaType("3gpp", "media")),
     )
-    // application/jsonpath is a valid token, so it renders unquoted
-    assertEquals(parsedQuoted.toOption.get.renderString, "Accept-Query: application/jsonpath")
+    // 3gpp/media is parsed from quoted string and rendered as standard media type
+    assertEquals(parsedDigit.toOption.get.renderString, "Accept-Query: 3gpp/media")
 
     // Quoted string with suffix (+)
     val suffixedQuoted = "\"application/ld+json\""
@@ -66,8 +66,7 @@ class AcceptQuerySuite extends HeaderLaws {
       parsedSuffixed.toOption.get.values,
       NonEmptyList.of(new MediaType("application", "ld+json")),
     )
-    // application/ld+json contains '+', which is not a permitted character in Structured Field tokens (RFC 9651 section 3.3.4), so it renders quoted
-    assertEquals(parsedSuffixed.toOption.get.renderString, "Accept-Query: \"application/ld+json\"")
+    assertEquals(parsedSuffixed.toOption.get.renderString, "Accept-Query: application/ld+json")
 
     // Mix of quoted/unquoted and parameters
     val mixed = "\"application/jsonpath\", application/sql;charset=\"UTF-8\""
@@ -82,7 +81,16 @@ class AcceptQuerySuite extends HeaderLaws {
     )
     assertEquals(
       parsedMixed.toOption.get.renderString,
-      "Accept-Query: application/jsonpath, application/sql;charset=\"UTF-8\"",
+      "Accept-Query: application/jsonpath, application/sql; charset=\"UTF-8\"",
+    )
+
+    // Quoted string with parameters
+    val quotedWithParams = "\"application/sql\";charset=\"UTF-8\""
+    val parsedQuotedWithParams = `Accept-Query`.parse(quotedWithParams)
+    assert(parsedQuotedWithParams.isRight)
+    assertEquals(
+      parsedQuotedWithParams.toOption.get.values,
+      NonEmptyList.of(MediaType.application.sql.withExtensions(Map("charset" -> "UTF-8"))),
     )
   }
 }

--- a/tests/shared/src/test/scala/org/http4s/headers/AcceptQuerySuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/headers/AcceptQuerySuite.scala
@@ -17,6 +17,7 @@
 package org.http4s
 package headers
 
+import cats.data.NonEmptyList
 import org.http4s.laws.discipline.arbitrary._
 import org.http4s.syntax.header._
 
@@ -25,6 +26,7 @@ class AcceptQuerySuite extends HeaderLaws {
 
   test("parse should fail on invalid formats") {
     assert(`Accept-Query`.parse("applic/*/").isLeft)
+    assert(`Accept-Query`.parse("").isLeft)
   }
 
   test("parse should succeed on wildcard formats") {
@@ -42,14 +44,17 @@ class AcceptQuerySuite extends HeaderLaws {
     val unquoted = "application/sql"
     val parsedUnquoted = `Accept-Query`.parse(unquoted)
     assert(parsedUnquoted.isRight)
-    assertEquals(parsedUnquoted.toOption.get.values, List(MediaType.application.sql))
+    assertEquals(parsedUnquoted.toOption.get.values, NonEmptyList.of(MediaType.application.sql))
     assertEquals(parsedUnquoted.toOption.get.renderString, s"Accept-Query: $unquoted")
 
-    // Quoted string (used for names containing + or starting with digit, or general Structured Fields strings)
+    // Quoted string (used for media types starting with a digit, containing forbidden characters like '+', or general Structured Fields strings)
     val quoted = "\"application/jsonpath\""
     val parsedQuoted = `Accept-Query`.parse(quoted)
     assert(parsedQuoted.isRight)
-    assertEquals(parsedQuoted.toOption.get.values, List(new MediaType("application", "jsonpath")))
+    assertEquals(
+      parsedQuoted.toOption.get.values,
+      NonEmptyList.of(new MediaType("application", "jsonpath")),
+    )
     // application/jsonpath is a valid token, so it renders unquoted
     assertEquals(parsedQuoted.toOption.get.renderString, "Accept-Query: application/jsonpath")
 
@@ -57,8 +62,11 @@ class AcceptQuerySuite extends HeaderLaws {
     val suffixedQuoted = "\"application/ld+json\""
     val parsedSuffixed = `Accept-Query`.parse(suffixedQuoted)
     assert(parsedSuffixed.isRight)
-    assertEquals(parsedSuffixed.toOption.get.values, List(new MediaType("application", "ld+json")))
-    // application/ld+json contains +, which is not a valid token character, so it renders quoted!
+    assertEquals(
+      parsedSuffixed.toOption.get.values,
+      NonEmptyList.of(new MediaType("application", "ld+json")),
+    )
+    // application/ld+json contains '+', which is not a permitted character in Structured Field tokens (RFC 9651 section 3.3.4), so it renders quoted
     assertEquals(parsedSuffixed.toOption.get.renderString, "Accept-Query: \"application/ld+json\"")
 
     // Mix of quoted/unquoted and parameters
@@ -67,7 +75,7 @@ class AcceptQuerySuite extends HeaderLaws {
     assert(parsedMixed.isRight)
     assertEquals(
       parsedMixed.toOption.get.values,
-      List(
+      NonEmptyList.of(
         new MediaType("application", "jsonpath"),
         MediaType.application.sql.withExtensions(Map("charset" -> "UTF-8")),
       ),


### PR DESCRIPTION
This change add support for RFC 10008, The HTTP QUERY Method.

Accept-Query is a bit different from other impls because it is defined to support Structured Fields.