### PR TITLE
fix: QueryOps.setQueryParams replaces values for existing keys

### DIFF
--- a/core/shared/src/main/scala/org/http4s/QueryOps.scala
+++ b/core/shared/src/main/scala/org/http4s/QueryOps.scala
@@ -115,13 +115,16 @@ trait QueryOps {
 
   /** Creates maybe a new `Self` with the specified parameters.
     * If any of the given parameters' keys already exists, the value(s) will be replaced.
+    * Other existing parameters are preserved.
     */
   def setQueryParams[K: QueryParamKeyLike, T: QueryParamEncoder](
       params: Map[K, collection.Seq[T]]
   ): Self = {
     val penc = QueryParamKeyLike[K]
     val venc = QueryParamEncoder[T]
-    val vec = params.foldLeft(query.toVector) {
+    val keys = params.iterator.map { case (k, _) => penc.getKey(k).value }.toSet
+    val base = query.toVector.filterNot { case (n, _) => keys.contains(n) }
+    val vec = params.foldLeft(base) {
       case (m, (k, Seq())) => m :+ (penc.getKey(k).value -> None)
       case (m, (k, vs)) =>
         vs.foldLeft(m) { case (m, v) => m :+ (penc.getKey(k).value -> Some(venc.encode(v).value)) }

--- a/tests/shared/src/test/scala/org/http4s/UriSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/UriSuite.scala
@@ -882,6 +882,29 @@ class UriSuite extends Http4sSuite {
       .withMultiValueQueryParams(Map("param2" -> List(4, 5)))
     assertEquals(u, Uri(query = Query.unsafeFromString("param1=3&param2=4&param2=5")))
   }
+  // #7106: setQueryParams must replace values for keys present in the map (per scaladoc)
+  test("Uri parameter convenience methods should setQueryParams replace existing keys") {
+    val uri = uri"http://example.com/a/b/c?m=5&n=6"
+    val updated = uri.setQueryParams(Map("m" -> Seq("10"), "X" -> Seq("10")))
+    assertEquals(
+      updated.query.multiParams,
+      Map("n" -> Seq("6"), "m" -> Seq("10"), "X" -> Seq("10")),
+    )
+    assertEquals(
+      updated,
+      uri"http://example.com/a/b/c?n=6&m=10&X=10",
+    )
+  }
+  test("Uri parameter convenience methods should setQueryParams replace multi-valued keys") {
+    val uri = Uri(query = Query.unsafeFromString("param1=1&param1=2&param2=3"))
+    val updated = uri.setQueryParams(Map("param1" -> Seq("a", "b")))
+    assertEquals(updated, Uri(query = Query.unsafeFromString("param2=3&param1=a&param1=b")))
+  }
+  test("Uri parameter convenience methods should setQueryParams leave unrelated params") {
+    val uri = uri"http://example.com/?m=5&n=6"
+    val updated = uri.setQueryParams(Map("X" -> Seq("10")))
+    assertEquals(updated.query.multiParams, Map("m" -> Seq("5"), "n" -> Seq("6"), "X" -> Seq("10")))
+  }
   test("Uri parameter convenience methods should contains not a parameter") {
     assertEquals(Uri(query = Query.empty) ? "param1", false)
   }


### PR DESCRIPTION
## What

`QueryOps#setQueryParams` now replaces values for keys present in the input map instead of appending duplicate pairs.

## Why

After #7126 the scaladoc states that if a key already exists, its value(s) will be replaced. The implementation still appended (`m=5` + `setQueryParams(Map("m" -> Seq("10")))` → `m=5&m=10`), which left duplicate keys and contradicted the docs (#7106).

Unrelated parameters are preserved (this is not a full query wipe). Full replacement remains available via `copy(query = …)` / building a new `Query`.

## Changes

- Filter keys present in the input map out of the current query before adding the new values
- Clarify scaladoc that other existing parameters are preserved
- Regression tests in `UriSuite` for replace-existing, multi-value replace, and unrelated params

## Tests

```text
sbt 'tests/testOnly org.http4s.UriSuite'
# Passed: Total 247, Failed 0 (Temurin 21, Scala 2.13)
```

Fixes #7106