### PR TITLE
Add an optional heartbeat to WebSocketBuilder

### DIFF
--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -137,21 +137,28 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
               .through(receiveSend)
               .foreach(writeFrame) -> onClose
           case WebSocketSeparatePipe(send, receive, onClose) =>
+            val closed: F[Unit] = close.update {
+              case Open => EndpointClosed
+              case _ => BothClosed
+            }
+
+            def writeOutgoing(frame: WebSocketFrame): F[Unit] = frame match {
+              case _: WebSocketFrame.Close => closed *> writeFrame(frame)
+              case _ => writeFrame(frame)
+            }
+
             val sendClosingFrame: F[Unit] = close.get.flatMap {
               case Open =>
                 for {
                   frame <- F.fromEither(WebSocketFrame.Close(1000))
-                  _ <- close.update {
-                    case Open => EndpointClosed
-                    case _ => BothClosed
-                  }
+                  _ <- closed
                   _ <- writeFrame(frame)
                 } yield ()
               case _ => F.unit
             }
 
             val writer: Stream[F, Nothing] =
-              send.foreach(writeFrame) ++ Stream.exec(sendClosingFrame)
+              send.foreach(writeOutgoing) ++ Stream.exec(sendClosingFrame)
 
             val reader = incoming
               .through(decodeFrames[F])
@@ -186,6 +193,9 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
               _ <- writeFrame(frame)
               _ <- closeState.set(BothClosed)
             } yield None
+          case EndpointClosed =>
+            // We closed first and the peer has now answered, so the handshake is complete.
+            closeState.set(BothClosed).as(None)
           case _ => F.pure(None)
         }
       case x => F.pure(Some(x))

