### PR TITLE
bugfix: Use List instead of Seq when pattern matching

### DIFF
--- a/core/shared/src/main/scala/org/http4s/headers/Content-Language.scala
+++ b/core/shared/src/main/scala/org/http4s/headers/Content-Language.scala
@@ -34,7 +34,7 @@ object `Content-Language` {
   private[http4s] val parser: Parser[headers.`Content-Language`] = {
     val languageTag: Parser[LanguageTag] =
       (Parser.string(Rfc5234.alpha.rep) ~ (Parser.string("-") *> Rfc2616.token).rep0).map {
-        case (main: String, sub: collection.Seq[String]) =>
+        case (main, sub) =>
           LanguageTag(main, QValue.One, sub)
       }
     CommonRules.headerRep1(languageTag).map { tags =>


### PR DESCRIPTION
Scala 3 starting with 3.9.0 will correctly infer type of anything that is pattern matched, previously it would be outer type being matched on.

In this case 'sub' was actually a List despite matching on Seq. emoved the types here, since List is the returned value anyway.

This should fix it before we migrate to newer LTS at any point.

Related to https://github.com/scala/scala3/issues/26625
