### PR TITLE
Disallow chunked transfer encoding over HTTP/1.0 in Ember Server

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -22,6 +22,7 @@ import fs2._
 import org.http4s._
 import org.http4s.headers.Host
 import org.http4s.headers.`Content-Length`
+import org.http4s.headers.`Transfer-Encoding`
 import org.http4s.internal.CharPredicate
 import org.http4s.internal.appendSanitized
 
@@ -37,8 +38,12 @@ private[ember] object Encoder {
   def respToBytes[F[_]: Applicative](
       resp: Response[F],
       writeBufferSize: Int = 32 * 1024,
+      disableChunkedEncoding: Boolean = false,
   ): Stream[F, Byte] = {
     var chunked = resp.isChunked
+    // RFC 9112 §6.1: a server MUST NOT send Transfer-Encoding in a
+    // response to an HTTP/1.0 request.
+    if (disableChunkedEncoding) chunked = false
     // resp.status.isEntityAllowed TODO
     val initSection = {
       var appliedContentLength = false
@@ -54,11 +59,16 @@ private[ember] object Encoder {
       // Apply each header followed by a CRLF
       resp.headers.foreach { h =>
         if (h.isNameValid) {
-          appliedContentLength = appliedContentLength || h.name == `Content-Length`.name
+          // Strip Transfer-Encoding for HTTP/1.0 responses
+          if (disableChunkedEncoding && h.name == `Transfer-Encoding`.name) {
+            ()
+          } else {
+            appliedContentLength = appliedContentLength || h.name == `Content-Length`.name
 
-          stringBuilder.append(h.name).append(": ")
-          appendSanitized(stringBuilder, h.value)
-          stringBuilder.append(CRLF)
+            stringBuilder.append(h.name).append(": ")
+            appendSanitized(stringBuilder, h.value)
+            stringBuilder.append(CRLF)
+          }
         }
       }
 
@@ -67,7 +77,7 @@ private[ember] object Encoder {
       if (!appliedContentLength && isEmptyBody && isEntityAllowed) {
         stringBuilder.append(zeroContentLengthRaw).append(CRLF)
         chunked = false
-      } else if (!chunked && !appliedContentLength && isEntityAllowed) {
+      } else if (!chunked && !appliedContentLength && isEntityAllowed && !disableChunkedEncoding) {
         stringBuilder.append(chunkedTransferEncodingHeaderRaw).append(CRLF)
         chunked = true
       }

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -427,15 +427,17 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       resp: Response[F],
       idleTimeout: Duration,
       onWriteFailure: (Option[Request[F]], Response[F], Throwable) => F[Unit],
-  ): F[Unit] =
+  ): F[Unit] = {
+    val isHttp10 = request.exists(_.httpVersion == HttpVersion.`HTTP/1.0`)
     Encoder
-      .respToBytes[F](resp)
+      .respToBytes[F](resp, disableChunkedEncoding = isHttp10)
       .through(_.chunks.foreach(c => timeoutMaybe(socket.write(c), idleTimeout)))
       .compile
       .drain
       .onError { case err =>
         onWriteFailure(request, resp, err)
       }
+  }
 
   private[internal] def postProcessResponse[F[_]: Concurrent: Clock](
       req: Request[F],


### PR DESCRIPTION
Fixes #6901

Per RFC 9112 §6.1, a server MUST NOT send a response containing `Transfer-Encoding` unless the corresponding request indicates HTTP/1.1 or later.

### Changes

- Added `disableChunkedEncoding` parameter to `Encoder.respToBytes`
- When the request is HTTP/1.0, the encoder strips any existing `Transfer-Encoding` headers and avoids adding new ones
- The response body is streamed without chunked encoding; the connection is closed to signal end-of-body per RFC 9112 §6.3
- Uses idiomatic `HttpVersion.\`HTTP/1.0\`` for version comparison

### Notes

The `scala-steward validate-repo-config` CI failure is a pre-existing issue unrelated to this PR (Java 11 runner vs Java 17 requirement).