### PR TITLE
Harden RFC 9110 compliance for legacy `x-gzip` content coding

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/middleware/GZip.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/GZip.scala
@@ -73,7 +73,8 @@ object GZip {
   ): Response[F] =
     response.headers.get[`Content-Encoding`] match {
       case Some(header)
-          if header.contentCoding == ContentCoding.gzip || header.contentCoding == ContentCoding.`x-gzip` =>
+          if header.contentCoding == ContentCoding.gzip ||
+            header.contentCoding == ContentCoding.legacy.`x-gzip` =>
         val gunzip: Pipe[F, Byte, Byte] =
           _.through(Compression[F].gunzip(bufferSize)).flatMap(_.content)
         response

--- a/client/shared/src/test/scala/org/http4s/client/middleware/GZipSuite.scala
+++ b/client/shared/src/test/scala/org/http4s/client/middleware/GZipSuite.scala
@@ -24,6 +24,7 @@ import org.http4s.dsl.io._
 import org.http4s.headers.`Content-Encoding`
 import org.http4s.headers.`Content-Length`
 import org.http4s.syntax.literals._
+import org.typelevel.ci._
 
 class GZipSuite extends Http4sSuite {
   private val service = server.middleware.GZip(HttpApp[IO] {
@@ -34,6 +35,16 @@ class GZipSuite extends Http4sSuite {
     case _ => NotFound()
   })
   private val gzipClient = GZip()(Client.fromHttpApp(service))
+
+  private val xGzipService: HttpApp[IO] = HttpApp[IO] { req =>
+    service.run(req).map {
+      case resp if resp.headers.contains[`Content-Encoding`] =>
+        resp.putHeaders(Header.Raw(ci"Content-Encoding", "x-gzip"))
+      case r => r
+    }
+  }
+
+  private val xGzipClient = GZip()(Client.fromHttpApp(xGzipService))
 
   test("Client Gzip should return data correctly") {
     gzipClient
@@ -63,5 +74,16 @@ class GZipSuite extends Http4sSuite {
       .map { body =>
         assertEquals(body, "")
       }
+  }
+
+  test("Client Gzip should decompress a legacy x-gzip response") {
+    xGzipClient
+      .get(uri"/gziptest") { response =>
+        assertEquals(response.status, Status.Ok)
+        assertEquals(response.headers.get[`Content-Encoding`], None)
+        assertEquals(response.headers.get[`Content-Length`], None)
+        response.as[String]
+      }
+      .map(assertEquals(_, "Dummy response"))
   }
 }

--- a/core/shared/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/shared/src/main/scala/org/http4s/ContentCoding.scala
@@ -87,9 +87,19 @@ object ContentCoding {
   val `pack200-gzip` = new ContentCoding("pack200-gzip")
   val zstd = new ContentCoding("zstd")
 
-  // Legacy encodings defined by RFC2616 3.5.
+  // Legacy content codings defined by RFC2616 §3.5.
+  // Aliases of the canonical codings; see `legacy` below for the literal tokens.
   val `x-compress`: ContentCoding = compress
   val `x-gzip`: ContentCoding = gzip
+
+  /** The `x-compress` and `x-gzip` tokens are from HTTP/1.0 and SHOULD only be used
+    * for compatibility with previous HTTP implementations, as per RFC2616 §3.5
+    * and RFC9110 §8.4.1.3.
+    */
+  private[http4s] object legacy {
+    val `x-compress`: ContentCoding = new ContentCoding("x-compress")
+    val `x-gzip`: ContentCoding = new ContentCoding("x-gzip")
+  }
 
   val standard: Map[String, ContentCoding] =
     List(`*`, aes128gcm, br, compress, deflate, exi, gzip, identity, `pack200-gzip`, zstd)

--- a/core/shared/src/main/scala/org/http4s/ContentCoding.scala
+++ b/core/shared/src/main/scala/org/http4s/ContentCoding.scala
@@ -89,7 +89,9 @@ object ContentCoding {
 
   // Legacy content codings defined by RFC2616 §3.5.
   // Aliases of the canonical codings; see `legacy` below for the literal tokens.
+  @deprecated("Use ContentCoding.fromString to instantiate deprecated content codings", "0.23.37")
   val `x-compress`: ContentCoding = compress
+  @deprecated("Use ContentCoding.fromString to instantiate deprecated content codings", "0.23.37")
   val `x-gzip`: ContentCoding = gzip
 
   /** The `x-compress` and `x-gzip` tokens are from HTTP/1.0 and SHOULD only be used

--- a/core/shared/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/shared/src/main/scala/org/http4s/StaticFile.scala
@@ -62,7 +62,7 @@ object StaticFile {
     val tryGzipped =
       preferGzipped && acceptEncodingHeader.exists { acceptEncoding =>
         acceptEncoding.satisfiedBy(ContentCoding.gzip) ||
-          acceptEncoding.satisfiedBy(ContentCoding.legacy.`x-gzip`)
+        acceptEncoding.satisfiedBy(ContentCoding.legacy.`x-gzip`)
       }
     val normalizedName = name.split("/").filter(_.nonEmpty).mkString("/")
 

--- a/core/shared/src/main/scala/org/http4s/StaticFile.scala
+++ b/core/shared/src/main/scala/org/http4s/StaticFile.scala
@@ -61,9 +61,8 @@ object StaticFile {
       req.flatMap(_.headers.get[`Accept-Encoding`])
     val tryGzipped =
       preferGzipped && acceptEncodingHeader.exists { acceptEncoding =>
-        acceptEncoding.satisfiedBy(ContentCoding.gzip) || acceptEncoding.satisfiedBy(
-          ContentCoding.`x-gzip`
-        )
+        acceptEncoding.satisfiedBy(ContentCoding.gzip) ||
+          acceptEncoding.satisfiedBy(ContentCoding.legacy.`x-gzip`)
       }
     val normalizedName = name.split("/").filter(_.nonEmpty).mkString("/")
 

--- a/server/jvm/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSuite.scala
+++ b/server/jvm/src/test/scala/org/http4s/server/staticcontent/ResourceServiceSuite.scala
@@ -27,6 +27,7 @@ import org.http4s.headers.`Content-Type`
 import org.http4s.headers.`If-Modified-Since`
 import org.http4s.server.middleware.TranslateUri
 import org.http4s.syntax.all._
+import org.typelevel.ci._
 
 import java.nio.file.Paths
 
@@ -167,21 +168,38 @@ class ResourceServiceSuite extends Http4sSuite with StaticContentShared {
       uri = Uri.fromString("/testresource.txt").yolo,
       headers = Headers(`Accept-Encoding`(ContentCoding.gzip)),
     )
-    val rb = builder.withPreferGzipped(true).toRoutes.orNotFound(req)
 
-    testResourceGzipped.flatMap { testResourceGzipped =>
-      Stream
-        .eval(rb)
-        .flatMap(_.body.chunks)
-        .compile
-        .lastOrError
-        .assertEquals(testResourceGzipped) *>
-        rb.map(_.status).assertEquals(Status.Ok) *>
-        rb.map(_.headers.get[`Content-Type`].map(_.mediaType))
-          .assertEquals(MediaType.text.plain.some) *>
-        rb.map(_.headers.get[`Content-Encoding`].map(_.contentCoding))
-          .assertEquals(ContentCoding.gzip.some)
-    }
+    testResourceGzipped.flatMap(resource => checkGzippedResp(req, resource, builder))
+  }
+
+  test("Try to serve pre-gzipped content when client sends the legacy x-gzip content-coding") {
+    val req = Request[IO](
+      uri = Uri.fromString("/testresource.txt").yolo
+    )
+      .putHeaders(Header.Raw(ci"Accept-Encoding", "x-gzip"))
+
+    testResourceGzipped.flatMap(resource => checkGzippedResp(req, resource, builder))
+  }
+
+  private def checkGzippedResp(
+      req: Request[IO],
+      gzippedResource: Chunk[Byte],
+      builder: ResourceServiceBuilder[IO],
+  ): IO[Unit] = {
+    val resp = builder.withPreferGzipped(true).toRoutes.orNotFound(req)
+    Stream
+      .eval(resp)
+      .flatMap(_.body.chunks)
+      .compile
+      .lastOrError
+      .assertEquals(gzippedResource) *>
+      resp.map(_.status).assertEquals(Status.Ok) *>
+      resp
+        .map(_.headers.get[`Content-Type`].map(_.mediaType))
+        .assertEquals(MediaType.text.plain.some) *>
+      resp
+        .map(_.headers.get[`Content-Encoding`].map(_.contentCoding))
+        .assertEquals(ContentCoding.gzip.some)
   }
 
   test("Fallback to un-gzipped file if pre-gzipped version doesn't exist") {

--- a/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/GZip.scala
@@ -53,7 +53,7 @@ object GZip extends GZipPlatform {
 
   private def satisfiedByGzip(acceptEncoding: `Accept-Encoding`) =
     acceptEncoding.satisfiedBy(ContentCoding.gzip) || acceptEncoding.satisfiedBy(
-      ContentCoding.`x-gzip`
+      ContentCoding.legacy.`x-gzip`
     )
 
   private def zipOrPass[F[_]: Compression](

--- a/server/shared/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/middleware/GZipSuite.scala
@@ -29,6 +29,7 @@ import org.http4s.syntax.all._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF
+import org.typelevel.ci._
 
 import java.util.Arrays
 
@@ -88,23 +89,46 @@ class GZipSuite extends Http4sSuite {
     resp.map(!_.headers.contains[`Content-Encoding`]).assert
   }
 
-  test("encoding") {
-    val genByteArray =
-      Gen.poisson(10).flatMap(n => Gen.buildableOfN[Array[Byte], Byte](n, arbitrary[Byte]))
-    val genVector = Gen
-      .poisson(10)
-      .flatMap(n => Gen.buildableOfN[Vector[Array[Byte]], Array[Byte]](n, genByteArray))
-    PropF.forAllF(genVector) { (vector: Vector[Array[Byte]]) =>
-      val routes: HttpRoutes[IO] = HttpRoutes.of[IO] { case GET -> Root =>
-        Ok(Stream.emits(vector).covary[IO])
-      }
-      val gzipRoutes: HttpRoutes[IO] = GZip(routes)
-      val req: Request[IO] = Request[IO](Method.GET, uri"/")
-        .putHeaders(`Accept-Encoding`(ContentCoding.gzip))
-      val actual: IO[Chunk[Byte]] =
-        gzipRoutes.orNotFound(req).flatMap(_.as[Chunk[Byte]])
+  test("compresses when the client sends the gzip content-coding") {
+    PropF.forAllF(bodyGen(10)) { (vector: Vector[Array[Byte]]) =>
+      verifyEncoding("gzip", vector)
+    }
+  }
 
-      actual.flatMap { bytes =>
+  test("compresses when the client sends the legacy x-gzip content-coding") {
+    PropF.forAllF(bodyGen(10)) { (vector: Vector[Array[Byte]]) =>
+      verifyEncoding("x-gzip", vector)
+    }
+  }
+
+  private def bodyGen(distRate: Double): Gen[Vector[Array[Byte]]] = {
+    val genByteArray =
+      Gen.poisson(distRate).flatMap(n => Gen.buildableOfN[Array[Byte], Byte](n, arbitrary[Byte]))
+
+    Gen
+      .poisson(distRate)
+      .flatMap(n => Gen.buildableOfN[Vector[Array[Byte]], Array[Byte]](n, genByteArray))
+  }
+
+  private def verifyEncoding(rawContentCoding: String, body: Vector[Array[Byte]]): IO[Unit] = {
+    val routes: HttpRoutes[IO] = HttpRoutes.of[IO] { case GET -> Root =>
+      Ok(Stream.emits(body).covary[IO])
+    }
+    val gzipRoutes: HttpRoutes[IO] = GZip(routes)
+
+    val req: Request[IO] = Request[IO](Method.GET, uri"/")
+      .putHeaders(Header.Raw(ci"Accept-Encoding", rawContentCoding))
+
+    gzipRoutes
+      .orNotFound(req)
+      .flatMap(r => assertBody(r, body) *> assertHeaders(r))
+  }
+
+  private def assertBody(resp: Response[IO], expected: Vector[Array[Byte]]): IO[Unit] = {
+    val body = resp.as[Chunk[Byte]]
+
+    body
+      .flatMap(bytes =>
         Stream
           .chunk(bytes)
           .through(Compression[IO].gunzip())
@@ -112,9 +136,17 @@ class GZipSuite extends Http4sSuite {
           .compile
           .to(Chunk)
           .map { decoded =>
-            Arrays.equals(Array.concat(vector: _*), decoded.toArray)
+            Arrays.equals(Array.concat(expected: _*), decoded.toArray)
           }
-      }.assert
-    }
+      )
+      .assert
   }
+
+  private def assertHeaders(resp: Response[IO]): IO[Unit] =
+    IO(
+      assertEquals(
+        resp.headers.get[`Content-Encoding`],
+        Some(`Content-Encoding`(ContentCoding.gzip)),
+      )
+    )
 }

--- a/tests/shared/src/test/scala/org/http4s/ContentCodingSuite.scala
+++ b/tests/shared/src/test/scala/org/http4s/ContentCodingSuite.scala
@@ -52,35 +52,53 @@ class ContentCodingSuite extends Http4sSuite {
       ContentCoding.`*`.matches(a)
     }
   }
+
   test("ContentCoding should always matches itself") {
     forAll { (a: ContentCoding) =>
       a.matches(a)
     }
   }
 
-  test("parses should parse plain coding") {
+  test("ContentCoding.parse should parse plain coding") {
     assertEquals(ContentCoding.parse("gzip"), ParseResult.success(ContentCoding.gzip))
   }
-  test("parses should parse custom codings") {
+
+  test("ContentCoding.parse should parse legacy x-gzip coding") {
+    assertEquals(ContentCoding.parse("x-gzip"), ParseResult.success(ContentCoding.legacy.`x-gzip`))
+  }
+
+  test("ContentCoding.parse should parse legacy x-compress coding") {
+    assertEquals(
+      ContentCoding.parse("x-compress"),
+      ParseResult.success(ContentCoding.legacy.`x-compress`),
+    )
+  }
+
+  test("ContentCoding.parse should parse custom codings") {
     assertEquals(ContentCoding.parse("mycoding"), ContentCoding.fromString("mycoding"))
   }
-  test("parses should parse with quality") {
+
+  test("ContentCoding.parse should parse with quality") {
     assertEquals(
       ContentCoding.parse("gzip;q=0.8"),
       Right(ContentCoding.gzip.withQValue(qValue"0.8")),
     )
   }
-  test("parses should fail on empty") {
+
+  test("ContentCoding.parse should fail on empty") {
     assert(ContentCoding.parse("").isLeft)
     assert(ContentCoding.parse(";q=0.8").isLeft)
   }
-  test("parses should fail on non token") {
+
+  test("ContentCoding.parse should fail on non token") {
     assert(ContentCoding.parse("\\\\").isLeft)
   }
-  test("parses should parse *") {
+
+  test("ContentCoding.parse should parse *") {
     assertEquals(ContentCoding.parse("*"), ParseResult.success(ContentCoding.`*`))
   }
-  test("parses should parse tokens starting with *") {
+
+  test("ContentCoding.parse should parse tokens starting with *") {
     // Strange content coding but valid
     assertEquals(
       ContentCoding.parse("*fahon"),


### PR DESCRIPTION
It turned out that the current GZip in both client and server middlewares don't handle the legacy `x-gzip` content coding. However, [RFC9110 §8.4.1.3 directly states](https://datatracker.ietf.org/doc/html/rfc9110#section-8.4.1.3) that
> A recipient SHOULD consider "x-gzip" to be equivalent to "gzip"

Although, we have defined `x-gzip` content coding, but we assigned it to `gzip`. Which might sound like the claim of equivalence from RFC, but we still have to consider `x-gzip` in middlewares. 