--- a/server/shared/src/main/scala/org/http4s/server/websocket/Heartbeat.scala
+++ b/server/shared/src/main/scala/org/http4s/server/websocket/Heartbeat.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package server.websocket
+
+import cats.effect.kernel.Temporal
+import cats.effect.std.Queue
+import cats.syntax.all._
+import cats.~>
+import fs2.Pipe
+import fs2.Stream
+import org.http4s.websocket.WebSocket
+import org.http4s.websocket.WebSocketCombinedPipe
+import org.http4s.websocket.WebSocketFrame
+import org.http4s.websocket.WebSocketSeparatePipe
+
+import scala.concurrent.duration.FiniteDuration
+
+/** The heartbeat of a single connection.
+  *
+  * @param withPings  Merges the pings into the outgoing frames, and terminates the stream with a
+  *                   close frame when a pong is overdue.
+  * @param isAnswer   Whether an incoming frame answers a ping of this heartbeat.
+  * @param answered   Settles the heartbeat, run when an answer comes in.
+  */
+private[websocket] final class Heartbeat[F[_]](
+    withPings: Pipe[F, WebSocketFrame, WebSocketFrame],
+    isAnswer: WebSocketFrame => Boolean,
+    answered: F[Unit],
+) {
+
+  /** Pings on the outgoing frames of `webSocket`, watching its incoming ones for the answers. */
+  def apply(webSocket: WebSocket[F]): WebSocket[F] = webSocket match {
+    case WebSocketCombinedPipe(receiveSend, onClose) =>
+      WebSocketCombinedPipe[F](
+        incoming => withPings(receiveSend(observeAnswers(incoming))),
+        onClose,
+      )
+    case WebSocketSeparatePipe(send, receive, onClose) =>
+      WebSocketSeparatePipe[F](withPings(send), receive.compose(observeAnswers), onClose)
+  }
+
+  def imapK[G[_]](fk: F ~> G)(gk: G ~> F): Heartbeat[G] =
+    new Heartbeat[G](sg => withPings(sg.translate(gk)).translate(fk), isAnswer, fk(answered))
+
+  // Every incoming frame passes through here, so the frames that are not answers must not cost
+  // an effect. One answer per chunk settles the heartbeat just as well as all of them.
+  private val observeAnswers: Pipe[F, WebSocketFrame, WebSocketFrame] =
+    _.chunks.flatMap { chunk =>
+      val frames = Stream.chunk(chunk)
+      if (chunk.exists(isAnswer)) Stream.exec(answered) ++ frames else frames
+    }
+}
+
+private[websocket] object Heartbeat {
+
+  /** Sends a `Ping` frame every `every` and closes the connection when the peer does not answer
+    * with a matching `Pong` within one interval of the ping being written.
+    *
+    * @param every  The interval between pings, which doubles as the time the peer has to answer
+    *               a ping and as the time the write side has to accept a frame.
+    * @param frame  The ping frame to send. A pong is only accepted as an answer to this heartbeat
+    *               when it echoes this payload, as required by rfc6455.
+    */
+  def start[F[_]](every: FiniteDuration, frame: WebSocketFrame.Ping)(implicit
+      F: Temporal[F]
+  ): F[Heartbeat[F]] =
+    (F.ref(false), F.deferred[Unit]).mapN { (pingOutstanding, stalled) =>
+      val overdue: WebSocketFrame =
+        WebSocketFrame
+          .Close(1011, s"No pong received within $every")
+          .getOrElse(WebSocketFrame.Close())
+
+      // Pong deadline starts one interval after the write begins (not after handoff from the
+      // queue). Stalled writes would stop the clock, so every handoff gets the same deadline.
+      // If write doesn't take a frame within one interval, `stalled` interrupts the merged
+      // stream without close frame. Interrupt must be on the merged stream, not just this one—
+      // a halt inside a blocked merge side doesn't reach the other side.
+      val pings: Stream[F, WebSocketFrame] =
+        Stream.eval(Queue.synchronous[F, Option[WebSocketFrame]]).flatMap { frames =>
+          def handOff(f: Option[WebSocketFrame]): F[Boolean] =
+            F.timeoutTo(frames.offer(f).as(true), every, stalled.complete(()).as(false))
+
+          def cycle: F[Unit] =
+            pingOutstanding.set(true) *>
+              handOff(Some(frame)).flatMap {
+                case false => F.unit
+                case true =>
+                  F.sleep(every) *> pingOutstanding.get.flatMap {
+                    case false => cycle
+                    case true =>
+                      handOff(Some(overdue)).flatMap(sent => F.whenA(sent)(handOff(None).void))
+                  }
+              }
+
+          Stream
+            .repeatEval(frames.take)
+            .unNoneTerminate
+            .concurrently(Stream.exec(F.sleep(every) *> cycle))
+        }
+
+      new Heartbeat[F](
+        _.mergeHaltBoth(pings).interruptWhen(stalled.get.attempt),
+        // A pong may arrive without a ping ever having been sent, and the send handler is free
+        // to ping on its own, so only a pong echoing our payload settles the heartbeat.
+        {
+          case WebSocketFrame.Pong(data) => data == frame.data
+          case _ => false
+        },
+        pingOutstanding.set(false),
+      )
+    }
+}

--- a/server/shared/src/main/scala/org/http4s/server/websocket/WebSocketBuilder2.scala
+++ b/server/shared/src/main/scala/org/http4s/server/websocket/WebSocketBuilder2.scala
@@ -18,6 +18,7 @@ package org.http4s
 package server.websocket
 
 import cats.Applicative
+import cats.effect.kernel.Temporal
 import cats.effect.kernel.Unique
 import cats.syntax.all._
 import cats.~>
