### PR TITLE
Properly signal the start of an Ember Unix socket server

### DIFF
--- a/docs/docs/client-middleware.md
+++ b/docs/docs/client-middleware.md
@@ -258,7 +258,6 @@ def server(socket: UnixSocketAddress) = EmberServerBuilder
   .withHttpApp(service.orNotFound)
   .withShutdownTimeout(1.second)
   .build
-  .evalTap(_ => IO.sleep(4.seconds))
 
 def client(socket: UnixSocketAddress) = EmberClientBuilder
   .default[IO]

--- a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
+++ b/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Server.scala
@@ -22,7 +22,6 @@ import cats.effect.std.Semaphore
 import cats.effect.syntax.all._
 import cats.syntax.all._
 import fs2._
-import fs2.io.IOException
 import fs2.io.net._
 import org.http4s._
 import org.typelevel.log4cats.Logger
@@ -58,13 +57,12 @@ private[ember] object H2Server {
   // Call on a new connection for http2-prior-knowledge
   // If left 1.1 if right 2
   def checkConnectionPreface[F[_]: MonadThrow](socket: Socket[F]): F[Either[ByteVector, Unit]] =
-    socket.read(Preface.clientBV.size.toInt).flatMap {
-      case Some(s) =>
-        val received = s.toByteVector
-        if (received == Preface.clientBV) Applicative[F].pure(Either.unit)
-        else Applicative[F].pure(Either.left(received))
-      case None =>
-        new IOException("Input Closed Before Receiving Data").raiseError
+    socket.readN(Preface.clientBV.size.toInt).flatMap { s =>
+      val received = s.toByteVector
+      if (received == Preface.clientBV)
+        Applicative[F].pure(Either.unit)
+      else
+        Applicative[F].pure(Either.left(received))
     }
 
   // For Anything that is guaranteed to only be h2 this method will fail

--- a/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
+++ b/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
@@ -59,8 +59,7 @@ class EmberUnixSocketSuite extends Http4sSuite {
 
       Files[IO].deleteIfExists(path) *>
         (server *> client).use { client =>
-          IO.sleep(4.seconds) *>
-            client.expect[String](request).assertEquals(msg) *>
+          client.expect[String](request).assertEquals(msg) *>
             client.expect[String](request).assertEquals(msg)
         }
     }
@@ -71,8 +70,6 @@ class EmberUnixSocketSuite extends Http4sSuite {
   }
 
   test("http/2") {
-    assume(!sys.props.get("java.specification.version").contains("1.8"))
-    assume(!sys.props.get("java.specification.version").contains("11"))
     run(_.withHttp2, _.withHttp2, _.withAttribute(Http2PriorKnowledge, ()))
   }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -193,10 +193,7 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
     copy(requestHeaderReceiveTimeout = requestHeaderReceiveTimeout)
   def withLogger(l: Logger[F]): EmberServerBuilder[F] = copy(logger = l)
 
-  /** Enables HTTP/2 support.
-    *
-    * No longer tested or supported with Unix sockets on Java < 17.
-    */
+  /** Enables HTTP/2 support. */
   def withHttp2: EmberServerBuilder[F] = copy(enableHttp2 = true)
   def withoutHttp2: EmberServerBuilder[F] = copy(enableHttp2 = false)
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/internal/ServerHelpers.scala
@@ -141,21 +141,24 @@ private[server] object ServerHelpers extends ServerHelpersPlatform {
       maxWebSocketFrameSize: Int,
   ): Stream[F, Nothing] = {
     val server =
-      // Our interface has an issue
       Stream
-        .eval(
-          ready.complete( // This is a lie, there isn't any signal from fs2 when the server is actually ready
-            Either.right(SocketAddress(Ipv4Address.fromBytes(0, 0, 0, 0), port"0"))
+        .resource(
+          Network[F].bind(
+            unixSocketAddress,
+            List(
+              SocketOption.unixSocketDeleteIfExists(deleteIfExists),
+              SocketOption.unixSocketDeleteOnClose(deleteOnClose),
+            ) ++ additionalSocketOptions,
           )
-        ) // Sketchy
-        .drain ++
-        Network[F].bindAndAccept(
-          unixSocketAddress,
-          List(
-            SocketOption.unixSocketDeleteIfExists(deleteIfExists),
-            SocketOption.unixSocketDeleteOnClose(deleteOnClose),
-          ) ++ additionalSocketOptions,
         )
+        .attempt
+        .evalTap(e =>
+          ready.complete(
+            e.as(SocketAddress(Ipv4Address.Wildcard, port"0"))
+          )
+        )
+        .rethrow
+        .flatMap(_.accept)
 
     serverInternal(
       server,


### PR DESCRIPTION
I think this is the real fix for #7889.  I had observed it to be JDK related and gone down the wrong path, but the implementation confessed the mistake.