### PR TITLE
Fix Ember encoder framing for 205 Reset Content

### DIFF
--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/Encoder.scala
@@ -58,10 +58,18 @@ private[ember] object Encoder {
         ()
       }
     }
-    if (!appliedContentLength && resp.entity == Entity.Empty && resp.status.isEntityAllowed) {
+    // RFC 9112 6.3: only 1xx, 204, and 304 responses are self-delimiting without a
+    // Content-Length or Transfer-Encoding header. 205 must still declare Content-Length: 0,
+    // even though its entity is disallowed, or clients on a persistent connection will block
+    // waiting for a body that never arrives.
+    def requiresNoFraming =
+      resp.status.responseClass == Status.Informational ||
+        resp.status.code == Status.NoContent.code ||
+        resp.status.code == Status.NotModified.code
+    if (!appliedContentLength && resp.entity == Entity.Empty && !requiresNoFraming) {
       stringBuilder.append(zeroContentLengthRaw).append(CRLF)
       chunked = false
-    } else if (!chunked && !appliedContentLength && resp.status.isEntityAllowed) {
+    } else if (!chunked && !appliedContentLength && !requiresNoFraming) {
       stringBuilder.append(chunkedTransferEncodingHeaderRaw).append(CRLF)
       chunked = true
     }
@@ -74,7 +82,6 @@ private[ember] object Encoder {
       resp: Response[F],
       writeBufferSize: Int = 32 * 1024,
   ): Stream[F, Byte] = {
-    // resp.status.isEntityAllowed TODO
     val (initSectionBytes, chunked) = initSection(resp)
     val initSectionChunk = Chunk.array(initSectionBytes)
 

--- a/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
+++ b/ember-core/shared/src/test/scala/org/http4s/ember/core/EncoderSuite.scala
@@ -213,6 +213,30 @@ class EncoderSuite extends Http4sSuite {
     Helpers.encodeResponseRig(resp).assertEquals(expected)
   }
 
+  test("encoder a response where entity is not allowed correctly (304 Not Modified)") {
+    val resp = Response[IO](Status.NotModified)
+    val expected =
+      """HTTP/1.1 304 Not Modified
+      |
+      |""".stripMargin
+
+    Helpers.encodeResponseRig(resp).assertEquals(expected)
+  }
+
+  test("respToBytes frames a 205 Reset Content with Content-Length: 0") {
+    // RFC 9112 6.3: unlike 204/304, a 205 response is not self-delimiting and must
+    // still declare its (empty) length or clients on a persistent connection will
+    // block waiting for a body that never arrives.
+    val resp = Response[IO](Status.ResetContent)
+    val expected =
+      """HTTP/1.1 205 Reset Content
+      |Content-Length: 0
+      |
+      |""".stripMargin
+
+    Helpers.encodeResponseRig(resp).assertEquals(expected)
+  }
+
   test("encode a response with a body correctly") {
     val resp = Response[IO](Status.NotFound)
       .withEntity("Not Found")


### PR DESCRIPTION
## Problem

Ember's response encoder (`Encoder.respToBytes`) decides whether to write a `Content-Length`/`Transfer-Encoding` framing header based on `Status#isEntityAllowed`, which is `false` for 204, 205, and 304 alike.

Per RFC 9112 §6.3, only **1xx, 204, and 304** responses are self-delimiting without an explicit length — the client is expected to assume an empty body. **205 is not in that exempt list.** With no framing header at all, an HTTP/1.1 client or intermediary on a persistent connection has no way to know the message is complete, and blocks waiting for a body that will never arrive (visible in practice behind reverse proxies pooling upstream keep-alive connections).

## Fix

Narrows the framing exemption from `isEntityAllowed` to the set RFC 9112 §6.3 actually grants (1xx, 204, 304), so:
- 205 with an empty entity now emits `Content-Length: 0`
- 204/304/1xx are unaffected — still no framing header, as before
- No entity is ever written for 205, satisfying RFC 9110 §15.3.6 separately from framing

## Testing

Added two `EncoderSuite` cases:
- 205 now encodes with `Content-Length: 0`
- 304 (existing exempt behavior) is unchanged, as a regression guard alongside the existing 204 test

Note: I don't have a local Scala/sbt toolchain to run the full suite, so I'm relying on CI here — happy to iterate on review feedback.

Fixes #7919