@@ -30,6 +31,9 @@ import org.http4s.websocket.WebSocketFrame
 import org.http4s.websocket.WebSocketFrameDefragmenter.defragFragment
 import org.http4s.websocket.WebSocketSeparatePipe
 import org.typelevel.vault.Key
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
 
 /** Build a response which will accept an HTTP websocket upgrade request and initiate a websocket connection using the
   * supplied exchange to process and respond to websocket messages.
@@ -44,6 +48,9 @@ import org.typelevel.vault.Key
   *                    To prevent WebSocketBuilder2 from handling defrag, you must explicitly call withDefragment(false).
   *                    For more information on defrag processing, see the WebSocketFrameDefragmenter comment.
   *                    default: true
+  * @param heartbeat If `Some`, send a `Ping` frame at the given interval and close the connection
+  *                  when the client does not answer it with a `Pong` in time.
+  *                  default: None
   */
 sealed abstract class WebSocketBuilder2[F[_]: Applicative] private (
     headers: Headers,
@@ -53,6 +60,7 @@ sealed abstract class WebSocketBuilder2[F[_]: Applicative] private (
     filterPingPongs: Boolean,
     defragFrame: Boolean,
     maxMessageSize: Long,
+    heartbeat: Option[F[Heartbeat[F]]],
     private[http4s] val webSocketKey: Key[WebSocketContext[F]],
 ) {
   import WebSocketBuilder2.impl
@@ -77,6 +85,7 @@ sealed abstract class WebSocketBuilder2[F[_]: Applicative] private (
       filterPingPongs = filterPingPongs,
       defragFrame = false,
       maxMessageSize = WebSocketBuilder2.DefaultMaxMessageSize,
+      heartbeat = None,
       webSocketKey = webSocketKey,
     )
 
@@ -89,6 +98,7 @@ sealed abstract class WebSocketBuilder2[F[_]: Applicative] private (
       defragFrame: Boolean = this.defragFrame,
       webSocketKey: Key[WebSocketContext[F]] = this.webSocketKey,
       maxMessageSize: Long = this.maxMessageSize,
+      heartbeat: Option[F[Heartbeat[F]]] = this.heartbeat,
   ): WebSocketBuilder2[F] = WebSocketBuilder2.impl[F](
     headers,
     onNonWebSocketRequest,
@@ -98,6 +108,7 @@ sealed abstract class WebSocketBuilder2[F[_]: Applicative] private (
     defragFrame,
     webSocketKey,
     maxMessageSize,
+    heartbeat,
   )
 
   def withHeaders(headers: Headers): WebSocketBuilder2[F] =
@@ -122,6 +133,31 @@ sealed abstract class WebSocketBuilder2[F[_]: Applicative] private (
   def withMaxMessageSize(maxMessageSize: Long): WebSocketBuilder2[F] =
     copy(maxMessageSize = maxMessageSize)
 
+  /** Closes connections to clients that stopped answering.
+    *
+    * Sends a `Ping` frame every `every`.
+    * If the client does not answer with a matching `Pong` (same payload) within `every`, closes the connection with
+    * code 1011.
+    *
+    * If a handler never reads from the connection, it sees no pongs at all, and closes when the first ping goes unanswered.
+    *
+    * @param every The interval between pings. It is also the time the client has to answer one.
+    *              default: 12 seconds
+    * @param frame The ping to send. Only a pong that echoes its payload is a valid answer.
+    *              default: an empty payload
+    * @see [[withoutHeartbeat]]
+    * @see [[https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#pings_and_pongs_the_heartbeat_of_websockets Pings and Pongs: The Heartbeat of WebSockets]]
+    */
+  def withHeartbeat(
+      every: FiniteDuration = 12.seconds,
+      frame: WebSocketFrame.Ping = WebSocketFrame.Ping(),
+  )(implicit F: Temporal[F]): WebSocketBuilder2[F] =
+    copy(heartbeat = Some(Heartbeat.start(every, frame)))
+
+  /** Do not send pings, the default. */
+  def withoutHeartbeat: WebSocketBuilder2[F] =
+    copy(heartbeat = None)
+
   /** Transform the parameterized effect from F to G. */
   def imapK[G[_]: Applicative](fk: F ~> G)(gk: G ~> F): WebSocketBuilder2[G] =
     impl[G](
@@ -133,15 +169,20 @@ sealed abstract class WebSocketBuilder2[F[_]: Applicative] private (
       defragFrame,
       webSocketKey.imap(_.imapK(fk)(gk))(_.imapK(gk)(fk)),
       maxMessageSize,
+      heartbeat.map(fk(_).map(_.imapK(fk)(gk))),
     )
 
-  private def buildResponse(webSocket: WebSocket[F]): F[Response[F]] =
-    onNonWebSocketRequest
-      .map(
-        _.withAttribute(
+  /** Starts the heartbeat, if there is one, and lets it ping on `webSocket`. */
+  private def startHeartbeat(webSocket: WebSocket[F]): F[WebSocket[F]] =
+    heartbeat.fold(webSocket.pure[F])(_.map(_(webSocket)))
+
+  private def buildResponse(webSocket: F[WebSocket[F]]): F[Response[F]] =
+    (webSocket, onNonWebSocketRequest)
+      .mapN((ws, response) =>
+        response.withAttribute(
           webSocketKey,
           WebSocketContext(
-            webSocket,
+            ws,
             headers,
             onHandshakeFailure,
           ),
@@ -178,7 +219,8 @@ sealed abstract class WebSocketBuilder2[F[_]: Applicative] private (
           sendReceive.compose(defragFragment(maxMessageSize).compose(filterPingPongFrames))
         case (false, true) => sendReceive.compose(defragFragment(maxMessageSize))
       }
-    buildResponse(WebSocketCombinedPipe(finalSendReceive, onClose))
+
+    buildResponse(startHeartbeat(WebSocketCombinedPipe(finalSendReceive, onClose)))
   }
 
   /** @param send     The send side of the Exchange represents the outgoing stream of messages that should be sent to the client
@@ -216,7 +258,7 @@ sealed abstract class WebSocketBuilder2[F[_]: Applicative] private (
         case (false, true) => receive.compose(defragFragment(maxMessageSize))
       }
 
-    buildResponse(WebSocketSeparatePipe(send, finalReceive, onClose))
+    buildResponse(startHeartbeat(WebSocketSeparatePipe(send, finalReceive, onClose)))
   }
 
   private val isPingPong: WebSocketFrame => Boolean = {
@@ -259,6 +301,7 @@ object WebSocketBuilder2 {
       defragFrame = true,
       webSocketKey = webSocketKey,
       maxMessageSize = WebSocketBuilder2.DefaultMaxMessageSize,
+      heartbeat = None,
     )
 
   private def impl[F[_]: Applicative](
@@ -270,6 +313,7 @@ object WebSocketBuilder2 {
       defragFrame: Boolean,
       webSocketKey: Key[WebSocketContext[F]],
       maxMessageSize: Long,
+      heartbeat: Option[F[Heartbeat[F]]],
   ): WebSocketBuilder2[F] =
     new WebSocketBuilder2[F](
       headers = headers,
@@ -280,5 +324,6 @@ object WebSocketBuilder2 {
       defragFrame = defragFrame,
       webSocketKey = webSocketKey,
       maxMessageSize = maxMessageSize,
+      heartbeat = heartbeat,
     ) {}
 }

--- a/server/shared/src/test/scala/org/http4s/server/websocket/WebSocketBuilderSuite.scala
+++ b/server/shared/src/test/scala/org/http4s/server/websocket/WebSocketBuilderSuite.scala
@@ -19,10 +19,19 @@ package server
 package websocket
 
 import cats.effect._
+import cats.effect.std.Queue
+import cats.effect.testkit.TestControl
+import fs2.Pipe
 import fs2.Stream
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
+import org.http4s.websocket.WebSocket
+import org.http4s.websocket.WebSocketCombinedPipe
 import org.http4s.websocket.WebSocketFrame
+import org.http4s.websocket.WebSocketSeparatePipe
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration._
 
 class WebSocketBuilderSuite extends Http4sSuite {
 
@@ -40,6 +49,168 @@ class WebSocketBuilderSuite extends Http4sSuite {
         .run(Request[IO](GET, uri"/ws"))
         .flatMap(_.as[String])
         .assertEquals("This is a WebSocket route.")
+    }
+  }
+
+  private def webSocket(build: WebSocketBuilder2[IO] => IO[Response[IO]]): IO[WebSocket[IO]] =
+    WebSocketBuilder2[IO].flatMap { wsb =>
+      build(wsb).map(_.attributes.lookup(wsb.webSocketKey).map(_.webSocket).get)
+    }
+
+  /** The first `take` frames the server sends to the client, given the frames it receives from it. */
+  private def outgoing(
+      build: WebSocketBuilder2[IO] => IO[Response[IO]],
+      incoming: Stream[IO, WebSocketFrame],
+      take: Long = Long.MaxValue,
+  ): IO[List[WebSocketFrame]] =
+    webSocket(build).flatMap {
+      case WebSocketCombinedPipe(receiveSend, _) =>
+        receiveSend(incoming).take(take).compile.toList
+      case WebSocketSeparatePipe(send, receive, _) =>
+        send.concurrently(incoming.through(receive)).take(take).compile.toList
+    }
+
+  private val heartbeat = 1.second
+  private val silence: Stream[IO, WebSocketFrame] = Stream.never[IO]
+  private val drain: Pipe[IO, WebSocketFrame, WebSocketFrame] = _.drain
+
+  private def pongsEvery(
+      period: FiniteDuration,
+      data: ByteVector = ByteVector.empty,
+  ): Stream[IO, WebSocketFrame] =
+    Stream.awakeDelay[IO](period).as(WebSocketFrame.Pong(data))
+
+  test("keep pinging as long as the client pongs") {
+    TestControl.executeEmbed {
+      outgoing(
+        _.withHeartbeat(heartbeat).build(drain),
+        pongsEvery(heartbeat / 2),
+        take = 3,
+      ).assertEquals(List.fill(3)(WebSocketFrame.Ping()))
+    }
+  }
+
+  test("ping every 12 seconds by default") {
+    TestControl.executeEmbed {
+      outgoing(_.withHeartbeat().build(drain), pongsEvery(1.second), take = 1)
+        .productR(IO.monotonic)
+        .assertEquals(12.seconds)
+    }
+  }
+
+  test("close the connection when a pong is overdue") {
+    TestControl.executeEmbed {
+      outgoing(_.withHeartbeat(heartbeat).build(drain), silence)
+        .map {
+          case List(WebSocketFrame.Ping(_), close: WebSocketFrame.Close) => close.closeCode
+          case other => fail(s"expected a ping followed by a close frame, got $other")
+        }
+        .assertEquals(1011)
+    }
+  }
+
+  test("only accept a pong echoing the payload of the ping") {
+    val ping = WebSocketFrame.Ping(ByteVector("beat".getBytes))
+    TestControl.executeEmbed {
+      outgoing(
+        _.withHeartbeat(heartbeat, ping).build(drain),
+        pongsEvery(heartbeat / 2, ByteVector("other".getBytes)),
+      ).map(_.lastOption)
+        .map {
+          case Some(close: WebSocketFrame.Close) => close.closeCode
+          case other => fail(s"expected a close frame, got $other")
+        }
+        .assertEquals(1011)
+    }
+  }
+
+  test("ping on the send side of a separate pipe") {
+    TestControl.executeEmbed {
+      outgoing(
+        _.withHeartbeat(heartbeat).build(silence, _.drain),
+        pongsEvery(heartbeat / 2),
+        take = 2,
+      ).assertEquals(List.fill(2)(WebSocketFrame.Ping()))
+    }
+  }
+
+  /** The frames the server sends, with each frame (or only the first, with `firstWriteOnly`)
+    * held for `write` to model the socket write.
+    */
+  private def outgoingSlowly(
+      incoming: Stream[IO, WebSocketFrame],
+      write: FiniteDuration,
+      take: Long = Long.MaxValue,
+      firstWriteOnly: Boolean = false,
+  ): IO[List[WebSocketFrame]] =
+    Ref.of[IO, Boolean](true).flatMap { first =>
+      webSocket(_.withHeartbeat(heartbeat).build(drain)).flatMap {
+        case WebSocketCombinedPipe(receiveSend, _) =>
+          receiveSend(incoming)
+            .evalTap { _ =>
+              first
+                .getAndSet(false)
+                .flatMap(wasFirst => IO.whenA(wasFirst || !firstWriteOnly)(IO.sleep(write)))
+            }
+            .take(take)
+            .compile
+            .toList
+        case ws => IO(fail(s"expected a combined pipe, got $ws"))
+      }
+    }
+
+  test("a slow socket write does not close a client that answers in time") {
+    TestControl.executeEmbed {
+      outgoingSlowly(pongsEvery(heartbeat / 2), write = heartbeat * 7 / 10, take = 4)
+        .assertEquals(List.fill(4)(WebSocketFrame.Ping()))
+    }
+  }
+
+  test("a stalled socket write does not postpone the detection of a dead client") {
+    TestControl.executeEmbed {
+      outgoingSlowly(silence, write = heartbeat * 5)
+        .product(IO.monotonic)
+        .assertEquals((Nil, 3 * heartbeat))
+    }
+  }
+
+  test("close a connection whose write path stalls even when the client answers") {
+    TestControl.executeEmbed {
+      outgoingSlowly(pongsEvery(heartbeat / 2), write = heartbeat * 10, firstWriteOnly = true)
+        .product(IO.monotonic)
+        .assertEquals((Nil, 4 * heartbeat))
+    }
+  }
+
+  test("close a connection that cannot deliver a ping within one interval") {
+    TestControl.executeEmbed {
+      Queue
+        .unbounded[IO, WebSocketFrame]
+        .flatMap { pongs =>
+          webSocket(_.withHeartbeat(heartbeat).build(drain)).flatMap {
+            case WebSocketCombinedPipe(receiveSend, _) =>
+              receiveSend(Stream.fromQueueUnterminated(pongs))
+                .evalTap(_ => IO.sleep(heartbeat * 3 / 2) *> pongs.offer(WebSocketFrame.Pong()))
+                .compile
+                .toList
+            case ws => IO(fail(s"expected a combined pipe, got $ws"))
+          }
+        }
+        .map(_.lastOption)
+        .map {
+          case Some(close: WebSocketFrame.Close) => close.closeCode
+          case other => fail(s"expected a close frame, got $other")
+        }
+        .assertEquals(1011)
+    }
+  }
+
+  test("withoutHeartbeat stops pinging") {
+    TestControl.executeEmbed {
+      outgoing(
+        _.withHeartbeat(heartbeat).withoutHeartbeat.build(drain),
+        Stream.sleep_[IO](3 * heartbeat),
+      ).assertEquals(Nil)
     }
   }
 


### PR DESCRIPTION
Closes #7347. Builds on #7348.

Adds a `withHeartbeat` to WebSocketBuilder that sends a `Ping` frame at a set interval (12 seconds by default). If the client does not answer with a matching `Pong` before the next ping is due, the server closes the connection with code 1011. Dead connections that no longer answer are now removed instead of held open.

In Ember, mark the close state when the send handler writes its own close frame. Before this change, the peer answer to that frame was not recognized, and the close handshake did not complete.

Open for discussion:

- Naming: `Heartbeat`/`KeepAlive`/`AutoPing` are all valid options. The MDN docs call it "heartbeat", so that is what I went with. Other websocket servers seem to prefer `keepAlive`.
- Defaults: 12 seconds is also the default from other websocket servers, but if wanted I could remove the default or change it.
- `interval`/`timeout`: Ping interval is the same as the timeout. This is simpler and in line with other websocket servers, but I can imagine users _might_ want to have separate durations.

https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#pings_and_pongs_the_heartbeat_of_websockets