### PR TITLE
In EmberWebSocketSuite, use client as a resource

### DIFF
--- a/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
+++ b/ember-server/jvm/src/test/scala/org/http4s/ember/server/EmberServerWebSocketSuite.scala
@@ -106,8 +106,8 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
     }
   }
 
-  def createClient(target: URI, dispatcher: Dispatcher[IO]): IO[Client] =
-    for {
+  def createClient(target: URI, dispatcher: Dispatcher[IO]): Resource[IO, Client] = {
+    val acquire = for {
       waitOpen <- Deferred[IO, Option[Throwable]]
       waitClose <- Deferred[IO, Option[Throwable]]
       queue <- Queue.unbounded[IO, String]
@@ -144,83 +144,91 @@ class EmberServerWebSocketSuite extends Http4sSuite with DispatcherIOFixture {
         }
       }
     } yield Client(waitOpen, waitClose, queue, pongQueue, remoteClosed, closeCode, client)
+    Resource.make(acquire)(client => IO(client.client.closeBlocking()))
+  }
 
   fixture.test("open and close connection to server") { case (server, dispatcher) =>
-    for {
-      client <- createClient(
-        URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-echo"),
-        dispatcher,
-      )
-      _ <- client.connect
-      _ <- client.close
-    } yield ()
+    createClient(
+      URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-echo"),
+      dispatcher,
+    ).use { client =>
+      for {
+        _ <- client.connect
+        _ <- client.close
+      } yield ()
+    }
   }
 
   fixture.test("send and receive a message") { case (server, dispatcher) =>
-    for {
-      client <- createClient(
-        URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-echo"),
-        dispatcher,
-      )
-      _ <- client.connect
-      _ <- client.send("foo")
-      msg <- client.messages.take
-      _ <- client.close
-    } yield assertEquals(msg, "foo")
+    createClient(
+      URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-echo"),
+      dispatcher,
+    ).use { client =>
+      for {
+        _ <- client.connect
+        _ <- client.send("foo")
+        msg <- client.messages.take
+        _ <- client.close
+      } yield assertEquals(msg, "foo")
+    }
   }
 
   fixture.test("respond to pings") { case (server, dispatcher) =>
-    for {
-      client <- createClient(
-        URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-echo"),
-        dispatcher,
-      )
-      _ <- client.connect
-      _ <- client.ping("hello")
-      data <- client.pongs.take
-      _ <- client.close
-    } yield assertEquals(data, "hello")
+    createClient(
+      URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-echo"),
+      dispatcher,
+    ).use { client =>
+      for {
+        _ <- client.connect
+        _ <- client.ping("hello")
+        data <- client.pongs.take
+        _ <- client.close
+      } yield assertEquals(data, "hello")
+    }
   }
 
   fixture.test("initiate close sequence with code=1000 (NORMAL) on stream termination") {
     case (server, dispatcher) =>
-      for {
-        client <- createClient(
-          URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-close"),
-          dispatcher,
-        )
-        _ <- client.connect
-        _ <- client.messages.take
-        _ <- client.remoteClosed.get
-        code <- client.closeCode.get
-      } yield assertEquals(code, CloseFrame.NORMAL)
+      createClient(
+        URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-close"),
+        dispatcher,
+      ).use { client =>
+        for {
+          _ <- client.connect
+          _ <- client.messages.take
+          _ <- client.remoteClosed.get
+          code <- client.closeCode.get
+        } yield assertEquals(code, CloseFrame.NORMAL)
+      }
   }
 
   fixture.test("respects withFilterPingPongs(false)") { case (server, dispatcher) =>
-    for {
-      client <- createClient(
-        URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-filter-false"),
-        dispatcher,
-      )
-      _ <- client.connect
-      _ <- client.ping("pingu")
-      _ <- client.remoteClosed.get
-    } yield ()
+    createClient(
+      URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-filter-false"),
+      dispatcher,
+    ).use { client =>
+      for {
+        _ <- client.connect
+        _ <- client.ping("pingu")
+        _ <- client.remoteClosed.get
+      } yield ()
+    }
   }
 
   fixture.test("send and receive multiple messages") { case (server, dispatcher) =>
     val n = 10
     val messages = List.tabulate(n)(i => s"${i + 1}")
-    for {
-      client <- createClient(
-        URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-echo"),
-        dispatcher,
-      )
-      _ <- client.connect
-      _ <- messages.traverse_(client.send)
-      messagesReceived <- client.messages.take.replicateA(n)
-      _ <- client.close
-    } yield assertEquals(messagesReceived, messages)
+    createClient(
+      URI.create(s"ws://${server.address.getHostName}:${server.address.getPort}/ws-echo"),
+      dispatcher,
+    ).use { client =>
+      for {
+        _ <- client.connect
+        _ <- messages.traverse_(client.send)
+        messagesReceived <- client.messages.take.replicateA(n)
+        _ <- client.close
+      } yield assertEquals(messagesReceived, messages)
+    }
   }
 
 }


### PR DESCRIPTION
This is an attempt to ensure that the client is fully shut down before MUnit releases the dispatcher.  Intent is to fix failures like:

```
Error: Exception in thread "WebSocketConnectReadThread-1177" java.lang.IllegalStateException: Dispatcher already closed
	at cats.effect.std.Dispatcher$$anon$2.inner$1(Dispatcher.scala:294)
	at cats.effect.std.Dispatcher$$anon$2.unsafeToFutureCancelable(Dispatcher.scala:371)
	at cats.effect.std.DispatcherPlatform.unsafeRunTimed(DispatcherPlatform.scala:60)
	at cats.effect.std.DispatcherPlatform.unsafeRunTimed$(DispatcherPlatform.scala:59)
	at cats.effect.std.Dispatcher$$anon$2.unsafeRunTimed(Dispatcher.scala:287)
	at cats.effect.std.DispatcherPlatform.unsafeRunSync(DispatcherPlatform.scala:52)
	at cats.effect.std.DispatcherPlatform.unsafeRunSync$(DispatcherPlatform.scala:51)
	at cats.effect.std.Dispatcher$$anon$2.unsafeRunSync(Dispatcher.scala:287)
	at org.http4s.ember.server.EmberServerWebSocketSuite$$anon$2.onError(EmberServerWebSocketSuite.scala:134)
	at org.java_websocket.client.WebSocketClient.run(WebSocketClient.java:551)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

as seen on 75bd166db91009b698a1c33d82f2e115fa76af99 and others.