### PR TITLE
fix: include Retry-After on Throttle.defaultResponse 429

### DIFF
--- a/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Throttle.scala
@@ -26,8 +26,8 @@ import org.http4s.HttpApp
 import org.http4s.HttpRoutes
 import org.http4s.Response
 import org.http4s.Status
+import org.http4s.headers.`Retry-After`
 
-import scala.annotation.nowarn
 import scala.concurrent.duration._
 
 /** Transform a service to reject any calls the go over a given rate.
@@ -140,8 +140,14 @@ object Throttle {
   ): F[HttpApp[F]] =
     apply(amount, per)(httpApp)
 
-  def defaultResponse[F[_]](@nowarn retryAfter: Option[FiniteDuration]): Response[F] =
-    Response[F](Status.TooManyRequests)
+  def defaultResponse[F[_]](retryAfter: Option[FiniteDuration]): Response[F] =
+    retryAfter match {
+      case Some(duration) =>
+        Response[F](Status.TooManyRequests)
+          .putHeaders(`Retry-After`.unsafeFromDuration(duration))
+      case None =>
+        Response[F](Status.TooManyRequests)
+    }
 
   /** Limits the supplied service using a provided [[TokenBucket]]
     *

--- a/server/shared/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/ThrottleSuite.scala
@@ -27,6 +27,7 @@ import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Status
 import org.http4s.dsl.io._
+import org.http4s.headers.`Retry-After`
 import org.http4s.laws.discipline.arbitrary.genFiniteDuration
 import org.http4s.server.middleware.Throttle._
 import org.http4s.syntax.all._
@@ -198,5 +199,41 @@ class ThrottleSuite extends Http4sSuite {
     val req = Request[IO](uri = uri"/nonexistent")
 
     TestControl.executeEmbed(testee(req).map(_.status)).assertEquals(Status.TooManyRequests)
+  }
+
+  test("defaultResponse should set Retry-After when a retry delay is provided") {
+    val response = defaultResponse[IO](Some(5.seconds))
+    assertEquals(response.status, Status.TooManyRequests)
+    assertEquals(
+      response.headers.get[`Retry-After`].map(_.retry),
+      Some(Right(5L)),
+    )
+  }
+
+  test("defaultResponse should omit Retry-After when no retry delay is provided") {
+    val response = defaultResponse[IO](None)
+    assertEquals(response.status, Status.TooManyRequests)
+    assertEquals(response.headers.get[`Retry-After`], None)
+  }
+
+  test("Throttle / should include Retry-After when the bucket reports a retry delay") {
+    testMiddleware { middleware =>
+      val retryAfter = 3.seconds
+      val limitReachedBucket = new TokenBucket[IO] {
+        override def takeToken: IO[TokenAvailability] =
+          TokenUnavailable(Some(retryAfter)).pure[IO]
+      }
+
+      val testee = middleware(limitReachedBucket, defaultResponse[IO] _)
+      val req = Request[IO](uri = uri"/")
+
+      TestControl
+        .executeEmbed(testee(req))
+        .map { response =>
+          response.status == Status.TooManyRequests &&
+          response.headers.get[`Retry-After`].map(_.retry).contains(Right(3L))
+        }
+        .assert
+    }
   }
 }


### PR DESCRIPTION
## What

`Throttle.defaultResponse` accepted an `Option[FiniteDuration]` for retry backoff but ignored it (`@nowarn`), so 429 responses never carried a `Retry-After` header even when the token bucket computed a next-token delay.

## Changes

- When `retryAfter` is `Some(duration)`, put `Retry-After` via `` `Retry-After`.unsafeFromDuration ``
- When `None`, keep a bare 429 with no `Retry-After` (remote buckets may not know a delay)
- Remove unused `scala.annotation.nowarn` import
- Tests for `defaultResponse` with/without delay and middleware path when the bucket reports a delay

## Motivation and Context

Fixes #7847

RFC 6585 §4 / RFC 7231 §7.1.3 recommend `Retry-After` on 429 so clients know how long to back off. The parameter was already threaded from `TokenUnavailable`; this uses it.

## How Has This Been Tested?

```text
sbt 'server/testOnly org.http4s.server.middleware.ThrottleSuite'
# Temurin 21 / Scala 2.13 — 11/11 passed
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.