### PR TITLE
Remove ember-server http/2 h2c support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -608,6 +608,9 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
           ProblemFilters.exclude[DirectMissingMethodProblem](
             "org.http4s.ember.core.h2.H2Frame#*.toRaw"
           ),
+          ProblemFilters.exclude[DirectMissingMethodProblem](
+            "org.http4s.ember.core.h2.H2Keys.H2cUpgrade"
+          ),
         )
       else Seq.empty
     },

--- a/core/shared/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/shared/src/main/scala/org/http4s/HttpVersion.scala
@@ -127,7 +127,7 @@ object HttpVersion {
   /** HTTP/2 is the second major version of HTTP.  It defines no minor
     * versions, so minor version `0` is implied.
     *
-    * @see [[https://datatracker.ietf.org/doc/html/rfc7540 RFC7540,
+    * @see [[https://datatracker.ietf.org/doc/html/rfc9113 RFC9113,
     * Hypertext Transfer Protocol Version 2 (HTTP/2)]]
     */
   val `HTTP/2`: HttpVersion = new HttpVersion(2, 0)

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Keys.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Keys.scala
@@ -34,7 +34,4 @@ object H2Keys {
   // mechanism.
   @deprecated(message = "Use org.http4s.h2.H2Keys.Http2PriorKnowledge instead", since = "0.23.27")
   val Http2PriorKnowledge: Key[Unit] = org.http4s.h2.H2Keys.Http2PriorKnowledge
-
-  private[ember] val H2cUpgrade =
-    Key.newKey[SyncIO, (H2Frame.Settings.ConnectionSettings, Request[fs2.Pure])].unsafeRunSync()
 }

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -17,8 +17,6 @@
 package org.http4s.ember.core.h2
 
 import cats._
-import cats.data.Kleisli
-import cats.data.OptionT
 import cats.effect._
 import cats.effect.std.Semaphore
 import cats.effect.syntax.all._
@@ -27,7 +25,6 @@ import fs2._
 import fs2.io.IOException
 import fs2.io.net._
 import org.http4s._
-import org.typelevel.ci._
 import org.typelevel.log4cats.Logger
 import scodec.bits._
 
@@ -40,7 +37,7 @@ import H2Frame.Settings.ConnectionSettings.{default => defaultSettings}
 private[ember] object H2Server {
 
   /*
-  3 Mechanism into H2
+  2 Mechanism into H2
 
   TlsContext => Yes => ALPN =>  h2       => HTTP2
                                 http/1.1 => HTTP1
@@ -56,92 +53,7 @@ private[ember] object H2Server {
   Note: implementations that support HTTP/2 over TLS MUST use protocol
     negotiation in TLS.
     So if TLS is used then this method is not allowed.
-
-
-  H2c
-            Request
-            Connection: Upgrade, HTTP2-Settings
-            Upgrade: h2c
-            HTTP2-Settings: <base64url encoding of HTTP/2 SETTINGS payload>
-              =>
-                HTTP/1.1 101 Switching Protocols
-                Connection: Upgrade
-                Upgrade: h2c
-
-                Socket                    => Http2
-
-            Normal                        => Resp
-
    */
-
-  private val upgradeResponse: Response[fs2.Pure] = Response(
-    status = Status.SwitchingProtocols,
-    httpVersion = HttpVersion.`HTTP/1.1`,
-    headers = Headers(
-      "connection" -> "Upgrade",
-      "upgrade" -> "h2c",
-    ),
-  )
-  // Apply this, if it ever becomes Some, then rather than the next request, become an h2 connection
-  def h2cUpgradeHttpRoute[F[_]: Concurrent]: HttpRoutes[F] =
-    Kleisli[OptionT[F, *], Request[F], Response[F]] { (req: Request[F]) =>
-      val connectionCheck = req.headers
-        .get[org.http4s.headers.Connection]
-        .exists(connection =>
-          connection.values.contains_(ci"upgrade") && connection.values
-            .contains_(ci"http2-settings")
-        )
-
-      // checks are cascading so we execute the least amount of work
-      // if there is no upgrade, which is the likely case.
-      val upgradeCheck = connectionCheck &&
-        req.headers
-          .get(ci"upgrade")
-          .exists(upgrade => upgrade.map(r => r.value).exists(_ === "h2c"))
-
-      val settings: Option[H2Frame.Settings.ConnectionSettings] = if (upgradeCheck) {
-        req.headers
-          .get(ci"http2-settings")
-          .collectFirstSome(settings =>
-            settings.map(_.value).collectFirstSome { value =>
-              for {
-                bv <- ByteVector.fromBase64(value, Bases.Alphabets.Base64Url) // Base64 Url
-                settings <- H2Frame.Settings
-                  .fromPayload(bv, 0, ack = false)
-                  .toOption // This isn't an entire frame
-                // It is Just the Payload section of the frame
-              } yield H2Frame.Settings
-                .updateSettings(settings, H2Frame.Settings.ConnectionSettings.default)
-            }
-          )
-      } else None
-      val upgrade = connectionCheck && upgradeCheck
-      (settings, upgrade) match {
-        case (Some(settings), true) =>
-          cats.data.OptionT.liftF(req.body.compile.to(ByteVector): F[ByteVector]).flatMap { bv =>
-            val newReq: Request[fs2.Pure] = Request[fs2.Pure](
-              req.method,
-              req.uri,
-              HttpVersion.`HTTP/2`,
-              req.headers,
-              Stream.chunk(Chunk.byteVector(bv)),
-              req.attributes,
-            )
-            cats.data.OptionT.some(
-              upgradeResponse.covary[F].withAttribute(H2Keys.H2cUpgrade, (settings, newReq))
-            )
-          }
-
-        case (_, _) => cats.data.OptionT.none
-      }
-    }
-
-  def h2cUpgradeMiddleware[F[_]: Concurrent](app: HttpApp[F]): HttpApp[F] =
-    cats.data.Kleisli { (req: Request[F]) =>
-      h2cUpgradeHttpRoute
-        .run(req)
-        .getOrElseF(app.run(req))
-    }
 
   // Call on a new connection for http2-prior-knowledge
   // If left 1.1 if right 2
@@ -174,25 +86,10 @@ private[ember] object H2Server {
       idleTimeout: Duration,
       localSettings: H2Frame.Settings.ConnectionSettings,
       logger: Logger[F],
-      // Only Used for http1 upgrade where remote settings are provided prior to escalation
-      initialRemoteSettings: H2Frame.Settings.ConnectionSettings = defaultSettings,
-      initialRequest: Option[Request[fs2.Pure]] = None,
   )(implicit F: Async[F]): Resource[F, Unit] = {
     import cats.effect.kernel.instances.spawn._
 
-    // h2c Initial Request Communication on h2c Upgrade
-    def sendInitialRequest(h2: H2Connection[F])(req: Request[Pure]): F[Unit] =
-      for {
-        h2Stream <- h2.initiateRemoteStreamById(1)
-        s <- h2Stream.state.modify { s =>
-          val x = s.copy(state = H2Stream.StreamState.HalfClosedRemote)
-          (x, x)
-        }
-        _ <- s.request.complete(Either.right(req))
-        er = Either.right(req.body.compile.to(fs2.Collector.supportsByteVector(ByteVector)))
-        _ <- s.readBuffer.send(er)
-        _ <- s.writeBlock.complete(Either.unit)
-      } yield ()
+    val initialRemoteSettings = defaultSettings
 
     def holdWhileOpen(stateRef: Ref[F, H2Connection.State[F]]): F[Unit] =
       F.sleep(1.seconds) >> stateRef.get.map(_.closed).ifM(F.unit, holdWhileOpen(stateRef))
@@ -333,10 +230,6 @@ private[ember] object H2Server {
       _ <- h2.writeLoop.compile.drain.background
       _ <- Resource.eval(h2.outgoing.offer(Chunk.singleton(settingsFrame)))
       _ <- h2.readLoop.background
-      // h2c Initial Request Communication on h2c Upgrade
-      _ <- Resource.eval(
-        initialRequest.traverse_(req => sendInitialRequest(h2)(req) >> h2.createdStreams.offer(1))
-      )
       maxStreams <- Resource.eval(
         Semaphore[F](localSettings.maxConcurrentStreams.maxConcurrency.toLong)
       )

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/PseudoHeaders.scala
@@ -164,7 +164,7 @@ private[h2] object PseudoHeaders {
   // Connection Specific Headers should be removed when doing h2
   // This is because connection mechanisms are handled by h2
   // rather than request/response cycle.
-  // https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.2
+  // https://httpwg.org/specs/rfc9113.html#rfc.section.8.2.2
   val connectionHeadersFields: Set[CIString] = Set(
     org.http4s.headers.`Transfer-Encoding`.headerInstance.name,
     org.http4s.headers.Connection.headerInstance.name,

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -32,7 +32,6 @@ import org.http4s.ember.core.Parser
 import org.http4s.ember.core.Read
 import org.http4s.ember.core.Util._
 import org.http4s.ember.core.h2.H2Frame
-import org.http4s.ember.core.h2.H2Keys
 import org.http4s.ember.core.h2.H2Server
 import org.http4s.ember.core.h2.H2TLS
 import org.http4s.headers.Connection
@@ -254,7 +253,6 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                   createRequestVault,
                   webSocketKey,
                   ByteVector.empty,
-                  enableHttp2,
                   requestLineParseErrorHandler,
                   maxHeaderSizeErrorHandler,
                   webSocketHelpers,
@@ -279,7 +277,6 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                           createRequestVault,
                           webSocketKey,
                           bv, // Pass read bytes we thought might be the prelude
-                          enableHttp2,
                           requestLineParseErrorHandler,
                           maxHeaderSizeErrorHandler,
                           webSocketHelpers,
@@ -313,7 +310,6 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                       createRequestVault,
                       webSocketKey,
                       ByteVector.empty,
-                      enableHttp2,
                       requestLineParseErrorHandler,
                       maxHeaderSizeErrorHandler,
                       webSocketHelpers,
@@ -460,21 +456,16 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       createRequestVault: Boolean,
       webSocketKey: Key[WebSocketContext[F]],
       initialBuffer: ByteVector,
-      enableHttp2: Boolean,
       requestLineParseErrorHandler: Throwable => F[Response[F]],
       maxHeaderSizeErrorHandler: EmberException.MessageTooLong => F[Response[F]],
       webSocketHelpers: WebSocketHelpers,
   ): Stream[F, Nothing] = {
     type State = (Array[Byte], Boolean)
-    val finalApp = if (enableHttp2) H2Server.h2cUpgradeMiddleware(httpApp) else httpApp
     val read: Read[F] = timeoutMaybe(socket.read(receiveBufferSize), idleTimeout)
       .adaptError {
         // TODO MERGE: Replace with TimeoutException on series/0.23+.
         case _: TimeoutException => EmberException.ReadTimeout(idleTimeout)
       }
-
-    val h2FrameSettings = H2Frame.Settings.ConnectionSettings.default
-      .copy(maxHeaderListSize = Some(H2Frame.Settings.SettingsMaxHeaderListSize(maxHeaderSize)))
 
     Stream
       .unfoldEval[F, State, Response[F]](initialBuffer.toArray -> false) { case (buffer, reuse) =>
@@ -500,7 +491,7 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
             read,
             maxHeaderSize,
             requestHeaderReceiveTimeout,
-            finalApp,
+            httpApp,
             errorHandler,
             socket,
             createRequestVault,
@@ -532,35 +523,12 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
                     Applicative[F].pure(None)
                 }
               case None =>
-                resp.attributes.lookup(H2Keys.H2cUpgrade) match {
-                  // Http1.1
-                  case None =>
-                    for {
-                      nextResp <- postProcessResponse(req, resp)
-                      _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
-                      nextBuffer <- drain
-                    } yield nextBuffer.map(buffer => (nextResp, (buffer, true)))
-                  // h2c escalation of the connection
-                  case Some((settings, newReq)) =>
-                    for {
-                      nextResp <- postProcessResponse(req, resp)
-                      _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
-                      _ <- H2Server.requireConnectionPreface(socket)
-                      out <- H2Server
-                        .fromSocket(
-                          socket,
-                          httpApp,
-                          requestHeaderReceiveTimeout,
-                          idleTimeout,
-                          h2FrameSettings,
-                          logger,
-                          settings,
-                          newReq.some,
-                        )
-                        .use(_ => Async[F].never[Unit])
-                        .as(None)
-                    } yield out
-                }
+                for {
+                  nextResp <- postProcessResponse(req, resp)
+                  _ <- send(socket)(Some(req), nextResp, idleTimeout, onWriteFailure)
+                  nextBuffer <- drain
+                } yield nextBuffer.map(buffer => (nextResp, (buffer, true)))
+
             }
           case Left(err) =>
             err match {

--- a/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
+++ b/examples/ember/src/main/scala/com/example/http4s/ember/EmberServerH2Example.scala
@@ -92,7 +92,7 @@ object EmberServerH2Example extends IOApp {
         .build
     } yield ()
 
-    // Can Test Both http2-prior-knowledge, and h2c
+    // Can Test http2-prior-knowledge
     def testCleartext[F[_]: Async: Console: Network] =
       EmberServerBuilder
         .default[F]


### PR DESCRIPTION
The plaintext HTTP/1.1 to HTTP/2 h2c mechanism is no longer supported in the updated HTTP/2 RFC 9113. Removing the corresponding code for Ember.