### PR TITLE
Warn on running Ember H2 with Unix sockets

### DIFF
--- a/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
+++ b/ember-server/js-jvm/src/test/scala/org/http4s/ember/server/EmberUnixSocketSuite.scala
@@ -70,9 +70,7 @@ class EmberUnixSocketSuite extends Http4sSuite {
     run(identity(_), identity(_), identity(_))
   }
 
-  test("http/2") {
-    assume(!sys.props.get("java.specification.version").contains("1.8"))
-    assume(!sys.props.get("java.specification.version").contains("11"))
+  test("http/2".flaky) {
     run(_.withHttp2, _.withHttp2, _.withAttribute(Http2PriorKnowledge, ()))
   }
 

--- a/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
+++ b/ember-server/shared/src/main/scala/org/http4s/ember/server/EmberServerBuilder.scala
@@ -253,6 +253,13 @@ final class EmberServerBuilder[F[_]: Async: Network] private (
 
   def build: Resource[F, Server] =
     for {
+      _ <-
+        if (unixSocketConfig.isDefined && enableHttp2)
+          Resource.eval(
+            logger.warn("Unix sockets are not tested on HTTP/2.  Proceed at your own risk.")
+          )
+        else
+          Resource.unit[F]
       ready <- Resource.eval(Deferred[F, Either[Throwable, SocketAddress[IpAddress]]])
       shutdown <- Resource.eval(Shutdown[F](shutdownTimeout))
       wsBuilder <- Resource.eval(


### PR DESCRIPTION
Followup to #7941.  I stand behind that change, but it isn't the issue.

Until someone cares enough about this feature intersection to stabilize the test, we're not going to let it continue to impede progress.