### PR TITLE
Harden RFC 6455 compliance for WebSocket closing handshake

### DIFF
--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -40,7 +40,6 @@ import org.java_websocket.handshake.ServerHandshake
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
-
 import scala.concurrent.duration._
 
 class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -204,23 +204,24 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
       } yield assertEquals(code, CloseFrame.NORMAL)
   }
 
-  fixture.test("combined pipe: server initiates close sequence with code=1000 (NORMAL) on stream completion") {
-    case (server, dispatcher) =>
-      for {
-        client <- createClient(
-          URI.create(
-            s"ws://${server.address.getHostName}:${server.address.getPort}/ws-close-combined"
-          ),
-          dispatcher,
-        )
-        _ <- client.connect
-        msg <- client.messages.take
-        code <- client.closeCode.get
-        _ <- client.remoteClosed.get.timeout(10.seconds)
-      } yield {
-        assertEquals(msg, "foo")
-        assertEquals(code, CloseFrame.NORMAL)
-      }
+  fixture.test(
+    "combined pipe: server initiates close sequence with code=1000 (NORMAL) on stream completion"
+  ) { case (server, dispatcher) =>
+    for {
+      client <- createClient(
+        URI.create(
+          s"ws://${server.address.getHostName}:${server.address.getPort}/ws-close-combined"
+        ),
+        dispatcher,
+      )
+      _ <- client.connect
+      msg <- client.messages.take
+      code <- client.closeCode.get
+      _ <- client.remoteClosed.get.timeout(10.seconds)
+    } yield {
+      assertEquals(msg, "foo")
+      assertEquals(code, CloseFrame.NORMAL)
+    }
   }
 
   fixture.test("respects withFilterPingPongs(false)") { case (server, dispatcher) =>

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -41,6 +41,8 @@ import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
+import scala.concurrent.duration._
+
 class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
 
   def service[F[_]](wsBuilder: WebSocketBuilder2[F])(implicit F: Async[F]): HttpApp[F] = {
@@ -60,6 +62,8 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
         case GET -> Root / "ws-close" =>
           val send = Stream(WebSocketFrame.Text("foo"))
           wsBuilder.build(send, _.void)
+        case GET -> Root / "ws-close-combined" =>
+          wsBuilder.build(_ => Stream(WebSocketFrame.Text("foo")))
         case GET -> Root / "ws-filter-false" =>
           F.deferred[Unit].flatMap { deferred =>
             wsBuilder
@@ -198,6 +202,25 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
         _ <- client.remoteClosed.get
         code <- client.closeCode.get
       } yield assertEquals(code, CloseFrame.NORMAL)
+  }
+
+  fixture.test("combined pipe: server initiates close sequence with code=1000 (NORMAL) on stream completion") {
+    case (server, dispatcher) =>
+      for {
+        client <- createClient(
+          URI.create(
+            s"ws://${server.address.getHostName}:${server.address.getPort}/ws-close-combined"
+          ),
+          dispatcher,
+        )
+        _ <- client.connect
+        msg <- client.messages.take
+        code <- client.closeCode.get
+        _ <- client.remoteClosed.get.timeout(10.seconds)
+      } yield {
+        assertEquals(msg, "foo")
+        assertEquals(code, CloseFrame.NORMAL)
+      }
   }
 
   fixture.test("respects withFilterPingPongs(false)") { case (server, dispatcher) =>

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -215,9 +215,9 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
         dispatcher,
       )
       _ <- client.connect
+      _ <- client.remoteClosed.get.timeout(10.seconds)
       msg <- client.messages.take
       code <- client.closeCode.get
-      _ <- client.remoteClosed.get.timeout(10.seconds)
     } yield {
       assertEquals(msg, "foo")
       assertEquals(code, CloseFrame.NORMAL)

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -63,6 +63,9 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
           wsBuilder.build(send, _.void)
         case GET -> Root / "ws-close-combined" =>
           wsBuilder.build(_ => Stream(WebSocketFrame.Text("foo")))
+        case GET -> Root / "ws-replicated-response" =>
+          val send = Stream(WebSocketFrame.Text("42")).repeatN(512)
+          wsBuilder.build(send, _.void)
         case GET -> Root / "ws-filter-false" =>
           F.deferred[Unit].flatMap { deferred =>
             wsBuilder
@@ -197,6 +200,45 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
         _ <- client.remoteClosed.get
         code <- client.closeCode.get
       } yield assertEquals(code, CloseFrame.NORMAL)
+  }
+
+  fixture.test("server response and pong frames do not interfere") { case (server, dispatcher) =>
+    val onCancel = IO.raiseError(new IllegalStateException("Fiber canceled"))
+
+    for {
+      client <- createClient(
+        URI.create(
+          s"ws://${server.address.getHostName}:${server.address.getPort}/ws-replicated-response"
+        ),
+        dispatcher,
+      )
+      _ <- client.connect
+      pings =
+        (0 to 511).toList
+          .traverse_(i => client.ping(s"ping-$i"))
+      takes = client.messages.take.replicateA(512)
+      serverResponse <-
+        IO.racePair(pings, takes)
+          .flatMap {
+            case Left((Outcome.Succeeded(_), takeFiber)) =>
+              takeFiber.joinWith(onCancel)
+            case Left((Outcome.Errored(ex), takeFiber)) =>
+              takeFiber.cancel *> IO.raiseError(ex)
+            case Left((Outcome.Canceled(), takeFiber)) =>
+              takeFiber.cancel *> onCancel
+            case Right((pingFiber, Outcome.Succeeded(res))) =>
+              pingFiber.cancel *> res
+            case Right((pingFiber, Outcome.Errored(ex))) =>
+              pingFiber.cancel *> IO.raiseError(ex)
+            case Right((pingFiber, Outcome.Canceled())) =>
+              pingFiber.cancel *> onCancel
+          }
+          .timeout(10.seconds)
+      code <- client.closeCode.get
+    } yield {
+      assertEquals(serverResponse, List.fill(512)("42"))
+      assertEquals(code, CloseFrame.NORMAL)
+    }
   }
 
   fixture.test(

--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -209,61 +209,63 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
   }
 
   fixture.test("server response and pong frames do not interfere") { case (server, dispatcher) =>
-    val onCancel = IO.raiseError(new IllegalStateException("Fiber canceled"))
+    createClient(
+      URI.create(
+        s"ws://${server.address.getHostName}:${server.address.getPort}/ws-replicated-response"
+      ),
+      dispatcher,
+    ).use { client =>
+      val onCancel = IO.raiseError(new IllegalStateException("Fiber canceled"))
 
-    for {
-      client <- createClient(
-        URI.create(
-          s"ws://${server.address.getHostName}:${server.address.getPort}/ws-replicated-response"
-        ),
-        dispatcher,
-      )
-      _ <- client.connect
-      pings =
-        (0 to 511).toList
-          .traverse_(i => client.ping(s"ping-$i"))
-      takes = client.messages.take.replicateA(512)
-      serverResponse <-
-        IO.racePair(pings, takes)
-          .flatMap {
-            case Left((Outcome.Succeeded(_), takeFiber)) =>
-              takeFiber.joinWith(onCancel)
-            case Left((Outcome.Errored(ex), takeFiber)) =>
-              takeFiber.cancel *> IO.raiseError(ex)
-            case Left((Outcome.Canceled(), takeFiber)) =>
-              takeFiber.cancel *> onCancel
-            case Right((pingFiber, Outcome.Succeeded(res))) =>
-              pingFiber.cancel *> res
-            case Right((pingFiber, Outcome.Errored(ex))) =>
-              pingFiber.cancel *> IO.raiseError(ex)
-            case Right((pingFiber, Outcome.Canceled())) =>
-              pingFiber.cancel *> onCancel
-          }
-          .timeout(10.seconds)
-      code <- client.closeCode.get
-    } yield {
-      assertEquals(serverResponse, List.fill(512)("42"))
-      assertEquals(code, CloseFrame.NORMAL)
+      for {
+        _ <- client.connect
+        pings =
+          (0 to 511).toList
+            .traverse_(i => client.ping(s"ping-$i"))
+        takes = client.messages.take.replicateA(512)
+        serverResponse <-
+          IO.racePair(pings, takes)
+            .flatMap {
+              case Left((Outcome.Succeeded(_), takeFiber)) =>
+                takeFiber.joinWith(onCancel)
+              case Left((Outcome.Errored(ex), takeFiber)) =>
+                takeFiber.cancel *> IO.raiseError(ex)
+              case Left((Outcome.Canceled(), takeFiber)) =>
+                takeFiber.cancel *> onCancel
+              case Right((pingFiber, Outcome.Succeeded(res))) =>
+                pingFiber.cancel *> res
+              case Right((pingFiber, Outcome.Errored(ex))) =>
+                pingFiber.cancel *> IO.raiseError(ex)
+              case Right((pingFiber, Outcome.Canceled())) =>
+                pingFiber.cancel *> onCancel
+            }
+            .timeout(10.seconds)
+        code <- client.closeCode.get
+      } yield {
+        assertEquals(serverResponse, List.fill(512)("42"))
+        assertEquals(code, CloseFrame.NORMAL)
+      }
     }
   }
 
   fixture.test(
     "combined pipe: server initiates close sequence with code=1000 (NORMAL) on stream completion"
   ) { case (server, dispatcher) =>
-    for {
-      client <- createClient(
-        URI.create(
-          s"ws://${server.address.getHostName}:${server.address.getPort}/ws-close-combined"
-        ),
-        dispatcher,
-      )
-      _ <- client.connect
-      _ <- client.remoteClosed.get.timeout(10.seconds)
-      msg <- client.messages.take
-      code <- client.closeCode.get
-    } yield {
-      assertEquals(msg, "foo")
-      assertEquals(code, CloseFrame.NORMAL)
+    createClient(
+      URI.create(
+        s"ws://${server.address.getHostName}:${server.address.getPort}/ws-close-combined"
+      ),
+      dispatcher,
+    ).use { client =>
+      for {
+        _ <- client.connect
+        _ <- client.remoteClosed.get.timeout(10.seconds)
+        msg <- client.messages.take
+        code <- client.closeCode.get
+      } yield {
+        assertEquals(msg, "foo")
+        assertEquals(code, CloseFrame.NORMAL)
+      }
     }
   }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -126,27 +126,26 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
         )
 
       val incoming = Stream.chunk(Chunk.array(buffer)) ++ readStream(read)
-
-      // TODO followup: handle close frames from the user?
+      
       SignallingRef[F, Close](Open).flatMap { close =>
-        val closed: F[Unit] = close.update {
-          case Open => EndpointClosed
-          case _ => BothClosed
-        }
+        def startClosing: F[Boolean] =
+          close.modify {
+            case Open => (EndpointClosed, true)
+            case s => (s, false)
+          }
 
         val sendClosingFrame: F[Unit] =
-          close
-            .modify {
-              case Open => (EndpointClosed, true)
-              case s => (s, false)
-            }
-            .flatMap {
-              case true => F.fromEither(WebSocketFrame.Close(1000)).flatMap(writeFrame)
-              case false => F.unit
-            }
+          startClosing.flatMap {
+            case true => F.fromEither(WebSocketFrame.Close(1000)).flatMap(writeFrame)
+            case false => F.unit
+          }
 
         def writeOutgoing(frame: WebSocketFrame): F[Unit] = frame match {
-          case _: WebSocketFrame.Close => closed *> writeFrame(frame)
+          case fr: WebSocketFrame.Close =>
+            startClosing.flatMap {
+              case true => writeFrame(fr)
+              case false => F.unit
+            }
           case _ => writeFrame(frame)
         }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -126,7 +126,7 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
         )
 
       val incoming = Stream.chunk(Chunk.array(buffer)) ++ readStream(read)
-      
+
       SignallingRef[F, Close](Open).flatMap { close =>
         def startClosing: F[Boolean] =
           close.modify {
@@ -146,7 +146,11 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
               case true => writeFrame(fr)
               case false => F.unit
             }
-          case _ => writeFrame(frame)
+          case _ =>
+            close.get.flatMap {
+              case Open => writeFrame(frame)
+              case _ => F.unit
+            }
         }
 
         val (stream, onClose) = ctx.webSocket match {

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -119,58 +119,56 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
   )(implicit F: Temporal[F]): F[Unit] =
     Mutex[F].flatMap { writeLock =>
       val read: Read[F] = timeoutMaybe(socket.read(receiveBufferSize), idleTimeout)
-      def writeFrame(frame: WebSocketFrame): F[Unit] =
-        // lock guarantees that frame chunks from auto-pong and send-path do not interleave
-        writeLock.lock.surround(
-          frameToBytes(frame).traverse_(c => timeoutMaybe(socket.write(c), idleTimeout))
-        )
+
+      // Writes without locking, so concurrent calls may result in interleaving of frame chunks
+      // and race on `close`. Use `writeLock` to guard the state.
+      def writeFrameUnsafe(frame: WebSocketFrame): F[Unit] =
+        frameToBytes(frame).traverse_(c => timeoutMaybe(socket.write(c), idleTimeout))
 
       val incoming = Stream.chunk(Chunk.array(buffer)) ++ readStream(read)
 
       SignallingRef[F, Close](Open).flatMap { close =>
-        def startClosing: F[Boolean] =
-          close.modify {
-            case Open => (EndpointClosed, true)
-            case s => (s, false)
-          }
-
-        val sendClosingFrame: F[Unit] =
-          startClosing.flatMap {
-            case true => F.fromEither(WebSocketFrame.Close(1000)).flatMap(writeFrame)
-            case false => F.unit
+        def writeClosingFrame(frame: WebSocketFrame): F[Unit] =
+          writeLock.lock.surround {
+            close.get.flatMap {
+              case Open =>
+                close.set(EndpointClosed).flatMap(_ => writeFrameUnsafe(frame))
+              case _ => F.unit
+            }
           }
 
         def writeOutgoing(frame: WebSocketFrame): F[Unit] = frame match {
           case fr: WebSocketFrame.Close =>
-            startClosing.flatMap {
-              case true => writeFrame(fr)
-              case false => F.unit
-            }
+            writeClosingFrame(fr)
           case _ =>
-            close.get.flatMap {
-              case Open => writeFrame(frame)
-              case _ => F.unit
+            writeLock.lock.surround {
+              close.get.flatMap {
+                case Open => writeFrameUnsafe(frame)
+                case _ => F.unit
+              }
             }
         }
 
+        val sendClosingFrame: F[Unit] =
+          F.fromEither(WebSocketFrame.Close(1000)).flatMap(writeClosingFrame)
+
         val (stream, onClose) = ctx.webSocket match {
           case WebSocketCombinedPipe(receiveSend, onClose) =>
-            val read = incoming
+            val reader = incoming
               .through(decodeFrames[F])
-              .evalMapFilter(handleIncomingFrame[F](writeFrame, close))
+              .evalMapFilter(handleIncomingFrame[F](writeFrameUnsafe, close, writeLock))
               .through(receiveSend)
+            val stream =
+              reader.foreach(writeOutgoing) ++ Stream.exec(sendClosingFrame)
 
-            val preparedStream =
-              read.foreach(writeOutgoing) ++ Stream.exec(sendClosingFrame)
+            stream -> onClose
 
-            preparedStream -> onClose
           case WebSocketSeparatePipe(send, receive, onClose) =>
             val writer: Stream[F, Nothing] =
               send.foreach(writeOutgoing) ++ Stream.exec(sendClosingFrame)
-
             val reader = incoming
               .through(decodeFrames[F])
-              .evalMapFilter(handleIncomingFrame[F](writeFrame, close))
+              .evalMapFilter(handleIncomingFrame[F](writeFrameUnsafe, close, writeLock))
               .through(receive)
 
             reader.concurrently(writer) -> onClose
@@ -187,25 +185,33 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
   private def handleIncomingFrame[F[_]](
       writeFrame: WebSocketFrame => F[Unit],
       closeState: Ref[F, Close],
+      writeLock: Mutex[F],
   )(
       frame: WebSocketFrame
   )(implicit F: Concurrent[F]): F[Option[WebSocketFrame]] =
     frame match {
       case ping @ WebSocketFrame.Ping(data) =>
-        writeFrame(WebSocketFrame.Pong(data)).as(ping.some)
+        writeLock.lock.surround(writeFrame(WebSocketFrame.Pong(data))).as(ping.some)
       case WebSocketFrame.Close(_) =>
-        closeState.get.flatMap {
-          case Open =>
-            for {
-              frame <- F.fromEither(WebSocketFrame.Close(1000))
-              _ <- writeFrame(frame)
-              _ <- closeState.set(BothClosed)
-            } yield None
-          case EndpointClosed =>
-            // We closed first and the peer has now answered, so the handshake is complete.
-            closeState.set(BothClosed).as(None)
-          case _ => F.pure(None)
-        }
+        writeLock.lock
+          .surround {
+            closeState.get.flatMap {
+              case Open =>
+                // Peer closed first, so we answer and then handshake is complete.
+                for {
+                  frame <- F.fromEither(WebSocketFrame.Close(1000))
+                  _ <- writeFrame(frame)
+                  _ <- closeState.set(BothClosed)
+                } yield ()
+
+              case EndpointClosed =>
+                // We closed first and the peer has now answered, so the handshake is complete.
+                closeState.set(BothClosed)
+
+              case _ => F.unit
+            }
+          }
+          .as(None)
       case x => F.pure(Some(x))
     }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -134,15 +134,16 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
           case _ => BothClosed
         }
 
-        val sendClosingFrame: F[Unit] = close.get.flatMap {
-          case Open =>
-            for {
-              frame <- F.fromEither(WebSocketFrame.Close(1000))
-              _ <- closed
-              _ <- writeFrame(frame)
-            } yield ()
-          case _ => F.unit
-        }
+        val sendClosingFrame: F[Unit] =
+          close
+            .modify {
+              case Open => (EndpointClosed, true)
+              case s => (s, false)
+            }
+            .flatMap {
+              case true => F.fromEither(WebSocketFrame.Close(1000)).flatMap(writeFrame)
+              case false => F.unit
+            }
 
         def writeOutgoing(frame: WebSocketFrame): F[Unit] = frame match {
           case _: WebSocketFrame.Close => closed *> writeFrame(frame)

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -129,34 +129,38 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
 
       // TODO followup: handle close frames from the user?
       SignallingRef[F, Close](Open).flatMap { close =>
+        val closed: F[Unit] = close.update {
+          case Open => EndpointClosed
+          case _ => BothClosed
+        }
+
+        val sendClosingFrame: F[Unit] = close.get.flatMap {
+          case Open =>
+            for {
+              frame <- F.fromEither(WebSocketFrame.Close(1000))
+              _ <- closed
+              _ <- writeFrame(frame)
+            } yield ()
+          case _ => F.unit
+        }
+
+        def writeOutgoing(frame: WebSocketFrame): F[Unit] = frame match {
+          case _: WebSocketFrame.Close => closed *> writeFrame(frame)
+          case _ => writeFrame(frame)
+        }
+
         val (stream, onClose) = ctx.webSocket match {
           case WebSocketCombinedPipe(receiveSend, onClose) =>
-            incoming
+            val read = incoming
               .through(decodeFrames[F])
               .evalMapFilter(handleIncomingFrame[F](writeFrame, close))
               .through(receiveSend)
-              .foreach(writeFrame) -> onClose
+
+            val preparedStream =
+              read.foreach(writeOutgoing) ++ Stream.exec(sendClosingFrame)
+
+            preparedStream -> onClose
           case WebSocketSeparatePipe(send, receive, onClose) =>
-            val closed: F[Unit] = close.update {
-              case Open => EndpointClosed
-              case _ => BothClosed
-            }
-
-            def writeOutgoing(frame: WebSocketFrame): F[Unit] = frame match {
-              case _: WebSocketFrame.Close => closed *> writeFrame(frame)
-              case _ => writeFrame(frame)
-            }
-
-            val sendClosingFrame: F[Unit] = close.get.flatMap {
-              case Open =>
-                for {
-                  frame <- F.fromEither(WebSocketFrame.Close(1000))
-                  _ <- closed
-                  _ <- writeFrame(frame)
-                } yield ()
-              case _ => F.unit
-            }
-
             val writer: Stream[F, Nothing] =
               send.foreach(writeOutgoing) ++ Stream.exec(sendClosingFrame)
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/WebSocketHelpers.scala
@@ -191,7 +191,18 @@ private[internal] class WebSocketHelpers(maxFrameSize: Int) {
   )(implicit F: Concurrent[F]): F[Option[WebSocketFrame]] =
     frame match {
       case ping @ WebSocketFrame.Ping(data) =>
-        mut.lock.surround(writeFrame(WebSocketFrame.Pong(data))).as(ping.some)
+        // As per RFC 6455 §5.5.2, an endpoint that receives a Ping after a Close
+        // from the peer is no longer required to respond to that Ping. Moreover,
+        // once the closing handshake has completed, the connection is being closed.
+        mut.lock.surround {
+          closeState.get.flatMap {
+            case EndpointClosed | Open =>
+              writeFrame(WebSocketFrame.Pong(data)).as(ping.some)
+            case _ =>
+              F.pure(None)
+          }
+        }
+
       case WebSocketFrame.Close(_) =>
         mut.lock
           .surround {


### PR DESCRIPTION
A follow-up to https://github.com/http4s/http4s/pull/7882. 

I've been retrospectively checking that PR and found the misalignment in closing handshake behavior between `WebSocketSeparatePipe` and `WebSocketCombinedPipe` (it wasn't introduced in that PR though). So currently, Ember drops the TCP connection without a Close frame for `WebSocketCombinedPipe`. In the Java client, this leads to abnormal stream termination (1006), while the stream actually completed normally. However, RFC 6455 §7.1.2 [states](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.2) that

> To _Start the WebSocket Closing Handshake_ with a status code (Section 7.4) /code/ and an optional close reason (Section 7.1.6) /reason/, an endpoint MUST send a Close control frame

This PR mainly addresses this, but I've also added several hardenings: 
* performing WS close state checks and transitions atomically
* guarding outgoing WS frames against closing state 
* and I hope, graceful handling of peer-initiated closing handshake 