### PR TITLE
Do not test Unix sockets on Ember on JDK < 17

### DIFF
--- a/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
+++ b/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
@@ -72,6 +72,7 @@ class EmberUnixSocketSuite extends Http4sSuite {
 
   test("http/2") {
     assume(!sys.props.get("java.specification.version").contains("1.8"))
+    assume(!sys.props.get("java.specification.version").contains("11"))
     run(_.withHttp2, _.withHttp2, _.withAttribute(Http2PriorKnowledge, ()))
   }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -195,8 +195,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
 
   /** Enables HTTP/2 support.
     *
-    * As of 0.23.35, no longer tested or supported with Unix sockets
-    * on Java 8.
+    * No longer tested or supported with Unix sockets on Java < 17.
     */
   def withHttp2: EmberServerBuilder[F] = copy(enableHttp2 = true)
   def withoutHttp2: EmberServerBuilder[F] = copy(enableHttp2 = false)


### PR DESCRIPTION
We're getting spurious failures on JDK11, too.

Fixes #7889.